### PR TITLE
test(hicasso): the reversed-fixed arm's first window — the slot is refuted, the substrate is masked (rf2-csca8)

### DIFF
--- a/docs/design/hicasso/studio/the-cluster-follows-the-mode-and-the-third-arm-is-still-missing.md
+++ b/docs/design/hicasso/studio/the-cluster-follows-the-mode-and-the-third-arm-is-still-missing.md
@@ -348,6 +348,28 @@ for another when a verdict weakened. The arithmetic is exactly what the first
 version computed, on a corrected corpus; what changed is what it is said to
 show.
 
+> **THE WINDOW HAS SINCE BEEN TAKEN, and this page's title is now half wrong.**
+> [The reversed fixed arm: a pre-registered fifteen-run window](the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md)
+> recorded fifteen runs — five `fixed-reversed`, five `fixed`, five `parity`,
+> interleaved in one session — so the third arm is no longer missing. Two things
+> on this page move as a result, and everything else stands.
+>
+> **The SLOT reading is refuted.** With `reagent-subs` in the second-driven slot
+> the cluster does not go with it: 1 of 82 windows, against the same session's
+> 8 of 63 at `fixed | uix-subs | pos1`.
+>
+> **"MODE" survives but narrows.** The matched baseline this page said the mode
+> claim lacked now exists — 7 of 8 `fixed` runs against 1 of 8 `parity` runs
+> across two matched sessions, p = 0.0101 — but `fixed-reversed` is exactly as
+> non-alternating as `fixed` and does **not** carry the term, so what separates
+> from `parity` is the **forward** fixed order specifically and not "a plan that
+> does not alternate".
+>
+> **The SUBSTRATE arm is still not settled**, and the new page names why: the
+> statistic below is a per-window MAXIMUM, and at position 0 the already-recorded
+> ~748 B rider competes with the cluster for it. So the reversed arm's `uix` cell
+> is masked, and the window that was supposed to settle the substrate could not.
+
 ## Why the discriminating arm is still owed a window
 
 The bead names its discriminator: *a fixed run with the segment order REVERSED

--- a/docs/design/hicasso/studio/the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md
+++ b/docs/design/hicasso/studio/the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md
@@ -1,0 +1,107 @@
+# The reversed fixed arm: a pre-registered fifteen-run window
+
+`rf2-csca8` asks which of three properties carries the ~1,050 – 1,224 B cluster
+that [the cluster follows the mode, and the third arm is still
+missing](the-cluster-follows-the-mode-and-the-third-arm-is-still-missing.md)
+read off the committed corpus: the **uix substrate**, the **position** in the
+round, or the segment-order **mode**. That record separated two of the three and
+refused the third, because inside `P0_ALLOC_SEG_ORDER=fixed` the substrate and
+the position are perfectly confounded — position 0 is always `reagent-subs` and
+position 1 is always `uix-subs`, in all 81 fixed windows the corpus holds.
+
+`P0_ALLOC_SEG_ORDER=fixed-reversed` landed in PR #8596 to break that confound:
+the same plan every round, so the mode is held constant, with `uix-subs` moved
+to position 0. **The arm existed and had answered nothing** — no dataset had
+ever been recorded through it. This page records the first one.
+
+## Pre-registration
+
+**Declared before the first run, and committed in this file before the runner was
+invoked once**, as the commit this file was added in on `worker/revarm-csca8`,
+authored off `cd0f9ce9bcd0d46295190c964b9972fa50aa77f5`, which is an ancestor of
+`origin/main` and is the anchor a fresh clone can resolve.
+
+| Field | Value |
+|---|---|
+| **Run count** | **15 runs, taken regardless of outcome** — 5 `fixed-reversed`, 5 `fixed`, 5 `parity` |
+| **Order** | interleaved, one run at a time, cycling `fixed-reversed` → `fixed` → `parity`, five times |
+| Substrate revision | `implementation/core/src` at `921d9c99115bf5de9313ef2c86632d143a86c899`, the tree at `cd0f9ce9bc` |
+| Plan | `P0_ALLOC_PLAN=floor`, `P0_ALLOC_WRITE=all`, `P0_ROOTS=4`, `P0_ALLOC_CELLS=6`, `P0_ALLOC_ROUNDS=18` (so B = 24) — identical to `segorder-rs8q6`'s six runs |
+| Statistic | the **worst leg** of a collection-free window (`falls === 0`) over that window's **own leg median**, in B |
+| Worst-leg reading | **signed-furthest** primary, which is what the published `8 of 38` is stated in; **largest-positive** printed beside it, never instead of it |
+| Band | **1,050 – 1,224 B primary**, the bead's own; 1,000 – 1,300 B reported beside it |
+| Admissibility | `alloc.controlVerdict.ok === true`, as `alloc_cluster_carrier.cjs` already enforces. A refused run is **named**, never dropped |
+| **Stopping rule** | **exactly 15**; the series does not stop early on a positive and does not extend on a null |
+| τ | **untouched in either direction**. `rf2-e9wr`'s refusal stands |
+
+### The level read, declared as a read and not as a filter
+
+The floor arm at this configuration is known to be **multi-modal** — see [the
+second mode: a pre-registered twenty-run window](the-second-mode-a-pre-registered-twenty-run-window.md)
+— so the level each run settled at is recorded before any comparative is quoted.
+The estimator is that window's own, unchanged:
+
+> the **median**, over **certified** windows at **round index ≥ 6**, of that
+> window's `legMedian` — per segment; **high mode** is either segment at or above
+> **21,000 B/write**.
+
+**No run is excluded on it.** If the arms of this window separate on level rather
+than on mode, that is a finding about the window and it is reported as one.
+
+### The tests, named before the data
+
+**PRIMARY, and it is a WITHIN-RUN contrast.** Inside the `fixed-reversed` runs
+alone, `uix-subs` at position 0 against `reagent-subs` at position 1. Both cells
+come from the same runs, the same session, the same mode and the same box, so
+every per-run term is held constant by construction. This is the one contrast
+the corpus could not supply at any n.
+
+The outcomes were pre-registered in the rig source itself when the arm landed
+(`p0_run.cjs`, above `ALLOC_SEG_ORDERS`), and are restated here verbatim rather
+than chosen after the run:
+
+- the cluster **FOLLOWS `uix` to position 0** → the carrier is the **substrate**
+  under fixed;
+- the cluster **STAYS at position 1** → the carrier is the **second-driven slot**,
+  whichever substrate occupies it;
+- **BOTH or NEITHER** → neither property is the carrier as stated.
+
+**SECONDARY, and matched by session rather than pooled.** The five `fixed` and
+five `parity` runs are taken in the same session and interleaved with the
+`fixed-reversed` ones so that the mode contrast has a matched baseline. The
+corpus's matched contrast is 8/38 against 1/23 at window level (p = 0.1344) and
+**3 of 3 runs against 1 of 3 (p = 0.4) at run level**, which is no power at all;
+the pooled p = 3.02e-9 spans 107 runs across several sessions, dates and
+revisions and is recorded as **associated, not established at a matched
+baseline**. The right answer to three clusters is more clusters, and that is what
+these ten companion runs supply.
+
+**No cluster-robust or mixed-effects estimate is offered here and none should
+be.** With a handful of clusters per arm a variance component is not identifiable
+and a cluster-robust standard error is badly biased. The run-level census is
+published beside every window-level p instead.
+
+## Reproduction
+
+From the **repository root**, one run at a time — two heavyweight runs on one box
+wedge rather than fail:
+
+```bash
+P0_PORT=8491 P0_ALLOC_PLAN=floor P0_ALLOC_WRITE=all \
+P0_ROOTS=4 P0_ALLOC_CELLS=6 P0_ALLOC_ROUNDS=18 P0_ALLOC_SEG_ORDER=fixed-reversed \
+P0_RAW_OUT=implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/reversed-1.json \
+  node implementation/core/test/re_frame/bench/p0_run.cjs --only alloc
+```
+
+with `P0_ALLOC_SEG_ORDER` cycling `fixed-reversed` → `fixed` → `parity` and the
+output name following it.
+
+Every measured figure below is re-derived from the committed records by:
+
+```bash
+node implementation/hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs --corpus
+```
+
+## Result
+
+*This section is written after the fifteenth run and not before it.*

--- a/docs/design/hicasso/studio/the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md
+++ b/docs/design/hicasso/studio/the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md
@@ -102,6 +102,208 @@ Every measured figure below is re-derived from the committed records by:
 node implementation/hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs --corpus
 ```
 
-## Result
+## The answer, first
 
-*This section is written after the fifteenth run and not before it.*
+**The SLOT hypothesis is REFUTED and the SUBSTRATE hypothesis is NOT SETTLED —
+and the reason it is not settled is a defect in the pre-registered statistic, not
+a shortage of runs.**
+
+- **On the pre-registered statistic the answer is NEITHER.** Inside
+  `fixed-reversed`, `uix-subs` at position 0 reads **1 of 68** and `reagent-subs`
+  at position 1 reads **1 of 82**. The primary within-run contrast between them is
+  p = 1.0000. The same-session `fixed` arm read **8 of 63** in four of its five
+  runs over the same fifteen-run session, so the instrument was not asleep.
+- **But that statistic is MASKED in the one cell the whole discriminator rests
+  on.** It counts a window only when the in-band leg is that window's **worst**,
+  and `fixed-reversed | uix-subs | pos0` has a median |worst leg| of **1,488 B** —
+  above the top of the band — with 35 of its 68 windows worse than 1,224 B. The
+  competing term is not a mystery: **position 0 is where the ~748 B rider lives**,
+  and [the rider follows the position, not the substrate](the-rider-follows-the-position-not-the-substrate.md)
+  established that it is position-locked rather than substrate-locked.
+- **On a masking-free companion the cluster DOES follow `uix`, at about a third
+  the rate.** Counting windows carrying an in-band leg whether or not it is the
+  worst: `fixed | uix-subs | pos1` 20.8%, `fixed-reversed | uix-subs | pos0`
+  **7.4% in four of five runs**, `parity | uix-subs | pos0` 1.3%,
+  `fixed-reversed | reagent-subs | pos1` 1.2%. **That companion is POST-HOC** —
+  written after this window was read — and it is labelled so everywhere it
+  appears. It cannot carry a verdict on its own and none is rested on it.
+- **What both readings agree on**: putting `reagent-subs` in the second-driven
+  slot does not move the cluster there. On the pre-registered statistic that is
+  8/63 against 1/82 (p = 0.0105); on the companion, 10/63 against 1/82
+  (p = 0.0011).
+
+**So the bead stays OPEN**, with a sharper question than it had and a named
+defect in the instrument that was supposed to answer it.
+
+### The methodological finding, which was knowable in advance
+
+**The discriminator's design and its pre-registered statistic are in tension.**
+The reversed arm exists to move `uix-subs` to position 0. Position 0 is where a
+second, already-recorded term sits. The statistic is a per-window **maximum**, so
+the two terms compete for it and the larger one wins. A reversed-arm read was
+therefore always going to under-count at `uix-subs`, and nothing about that
+needed the data to see — the rider record predates this window by days.
+
+It is recorded here rather than repaired, because repairing it means
+**pre-registering a masking-free statistic and taking the window again**, and
+choosing a statistic after seeing which one gives the wanted answer is exactly
+what pre-registration exists to prevent.
+
+## The window
+
+Fifteen runs, one session, one revision, one box, interleaved one at a time.
+**All fifteen were taken; none was dropped, extended or re-rolled.**
+
+| | `fixed-reversed` | `fixed` | `parity` |
+|---|---|---|---|
+| runs | 5 | 5 | 5 |
+| control refused | 0 | 0 | 0 |
+| arm windows | 180 | 180 | 180 |
+| collection-free | 150 | 135 | 145 |
+
+540 arm windows, **430 collection-free**, all 430 in the position tables
+(`controlSlot = first` throughout), **0 control-refused**.
+
+**Every run exited 1**, on the falls gate (4 – 16 collections inside measured
+windows) and the leg-tolerance gate (9 – 24 windows) — the normal verdict for
+this row, and by construction outside the statistic, which is defined over
+`falls === 0` windows only. **No gate was widened or narrowed and τ was not
+touched in either direction.**
+
+### The arm did what it says
+
+A positive control on the rig rather than on the finding: every round of every
+`fixed-reversed` run drove `uix-subs` then `reagent-subs`, and every round of
+every `fixed` run drove `reagent-subs` then `uix-subs`, while `parity`
+alternated. Pinned in the reader's self-test.
+
+### The level read, before any comparative
+
+| level (reagent / uix, B/write) | runs | which |
+|---|---|---|
+| 19,370 – 19,384 / 19,816 – 19,824 | 12 | four `fixed`, four `parity`, four `fixed-reversed` |
+| 21,844 / 22,278 – 22,284 | 2 | `fixed-5`, `reversed-1` |
+| 23,068 / 23,508 | 1 | `parity-2` |
+
+**The three high-mode runs are ONE PER ARM**, so the level is not confounded with
+the property under test. **No unexplained excursion**: every level here sits
+inside the corpus's already-documented modes, and `reversed-1` settled on the
+**identical** `reagent-subs` level to `segorder-rs8q6/fixed-1` and agrees with it
+to **6 B** on `uix-subs` — across two sessions, two dates and two segment-order
+modes, which is the strongest single check available that this is the same
+instrument on the same estimand.
+
+**The null arm carries nothing**: 4,818 control legs in this window, **0** in the
+1,000 – 1,300 B band.
+
+## The census
+
+Worst leg per collection-free window over its own leg median, **signed-furthest**,
+in the primary 1,050 – 1,224 B band. This window only.
+
+| mode \| segment \| position | windows | in band | rate | runs w/ a hit |
+|---|---|---|---|---|
+| `fixed` \| `uix-subs` \| pos1 | 63 | **8** | 12.7% | **4 of 5** |
+| `fixed` \| `reagent-subs` \| pos0 | 72 | 1 | 1.4% | 1 of 5 |
+| `fixed-reversed` \| `uix-subs` \| pos0 | 68 | 1 | 1.5% | 1 of 5 |
+| `fixed-reversed` \| `reagent-subs` \| pos1 | 82 | 1 | 1.2% | 1 of 5 |
+| `parity` \| `uix-subs` \| pos0 | 41 | 0 | 0.0% | 0 of 5 |
+| `parity` \| `uix-subs` \| pos1 | 32 | 0 | 0.0% | 0 of 5 |
+| `parity` \| `reagent-subs` \| pos0 | 31 | 0 | 0.0% | 0 of 5 |
+| `parity` \| `reagent-subs` \| pos1 | 41 | 0 | 0.0% | 0 of 5 |
+
+Read as **largest-positive** the `fixed | uix-subs | pos1` cell is 9 of 63 rather
+than 8; every other cell is identical under both readings. The record quotes
+signed-furthest because that is what the published `8 of 38` was stated in.
+
+| contrast, primary band | window | p | run level | p |
+|---|---|---|---|---|
+| **CARRIER** — `fixed-reversed`, uix pos0 vs reagent pos1 | 1/68 vs 1/82 | 1.0000 | 1 of 5 vs 1 of 5 | 1.0000 |
+| **FOLLOWS** — uix, `fixed` pos1 vs `fixed-reversed` pos0 | 8/63 vs 1/68 | 0.0142 | 4 of 5 vs 1 of 5 | 0.2063 |
+| **STAYS** — pos1, `fixed` uix vs `fixed-reversed` reagent | 8/63 vs 1/82 | 0.0105 | 4 of 5 vs 1 of 5 | 0.2063 |
+| **MODE** — uix pos1, `fixed` vs `parity` | 8/63 vs 0/32 | 0.0483 | **4 of 5 vs 0 of 5** | **0.0476** |
+| **MODE** — uix pooled, `fixed-reversed` vs `parity` | 1/68 vs 0/73 | 0.4823 | 1 of 5 vs 0 of 5 | 1.0000 |
+
+### The masking diagnostic, POST-HOC
+
+Written after this window was read. **ANY-LEG** counts a window carrying an
+in-band leg whether or not it is that window's worst; **share** is how often it
+IS the worst, which is the masking rate itself.
+
+| cell, this window | windows | any-leg | worst-leg | share | median \|worst\| |
+|---|---|---|---|---|---|
+| `fixed` \| `uix-subs` \| pos1 | 63 | 10 | 8 | 80% | 1,056 B |
+| `fixed-reversed` \| `uix-subs` \| pos0 | 68 | **5** | **1** | **20%** | **1,488 B** |
+| `fixed-reversed` \| `reagent-subs` \| pos1 | 82 | 1 | 1 | 100% | 24 B |
+| `fixed` \| `reagent-subs` \| pos0 | 72 | 1 | 1 | 100% | 748 B |
+
+**Four of the five `fixed-reversed` runs carry an in-band `uix` leg at position
+0**, against one of five carrying one at `reagent-subs`, and zero of five parity
+runs at `uix-subs` in either position. The 20% share against `fixed`'s 80% is the
+masking, stated as a number.
+
+## Read against the corpus
+
+With this window the admissible corpus is **131 runs / 3,688 collection-free /
+3,520 positional**, against 116 / 3,258 / 3,090 before it. The two
+control-refused runs are still named and still refused; nothing here relaxes
+that rule.
+
+| cell | windows | primary band | any-leg (post-hoc) |
+|---|---|---|---|
+| `fixed` \| `uix-subs` \| pos1 | 101 | 16 (15.8%) | 21 (20.8%) |
+| `fixed-reversed` \| `uix-subs` \| pos0 | 68 | 1 (1.5%) | 5 (7.4%) |
+| `fixed-reversed` \| `reagent-subs` \| pos1 | 82 | 1 (1.2%) | 1 (1.2%) |
+| `fixed` \| `reagent-subs` \| pos0 | 115 | 1 (0.9%) | 2 (1.7%) |
+| `parity` \| `uix-subs` \| pos0 | 774 | 8 (1.0%) | 10 (1.3%) |
+| `parity` \| `uix-subs` \| pos1 | 744 | 3 (0.4%) | 21 (2.8%) |
+| `parity` \| `reagent-subs` \| pos0 | 697 | 2 (0.3%) | 2 (0.3%) |
+| `parity` \| `reagent-subs` \| pos1 | 939 | 0 (0.0%) | 0 (0.0%) |
+
+On the post-hoc companion the reversed `uix` cell sits **between** the two:
+7.4% against `fixed`'s 20.8% (p = 0.0179) and against `parity | uix | pos0`'s
+1.3% (p = 0.0047). On the pre-registered statistic it sits at the parity floor,
+for the masking reason above. **Neither reading is discarded and neither is
+allowed to stand alone.**
+
+### What this window does settle: the matched MODE baseline
+
+The bead recorded MODE as *associated, not established at a matched baseline*,
+because the strictly matched same-session contrast was 8/38 against 1/23
+(p = 0.1344) at window level and **3 of 3 runs against 1 of 3 (p = 0.4)** at run
+level — no power at all. This window adds a second matched session at **4 of 5
+against 0 of 5, p = 0.0476**. Taken together the two matched windows are **7 of 8
+`fixed` runs against 1 of 8 `parity` runs, p = 0.0101** — the first run-level
+separation the record has had that controls session, date and revision.
+
+**But "MODE" must now be read narrowly.** `fixed-reversed` is exactly as
+non-alternating as `fixed`, and it reads 1.5% / 7.4% at `uix-subs` rather than
+`fixed`'s 15.8% / 20.8%. So what separates from `parity` is **the forward fixed
+order specifically** — `reagent-subs` driven first and `uix-subs` second, every
+round — and not "a plan that does not alternate".
+
+## What is NOT concluded
+
+- **No mechanism is named**, here or anywhere in this window. What allocates
+  ~1,056 B on some `uix-subs` legs is not identified and no candidate is offered.
+- **No cluster-robust or mixed-effects estimate is offered**, and none should be:
+  five clusters per arm will not identify a variance component and a
+  cluster-robust standard error on that many clusters is badly biased. Every
+  window-level p is published beside its run-level counterpart instead.
+- **The post-hoc companion is not promoted.** It is reported because suppressing
+  it would be dishonest, not because it settles anything.
+- **τ is untouched in either direction.** `rf2-e9wr`'s refusal stands and
+  `rf2-rs8q6`'s fence against widening is restated. No gate, threshold, band or
+  budget moved.
+- **The `parity | uix-subs | pos0` last-leg term is still nobody's.** It is the
+  reason the 1,000 – 1,300 B band and the 1,050 – 1,224 B band do not answer the
+  same question, it is untouched by this window, and it is described rather than
+  chased.
+
+## What would settle it
+
+**A masking-free statistic, pre-registered as such, and the reversed arm taken
+again under it.** The rig needs no change — the arm exists and this window shows
+it drives correctly. What needs changing is the statistic the next window
+declares in advance, and the choice must be made and committed before the runner
+is invoked, exactly as this window's was.

--- a/implementation/hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs
@@ -79,9 +79,22 @@
 // so the tree contradicted itself about one dataset. `admit()` below closes
 // that, and `partition()` NAMES every refusal rather than dropping it.
 //
-// The corrected corpus is 116 runs / 3,258 collection-free / 3,090 positional,
-// against 118 / 3,308 / 3,140 before. Every primary-band numerator is unchanged
-// and every denominator moves.
+// The corrected corpus was 116 runs / 3,258 collection-free / 3,090 positional,
+// against 118 / 3,308 / 3,140 before that repair. Every primary-band numerator
+// was unchanged by it and every denominator moved.
+//
+// ## AND THEN THE THIRD ARM WAS RECORDED (rf2-csca8)
+//
+// `revarm-csca8` adds fifteen runs taken in one session on one revision — five
+// `fixed-reversed`, five `fixed`, five `parity`, interleaved one at a time — and
+// the corpus is now 131 runs / 3,688 collection-free / 3,520 positional. What
+// that window found is the pre-registered THIRD branch: the cluster did NOT
+// follow `uix` to position 0 (1 of 68) and did NOT stay in the second-driven
+// slot (1 of 82), while the same-session `fixed` arm carried it at 8 of 63 in
+// four of its five runs. Neither the substrate nor the slot is the carrier as
+// stated. `fixed-reversed` is exactly as non-alternating as `fixed`, so what
+// survives is narrower than "the mode": the ORDERED PAIR, `reagent-subs` driven
+// first and `uix-subs` second, in every round.
 //
 // ## WHAT THIS IS NOT
 //
@@ -356,6 +369,65 @@ function analyse(datasets, opts = {}) {
     band: controlLegs.filter((b) => inBand(b, BAND_LO_B, BAND_HI_B)).length,
   };
 
+  // --- THE MASKING DIAGNOSTIC, WHICH IS POST-HOC AND SAYS SO (rf2-csca8) ---
+  //
+  // WRITTEN AFTER THE REVERSED WINDOW WAS READ, not before it, and it is
+  // labelled post-hoc everywhere it prints. The pre-registered statistic stays
+  // primary; this does not replace it and no verdict rests on this alone.
+  //
+  // WHY IT EXISTS. The pre-registered statistic is the window's WORST leg, so a
+  // window registers in the band only if nothing in it deviates FURTHER. That is
+  // fine when the cells being compared have similar worst-leg distributions and
+  // it is not fine when they do not — and in the reversed arm they do not. The
+  // `uix-subs` cell at position 0 has a median |worst leg| of 1,488 B, ABOVE the
+  // top of the band, because POSITION 0 IS WHERE THE ~748 B RIDER LIVES
+  // (`the-rider-follows-the-position-not-the-substrate.md`, and the rider is
+  // position-locked rather than substrate-locked). So more than half of that
+  // cell's windows cannot register a band hit whatever else they carry.
+  //
+  // That is a tension between the discriminator's DESIGN and its STATISTIC: the
+  // reversed arm exists precisely to move `uix` to position 0, and position 0 is
+  // precisely where a competing term inflates the worst leg. It was knowable in
+  // advance from the rider record and was not noticed.
+  //
+  // WHAT THIS COMPUTES. Two masking-free companions to the pre-registered count:
+  // ANY-LEG, the count of windows carrying an in-band leg whether or not it is
+  // that window's worst; and the SHARE of those windows in which it IS the
+  // worst, which is the masking rate itself.
+  const maskLo = OBSERVED_LO_B;
+  const maskHi = OBSERVED_HI_B;
+  const absSort = (xs) => xs.slice().sort((x, y) => x - y);
+  const mask = {};
+  for (const w of positional) {
+    const k = CELL_KEY(w);
+    mask[k] = mask[k] || { key: k, segOrder: w.segOrder, segment: w.segment, position: w.position, windows: 0, anyLeg: 0, worstLeg: 0, anyLegRuns: {}, worstAbs: [] };
+    const m = mask[k];
+    m.windows++;
+    const e = excesses(w);
+    const any = e.some((b) => inBand(b, maskLo, maskHi));
+    if (any) {
+      m.anyLeg++;
+      m.anyLegRuns[w.runId] = true;
+    }
+    if (inBand(worstExcessSignedB(w), maskLo, maskHi)) m.worstLeg++;
+    const worst = worstExcessSignedB(w);
+    if (worst !== null) m.worstAbs.push(Math.abs(worst));
+  }
+  out.masking = Object.values(mask)
+    .map((m) => {
+      const s = absSort(m.worstAbs);
+      return {
+        key: m.key,
+        windows: m.windows,
+        anyLeg: m.anyLeg,
+        worstLeg: m.worstLeg,
+        anyLegRuns: Object.keys(m.anyLegRuns).length,
+        medianWorstAbsB: s.length ? s[s.length >> 1] : null,
+        overBandTop: m.worstAbs.filter((x) => x > maskHi).length,
+      };
+    })
+    .sort((p, q) => p.key.localeCompare(q.key));
+
   // --- THE LEVEL EACH RUN SETTLED AT (rf2-csca8) --------------------------
   //
   // The floor arm at this configuration is MULTI-MODAL — see
@@ -481,6 +553,20 @@ function report(a) {
   L.push(`NULL ARM — control legs ${a.control.legs}, of which in the ${BAND_LO_B}-${BAND_HI_B} B band: ${a.control.band}`);
   L.push('');
 
+  // THE MASKING DIAGNOSTIC. POST-HOC — see the note above `out.masking`.
+  if (a.masking && a.masking.length) {
+    L.push(`MASKING DIAGNOSTIC (POST-HOC, band ${OBSERVED_LO_B}-${OBSERVED_HI_B} B). The pre-registered`);
+    L.push('  statistic counts a window only when the in-band leg is that window\'s WORST, so a cell');
+    L.push('  whose worst-leg distribution sits above the band cannot register whatever it carries.');
+    L.push('  ANY-LEG is the masking-free companion; SHARE is how often the in-band leg IS the worst.');
+    L.push(`    ${'mode | segment | position'.padEnd(34)}${'windows'.padStart(9)}${'any-leg'.padStart(9)}${'worst-leg'.padStart(11)}${'share'.padStart(8)}${'med |worst|'.padStart(12)}${'> band top'.padStart(11)}`);
+    for (const m of a.masking) {
+      const share = m.anyLeg ? `${((100 * m.worstLeg) / m.anyLeg).toFixed(0)}%` : 'n/a';
+      L.push(`    ${m.key.replace(/\|/g, ' | ').padEnd(34)}${String(m.windows).padStart(9)}${String(m.anyLeg).padStart(9)}${String(m.worstLeg).padStart(11)}${share.padStart(8)}${String(m.medianWorstAbsB).padStart(12)}${String(m.overBandTop).padStart(11)}`);
+    }
+    L.push('');
+  }
+
   // THE LEVEL READ, printed BEFORE any comparative below it, deliberately.
   if (a.levels && a.levels.length) {
     const byMode = {};
@@ -546,9 +632,10 @@ function report(a) {
     L.push('  WHAT THESE p-VALUES ARE NOT. Fisher counts each WINDOW as an independent trial.');
     L.push('  Windows repeat within runs, so any per-run term — the box that minute, the');
     L.push('  revision, the session — is shared across a whole row of them. Read the run-level');
-    L.push('  table above beside every p: the entire `fixed` exposure is THREE runs in ONE');
-    L.push('  session. A window-level p is an association at the window level and NOT a test of');
-    L.push('  a hypothesis about modes, substrates or positions as properties of a run.');
+    L.push('  table above beside every p: the `fixed` exposure is EIGHT runs across TWO');
+    L.push('  sessions and the `fixed-reversed` exposure is FIVE runs in ONE. A window-level p');
+    L.push('  is an association at the window level and NOT a test of a hypothesis about modes,');
+    L.push('  substrates or positions as properties of a run.');
     L.push('');
   }
   return L;
@@ -718,10 +805,10 @@ function selfTest() {
     // `the-eight-signs-are-one-block.md` already excludes on this same corpus.
     ok('corpus: bisect-5 is refused here as it already was on the eight-signs record',
       excluded.some((e) => e.id === 'alloc-9jrhi/bisect-5-a-4a1537cb71-replicate'));
-    ok('corpus: 116 admissible floor runs, of 118', admitted.length === 116 && floor.length === 118);
-    ok('corpus: 3,258 collection-free and 3,090 positional windows — NOT 3,308 / 3,140',
-      c.collectionFree === 3258 && c.positional === 3090);
-    ok('corpus: the runs count is the admissible 116', c.runs === 116);
+    ok('corpus: 131 admissible floor runs, of 133', admitted.length === 131 && floor.length === 133);
+    ok('corpus: 3,688 collection-free and 3,520 positional windows, after the reversed arm landed',
+      c.collectionFree === 3688 && c.positional === 3520);
+    ok('corpus: the runs count is the admissible 131', c.runs === 131);
 
     // The extraction check runs BEFORE admissibility, deliberately, so it still
     // reproduces the figure the earlier record published over all 14 runs.
@@ -738,16 +825,16 @@ function selfTest() {
     // repair: neither refused run carried an in-band window in the primary
     // band, so nothing the record claims positively rests on them — but every
     // rate they sat in was computed over too many windows.
-    ok('corpus: fixed|uix|pos1 reads 8 of 38 signed-furthest', (find('signed-furthest', 'fixed|uix-subs|pos1') || {}).band === 8);
-    ok('corpus: fixed|uix|pos1 reads 9 of 38 largest-positive', (find('largest-positive', 'fixed|uix-subs|pos1') || {}).band === 9);
-    ok('corpus: fixed|reagent|pos0 reads 0 of 43', (find('signed-furthest', 'fixed|reagent-subs|pos0') || {}).band === 0);
-    ok('corpus: parity|uix|pos0 reads 44 of 733 — NOT 45 of 747', (find('signed-furthest', 'parity|uix-subs|pos0') || {}).band === 44 && find('signed-furthest', 'parity|uix-subs|pos0').windows === 733);
-    ok('corpus: parity|uix|pos1 reads 3 of 712 — NOT 3 of 724', (find('signed-furthest', 'parity|uix-subs|pos1') || {}).band === 3 && find('signed-furthest', 'parity|uix-subs|pos1').windows === 712);
-    ok('corpus: parity|reagent|pos0 reads 15 of 666 — the substrate NECESSITY claim fails here', (find('signed-furthest', 'parity|reagent-subs|pos0') || {}).band === 15 && find('signed-furthest', 'parity|reagent-subs|pos0').windows === 666);
-    ok('corpus: parity|reagent|pos1 reads 0 of 898 — NOT 0 of 913', (find('signed-furthest', 'parity|reagent-subs|pos1') || {}).band === 0 && find('signed-furthest', 'parity|reagent-subs|pos1').windows === 898);
-    ok('corpus: the primary-band numerators are unchanged at 8 / 3 / 2 / 0', (() => {
+    ok('corpus: fixed|uix|pos1 reads 20 of 101 signed-furthest', (find('signed-furthest', 'fixed|uix-subs|pos1') || {}).band === 20 && find('signed-furthest', 'fixed|uix-subs|pos1').windows === 101);
+    ok('corpus: fixed|uix|pos1 reads 22 of 101 largest-positive', (find('largest-positive', 'fixed|uix-subs|pos1') || {}).band === 22);
+    ok('corpus: fixed|reagent|pos0 reads 2 of 115', (find('signed-furthest', 'fixed|reagent-subs|pos0') || {}).band === 2 && find('signed-furthest', 'fixed|reagent-subs|pos0').windows === 115);
+    ok('corpus: parity|uix|pos0 reads 44 of 774', (find('signed-furthest', 'parity|uix-subs|pos0') || {}).band === 44 && find('signed-furthest', 'parity|uix-subs|pos0').windows === 774);
+    ok('corpus: parity|uix|pos1 reads 3 of 744', (find('signed-furthest', 'parity|uix-subs|pos1') || {}).band === 3 && find('signed-furthest', 'parity|uix-subs|pos1').windows === 744);
+    ok('corpus: parity|reagent|pos0 reads 17 of 697 — the substrate NECESSITY claim fails here', (find('signed-furthest', 'parity|reagent-subs|pos0') || {}).band === 17 && find('signed-furthest', 'parity|reagent-subs|pos0').windows === 697);
+    ok('corpus: parity|reagent|pos1 reads 0 of 939', (find('signed-furthest', 'parity|reagent-subs|pos1') || {}).band === 0 && find('signed-furthest', 'parity|reagent-subs|pos1').windows === 939);
+    ok('corpus: the primary-band numerators read 16 / 3 / 2 / 0', (() => {
       const n = (k) => (find('signed-furthest', k) || {}).observed;
-      return n('fixed|uix-subs|pos1') === 8 && n('parity|uix-subs|pos1') === 3 &&
+      return n('fixed|uix-subs|pos1') === 16 && n('parity|uix-subs|pos1') === 3 &&
         n('parity|reagent-subs|pos0') === 2 && n('parity|reagent-subs|pos1') === 0;
     })());
     // The ordinal structure, which is what bounds the pooled parity result.
@@ -758,16 +845,16 @@ function selfTest() {
     // --- THE RUN-LEVEL BOUND, which is why no verdict here says CONFIRMED --
     const rl = (key, band = `${OBSERVED_LO_B}-${OBSERVED_HI_B}`) =>
       c.runLevel['signed-furthest'][band].find((x) => x.key === key);
-    ok('corpus: the whole `fixed` exposure is THREE runs', rl('fixed|uix-subs|pos1').runs === 3);
-    ok('corpus: all three `fixed` runs carry the term, and none carries it more than four times',
-      rl('fixed|uix-subs|pos1').runsWithHit === 3 && rl('fixed|uix-subs|pos1').maxPerRun === 4);
+    ok('corpus: the `fixed` exposure is EIGHT runs, across two sessions', rl('fixed|uix-subs|pos1').runs === 8);
+    ok('corpus: SEVEN of the eight `fixed` runs carry the term, none more than four times',
+      rl('fixed|uix-subs|pos1').runsWithHit === 7 && rl('fixed|uix-subs|pos1').maxPerRun === 4);
     // The parity cells are barely clustered at the primary band — at most one
     // window per run — so the repeated-measures caveat bites hardest on the
     // `fixed` arm, which is exactly the arm the strongest claim rested on.
     ok('corpus: at the primary band no parity run carries more than ONE in-band window',
       rl('parity|uix-subs|pos0').maxPerRun === 1 && rl('parity|uix-subs|pos1').maxPerRun === 1);
-    ok('corpus: the parity baseline spans 107 runs against the fixed arm\'s 3',
-      rl('parity|uix-subs|pos1').runs === 107);
+    ok('corpus: the parity baseline spans 112 runs against the fixed arm\'s 8',
+      rl('parity|uix-subs|pos1').runs === 112);
 
     // THE PUBLISHED p-VALUES, and the pin DISCRIMINATES between the two bands
     // rather than restating one of them: the position verdict FLIPS across
@@ -815,6 +902,96 @@ function selfTest() {
       const p = at('parity');
       return f.runs === 3 && f.runsWithHit === 3 && p.runs === 3 && p.runsWithHit === 1 &&
         Math.abs(fisherExactTwoSided(3, 0, 1, 2) - 0.4) < 1e-9;
+    })());
+
+    // --- THE REVERSED ARM'S OWN WINDOW (rf2-csca8) ------------------------
+    //
+    // Scoped to `revarm-csca8/` so these pins say what THAT window found,
+    // matched by session, and do not move when the wider corpus grows.
+    const rev = () => analyse(admitted.filter((d) => d.id.startsWith('revarm-csca8/')));
+    ok('window: fifteen runs, five per arm, all three modes present', (() => {
+      const w = rev();
+      return w.runs === 15 && w.modes.join(',') === 'fixed,fixed-reversed,parity';
+    })());
+    ok('window: no run in it was control-refused', (() => {
+      const { excluded } = partition(corpus().map(load).filter(isFloorAlloc)
+        .filter((d) => d.id.startsWith('revarm-csca8/')));
+      return excluded.length === 0;
+    })());
+    // THE PRE-REGISTERED PRIMARY, and it is the only WITHIN-RUN row on the
+    // list: inside `fixed-reversed` alone, uix at position 0 against reagent
+    // at position 1. Neither cell carries the cluster and they do not differ.
+    ok('window: the CARRIER contrast inside fixed-reversed is 1/68 vs 1/82, p = 1', (() => {
+      const c2 = rev().byStatistic['signed-furthest']
+        .comparisons[`${OBSERVED_LO_B}-${OBSERVED_HI_B}`]
+        .find((x) => x.label.startsWith('CARRIER'));
+      return !!c2 && c2.a.k === 1 && c2.a.n === 68 && c2.b.k === 1 && c2.b.n === 82 &&
+        Math.abs(c2.p - 1) < 1e-9;
+    })());
+    // AND THE FIXED ARM IN THE SAME SESSION DID CARRY IT, which is what makes
+    // the two zeros above a finding rather than a dead instrument.
+    ok('window: the same-session fixed arm reads 8/63 at uix pos1', (() => {
+      const c2 = rev().byStatistic['signed-furthest'].cells
+        .find((x) => x.key === 'fixed|uix-subs|pos1');
+      return !!c2 && c2.observed === 8 && c2.windows === 63;
+    })());
+    ok('window: FOLLOWS is 8/63 vs 1/68 and STAYS is 8/63 vs 1/82 — the cluster did NEITHER', (() => {
+      const cs = rev().byStatistic['signed-furthest']
+        .comparisons[`${OBSERVED_LO_B}-${OBSERVED_HI_B}`];
+      const f = cs.find((x) => x.label.startsWith('FOLLOWS'));
+      const s2 = cs.find((x) => x.label.startsWith('STAYS'));
+      return !!f && !!s2 && f.a.k === 8 && f.a.n === 63 && f.b.k === 1 && f.b.n === 68 &&
+        s2.b.k === 1 && s2.b.n === 82 && f.p < 0.05 && s2.p < 0.05;
+    })());
+    // THE MATCHED MODE CONTRAST, which is the one this bead said needed power.
+    // At RUN level in this window it is 4 of 5 against 0 of 5 — the first
+    // matched run-level separation the record has had.
+    ok('window: at RUN level the matched fixed-vs-parity contrast is 4 of 5 against 0 of 5', (() => {
+      const rlw = rev().runLevel['signed-furthest'][`${OBSERVED_LO_B}-${OBSERVED_HI_B}`];
+      const f = rlw.find((x) => x.key === 'fixed|uix-subs|pos1');
+      const p = rlw.find((x) => x.key === 'parity|uix-subs|pos1');
+      return !!f && !!p && f.runs === 5 && f.runsWithHit === 4 && p.runs === 5 && p.runsWithHit === 0 &&
+        Math.abs(fisherExactTwoSided(4, 1, 0, 5) - 0.047619047619) < 1e-9;
+    })());
+    // AND THE REVERSED ARM AT RUN LEVEL IS THE PARITY BASELINE, not the fixed
+    // one: one run of five in each of its two cells, one window apiece.
+    // A MISSING CELL FAILS rather than throws. That is not defensive noise: a
+    // plant that makes the reversed windows group as `fixed` deletes these two
+    // keys outright, and a pin that dereferences the absent row aborts the whole
+    // suite instead of reporting one red — so the sabotage run that proves these
+    // pins discriminate would kill every check after it.
+    ok('window: each fixed-reversed cell is 1 run of 5, one window', (() => {
+      const rlw = rev().runLevel['signed-furthest'][`${OBSERVED_LO_B}-${OBSERVED_HI_B}`];
+      return ['fixed-reversed|uix-subs|pos0', 'fixed-reversed|reagent-subs|pos1'].every((k) => {
+        const x = rlw.find((y) => y.key === k);
+        return !!x && x.runs === 5 && x.runsWithHit === 1 && x.band === 1;
+      });
+    })());
+    // THE LEVEL READ, which is what says the window is not standing on a floor
+    // excursion: three of fifteen runs read high mode and they are ONE PER ARM,
+    // so level is not confounded with the property under test.
+    ok('window: the three high-mode runs are one per arm', (() => {
+      const high = rev().levels.filter((r) => r.highMode);
+      return high.length === 3 &&
+        new Set(high.map((r) => r.segOrder)).size === 3;
+    })());
+    // AND THE INSTRUMENT IS THE SAME ONE the earlier window used: `reversed-1`
+    // and `segorder-rs8q6/fixed-1` settled on the IDENTICAL reagent level and
+    // agree on uix to 6 B, across two sessions, two dates and two modes.
+    ok('window: reversed-1 and segorder fixed-1 read the same level to the byte on reagent', (() => {
+      const at = (id) => c.levels.find((r) => r.runId === id);
+      const a2 = at('revarm-csca8/reversed-1');
+      const b2 = at('segorder-rs8q6/fixed-1');
+      return a2 && b2 && a2.per['reagent-subs'].median === b2.per['reagent-subs'].median &&
+        Math.abs(a2.per['uix-subs'].median - b2.per['uix-subs'].median) <= 6;
+    })());
+    // THE ARM ITSELF, as a positive control on the rig rather than on the
+    // finding: every round of every `fixed-reversed` run drove uix FIRST.
+    ok('window: every fixed-reversed round drove uix-subs then reagent-subs', (() => {
+      const files = corpus().map(load).filter((d) => d.id.startsWith('revarm-csca8/reversed-'));
+      if (files.length !== 5) return false;
+      return files.every((d) => d.data.alloc.perRound.every((r) =>
+        Object.values(r.arms).map((w) => w.segment).join('>') === 'uix-subs>reagent-subs'));
     })());
   } else {
     ok('corpus: data directory present', false);

--- a/implementation/hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs
@@ -316,6 +316,25 @@ function analyse(datasets, opts = {}) {
         compare('SUBSTRATE | parity pooled, uix vs reagent', pick('parity', 'uix-subs', null), pick('parity', 'reagent-subs', null)),
         compare('MODE      | uix at pos1, fixed vs parity', pick('fixed', 'uix-subs', 1), pick('parity', 'uix-subs', 1)),
         compare('MODE      | reagent at pos0, fixed vs parity', pick('fixed', 'reagent-subs', 0), pick('parity', 'reagent-subs', 0)),
+        // --- THE REVERSED ARM (rf2-csca8) ---------------------------------
+        //
+        // These four rows were added to this reader BEFORE the first
+        // `fixed-reversed` record existed, so what they compute was fixed in
+        // advance of what they would find. Under `fixed-reversed` the plan is
+        // driven reversed every round: the mode is held constant and `uix-subs`
+        // moves to position 0, which is the one arrangement no committed run
+        // supplied.
+        //
+        // CARRIER is the PRIMARY row and the only WITHIN-RUN one on this list.
+        // Both of its cells come from the same runs, the same session and the
+        // same mode, so every per-run term — the box that minute, the revision,
+        // the level the floor settled at — is held constant by construction
+        // rather than by matching. The three rows under it are between-mode and
+        // carry the repeated-measures bound every other row here carries.
+        compare('CARRIER   | fixed-reversed, uix pos0 vs reagent pos1', pick('fixed-reversed', 'uix-subs', 0), pick('fixed-reversed', 'reagent-subs', 1)),
+        compare('FOLLOWS   | uix, fixed pos1 vs fixed-reversed pos0', pick('fixed', 'uix-subs', 1), pick('fixed-reversed', 'uix-subs', 0)),
+        compare('STAYS     | pos1, fixed uix vs fixed-reversed reagent', pick('fixed', 'uix-subs', 1), pick('fixed-reversed', 'reagent-subs', 1)),
+        compare('MODE      | uix pooled, fixed-reversed vs parity', pick('fixed-reversed', 'uix-subs', null), pick('parity', 'uix-subs', null)),
       ];
     }
 
@@ -336,6 +355,42 @@ function analyse(datasets, opts = {}) {
     legs: controlLegs.length,
     band: controlLegs.filter((b) => inBand(b, BAND_LO_B, BAND_HI_B)).length,
   };
+
+  // --- THE LEVEL EACH RUN SETTLED AT (rf2-csca8) --------------------------
+  //
+  // The floor arm at this configuration is MULTI-MODAL — see
+  // `the-second-mode-a-pre-registered-twenty-run-window.md`, which pre-registered
+  // this estimator and this criterion, and both are reused here verbatim rather
+  // than re-invented: the MEDIAN, over CERTIFIED windows at ROUND INDEX >= 6, of
+  // that window's `legMedian`, per segment; HIGH MODE is either segment at or
+  // above 21,000 B/write.
+  //
+  // IT IS A READ AND NOT A FILTER. Nothing here excludes a run, and no census
+  // above consults it. Its job is to make a level excursion VISIBLE before a
+  // comparative is quoted over it, because a window whose arms separate on level
+  // rather than on the property under test has found something about the box and
+  // not about the property — and an unexplained excursion reported plainly is
+  // worth more than a clean-looking number taken over it.
+  const LEVEL_FROM_ROUND = 6;
+  const HIGH_MODE_B = 21000;
+  const median = (xs) => {
+    const s = xs.slice().sort((x, y) => x - y);
+    return s.length ? s[s.length >> 1] : null;
+  };
+  const levels = {};
+  for (const w of all) {
+    if (!w.certified || w.round < LEVEL_FROM_ROUND) continue;
+    const r = (levels[w.runId] = levels[w.runId] || { runId: w.runId, segOrder: w.segOrder, segments: {} });
+    (r.segments[w.segment] = r.segments[w.segment] || []).push(w.legMedian);
+  }
+  out.levels = Object.values(levels)
+    .map((r) => {
+      const per = {};
+      for (const [seg, xs] of Object.entries(r.segments)) per[seg] = { n: xs.length, median: median(xs) };
+      const highest = Math.max(...Object.values(per).map((x) => x.median));
+      return { runId: r.runId, segOrder: r.segOrder, per, highMode: highest >= HIGH_MODE_B };
+    })
+    .sort((p, q) => p.runId.localeCompare(q.runId));
 
   // AND THE READER'S OWN CONTROL: the published 14-run parity figures. If this
   // reader's window extraction has drifted, these move. Computed over
@@ -425,6 +480,41 @@ function report(a) {
   L.push('');
   L.push(`NULL ARM — control legs ${a.control.legs}, of which in the ${BAND_LO_B}-${BAND_HI_B} B band: ${a.control.band}`);
   L.push('');
+
+  // THE LEVEL READ, printed BEFORE any comparative below it, deliberately.
+  if (a.levels && a.levels.length) {
+    const byMode = {};
+    for (const r of a.levels) {
+      byMode[r.segOrder] = byMode[r.segOrder] || { runs: 0, high: 0 };
+      byMode[r.segOrder].runs++;
+      if (r.highMode) byMode[r.segOrder].high++;
+    }
+    L.push('LEVEL — median legMedian over certified windows at round >= 6, per segment.');
+    L.push('  High mode is either segment at or above 21,000 B/write, the criterion');
+    L.push('  `the-second-mode-a-pre-registered-twenty-run-window.md` pre-registered. A READ, NOT A FILTER:');
+    L.push('  no census here consults it and no run is excluded on it.');
+    for (const [mode, s] of Object.entries(byMode).sort()) {
+      L.push(`    ${mode.padEnd(16)}${String(s.runs).padStart(5)} runs, ${String(s.high).padStart(4)} high mode`);
+    }
+    // The per-run rows, for the segment-order windows only: a directory that
+    // carries a non-`parity` mode is a MATCHED window, and its arms' levels are
+    // exactly what a comparative between them can be confounded by.
+    const dirsWithModes = new Set(
+      a.levels.filter((r) => r.segOrder !== 'parity').map((r) => r.runId.split('/')[0])
+    );
+    const rows = a.levels.filter((r) => dirsWithModes.has(r.runId.split('/')[0]));
+    if (rows.length) {
+      L.push('');
+      L.push('  PER RUN, for the matched segment-order windows:');
+      const segs = [...new Set(rows.flatMap((r) => Object.keys(r.per)))].sort();
+      L.push(`    ${'run'.padEnd(30)}${'mode'.padEnd(16)}${segs.map((s) => s.padStart(14)).join('')}   level`);
+      for (const r of rows) {
+        const cells = segs.map((s) => String((r.per[s] || {}).median ?? '-').padStart(14)).join('');
+        L.push(`    ${r.runId.padEnd(30)}${r.segOrder.padEnd(16)}${cells}   ${r.highMode ? 'HIGH' : 'low'}`);
+      }
+    }
+    L.push('');
+  }
 
   for (const [name, s] of Object.entries(a.byStatistic)) {
     L.push(`=== worst leg read as ${name.toUpperCase()} ===`);

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/fixed-1.json
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/fixed-1.json
@@ -1,0 +1,7565 @@
+{
+  "generatedAt": "2026-08-20T20:25:00.991Z",
+  "build": "hicasso-bench",
+  "initFn": "re-frame.bench.p0-app/-main",
+  "alloc": {
+    "benchmark": "P0:steady-state-allocation-slope",
+    "bead": "rf2-2rtt6.76",
+    "roots": 4,
+    "perRoot": {
+      "list": 300,
+      "grid": 6
+    },
+    "publishedPerRoot": {
+      "list": 300,
+      "grid": 300
+    },
+    "arm": {
+      "cells": 6,
+      "roots": 4,
+      "boundaries": 24,
+      "writes": 6,
+      "refusals": [],
+      "admissible": true
+    },
+    "boundaries": 24,
+    "writes": 6,
+    "primeWrites": 1,
+    "windowWrites": 7,
+    "bySite": false,
+    "sites": 2,
+    "siteNames": [
+      "dispatch",
+      "drain"
+    ],
+    "warmups": 3,
+    "rounds": 18,
+    "preciseMemory": true,
+    "controlDoubles": {
+      "d1": 1000,
+      "d2": 400
+    },
+    "controlSlack": 0.75,
+    "writeSelector": "all",
+    "writeLegs": [
+      "all"
+    ],
+    "writePaired": false,
+    "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+    "plan": {
+      "name": "floor",
+      "arms": true,
+      "rungs": false,
+      "fits": false
+    },
+    "segOrder": "fixed",
+    "passOrder": "parity",
+    "passSeed": "1787257460292",
+    "passSchedule": {
+      "flips": [
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true
+      ],
+      "attempts": 1,
+      "parityTied": false
+    },
+    "controlSlot": "first",
+    "instrument": "in-page performance.memory.usedJSHeapSize sampled at every leg boundary, rising steps accumulated separately from falling ones; --enable-precise-memory-info. A falling step is a collection this counter SAW; a leg that deviates from its cohort median by more than the leg tolerance is a work unit that is not one; and under the by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the other two can see. TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg has no interior reading and so no site step to be negative, and the intra-leg gate returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with these (see `bySite`), so a witness comparing byte for byte against a figure published at stride 2 can never be screened by all three",
+    "fallThresholdB": 600000,
+    "legTolerance": 0.25,
+    "verification": {
+      "unverified": 0,
+      "detail": []
+    },
+    "workCount": false,
+    "workVerification": {
+      "counted": false
+    },
+    "perRound": [
+      {
+        "round": 0,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 524,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              524
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 116.66666666666667,
+            "cdpBracket": 46232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3840262,
+              3840278,
+              3840294,
+              3840310,
+              3840326,
+              3840342,
+              3840358,
+              3840374,
+              3840390,
+              3840406,
+              3840422,
+              3840438,
+              3840454,
+              3840978,
+              3840994
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48576,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8144,
+            "endpoints": 48576,
+            "legs": [
+              8144,
+              8080,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.00992063492063492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8096,
+            "cdpBracket": 87388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3853886,
+              3853902,
+              3861966,
+              3861982,
+              3870126,
+              3870142,
+              3878222,
+              3878238,
+              3886302,
+              3886318,
+              3894382,
+              3894398,
+              3902462,
+              3902478,
+              3910542
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 52328,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3849986,
+              3850002,
+              3853266,
+              3853282,
+              3856546,
+              3856562,
+              3859826,
+              3859842,
+              3863106,
+              3863122,
+              3866386,
+              3866402,
+              3869666,
+              3869682,
+              3872946
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 603340,
+            "fall": 643908,
+            "falls": 3,
+            "maxStep": 279460,
+            "endpoints": -40568,
+            "legs": [
+              20456,
+              19692,
+              279460,
+              -230572,
+              263976,
+              19692
+            ],
+            "gaps": [
+              -171948,
+              16,
+              16,
+              16,
+              16,
+              -241388
+            ],
+            "legMedian": 20074,
+            "legWorstDeviation": 12.921490485204743,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 279460 B against a cohort median of 20074 B (+259386 B, 1292.1%), past the ±25% leg tolerance (±5018.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -230572 B against a cohort median of 20074 B (-250646 B, -1248.6%), past the ±25% leg tolerance (±5018.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 5 of 6 read 263976 B against a cohort median of 20074 B (+243902 B, 1215.0%), past the ±25% leg tolerance (±5018.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 279460 B against a cohort median of 20074 B (+259386 B, 1292.1%), past the ±25% leg tolerance (±5018.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -230572 B against a cohort median of 20074 B (-250646 B, -1248.6%), past the ±25% leg tolerance (±5018.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 5 of 6 read 263976 B against a cohort median of 20074 B (+243902 B, 1215.0%), past the ±25% leg tolerance (±5018.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              199340
+            ],
+            "primeExcess": 179266,
+            "perWrite": 100556.66666666667,
+            "perBoundaryPerWrite": 4189.861111111111,
+            "cdpBracket": 192976,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              4777307,
+              4777323,
+              4976663,
+              4804715,
+              4825171,
+              4825187,
+              4844879,
+              4844895,
+              5124355,
+              5124371,
+              4893799,
+              4893815,
+              5157791,
+              4916403,
+              4936095
+            ],
+            "tick0": 21,
+            "tick": 28,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 672944,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 567516,
+            "endpoints": 672944,
+            "legs": [
+              20664,
+              19916,
+              22160,
+              22748,
+              19844,
+              567516
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21412,
+            "legWorstDeviation": 25.50457687278162,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 567516 B against a cohort median of 21412 B (+546104 B, 2550.5%), past the ±25% leg tolerance (±5353 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 567516 B against a cohort median of 21412 B (+546104 B, 2550.5%), past the ±25% leg tolerance (±5353 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30368
+            ],
+            "primeExcess": 8956,
+            "perWrite": 112157.33333333333,
+            "perBoundaryPerWrite": 4673.222222222222,
+            "cdpBracket": 201320,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5059767,
+              5059783,
+              5090151,
+              5090167,
+              5110831,
+              5110847,
+              5130763,
+              5130779,
+              5152939,
+              5152955,
+              5175703,
+              5175719,
+              5195563,
+              5195579,
+              5763095
+            ],
+            "tick0": 49,
+            "tick": 56,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 1,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5046995,
+              5047011,
+              5047027,
+              5047043,
+              5047059,
+              5047075,
+              5047091,
+              5047107,
+              5047123,
+              5047139,
+              5047155,
+              5047171,
+              5047187,
+              5047203,
+              5047219
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 87716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5055003,
+              5055019,
+              5063083,
+              5063099,
+              5071163,
+              5071179,
+              5079243,
+              5079259,
+              5087323,
+              5087339,
+              5095403,
+              5095419,
+              5103483,
+              5103499,
+              5111563
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5052447,
+              5052463,
+              5055727,
+              5055743,
+              5059007,
+              5059023,
+              5062287,
+              5062303,
+              5065567,
+              5065583,
+              5068847,
+              5068863,
+              5072127,
+              5072143,
+              5075407
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 101240,
+            "fall": 174208,
+            "falls": 2,
+            "maxStep": 21912,
+            "endpoints": -72968,
+            "legs": [
+              -91008,
+              19332,
+              19332,
+              21912,
+              19296,
+              21288
+            ],
+            "gaps": [
+              -83200,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19332,
+            "legWorstDeviation": -5.707635009310987,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read -91008 B against a cohort median of 19332 B (-110340 B, -570.8%), past the ±25% leg tolerance (±4833 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read -91008 B against a cohort median of 19332 B (-110340 B, -570.8%), past the ±25% leg tolerance (±4833 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              225592
+            ],
+            "primeExcess": 206260,
+            "perWrite": 16873.333333333332,
+            "perBoundaryPerWrite": 703.0555555555555,
+            "cdpBracket": 184156,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5177155,
+              5177171,
+              5402763,
+              5319563,
+              5228555,
+              5228571,
+              5247903,
+              5247919,
+              5267251,
+              5267267,
+              5289179,
+              5289195,
+              5308491,
+              5308507,
+              5329795
+            ],
+            "tick0": 77,
+            "tick": 84,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 361732,
+            "fall": 236152,
+            "falls": 1,
+            "maxStep": 283104,
+            "endpoints": 125580,
+            "legs": [
+              19660,
+              283104,
+              -236152,
+              19624,
+              19624,
+              19624
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19624,
+            "legWorstDeviation": 13.426416632694659,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 283104 B against a cohort median of 19624 B (+263480 B, 1342.6%), past the ±25% leg tolerance (±4906 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -236152 B against a cohort median of 19624 B (-255776 B, -1303.4%), past the ±25% leg tolerance (±4906 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 283104 B against a cohort median of 19624 B (+263480 B, 1342.6%), past the ±25% leg tolerance (±4906 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -236152 B against a cohort median of 19624 B (-255776 B, -1303.4%), past the ±25% leg tolerance (±4906 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6920,
+            "perWrite": 60288.666666666664,
+            "perBoundaryPerWrite": 2512.027777777778,
+            "cdpBracket": 180560,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5295159,
+              5295175,
+              5321719,
+              5321735,
+              5341395,
+              5341411,
+              5624515,
+              5624531,
+              5388379,
+              5388395,
+              5408019,
+              5408035,
+              5427659,
+              5427675,
+              5447299
+            ],
+            "tick0": 105,
+            "tick": 112,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 2,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5259363,
+              5259379,
+              5259395,
+              5259411,
+              5259427,
+              5259443,
+              5259459,
+              5259475,
+              5259491,
+              5259507,
+              5259523,
+              5259539,
+              5259555,
+              5259571,
+              5259587
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85088,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5267387,
+              5267403,
+              5275467,
+              5275483,
+              5283547,
+              5283563,
+              5291627,
+              5291643,
+              5299707,
+              5299723,
+              5307787,
+              5307803,
+              5315867,
+              5315883,
+              5323947
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5262587,
+              5262603,
+              5265867,
+              5265883,
+              5269147,
+              5269163,
+              5272427,
+              5272443,
+              5275707,
+              5275723,
+              5278987,
+              5279003,
+              5282267,
+              5282283,
+              5285547
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 148924,
+            "fall": 32036,
+            "falls": 1,
+            "maxStep": 51820,
+            "endpoints": 116888,
+            "legs": [
+              19256,
+              -32036,
+              20000,
+              19256,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              51820,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": -2.6636892397174905,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read -32036 B against a cohort median of 19256 B (-51292 B, -266.4%), past the ±25% leg tolerance (±4814 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read -32036 B against a cohort median of 19256 B (-51292 B, -266.4%), past the ±25% leg tolerance (±4814 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26028
+            ],
+            "primeExcess": 6772,
+            "perWrite": 24820.666666666668,
+            "perBoundaryPerWrite": 1034.1944444444446,
+            "cdpBracket": 173976,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5344067,
+              5344083,
+              5370111,
+              5370127,
+              5389383,
+              5441203,
+              5409167,
+              5409183,
+              5429183,
+              5429199,
+              5448455,
+              5448471,
+              5467727,
+              5467743,
+              5486999
+            ],
+            "tick0": 133,
+            "tick": 140,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 121324,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21692,
+            "endpoints": 121324,
+            "legs": [
+              19696,
+              20752,
+              21692,
+              19696,
+              19696,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": 0.10134037367993501,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6848,
+            "perWrite": 20220.666666666668,
+            "perBoundaryPerWrite": 842.5277777777778,
+            "cdpBracket": 175848,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5419875,
+              5419891,
+              5446435,
+              5446451,
+              5466147,
+              5466163,
+              5486915,
+              5486931,
+              5508623,
+              5508639,
+              5528335,
+              5528351,
+              5548047,
+              5548063,
+              5567759
+            ],
+            "tick0": 161,
+            "tick": 168,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 3,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 29120,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5381963,
+              5381979,
+              5381995,
+              5382011,
+              5382027,
+              5382043,
+              5382059,
+              5382075,
+              5382091,
+              5382107,
+              5382123,
+              5382139,
+              5382155,
+              5382171,
+              5382187
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5390899,
+              5390915,
+              5398979,
+              5398995,
+              5407059,
+              5407075,
+              5415139,
+              5415155,
+              5423219,
+              5423235,
+              5431299,
+              5431315,
+              5439379,
+              5439395,
+              5447459
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5386099,
+              5386115,
+              5389379,
+              5389395,
+              5392659,
+              5392675,
+              5395939,
+              5395955,
+              5399219,
+              5399235,
+              5402499,
+              5402515,
+              5405779,
+              5405795,
+              5409059
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 115632,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19256,
+            "endpoints": 115632,
+            "legs": [
+              19256,
+              19256,
+              19256,
+              19256,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19272,
+            "perBoundaryPerWrite": 803,
+            "cdpBracket": 169632,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5453631,
+              5453647,
+              5479687,
+              5479703,
+              5498959,
+              5498975,
+              5518231,
+              5518247,
+              5537503,
+              5537519,
+              5556775,
+              5556791,
+              5576047,
+              5576063,
+              5595319
+            ],
+            "tick0": 189,
+            "tick": 196,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118200,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19696,
+            "endpoints": 118200,
+            "legs": [
+              19696,
+              19696,
+              19696,
+              19660,
+              19660,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": -0.0018277822908204712,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6848,
+            "perWrite": 19700,
+            "perBoundaryPerWrite": 820.8333333333334,
+            "cdpBracket": 172724,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5485903,
+              5485919,
+              5512463,
+              5512479,
+              5532175,
+              5532191,
+              5551887,
+              5551903,
+              5571599,
+              5571615,
+              5591275,
+              5591291,
+              5610951,
+              5610967,
+              5630663
+            ],
+            "tick0": 217,
+            "tick": 224,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 4,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5444939,
+              5444955,
+              5444971,
+              5444987,
+              5445003,
+              5445019,
+              5445035,
+              5445051,
+              5445067,
+              5445083,
+              5445099,
+              5445115,
+              5445131,
+              5445147,
+              5445163
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5452947,
+              5452963,
+              5461027,
+              5461043,
+              5469107,
+              5469123,
+              5477187,
+              5477203,
+              5485267,
+              5485283,
+              5493347,
+              5493363,
+              5501427,
+              5501443,
+              5509507
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5448147,
+              5448163,
+              5451427,
+              5451443,
+              5454707,
+              5454723,
+              5457987,
+              5458003,
+              5461267,
+              5461283,
+              5464547,
+              5464563,
+              5467827,
+              5467843,
+              5471107
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 568136,
+            "fall": 440168,
+            "falls": 2,
+            "maxStep": 358356,
+            "endpoints": 127968,
+            "legs": [
+              358356,
+              -311816,
+              -128352,
+              19448,
+              21372,
+              19448
+            ],
+            "gaps": [
+              16,
+              149432,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19448,
+            "legWorstDeviation": 17.42636774989716,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 358356 B against a cohort median of 19448 B (+338908 B, 1742.6%), past the ±25% leg tolerance (±4862 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -311816 B against a cohort median of 19448 B (-331264 B, -1703.3%), past the ±25% leg tolerance (±4862 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 3 of 6 read -128352 B against a cohort median of 19448 B (-147800 B, -760.0%), past the ±25% leg tolerance (±4862 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 358356 B against a cohort median of 19448 B (+338908 B, 1742.6%), past the ±25% leg tolerance (±4862 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -311816 B against a cohort median of 19448 B (-331264 B, -1703.3%), past the ±25% leg tolerance (±4862 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 3 of 6 read -128352 B against a cohort median of 19448 B (-147800 B, -760.0%), past the ±25% leg tolerance (±4862 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28008
+            ],
+            "primeExcess": 8560,
+            "perWrite": 94689.33333333333,
+            "perBoundaryPerWrite": 3945.3888888888887,
+            "cdpBracket": 184064,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5615099,
+              5615115,
+              5643123,
+              5643139,
+              6001495,
+              6150927,
+              5839111,
+              5839127,
+              5710775,
+              5710791,
+              5730239,
+              5730255,
+              5751627,
+              5751643,
+              5771091
+            ],
+            "tick0": 245,
+            "tick": 252,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 123092,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20928,
+            "endpoints": 123092,
+            "legs": [
+              19872,
+              19872,
+              19872,
+              15548,
+              20928,
+              19872
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              7048,
+              16,
+              16
+            ],
+            "legMedian": 19872,
+            "legWorstDeviation": -0.2175925925925926,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26736
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20515.333333333332,
+            "perBoundaryPerWrite": 854.8055555555555,
+            "cdpBracket": 177808,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5704719,
+              5704735,
+              5731471,
+              5731487,
+              5751359,
+              5751375,
+              5771247,
+              5771263,
+              5791135,
+              5798183,
+              5813731,
+              5813747,
+              5834675,
+              5834691,
+              5854563
+            ],
+            "tick0": 273,
+            "tick": 280,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 5,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5666127,
+              5666143,
+              5666159,
+              5666175,
+              5666191,
+              5666207,
+              5666223,
+              5666239,
+              5666255,
+              5666271,
+              5666287,
+              5666303,
+              5666319,
+              5666335,
+              5666351
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5674135,
+              5674151,
+              5682215,
+              5682231,
+              5690295,
+              5690311,
+              5698375,
+              5698391,
+              5706455,
+              5706471,
+              5714535,
+              5714551,
+              5722615,
+              5722631,
+              5730695
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5669335,
+              5669351,
+              5672615,
+              5672631,
+              5675895,
+              5675911,
+              5679175,
+              5679191,
+              5682455,
+              5682471,
+              5685735,
+              5685751,
+              5689015,
+              5689031,
+              5692295
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 119956,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20780,
+            "endpoints": 119956,
+            "legs": [
+              19432,
+              19432,
+              20616,
+              20180,
+              19420,
+              20780
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19806,
+            "legWorstDeviation": 0.0491770170655357,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26232
+            ],
+            "primeExcess": 6426,
+            "perWrite": 19992.666666666668,
+            "perBoundaryPerWrite": 833.0277777777778,
+            "cdpBracket": 174148,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5719787,
+              5719803,
+              5746035,
+              5746051,
+              5765483,
+              5765499,
+              5784931,
+              5784947,
+              5805563,
+              5805579,
+              5825759,
+              5825775,
+              5845195,
+              5845211,
+              5865991
+            ],
+            "tick0": 301,
+            "tick": 308,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119328,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19872,
+            "endpoints": 119328,
+            "legs": [
+              19872,
+              19872,
+              19872,
+              19872,
+              19872,
+              19872
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19872,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26724
+            ],
+            "primeExcess": 6852,
+            "perWrite": 19888,
+            "perBoundaryPerWrite": 828.6666666666666,
+            "cdpBracket": 174032,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5744827,
+              5744843,
+              5771567,
+              5771583,
+              5791455,
+              5791471,
+              5811343,
+              5811359,
+              5831231,
+              5831247,
+              5851119,
+              5851135,
+              5871007,
+              5871023,
+              5890895
+            ],
+            "tick0": 329,
+            "tick": 336,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 6,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5703863,
+              5703879,
+              5703895,
+              5703911,
+              5703927,
+              5703943,
+              5703959,
+              5703975,
+              5703991,
+              5704007,
+              5704023,
+              5704039,
+              5704055,
+              5704071,
+              5704087
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5711871,
+              5711887,
+              5719951,
+              5719967,
+              5728031,
+              5728047,
+              5736111,
+              5736127,
+              5744191,
+              5744207,
+              5752271,
+              5752287,
+              5760351,
+              5760367,
+              5768431
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5707071,
+              5707087,
+              5710351,
+              5710367,
+              5713631,
+              5713647,
+              5716911,
+              5716927,
+              5720191,
+              5720207,
+              5723471,
+              5723487,
+              5726751,
+              5726767,
+              5730031
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 118164,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20152,
+            "endpoints": 118164,
+            "legs": [
+              19416,
+              19828,
+              19416,
+              19852,
+              20152,
+              19404
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19622,
+            "legWorstDeviation": 0.02701049842014066,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26204
+            ],
+            "primeExcess": 6582,
+            "perWrite": 19694,
+            "perBoundaryPerWrite": 820.5833333333334,
+            "cdpBracket": 172456,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5764091,
+              5764107,
+              5790311,
+              5790327,
+              5809743,
+              5809759,
+              5829587,
+              5829603,
+              5849019,
+              5849035,
+              5868887,
+              5868903,
+              5889055,
+              5889071,
+              5908475
+            ],
+            "tick0": 357,
+            "tick": 364,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 302240,
+            "fall": 181784,
+            "falls": 1,
+            "maxStep": 202880,
+            "endpoints": 120456,
+            "legs": [
+              19856,
+              -181784,
+              19856,
+              19856,
+              19856,
+              19856
+            ],
+            "gaps": [
+              16,
+              202880,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19856,
+            "legWorstDeviation": -10.155116841257051,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read -181784 B against a cohort median of 19856 B (-201640 B, -1015.5%), past the ±25% leg tolerance (±4964 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read -181784 B against a cohort median of 19856 B (-201640 B, -1015.5%), past the ±25% leg tolerance (±4964 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26708
+            ],
+            "primeExcess": 6852,
+            "perWrite": 50373.333333333336,
+            "perBoundaryPerWrite": 2098.888888888889,
+            "cdpBracket": 175144,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5790607,
+              5790623,
+              5817331,
+              5817347,
+              5837203,
+              6040083,
+              5858299,
+              5858315,
+              5878171,
+              5878187,
+              5898043,
+              5898059,
+              5917915,
+              5917931,
+              5937787
+            ],
+            "tick0": 385,
+            "tick": 392,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 7,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 2416,
+            "fall": 1716,
+            "falls": 1,
+            "maxStep": 2256,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              2256,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              -1716,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 140,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 2256 B against a cohort median of 16 B (+2240 B, 14000.0%), past the ±25% leg tolerance (±4 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 2256 B against a cohort median of 16 B (+2240 B, 14000.0%), past the ±25% leg tolerance (±4 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 402.6666666666667,
+            "cdpBracket": 28812,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5750747,
+              5750763,
+              5750779,
+              5750795,
+              5750811,
+              5750827,
+              5750843,
+              5750859,
+              5750875,
+              5750891,
+              5753147,
+              5751431,
+              5751447,
+              5751463,
+              5751479
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5759263,
+              5759279,
+              5767343,
+              5767359,
+              5775423,
+              5775439,
+              5783503,
+              5783519,
+              5791583,
+              5791599,
+              5799663,
+              5799679,
+              5807743,
+              5807759,
+              5815823
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5754463,
+              5754479,
+              5757743,
+              5757759,
+              5761023,
+              5761039,
+              5764303,
+              5764319,
+              5767583,
+              5767599,
+              5770863,
+              5770879,
+              5774143,
+              5774159,
+              5777423
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 119636,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21060,
+            "endpoints": 119636,
+            "legs": [
+              19396,
+              19408,
+              20152,
+              19396,
+              21060,
+              19408
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              736
+            ],
+            "legMedian": 19408,
+            "legWorstDeviation": 0.08511953833470734,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26196
+            ],
+            "primeExcess": 6788,
+            "perWrite": 19939.333333333332,
+            "perBoundaryPerWrite": 830.8055555555555,
+            "cdpBracket": 180716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5818927,
+              5818943,
+              5845139,
+              5845155,
+              5864551,
+              5864567,
+              5883975,
+              5883991,
+              5904143,
+              5904159,
+              5923555,
+              5923571,
+              5944631,
+              5945367,
+              5964775
+            ],
+            "tick0": 413,
+            "tick": 420,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 123096,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23772,
+            "endpoints": 123096,
+            "legs": [
+              19848,
+              19848,
+              19848,
+              19848,
+              19836,
+              23772
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19848,
+            "legWorstDeviation": 0.1977025392986699,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26712
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20516,
+            "perBoundaryPerWrite": 854.8333333333334,
+            "cdpBracket": 177788,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5844507,
+              5844523,
+              5871235,
+              5871251,
+              5891099,
+              5891115,
+              5910963,
+              5910979,
+              5930827,
+              5930843,
+              5950691,
+              5950707,
+              5970543,
+              5970559,
+              5994331
+            ],
+            "tick0": 441,
+            "tick": 448,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 8,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5807467,
+              5807483,
+              5807499,
+              5807515,
+              5807531,
+              5807547,
+              5807563,
+              5807579,
+              5807595,
+              5807611,
+              5807627,
+              5807643,
+              5807659,
+              5807675,
+              5807691
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5815475,
+              5815491,
+              5823555,
+              5823571,
+              5831635,
+              5831651,
+              5839715,
+              5839731,
+              5847795,
+              5847811,
+              5855875,
+              5855891,
+              5863955,
+              5863971,
+              5872035
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5810675,
+              5810691,
+              5813955,
+              5813971,
+              5817235,
+              5817251,
+              5820515,
+              5820531,
+              5823795,
+              5823811,
+              5827075,
+              5827091,
+              5830355,
+              5830371,
+              5833635
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 118956,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21132,
+            "endpoints": 118956,
+            "legs": [
+              21132,
+              19396,
+              19396,
+              19396,
+              19396,
+              20144
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19396,
+            "legWorstDeviation": 0.08950299030727984,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26196
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19826,
+            "perBoundaryPerWrite": 826.0833333333334,
+            "cdpBracket": 173240,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5872915,
+              5872931,
+              5899127,
+              5899143,
+              5920275,
+              5920291,
+              5939687,
+              5939703,
+              5959099,
+              5959115,
+              5978511,
+              5978527,
+              5997923,
+              5997939,
+              6018083
+            ],
+            "tick0": 469,
+            "tick": 476,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 127452,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 46548,
+            "endpoints": 127452,
+            "legs": [
+              19836,
+              46548,
+              10808,
+              10480,
+              19848,
+              19836
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19836,
+            "legWorstDeviation": 1.3466424682395643,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 46548 B against a cohort median of 19836 B (+26712 B, 134.7%), past the ±25% leg tolerance (±4959 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read 10808 B against a cohort median of 19836 B (-9028 B, -45.5%), past the ±25% leg tolerance (±4959 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 4 of 6 read 10480 B against a cohort median of 19836 B (-9356 B, -47.2%), past the ±25% leg tolerance (±4959 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 46548 B against a cohort median of 19836 B (+26712 B, 134.7%), past the ±25% leg tolerance (±4959 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read 10808 B against a cohort median of 19836 B (-9028 B, -45.5%), past the ±25% leg tolerance (±4959 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 4 of 6 read 10480 B against a cohort median of 19836 B (-9356 B, -47.2%), past the ±25% leg tolerance (±4959 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26712
+            ],
+            "primeExcess": 6876,
+            "perWrite": 21242,
+            "perBoundaryPerWrite": 885.0833333333334,
+            "cdpBracket": 182144,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5907923,
+              5907939,
+              5934651,
+              5934667,
+              5954503,
+              5954519,
+              6001067,
+              6001083,
+              6011891,
+              6011907,
+              6022387,
+              6022403,
+              6042251,
+              6042267,
+              6062103
+            ],
+            "tick0": 497,
+            "tick": 504,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 9,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5875259,
+              5875275,
+              5875291,
+              5875307,
+              5875323,
+              5875339,
+              5875355,
+              5875371,
+              5875387,
+              5875403,
+              5875419,
+              5875435,
+              5875451,
+              5875467,
+              5875483
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5883267,
+              5883283,
+              5891347,
+              5891363,
+              5899427,
+              5899443,
+              5907507,
+              5907523,
+              5915587,
+              5915603,
+              5923667,
+              5923683,
+              5931747,
+              5931763,
+              5939827
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5878467,
+              5878483,
+              5881747,
+              5881763,
+              5885027,
+              5885043,
+              5888307,
+              5888323,
+              5891587,
+              5891603,
+              5894867,
+              5894883,
+              5898147,
+              5898163,
+              5901427
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117148,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20136,
+            "endpoints": 117148,
+            "legs": [
+              19388,
+              19388,
+              19388,
+              19364,
+              19388,
+              20136
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19388,
+            "legWorstDeviation": 0.03858056529812255,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26200
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19524.666666666668,
+            "perBoundaryPerWrite": 813.5277777777778,
+            "cdpBracket": 171308,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5933347,
+              5933363,
+              5959563,
+              5959579,
+              5978967,
+              5978983,
+              5998371,
+              5998387,
+              6017775,
+              6017791,
+              6037155,
+              6037171,
+              6056559,
+              6056575,
+              6076711
+            ],
+            "tick0": 525,
+            "tick": 532,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 129860,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 30588,
+            "endpoints": 129860,
+            "legs": [
+              19840,
+              19840,
+              19840,
+              30588,
+              19828,
+              19828
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19840,
+            "legWorstDeviation": 0.541733870967742,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 30588 B against a cohort median of 19840 B (+10748 B, 54.2%), past the ±25% leg tolerance (±4960 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 30588 B against a cohort median of 19840 B (+10748 B, 54.2%), past the ±25% leg tolerance (±4960 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26704
+            ],
+            "primeExcess": 6864,
+            "perWrite": 21643.333333333332,
+            "perBoundaryPerWrite": 901.8055555555555,
+            "cdpBracket": 184544,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5955691,
+              5955707,
+              5982411,
+              5982427,
+              6002267,
+              6002283,
+              6022123,
+              6022139,
+              6041979,
+              6041995,
+              6072583,
+              6072599,
+              6092427,
+              6092443,
+              6112271
+            ],
+            "tick0": 553,
+            "tick": 560,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 10,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5925487,
+              5925503,
+              5925519,
+              5925535,
+              5925551,
+              5925567,
+              5925583,
+              5925599,
+              5925615,
+              5925631,
+              5925647,
+              5925663,
+              5925679,
+              5925695,
+              5925711
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5933495,
+              5933511,
+              5941575,
+              5941591,
+              5949655,
+              5949671,
+              5957735,
+              5957751,
+              5965815,
+              5965831,
+              5973895,
+              5973911,
+              5981975,
+              5981991,
+              5990055
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5928695,
+              5928711,
+              5931975,
+              5931991,
+              5935255,
+              5935271,
+              5938535,
+              5938551,
+              5941815,
+              5941831,
+              5945095,
+              5945111,
+              5948375,
+              5948391,
+              5951655
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 158964,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 61928,
+            "endpoints": 158964,
+            "legs": [
+              19364,
+              19388,
+              19400,
+              19400,
+              61928,
+              19388
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19394,
+            "legWorstDeviation": 2.1931525213983707,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read 61928 B against a cohort median of 19394 B (+42534 B, 219.3%), past the ±25% leg tolerance (±4848.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read 61928 B against a cohort median of 19394 B (+42534 B, 219.3%), past the ±25% leg tolerance (±4848.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26200
+            ],
+            "primeExcess": 6806,
+            "perWrite": 26494,
+            "perBoundaryPerWrite": 1103.9166666666667,
+            "cdpBracket": 173972,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5979767,
+              5979783,
+              6005983,
+              6005999,
+              6025363,
+              6025379,
+              6044767,
+              6044783,
+              6064183,
+              6064199,
+              6083599,
+              6083615,
+              6145543,
+              6145559,
+              6164947
+            ],
+            "tick0": 581,
+            "tick": 588,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 313116,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 212576,
+            "endpoints": 313116,
+            "legs": [
+              19820,
+              19832,
+              19820,
+              21140,
+              19832,
+              212576
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19832,
+            "legWorstDeviation": 9.718838241226301,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 212576 B against a cohort median of 19832 B (+192744 B, 971.9%), past the ±25% leg tolerance (±4958 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 212576 B against a cohort median of 19832 B (+192744 B, 971.9%), past the ±25% leg tolerance (±4958 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26696
+            ],
+            "primeExcess": 6864,
+            "perWrite": 52186,
+            "perBoundaryPerWrite": 2174.4166666666665,
+            "cdpBracket": 176528,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5992939,
+              5992955,
+              6019651,
+              6019667,
+              6039487,
+              6039503,
+              6059335,
+              6059351,
+              6079171,
+              6079187,
+              6100327,
+              6100343,
+              6120175,
+              6120191,
+              6332767
+            ],
+            "tick0": 609,
+            "tick": 616,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 11,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5953115,
+              5953131,
+              5953147,
+              5953163,
+              5953179,
+              5953195,
+              5953211,
+              5953227,
+              5953243,
+              5953259,
+              5953275,
+              5953291,
+              5953307,
+              5953323,
+              5953339
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5961123,
+              5961139,
+              5969203,
+              5969219,
+              5977283,
+              5977299,
+              5985363,
+              5985379,
+              5993443,
+              5993459,
+              6001523,
+              6001539,
+              6009603,
+              6009619,
+              6017683
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5956323,
+              5956339,
+              5959603,
+              5959619,
+              5962883,
+              5962899,
+              5966163,
+              5966179,
+              5969443,
+              5969459,
+              5972723,
+              5972739,
+              5976003,
+              5976019,
+              5979283
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117100,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20120,
+            "endpoints": 117100,
+            "legs": [
+              19372,
+              19384,
+              19384,
+              19372,
+              20120,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.038290845288471466,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19516.666666666668,
+            "perBoundaryPerWrite": 813.1944444444445,
+            "cdpBracket": 171244,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5998375,
+              5998391,
+              6024575,
+              6024591,
+              6043963,
+              6043979,
+              6063363,
+              6063379,
+              6082763,
+              6082779,
+              6102151,
+              6102167,
+              6122287,
+              6122303,
+              6141675
+            ],
+            "tick0": 637,
+            "tick": 644,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118968,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 118968,
+            "legs": [
+              19824,
+              19824,
+              19812,
+              19812,
+              19812,
+              19788
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": -0.0012113870381586917,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              31920
+            ],
+            "primeExcess": 12108,
+            "perWrite": 19828,
+            "perBoundaryPerWrite": 826.1666666666666,
+            "cdpBracket": 180080,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6017495,
+              6017511,
+              6049431,
+              6049447,
+              6069271,
+              6069287,
+              6089111,
+              6089127,
+              6108939,
+              6108955,
+              6128767,
+              6128783,
+              6148595,
+              6148611,
+              6168399
+            ],
+            "tick0": 665,
+            "tick": 672,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 12,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5981799,
+              5981815,
+              5981831,
+              5981847,
+              5981863,
+              5981879,
+              5981895,
+              5981911,
+              5981927,
+              5981943,
+              5981959,
+              5981975,
+              5981991,
+              5982007,
+              5982023
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5989807,
+              5989823,
+              5997887,
+              5997903,
+              6005967,
+              6005983,
+              6014047,
+              6014063,
+              6022127,
+              6022143,
+              6030207,
+              6030223,
+              6038287,
+              6038303,
+              6046367
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5985007,
+              5985023,
+              5988287,
+              5988303,
+              5991567,
+              5991583,
+              5994847,
+              5994863,
+              5998127,
+              5998143,
+              6001407,
+              6001423,
+              6004687,
+              6004703,
+              6007967
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117088,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20120,
+            "endpoints": 117088,
+            "legs": [
+              19372,
+              19372,
+              19372,
+              19384,
+              20120,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.038612430311790215,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19514.666666666668,
+            "perBoundaryPerWrite": 813.1111111111112,
+            "cdpBracket": 171344,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6046743,
+              6046759,
+              6072943,
+              6072959,
+              6092331,
+              6092347,
+              6111719,
+              6111735,
+              6131107,
+              6131123,
+              6150507,
+              6150523,
+              6170643,
+              6170659,
+              6190031
+            ],
+            "tick0": 693,
+            "tick": 700,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120048,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20868,
+            "endpoints": 120048,
+            "legs": [
+              19824,
+              19824,
+              19824,
+              19824,
+              20868,
+              19788
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.0526634382566586,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20008,
+            "perBoundaryPerWrite": 833.6666666666666,
+            "cdpBracket": 174700,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6075739,
+              6075755,
+              6102443,
+              6102459,
+              6122283,
+              6122299,
+              6142123,
+              6142139,
+              6161963,
+              6161979,
+              6181803,
+              6181819,
+              6202687,
+              6202703,
+              6222491
+            ],
+            "tick0": 721,
+            "tick": 728,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 13,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 31952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6035831,
+              6035847,
+              6035863,
+              6035879,
+              6035895,
+              6035911,
+              6035927,
+              6035943,
+              6035959,
+              6035975,
+              6035991,
+              6036007,
+              6036023,
+              6036039,
+              6036055
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6047859,
+              6047875,
+              6055939,
+              6055955,
+              6064019,
+              6064035,
+              6072099,
+              6072115,
+              6080179,
+              6080195,
+              6088259,
+              6088275,
+              6096339,
+              6096355,
+              6104419
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6043059,
+              6043075,
+              6046339,
+              6046355,
+              6049619,
+              6049635,
+              6052899,
+              6052915,
+              6056179,
+              6056195,
+              6059459,
+              6059475,
+              6062739,
+              6062755,
+              6066019
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117780,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20092,
+            "endpoints": 117780,
+            "legs": [
+              20092,
+              19372,
+              19372,
+              19384,
+              20092,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.03684590773041593,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19630,
+            "perBoundaryPerWrite": 817.9166666666666,
+            "cdpBracket": 171908,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6084791,
+              6084807,
+              6110991,
+              6111007,
+              6131099,
+              6131115,
+              6150487,
+              6150503,
+              6169875,
+              6169891,
+              6189275,
+              6189291,
+              6209383,
+              6209399,
+              6228771
+            ],
+            "tick0": 749,
+            "tick": 756,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118980,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 118980,
+            "legs": [
+              19812,
+              19812,
+              19812,
+              19824,
+              19812,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": 0.0006056935190793458,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6876,
+            "perWrite": 19830,
+            "perBoundaryPerWrite": 826.25,
+            "cdpBracket": 173632,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6107179,
+              6107195,
+              6133883,
+              6133899,
+              6153711,
+              6153727,
+              6173539,
+              6173555,
+              6193367,
+              6193383,
+              6213207,
+              6213223,
+              6233035,
+              6233051,
+              6252863
+            ],
+            "tick0": 777,
+            "tick": 784,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 14,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6066215,
+              6066231,
+              6066247,
+              6066263,
+              6066279,
+              6066295,
+              6066311,
+              6066327,
+              6066343,
+              6066359,
+              6066375,
+              6066391,
+              6066407,
+              6066423,
+              6066439
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6074223,
+              6074239,
+              6082303,
+              6082319,
+              6090383,
+              6090399,
+              6098463,
+              6098479,
+              6106543,
+              6106559,
+              6114623,
+              6114639,
+              6122703,
+              6122719,
+              6130783
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6069423,
+              6069439,
+              6072703,
+              6072719,
+              6075983,
+              6075999,
+              6079263,
+              6079279,
+              6082543,
+              6082559,
+              6085823,
+              6085839,
+              6089103,
+              6089119,
+              6092383
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 384012,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 286284,
+            "endpoints": 384012,
+            "legs": [
+              19372,
+              19384,
+              19372,
+              19384,
+              20120,
+              286284
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19384,
+            "legWorstDeviation": 13.76908790755262,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 286284 B against a cohort median of 19384 B (+266900 B, 1376.9%), past the ±25% leg tolerance (±4846 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 286284 B against a cohort median of 19384 B (+266900 B, 1376.9%), past the ±25% leg tolerance (±4846 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6800,
+            "perWrite": 64002,
+            "perBoundaryPerWrite": 2666.75,
+            "cdpBracket": 173704,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6111759,
+              6111775,
+              6137959,
+              6137975,
+              6157347,
+              6157363,
+              6176747,
+              6176763,
+              6196135,
+              6196151,
+              6215535,
+              6215551,
+              6235671,
+              6235687,
+              6521971
+            ],
+            "tick0": 805,
+            "tick": 812,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120024,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20868,
+            "endpoints": 120024,
+            "legs": [
+              19788,
+              19812,
+              19812,
+              19824,
+              20868,
+              19824
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 0.052982137450802304,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6870,
+            "perWrite": 20004,
+            "perBoundaryPerWrite": 833.5,
+            "cdpBracket": 174676,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6129407,
+              6129423,
+              6156111,
+              6156127,
+              6175915,
+              6175931,
+              6195743,
+              6195759,
+              6215571,
+              6215587,
+              6235411,
+              6235427,
+              6256295,
+              6256311,
+              6276135
+            ],
+            "tick0": 833,
+            "tick": 840,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 15,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6089499,
+              6089515,
+              6089531,
+              6089547,
+              6089563,
+              6089579,
+              6089595,
+              6089611,
+              6089627,
+              6089643,
+              6089659,
+              6089675,
+              6089691,
+              6089707,
+              6089723
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6097507,
+              6097523,
+              6105587,
+              6105603,
+              6113667,
+              6113683,
+              6121747,
+              6121763,
+              6129827,
+              6129843,
+              6137907,
+              6137923,
+              6145987,
+              6146003,
+              6154067
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6092707,
+              6092723,
+              6095987,
+              6096003,
+              6099267,
+              6099283,
+              6102547,
+              6102563,
+              6105827,
+              6105843,
+              6109107,
+              6109123,
+              6112387,
+              6112403,
+              6115667
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117076,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20096,
+            "endpoints": 117076,
+            "legs": [
+              19372,
+              19384,
+              19384,
+              19372,
+              19372,
+              20096
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.037052327381566726,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19512.666666666668,
+            "perBoundaryPerWrite": 813.0277777777778,
+            "cdpBracket": 173576,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6137075,
+              6137091,
+              6163275,
+              6163291,
+              6182663,
+              6182679,
+              6202063,
+              6202079,
+              6221463,
+              6221479,
+              6240851,
+              6240867,
+              6260239,
+              6260255,
+              6280351
+            ],
+            "tick0": 861,
+            "tick": 868,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119736,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20556,
+            "endpoints": 119736,
+            "legs": [
+              19812,
+              19824,
+              19812,
+              19812,
+              19824,
+              20556
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 0.03723887375113533,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26676
+            ],
+            "primeExcess": 6858,
+            "perWrite": 19956,
+            "perBoundaryPerWrite": 831.5,
+            "cdpBracket": 174376,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6158243,
+              6158259,
+              6184935,
+              6184951,
+              6204763,
+              6204779,
+              6224603,
+              6224619,
+              6244431,
+              6244447,
+              6264259,
+              6264275,
+              6284099,
+              6284115,
+              6304671
+            ],
+            "tick0": 889,
+            "tick": 896,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 16,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6112163,
+              6112179,
+              6112195,
+              6112211,
+              6112227,
+              6112243,
+              6112259,
+              6112275,
+              6112291,
+              6112307,
+              6112323,
+              6112339,
+              6112355,
+              6112371,
+              6112387
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6120171,
+              6120187,
+              6128251,
+              6128267,
+              6136331,
+              6136347,
+              6144411,
+              6144427,
+              6152491,
+              6152507,
+              6160571,
+              6160587,
+              6168651,
+              6168667,
+              6176731
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6115371,
+              6115387,
+              6118651,
+              6118667,
+              6121931,
+              6121947,
+              6125211,
+              6125227,
+              6128491,
+              6128507,
+              6131771,
+              6131787,
+              6135051,
+              6135067,
+              6138331
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 119376,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22420,
+            "endpoints": 119376,
+            "legs": [
+              19372,
+              19384,
+              19384,
+              19372,
+              19348,
+              22420
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.15698214470017546,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6794,
+            "perWrite": 19896,
+            "perBoundaryPerWrite": 829,
+            "cdpBracket": 173620,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6153051,
+              6153067,
+              6179239,
+              6179255,
+              6198627,
+              6198643,
+              6218027,
+              6218043,
+              6237427,
+              6237443,
+              6256815,
+              6256831,
+              6276179,
+              6276195,
+              6298615
+            ],
+            "tick0": 917,
+            "tick": 924,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 217408,
+            "fall": 93400,
+            "falls": 1,
+            "maxStep": 116884,
+            "endpoints": 124008,
+            "legs": [
+              19824,
+              21160,
+              19824,
+              -93400,
+              19812,
+              19824
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              116884,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": -5.711460855528652,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read -93400 B against a cohort median of 19824 B (-113224 B, -571.1%), past the ±25% leg tolerance (±4956 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read -93400 B against a cohort median of 19824 B (-113224 B, -571.1%), past the ±25% leg tolerance (±4956 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26676
+            ],
+            "primeExcess": 6852,
+            "perWrite": 36234.666666666664,
+            "perBoundaryPerWrite": 1509.7777777777776,
+            "cdpBracket": 178648,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6169567,
+              6169583,
+              6196259,
+              6196275,
+              6216099,
+              6216115,
+              6237275,
+              6237291,
+              6257115,
+              6373999,
+              6280599,
+              6280615,
+              6300427,
+              6300443,
+              6320267
+            ],
+            "tick0": 945,
+            "tick": 952,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 17,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6127011,
+              6127027,
+              6127043,
+              6127059,
+              6127075,
+              6127091,
+              6127107,
+              6127123,
+              6127139,
+              6127155,
+              6127171,
+              6127187,
+              6127203,
+              6127219,
+              6127235
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6135019,
+              6135035,
+              6143099,
+              6143115,
+              6151179,
+              6151195,
+              6159259,
+              6159275,
+              6167339,
+              6167355,
+              6175419,
+              6175435,
+              6183499,
+              6183515,
+              6191579
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6130219,
+              6130235,
+              6133499,
+              6133515,
+              6136779,
+              6136795,
+              6140059,
+              6140075,
+              6143339,
+              6143355,
+              6146619,
+              6146635,
+              6149899,
+              6149915,
+              6153179
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 119912,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23028,
+            "endpoints": 119912,
+            "legs": [
+              19372,
+              19372,
+              19372,
+              19372,
+              23028,
+              19300
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.18872599628329548,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19985.333333333332,
+            "perBoundaryPerWrite": 832.7222222222222,
+            "cdpBracket": 174028,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6181915,
+              6181931,
+              6208103,
+              6208119,
+              6227491,
+              6227507,
+              6246879,
+              6246895,
+              6266267,
+              6266283,
+              6285655,
+              6285671,
+              6308699,
+              6308715,
+              6328015
+            ],
+            "tick0": 973,
+            "tick": 980,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119028,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19828,
+            "endpoints": 119028,
+            "legs": [
+              19816,
+              19828,
+              19816,
+              19816,
+              19828,
+              19828
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19822,
+            "legWorstDeviation": -0.0003026939763898698,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26680
+            ],
+            "primeExcess": 6858,
+            "perWrite": 19838,
+            "perBoundaryPerWrite": 826.5833333333334,
+            "cdpBracket": 173672,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6198143,
+              6198159,
+              6224839,
+              6224855,
+              6244671,
+              6244687,
+              6264515,
+              6264531,
+              6284347,
+              6284363,
+              6304179,
+              6304195,
+              6324023,
+              6324039,
+              6343867
+            ],
+            "tick0": 1001,
+            "tick": 1008,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      }
+    ],
+    "allocFits": {
+      "perRound": {},
+      "mean": {}
+    },
+    "writeDriven": true,
+    "writeProvenance": {
+      "windows": 36,
+      "pairs": 36,
+      "unnamed": [],
+      "incomplete": [],
+      "ok": true
+    },
+    "controlVerdict": {
+      "ok": true,
+      "perDouble": 8.08088888888889,
+      "differential": 8.00148148148148
+    },
+    "fallsInMeasuredWindows": 11,
+    "refusedWindows": 13,
+    "refusalReasons": 20
+  },
+  "box": {
+    "bead": "rf2-24o2z",
+    "chromium": "chromium/147.0.7727.15",
+    "node": "v24.13.0",
+    "platform": "win32/x64/10.0.26200",
+    "load": {
+      "open": {
+        "at": "2026-08-20T20:25:01.065Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13471604457,
+        "cpuBusyMs": 3625808048,
+        "freeMemB": 15749230592,
+        "totalMemB": 68112736256,
+        "uptimeS": 708663.859
+      },
+      "close": {
+        "at": "2026-08-20T20:25:27.200Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13472120301,
+        "cpuBusyMs": 3625921266,
+        "freeMemB": 16286203904,
+        "totalMemB": 68112736256,
+        "uptimeS": 708690
+      },
+      "busyFraction": 0.1799790799635012
+    },
+    "session": {
+      "startedAt": "2026-08-20T20:24:20.291Z",
+      "sessionStartedAt": "2026-08-20T19:39:26.627Z",
+      "runsInSession": 4,
+      "sessionGapMs": 3600000,
+      "previousRun": {
+        "startedAt": "2026-08-20T20:23:06.056Z",
+        "endedAt": "2026-08-20T20:24:16.447Z",
+        "sinceStartMs": 74235,
+        "sinceEndMs": 3844,
+        "sameSession": true
+      }
+    }
+  }
+}

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/fixed-2.json
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/fixed-2.json
@@ -1,0 +1,7569 @@
+{
+  "generatedAt": "2026-08-20T20:28:05.991Z",
+  "build": "hicasso-bench",
+  "initFn": "re-frame.bench.p0-app/-main",
+  "alloc": {
+    "benchmark": "P0:steady-state-allocation-slope",
+    "bead": "rf2-2rtt6.76",
+    "roots": 4,
+    "perRoot": {
+      "list": 300,
+      "grid": 6
+    },
+    "publishedPerRoot": {
+      "list": 300,
+      "grid": 300
+    },
+    "arm": {
+      "cells": 6,
+      "roots": 4,
+      "boundaries": 24,
+      "writes": 6,
+      "refusals": [],
+      "admissible": true
+    },
+    "boundaries": 24,
+    "writes": 6,
+    "primeWrites": 1,
+    "windowWrites": 7,
+    "bySite": false,
+    "sites": 2,
+    "siteNames": [
+      "dispatch",
+      "drain"
+    ],
+    "warmups": 3,
+    "rounds": 18,
+    "preciseMemory": true,
+    "controlDoubles": {
+      "d1": 1000,
+      "d2": 400
+    },
+    "controlSlack": 0.75,
+    "writeSelector": "all",
+    "writeLegs": [
+      "all"
+    ],
+    "writePaired": false,
+    "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+    "plan": {
+      "name": "floor",
+      "arms": true,
+      "rungs": false,
+      "fits": false
+    },
+    "segOrder": "fixed",
+    "passOrder": "parity",
+    "passSeed": "1787257649241",
+    "passSchedule": {
+      "flips": [
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true
+      ],
+      "attempts": 1,
+      "parityTied": false
+    },
+    "controlSlot": "first",
+    "instrument": "in-page performance.memory.usedJSHeapSize sampled at every leg boundary, rising steps accumulated separately from falling ones; --enable-precise-memory-info. A falling step is a collection this counter SAW; a leg that deviates from its cohort median by more than the leg tolerance is a work unit that is not one; and under the by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the other two can see. TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg has no interior reading and so no site step to be negative, and the intra-leg gate returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with these (see `bySite`), so a witness comparing byte for byte against a figure published at stride 2 can never be screened by all three",
+    "fallThresholdB": 600000,
+    "legTolerance": 0.25,
+    "verification": {
+      "unverified": 0,
+      "detail": []
+    },
+    "workCount": false,
+    "workVerification": {
+      "counted": false
+    },
+    "perRound": [
+      {
+        "round": 0,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 524,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              524
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 116.66666666666667,
+            "cdpBracket": 46232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3840294,
+              3840310,
+              3840326,
+              3840342,
+              3840358,
+              3840374,
+              3840390,
+              3840406,
+              3840422,
+              3840438,
+              3840454,
+              3840470,
+              3840486,
+              3841010,
+              3841026
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48576,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8144,
+            "endpoints": 48576,
+            "legs": [
+              8144,
+              8080,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.00992063492063492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8096,
+            "cdpBracket": 87388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3853918,
+              3853934,
+              3861998,
+              3862014,
+              3870158,
+              3870174,
+              3878254,
+              3878270,
+              3886334,
+              3886350,
+              3894414,
+              3894430,
+              3902494,
+              3902510,
+              3910574
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 52328,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3850018,
+              3850034,
+              3853298,
+              3853314,
+              3856578,
+              3856594,
+              3859858,
+              3859874,
+              3863138,
+              3863154,
+              3866418,
+              3866434,
+              3869698,
+              3869714,
+              3872978
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 627220,
+            "fall": 495908,
+            "falls": 2,
+            "maxStep": 304624,
+            "endpoints": 131312,
+            "legs": [
+              304624,
+              19692,
+              19764,
+              -239304,
+              20916,
+              -256604
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              262144,
+              16,
+              16
+            ],
+            "legMedian": 19728,
+            "legWorstDeviation": 14.441200324412003,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 304624 B against a cohort median of 19728 B (+284896 B, 1444.1%), past the ±25% leg tolerance (±4932 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -239304 B against a cohort median of 19728 B (-259032 B, -1313.0%), past the ±25% leg tolerance (±4932 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 6 of 6 read -256604 B against a cohort median of 19728 B (-276332 B, -1400.7%), past the ±25% leg tolerance (±4932 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 304624 B against a cohort median of 19728 B (+284896 B, 1444.1%), past the ±25% leg tolerance (±4932 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -239304 B against a cohort median of 19728 B (-259032 B, -1313.0%), past the ±25% leg tolerance (±4932 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 6 of 6 read -256604 B against a cohort median of 19728 B (-276332 B, -1400.7%), past the ±25% leg tolerance (±4932 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              27388
+            ],
+            "primeExcess": 7660,
+            "perWrite": 104536.66666666667,
+            "perBoundaryPerWrite": 4355.694444444444,
+            "cdpBracket": 187100,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              4782631,
+              4782647,
+              4810035,
+              4810051,
+              5114675,
+              5114691,
+              5134383,
+              5134399,
+              5154163,
+              5416307,
+              5177003,
+              5177019,
+              5197935,
+              5197951,
+              4941347
+            ],
+            "tick0": 21,
+            "tick": 28,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 549216,
+            "fall": 420232,
+            "falls": 1,
+            "maxStep": 354056,
+            "endpoints": 128984,
+            "legs": [
+              19916,
+              135460,
+              354056,
+              -420232,
+              19844,
+              19844
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19880,
+            "legWorstDeviation": -22.138430583501005,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 135460 B against a cohort median of 19880 B (+115580 B, 581.4%), past the ±25% leg tolerance (±4970 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read 354056 B against a cohort median of 19880 B (+334176 B, 1681.0%), past the ±25% leg tolerance (±4970 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -420232 B against a cohort median of 19880 B (-440112 B, -2213.8%), past the ±25% leg tolerance (±4970 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 135460 B against a cohort median of 19880 B (+115580 B, 581.4%), past the ±25% leg tolerance (±4970 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read 354056 B against a cohort median of 19880 B (+334176 B, 1681.0%), past the ±25% leg tolerance (±4970 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -420232 B against a cohort median of 19880 B (-440112 B, -2213.8%), past the ±25% leg tolerance (±4970 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26764
+            ],
+            "primeExcess": 6884,
+            "perWrite": 91536,
+            "perBoundaryPerWrite": 3814,
+            "cdpBracket": 483148,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5059159,
+              5059175,
+              5085939,
+              5085955,
+              5105871,
+              5105887,
+              5241347,
+              5241363,
+              5595419,
+              5595435,
+              5175203,
+              5175219,
+              5195063,
+              5195079,
+              5214923
+            ],
+            "tick0": 49,
+            "tick": 56,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 1,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5046495,
+              5046511,
+              5046527,
+              5046543,
+              5046559,
+              5046575,
+              5046591,
+              5046607,
+              5046623,
+              5046639,
+              5046655,
+              5046671,
+              5046687,
+              5046703,
+              5046719
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 87716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5054503,
+              5054519,
+              5062583,
+              5062599,
+              5070663,
+              5070679,
+              5078743,
+              5078759,
+              5086823,
+              5086839,
+              5094903,
+              5094919,
+              5102983,
+              5102999,
+              5111063
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5051947,
+              5051963,
+              5055227,
+              5055243,
+              5058507,
+              5058523,
+              5061787,
+              5061803,
+              5065067,
+              5065083,
+              5068347,
+              5068363,
+              5071627,
+              5071643,
+              5074907
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 101292,
+            "fall": 169248,
+            "falls": 1,
+            "maxStep": 21912,
+            "endpoints": -67956,
+            "legs": [
+              -169248,
+              19332,
+              19332,
+              21912,
+              19332,
+              21288
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19332,
+            "legWorstDeviation": -9.754810676598385,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read -169248 B against a cohort median of 19332 B (-188580 B, -975.5%), past the ±25% leg tolerance (±4833 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read -169248 B against a cohort median of 19332 B (-188580 B, -975.5%), past the ±25% leg tolerance (±4833 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              220580
+            ],
+            "primeExcess": 201248,
+            "perWrite": 16882,
+            "perBoundaryPerWrite": 703.4166666666666,
+            "cdpBracket": 184156,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5176571,
+              5176587,
+              5397167,
+              5397183,
+              5227935,
+              5227951,
+              5247283,
+              5247299,
+              5266631,
+              5266647,
+              5288559,
+              5288575,
+              5307907,
+              5307923,
+              5329211
+            ],
+            "tick0": 77,
+            "tick": 84,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 194248,
+            "fall": 68524,
+            "falls": 1,
+            "maxStep": 74380,
+            "endpoints": 125724,
+            "legs": [
+              19696,
+              74380,
+              22096,
+              19588,
+              -68524,
+              19624
+            ],
+            "gaps": [
+              16,
+              16,
+              38784,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19660,
+            "legWorstDeviation": -4.485452695829094,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 74380 B against a cohort median of 19660 B (+54720 B, 278.3%), past the ±25% leg tolerance (±4915 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -68524 B against a cohort median of 19660 B (-88184 B, -448.5%), past the ±25% leg tolerance (±4915 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 74380 B against a cohort median of 19660 B (+54720 B, 278.3%), past the ±25% leg tolerance (±4915 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -68524 B against a cohort median of 19660 B (-88184 B, -448.5%), past the ±25% leg tolerance (±4915 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6884,
+            "perWrite": 32374.666666666668,
+            "perBoundaryPerWrite": 1348.9444444444446,
+            "cdpBracket": 180704,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5294563,
+              5294579,
+              5321123,
+              5321139,
+              5340835,
+              5340851,
+              5415231,
+              5454015,
+              5476111,
+              5476127,
+              5495715,
+              5495731,
+              5427207,
+              5427223,
+              5446847
+            ],
+            "tick0": 105,
+            "tick": 112,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 2,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5258767,
+              5258783,
+              5258799,
+              5258815,
+              5258831,
+              5258847,
+              5258863,
+              5258879,
+              5258895,
+              5258911,
+              5258927,
+              5258943,
+              5258959,
+              5258975,
+              5258991
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85088,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5266791,
+              5266807,
+              5274871,
+              5274887,
+              5282951,
+              5282967,
+              5291031,
+              5291047,
+              5299111,
+              5299127,
+              5307191,
+              5307207,
+              5315271,
+              5315287,
+              5323351
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5261991,
+              5262007,
+              5265271,
+              5265287,
+              5268551,
+              5268567,
+              5271831,
+              5271847,
+              5275111,
+              5275127,
+              5278391,
+              5278407,
+              5281671,
+              5281687,
+              5284951
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 141668,
+            "fall": 25548,
+            "falls": 1,
+            "maxStep": 45332,
+            "endpoints": 116120,
+            "legs": [
+              19256,
+              -25548,
+              19256,
+              19256,
+              19244,
+              19244
+            ],
+            "gaps": [
+              16,
+              45332,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19250,
+            "legWorstDeviation": -2.327168831168831,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read -25548 B against a cohort median of 19250 B (-44798 B, -232.7%), past the ±25% leg tolerance (±4812.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read -25548 B against a cohort median of 19250 B (-44798 B, -232.7%), past the ±25% leg tolerance (±4812.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6790,
+            "perWrite": 23611.333333333332,
+            "perBoundaryPerWrite": 983.8055555555555,
+            "cdpBracket": 173220,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5343495,
+              5343511,
+              5369551,
+              5369567,
+              5388823,
+              5434155,
+              5408607,
+              5408623,
+              5427879,
+              5427895,
+              5447151,
+              5447167,
+              5466411,
+              5466427,
+              5485671
+            ],
+            "tick0": 133,
+            "tick": 140,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 508828,
+            "fall": 385332,
+            "falls": 1,
+            "maxStep": 429048,
+            "endpoints": 123496,
+            "legs": [
+              19696,
+              20740,
+              429048,
+              -385332,
+              19624,
+              19624
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19660,
+            "legWorstDeviation": 20.823397761953206,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 429048 B against a cohort median of 19660 B (+409388 B, 2082.3%), past the ±25% leg tolerance (±4915 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -385332 B against a cohort median of 19660 B (-404992 B, -2060.0%), past the ±25% leg tolerance (±4915 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 429048 B against a cohort median of 19660 B (+409388 B, 2082.3%), past the ±25% leg tolerance (±4915 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -385332 B against a cohort median of 19660 B (-404992 B, -2060.0%), past the ±25% leg tolerance (±4915 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6884,
+            "perWrite": 84804.66666666667,
+            "perBoundaryPerWrite": 3533.527777777778,
+            "cdpBracket": 178020,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5419255,
+              5419271,
+              5445815,
+              5445831,
+              5465527,
+              5465543,
+              5486283,
+              5486299,
+              5915347,
+              5915363,
+              5530031,
+              5530047,
+              5549671,
+              5549687,
+              5569311
+            ],
+            "tick0": 161,
+            "tick": 168,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 3,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 29120,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5381379,
+              5381395,
+              5381411,
+              5381427,
+              5381443,
+              5381459,
+              5381475,
+              5381491,
+              5381507,
+              5381523,
+              5381539,
+              5381555,
+              5381571,
+              5381587,
+              5381603
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5390315,
+              5390331,
+              5398395,
+              5398411,
+              5406475,
+              5406491,
+              5414555,
+              5414571,
+              5422635,
+              5422651,
+              5430715,
+              5430731,
+              5438795,
+              5438811,
+              5446875
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5385515,
+              5385531,
+              5388795,
+              5388811,
+              5392075,
+              5392091,
+              5395355,
+              5395371,
+              5398635,
+              5398651,
+              5401915,
+              5401931,
+              5405195,
+              5405211,
+              5408475
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 115596,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19256,
+            "endpoints": 115596,
+            "legs": [
+              19220,
+              19256,
+              19256,
+              19256,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": -0.0018695471541337765,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26028
+            ],
+            "primeExcess": 6772,
+            "perWrite": 19266,
+            "perBoundaryPerWrite": 802.75,
+            "cdpBracket": 169584,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5453047,
+              5453063,
+              5479091,
+              5479107,
+              5498327,
+              5498343,
+              5517599,
+              5517615,
+              5536871,
+              5536887,
+              5556143,
+              5556159,
+              5575415,
+              5575431,
+              5594687
+            ],
+            "tick0": 189,
+            "tick": 196,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120492,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22132,
+            "endpoints": 120492,
+            "legs": [
+              19696,
+              19696,
+              22132,
+              19624,
+              19624,
+              19624
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19660,
+            "legWorstDeviation": 0.12573753814852492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6884,
+            "perWrite": 20082,
+            "perBoundaryPerWrite": 836.75,
+            "cdpBracket": 175016,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5485027,
+              5485043,
+              5511587,
+              5511603,
+              5531299,
+              5531315,
+              5551011,
+              5551027,
+              5573159,
+              5573175,
+              5592799,
+              5592815,
+              5612439,
+              5612455,
+              5632079
+            ],
+            "tick0": 217,
+            "tick": 224,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 4,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5444099,
+              5444115,
+              5444131,
+              5444147,
+              5444163,
+              5444179,
+              5444195,
+              5444211,
+              5444227,
+              5444243,
+              5444259,
+              5444275,
+              5444291,
+              5444307,
+              5444323
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5452107,
+              5452123,
+              5460187,
+              5460203,
+              5468267,
+              5468283,
+              5476347,
+              5476363,
+              5484427,
+              5484443,
+              5492507,
+              5492523,
+              5500587,
+              5500603,
+              5508667
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5447307,
+              5447323,
+              5450587,
+              5450603,
+              5453867,
+              5453883,
+              5457147,
+              5457163,
+              5460427,
+              5460443,
+              5463707,
+              5463723,
+              5466987,
+              5467003,
+              5470267
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 100500,
+            "fall": 481084,
+            "falls": 1,
+            "maxStep": 22476,
+            "endpoints": -380584,
+            "legs": [
+              19584,
+              19448,
+              22476,
+              19448,
+              -481084,
+              19448
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19448,
+            "legWorstDeviation": -25.73693953105718,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read -481084 B against a cohort median of 19448 B (-500532 B, -2573.7%), past the ±25% leg tolerance (±4862 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read -481084 B against a cohort median of 19448 B (-500532 B, -2573.7%), past the ±25% leg tolerance (±4862 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              536548
+            ],
+            "primeExcess": 517100,
+            "perWrite": 16750,
+            "perBoundaryPerWrite": 697.9166666666666,
+            "cdpBracket": 184052,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5614251,
+              5614267,
+              6150815,
+              6150831,
+              6170415,
+              6170431,
+              6189879,
+              6189895,
+              6212371,
+              6212387,
+              6231835,
+              6231851,
+              5750767,
+              5750783,
+              5770231
+            ],
+            "tick0": 245,
+            "tick": 252,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 126056,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23136,
+            "endpoints": 126056,
+            "legs": [
+              19872,
+              23136,
+              22508,
+              19800,
+              20844,
+              19800
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20358,
+            "legWorstDeviation": 0.13645741231948127,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26736
+            ],
+            "primeExcess": 6378,
+            "perWrite": 21009.333333333332,
+            "perBoundaryPerWrite": 875.3888888888888,
+            "cdpBracket": 180772,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5704231,
+              5704247,
+              5730983,
+              5730999,
+              5750871,
+              5750887,
+              5774023,
+              5774039,
+              5796547,
+              5796563,
+              5816363,
+              5816379,
+              5837223,
+              5837239,
+              5857039
+            ],
+            "tick0": 273,
+            "tick": 280,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 5,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5665927,
+              5665943,
+              5665959,
+              5665975,
+              5665991,
+              5666007,
+              5666023,
+              5666039,
+              5666055,
+              5666071,
+              5666087,
+              5666103,
+              5666119,
+              5666135,
+              5666151
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5673935,
+              5673951,
+              5682015,
+              5682031,
+              5690095,
+              5690111,
+              5698175,
+              5698191,
+              5706255,
+              5706271,
+              5714335,
+              5714351,
+              5722415,
+              5722431,
+              5730495
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5669135,
+              5669151,
+              5672415,
+              5672431,
+              5675695,
+              5675711,
+              5678975,
+              5678991,
+              5682255,
+              5682271,
+              5685535,
+              5685551,
+              5688815,
+              5688831,
+              5692095
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 143992,
+            "fall": 24612,
+            "falls": 1,
+            "maxStep": 44808,
+            "endpoints": 119380,
+            "legs": [
+              19432,
+              20040,
+              44808,
+              19420,
+              19432,
+              20780
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              -24612,
+              16,
+              16
+            ],
+            "legMedian": 19736,
+            "legWorstDeviation": 1.270368869071747,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 44808 B against a cohort median of 19736 B (+25072 B, 127.0%), past the ±25% leg tolerance (±4934 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 44808 B against a cohort median of 19736 B (+25072 B, 127.0%), past the ±25% leg tolerance (±4934 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26232
+            ],
+            "primeExcess": 6496,
+            "perWrite": 23998.666666666668,
+            "perBoundaryPerWrite": 999.9444444444445,
+            "cdpBracket": 173572,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5719563,
+              5719579,
+              5745811,
+              5745827,
+              5765259,
+              5765275,
+              5785315,
+              5785331,
+              5830139,
+              5805527,
+              5824947,
+              5824963,
+              5844395,
+              5844411,
+              5865191
+            ],
+            "tick0": 301,
+            "tick": 308,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 326520,
+            "fall": 205020,
+            "falls": 1,
+            "maxStep": 226308,
+            "endpoints": 121500,
+            "legs": [
+              19872,
+              226308,
+              -205020,
+              19800,
+              19788,
+              19764
+            ],
+            "gaps": [
+              16,
+              16,
+              20908,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19794,
+            "legWorstDeviation": -11.357684146711124,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 226308 B against a cohort median of 19794 B (+206514 B, 1043.3%), past the ±25% leg tolerance (±4948.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -205020 B against a cohort median of 19794 B (-224814 B, -1135.8%), past the ±25% leg tolerance (±4948.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 226308 B against a cohort median of 19794 B (+206514 B, 1043.3%), past the ±25% leg tolerance (±4948.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -205020 B against a cohort median of 19794 B (-224814 B, -1135.8%), past the ±25% leg tolerance (±4948.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26736
+            ],
+            "primeExcess": 6942,
+            "perWrite": 54420,
+            "perBoundaryPerWrite": 2267.5,
+            "cdpBracket": 176216,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5744479,
+              5744495,
+              5771231,
+              5771247,
+              5791119,
+              5791135,
+              6017443,
+              6038351,
+              5833331,
+              5833347,
+              5853147,
+              5853163,
+              5872951,
+              5872967,
+              5892731
+            ],
+            "tick0": 329,
+            "tick": 336,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 6,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5705675,
+              5705691,
+              5705707,
+              5705723,
+              5705739,
+              5705755,
+              5705771,
+              5705787,
+              5705803,
+              5705819,
+              5705835,
+              5705851,
+              5705867,
+              5705883,
+              5705899
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5713683,
+              5713699,
+              5721763,
+              5721779,
+              5729843,
+              5729859,
+              5737923,
+              5737939,
+              5746003,
+              5746019,
+              5754083,
+              5754099,
+              5762163,
+              5762179,
+              5770243
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5708883,
+              5708899,
+              5712163,
+              5712179,
+              5715443,
+              5715459,
+              5718723,
+              5718739,
+              5722003,
+              5722019,
+              5725283,
+              5725299,
+              5728563,
+              5728579,
+              5731843
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 118152,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20164,
+            "endpoints": 118152,
+            "legs": [
+              19416,
+              19828,
+              19816,
+              20164,
+              19416,
+              19416
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19616,
+            "legWorstDeviation": 0.02793637846655791,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26216
+            ],
+            "primeExcess": 6600,
+            "perWrite": 19692,
+            "perBoundaryPerWrite": 820.5,
+            "cdpBracket": 172456,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5763791,
+              5763807,
+              5790023,
+              5790039,
+              5809455,
+              5809471,
+              5829299,
+              5829315,
+              5849131,
+              5849147,
+              5869311,
+              5869327,
+              5888743,
+              5888759,
+              5908175
+            ],
+            "tick0": 357,
+            "tick": 364,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122460,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23480,
+            "endpoints": 122460,
+            "legs": [
+              23480,
+              19784,
+              19784,
+              19748,
+              19784,
+              19784
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19784,
+            "legWorstDeviation": 0.18681763040841085,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26720
+            ],
+            "primeExcess": 6936,
+            "perWrite": 20410,
+            "perBoundaryPerWrite": 850.4166666666666,
+            "cdpBracket": 177160,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5790307,
+              5790323,
+              5817043,
+              5817059,
+              5840539,
+              5840555,
+              5860339,
+              5860355,
+              5880139,
+              5880155,
+              5899903,
+              5899919,
+              5919703,
+              5919719,
+              5939503
+            ],
+            "tick0": 385,
+            "tick": 392,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 7,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 2320,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 2144,
+            "endpoints": 2320,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              2144
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 386.6666666666667,
+            "cdpBracket": 28812,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5750459,
+              5750475,
+              5750491,
+              5750507,
+              5750523,
+              5750539,
+              5750555,
+              5750571,
+              5750587,
+              5750603,
+              5750619,
+              5750635,
+              5750651,
+              5752795,
+              5752811
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5758975,
+              5758991,
+              5767055,
+              5767071,
+              5775135,
+              5775151,
+              5783215,
+              5783231,
+              5791295,
+              5791311,
+              5799375,
+              5799391,
+              5807455,
+              5807471,
+              5815535
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5754175,
+              5754191,
+              5757455,
+              5757471,
+              5760735,
+              5760751,
+              5764015,
+              5764031,
+              5767295,
+              5767311,
+              5770575,
+              5770591,
+              5773855,
+              5773871,
+              5777135
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 121052,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 31564,
+            "endpoints": 121052,
+            "legs": [
+              19396,
+              19396,
+              20320,
+              31564,
+              10872,
+              19408
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19402,
+            "legWorstDeviation": 0.626842593547057,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 31564 B against a cohort median of 19402 B (+12162 B, 62.7%), past the ±25% leg tolerance (±4850.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read 10872 B against a cohort median of 19402 B (-8530 B, -44.0%), past the ±25% leg tolerance (±4850.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 31564 B against a cohort median of 19402 B (+12162 B, 62.7%), past the ±25% leg tolerance (±4850.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read 10872 B against a cohort median of 19402 B (-8530 B, -44.0%), past the ±25% leg tolerance (±4850.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26208
+            ],
+            "primeExcess": 6806,
+            "perWrite": 20175.333333333332,
+            "perBoundaryPerWrite": 840.6388888888888,
+            "cdpBracket": 182144,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5818195,
+              5818211,
+              5844419,
+              5844435,
+              5863831,
+              5863847,
+              5883243,
+              5883259,
+              5903579,
+              5903595,
+              5935159,
+              5935175,
+              5946047,
+              5946063,
+              5965471
+            ],
+            "tick0": 413,
+            "tick": 420,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 125100,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22920,
+            "endpoints": 125100,
+            "legs": [
+              19836,
+              22164,
+              19776,
+              19764,
+              22920,
+              20544
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20190,
+            "legWorstDeviation": 0.1352154531946508,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26712
+            ],
+            "primeExcess": 6522,
+            "perWrite": 20850,
+            "perBoundaryPerWrite": 868.75,
+            "cdpBracket": 179792,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5844255,
+              5844271,
+              5870983,
+              5870999,
+              5890835,
+              5890851,
+              5913015,
+              5913031,
+              5932807,
+              5932823,
+              5952587,
+              5952603,
+              5975523,
+              5975539,
+              5996083
+            ],
+            "tick0": 441,
+            "tick": 448,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 8,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5807227,
+              5807243,
+              5807259,
+              5807275,
+              5807291,
+              5807307,
+              5807323,
+              5807339,
+              5807355,
+              5807371,
+              5807387,
+              5807403,
+              5807419,
+              5807435,
+              5807451
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5815235,
+              5815251,
+              5823315,
+              5823331,
+              5831395,
+              5831411,
+              5839475,
+              5839491,
+              5847555,
+              5847571,
+              5855635,
+              5855651,
+              5863715,
+              5863731,
+              5871795
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5810435,
+              5810451,
+              5813715,
+              5813731,
+              5816995,
+              5817011,
+              5820275,
+              5820291,
+              5823555,
+              5823571,
+              5826835,
+              5826851,
+              5830115,
+              5830131,
+              5833395
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 118968,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21120,
+            "endpoints": 118968,
+            "legs": [
+              19396,
+              21120,
+              19396,
+              20144,
+              19408,
+              19408
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19408,
+            "legWorstDeviation": 0.08821104699093157,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26208
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19828,
+            "perBoundaryPerWrite": 826.1666666666666,
+            "cdpBracket": 173264,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5872483,
+              5872499,
+              5898707,
+              5898723,
+              5918119,
+              5918135,
+              5939255,
+              5939271,
+              5958667,
+              5958683,
+              5978827,
+              5978843,
+              5998251,
+              5998267,
+              6017675
+            ],
+            "tick0": 469,
+            "tick": 476,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 305836,
+            "fall": 176164,
+            "falls": 1,
+            "maxStep": 229412,
+            "endpoints": 129672,
+            "legs": [
+              229412,
+              -176164,
+              17024,
+              19764,
+              19764,
+              19776
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19764,
+            "legWorstDeviation": 10.607569317951832,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 229412 B against a cohort median of 19764 B (+209648 B, 1060.8%), past the ±25% leg tolerance (±4941 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -176164 B against a cohort median of 19764 B (-195928 B, -991.3%), past the ±25% leg tolerance (±4941 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 229412 B against a cohort median of 19764 B (+209648 B, 1060.8%), past the ±25% leg tolerance (±4941 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -176164 B against a cohort median of 19764 B (-195928 B, -991.3%), past the ±25% leg tolerance (±4941 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26712
+            ],
+            "primeExcess": 6948,
+            "perWrite": 50972.666666666664,
+            "perBoundaryPerWrite": 2123.861111111111,
+            "cdpBracket": 184364,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5907719,
+              5907735,
+              5934447,
+              5934463,
+              6163875,
+              6163891,
+              5987727,
+              5987743,
+              6004767,
+              6004783,
+              6024547,
+              6024563,
+              6044327,
+              6044343,
+              6064119
+            ],
+            "tick0": 497,
+            "tick": 504,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 9,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5875115,
+              5875131,
+              5875147,
+              5875163,
+              5875179,
+              5875195,
+              5875211,
+              5875227,
+              5875243,
+              5875259,
+              5875275,
+              5875291,
+              5875307,
+              5875323,
+              5875339
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5883123,
+              5883139,
+              5891203,
+              5891219,
+              5899283,
+              5899299,
+              5907363,
+              5907379,
+              5915443,
+              5915459,
+              5923523,
+              5923539,
+              5931603,
+              5931619,
+              5939683
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5878323,
+              5878339,
+              5881603,
+              5881619,
+              5884883,
+              5884899,
+              5888163,
+              5888179,
+              5891443,
+              5891459,
+              5894723,
+              5894739,
+              5898003,
+              5898019,
+              5901283
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117220,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20136,
+            "endpoints": 117220,
+            "legs": [
+              19400,
+              19400,
+              19388,
+              20136,
+              19400,
+              19400
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19400,
+            "legWorstDeviation": 0.03793814432989691,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26188
+            ],
+            "primeExcess": 6788,
+            "perWrite": 19536.666666666668,
+            "perBoundaryPerWrite": 814.0277777777778,
+            "cdpBracket": 171368,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5933083,
+              5933099,
+              5959287,
+              5959303,
+              5978703,
+              5978719,
+              5998119,
+              5998135,
+              6017523,
+              6017539,
+              6037675,
+              6037691,
+              6057091,
+              6057107,
+              6076507
+            ],
+            "tick0": 525,
+            "tick": 532,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 481752,
+            "fall": 351916,
+            "falls": 2,
+            "maxStep": 402336,
+            "endpoints": 129836,
+            "legs": [
+              19840,
+              19840,
+              19828,
+              19828,
+              402336,
+              -305476
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              -46440
+            ],
+            "legMedian": 19834,
+            "legWorstDeviation": 19.28516688514672,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read 402336 B against a cohort median of 19834 B (+382502 B, 1928.5%), past the ±25% leg tolerance (±4958.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read -305476 B against a cohort median of 19834 B (-325310 B, -1640.2%), past the ±25% leg tolerance (±4958.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read 402336 B against a cohort median of 19834 B (+382502 B, 1928.5%), past the ±25% leg tolerance (±4958.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read -305476 B against a cohort median of 19834 B (-325310 B, -1640.2%), past the ±25% leg tolerance (±4958.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26704
+            ],
+            "primeExcess": 6870,
+            "perWrite": 80292,
+            "perBoundaryPerWrite": 3345.5,
+            "cdpBracket": 185264,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5955443,
+              5955459,
+              5982163,
+              5982179,
+              6002019,
+              6002035,
+              6021875,
+              6021891,
+              6041719,
+              6041735,
+              6061563,
+              6061579,
+              6463915,
+              6417475,
+              6111999
+            ],
+            "tick0": 553,
+            "tick": 560,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 10,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5925251,
+              5925267,
+              5925283,
+              5925299,
+              5925315,
+              5925331,
+              5925347,
+              5925363,
+              5925379,
+              5925395,
+              5925411,
+              5925427,
+              5925443,
+              5925459,
+              5925475
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5933259,
+              5933275,
+              5941339,
+              5941355,
+              5949419,
+              5949435,
+              5957499,
+              5957515,
+              5965579,
+              5965595,
+              5973659,
+              5973675,
+              5981739,
+              5981755,
+              5989819
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5928459,
+              5928475,
+              5931739,
+              5931755,
+              5935019,
+              5935035,
+              5938299,
+              5938315,
+              5941579,
+              5941595,
+              5944859,
+              5944875,
+              5948139,
+              5948155,
+              5951419
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117208,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20148,
+            "endpoints": 117208,
+            "legs": [
+              19400,
+              19364,
+              19400,
+              20148,
+              19400,
+              19400
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19400,
+            "legWorstDeviation": 0.038556701030927835,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26200
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19534.666666666668,
+            "perBoundaryPerWrite": 813.9444444444445,
+            "cdpBracket": 174008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5981427,
+              5981443,
+              6007643,
+              6007659,
+              6027059,
+              6027075,
+              6046439,
+              6046455,
+              6065855,
+              6065871,
+              6086019,
+              6086035,
+              6105435,
+              6105451,
+              6124851
+            ],
+            "tick0": 581,
+            "tick": 588,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120360,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21140,
+            "endpoints": 120360,
+            "legs": [
+              19820,
+              19832,
+              19820,
+              21140,
+              19832,
+              19820
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19826,
+            "legWorstDeviation": 0.06627660647634419,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26684
+            ],
+            "primeExcess": 6858,
+            "perWrite": 20060,
+            "perBoundaryPerWrite": 835.8333333333334,
+            "cdpBracket": 176516,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5994671,
+              5994687,
+              6021371,
+              6021387,
+              6041207,
+              6041223,
+              6061055,
+              6061071,
+              6080891,
+              6080907,
+              6102047,
+              6102063,
+              6121895,
+              6121911,
+              6141731
+            ],
+            "tick0": 609,
+            "tick": 616,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 11,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5954847,
+              5954863,
+              5954879,
+              5954895,
+              5954911,
+              5954927,
+              5954943,
+              5954959,
+              5954975,
+              5954991,
+              5955007,
+              5955023,
+              5955039,
+              5955055,
+              5955071
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5962855,
+              5962871,
+              5970935,
+              5970951,
+              5979015,
+              5979031,
+              5987095,
+              5987111,
+              5995175,
+              5995191,
+              6003255,
+              6003271,
+              6011335,
+              6011351,
+              6019415
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5958055,
+              5958071,
+              5961335,
+              5961351,
+              5964615,
+              5964631,
+              5967895,
+              5967911,
+              5971175,
+              5971191,
+              5974455,
+              5974471,
+              5977735,
+              5977751,
+              5981015
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117112,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20132,
+            "endpoints": 117112,
+            "legs": [
+              19372,
+              19372,
+              19384,
+              20132,
+              19384,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.03891010424192383,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19518.666666666668,
+            "perBoundaryPerWrite": 813.2777777777778,
+            "cdpBracket": 171256,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6000755,
+              6000771,
+              6026955,
+              6026971,
+              6046343,
+              6046359,
+              6065731,
+              6065747,
+              6085131,
+              6085147,
+              6105279,
+              6105295,
+              6124679,
+              6124695,
+              6144067
+            ],
+            "tick0": 637,
+            "tick": 644,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118968,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19812,
+            "endpoints": 118968,
+            "legs": [
+              19812,
+              19812,
+              19812,
+              19812,
+              19812,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              31920
+            ],
+            "primeExcess": 12108,
+            "perWrite": 19828,
+            "perBoundaryPerWrite": 826.1666666666666,
+            "cdpBracket": 180080,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6029343,
+              6029359,
+              6061279,
+              6061295,
+              6081107,
+              6081123,
+              6100935,
+              6100951,
+              6120763,
+              6120779,
+              6140591,
+              6140607,
+              6160419,
+              6160435,
+              6180247
+            ],
+            "tick0": 665,
+            "tick": 672,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 12,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5993647,
+              5993663,
+              5993679,
+              5993695,
+              5993711,
+              5993727,
+              5993743,
+              5993759,
+              5993775,
+              5993791,
+              5993807,
+              5993823,
+              5993839,
+              5993855,
+              5993871
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6001655,
+              6001671,
+              6009735,
+              6009751,
+              6017815,
+              6017831,
+              6025895,
+              6025911,
+              6033975,
+              6033991,
+              6042055,
+              6042071,
+              6050135,
+              6050151,
+              6058215
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5996855,
+              5996871,
+              6000135,
+              6000151,
+              6003415,
+              6003431,
+              6006695,
+              6006711,
+              6009975,
+              6009991,
+              6013255,
+              6013271,
+              6016535,
+              6016551,
+              6019815
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 134816,
+            "fall": 17000,
+            "falls": 1,
+            "maxStep": 57220,
+            "endpoints": 117816,
+            "legs": [
+              19384,
+              19372,
+              19372,
+              57220,
+              -17000,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 1.9537476770596738,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 57220 B against a cohort median of 19372 B (+37848 B, 195.4%), past the ±25% leg tolerance (±4843 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -17000 B against a cohort median of 19372 B (-36372 B, -187.8%), past the ±25% leg tolerance (±4843 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 57220 B against a cohort median of 19372 B (+37848 B, 195.4%), past the ±25% leg tolerance (±4843 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -17000 B against a cohort median of 19372 B (-36372 B, -187.8%), past the ±25% leg tolerance (±4843 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 22469.333333333332,
+            "perBoundaryPerWrite": 936.2222222222222,
+            "cdpBracket": 172072,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6058699,
+              6058715,
+              6084899,
+              6084915,
+              6104299,
+              6104315,
+              6123687,
+              6123703,
+              6143075,
+              6143091,
+              6200311,
+              6200327,
+              6183327,
+              6183343,
+              6202715
+            ],
+            "tick0": 693,
+            "tick": 700,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120060,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20868,
+            "endpoints": 120060,
+            "legs": [
+              19812,
+              19824,
+              19812,
+              20868,
+              19824,
+              19824
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.0526634382566586,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20010,
+            "perBoundaryPerWrite": 833.75,
+            "cdpBracket": 174712,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6087599,
+              6087615,
+              6114303,
+              6114319,
+              6134131,
+              6134147,
+              6153971,
+              6153987,
+              6173799,
+              6173815,
+              6194683,
+              6194699,
+              6214523,
+              6214539,
+              6234363
+            ],
+            "tick0": 721,
+            "tick": 728,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 13,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 31952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6047703,
+              6047719,
+              6047735,
+              6047751,
+              6047767,
+              6047783,
+              6047799,
+              6047815,
+              6047831,
+              6047847,
+              6047863,
+              6047879,
+              6047895,
+              6047911,
+              6047927
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6059731,
+              6059747,
+              6067811,
+              6067827,
+              6075891,
+              6075907,
+              6083971,
+              6083987,
+              6092051,
+              6092067,
+              6100131,
+              6100147,
+              6108211,
+              6108227,
+              6116291
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6054931,
+              6054947,
+              6058211,
+              6058227,
+              6061491,
+              6061507,
+              6064771,
+              6064787,
+              6068051,
+              6068067,
+              6071331,
+              6071347,
+              6074611,
+              6074627,
+              6077891
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117088,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20132,
+            "endpoints": 117088,
+            "legs": [
+              19348,
+              19372,
+              19384,
+              20132,
+              19384,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.03891010424192383,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19514.666666666668,
+            "perBoundaryPerWrite": 813.1111111111112,
+            "cdpBracket": 171216,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6096663,
+              6096679,
+              6122863,
+              6122879,
+              6142227,
+              6142243,
+              6161615,
+              6161631,
+              6181015,
+              6181031,
+              6201163,
+              6201179,
+              6220563,
+              6220579,
+              6239951
+            ],
+            "tick0": 749,
+            "tick": 756,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118980,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 118980,
+            "legs": [
+              19824,
+              19812,
+              19812,
+              19812,
+              19812,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": 0.0006056935190793458,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6876,
+            "perWrite": 19830,
+            "perBoundaryPerWrite": 826.25,
+            "cdpBracket": 173632,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6108671,
+              6108687,
+              6135375,
+              6135391,
+              6155215,
+              6155231,
+              6175043,
+              6175059,
+              6194871,
+              6194887,
+              6214699,
+              6214715,
+              6234527,
+              6234543,
+              6254355
+            ],
+            "tick0": 777,
+            "tick": 784,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 14,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6067707,
+              6067723,
+              6067739,
+              6067755,
+              6067771,
+              6067787,
+              6067803,
+              6067819,
+              6067835,
+              6067851,
+              6067867,
+              6067883,
+              6067899,
+              6067915,
+              6067931
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6075715,
+              6075731,
+              6083795,
+              6083811,
+              6091875,
+              6091891,
+              6099955,
+              6099971,
+              6108035,
+              6108051,
+              6116115,
+              6116131,
+              6124195,
+              6124211,
+              6132275
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6070915,
+              6070931,
+              6074195,
+              6074211,
+              6077475,
+              6077491,
+              6080755,
+              6080771,
+              6084035,
+              6084051,
+              6087315,
+              6087331,
+              6090595,
+              6090611,
+              6093875
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117112,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20132,
+            "endpoints": 117112,
+            "legs": [
+              19372,
+              19372,
+              19384,
+              19372,
+              20132,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.03891010424192383,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19518.666666666668,
+            "perBoundaryPerWrite": 813.2777777777778,
+            "cdpBracket": 173884,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6113251,
+              6113267,
+              6139451,
+              6139467,
+              6158839,
+              6158855,
+              6178227,
+              6178243,
+              6197627,
+              6197643,
+              6217015,
+              6217031,
+              6237163,
+              6237179,
+              6256563
+            ],
+            "tick0": 805,
+            "tick": 812,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120012,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20844,
+            "endpoints": 120012,
+            "legs": [
+              19812,
+              19812,
+              19824,
+              20844,
+              19812,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": 0.05208964264082374,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6876,
+            "perWrite": 20002,
+            "perBoundaryPerWrite": 833.4166666666666,
+            "cdpBracket": 174664,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6131091,
+              6131107,
+              6157795,
+              6157811,
+              6177623,
+              6177639,
+              6197451,
+              6197467,
+              6217291,
+              6217307,
+              6238151,
+              6238167,
+              6257979,
+              6257995,
+              6277807
+            ],
+            "tick0": 833,
+            "tick": 840,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 15,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6091195,
+              6091211,
+              6091227,
+              6091243,
+              6091259,
+              6091275,
+              6091291,
+              6091307,
+              6091323,
+              6091339,
+              6091355,
+              6091371,
+              6091387,
+              6091403,
+              6091419
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6099203,
+              6099219,
+              6107283,
+              6107299,
+              6115363,
+              6115379,
+              6123443,
+              6123459,
+              6131523,
+              6131539,
+              6139603,
+              6139619,
+              6147683,
+              6147699,
+              6155763
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6094403,
+              6094419,
+              6097683,
+              6097699,
+              6100963,
+              6100979,
+              6104243,
+              6104259,
+              6107523,
+              6107539,
+              6110803,
+              6110819,
+              6114083,
+              6114099,
+              6117363
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117124,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20120,
+            "endpoints": 117124,
+            "legs": [
+              19372,
+              19384,
+              19384,
+              19384,
+              19384,
+              20120
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19384,
+            "legWorstDeviation": 0.037969459347915804,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26148
+            ],
+            "primeExcess": 6764,
+            "perWrite": 19520.666666666668,
+            "perBoundaryPerWrite": 813.3611111111112,
+            "cdpBracket": 171216,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6138747,
+              6138763,
+              6164911,
+              6164927,
+              6184299,
+              6184315,
+              6203699,
+              6203715,
+              6223099,
+              6223115,
+              6242499,
+              6242515,
+              6261899,
+              6261915,
+              6282035
+            ],
+            "tick0": 861,
+            "tick": 868,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119004,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 119004,
+            "legs": [
+              19824,
+              19824,
+              19812,
+              19824,
+              19812,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 0.0003027550711474417,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6870,
+            "perWrite": 19834,
+            "perBoundaryPerWrite": 826.4166666666666,
+            "cdpBracket": 173656,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6159735,
+              6159751,
+              6186439,
+              6186455,
+              6206279,
+              6206295,
+              6226119,
+              6226135,
+              6245947,
+              6245963,
+              6265787,
+              6265803,
+              6285615,
+              6285631,
+              6305443
+            ],
+            "tick0": 889,
+            "tick": 896,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 16,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6113655,
+              6113671,
+              6113687,
+              6113703,
+              6113719,
+              6113735,
+              6113751,
+              6113767,
+              6113783,
+              6113799,
+              6113815,
+              6113831,
+              6113847,
+              6113863,
+              6113879
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6121663,
+              6121679,
+              6129743,
+              6129759,
+              6137823,
+              6137839,
+              6145903,
+              6145919,
+              6153983,
+              6153999,
+              6162063,
+              6162079,
+              6170143,
+              6170159,
+              6178223
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6116863,
+              6116879,
+              6120143,
+              6120159,
+              6123423,
+              6123439,
+              6126703,
+              6126719,
+              6129983,
+              6129999,
+              6133263,
+              6133279,
+              6136543,
+              6136559,
+              6139823
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117076,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20120,
+            "endpoints": 117076,
+            "legs": [
+              19372,
+              19384,
+              19384,
+              19372,
+              19348,
+              20120
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.038290845288471466,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6794,
+            "perWrite": 19512.666666666668,
+            "perBoundaryPerWrite": 813.0277777777778,
+            "cdpBracket": 171320,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6152243,
+              6152259,
+              6178431,
+              6178447,
+              6197819,
+              6197835,
+              6217219,
+              6217235,
+              6236619,
+              6236635,
+              6256007,
+              6256023,
+              6275371,
+              6275387,
+              6295507
+            ],
+            "tick0": 917,
+            "tick": 924,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 125560,
+            "fall": 1576,
+            "falls": 1,
+            "maxStep": 22752,
+            "endpoints": 123984,
+            "legs": [
+              19812,
+              22752,
+              22412,
+              20880,
+              19812,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              -1576,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20346,
+            "legWorstDeviation": 0.11825420230020643,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6342,
+            "perWrite": 20926.666666666668,
+            "perBoundaryPerWrite": 871.9444444444445,
+            "cdpBracket": 178636,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6168795,
+              6168811,
+              6195499,
+              6195515,
+              6215327,
+              6215343,
+              6238095,
+              6236519,
+              6258931,
+              6258947,
+              6279827,
+              6279843,
+              6299655,
+              6299671,
+              6319483
+            ],
+            "tick0": 945,
+            "tick": 952,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 17,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6126039,
+              6126055,
+              6126071,
+              6126087,
+              6126103,
+              6126119,
+              6126135,
+              6126151,
+              6126167,
+              6126183,
+              6126199,
+              6126215,
+              6126231,
+              6126247,
+              6126263
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6134047,
+              6134063,
+              6142127,
+              6142143,
+              6150207,
+              6150223,
+              6158287,
+              6158303,
+              6166367,
+              6166383,
+              6174447,
+              6174463,
+              6182527,
+              6182543,
+              6190607
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6129247,
+              6129263,
+              6132527,
+              6132543,
+              6135807,
+              6135823,
+              6139087,
+              6139103,
+              6142367,
+              6142383,
+              6145647,
+              6145663,
+              6148927,
+              6148943,
+              6152207
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117112,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20120,
+            "endpoints": 117112,
+            "legs": [
+              19384,
+              19372,
+              19372,
+              19384,
+              20120,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19384,
+            "legWorstDeviation": 0.037969459347915804,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6788,
+            "perWrite": 19518.666666666668,
+            "perBoundaryPerWrite": 813.2777777777778,
+            "cdpBracket": 171228,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6180507,
+              6180523,
+              6206695,
+              6206711,
+              6226095,
+              6226111,
+              6245483,
+              6245499,
+              6264871,
+              6264887,
+              6284271,
+              6284287,
+              6304407,
+              6304423,
+              6323807
+            ],
+            "tick0": 973,
+            "tick": 980,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119028,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19828,
+            "endpoints": 119028,
+            "legs": [
+              19816,
+              19828,
+              19816,
+              19828,
+              19828,
+              19816
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19822,
+            "legWorstDeviation": -0.0003026939763898698,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26680
+            ],
+            "primeExcess": 6858,
+            "perWrite": 19838,
+            "perBoundaryPerWrite": 826.5833333333334,
+            "cdpBracket": 173672,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6196555,
+              6196571,
+              6223251,
+              6223267,
+              6243083,
+              6243099,
+              6262927,
+              6262943,
+              6282759,
+              6282775,
+              6302603,
+              6302619,
+              6322447,
+              6322463,
+              6342279
+            ],
+            "tick0": 1001,
+            "tick": 1008,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      }
+    ],
+    "allocFits": {
+      "perRound": {},
+      "mean": {}
+    },
+    "writeDriven": true,
+    "writeProvenance": {
+      "windows": 36,
+      "pairs": 36,
+      "unnamed": [],
+      "incomplete": [],
+      "ok": true
+    },
+    "controlVerdict": {
+      "ok": true,
+      "perDouble": 8.08088888888889,
+      "differential": 8.00148148148148
+    },
+    "fallsInMeasuredWindows": 15,
+    "refusedWindows": 13,
+    "refusalReasons": 24
+  },
+  "box": {
+    "bead": "rf2-24o2z",
+    "chromium": "chromium/147.0.7727.15",
+    "node": "v24.13.0",
+    "platform": "win32/x64/10.0.26200",
+    "load": {
+      "open": {
+        "at": "2026-08-20T20:28:06.061Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13474789865,
+        "cpuBusyMs": 3627090467,
+        "freeMemB": 16184250368,
+        "totalMemB": 68112736256,
+        "uptimeS": 708848.859
+      },
+      "close": {
+        "at": "2026-08-20T20:28:32.258Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13475299957,
+        "cpuBusyMs": 3627212329,
+        "freeMemB": 16220778496,
+        "totalMemB": 68112736256,
+        "uptimeS": 708875.062
+      },
+      "busyFraction": 0.19283365561417445
+    },
+    "session": {
+      "startedAt": "2026-08-20T20:27:29.240Z",
+      "sessionStartedAt": "2026-08-20T19:39:26.627Z",
+      "runsInSession": 7,
+      "sessionGapMs": 3600000,
+      "previousRun": {
+        "startedAt": "2026-08-20T20:26:27.996Z",
+        "endedAt": "2026-08-20T20:27:29.089Z",
+        "sinceStartMs": 61244,
+        "sinceEndMs": 151,
+        "sameSession": true
+      }
+    }
+  }
+}

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/fixed-3.json
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/fixed-3.json
@@ -1,0 +1,7535 @@
+{
+  "generatedAt": "2026-08-20T20:31:10.805Z",
+  "build": "hicasso-bench",
+  "initFn": "re-frame.bench.p0-app/-main",
+  "alloc": {
+    "benchmark": "P0:steady-state-allocation-slope",
+    "bead": "rf2-2rtt6.76",
+    "roots": 4,
+    "perRoot": {
+      "list": 300,
+      "grid": 6
+    },
+    "publishedPerRoot": {
+      "list": 300,
+      "grid": 300
+    },
+    "arm": {
+      "cells": 6,
+      "roots": 4,
+      "boundaries": 24,
+      "writes": 6,
+      "refusals": [],
+      "admissible": true
+    },
+    "boundaries": 24,
+    "writes": 6,
+    "primeWrites": 1,
+    "windowWrites": 7,
+    "bySite": false,
+    "sites": 2,
+    "siteNames": [
+      "dispatch",
+      "drain"
+    ],
+    "warmups": 3,
+    "rounds": 18,
+    "preciseMemory": true,
+    "controlDoubles": {
+      "d1": 1000,
+      "d2": 400
+    },
+    "controlSlack": 0.75,
+    "writeSelector": "all",
+    "writeLegs": [
+      "all"
+    ],
+    "writePaired": false,
+    "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+    "plan": {
+      "name": "floor",
+      "arms": true,
+      "rungs": false,
+      "fits": false
+    },
+    "segOrder": "fixed",
+    "passOrder": "parity",
+    "passSeed": "1787257837667",
+    "passSchedule": {
+      "flips": [
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true
+      ],
+      "attempts": 1,
+      "parityTied": false
+    },
+    "controlSlot": "first",
+    "instrument": "in-page performance.memory.usedJSHeapSize sampled at every leg boundary, rising steps accumulated separately from falling ones; --enable-precise-memory-info. A falling step is a collection this counter SAW; a leg that deviates from its cohort median by more than the leg tolerance is a work unit that is not one; and under the by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the other two can see. TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg has no interior reading and so no site step to be negative, and the intra-leg gate returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with these (see `bySite`), so a witness comparing byte for byte against a figure published at stride 2 can never be screened by all three",
+    "fallThresholdB": 600000,
+    "legTolerance": 0.25,
+    "verification": {
+      "unverified": 0,
+      "detail": []
+    },
+    "workCount": false,
+    "workVerification": {
+      "counted": false
+    },
+    "perRound": [
+      {
+        "round": 0,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 524,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              524
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 116.66666666666667,
+            "cdpBracket": 46232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3840262,
+              3840278,
+              3840294,
+              3840310,
+              3840326,
+              3840342,
+              3840358,
+              3840374,
+              3840390,
+              3840406,
+              3840422,
+              3840438,
+              3840454,
+              3840978,
+              3840994
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48576,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8144,
+            "endpoints": 48576,
+            "legs": [
+              8144,
+              8080,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.00992063492063492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8096,
+            "cdpBracket": 87388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3853886,
+              3853902,
+              3861966,
+              3861982,
+              3870126,
+              3870142,
+              3878222,
+              3878238,
+              3886302,
+              3886318,
+              3894382,
+              3894398,
+              3902462,
+              3902478,
+              3910542
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 52328,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3849986,
+              3850002,
+              3853266,
+              3853282,
+              3856546,
+              3856562,
+              3859826,
+              3859842,
+              3863106,
+              3863122,
+              3866386,
+              3866402,
+              3869666,
+              3869682,
+              3872946
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 655668,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 303932,
+            "endpoints": 655668,
+            "legs": [
+              21384,
+              19692,
+              19752,
+              303932,
+              282000,
+              8812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20568,
+            "legWorstDeviation": 13.776935044729678,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 303932 B against a cohort median of 20568 B (+283364 B, 1377.7%), past the ±25% leg tolerance (±5142 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read 282000 B against a cohort median of 20568 B (+261432 B, 1271.1%), past the ±25% leg tolerance (±5142 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read 8812 B against a cohort median of 20568 B (-11756 B, -57.2%), past the ±25% leg tolerance (±5142 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 303932 B against a cohort median of 20568 B (+283364 B, 1377.7%), past the ±25% leg tolerance (±5142 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read 282000 B against a cohort median of 20568 B (+261432 B, 1271.1%), past the ±25% leg tolerance (±5142 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read 8812 B against a cohort median of 20568 B (-11756 B, -57.2%), past the ±25% leg tolerance (±5142 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26460
+            ],
+            "primeExcess": 5892,
+            "perWrite": 109278,
+            "perBoundaryPerWrite": 4553.25,
+            "cdpBracket": 193712,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              4777307,
+              4777323,
+              4803783,
+              4803799,
+              4825183,
+              4825199,
+              4844891,
+              4844907,
+              4864659,
+              4864675,
+              5168607,
+              5168623,
+              5450623,
+              5450639,
+              5459451
+            ],
+            "tick0": 21,
+            "tick": 28,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 411108,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 304424,
+            "endpoints": 411108,
+            "legs": [
+              23520,
+              19916,
+              22160,
+              304424,
+              20536,
+              20456
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21348,
+            "legWorstDeviation": 13.260071201049278,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 304424 B against a cohort median of 21348 B (+283076 B, 1326.0%), past the ±25% leg tolerance (±5337 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 304424 B against a cohort median of 21348 B (+283076 B, 1326.0%), past the ±25% leg tolerance (±5337 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26764
+            ],
+            "primeExcess": 5416,
+            "perWrite": 68518,
+            "perBoundaryPerWrite": 2854.9166666666665,
+            "cdpBracket": 200896,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5067139,
+              5067155,
+              5093919,
+              5093935,
+              5117455,
+              5117471,
+              5137387,
+              5137403,
+              5159563,
+              5159579,
+              5464003,
+              5464019,
+              5484555,
+              5484571,
+              5505027
+            ],
+            "tick0": 49,
+            "tick": 56,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 1,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5053411,
+              5053427,
+              5053443,
+              5053459,
+              5053475,
+              5053491,
+              5053507,
+              5053523,
+              5053539,
+              5053555,
+              5053571,
+              5053587,
+              5053603,
+              5053619,
+              5053635
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 87716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5061419,
+              5061435,
+              5069499,
+              5069515,
+              5077579,
+              5077595,
+              5085659,
+              5085675,
+              5093739,
+              5093755,
+              5101819,
+              5101835,
+              5109899,
+              5109915,
+              5117979
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5058863,
+              5058879,
+              5062143,
+              5062159,
+              5065423,
+              5065439,
+              5068703,
+              5068719,
+              5071983,
+              5071999,
+              5075263,
+              5075279,
+              5078543,
+              5078559,
+              5081823
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 120952,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21744,
+            "endpoints": 120952,
+            "legs": [
+              19840,
+              19320,
+              19332,
+              21744,
+              19332,
+              21288
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19586,
+            "legWorstDeviation": 0.11018074134585928,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              31636
+            ],
+            "primeExcess": 12050,
+            "perWrite": 20158.666666666668,
+            "perBoundaryPerWrite": 839.9444444444445,
+            "cdpBracket": 184120,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5181235,
+              5181251,
+              5212887,
+              5212903,
+              5232743,
+              5232759,
+              5252079,
+              5252095,
+              5271427,
+              5271443,
+              5293187,
+              5293203,
+              5312535,
+              5312551,
+              5333839
+            ],
+            "tick0": 77,
+            "tick": 84,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 355168,
+            "fall": 228868,
+            "falls": 1,
+            "maxStep": 275808,
+            "endpoints": 126300,
+            "legs": [
+              19696,
+              275808,
+              -228868,
+              19588,
+              19624,
+              20356
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19660,
+            "legWorstDeviation": 13.028891149542218,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 275808 B against a cohort median of 19660 B (+256148 B, 1302.9%), past the ±25% leg tolerance (±4915 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -228868 B against a cohort median of 19660 B (-248528 B, -1264.1%), past the ±25% leg tolerance (±4915 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 275808 B against a cohort median of 19660 B (+256148 B, 1302.9%), past the ±25% leg tolerance (±4915 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -228868 B against a cohort median of 19660 B (-248528 B, -1264.1%), past the ±25% leg tolerance (±4915 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6884,
+            "perWrite": 59194.666666666664,
+            "perBoundaryPerWrite": 2466.4444444444443,
+            "cdpBracket": 181280,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5297999,
+              5298015,
+              5324559,
+              5324575,
+              5344271,
+              5344287,
+              5620095,
+              5620111,
+              5391243,
+              5391259,
+              5410847,
+              5410863,
+              5430487,
+              5430503,
+              5450859
+            ],
+            "tick0": 105,
+            "tick": 112,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 2,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5262203,
+              5262219,
+              5262235,
+              5262251,
+              5262267,
+              5262283,
+              5262299,
+              5262315,
+              5262331,
+              5262347,
+              5262363,
+              5262379,
+              5262395,
+              5262411,
+              5262427
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85088,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5270227,
+              5270243,
+              5278307,
+              5278323,
+              5286387,
+              5286403,
+              5294467,
+              5294483,
+              5302547,
+              5302563,
+              5310627,
+              5310643,
+              5318707,
+              5318723,
+              5326787
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5265427,
+              5265443,
+              5268707,
+              5268723,
+              5271987,
+              5272003,
+              5275267,
+              5275283,
+              5278547,
+              5278563,
+              5281827,
+              5281843,
+              5285107,
+              5285123,
+              5288387
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116840,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20000,
+            "endpoints": 116840,
+            "legs": [
+              19768,
+              20000,
+              19256,
+              19244,
+              19220,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": 0.03863730785209805,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19473.333333333332,
+            "perBoundaryPerWrite": 811.3888888888888,
+            "cdpBracket": 174024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5347011,
+              5347027,
+              5373067,
+              5373083,
+              5392851,
+              5392867,
+              5412867,
+              5412883,
+              5432139,
+              5432155,
+              5451399,
+              5451415,
+              5470635,
+              5470651,
+              5489907
+            ],
+            "tick0": 133,
+            "tick": 140,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 123412,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23224,
+            "endpoints": 123412,
+            "legs": [
+              23224,
+              19624,
+              21632,
+              19624,
+              19588,
+              19624
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19624,
+            "legWorstDeviation": 0.18344883815735832,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6920,
+            "perWrite": 20568.666666666668,
+            "perBoundaryPerWrite": 857.0277777777778,
+            "cdpBracket": 177936,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5421195,
+              5421211,
+              5447755,
+              5447771,
+              5470995,
+              5471011,
+              5490635,
+              5490651,
+              5512283,
+              5512299,
+              5531923,
+              5531939,
+              5551527,
+              5551543,
+              5571167
+            ],
+            "tick0": 161,
+            "tick": 168,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 3,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 29120,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5383319,
+              5383335,
+              5383351,
+              5383367,
+              5383383,
+              5383399,
+              5383415,
+              5383431,
+              5383447,
+              5383463,
+              5383479,
+              5383495,
+              5383511,
+              5383527,
+              5383543
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5392255,
+              5392271,
+              5400335,
+              5400351,
+              5408415,
+              5408431,
+              5416495,
+              5416511,
+              5424575,
+              5424591,
+              5432655,
+              5432671,
+              5440735,
+              5440751,
+              5448815
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5387455,
+              5387471,
+              5390735,
+              5390751,
+              5394015,
+              5394031,
+              5397295,
+              5397311,
+              5400575,
+              5400591,
+              5403855,
+              5403871,
+              5407135,
+              5407151,
+              5410415
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 115584,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19256,
+            "endpoints": 115584,
+            "legs": [
+              19256,
+              19256,
+              19244,
+              19220,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": -0.0018695471541337765,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19264,
+            "perBoundaryPerWrite": 802.6666666666666,
+            "cdpBracket": 169584,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5454903,
+              5454919,
+              5480959,
+              5480975,
+              5500231,
+              5500247,
+              5519503,
+              5519519,
+              5538763,
+              5538779,
+              5557999,
+              5558015,
+              5577271,
+              5577287,
+              5596543
+            ],
+            "tick0": 189,
+            "tick": 196,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120420,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22132,
+            "endpoints": 120420,
+            "legs": [
+              19696,
+              22132,
+              19624,
+              19624,
+              19624,
+              19624
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19624,
+            "legWorstDeviation": 0.12780269058295965,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26532
+            ],
+            "primeExcess": 6908,
+            "perWrite": 20070,
+            "perBoundaryPerWrite": 836.25,
+            "cdpBracket": 174932,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5485735,
+              5485751,
+              5512283,
+              5512299,
+              5531995,
+              5532011,
+              5554143,
+              5554159,
+              5573783,
+              5573799,
+              5593423,
+              5593439,
+              5613063,
+              5613079,
+              5632703
+            ],
+            "tick0": 217,
+            "tick": 224,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 4,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5444807,
+              5444823,
+              5444839,
+              5444855,
+              5444871,
+              5444887,
+              5444903,
+              5444919,
+              5444935,
+              5444951,
+              5444967,
+              5444983,
+              5444999,
+              5445015,
+              5445031
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5452815,
+              5452831,
+              5460895,
+              5460911,
+              5468975,
+              5468991,
+              5477055,
+              5477071,
+              5485135,
+              5485151,
+              5493215,
+              5493231,
+              5501295,
+              5501311,
+              5509375
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5448015,
+              5448031,
+              5451295,
+              5451311,
+              5454575,
+              5454591,
+              5457855,
+              5457871,
+              5461135,
+              5461151,
+              5464415,
+              5464431,
+              5467695,
+              5467711,
+              5470975
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 102968,
+            "fall": 304984,
+            "falls": 1,
+            "maxStep": 22624,
+            "endpoints": -202016,
+            "legs": [
+              22624,
+              -304984,
+              19448,
+              19448,
+              21372,
+              19436
+            ],
+            "gaps": [
+              16,
+              560,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19448,
+            "legWorstDeviation": -16.682023858494446,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read -304984 B against a cohort median of 19448 B (-324432 B, -1668.2%), past the ±25% leg tolerance (±4862 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read -304984 B against a cohort median of 19448 B (-324432 B, -1668.2%), past the ±25% leg tolerance (±4862 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              357980
+            ],
+            "primeExcess": 338532,
+            "perWrite": 17161.333333333332,
+            "perBoundaryPerWrite": 715.0555555555555,
+            "cdpBracket": 184800,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5616127,
+              5616143,
+              5974123,
+              5974139,
+              5996763,
+              5997323,
+              5692339,
+              5692355,
+              5711803,
+              5711819,
+              5731267,
+              5731283,
+              5752655,
+              5752671,
+              5772107
+            ],
+            "tick0": 245,
+            "tick": 252,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 126204,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24188,
+            "endpoints": 126204,
+            "legs": [
+              19872,
+              19872,
+              24188,
+              19872,
+              21168,
+              21136
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20504,
+            "legWorstDeviation": 0.1796722590714007,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26736
+            ],
+            "primeExcess": 6232,
+            "perWrite": 21034,
+            "perBoundaryPerWrite": 876.4166666666666,
+            "cdpBracket": 180920,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5706087,
+              5706103,
+              5732839,
+              5732855,
+              5752727,
+              5752743,
+              5772615,
+              5772631,
+              5796819,
+              5796835,
+              5816707,
+              5816723,
+              5837891,
+              5837907,
+              5859043
+            ],
+            "tick0": 273,
+            "tick": 280,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 5,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5666807,
+              5666823,
+              5666839,
+              5666855,
+              5666871,
+              5666887,
+              5666903,
+              5666919,
+              5666935,
+              5666951,
+              5666967,
+              5666983,
+              5666999,
+              5667015,
+              5667031
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5674815,
+              5674831,
+              5682895,
+              5682911,
+              5690975,
+              5690991,
+              5699055,
+              5699071,
+              5707135,
+              5707151,
+              5715215,
+              5715231,
+              5723295,
+              5723311,
+              5731375
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5670015,
+              5670031,
+              5673295,
+              5673311,
+              5676575,
+              5676591,
+              5679855,
+              5679871,
+              5683135,
+              5683151,
+              5686415,
+              5686431,
+              5689695,
+              5689711,
+              5692975
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 312388,
+            "fall": 193804,
+            "falls": 1,
+            "maxStep": 214000,
+            "endpoints": 118584,
+            "legs": [
+              19432,
+              19396,
+              18436,
+              19432,
+              -193804,
+              19432
+            ],
+            "gaps": [
+              16,
+              16,
+              2196,
+              16,
+              214000,
+              16
+            ],
+            "legMedian": 19414,
+            "legWorstDeviation": -10.982692902029463,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read -193804 B against a cohort median of 19414 B (-213218 B, -1098.3%), past the ±25% leg tolerance (±4853.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read -193804 B against a cohort median of 19414 B (-213218 B, -1098.3%), past the ±25% leg tolerance (±4853.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26232
+            ],
+            "primeExcess": 6818,
+            "perWrite": 52064.666666666664,
+            "perBoundaryPerWrite": 2169.361111111111,
+            "cdpBracket": 173984,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5720455,
+              5720471,
+              5746703,
+              5746719,
+              5766151,
+              5766167,
+              5785563,
+              5787759,
+              5806195,
+              5806211,
+              5825643,
+              6039643,
+              5845839,
+              5845855,
+              5865287
+            ],
+            "tick0": 301,
+            "tick": 308,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119232,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19856,
+            "endpoints": 119232,
+            "legs": [
+              19856,
+              19856,
+              19856,
+              19856,
+              19856,
+              19856
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19856,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26720
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19872,
+            "perBoundaryPerWrite": 828,
+            "cdpBracket": 173932,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5748131,
+              5748147,
+              5774867,
+              5774883,
+              5794739,
+              5794755,
+              5814611,
+              5814627,
+              5834483,
+              5834499,
+              5854355,
+              5854371,
+              5874227,
+              5874243,
+              5894099
+            ],
+            "tick0": 329,
+            "tick": 336,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 6,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5708503,
+              5708519,
+              5708535,
+              5708551,
+              5708567,
+              5708583,
+              5708599,
+              5708615,
+              5708631,
+              5708647,
+              5708663,
+              5708679,
+              5708695,
+              5708711,
+              5708727
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5716511,
+              5716527,
+              5724591,
+              5724607,
+              5732671,
+              5732687,
+              5740751,
+              5740767,
+              5748831,
+              5748847,
+              5756911,
+              5756927,
+              5764991,
+              5765007,
+              5773071
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5711711,
+              5711727,
+              5714991,
+              5715007,
+              5718271,
+              5718287,
+              5721551,
+              5721567,
+              5724831,
+              5724847,
+              5728111,
+              5728127,
+              5731391,
+              5731407,
+              5734671
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 118080,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20148,
+            "endpoints": 118080,
+            "legs": [
+              19400,
+              19812,
+              19836,
+              19400,
+              19388,
+              20148
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19606,
+            "legWorstDeviation": 0.027644598592267672,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26200
+            ],
+            "primeExcess": 6594,
+            "perWrite": 19680,
+            "perBoundaryPerWrite": 820,
+            "cdpBracket": 172368,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5766643,
+              5766659,
+              5792859,
+              5792875,
+              5812275,
+              5812291,
+              5832103,
+              5832119,
+              5851955,
+              5851971,
+              5871371,
+              5871387,
+              5890775,
+              5890791,
+              5910939
+            ],
+            "tick0": 357,
+            "tick": 364,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20896,
+            "endpoints": 120192,
+            "legs": [
+              19840,
+              20896,
+              19840,
+              19840,
+              19840,
+              19840
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19840,
+            "legWorstDeviation": 0.0532258064516129,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26704
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20032,
+            "perBoundaryPerWrite": 834.6666666666666,
+            "cdpBracket": 174876,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5793159,
+              5793175,
+              5819879,
+              5819895,
+              5839735,
+              5839751,
+              5860647,
+              5860663,
+              5880503,
+              5880519,
+              5900359,
+              5900375,
+              5920215,
+              5920231,
+              5940071
+            ],
+            "tick0": 385,
+            "tick": 392,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 7,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5753251,
+              5753267,
+              5753283,
+              5753299,
+              5753315,
+              5753331,
+              5753347,
+              5753363,
+              5753379,
+              5753395,
+              5753411,
+              5753427,
+              5753443,
+              5753459,
+              5753475
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 50976,
+            "fall": 1988,
+            "falls": 1,
+            "maxStep": 10192,
+            "endpoints": 48988,
+            "legs": [
+              8064,
+              10192,
+              8064,
+              8448,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              -1988,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.2638888888888889,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 10192 B against a cohort median of 8064 B (+2128 B, 26.4%), past the ±25% leg tolerance (±2016 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 10192 B against a cohort median of 8064 B (+2128 B, 26.4%), past the ±25% leg tolerance (±2016 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8496,
+            "cdpBracket": 85132,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5761259,
+              5761275,
+              5769339,
+              5769355,
+              5777419,
+              5777435,
+              5787627,
+              5787643,
+              5795707,
+              5795723,
+              5804171,
+              5802183,
+              5810247,
+              5810263,
+              5818327
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5756967,
+              5756983,
+              5760247,
+              5760263,
+              5763527,
+              5763543,
+              5766807,
+              5766823,
+              5770087,
+              5770103,
+              5773367,
+              5773383,
+              5776647,
+              5776663,
+              5779927
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 119504,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21764,
+            "endpoints": 119504,
+            "legs": [
+              19392,
+              17248,
+              19356,
+              19380,
+              19392,
+              21764
+            ],
+            "gaps": [
+              16,
+              2892,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19386,
+            "legWorstDeviation": 0.12266584132879398,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26192
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19917.333333333332,
+            "perBoundaryPerWrite": 829.8888888888888,
+            "cdpBracket": 180580,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5821287,
+              5821303,
+              5847495,
+              5847511,
+              5866903,
+              5869795,
+              5887043,
+              5887059,
+              5906415,
+              5906431,
+              5925811,
+              5925827,
+              5945219,
+              5945235,
+              5966999
+            ],
+            "tick0": 413,
+            "tick": 420,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122952,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23756,
+            "endpoints": 122952,
+            "legs": [
+              19832,
+              19832,
+              19820,
+              19820,
+              19796,
+              23756
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19826,
+            "legWorstDeviation": 0.19822455361646324,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26696
+            ],
+            "primeExcess": 6870,
+            "perWrite": 20492,
+            "perBoundaryPerWrite": 853.8333333333334,
+            "cdpBracket": 177628,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5846227,
+              5846243,
+              5872939,
+              5872955,
+              5892787,
+              5892803,
+              5912635,
+              5912651,
+              5932471,
+              5932487,
+              5952307,
+              5952323,
+              5972119,
+              5972135,
+              5995891
+            ],
+            "tick0": 441,
+            "tick": 448,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 8,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5809187,
+              5809203,
+              5809219,
+              5809235,
+              5809251,
+              5809267,
+              5809283,
+              5809299,
+              5809315,
+              5809331,
+              5809347,
+              5809363,
+              5809379,
+              5809395,
+              5809411
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5817195,
+              5817211,
+              5825275,
+              5825291,
+              5833355,
+              5833371,
+              5841435,
+              5841451,
+              5849515,
+              5849531,
+              5857595,
+              5857611,
+              5865675,
+              5865691,
+              5873755
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5812395,
+              5812411,
+              5815675,
+              5815691,
+              5818955,
+              5818971,
+              5822235,
+              5822251,
+              5825515,
+              5825531,
+              5828795,
+              5828811,
+              5832075,
+              5832091,
+              5835355
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 118860,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21104,
+            "endpoints": 118860,
+            "legs": [
+              19392,
+              21104,
+              19392,
+              19392,
+              20104,
+              19380
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19392,
+            "legWorstDeviation": 0.08828382838283828,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26192
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19810,
+            "perBoundaryPerWrite": 825.4166666666666,
+            "cdpBracket": 173140,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5874643,
+              5874659,
+              5900851,
+              5900867,
+              5920259,
+              5920275,
+              5941379,
+              5941395,
+              5960787,
+              5960803,
+              5980195,
+              5980211,
+              6000315,
+              6000331,
+              6019711
+            ],
+            "tick0": 469,
+            "tick": 476,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 334836,
+            "fall": 206448,
+            "falls": 1,
+            "maxStep": 222056,
+            "endpoints": 128388,
+            "legs": [
+              19820,
+              222056,
+              33240,
+              19988,
+              19832,
+              19820
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              -206448,
+              16
+            ],
+            "legMedian": 19910,
+            "legWorstDeviation": 10.152988448016073,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 222056 B against a cohort median of 19910 B (+202146 B, 1015.3%), past the ±25% leg tolerance (±4977.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read 33240 B against a cohort median of 19910 B (+13330 B, 67.0%), past the ±25% leg tolerance (±4977.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 222056 B against a cohort median of 19910 B (+202146 B, 1015.3%), past the ±25% leg tolerance (±4977.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read 33240 B against a cohort median of 19910 B (+13330 B, 67.0%), past the ±25% leg tolerance (±4977.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26696
+            ],
+            "primeExcess": 6786,
+            "perWrite": 55806,
+            "perBoundaryPerWrite": 2325.25,
+            "cdpBracket": 183064,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5909583,
+              5909599,
+              5936295,
+              5936311,
+              5956131,
+              5956147,
+              6178203,
+              6178219,
+              6211459,
+              6211475,
+              6231463,
+              6025015,
+              6044847,
+              6044863,
+              6064683
+            ],
+            "tick0": 497,
+            "tick": 504,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 9,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5877267,
+              5877283,
+              5877299,
+              5877315,
+              5877331,
+              5877347,
+              5877363,
+              5877379,
+              5877395,
+              5877411,
+              5877427,
+              5877443,
+              5877459,
+              5877475,
+              5877491
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5885275,
+              5885291,
+              5893355,
+              5893371,
+              5901435,
+              5901451,
+              5909515,
+              5909531,
+              5917595,
+              5917611,
+              5925675,
+              5925691,
+              5933755,
+              5933771,
+              5941835
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5880475,
+              5880491,
+              5883755,
+              5883771,
+              5887035,
+              5887051,
+              5890315,
+              5890331,
+              5893595,
+              5893611,
+              5896875,
+              5896891,
+              5900155,
+              5900171,
+              5903435
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116352,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116352,
+            "legs": [
+              19372,
+              19372,
+              19372,
+              19372,
+              19384,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0006194507536650836,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19392,
+            "perBoundaryPerWrite": 808,
+            "cdpBracket": 171232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5935263,
+              5935279,
+              5961451,
+              5961467,
+              5980839,
+              5980855,
+              6000227,
+              6000243,
+              6019615,
+              6019631,
+              6039003,
+              6039019,
+              6058403,
+              6058419,
+              6077803
+            ],
+            "tick0": 525,
+            "tick": 532,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 123172,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24004,
+            "endpoints": 123172,
+            "legs": [
+              19824,
+              19824,
+              19824,
+              19788,
+              19812,
+              24004
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.21085552865213883,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20528.666666666668,
+            "perBoundaryPerWrite": 855.3611111111112,
+            "cdpBracket": 184420,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5957543,
+              5957559,
+              5984247,
+              5984263,
+              6004087,
+              6004103,
+              6023927,
+              6023943,
+              6043767,
+              6043783,
+              6063571,
+              6063587,
+              6083399,
+              6083415,
+              6107419
+            ],
+            "tick0": 553,
+            "tick": 560,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 10,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5927327,
+              5927343,
+              5927359,
+              5927375,
+              5927391,
+              5927407,
+              5927423,
+              5927439,
+              5927455,
+              5927471,
+              5927487,
+              5927503,
+              5927519,
+              5927535,
+              5927551
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5935335,
+              5935351,
+              5943415,
+              5943431,
+              5951495,
+              5951511,
+              5959575,
+              5959591,
+              5967655,
+              5967671,
+              5975735,
+              5975751,
+              5983815,
+              5983831,
+              5991895
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5930535,
+              5930551,
+              5933815,
+              5933831,
+              5937095,
+              5937111,
+              5940375,
+              5940391,
+              5943655,
+              5943671,
+              5946935,
+              5946951,
+              5950215,
+              5950231,
+              5953495
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117100,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20132,
+            "endpoints": 117100,
+            "legs": [
+              19372,
+              19372,
+              19384,
+              19372,
+              19372,
+              20132
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0392318810654553,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19516.666666666668,
+            "perBoundaryPerWrite": 813.1944444444445,
+            "cdpBracket": 171372,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5981655,
+              5981671,
+              6007855,
+              6007871,
+              6027243,
+              6027259,
+              6046631,
+              6046647,
+              6066031,
+              6066047,
+              6085419,
+              6085435,
+              6104807,
+              6104823,
+              6124955
+            ],
+            "tick0": 581,
+            "tick": 588,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120336,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21132,
+            "endpoints": 120336,
+            "legs": [
+              19824,
+              19824,
+              19824,
+              21132,
+              19812,
+              19824
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.06598062953995157,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20056,
+            "perBoundaryPerWrite": 835.6666666666666,
+            "cdpBracket": 176496,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5994375,
+              5994391,
+              6021079,
+              6021095,
+              6040919,
+              6040935,
+              6060759,
+              6060775,
+              6080599,
+              6080615,
+              6101747,
+              6101763,
+              6121575,
+              6121591,
+              6141415
+            ],
+            "tick0": 609,
+            "tick": 616,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 11,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5954551,
+              5954567,
+              5954583,
+              5954599,
+              5954615,
+              5954631,
+              5954647,
+              5954663,
+              5954679,
+              5954695,
+              5954711,
+              5954727,
+              5954743,
+              5954759,
+              5954775
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5962559,
+              5962575,
+              5970639,
+              5970655,
+              5978719,
+              5978735,
+              5986799,
+              5986815,
+              5994879,
+              5994895,
+              6002959,
+              6002975,
+              6011039,
+              6011055,
+              6019119
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5957759,
+              5957775,
+              5961039,
+              5961055,
+              5964319,
+              5964335,
+              5967599,
+              5967615,
+              5970879,
+              5970895,
+              5974159,
+              5974175,
+              5977439,
+              5977455,
+              5980719
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117124,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20140,
+            "endpoints": 117124,
+            "legs": [
+              19392,
+              19380,
+              19356,
+              19380,
+              19380,
+              20140
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19380,
+            "legWorstDeviation": 0.0392156862745098,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26192
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19520.666666666668,
+            "perBoundaryPerWrite": 813.3611111111112,
+            "cdpBracket": 171276,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5997239,
+              5997255,
+              6023447,
+              6023463,
+              6042855,
+              6042871,
+              6062251,
+              6062267,
+              6081623,
+              6081639,
+              6101019,
+              6101035,
+              6120415,
+              6120431,
+              6140571
+            ],
+            "tick0": 637,
+            "tick": 644,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118956,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 118956,
+            "legs": [
+              19812,
+              19824,
+              19812,
+              19812,
+              19788,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": -0.0012113870381586917,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              31920
+            ],
+            "primeExcess": 12108,
+            "perWrite": 19826,
+            "perBoundaryPerWrite": 826.0833333333334,
+            "cdpBracket": 180068,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6015455,
+              6015471,
+              6047391,
+              6047407,
+              6067219,
+              6067235,
+              6087059,
+              6087075,
+              6106887,
+              6106903,
+              6126715,
+              6126731,
+              6146519,
+              6146535,
+              6166347
+            ],
+            "tick0": 665,
+            "tick": 672,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 12,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5979759,
+              5979775,
+              5979791,
+              5979807,
+              5979823,
+              5979839,
+              5979855,
+              5979871,
+              5979887,
+              5979903,
+              5979919,
+              5979935,
+              5979951,
+              5979967,
+              5979983
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5987767,
+              5987783,
+              5995847,
+              5995863,
+              6003927,
+              6003943,
+              6012007,
+              6012023,
+              6020087,
+              6020103,
+              6028167,
+              6028183,
+              6036247,
+              6036263,
+              6044327
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5982967,
+              5982983,
+              5986247,
+              5986263,
+              5989527,
+              5989543,
+              5992807,
+              5992823,
+              5996087,
+              5996103,
+              5999367,
+              5999383,
+              6002647,
+              6002663,
+              6005927
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117088,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20120,
+            "endpoints": 117088,
+            "legs": [
+              19372,
+              19384,
+              19372,
+              19372,
+              19372,
+              20120
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.038612430311790215,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19514.666666666668,
+            "perBoundaryPerWrite": 813.1111111111112,
+            "cdpBracket": 171344,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6044511,
+              6044527,
+              6070711,
+              6070727,
+              6090099,
+              6090115,
+              6109499,
+              6109515,
+              6128887,
+              6128903,
+              6148275,
+              6148291,
+              6167663,
+              6167679,
+              6187799
+            ],
+            "tick0": 693,
+            "tick": 700,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120036,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20868,
+            "endpoints": 120036,
+            "legs": [
+              19824,
+              19788,
+              19824,
+              19824,
+              20868,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.0526634382566586,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20006,
+            "perBoundaryPerWrite": 833.5833333333334,
+            "cdpBracket": 174688,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6073507,
+              6073523,
+              6100211,
+              6100227,
+              6120051,
+              6120067,
+              6139855,
+              6139871,
+              6159695,
+              6159711,
+              6179535,
+              6179551,
+              6200419,
+              6200435,
+              6220247
+            ],
+            "tick0": 721,
+            "tick": 728,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 13,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 31952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6033599,
+              6033615,
+              6033631,
+              6033647,
+              6033663,
+              6033679,
+              6033695,
+              6033711,
+              6033727,
+              6033743,
+              6033759,
+              6033775,
+              6033791,
+              6033807,
+              6033823
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6045627,
+              6045643,
+              6053707,
+              6053723,
+              6061787,
+              6061803,
+              6069867,
+              6069883,
+              6077947,
+              6077963,
+              6086027,
+              6086043,
+              6094107,
+              6094123,
+              6102187
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6040827,
+              6040843,
+              6044107,
+              6044123,
+              6047387,
+              6047403,
+              6050667,
+              6050683,
+              6053947,
+              6053963,
+              6057227,
+              6057243,
+              6060507,
+              6060523,
+              6063787
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117076,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20132,
+            "endpoints": 117076,
+            "legs": [
+              19372,
+              19384,
+              19372,
+              19372,
+              19348,
+              20132
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0392318810654553,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19512.666666666668,
+            "perBoundaryPerWrite": 813.0277777777778,
+            "cdpBracket": 171192,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6082559,
+              6082575,
+              6108747,
+              6108763,
+              6128135,
+              6128151,
+              6147535,
+              6147551,
+              6166923,
+              6166939,
+              6186311,
+              6186327,
+              6205675,
+              6205691,
+              6225823
+            ],
+            "tick0": 749,
+            "tick": 756,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118980,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 118980,
+            "legs": [
+              19812,
+              19812,
+              19812,
+              19824,
+              19812,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": 0.0006056935190793458,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6876,
+            "perWrite": 19830,
+            "perBoundaryPerWrite": 826.25,
+            "cdpBracket": 173632,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6105715,
+              6105731,
+              6132419,
+              6132435,
+              6152247,
+              6152263,
+              6172075,
+              6172091,
+              6191903,
+              6191919,
+              6211743,
+              6211759,
+              6231571,
+              6231587,
+              6251399
+            ],
+            "tick0": 777,
+            "tick": 784,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 14,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6064751,
+              6064767,
+              6064783,
+              6064799,
+              6064815,
+              6064831,
+              6064847,
+              6064863,
+              6064879,
+              6064895,
+              6064911,
+              6064927,
+              6064943,
+              6064959,
+              6064975
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6072759,
+              6072775,
+              6080839,
+              6080855,
+              6088919,
+              6088935,
+              6096999,
+              6097015,
+              6105079,
+              6105095,
+              6113159,
+              6113175,
+              6121239,
+              6121255,
+              6129319
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6067959,
+              6067975,
+              6071239,
+              6071255,
+              6074519,
+              6074535,
+              6077799,
+              6077815,
+              6081079,
+              6081095,
+              6084359,
+              6084375,
+              6087639,
+              6087655,
+              6090919
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117112,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20132,
+            "endpoints": 117112,
+            "legs": [
+              19384,
+              19384,
+              19372,
+              19372,
+              19372,
+              20132
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.03891010424192383,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6794,
+            "perWrite": 19518.666666666668,
+            "perBoundaryPerWrite": 813.2777777777778,
+            "cdpBracket": 173872,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6110583,
+              6110599,
+              6136771,
+              6136787,
+              6156171,
+              6156187,
+              6175571,
+              6175587,
+              6194959,
+              6194975,
+              6214347,
+              6214363,
+              6233735,
+              6233751,
+              6253883
+            ],
+            "tick0": 805,
+            "tick": 812,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120624,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21456,
+            "endpoints": 120624,
+            "legs": [
+              19824,
+              19824,
+              19824,
+              19812,
+              21456,
+              19788
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.08232445520581114,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20104,
+            "perBoundaryPerWrite": 837.6666666666666,
+            "cdpBracket": 175276,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6128147,
+              6128163,
+              6154851,
+              6154867,
+              6174691,
+              6174707,
+              6194531,
+              6194547,
+              6214371,
+              6214387,
+              6234199,
+              6234215,
+              6255671,
+              6255687,
+              6275475
+            ],
+            "tick0": 833,
+            "tick": 840,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 15,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6088431,
+              6088447,
+              6088463,
+              6088479,
+              6088495,
+              6088511,
+              6088527,
+              6088543,
+              6088559,
+              6088575,
+              6088591,
+              6088607,
+              6088623,
+              6088639,
+              6088655
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6096439,
+              6096455,
+              6104519,
+              6104535,
+              6112599,
+              6112615,
+              6120679,
+              6120695,
+              6128759,
+              6128775,
+              6136839,
+              6136855,
+              6144919,
+              6144935,
+              6152999
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6091639,
+              6091655,
+              6094919,
+              6094935,
+              6098199,
+              6098215,
+              6101479,
+              6101495,
+              6104759,
+              6104775,
+              6108039,
+              6108055,
+              6111319,
+              6111335,
+              6114599
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117100,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20120,
+            "endpoints": 117100,
+            "legs": [
+              19372,
+              19384,
+              19372,
+              19384,
+              19372,
+              20120
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.038290845288471466,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19516.666666666668,
+            "perBoundaryPerWrite": 813.1944444444445,
+            "cdpBracket": 173488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6135995,
+              6136011,
+              6162195,
+              6162211,
+              6181583,
+              6181599,
+              6200983,
+              6200999,
+              6220371,
+              6220387,
+              6239771,
+              6239787,
+              6259159,
+              6259175,
+              6279295
+            ],
+            "tick0": 861,
+            "tick": 868,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119016,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 119016,
+            "legs": [
+              19812,
+              19812,
+              19824,
+              19824,
+              19824,
+              19824
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": -0.0006053268765133172,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19836,
+            "perBoundaryPerWrite": 826.5,
+            "cdpBracket": 173668,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6157343,
+              6157359,
+              6184047,
+              6184063,
+              6203875,
+              6203891,
+              6223703,
+              6223719,
+              6243543,
+              6243559,
+              6263383,
+              6263399,
+              6283223,
+              6283239,
+              6303063
+            ],
+            "tick0": 889,
+            "tick": 896,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 16,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6111263,
+              6111279,
+              6111295,
+              6111311,
+              6111327,
+              6111343,
+              6111359,
+              6111375,
+              6111391,
+              6111407,
+              6111423,
+              6111439,
+              6111455,
+              6111471,
+              6111487
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6119271,
+              6119287,
+              6127351,
+              6127367,
+              6135431,
+              6135447,
+              6143511,
+              6143527,
+              6151591,
+              6151607,
+              6159671,
+              6159687,
+              6167751,
+              6167767,
+              6175831
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6114471,
+              6114487,
+              6117751,
+              6117767,
+              6121031,
+              6121047,
+              6124311,
+              6124327,
+              6127591,
+              6127607,
+              6130871,
+              6130887,
+              6134151,
+              6134167,
+              6137431
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117804,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20116,
+            "endpoints": 117804,
+            "legs": [
+              19372,
+              19372,
+              19384,
+              20116,
+              19372,
+              20092
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.038084425637320674,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6794,
+            "perWrite": 19634,
+            "perBoundaryPerWrite": 818.0833333333334,
+            "cdpBracket": 174308,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6149851,
+              6149867,
+              6176039,
+              6176055,
+              6195427,
+              6195443,
+              6214815,
+              6214831,
+              6234215,
+              6234231,
+              6254347,
+              6254363,
+              6273735,
+              6273751,
+              6293843
+            ],
+            "tick0": 917,
+            "tick": 924,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 129592,
+            "fall": 5572,
+            "falls": 1,
+            "maxStep": 26748,
+            "endpoints": 124020,
+            "legs": [
+              19812,
+              26748,
+              23480,
+              19824,
+              19824,
+              19824
+            ],
+            "gaps": [
+              16,
+              16,
+              -5572,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.349273607748184,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 26748 B against a cohort median of 19824 B (+6924 B, 34.9%), past the ±25% leg tolerance (±4956 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 26748 B against a cohort median of 19824 B (+6924 B, 34.9%), past the ±25% leg tolerance (±4956 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 21598.666666666668,
+            "perBoundaryPerWrite": 899.9444444444445,
+            "cdpBracket": 178672,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6166367,
+              6166383,
+              6193071,
+              6193087,
+              6212899,
+              6212915,
+              6239663,
+              6234091,
+              6257571,
+              6257587,
+              6277411,
+              6277427,
+              6297251,
+              6297267,
+              6317091
+            ],
+            "tick0": 945,
+            "tick": 952,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 17,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6123811,
+              6123827,
+              6123843,
+              6123859,
+              6123875,
+              6123891,
+              6123907,
+              6123923,
+              6123939,
+              6123955,
+              6123971,
+              6123987,
+              6124003,
+              6124019,
+              6124035
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6131819,
+              6131835,
+              6139899,
+              6139915,
+              6147979,
+              6147995,
+              6156059,
+              6156075,
+              6164139,
+              6164155,
+              6172219,
+              6172235,
+              6180299,
+              6180315,
+              6188379
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6127019,
+              6127035,
+              6130299,
+              6130315,
+              6133579,
+              6133595,
+              6136859,
+              6136875,
+              6140139,
+              6140155,
+              6143419,
+              6143435,
+              6146699,
+              6146715,
+              6149979
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 119460,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22492,
+            "endpoints": 119460,
+            "legs": [
+              19348,
+              19384,
+              19372,
+              19384,
+              19384,
+              22492
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19384,
+            "legWorstDeviation": 0.16033842344201404,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19910,
+            "perBoundaryPerWrite": 829.5833333333334,
+            "cdpBracket": 173588,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6178267,
+              6178283,
+              6204467,
+              6204483,
+              6223831,
+              6223847,
+              6243231,
+              6243247,
+              6262619,
+              6262635,
+              6282019,
+              6282035,
+              6301419,
+              6301435,
+              6323927
+            ],
+            "tick0": 973,
+            "tick": 980,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119772,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20572,
+            "endpoints": 119772,
+            "legs": [
+              19828,
+              20572,
+              19816,
+              19816,
+              19828,
+              19816
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19822,
+            "legWorstDeviation": 0.03783674704873373,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26692
+            ],
+            "primeExcess": 6870,
+            "perWrite": 19962,
+            "perBoundaryPerWrite": 831.75,
+            "cdpBracket": 174428,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6194103,
+              6194119,
+              6220811,
+              6220827,
+              6240655,
+              6240671,
+              6261243,
+              6261259,
+              6281075,
+              6281091,
+              6300907,
+              6300923,
+              6320751,
+              6320767,
+              6340583
+            ],
+            "tick0": 1001,
+            "tick": 1008,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      }
+    ],
+    "allocFits": {
+      "perRound": {},
+      "mean": {}
+    },
+    "writeDriven": true,
+    "writeProvenance": {
+      "windows": 36,
+      "pairs": 36,
+      "unnamed": [],
+      "incomplete": [],
+      "ok": true
+    },
+    "controlVerdict": {
+      "ok": true,
+      "perDouble": 8.104,
+      "differential": 8.04
+    },
+    "fallsInMeasuredWindows": 5,
+    "refusedWindows": 7,
+    "refusalReasons": 11
+  },
+  "box": {
+    "bead": "rf2-24o2z",
+    "chromium": "chromium/147.0.7727.15",
+    "node": "v24.13.0",
+    "platform": "win32/x64/10.0.26200",
+    "load": {
+      "open": {
+        "at": "2026-08-20T20:31:10.877Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13477971739,
+        "cpuBusyMs": 3628375341,
+        "freeMemB": 16095547392,
+        "totalMemB": 68112736256,
+        "uptimeS": 709033.671
+      },
+      "close": {
+        "at": "2026-08-20T20:31:37.022Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13478457911,
+        "cpuBusyMs": 3628519576,
+        "freeMemB": 16180916224,
+        "totalMemB": 68112736256,
+        "uptimeS": 709059.828
+      },
+      "busyFraction": 0.2287966345551366
+    },
+    "session": {
+      "startedAt": "2026-08-20T20:30:37.666Z",
+      "sessionStartedAt": "2026-08-20T19:39:26.627Z",
+      "runsInSession": 10,
+      "sessionGapMs": 3600000,
+      "previousRun": {
+        "startedAt": "2026-08-20T20:29:35.832Z",
+        "endedAt": "2026-08-20T20:30:37.530Z",
+        "sinceStartMs": 61834,
+        "sinceEndMs": 136,
+        "sameSession": true
+      }
+    }
+  }
+}

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/fixed-4.json
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/fixed-4.json
@@ -1,0 +1,7563 @@
+{
+  "generatedAt": "2026-08-20T20:34:36.163Z",
+  "build": "hicasso-bench",
+  "initFn": "re-frame.bench.p0-app/-main",
+  "alloc": {
+    "benchmark": "P0:steady-state-allocation-slope",
+    "bead": "rf2-2rtt6.76",
+    "roots": 4,
+    "perRoot": {
+      "list": 300,
+      "grid": 6
+    },
+    "publishedPerRoot": {
+      "list": 300,
+      "grid": 300
+    },
+    "arm": {
+      "cells": 6,
+      "roots": 4,
+      "boundaries": 24,
+      "writes": 6,
+      "refusals": [],
+      "admissible": true
+    },
+    "boundaries": 24,
+    "writes": 6,
+    "primeWrites": 1,
+    "windowWrites": 7,
+    "bySite": false,
+    "sites": 2,
+    "siteNames": [
+      "dispatch",
+      "drain"
+    ],
+    "warmups": 3,
+    "rounds": 18,
+    "preciseMemory": true,
+    "controlDoubles": {
+      "d1": 1000,
+      "d2": 400
+    },
+    "controlSlack": 0.75,
+    "writeSelector": "all",
+    "writeLegs": [
+      "all"
+    ],
+    "writePaired": false,
+    "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+    "plan": {
+      "name": "floor",
+      "arms": true,
+      "rungs": false,
+      "fits": false
+    },
+    "segOrder": "fixed",
+    "passOrder": "parity",
+    "passSeed": "1787258029572",
+    "passSchedule": {
+      "flips": [
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false
+      ],
+      "attempts": 1,
+      "parityTied": false
+    },
+    "controlSlot": "first",
+    "instrument": "in-page performance.memory.usedJSHeapSize sampled at every leg boundary, rising steps accumulated separately from falling ones; --enable-precise-memory-info. A falling step is a collection this counter SAW; a leg that deviates from its cohort median by more than the leg tolerance is a work unit that is not one; and under the by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the other two can see. TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg has no interior reading and so no site step to be negative, and the intra-leg gate returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with these (see `bySite`), so a witness comparing byte for byte against a figure published at stride 2 can never be screened by all three",
+    "fallThresholdB": 600000,
+    "legTolerance": 0.25,
+    "verification": {
+      "unverified": 0,
+      "detail": []
+    },
+    "workCount": false,
+    "workVerification": {
+      "counted": false
+    },
+    "perRound": [
+      {
+        "round": 0,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 524,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              524
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 116.66666666666667,
+            "cdpBracket": 46232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3840294,
+              3840310,
+              3840326,
+              3840342,
+              3840358,
+              3840374,
+              3840390,
+              3840406,
+              3840422,
+              3840438,
+              3840454,
+              3840470,
+              3840486,
+              3841010,
+              3841026
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48576,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8144,
+            "endpoints": 48576,
+            "legs": [
+              8144,
+              8080,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.00992063492063492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8096,
+            "cdpBracket": 87388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3853918,
+              3853934,
+              3861998,
+              3862014,
+              3870158,
+              3870174,
+              3878254,
+              3878270,
+              3886334,
+              3886350,
+              3894414,
+              3894430,
+              3902494,
+              3902510,
+              3910574
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 52328,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3850018,
+              3850034,
+              3853298,
+              3853314,
+              3856578,
+              3856594,
+              3859858,
+              3859874,
+              3863138,
+              3863154,
+              3866418,
+              3866434,
+              3869698,
+              3869714,
+              3872978
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 378792,
+            "fall": 246516,
+            "falls": 1,
+            "maxStep": 275656,
+            "endpoints": 132276,
+            "legs": [
+              21336,
+              19692,
+              19764,
+              -246516,
+              22572,
+              19692
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              275656,
+              16,
+              16
+            ],
+            "legMedian": 19728,
+            "legWorstDeviation": -13.495742092457421,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read -246516 B against a cohort median of 19728 B (-266244 B, -1349.6%), past the ±25% leg tolerance (±4932 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read -246516 B against a cohort median of 19728 B (-266244 B, -1349.6%), past the ±25% leg tolerance (±4932 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26460
+            ],
+            "primeExcess": 6732,
+            "perWrite": 63132,
+            "perBoundaryPerWrite": 2630.5,
+            "cdpBracket": 187136,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              4782603,
+              4782619,
+              4809079,
+              4809095,
+              4830431,
+              4830447,
+              4850139,
+              4850155,
+              4869919,
+              5145575,
+              4899059,
+              4899075,
+              4921647,
+              4921663,
+              4941355
+            ],
+            "tick0": 21,
+            "tick": 28,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 210736,
+            "fall": 82068,
+            "falls": 1,
+            "maxStep": 107712,
+            "endpoints": 128668,
+            "legs": [
+              23508,
+              19916,
+              -82068,
+              19844,
+              19832,
+              19844
+            ],
+            "gaps": [
+              16,
+              16,
+              107712,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19844,
+            "legWorstDeviation": -5.135658133440838,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read -82068 B against a cohort median of 19844 B (-101912 B, -513.6%), past the ±25% leg tolerance (±4961 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read -82068 B against a cohort median of 19844 B (-101912 B, -513.6%), past the ±25% leg tolerance (±4961 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26764
+            ],
+            "primeExcess": 6920,
+            "perWrite": 35122.666666666664,
+            "perBoundaryPerWrite": 1463.4444444444443,
+            "cdpBracket": 203392,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5066531,
+              5066547,
+              5093311,
+              5093327,
+              5116835,
+              5116851,
+              5136767,
+              5244479,
+              5162411,
+              5162427,
+              5182271,
+              5182287,
+              5202119,
+              5202135,
+              5221979
+            ],
+            "tick0": 49,
+            "tick": 56,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 1,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5052899,
+              5052915,
+              5052931,
+              5052947,
+              5052963,
+              5052979,
+              5052995,
+              5053011,
+              5053027,
+              5053043,
+              5053059,
+              5053075,
+              5053091,
+              5053107,
+              5053123
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 87716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5060907,
+              5060923,
+              5068987,
+              5069003,
+              5077067,
+              5077083,
+              5085147,
+              5085163,
+              5093227,
+              5093243,
+              5101307,
+              5101323,
+              5109387,
+              5109403,
+              5117467
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5058351,
+              5058367,
+              5061631,
+              5061647,
+              5064911,
+              5064927,
+              5068191,
+              5068207,
+              5071471,
+              5071487,
+              5074751,
+              5074767,
+              5078031,
+              5078047,
+              5081311
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 120932,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21744,
+            "endpoints": 120932,
+            "legs": [
+              19840,
+              19332,
+              19332,
+              21744,
+              19332,
+              21256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19586,
+            "legWorstDeviation": 0.11018074134585928,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              31624
+            ],
+            "primeExcess": 12038,
+            "perWrite": 20155.333333333332,
+            "perBoundaryPerWrite": 839.8055555555555,
+            "cdpBracket": 184472,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5180579,
+              5180595,
+              5212219,
+              5212235,
+              5232075,
+              5232091,
+              5251423,
+              5251439,
+              5270771,
+              5270787,
+              5292531,
+              5292547,
+              5311879,
+              5311895,
+              5333151
+            ],
+            "tick0": 77,
+            "tick": 84,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 213080,
+            "fall": 86744,
+            "falls": 2,
+            "maxStep": 113676,
+            "endpoints": 126336,
+            "legs": [
+              113676,
+              20112,
+              19624,
+              20356,
+              19624,
+              19624
+            ],
+            "gaps": [
+              16,
+              -37828,
+              -48916,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19868,
+            "legWorstDeviation": 4.721562311254278,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 113676 B against a cohort median of 19868 B (+93808 B, 472.2%), past the ±25% leg tolerance (±4967 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 113676 B against a cohort median of 19868 B (+93808 B, 472.2%), past the ±25% leg tolerance (±4967 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6676,
+            "perWrite": 35513.333333333336,
+            "perBoundaryPerWrite": 1479.7222222222224,
+            "cdpBracket": 181316,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5297355,
+              5297371,
+              5323915,
+              5323931,
+              5437607,
+              5399779,
+              5419891,
+              5370975,
+              5390599,
+              5390615,
+              5410971,
+              5410987,
+              5430611,
+              5430627,
+              5450251
+            ],
+            "tick0": 105,
+            "tick": 112,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 2,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5261559,
+              5261575,
+              5261591,
+              5261607,
+              5261623,
+              5261639,
+              5261655,
+              5261671,
+              5261687,
+              5261703,
+              5261719,
+              5261735,
+              5261751,
+              5261767,
+              5261783
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85088,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5269583,
+              5269599,
+              5277663,
+              5277679,
+              5285743,
+              5285759,
+              5293823,
+              5293839,
+              5301903,
+              5301919,
+              5309983,
+              5309999,
+              5318063,
+              5318079,
+              5326143
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5264783,
+              5264799,
+              5268063,
+              5268079,
+              5271343,
+              5271359,
+              5274623,
+              5274639,
+              5277903,
+              5277919,
+              5281183,
+              5281199,
+              5284463,
+              5284479,
+              5287743
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 166824,
+            "fall": 49936,
+            "falls": 1,
+            "maxStep": 69720,
+            "endpoints": 116888,
+            "legs": [
+              69720,
+              20000,
+              19256,
+              19256,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              -49936,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": 2.6206896551724137,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 69720 B against a cohort median of 19256 B (+50464 B, 262.1%), past the ±25% leg tolerance (±4814 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 69720 B against a cohort median of 19256 B (+50464 B, 262.1%), past the ±25% leg tolerance (±4814 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 27804,
+            "perBoundaryPerWrite": 1158.5,
+            "cdpBracket": 173988,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5346427,
+              5346443,
+              5372483,
+              5372499,
+              5442219,
+              5392283,
+              5412283,
+              5412299,
+              5431555,
+              5431571,
+              5450827,
+              5450843,
+              5470099,
+              5470115,
+              5489371
+            ],
+            "tick0": 133,
+            "tick": 140,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 367584,
+            "fall": 244232,
+            "falls": 1,
+            "maxStep": 264312,
+            "endpoints": 123352,
+            "legs": [
+              23152,
+              264312,
+              21180,
+              19612,
+              19624,
+              19624
+            ],
+            "gaps": [
+              16,
+              16,
+              -244232,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20402,
+            "legWorstDeviation": 11.955200470542104,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 264312 B against a cohort median of 20402 B (+243910 B, 1195.5%), past the ±25% leg tolerance (±5100.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 264312 B against a cohort median of 20402 B (+243910 B, 1195.5%), past the ±25% leg tolerance (±5100.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6142,
+            "perWrite": 61264,
+            "perBoundaryPerWrite": 2552.6666666666665,
+            "cdpBracket": 177876,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5420599,
+              5420615,
+              5447159,
+              5447175,
+              5470327,
+              5470343,
+              5734655,
+              5490423,
+              5511603,
+              5511619,
+              5531231,
+              5531247,
+              5550871,
+              5550887,
+              5570511
+            ],
+            "tick0": 161,
+            "tick": 168,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 3,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 29232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5382723,
+              5382739,
+              5382755,
+              5382771,
+              5382787,
+              5382803,
+              5382819,
+              5382835,
+              5382851,
+              5382867,
+              5382883,
+              5382899,
+              5382915,
+              5382931,
+              5382947
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5391659,
+              5391675,
+              5399739,
+              5399755,
+              5407819,
+              5407835,
+              5415899,
+              5415915,
+              5423979,
+              5423995,
+              5432059,
+              5432075,
+              5440139,
+              5440155,
+              5448219
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5386859,
+              5386875,
+              5390139,
+              5390155,
+              5393419,
+              5393435,
+              5396699,
+              5396715,
+              5399979,
+              5399995,
+              5403259,
+              5403275,
+              5406539,
+              5406555,
+              5409819
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 115620,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19256,
+            "endpoints": 115620,
+            "legs": [
+              19256,
+              19256,
+              19244,
+              19256,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": -0.0006231823847112588,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19270,
+            "perBoundaryPerWrite": 802.9166666666666,
+            "cdpBracket": 169620,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5454319,
+              5454335,
+              5480375,
+              5480391,
+              5499647,
+              5499663,
+              5518919,
+              5518935,
+              5538179,
+              5538195,
+              5557451,
+              5557467,
+              5576723,
+              5576739,
+              5595995
+            ],
+            "tick0": 189,
+            "tick": 196,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118272,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19696,
+            "endpoints": 118272,
+            "legs": [
+              19696,
+              19696,
+              19696,
+              19696,
+              19696,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26532
+            ],
+            "primeExcess": 6836,
+            "perWrite": 19712,
+            "perBoundaryPerWrite": 821.3333333333334,
+            "cdpBracket": 172784,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5485187,
+              5485203,
+              5511735,
+              5511751,
+              5531447,
+              5531463,
+              5551159,
+              5551175,
+              5570871,
+              5570887,
+              5590583,
+              5590599,
+              5610295,
+              5610311,
+              5630007
+            ],
+            "tick0": 217,
+            "tick": 224,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 4,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5444223,
+              5444239,
+              5444255,
+              5444271,
+              5444287,
+              5444303,
+              5444319,
+              5444335,
+              5444351,
+              5444367,
+              5444383,
+              5444399,
+              5444415,
+              5444431,
+              5444447
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5452231,
+              5452247,
+              5460311,
+              5460327,
+              5468391,
+              5468407,
+              5476471,
+              5476487,
+              5484551,
+              5484567,
+              5492631,
+              5492647,
+              5500711,
+              5500727,
+              5508791
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5447431,
+              5447447,
+              5450711,
+              5450727,
+              5453991,
+              5454007,
+              5457271,
+              5457287,
+              5460551,
+              5460567,
+              5463831,
+              5463847,
+              5467111,
+              5467127,
+              5470391
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 100500,
+            "fall": 294900,
+            "falls": 1,
+            "maxStep": 26456,
+            "endpoints": -194400,
+            "legs": [
+              19596,
+              19448,
+              26456,
+              15468,
+              -294900,
+              19436
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19442,
+            "legWorstDeviation": -16.16819257278058,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 26456 B against a cohort median of 19442 B (+7014 B, 36.1%), past the ±25% leg tolerance (±4860.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -294900 B against a cohort median of 19442 B (-314342 B, -1616.8%), past the ±25% leg tolerance (±4860.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 26456 B against a cohort median of 19442 B (+7014 B, 36.1%), past the ±25% leg tolerance (±4860.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -294900 B against a cohort median of 19442 B (-314342 B, -1616.8%), past the ±25% leg tolerance (±4860.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              350364
+            ],
+            "primeExcess": 330922,
+            "perWrite": 16750,
+            "perBoundaryPerWrite": 697.9166666666666,
+            "cdpBracket": 184052,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5615535,
+              5615551,
+              5965915,
+              5965931,
+              5985527,
+              5985543,
+              6004991,
+              6005007,
+              6031463,
+              6031479,
+              6046947,
+              6046963,
+              5752063,
+              5752079,
+              5771515
+            ],
+            "tick0": 245,
+            "tick": 252,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 124196,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23432,
+            "endpoints": 124196,
+            "legs": [
+              19872,
+              19872,
+              19872,
+              23432,
+              21180,
+              19872
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19872,
+            "legWorstDeviation": 0.17914653784219,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26736
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20699.333333333332,
+            "perBoundaryPerWrite": 862.4722222222222,
+            "cdpBracket": 178912,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5705515,
+              5705531,
+              5732267,
+              5732283,
+              5752155,
+              5752171,
+              5772043,
+              5772059,
+              5791931,
+              5791947,
+              5815379,
+              5815395,
+              5836575,
+              5836591,
+              5856463
+            ],
+            "tick0": 273,
+            "tick": 280,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 5,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5666223,
+              5666239,
+              5666255,
+              5666271,
+              5666287,
+              5666303,
+              5666319,
+              5666335,
+              5666351,
+              5666367,
+              5666383,
+              5666399,
+              5666415,
+              5666431,
+              5666447
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5674231,
+              5674247,
+              5682311,
+              5682327,
+              5690391,
+              5690407,
+              5698471,
+              5698487,
+              5706551,
+              5706567,
+              5714631,
+              5714647,
+              5722711,
+              5722727,
+              5730791
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5669431,
+              5669447,
+              5672711,
+              5672727,
+              5675991,
+              5676007,
+              5679271,
+              5679287,
+              5682551,
+              5682567,
+              5685831,
+              5685847,
+              5689111,
+              5689127,
+              5692391
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 119956,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20780,
+            "endpoints": 119956,
+            "legs": [
+              19432,
+              20616,
+              20168,
+              19432,
+              19432,
+              20780
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19800,
+            "legWorstDeviation": 0.049494949494949494,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26232
+            ],
+            "primeExcess": 6432,
+            "perWrite": 19992.666666666668,
+            "perBoundaryPerWrite": 833.0277777777778,
+            "cdpBracket": 174148,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5719871,
+              5719887,
+              5746119,
+              5746135,
+              5765567,
+              5765583,
+              5786199,
+              5786215,
+              5806383,
+              5806399,
+              5825831,
+              5825847,
+              5845279,
+              5845295,
+              5866075
+            ],
+            "tick0": 301,
+            "tick": 308,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119196,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19856,
+            "endpoints": 119196,
+            "legs": [
+              19856,
+              19856,
+              19856,
+              19820,
+              19856,
+              19856
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19856,
+            "legWorstDeviation": -0.0018130539887187753,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26720
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19866,
+            "perBoundaryPerWrite": 827.75,
+            "cdpBracket": 173896,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5747547,
+              5747563,
+              5774283,
+              5774299,
+              5794155,
+              5794171,
+              5814027,
+              5814043,
+              5833899,
+              5833915,
+              5853735,
+              5853751,
+              5873607,
+              5873623,
+              5893479
+            ],
+            "tick0": 329,
+            "tick": 336,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 6,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5706583,
+              5706599,
+              5706615,
+              5706631,
+              5706647,
+              5706663,
+              5706679,
+              5706695,
+              5706711,
+              5706727,
+              5706743,
+              5706759,
+              5706775,
+              5706791,
+              5706807
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5714591,
+              5714607,
+              5722671,
+              5722687,
+              5730751,
+              5730767,
+              5738831,
+              5738847,
+              5746911,
+              5746927,
+              5754991,
+              5755007,
+              5763071,
+              5763087,
+              5771151
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5709791,
+              5709807,
+              5713071,
+              5713087,
+              5716351,
+              5716367,
+              5719631,
+              5719647,
+              5722911,
+              5722927,
+              5726191,
+              5726207,
+              5729471,
+              5729487,
+              5732751
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 118092,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20584,
+            "endpoints": 118092,
+            "legs": [
+              19400,
+              19812,
+              19400,
+              20584,
+              19400,
+              19400
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19400,
+            "legWorstDeviation": 0.06103092783505155,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26200
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19682,
+            "perBoundaryPerWrite": 820.0833333333334,
+            "cdpBracket": 172380,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5766047,
+              5766063,
+              5792263,
+              5792279,
+              5811679,
+              5811695,
+              5831507,
+              5831523,
+              5850923,
+              5850939,
+              5871523,
+              5871539,
+              5890939,
+              5890955,
+              5910355
+            ],
+            "tick0": 357,
+            "tick": 364,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 313140,
+            "fall": 192972,
+            "falls": 1,
+            "maxStep": 213884,
+            "endpoints": 120168,
+            "legs": [
+              213884,
+              19840,
+              19840,
+              19840,
+              19828,
+              19828
+            ],
+            "gaps": [
+              16,
+              -192972,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19840,
+            "legWorstDeviation": 9.780443548387098,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 213884 B against a cohort median of 19840 B (+194044 B, 978.0%), past the ±25% leg tolerance (±4960 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 213884 B against a cohort median of 19840 B (+194044 B, 978.0%), past the ±25% leg tolerance (±4960 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26704
+            ],
+            "primeExcess": 6864,
+            "perWrite": 52190,
+            "perBoundaryPerWrite": 2174.5833333333335,
+            "cdpBracket": 174852,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5792575,
+              5792591,
+              5819295,
+              5819311,
+              6033195,
+              5840223,
+              5860063,
+              5860079,
+              5879919,
+              5879935,
+              5899775,
+              5899791,
+              5919619,
+              5919635,
+              5939463
+            ],
+            "tick0": 385,
+            "tick": 392,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 7,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5752667,
+              5752683,
+              5752699,
+              5752715,
+              5752731,
+              5752747,
+              5752763,
+              5752779,
+              5752795,
+              5752811,
+              5752827,
+              5752843,
+              5752859,
+              5752875,
+              5752891
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85132,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5760675,
+              5760691,
+              5768755,
+              5768771,
+              5776835,
+              5776851,
+              5784915,
+              5784931,
+              5792995,
+              5793011,
+              5801075,
+              5801091,
+              5809155,
+              5809171,
+              5817235
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5756383,
+              5756399,
+              5759663,
+              5759679,
+              5762943,
+              5762959,
+              5766223,
+              5766239,
+              5769503,
+              5769519,
+              5772783,
+              5772799,
+              5776063,
+              5776079,
+              5779343
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 118800,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21032,
+            "endpoints": 118800,
+            "legs": [
+              19392,
+              19380,
+              19392,
+              20128,
+              21032,
+              19380
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19392,
+            "legWorstDeviation": 0.08457095709570957,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26156
+            ],
+            "primeExcess": 6764,
+            "perWrite": 19800,
+            "perBoundaryPerWrite": 825,
+            "cdpBracket": 179840,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5820703,
+              5820719,
+              5846875,
+              5846891,
+              5866283,
+              5866299,
+              5885679,
+              5885695,
+              5905087,
+              5905103,
+              5925231,
+              5925247,
+              5946279,
+              5946295,
+              5965675
+            ],
+            "tick0": 413,
+            "tick": 420,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122988,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22988,
+            "endpoints": 122988,
+            "legs": [
+              19820,
+              19832,
+              19820,
+              19832,
+              22988,
+              20600
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19832,
+            "legWorstDeviation": 0.1591367486889875,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26696
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20498,
+            "perBoundaryPerWrite": 854.0833333333334,
+            "cdpBracket": 177664,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5845631,
+              5845647,
+              5872343,
+              5872359,
+              5892179,
+              5892195,
+              5912027,
+              5912043,
+              5931863,
+              5931879,
+              5951711,
+              5951727,
+              5974715,
+              5974731,
+              5995331
+            ],
+            "tick0": 441,
+            "tick": 448,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 8,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5808591,
+              5808607,
+              5808623,
+              5808639,
+              5808655,
+              5808671,
+              5808687,
+              5808703,
+              5808719,
+              5808735,
+              5808751,
+              5808767,
+              5808783,
+              5808799,
+              5808815
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5816599,
+              5816615,
+              5824679,
+              5824695,
+              5832759,
+              5832775,
+              5840839,
+              5840855,
+              5848919,
+              5848935,
+              5856999,
+              5857015,
+              5865079,
+              5865095,
+              5873159
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5811799,
+              5811815,
+              5815079,
+              5815095,
+              5818359,
+              5818375,
+              5821639,
+              5821655,
+              5824919,
+              5824935,
+              5828199,
+              5828215,
+              5831479,
+              5831495,
+              5834759
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 285756,
+            "fall": 166860,
+            "falls": 1,
+            "maxStep": 187980,
+            "endpoints": 118896,
+            "legs": [
+              187980,
+              19392,
+              19392,
+              20140,
+              19380,
+              19392
+            ],
+            "gaps": [
+              16,
+              -166860,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19392,
+            "legWorstDeviation": 8.693688118811881,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 187980 B against a cohort median of 19392 B (+168588 B, 869.4%), past the ±25% leg tolerance (±4848 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 187980 B against a cohort median of 19392 B (+168588 B, 869.4%), past the ±25% leg tolerance (±4848 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26180
+            ],
+            "primeExcess": 6788,
+            "perWrite": 47626,
+            "perBoundaryPerWrite": 1984.4166666666667,
+            "cdpBracket": 173164,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5873867,
+              5873883,
+              5900063,
+              5900079,
+              6088059,
+              5921199,
+              5940591,
+              5940607,
+              5959999,
+              5960015,
+              5980155,
+              5980171,
+              5999551,
+              5999567,
+              6018959
+            ],
+            "tick0": 469,
+            "tick": 476,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 322076,
+            "fall": 193688,
+            "falls": 2,
+            "maxStep": 242716,
+            "endpoints": 128388,
+            "legs": [
+              19820,
+              242716,
+              19820,
+              19820,
+              -186412,
+              19820
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              -7276,
+              16
+            ],
+            "legMedian": 19820,
+            "legWorstDeviation": 11.2460141271443,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 242716 B against a cohort median of 19820 B (+222896 B, 1124.6%), past the ±25% leg tolerance (±4955 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -186412 B against a cohort median of 19820 B (-206232 B, -1040.5%), past the ±25% leg tolerance (±4955 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 242716 B against a cohort median of 19820 B (+222896 B, 1124.6%), past the ±25% leg tolerance (±4955 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -186412 B against a cohort median of 19820 B (-206232 B, -1040.5%), past the ±25% leg tolerance (±4955 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26684
+            ],
+            "primeExcess": 6864,
+            "perWrite": 53679.333333333336,
+            "perBoundaryPerWrite": 2236.638888888889,
+            "cdpBracket": 183052,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5896695,
+              5896711,
+              5923395,
+              5923411,
+              5943231,
+              5943247,
+              6185963,
+              6185979,
+              6205799,
+              6205815,
+              6225635,
+              6218359,
+              6031947,
+              6031963,
+              6051783
+            ],
+            "tick0": 497,
+            "tick": 504,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 9,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5864379,
+              5864395,
+              5864411,
+              5864427,
+              5864443,
+              5864459,
+              5864475,
+              5864491,
+              5864507,
+              5864523,
+              5864539,
+              5864555,
+              5864571,
+              5864587,
+              5864603
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5872387,
+              5872403,
+              5880467,
+              5880483,
+              5888547,
+              5888563,
+              5896627,
+              5896643,
+              5904707,
+              5904723,
+              5912787,
+              5912803,
+              5920867,
+              5920883,
+              5928947
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5867587,
+              5867603,
+              5870867,
+              5870883,
+              5874147,
+              5874163,
+              5877427,
+              5877443,
+              5880707,
+              5880723,
+              5883987,
+              5884003,
+              5887267,
+              5887283,
+              5890547
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117064,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20120,
+            "endpoints": 117064,
+            "legs": [
+              19372,
+              19372,
+              19348,
+              19372,
+              20120,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.038612430311790215,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19510.666666666668,
+            "perBoundaryPerWrite": 812.9444444444445,
+            "cdpBracket": 171208,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5922107,
+              5922123,
+              5948307,
+              5948323,
+              5967695,
+              5967711,
+              5987083,
+              5987099,
+              6006447,
+              6006463,
+              6025835,
+              6025851,
+              6045971,
+              6045987,
+              6065371
+            ],
+            "tick0": 525,
+            "tick": 532,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 333592,
+            "fall": 203600,
+            "falls": 1,
+            "maxStep": 234444,
+            "endpoints": 129992,
+            "legs": [
+              19816,
+              19816,
+              19816,
+              19804,
+              234444,
+              19816
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              -203600
+            ],
+            "legMedian": 19816,
+            "legWorstDeviation": 10.831045619701252,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read 234444 B against a cohort median of 19816 B (+214628 B, 1083.1%), past the ±25% leg tolerance (±4954 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read 234444 B against a cohort median of 19816 B (+214628 B, 1083.1%), past the ±25% leg tolerance (±4954 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26680
+            ],
+            "primeExcess": 6864,
+            "perWrite": 55598.666666666664,
+            "perBoundaryPerWrite": 2316.611111111111,
+            "cdpBracket": 184652,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5947603,
+              5947619,
+              5974299,
+              5974315,
+              5994131,
+              5994147,
+              6013963,
+              6013979,
+              6033795,
+              6033811,
+              6053615,
+              6053631,
+              6288075,
+              6084475,
+              6104291
+            ],
+            "tick0": 553,
+            "tick": 560,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 10,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5917483,
+              5917499,
+              5917515,
+              5917531,
+              5917547,
+              5917563,
+              5917579,
+              5917595,
+              5917611,
+              5917627,
+              5917643,
+              5917659,
+              5917675,
+              5917691,
+              5917707
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5925491,
+              5925507,
+              5933571,
+              5933587,
+              5941651,
+              5941667,
+              5949731,
+              5949747,
+              5957811,
+              5957827,
+              5965891,
+              5965907,
+              5973971,
+              5973987,
+              5982051
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5920691,
+              5920707,
+              5923971,
+              5923987,
+              5927251,
+              5927267,
+              5930531,
+              5930547,
+              5933811,
+              5933827,
+              5937091,
+              5937107,
+              5940371,
+              5940387,
+              5943651
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116280,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19364,
+            "endpoints": 116280,
+            "legs": [
+              19364,
+              19364,
+              19364,
+              19364,
+              19364,
+              19364
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19364,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26176
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19380,
+            "perBoundaryPerWrite": 807.5,
+            "cdpBracket": 171292,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5974331,
+              5974347,
+              6000523,
+              6000539,
+              6019903,
+              6019919,
+              6039283,
+              6039299,
+              6058663,
+              6058679,
+              6078043,
+              6078059,
+              6097423,
+              6097439,
+              6116803
+            ],
+            "tick0": 581,
+            "tick": 588,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 121056,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20872,
+            "endpoints": 121056,
+            "legs": [
+              19804,
+              19780,
+              19816,
+              20872,
+              20872,
+              19816
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19816,
+            "legWorstDeviation": 0.05329027048849415,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26680
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20176,
+            "perBoundaryPerWrite": 840.6666666666666,
+            "cdpBracket": 177208,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5986367,
+              5986383,
+              6013063,
+              6013079,
+              6032883,
+              6032899,
+              6052679,
+              6052695,
+              6072511,
+              6072527,
+              6093399,
+              6093415,
+              6114287,
+              6114303,
+              6134119
+            ],
+            "tick0": 609,
+            "tick": 616,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 11,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5946179,
+              5946195,
+              5946211,
+              5946227,
+              5946243,
+              5946259,
+              5946275,
+              5946291,
+              5946307,
+              5946323,
+              5946339,
+              5946355,
+              5946371,
+              5946387,
+              5946403
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5954187,
+              5954203,
+              5962267,
+              5962283,
+              5970347,
+              5970363,
+              5978427,
+              5978443,
+              5986507,
+              5986523,
+              5994587,
+              5994603,
+              6002667,
+              6002683,
+              6010747
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5949387,
+              5949403,
+              5952667,
+              5952683,
+              5955947,
+              5955963,
+              5959227,
+              5959243,
+              5962507,
+              5962523,
+              5965787,
+              5965803,
+              5969067,
+              5969083,
+              5972347
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117076,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20124,
+            "endpoints": 117076,
+            "legs": [
+              19364,
+              19376,
+              19376,
+              19364,
+              19376,
+              20124
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19376,
+            "legWorstDeviation": 0.038604459124690335,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26140
+            ],
+            "primeExcess": 6764,
+            "perWrite": 19512.666666666668,
+            "perBoundaryPerWrite": 813.0277777777778,
+            "cdpBracket": 171176,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5990135,
+              5990151,
+              6016291,
+              6016307,
+              6035671,
+              6035687,
+              6055063,
+              6055079,
+              6074455,
+              6074471,
+              6093835,
+              6093851,
+              6113227,
+              6113243,
+              6133367
+            ],
+            "tick0": 637,
+            "tick": 644,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 124884,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 25048,
+            "endpoints": 124884,
+            "legs": [
+              19780,
+              25048,
+              19804,
+              20548,
+              19804,
+              19804
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19804,
+            "legWorstDeviation": 0.26479499091092706,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 25048 B against a cohort median of 19804 B (+5244 B, 26.5%), past the ±25% leg tolerance (±4951 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 25048 B against a cohort median of 19804 B (+5244 B, 26.5%), past the ±25% leg tolerance (±4951 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26668
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20814,
+            "perBoundaryPerWrite": 867.25,
+            "cdpBracket": 180744,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6019975,
+              6019991,
+              6046659,
+              6046675,
+              6066455,
+              6066471,
+              6091519,
+              6091535,
+              6111339,
+              6111355,
+              6131903,
+              6131919,
+              6151723,
+              6151739,
+              6171543
+            ],
+            "tick0": 665,
+            "tick": 672,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 12,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5984279,
+              5984295,
+              5984311,
+              5984327,
+              5984343,
+              5984359,
+              5984375,
+              5984391,
+              5984407,
+              5984423,
+              5984439,
+              5984455,
+              5984471,
+              5984487,
+              5984503
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5992287,
+              5992303,
+              6000367,
+              6000383,
+              6008447,
+              6008463,
+              6016527,
+              6016543,
+              6024607,
+              6024623,
+              6032687,
+              6032703,
+              6040767,
+              6040783,
+              6048847
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5987487,
+              5987503,
+              5990767,
+              5990783,
+              5994047,
+              5994063,
+              5997327,
+              5997343,
+              6000607,
+              6000623,
+              6003887,
+              6003903,
+              6007167,
+              6007183,
+              6010447
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117076,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20124,
+            "endpoints": 117076,
+            "legs": [
+              19364,
+              19376,
+              19364,
+              19376,
+              20124,
+              19376
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19376,
+            "legWorstDeviation": 0.038604459124690335,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26176
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19512.666666666668,
+            "perBoundaryPerWrite": 813.0277777777778,
+            "cdpBracket": 171324,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6049219,
+              6049235,
+              6075411,
+              6075427,
+              6094791,
+              6094807,
+              6114183,
+              6114199,
+              6133563,
+              6133579,
+              6152955,
+              6152971,
+              6173095,
+              6173111,
+              6192487
+            ],
+            "tick0": 693,
+            "tick": 700,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120744,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20872,
+            "endpoints": 120744,
+            "legs": [
+              20524,
+              19816,
+              19816,
+              20872,
+              19804,
+              19816
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19816,
+            "legWorstDeviation": 0.05329027048849415,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26680
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20124,
+            "perBoundaryPerWrite": 838.5,
+            "cdpBracket": 175388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6078191,
+              6078207,
+              6104887,
+              6104903,
+              6125427,
+              6125443,
+              6145259,
+              6145275,
+              6165091,
+              6165107,
+              6185979,
+              6185995,
+              6205799,
+              6205815,
+              6225631
+            ],
+            "tick0": 721,
+            "tick": 728,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 13,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 31952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6038283,
+              6038299,
+              6038315,
+              6038331,
+              6038347,
+              6038363,
+              6038379,
+              6038395,
+              6038411,
+              6038427,
+              6038443,
+              6038459,
+              6038475,
+              6038491,
+              6038507
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6050311,
+              6050327,
+              6058391,
+              6058407,
+              6066471,
+              6066487,
+              6074551,
+              6074567,
+              6082631,
+              6082647,
+              6090711,
+              6090727,
+              6098791,
+              6098807,
+              6106871
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6045511,
+              6045527,
+              6048791,
+              6048807,
+              6052071,
+              6052087,
+              6055351,
+              6055367,
+              6058631,
+              6058647,
+              6061911,
+              6061927,
+              6065191,
+              6065207,
+              6068471
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116256,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19364,
+            "endpoints": 116256,
+            "legs": [
+              19340,
+              19364,
+              19364,
+              19364,
+              19364,
+              19364
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19364,
+            "legWorstDeviation": -0.0012394133443503407,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26164
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19376,
+            "perBoundaryPerWrite": 807.3333333333334,
+            "cdpBracket": 171112,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6087279,
+              6087295,
+              6113459,
+              6113475,
+              6132815,
+              6132831,
+              6152195,
+              6152211,
+              6171575,
+              6171591,
+              6190955,
+              6190971,
+              6210335,
+              6210351,
+              6229715
+            ],
+            "tick0": 749,
+            "tick": 756,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118896,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19804,
+            "endpoints": 118896,
+            "legs": [
+              19804,
+              19804,
+              19804,
+              19804,
+              19780,
+              19804
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19804,
+            "legWorstDeviation": -0.001211876388608362,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26680
+            ],
+            "primeExcess": 6876,
+            "perWrite": 19816,
+            "perBoundaryPerWrite": 825.6666666666666,
+            "cdpBracket": 173540,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6099479,
+              6099495,
+              6126175,
+              6126191,
+              6145995,
+              6146011,
+              6165815,
+              6165831,
+              6185635,
+              6185651,
+              6205455,
+              6205471,
+              6225251,
+              6225267,
+              6245071
+            ],
+            "tick0": 777,
+            "tick": 784,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 14,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6058515,
+              6058531,
+              6058547,
+              6058563,
+              6058579,
+              6058595,
+              6058611,
+              6058627,
+              6058643,
+              6058659,
+              6058675,
+              6058691,
+              6058707,
+              6058723,
+              6058739
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6066523,
+              6066539,
+              6074603,
+              6074619,
+              6082683,
+              6082699,
+              6090763,
+              6090779,
+              6098843,
+              6098859,
+              6106923,
+              6106939,
+              6115003,
+              6115019,
+              6123083
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6061723,
+              6061739,
+              6065003,
+              6065019,
+              6068283,
+              6068299,
+              6071563,
+              6071579,
+              6074843,
+              6074859,
+              6078123,
+              6078139,
+              6081403,
+              6081419,
+              6084683
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117016,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20112,
+            "endpoints": 117016,
+            "legs": [
+              19364,
+              19340,
+              19364,
+              19376,
+              19364,
+              20112
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19364,
+            "legWorstDeviation": 0.03862838256558562,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26176
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19502.666666666668,
+            "perBoundaryPerWrite": 812.6111111111112,
+            "cdpBracket": 171264,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6104059,
+              6104075,
+              6130251,
+              6130267,
+              6149631,
+              6149647,
+              6168987,
+              6169003,
+              6188367,
+              6188383,
+              6207759,
+              6207775,
+              6227139,
+              6227155,
+              6247267
+            ],
+            "tick0": 805,
+            "tick": 812,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 269140,
+            "fall": 149164,
+            "falls": 1,
+            "maxStep": 170040,
+            "endpoints": 119976,
+            "legs": [
+              19780,
+              19804,
+              19804,
+              170040,
+              19816,
+              19816
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              -149164,
+              16
+            ],
+            "legMedian": 19810,
+            "legWorstDeviation": 7.58354366481575,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 170040 B against a cohort median of 19810 B (+150230 B, 758.4%), past the ±25% leg tolerance (±4952.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 170040 B against a cohort median of 19810 B (+150230 B, 758.4%), past the ±25% leg tolerance (±4952.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26680
+            ],
+            "primeExcess": 6870,
+            "perWrite": 44856.666666666664,
+            "perBoundaryPerWrite": 1869.0277777777776,
+            "cdpBracket": 174620,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6121419,
+              6121435,
+              6148115,
+              6148131,
+              6167911,
+              6167927,
+              6187731,
+              6187747,
+              6207551,
+              6207567,
+              6377607,
+              6228443,
+              6248259,
+              6248275,
+              6268091
+            ],
+            "tick0": 833,
+            "tick": 840,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 15,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6081511,
+              6081527,
+              6081543,
+              6081559,
+              6081575,
+              6081591,
+              6081607,
+              6081623,
+              6081639,
+              6081655,
+              6081671,
+              6081687,
+              6081703,
+              6081719,
+              6081735
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6089519,
+              6089535,
+              6097599,
+              6097615,
+              6105679,
+              6105695,
+              6113759,
+              6113775,
+              6121839,
+              6121855,
+              6129919,
+              6129935,
+              6137999,
+              6138015,
+              6146079
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6084719,
+              6084735,
+              6087999,
+              6088015,
+              6091279,
+              6091295,
+              6094559,
+              6094575,
+              6097839,
+              6097855,
+              6101119,
+              6101135,
+              6104399,
+              6104415,
+              6107679
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117040,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20112,
+            "endpoints": 117040,
+            "legs": [
+              19364,
+              19364,
+              19364,
+              19376,
+              19364,
+              20112
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19364,
+            "legWorstDeviation": 0.03862838256558562,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26176
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19506.666666666668,
+            "perBoundaryPerWrite": 812.7777777777778,
+            "cdpBracket": 171160,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6129507,
+              6129523,
+              6155699,
+              6155715,
+              6175079,
+              6175095,
+              6194459,
+              6194475,
+              6213839,
+              6213855,
+              6233231,
+              6233247,
+              6252611,
+              6252627,
+              6272739
+            ],
+            "tick0": 861,
+            "tick": 868,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 342136,
+            "fall": 219600,
+            "falls": 2,
+            "maxStep": 179900,
+            "endpoints": 122536,
+            "legs": [
+              179900,
+              122520,
+              -138592,
+              -81008,
+              19804,
+              19816
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19810,
+            "legWorstDeviation": 8.081272084805654,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 179900 B against a cohort median of 19810 B (+160090 B, 808.1%), past the ±25% leg tolerance (±4952.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read 122520 B against a cohort median of 19810 B (+102710 B, 518.5%), past the ±25% leg tolerance (±4952.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -138592 B against a cohort median of 19810 B (-158402 B, -799.6%), past the ±25% leg tolerance (±4952.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 4 of 6 read -81008 B against a cohort median of 19810 B (-100818 B, -508.9%), past the ±25% leg tolerance (±4952.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 179900 B against a cohort median of 19810 B (+160090 B, 808.1%), past the ±25% leg tolerance (±4952.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read 122520 B against a cohort median of 19810 B (+102710 B, 518.5%), past the ±25% leg tolerance (±4952.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -138592 B against a cohort median of 19810 B (-158402 B, -799.6%), past the ±25% leg tolerance (±4952.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 4 of 6 read -81008 B against a cohort median of 19810 B (-100818 B, -508.9%), past the ±25% leg tolerance (±4952.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26680
+            ],
+            "primeExcess": 6870,
+            "perWrite": 57022.666666666664,
+            "perBoundaryPerWrite": 2375.9444444444443,
+            "cdpBracket": 177180,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6148619,
+              6148635,
+              6175315,
+              6175331,
+              6355231,
+              6355247,
+              6477767,
+              6477783,
+              6339191,
+              6339207,
+              6258199,
+              6258215,
+              6278019,
+              6278035,
+              6297851
+            ],
+            "tick0": 889,
+            "tick": 896,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 16,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6104451,
+              6104467,
+              6104483,
+              6104499,
+              6104515,
+              6104531,
+              6104547,
+              6104563,
+              6104579,
+              6104595,
+              6104611,
+              6104627,
+              6104643,
+              6104659,
+              6104675
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6112459,
+              6112475,
+              6120539,
+              6120555,
+              6128619,
+              6128635,
+              6136699,
+              6136715,
+              6144779,
+              6144795,
+              6152859,
+              6152875,
+              6160939,
+              6160955,
+              6169019
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6107659,
+              6107675,
+              6110939,
+              6110955,
+              6114219,
+              6114235,
+              6117499,
+              6117515,
+              6120779,
+              6120795,
+              6124059,
+              6124075,
+              6127339,
+              6127355,
+              6130619
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117088,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20124,
+            "endpoints": 117088,
+            "legs": [
+              19376,
+              19376,
+              19364,
+              19376,
+              19376,
+              20124
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19376,
+            "legWorstDeviation": 0.038604459124690335,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26164
+            ],
+            "primeExcess": 6788,
+            "perWrite": 19514.666666666668,
+            "perBoundaryPerWrite": 813.1111111111112,
+            "cdpBracket": 171324,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6143231,
+              6143247,
+              6169411,
+              6169427,
+              6188803,
+              6188819,
+              6208195,
+              6208211,
+              6227575,
+              6227591,
+              6246967,
+              6246983,
+              6266359,
+              6266375,
+              6286499
+            ],
+            "tick0": 917,
+            "tick": 924,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 466628,
+            "fall": 341384,
+            "falls": 1,
+            "maxStep": 385968,
+            "endpoints": 125244,
+            "legs": [
+              19804,
+              21164,
+              19780,
+              385968,
+              -341384,
+              19816
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19810,
+            "legWorstDeviation": 18.48349318525997,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 385968 B against a cohort median of 19810 B (+366158 B, 1848.3%), past the ±25% leg tolerance (±4952.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -341384 B against a cohort median of 19810 B (-361194 B, -1823.3%), past the ±25% leg tolerance (±4952.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 385968 B against a cohort median of 19810 B (+366158 B, 1848.3%), past the ±25% leg tolerance (±4952.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -341384 B against a cohort median of 19810 B (-361194 B, -1823.3%), past the ±25% leg tolerance (±4952.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26680
+            ],
+            "primeExcess": 6870,
+            "perWrite": 77771.33333333333,
+            "perBoundaryPerWrite": 3240.472222222222,
+            "cdpBracket": 179888,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6159783,
+              6159799,
+              6186479,
+              6186495,
+              6206299,
+              6206315,
+              6227479,
+              6227495,
+              6247275,
+              6247291,
+              6633259,
+              6633275,
+              6291891,
+              6291907,
+              6311723
+            ],
+            "tick0": 945,
+            "tick": 952,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 17,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6117407,
+              6117423,
+              6117439,
+              6117455,
+              6117471,
+              6117487,
+              6117503,
+              6117519,
+              6117535,
+              6117551,
+              6117567,
+              6117583,
+              6117599,
+              6117615,
+              6117631
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6125415,
+              6125431,
+              6133495,
+              6133511,
+              6141575,
+              6141591,
+              6149655,
+              6149671,
+              6157735,
+              6157751,
+              6165815,
+              6165831,
+              6173895,
+              6173911,
+              6181975
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6120615,
+              6120631,
+              6123895,
+              6123911,
+              6127175,
+              6127191,
+              6130455,
+              6130471,
+              6133735,
+              6133751,
+              6137015,
+              6137031,
+              6140295,
+              6140311,
+              6143575
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116268,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19376,
+            "endpoints": 116268,
+            "legs": [
+              19376,
+              19364,
+              19364,
+              19364,
+              19340,
+              19364
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19364,
+            "legWorstDeviation": -0.0012394133443503407,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26176
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19378,
+            "perBoundaryPerWrite": 807.4166666666666,
+            "cdpBracket": 170388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6171695,
+              6171711,
+              6197887,
+              6197903,
+              6217279,
+              6217295,
+              6236659,
+              6236675,
+              6256039,
+              6256055,
+              6275419,
+              6275435,
+              6294775,
+              6294791,
+              6314155
+            ],
+            "tick0": 973,
+            "tick": 980,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118980,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19820,
+            "endpoints": 118980,
+            "legs": [
+              19820,
+              19808,
+              19820,
+              19808,
+              19808,
+              19820
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19814,
+            "legWorstDeviation": 0.0003028161905723226,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26672
+            ],
+            "primeExcess": 6858,
+            "perWrite": 19830,
+            "perBoundaryPerWrite": 826.25,
+            "cdpBracket": 173616,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6189855,
+              6189871,
+              6216543,
+              6216559,
+              6236379,
+              6236395,
+              6256203,
+              6256219,
+              6276039,
+              6276055,
+              6295863,
+              6295879,
+              6315687,
+              6315703,
+              6335523
+            ],
+            "tick0": 1001,
+            "tick": 1008,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      }
+    ],
+    "allocFits": {
+      "perRound": {},
+      "mean": {}
+    },
+    "writeDriven": true,
+    "writeProvenance": {
+      "windows": 36,
+      "pairs": 36,
+      "unnamed": [],
+      "incomplete": [],
+      "ok": true
+    },
+    "controlVerdict": {
+      "ok": true,
+      "perDouble": 8.08088888888889,
+      "differential": 8.00148148148148
+    },
+    "fallsInMeasuredWindows": 16,
+    "refusedWindows": 14,
+    "refusalReasons": 20
+  },
+  "box": {
+    "bead": "rf2-24o2z",
+    "chromium": "chromium/147.0.7727.15",
+    "node": "v24.13.0",
+    "platform": "win32/x64/10.0.26200",
+    "load": {
+      "open": {
+        "at": "2026-08-20T20:34:36.488Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13481146037,
+        "cpuBusyMs": 3630173921,
+        "freeMemB": 15993946112,
+        "totalMemB": 68112736256,
+        "uptimeS": 709239.296
+      },
+      "close": {
+        "at": "2026-08-20T20:35:02.662Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13481641382,
+        "cpuBusyMs": 3630309547,
+        "freeMemB": 16019857408,
+        "totalMemB": 68112736256,
+        "uptimeS": 709265.468
+      },
+      "busyFraction": 0.21494807209840072
+    },
+    "session": {
+      "startedAt": "2026-08-20T20:33:49.570Z",
+      "sessionStartedAt": "2026-08-20T19:39:26.627Z",
+      "runsInSession": 13,
+      "sessionGapMs": 3600000,
+      "previousRun": {
+        "startedAt": "2026-08-20T20:32:42.744Z",
+        "endedAt": "2026-08-20T20:33:49.137Z",
+        "sinceStartMs": 66826,
+        "sinceEndMs": 433,
+        "sameSession": true
+      }
+    }
+  }
+}

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/fixed-5.json
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/fixed-5.json
@@ -1,0 +1,7545 @@
+{
+  "generatedAt": "2026-08-20T20:37:49.736Z",
+  "build": "hicasso-bench",
+  "initFn": "re-frame.bench.p0-app/-main",
+  "alloc": {
+    "benchmark": "P0:steady-state-allocation-slope",
+    "bead": "rf2-2rtt6.76",
+    "roots": 4,
+    "perRoot": {
+      "list": 300,
+      "grid": 6
+    },
+    "publishedPerRoot": {
+      "list": 300,
+      "grid": 300
+    },
+    "arm": {
+      "cells": 6,
+      "roots": 4,
+      "boundaries": 24,
+      "writes": 6,
+      "refusals": [],
+      "admissible": true
+    },
+    "boundaries": 24,
+    "writes": 6,
+    "primeWrites": 1,
+    "windowWrites": 7,
+    "bySite": false,
+    "sites": 2,
+    "siteNames": [
+      "dispatch",
+      "drain"
+    ],
+    "warmups": 3,
+    "rounds": 18,
+    "preciseMemory": true,
+    "controlDoubles": {
+      "d1": 1000,
+      "d2": 400
+    },
+    "controlSlack": 0.75,
+    "writeSelector": "all",
+    "writeLegs": [
+      "all"
+    ],
+    "writePaired": false,
+    "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+    "plan": {
+      "name": "floor",
+      "arms": true,
+      "rungs": false,
+      "fits": false
+    },
+    "segOrder": "fixed",
+    "passOrder": "parity",
+    "passSeed": "1787258232276",
+    "passSchedule": {
+      "flips": [
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true
+      ],
+      "attempts": 1,
+      "parityTied": false
+    },
+    "controlSlot": "first",
+    "instrument": "in-page performance.memory.usedJSHeapSize sampled at every leg boundary, rising steps accumulated separately from falling ones; --enable-precise-memory-info. A falling step is a collection this counter SAW; a leg that deviates from its cohort median by more than the leg tolerance is a work unit that is not one; and under the by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the other two can see. TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg has no interior reading and so no site step to be negative, and the intra-leg gate returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with these (see `bySite`), so a witness comparing byte for byte against a figure published at stride 2 can never be screened by all three",
+    "fallThresholdB": 600000,
+    "legTolerance": 0.25,
+    "verification": {
+      "unverified": 0,
+      "detail": []
+    },
+    "workCount": false,
+    "workVerification": {
+      "counted": false
+    },
+    "perRound": [
+      {
+        "round": 0,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 524,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              524
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 116.66666666666667,
+            "cdpBracket": 46232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3840290,
+              3840306,
+              3840322,
+              3840338,
+              3840354,
+              3840370,
+              3840386,
+              3840402,
+              3840418,
+              3840434,
+              3840450,
+              3840466,
+              3840482,
+              3841006,
+              3841022
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48576,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8144,
+            "endpoints": 48576,
+            "legs": [
+              8144,
+              8080,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.00992063492063492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8096,
+            "cdpBracket": 87388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3853914,
+              3853930,
+              3861994,
+              3862010,
+              3870154,
+              3870170,
+              3878250,
+              3878266,
+              3886330,
+              3886346,
+              3894410,
+              3894426,
+              3902490,
+              3902506,
+              3910570
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 52328,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3850014,
+              3850030,
+              3853294,
+              3853310,
+              3856574,
+              3856590,
+              3859854,
+              3859870,
+              3863134,
+              3863150,
+              3866414,
+              3866430,
+              3869694,
+              3869710,
+              3872974
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 360340,
+            "fall": 228076,
+            "falls": 1,
+            "maxStep": 278536,
+            "endpoints": 132264,
+            "legs": [
+              278536,
+              19692,
+              19752,
+              -228076,
+              20952,
+              21312
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20352,
+            "legWorstDeviation": 12.685927672955975,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 278536 B against a cohort median of 20352 B (+258184 B, 1268.6%), past the ±25% leg tolerance (±5088 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -228076 B against a cohort median of 20352 B (-248428 B, -1220.7%), past the ±25% leg tolerance (±5088 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 278536 B against a cohort median of 20352 B (+258184 B, 1268.6%), past the ±25% leg tolerance (±5088 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -228076 B against a cohort median of 20352 B (-248428 B, -1220.7%), past the ±25% leg tolerance (±5088 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26460
+            ],
+            "primeExcess": 6108,
+            "perWrite": 60056.666666666664,
+            "perBoundaryPerWrite": 2502.361111111111,
+            "cdpBracket": 187124,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              4782611,
+              4782627,
+              4809087,
+              4809103,
+              5087639,
+              5087655,
+              5107347,
+              5107363,
+              5127115,
+              5127131,
+              4899055,
+              4899071,
+              4920023,
+              4920039,
+              4941351
+            ],
+            "tick0": 21,
+            "tick": 28,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 499236,
+            "fall": 91852,
+            "falls": 1,
+            "maxStep": 298136,
+            "endpoints": 407384,
+            "legs": [
+              24268,
+              19916,
+              134304,
+              -91852,
+              298136,
+              20036
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              2496,
+              16,
+              16
+            ],
+            "legMedian": 22152,
+            "legWorstDeviation": 12.458649331888768,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 134304 B against a cohort median of 22152 B (+112152 B, 506.3%), past the ±25% leg tolerance (±5538 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -91852 B against a cohort median of 22152 B (-114004 B, -514.6%), past the ±25% leg tolerance (±5538 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 5 of 6 read 298136 B against a cohort median of 22152 B (+275984 B, 1245.9%), past the ±25% leg tolerance (±5538 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 134304 B against a cohort median of 22152 B (+112152 B, 506.3%), past the ±25% leg tolerance (±5538 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -91852 B against a cohort median of 22152 B (-114004 B, -514.6%), past the ±25% leg tolerance (±5538 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 5 of 6 read 298136 B against a cohort median of 22152 B (+275984 B, 1245.9%), past the ±25% leg tolerance (±5538 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26764
+            ],
+            "primeExcess": 4612,
+            "perWrite": 83206,
+            "perBoundaryPerWrite": 3466.9166666666665,
+            "cdpBracket": 204512,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5059167,
+              5059183,
+              5085947,
+              5085963,
+              5110231,
+              5110247,
+              5130163,
+              5130179,
+              5264483,
+              5266979,
+              5175127,
+              5175143,
+              5473279,
+              5473295,
+              5493331
+            ],
+            "tick0": 49,
+            "tick": 56,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 1,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5057887,
+              5057903,
+              5057919,
+              5057935,
+              5057951,
+              5057967,
+              5057983,
+              5057999,
+              5058015,
+              5058031,
+              5058047,
+              5058063,
+              5058079,
+              5058095,
+              5058111
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 87716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5065895,
+              5065911,
+              5073975,
+              5073991,
+              5082055,
+              5082071,
+              5090135,
+              5090151,
+              5098215,
+              5098231,
+              5106295,
+              5106311,
+              5114375,
+              5114391,
+              5122455
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5063339,
+              5063355,
+              5066619,
+              5066635,
+              5069899,
+              5069915,
+              5073179,
+              5073195,
+              5076459,
+              5076475,
+              5079739,
+              5079755,
+              5083019,
+              5083035,
+              5086299
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 121088,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21912,
+            "endpoints": 121088,
+            "legs": [
+              19828,
+              19332,
+              19332,
+              21912,
+              19332,
+              21256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19580,
+            "legWorstDeviation": 0.11910112359550562,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              31528
+            ],
+            "primeExcess": 11948,
+            "perWrite": 20181.333333333332,
+            "perBoundaryPerWrite": 840.8888888888888,
+            "cdpBracket": 184148,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5187323,
+              5187339,
+              5218867,
+              5218883,
+              5238711,
+              5238727,
+              5258059,
+              5258075,
+              5277407,
+              5277423,
+              5299335,
+              5299351,
+              5318683,
+              5318699,
+              5339955
+            ],
+            "tick0": 77,
+            "tick": 84,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 155124,
+            "fall": 28788,
+            "falls": 1,
+            "maxStep": 51632,
+            "endpoints": 126336,
+            "legs": [
+              19696,
+              -28788,
+              24112,
+              19624,
+              19624,
+              20356
+            ],
+            "gaps": [
+              16,
+              51632,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19660,
+            "legWorstDeviation": -2.4642929806714142,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read -28788 B against a cohort median of 19660 B (-48448 B, -246.4%), past the ±25% leg tolerance (±4915 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read -28788 B against a cohort median of 19660 B (-48448 B, -246.4%), past the ±25% leg tolerance (±4915 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6884,
+            "perWrite": 25854,
+            "perBoundaryPerWrite": 1077.25,
+            "cdpBracket": 181316,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5304683,
+              5304699,
+              5331243,
+              5331259,
+              5350955,
+              5402587,
+              5373799,
+              5373815,
+              5397927,
+              5397943,
+              5417567,
+              5417583,
+              5437207,
+              5437223,
+              5457579
+            ],
+            "tick0": 105,
+            "tick": 112,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 2,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5268875,
+              5268891,
+              5268907,
+              5268923,
+              5268939,
+              5268955,
+              5268971,
+              5268987,
+              5269003,
+              5269019,
+              5269035,
+              5269051,
+              5269067,
+              5269083,
+              5269099
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85088,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5276899,
+              5276915,
+              5284979,
+              5284995,
+              5293059,
+              5293075,
+              5301139,
+              5301155,
+              5309219,
+              5309235,
+              5317299,
+              5317315,
+              5325379,
+              5325395,
+              5333459
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5272099,
+              5272115,
+              5275379,
+              5275395,
+              5278659,
+              5278675,
+              5281939,
+              5281955,
+              5285219,
+              5285235,
+              5288499,
+              5288515,
+              5291779,
+              5291795,
+              5295059
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116876,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20000,
+            "endpoints": 116876,
+            "legs": [
+              19256,
+              19768,
+              20000,
+              19256,
+              19256,
+              19244
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": 0.03863730785209805,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19479.333333333332,
+            "perBoundaryPerWrite": 811.6388888888888,
+            "cdpBracket": 173976,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5353511,
+              5353527,
+              5379567,
+              5379583,
+              5398839,
+              5398855,
+              5418623,
+              5418639,
+              5438639,
+              5438655,
+              5457911,
+              5457927,
+              5477183,
+              5477199,
+              5496443
+            ],
+            "tick0": 133,
+            "tick": 140,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 144840,
+            "fall": 23528,
+            "falls": 1,
+            "maxStep": 45248,
+            "endpoints": 121312,
+            "legs": [
+              19684,
+              20740,
+              45248,
+              19696,
+              19696,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              -23528,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": 1.29731925264013,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 45248 B against a cohort median of 19696 B (+25552 B, 129.7%), past the ±25% leg tolerance (±4924 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 45248 B against a cohort median of 19696 B (+25552 B, 129.7%), past the ±25% leg tolerance (±4924 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6848,
+            "perWrite": 24140,
+            "perBoundaryPerWrite": 1005.8333333333334,
+            "cdpBracket": 175836,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5427143,
+              5427159,
+              5453703,
+              5453719,
+              5473403,
+              5473419,
+              5494159,
+              5494175,
+              5539423,
+              5515895,
+              5535591,
+              5535607,
+              5555303,
+              5555319,
+              5575015
+            ],
+            "tick0": 161,
+            "tick": 168,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 3,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 224360,
+            "fall": 223240,
+            "falls": 1,
+            "maxStep": 200700,
+            "endpoints": 1120,
+            "legs": [
+              16,
+              16,
+              16,
+              200700,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              23516,
+              -223240,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 12542.75,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 200700 B against a cohort median of 16 B (+200684 B, 1254275.0%), past the ±25% leg tolerance (±4 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 200700 B against a cohort median of 16 B (+200684 B, 1254275.0%), past the ±25% leg tolerance (±4 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 37393.333333333336,
+            "cdpBracket": 29232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5389243,
+              5389259,
+              5389275,
+              5389291,
+              5389307,
+              5389323,
+              5389339,
+              5389355,
+              5389371,
+              5412887,
+              5613587,
+              5390347,
+              5390363,
+              5390379,
+              5390395
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5398179,
+              5398195,
+              5406259,
+              5406275,
+              5414339,
+              5414355,
+              5422419,
+              5422435,
+              5430499,
+              5430515,
+              5438579,
+              5438595,
+              5446659,
+              5446675,
+              5454739
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5393379,
+              5393395,
+              5396659,
+              5396675,
+              5399939,
+              5399955,
+              5403219,
+              5403235,
+              5406499,
+              5406515,
+              5409779,
+              5409795,
+              5413059,
+              5413075,
+              5416339
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 115596,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19256,
+            "endpoints": 115596,
+            "legs": [
+              19256,
+              19256,
+              19220,
+              19256,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": -0.0018695471541337765,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19266,
+            "perBoundaryPerWrite": 802.75,
+            "cdpBracket": 169596,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5460911,
+              5460927,
+              5486967,
+              5486983,
+              5506239,
+              5506255,
+              5525511,
+              5525527,
+              5544747,
+              5544763,
+              5564019,
+              5564035,
+              5583291,
+              5583307,
+              5602563
+            ],
+            "tick0": 189,
+            "tick": 196,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118224,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19696,
+            "endpoints": 118224,
+            "legs": [
+              19696,
+              19696,
+              19684,
+              19660,
+              19696,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": -0.0018277822908204712,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6848,
+            "perWrite": 19704,
+            "perBoundaryPerWrite": 821,
+            "cdpBracket": 172748,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5492943,
+              5492959,
+              5519503,
+              5519519,
+              5539215,
+              5539231,
+              5558927,
+              5558943,
+              5578627,
+              5578643,
+              5598303,
+              5598319,
+              5618015,
+              5618031,
+              5637727
+            ],
+            "tick0": 217,
+            "tick": 224,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 4,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5451979,
+              5451995,
+              5452011,
+              5452027,
+              5452043,
+              5452059,
+              5452075,
+              5452091,
+              5452107,
+              5452123,
+              5452139,
+              5452155,
+              5452171,
+              5452187,
+              5452203
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5459987,
+              5460003,
+              5468067,
+              5468083,
+              5476147,
+              5476163,
+              5484227,
+              5484243,
+              5492307,
+              5492323,
+              5500387,
+              5500403,
+              5508467,
+              5508483,
+              5516547
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5455187,
+              5455203,
+              5458467,
+              5458483,
+              5461747,
+              5461763,
+              5465027,
+              5465043,
+              5468307,
+              5468323,
+              5471587,
+              5471603,
+              5474867,
+              5474883,
+              5478147
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 132372,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 26152,
+            "endpoints": 132372,
+            "legs": [
+              26152,
+              23480,
+              20192,
+              20192,
+              22092,
+              20168
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21142,
+            "legWorstDeviation": 0.2369690663134992,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28752
+            ],
+            "primeExcess": 7610,
+            "perWrite": 22062,
+            "perBoundaryPerWrite": 919.25,
+            "cdpBracket": 189212,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5622395,
+              5622411,
+              5651163,
+              5651179,
+              5677331,
+              5677347,
+              5700827,
+              5700843,
+              5721035,
+              5721051,
+              5741243,
+              5741259,
+              5763351,
+              5763367,
+              5783535
+            ],
+            "tick0": 245,
+            "tick": 252,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 128144,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21648,
+            "endpoints": 128144,
+            "legs": [
+              21336,
+              20592,
+              20592,
+              20592,
+              21648,
+              20580
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              2724,
+              16,
+              16
+            ],
+            "legMedian": 20592,
+            "legWorstDeviation": 0.05128205128205128,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              27456
+            ],
+            "primeExcess": 6864,
+            "perWrite": 21357.333333333332,
+            "perBoundaryPerWrite": 889.8888888888888,
+            "cdpBracket": 183580,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5714711,
+              5714727,
+              5742183,
+              5742199,
+              5763535,
+              5763551,
+              5784143,
+              5784159,
+              5804751,
+              5807475,
+              5828067,
+              5828083,
+              5849731,
+              5849747,
+              5870327
+            ],
+            "tick0": 273,
+            "tick": 280,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 5,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5675531,
+              5675547,
+              5675563,
+              5675579,
+              5675595,
+              5675611,
+              5675627,
+              5675643,
+              5675659,
+              5675675,
+              5675691,
+              5675707,
+              5675723,
+              5675739,
+              5675755
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5683539,
+              5683555,
+              5691619,
+              5691635,
+              5699699,
+              5699715,
+              5707779,
+              5707795,
+              5715859,
+              5715875,
+              5723939,
+              5723955,
+              5732019,
+              5732035,
+              5740099
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5678739,
+              5678755,
+              5682019,
+              5682035,
+              5685299,
+              5685315,
+              5688579,
+              5688595,
+              5691859,
+              5691875,
+              5695139,
+              5695155,
+              5698419,
+              5698435,
+              5701699
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 123712,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21500,
+            "endpoints": 123712,
+            "legs": [
+              20152,
+              20760,
+              20900,
+              20152,
+              20152,
+              21500
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20456,
+            "legWorstDeviation": 0.0510363707469691,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26952
+            ],
+            "primeExcess": 6496,
+            "perWrite": 20618.666666666668,
+            "perBoundaryPerWrite": 859.1111111111112,
+            "cdpBracket": 178624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5729371,
+              5729387,
+              5756339,
+              5756355,
+              5776507,
+              5776523,
+              5797283,
+              5797299,
+              5818199,
+              5818215,
+              5838367,
+              5838383,
+              5858535,
+              5858551,
+              5880051
+            ],
+            "tick0": 301,
+            "tick": 308,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 123516,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20576,
+            "endpoints": 123516,
+            "legs": [
+              20576,
+              20576,
+              20576,
+              20576,
+              20540,
+              20576
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20576,
+            "legWorstDeviation": -0.001749611197511664,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              27440
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20586,
+            "perBoundaryPerWrite": 857.75,
+            "cdpBracket": 178936,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5756843,
+              5756859,
+              5784299,
+              5784315,
+              5804891,
+              5804907,
+              5825483,
+              5825499,
+              5846075,
+              5846091,
+              5866667,
+              5866683,
+              5887223,
+              5887239,
+              5907815
+            ],
+            "tick0": 329,
+            "tick": 336,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 6,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5717463,
+              5717479,
+              5717495,
+              5717511,
+              5717527,
+              5717543,
+              5717559,
+              5717575,
+              5717591,
+              5717607,
+              5717623,
+              5717639,
+              5717655,
+              5717671,
+              5717687
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5725471,
+              5725487,
+              5733551,
+              5733567,
+              5741631,
+              5741647,
+              5749711,
+              5749727,
+              5757791,
+              5757807,
+              5765871,
+              5765887,
+              5773951,
+              5773967,
+              5782031
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5720671,
+              5720687,
+              5723951,
+              5723967,
+              5727231,
+              5727247,
+              5730511,
+              5730527,
+              5733791,
+              5733807,
+              5737071,
+              5737087,
+              5740351,
+              5740367,
+              5743631
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 133644,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22740,
+            "endpoints": 133644,
+            "legs": [
+              21992,
+              22404,
+              21992,
+              22428,
+              22740,
+              21992
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22198,
+            "legWorstDeviation": 0.024416614109379224,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28780
+            ],
+            "primeExcess": 6582,
+            "perWrite": 22274,
+            "perBoundaryPerWrite": 928.0833333333334,
+            "cdpBracket": 190512,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5775687,
+              5775703,
+              5804483,
+              5804499,
+              5826491,
+              5826507,
+              5848911,
+              5848927,
+              5870919,
+              5870935,
+              5893363,
+              5893379,
+              5916119,
+              5916135,
+              5938127
+            ],
+            "tick0": 357,
+            "tick": 364,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 135912,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23656,
+            "endpoints": 135912,
+            "legs": [
+              22432,
+              23656,
+              22432,
+              22432,
+              22432,
+              22432
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22432,
+            "legWorstDeviation": 0.05456490727532097,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29296
+            ],
+            "primeExcess": 6864,
+            "perWrite": 22652,
+            "perBoundaryPerWrite": 943.8333333333334,
+            "cdpBracket": 193188,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5799395,
+              5799411,
+              5828707,
+              5828723,
+              5851155,
+              5851171,
+              5874827,
+              5874843,
+              5897275,
+              5897291,
+              5919723,
+              5919739,
+              5942171,
+              5942187,
+              5964619
+            ],
+            "tick0": 385,
+            "tick": 392,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 7,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 223484,
+            "fall": 222784,
+            "falls": 1,
+            "maxStep": 223324,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              223324,
+              -222784
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 13956.75,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read 223324 B against a cohort median of 16 B (+223308 B, 1395675.0%), past the ±25% leg tolerance (±4 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read -222784 B against a cohort median of 16 B (-222800 B, -1392500.0%), past the ±25% leg tolerance (±4 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read 223324 B against a cohort median of 16 B (+223308 B, 1395675.0%), past the ±25% leg tolerance (±4 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read -222784 B against a cohort median of 16 B (-222800 B, -1392500.0%), past the ±25% leg tolerance (±4 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 37247.333333333336,
+            "cdpBracket": 28812,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5759547,
+              5759563,
+              5759579,
+              5759595,
+              5759611,
+              5759627,
+              5759643,
+              5759659,
+              5759675,
+              5759691,
+              5759707,
+              5759723,
+              5983047,
+              5983063,
+              5760279
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5768063,
+              5768079,
+              5776143,
+              5776159,
+              5784223,
+              5784239,
+              5792303,
+              5792319,
+              5800383,
+              5800399,
+              5808463,
+              5808479,
+              5816543,
+              5816559,
+              5824623
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5763263,
+              5763279,
+              5766543,
+              5766559,
+              5769823,
+              5769839,
+              5773103,
+              5773119,
+              5776383,
+              5776399,
+              5779663,
+              5779679,
+              5782943,
+              5782959,
+              5786223
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 134340,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24372,
+            "endpoints": 134340,
+            "legs": [
+              21972,
+              21972,
+              21972,
+              21984,
+              24372,
+              21972
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21972,
+            "legWorstDeviation": 0.10922992900054615,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28772
+            ],
+            "primeExcess": 6800,
+            "perWrite": 22390,
+            "perBoundaryPerWrite": 932.9166666666666,
+            "cdpBracket": 198712,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5827583,
+              5827599,
+              5856371,
+              5856387,
+              5878359,
+              5878375,
+              5900347,
+              5900363,
+              5922335,
+              5922351,
+              5944335,
+              5944351,
+              5968723,
+              5968739,
+              5990711
+            ],
+            "tick0": 413,
+            "tick": 420,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 138504,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 26324,
+            "endpoints": 138504,
+            "legs": [
+              22424,
+              22412,
+              22412,
+              22424,
+              22412,
+              26324
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22418,
+            "legWorstDeviation": 0.17423498974038718,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29288
+            ],
+            "primeExcess": 6870,
+            "perWrite": 23084,
+            "perBoundaryPerWrite": 961.8333333333334,
+            "cdpBracket": 195772,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5853247,
+              5853263,
+              5882551,
+              5882567,
+              5904991,
+              5905007,
+              5927419,
+              5927435,
+              5949847,
+              5949863,
+              5972287,
+              5972303,
+              5994715,
+              5994731,
+              6021055
+            ],
+            "tick0": 441,
+            "tick": 448,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 8,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5816207,
+              5816223,
+              5816239,
+              5816255,
+              5816271,
+              5816287,
+              5816303,
+              5816319,
+              5816335,
+              5816351,
+              5816367,
+              5816383,
+              5816399,
+              5816415,
+              5816431
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5824215,
+              5824231,
+              5832295,
+              5832311,
+              5840375,
+              5840391,
+              5848455,
+              5848471,
+              5856535,
+              5856551,
+              5864615,
+              5864631,
+              5872695,
+              5872711,
+              5880775
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5819415,
+              5819431,
+              5822695,
+              5822711,
+              5825975,
+              5825991,
+              5829255,
+              5829271,
+              5832535,
+              5832551,
+              5835815,
+              5835831,
+              5839095,
+              5839111,
+              5842375
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 134984,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23672,
+            "endpoints": 134984,
+            "legs": [
+              23672,
+              22704,
+              21960,
+              21948,
+              21924,
+              22680
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22320,
+            "legWorstDeviation": 0.06057347670250896,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28760
+            ],
+            "primeExcess": 6440,
+            "perWrite": 22497.333333333332,
+            "perBoundaryPerWrite": 937.3888888888888,
+            "cdpBracket": 191832,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5881531,
+              5881547,
+              5910307,
+              5910323,
+              5933995,
+              5934011,
+              5956715,
+              5956731,
+              5978691,
+              5978707,
+              6000655,
+              6000671,
+              6022595,
+              6022611,
+              6045291
+            ],
+            "tick0": 469,
+            "tick": 476,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 321092,
+            "fall": 178568,
+            "falls": 1,
+            "maxStep": 220240,
+            "endpoints": 142524,
+            "legs": [
+              220240,
+              33844,
+              -178568,
+              22304,
+              22304,
+              22304
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22304,
+            "legWorstDeviation": -9.00609756097561,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 220240 B against a cohort median of 22304 B (+197936 B, 887.4%), past the ±25% leg tolerance (±5576 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read 33844 B against a cohort median of 22304 B (+11540 B, 51.7%), past the ±25% leg tolerance (±5576 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -178568 B against a cohort median of 22304 B (-200872 B, -900.6%), past the ±25% leg tolerance (±5576 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 220240 B against a cohort median of 22304 B (+197936 B, 887.4%), past the ±25% leg tolerance (±5576 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read 33844 B against a cohort median of 22304 B (+11540 B, 51.7%), past the ±25% leg tolerance (±5576 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -178568 B against a cohort median of 22304 B (-200872 B, -900.6%), past the ±25% leg tolerance (±5576 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29180
+            ],
+            "primeExcess": 6876,
+            "perWrite": 53515.333333333336,
+            "perBoundaryPerWrite": 2229.8055555555557,
+            "cdpBracket": 199684,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5917615,
+              5917631,
+              5946811,
+              5946827,
+              6167067,
+              6167083,
+              6200927,
+              6200943,
+              6022375,
+              6022391,
+              6044695,
+              6044711,
+              6067015,
+              6067031,
+              6089335
+            ],
+            "tick0": 497,
+            "tick": 504,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 9,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5885035,
+              5885051,
+              5885067,
+              5885083,
+              5885099,
+              5885115,
+              5885131,
+              5885147,
+              5885163,
+              5885179,
+              5885195,
+              5885211,
+              5885227,
+              5885243,
+              5885259
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5893043,
+              5893059,
+              5901123,
+              5901139,
+              5909203,
+              5909219,
+              5917283,
+              5917299,
+              5925363,
+              5925379,
+              5933443,
+              5933459,
+              5941523,
+              5941539,
+              5949603
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5888243,
+              5888259,
+              5891523,
+              5891539,
+              5894803,
+              5894819,
+              5898083,
+              5898099,
+              5901363,
+              5901379,
+              5904643,
+              5904659,
+              5907923,
+              5907939,
+              5911203
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 132588,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22588,
+            "endpoints": 132588,
+            "legs": [
+              22588,
+              21844,
+              21832,
+              21832,
+              21832,
+              22564
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21838,
+            "legWorstDeviation": 0.03434380437769027,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28632
+            ],
+            "primeExcess": 6794,
+            "perWrite": 22098,
+            "perBoundaryPerWrite": 920.75,
+            "cdpBracket": 189180,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5942763,
+              5942779,
+              5971411,
+              5971427,
+              5994015,
+              5994031,
+              6015875,
+              6015891,
+              6037723,
+              6037739,
+              6059571,
+              6059587,
+              6081419,
+              6081435,
+              6103999
+            ],
+            "tick0": 525,
+            "tick": 532,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 480172,
+            "fall": 335672,
+            "falls": 1,
+            "maxStep": 362140,
+            "endpoints": 144500,
+            "legs": [
+              22284,
+              22272,
+              22272,
+              22272,
+              362140,
+              28852
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              -335672
+            ],
+            "legMedian": 22278,
+            "legWorstDeviation": 15.255498698267349,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read 362140 B against a cohort median of 22278 B (+339862 B, 1525.5%), past the ±25% leg tolerance (±5569.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read 28852 B against a cohort median of 22278 B (+6574 B, 29.5%), past the ±25% leg tolerance (±5569.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read 362140 B against a cohort median of 22278 B (+339862 B, 1525.5%), past the ±25% leg tolerance (±5569.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read 28852 B against a cohort median of 22278 B (+6574 B, 29.5%), past the ±25% leg tolerance (±5569.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29148
+            ],
+            "primeExcess": 6870,
+            "perWrite": 80028.66666666667,
+            "perBoundaryPerWrite": 3334.527777777778,
+            "cdpBracket": 201628,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5965023,
+              5965039,
+              5994187,
+              5994203,
+              6016487,
+              6016503,
+              6038775,
+              6038791,
+              6061063,
+              6061079,
+              6083351,
+              6083367,
+              6445507,
+              6109835,
+              6138687
+            ],
+            "tick0": 553,
+            "tick": 560,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 10,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5934807,
+              5934823,
+              5934839,
+              5934855,
+              5934871,
+              5934887,
+              5934903,
+              5934919,
+              5934935,
+              5934951,
+              5934967,
+              5934983,
+              5934999,
+              5935015,
+              5935031
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5942815,
+              5942831,
+              5950895,
+              5950911,
+              5958975,
+              5958991,
+              5967055,
+              5967071,
+              5975135,
+              5975151,
+              5983215,
+              5983231,
+              5991295,
+              5991311,
+              5999375
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5938015,
+              5938031,
+              5941295,
+              5941311,
+              5944575,
+              5944591,
+              5947855,
+              5947871,
+              5951135,
+              5951151,
+              5954415,
+              5954431,
+              5957695,
+              5957711,
+              5960975
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 132552,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22576,
+            "endpoints": 132552,
+            "legs": [
+              21844,
+              22576,
+              21808,
+              21832,
+              21844,
+              22552
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21844,
+            "legWorstDeviation": 0.03351034609045962,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28644
+            ],
+            "primeExcess": 6800,
+            "perWrite": 22092,
+            "perBoundaryPerWrite": 920.5,
+            "cdpBracket": 189284,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5990995,
+              5991011,
+              6019655,
+              6019671,
+              6041515,
+              6041531,
+              6064107,
+              6064123,
+              6085931,
+              6085947,
+              6107779,
+              6107795,
+              6129639,
+              6129655,
+              6152207
+            ],
+            "tick0": 581,
+            "tick": 588,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 135416,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23948,
+            "endpoints": 135416,
+            "legs": [
+              22284,
+              22284,
+              22284,
+              23948,
+              22248,
+              22272
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22284,
+            "legWorstDeviation": 0.07467241069825883,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29148
+            ],
+            "primeExcess": 6864,
+            "perWrite": 22569.333333333332,
+            "perBoundaryPerWrite": 940.3888888888888,
+            "cdpBracket": 194036,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6002983,
+              6002999,
+              6032147,
+              6032163,
+              6054447,
+              6054463,
+              6076747,
+              6076763,
+              6099047,
+              6099063,
+              6123011,
+              6123027,
+              6145275,
+              6145291,
+              6167563
+            ],
+            "tick0": 609,
+            "tick": 616,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 11,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5963683,
+              5963699,
+              5963715,
+              5963731,
+              5963747,
+              5963763,
+              5963779,
+              5963795,
+              5963811,
+              5963827,
+              5963843,
+              5963859,
+              5963875,
+              5963891,
+              5963907
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5971691,
+              5971707,
+              5979771,
+              5979787,
+              5987851,
+              5987867,
+              5995931,
+              5995947,
+              6004011,
+              6004027,
+              6012091,
+              6012107,
+              6020171,
+              6020187,
+              6028251
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5966891,
+              5966907,
+              5970171,
+              5970187,
+              5973451,
+              5973467,
+              5976731,
+              5976747,
+              5980011,
+              5980027,
+              5983291,
+              5983307,
+              5986571,
+              5986587,
+              5989851
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 271876,
+            "fall": 139252,
+            "falls": 1,
+            "maxStep": 161864,
+            "endpoints": 132624,
+            "legs": [
+              21840,
+              21840,
+              161864,
+              21840,
+              21852,
+              22560
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              -139252,
+              16,
+              16
+            ],
+            "legMedian": 21846,
+            "legWorstDeviation": 6.4093197839421405,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 161864 B against a cohort median of 21846 B (+140018 B, 640.9%), past the ±25% leg tolerance (±5461.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 161864 B against a cohort median of 21846 B (+140018 B, 640.9%), past the ±25% leg tolerance (±5461.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28652
+            ],
+            "primeExcess": 6806,
+            "perWrite": 45312.666666666664,
+            "perBoundaryPerWrite": 1888.0277777777776,
+            "cdpBracket": 189236,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6007071,
+              6007087,
+              6035739,
+              6035755,
+              6057595,
+              6057611,
+              6079451,
+              6079467,
+              6241331,
+              6102079,
+              6123919,
+              6123935,
+              6145787,
+              6145803,
+              6168363
+            ],
+            "tick0": 637,
+            "tick": 644,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 133776,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22284,
+            "endpoints": 133776,
+            "legs": [
+              22284,
+              22272,
+              22284,
+              22284,
+              22284,
+              22272
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22284,
+            "legWorstDeviation": -0.0005385029617662897,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              34620
+            ],
+            "primeExcess": 12336,
+            "perWrite": 22296,
+            "perBoundaryPerWrite": 929,
+            "cdpBracket": 197588,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6037279,
+              6037295,
+              6071915,
+              6071931,
+              6094215,
+              6094231,
+              6116503,
+              6116519,
+              6138803,
+              6138819,
+              6161103,
+              6161119,
+              6183403,
+              6183419,
+              6205691
+            ],
+            "tick0": 665,
+            "tick": 672,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 12,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6001667,
+              6001683,
+              6001699,
+              6001715,
+              6001731,
+              6001747,
+              6001763,
+              6001779,
+              6001795,
+              6001811,
+              6001827,
+              6001843,
+              6001859,
+              6001875,
+              6001891
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6009675,
+              6009691,
+              6017755,
+              6017771,
+              6025835,
+              6025851,
+              6033915,
+              6033931,
+              6041995,
+              6042011,
+              6050075,
+              6050091,
+              6058155,
+              6058171,
+              6066235
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6004875,
+              6004891,
+              6008155,
+              6008171,
+              6011435,
+              6011451,
+              6014715,
+              6014731,
+              6017995,
+              6018011,
+              6021275,
+              6021291,
+              6024555,
+              6024571,
+              6027835
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 132600,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23308,
+            "endpoints": 132600,
+            "legs": [
+              21844,
+              21832,
+              21844,
+              21832,
+              21844,
+              23308
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21844,
+            "legWorstDeviation": 0.06702069218091924,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28644
+            ],
+            "primeExcess": 6800,
+            "perWrite": 22100,
+            "perBoundaryPerWrite": 920.8333333333334,
+            "cdpBracket": 189316,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6066523,
+              6066539,
+              6095183,
+              6095199,
+              6117043,
+              6117059,
+              6138891,
+              6138907,
+              6160751,
+              6160767,
+              6182599,
+              6182615,
+              6204459,
+              6204475,
+              6227783
+            ],
+            "tick0": 693,
+            "tick": 700,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 134844,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23340,
+            "endpoints": 134844,
+            "legs": [
+              22284,
+              22284,
+              22272,
+              23340,
+              22284,
+              22284
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22284,
+            "legWorstDeviation": 0.04738826063543349,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29148
+            ],
+            "primeExcess": 6864,
+            "perWrite": 22474,
+            "perBoundaryPerWrite": 936.4166666666666,
+            "cdpBracket": 191956,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6095507,
+              6095523,
+              6124671,
+              6124687,
+              6146971,
+              6146987,
+              6169271,
+              6169287,
+              6191559,
+              6191575,
+              6214915,
+              6214931,
+              6237215,
+              6237231,
+              6259515
+            ],
+            "tick0": 721,
+            "tick": 728,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 13,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 31952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6055611,
+              6055627,
+              6055643,
+              6055659,
+              6055675,
+              6055691,
+              6055707,
+              6055723,
+              6055739,
+              6055755,
+              6055771,
+              6055787,
+              6055803,
+              6055819,
+              6055835
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6067639,
+              6067655,
+              6075719,
+              6075735,
+              6083799,
+              6083815,
+              6091879,
+              6091895,
+              6099959,
+              6099975,
+              6108039,
+              6108055,
+              6116119,
+              6116135,
+              6124199
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6062839,
+              6062855,
+              6066119,
+              6066135,
+              6069399,
+              6069415,
+              6072679,
+              6072695,
+              6075959,
+              6075975,
+              6079239,
+              6079255,
+              6082519,
+              6082535,
+              6085799
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 131088,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21832,
+            "endpoints": 131088,
+            "legs": [
+              21832,
+              21832,
+              21832,
+              21832,
+              21832,
+              21832
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21832,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28632
+            ],
+            "primeExcess": 6800,
+            "perWrite": 21848,
+            "perBoundaryPerWrite": 910.3333333333334,
+            "cdpBracket": 188384,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6104571,
+              6104587,
+              6133219,
+              6133235,
+              6155067,
+              6155083,
+              6176915,
+              6176931,
+              6198763,
+              6198779,
+              6220611,
+              6220627,
+              6242459,
+              6242475,
+              6264307
+            ],
+            "tick0": 749,
+            "tick": 756,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 133704,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22272,
+            "endpoints": 133704,
+            "legs": [
+              22272,
+              22248,
+              22272,
+              22272,
+              22272,
+              22272
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22272,
+            "legWorstDeviation": -0.0010775862068965517,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29136
+            ],
+            "primeExcess": 6864,
+            "perWrite": 22284,
+            "perBoundaryPerWrite": 928.5,
+            "cdpBracket": 190804,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6116567,
+              6116583,
+              6145719,
+              6145735,
+              6168007,
+              6168023,
+              6190271,
+              6190287,
+              6212559,
+              6212575,
+              6234847,
+              6234863,
+              6257135,
+              6257151,
+              6279423
+            ],
+            "tick0": 777,
+            "tick": 784,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 14,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6075603,
+              6075619,
+              6075635,
+              6075651,
+              6075667,
+              6075683,
+              6075699,
+              6075715,
+              6075731,
+              6075747,
+              6075763,
+              6075779,
+              6075795,
+              6075811,
+              6075827
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6083611,
+              6083627,
+              6091691,
+              6091707,
+              6099771,
+              6099787,
+              6107851,
+              6107867,
+              6115931,
+              6115947,
+              6124011,
+              6124027,
+              6132091,
+              6132107,
+              6140171
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6078811,
+              6078827,
+              6082091,
+              6082107,
+              6085371,
+              6085387,
+              6088651,
+              6088667,
+              6091931,
+              6091947,
+              6095211,
+              6095227,
+              6098491,
+              6098507,
+              6101771
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 131136,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21844,
+            "endpoints": 131136,
+            "legs": [
+              21832,
+              21832,
+              21844,
+              21844,
+              21844,
+              21844
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21844,
+            "legWorstDeviation": -0.0005493499359091741,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28632
+            ],
+            "primeExcess": 6788,
+            "perWrite": 21856,
+            "perBoundaryPerWrite": 910.6666666666666,
+            "cdpBracket": 191104,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6121159,
+              6121175,
+              6149807,
+              6149823,
+              6171655,
+              6171671,
+              6193503,
+              6193519,
+              6215363,
+              6215379,
+              6237223,
+              6237239,
+              6259083,
+              6259099,
+              6280943
+            ],
+            "tick0": 805,
+            "tick": 812,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 135564,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23340,
+            "endpoints": 135564,
+            "legs": [
+              23016,
+              22284,
+              22272,
+              23340,
+              22284,
+              22272
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22284,
+            "legWorstDeviation": 0.04738826063543349,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29148
+            ],
+            "primeExcess": 6864,
+            "perWrite": 22594,
+            "perBoundaryPerWrite": 941.4166666666666,
+            "cdpBracket": 192676,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6140123,
+              6140139,
+              6169287,
+              6169303,
+              6192319,
+              6192335,
+              6214619,
+              6214635,
+              6236907,
+              6236923,
+              6260263,
+              6260279,
+              6282563,
+              6282579,
+              6304851
+            ],
+            "tick0": 833,
+            "tick": 840,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 15,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6100215,
+              6100231,
+              6100247,
+              6100263,
+              6100279,
+              6100295,
+              6100311,
+              6100327,
+              6100343,
+              6100359,
+              6100375,
+              6100391,
+              6100407,
+              6100423,
+              6100439
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6108223,
+              6108239,
+              6116303,
+              6116319,
+              6124383,
+              6124399,
+              6132463,
+              6132479,
+              6140543,
+              6140559,
+              6148623,
+              6148639,
+              6156703,
+              6156719,
+              6164783
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6103423,
+              6103439,
+              6106703,
+              6106719,
+              6109983,
+              6109999,
+              6113263,
+              6113279,
+              6116543,
+              6116559,
+              6119823,
+              6119839,
+              6123103,
+              6123119,
+              6126383
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 134196,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24880,
+            "endpoints": 134196,
+            "legs": [
+              21844,
+              21844,
+              21844,
+              21844,
+              21844,
+              24880
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21844,
+            "legWorstDeviation": 0.13898553378502107,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28608
+            ],
+            "primeExcess": 6764,
+            "perWrite": 22366,
+            "perBoundaryPerWrite": 931.9166666666666,
+            "cdpBracket": 190748,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6148211,
+              6148227,
+              6176835,
+              6176851,
+              6198695,
+              6198711,
+              6220555,
+              6220571,
+              6242415,
+              6242431,
+              6264275,
+              6264291,
+              6286135,
+              6286151,
+              6311031
+            ],
+            "tick0": 861,
+            "tick": 868,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 133680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22272,
+            "endpoints": 133680,
+            "legs": [
+              22272,
+              22260,
+              22272,
+              22260,
+              22260,
+              22260
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22260,
+            "legWorstDeviation": 0.0005390835579514825,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29124
+            ],
+            "primeExcess": 6864,
+            "perWrite": 22280,
+            "perBoundaryPerWrite": 928.3333333333334,
+            "cdpBracket": 190768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6169123,
+              6169139,
+              6198263,
+              6198279,
+              6220551,
+              6220567,
+              6242827,
+              6242843,
+              6265115,
+              6265131,
+              6287391,
+              6287407,
+              6309667,
+              6309683,
+              6331943
+            ],
+            "tick0": 889,
+            "tick": 896,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 16,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6123043,
+              6123059,
+              6123075,
+              6123091,
+              6123107,
+              6123123,
+              6123139,
+              6123155,
+              6123171,
+              6123187,
+              6123203,
+              6123219,
+              6123235,
+              6123251,
+              6123267
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6131051,
+              6131067,
+              6139131,
+              6139147,
+              6147211,
+              6147227,
+              6155291,
+              6155307,
+              6163371,
+              6163387,
+              6171451,
+              6171467,
+              6179531,
+              6179547,
+              6187611
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6126251,
+              6126267,
+              6129531,
+              6129547,
+              6132811,
+              6132827,
+              6136091,
+              6136107,
+              6139371,
+              6139387,
+              6142651,
+              6142667,
+              6145931,
+              6145947,
+              6149211
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 133296,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24148,
+            "endpoints": 133296,
+            "legs": [
+              21832,
+              21832,
+              21820,
+              21820,
+              24148,
+              21748
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21826,
+            "legWorstDeviation": 0.10638687803537066,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28620
+            ],
+            "primeExcess": 6794,
+            "perWrite": 22216,
+            "perBoundaryPerWrite": 925.6666666666666,
+            "cdpBracket": 190708,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6164003,
+              6164019,
+              6192639,
+              6192655,
+              6214487,
+              6214503,
+              6236335,
+              6236351,
+              6258171,
+              6258187,
+              6280007,
+              6280023,
+              6304171,
+              6304187,
+              6325935
+            ],
+            "tick0": 917,
+            "tick": 924,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 138648,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 25916,
+            "endpoints": 138648,
+            "legs": [
+              22272,
+              21312,
+              22260,
+              25916,
+              22260,
+              22236
+            ],
+            "gaps": [
+              16,
+              2312,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22260,
+            "legWorstDeviation": 0.16424079065588498,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29136
+            ],
+            "primeExcess": 6876,
+            "perWrite": 23108,
+            "perBoundaryPerWrite": 962.8333333333334,
+            "cdpBracket": 195748,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6180507,
+              6180523,
+              6209659,
+              6209675,
+              6231947,
+              6234259,
+              6255571,
+              6255587,
+              6277847,
+              6277863,
+              6303779,
+              6303795,
+              6326055,
+              6326071,
+              6348307
+            ],
+            "tick0": 945,
+            "tick": 952,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 17,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6137951,
+              6137967,
+              6137983,
+              6137999,
+              6138015,
+              6138031,
+              6138047,
+              6138063,
+              6138079,
+              6138095,
+              6138111,
+              6138127,
+              6138143,
+              6138159,
+              6138175
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6145959,
+              6145975,
+              6154039,
+              6154055,
+              6162119,
+              6162135,
+              6170199,
+              6170215,
+              6178279,
+              6178295,
+              6186359,
+              6186375,
+              6194439,
+              6194455,
+              6202519
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6141159,
+              6141175,
+              6144439,
+              6144455,
+              6147719,
+              6147735,
+              6150999,
+              6151015,
+              6154279,
+              6154295,
+              6157559,
+              6157575,
+              6160839,
+              6160855,
+              6164119
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 133884,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24160,
+            "endpoints": 133884,
+            "legs": [
+              21832,
+              21820,
+              24160,
+              21760,
+              22468,
+              21748
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21826,
+            "legWorstDeviation": 0.10693668102263355,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28632
+            ],
+            "primeExcess": 6806,
+            "perWrite": 22314,
+            "perBoundaryPerWrite": 929.75,
+            "cdpBracket": 190460,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6192471,
+              6192487,
+              6221119,
+              6221135,
+              6242967,
+              6242983,
+              6264803,
+              6264819,
+              6288979,
+              6288995,
+              6310755,
+              6310771,
+              6333239,
+              6333255,
+              6355003
+            ],
+            "tick0": 973,
+            "tick": 980,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 133680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22276,
+            "endpoints": 133680,
+            "legs": [
+              22264,
+              22276,
+              22240,
+              22264,
+              22276,
+              22264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22264,
+            "legWorstDeviation": -0.0010779734099892202,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29140
+            ],
+            "primeExcess": 6876,
+            "perWrite": 22280,
+            "perBoundaryPerWrite": 928.3333333333334,
+            "cdpBracket": 190784,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6208307,
+              6208323,
+              6237463,
+              6237479,
+              6259743,
+              6259759,
+              6282035,
+              6282051,
+              6304291,
+              6304307,
+              6326571,
+              6326587,
+              6348863,
+              6348879,
+              6371143
+            ],
+            "tick0": 1001,
+            "tick": 1008,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      }
+    ],
+    "allocFits": {
+      "perRound": {},
+      "mean": {}
+    },
+    "writeDriven": true,
+    "writeProvenance": {
+      "windows": 36,
+      "pairs": 36,
+      "unnamed": [],
+      "incomplete": [],
+      "ok": true
+    },
+    "controlVerdict": {
+      "ok": true,
+      "perDouble": 8.08088888888889,
+      "differential": 8.00148148148148
+    },
+    "fallsInMeasuredWindows": 7,
+    "refusedWindows": 7,
+    "refusalReasons": 13
+  },
+  "box": {
+    "bead": "rf2-24o2z",
+    "chromium": "chromium/147.0.7727.15",
+    "node": "v24.13.0",
+    "platform": "win32/x64/10.0.26200",
+    "load": {
+      "open": {
+        "at": "2026-08-20T20:37:51.076Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13484297910,
+        "cpuBusyMs": 3631724093,
+        "freeMemB": 15548403712,
+        "totalMemB": 68112736256,
+        "uptimeS": 709433.875
+      },
+      "close": {
+        "at": "2026-08-20T20:38:19.525Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13484852054,
+        "cpuBusyMs": 3631855920,
+        "freeMemB": 16071008256,
+        "totalMemB": 68112736256,
+        "uptimeS": 709462.328
+      },
+      "busyFraction": 0.19217576253223534
+    },
+    "session": {
+      "startedAt": "2026-08-20T20:37:12.274Z",
+      "sessionStartedAt": "2026-08-20T19:39:26.627Z",
+      "runsInSession": 16,
+      "sessionGapMs": 3600000,
+      "previousRun": {
+        "startedAt": "2026-08-20T20:36:08.843Z",
+        "endedAt": "2026-08-20T20:37:12.139Z",
+        "sinceStartMs": 63431,
+        "sinceEndMs": 135,
+        "sameSession": true
+      }
+    }
+  }
+}

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/parity-1.json
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/parity-1.json
@@ -1,0 +1,7553 @@
+{
+  "generatedAt": "2026-08-20T20:26:01.556Z",
+  "build": "hicasso-bench",
+  "initFn": "re-frame.bench.p0-app/-main",
+  "alloc": {
+    "benchmark": "P0:steady-state-allocation-slope",
+    "bead": "rf2-2rtt6.76",
+    "roots": 4,
+    "perRoot": {
+      "list": 300,
+      "grid": 6
+    },
+    "publishedPerRoot": {
+      "list": 300,
+      "grid": 300
+    },
+    "arm": {
+      "cells": 6,
+      "roots": 4,
+      "boundaries": 24,
+      "writes": 6,
+      "refusals": [],
+      "admissible": true
+    },
+    "boundaries": 24,
+    "writes": 6,
+    "primeWrites": 1,
+    "windowWrites": 7,
+    "bySite": false,
+    "sites": 2,
+    "siteNames": [
+      "dispatch",
+      "drain"
+    ],
+    "warmups": 3,
+    "rounds": 18,
+    "preciseMemory": true,
+    "controlDoubles": {
+      "d1": 1000,
+      "d2": 400
+    },
+    "controlSlack": 0.75,
+    "writeSelector": "all",
+    "writeLegs": [
+      "all"
+    ],
+    "writePaired": false,
+    "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+    "plan": {
+      "name": "floor",
+      "arms": true,
+      "rungs": false,
+      "fits": false
+    },
+    "segOrder": "parity",
+    "passOrder": "parity",
+    "passSeed": "1787257527341",
+    "passSchedule": {
+      "flips": [
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true
+      ],
+      "attempts": 1,
+      "parityTied": false
+    },
+    "controlSlot": "first",
+    "instrument": "in-page performance.memory.usedJSHeapSize sampled at every leg boundary, rising steps accumulated separately from falling ones; --enable-precise-memory-info. A falling step is a collection this counter SAW; a leg that deviates from its cohort median by more than the leg tolerance is a work unit that is not one; and under the by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the other two can see. TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg has no interior reading and so no site step to be negative, and the intra-leg gate returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with these (see `bySite`), so a witness comparing byte for byte against a figure published at stride 2 can never be screened by all three",
+    "fallThresholdB": 600000,
+    "legTolerance": 0.25,
+    "verification": {
+      "unverified": 0,
+      "detail": []
+    },
+    "workCount": false,
+    "workVerification": {
+      "counted": false
+    },
+    "perRound": [
+      {
+        "round": 0,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 524,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              524
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 116.66666666666667,
+            "cdpBracket": 46232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3840294,
+              3840310,
+              3840326,
+              3840342,
+              3840358,
+              3840374,
+              3840390,
+              3840406,
+              3840422,
+              3840438,
+              3840454,
+              3840470,
+              3840486,
+              3841010,
+              3841026
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48576,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8144,
+            "endpoints": 48576,
+            "legs": [
+              8144,
+              8080,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.00992063492063492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8096,
+            "cdpBracket": 87388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3853918,
+              3853934,
+              3861998,
+              3862014,
+              3870158,
+              3870174,
+              3878254,
+              3878270,
+              3886334,
+              3886350,
+              3894414,
+              3894430,
+              3902494,
+              3902510,
+              3910574
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 52328,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3850018,
+              3850034,
+              3853298,
+              3853314,
+              3856578,
+              3856594,
+              3859858,
+              3859874,
+              3863138,
+              3863154,
+              3866418,
+              3866434,
+              3869698,
+              3869714,
+              3872978
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 613124,
+            "fall": 480884,
+            "falls": 2,
+            "maxStep": 284560,
+            "endpoints": 132240,
+            "legs": [
+              21336,
+              19692,
+              19764,
+              -244852,
+              284560,
+              -236032
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              267692,
+              16,
+              16
+            ],
+            "legMedian": 19728,
+            "legWorstDeviation": 13.424168694241686,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read -244852 B against a cohort median of 19728 B (-264580 B, -1341.1%), past the ±25% leg tolerance (±4932 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 5 of 6 read 284560 B against a cohort median of 19728 B (+264832 B, 1342.4%), past the ±25% leg tolerance (±4932 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read -236032 B against a cohort median of 19728 B (-255760 B, -1296.4%), past the ±25% leg tolerance (±4932 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read -244852 B against a cohort median of 19728 B (-264580 B, -1341.1%), past the ±25% leg tolerance (±4932 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 5 of 6 read 284560 B against a cohort median of 19728 B (+264832 B, 1342.4%), past the ±25% leg tolerance (±4932 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read -236032 B against a cohort median of 19728 B (-255760 B, -1296.4%), past the ±25% leg tolerance (±4932 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26460
+            ],
+            "primeExcess": 6732,
+            "perWrite": 102187.33333333333,
+            "perBoundaryPerWrite": 4257.805555555556,
+            "cdpBracket": 187100,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              4782631,
+              4782647,
+              4809107,
+              4809123,
+              4830459,
+              4830475,
+              4850167,
+              4850183,
+              4869947,
+              5137639,
+              4892787,
+              4892803,
+              5177363,
+              5177379,
+              4941347
+            ],
+            "tick0": 21,
+            "tick": 28,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 242364,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 127272,
+            "endpoints": 242364,
+            "legs": [
+              23520,
+              19916,
+              22160,
+              28908,
+              127272,
+              20492
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22840,
+            "legWorstDeviation": 4.572329246935201,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 28908 B against a cohort median of 22840 B (+6068 B, 26.6%), past the ±25% leg tolerance (±5710 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read 127272 B against a cohort median of 22840 B (+104432 B, 457.2%), past the ±25% leg tolerance (±5710 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 28908 B against a cohort median of 22840 B (+6068 B, 26.6%), past the ±25% leg tolerance (±5710 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read 127272 B against a cohort median of 22840 B (+104432 B, 457.2%), past the ±25% leg tolerance (±5710 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26764
+            ],
+            "primeExcess": 3924,
+            "perWrite": 40394,
+            "perBoundaryPerWrite": 1683.0833333333333,
+            "cdpBracket": 301220,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5060891,
+              5060907,
+              5087671,
+              5087687,
+              5111207,
+              5111223,
+              5131139,
+              5131155,
+              5153315,
+              5153331,
+              5182239,
+              5182255,
+              5309527,
+              5309543,
+              5330035
+            ],
+            "tick0": 49,
+            "tick": 56,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 1,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5048227,
+              5048243,
+              5048259,
+              5048275,
+              5048291,
+              5048307,
+              5048323,
+              5048339,
+              5048355,
+              5048371,
+              5048387,
+              5048403,
+              5048419,
+              5048435,
+              5048451
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 87716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5056235,
+              5056251,
+              5064315,
+              5064331,
+              5072395,
+              5072411,
+              5080475,
+              5080491,
+              5088555,
+              5088571,
+              5096635,
+              5096651,
+              5104715,
+              5104731,
+              5112795
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5053679,
+              5053695,
+              5056959,
+              5056975,
+              5060239,
+              5060255,
+              5063519,
+              5063535,
+              5066799,
+              5066815,
+              5070079,
+              5070095,
+              5073359,
+              5073375,
+              5076639
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 841948,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 392272,
+            "endpoints": 841948,
+            "legs": [
+              110080,
+              20496,
+              392272,
+              19772,
+              279208,
+              20024
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 65288,
+            "legWorstDeviation": 5.00833231221664,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 110080 B against a cohort median of 65288 B (+44792 B, 68.6%), past the ±25% leg tolerance (±16322 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read 20496 B against a cohort median of 65288 B (-44792 B, -68.6%), past the ±25% leg tolerance (±16322 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 3 of 6 read 392272 B against a cohort median of 65288 B (+326984 B, 500.8%), past the ±25% leg tolerance (±16322 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read 19772 B against a cohort median of 65288 B (-45516 B, -69.7%), past the ±25% leg tolerance (±16322 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 5 of 6 read 279208 B against a cohort median of 65288 B (+213920 B, 327.7%), past the ±25% leg tolerance (±16322 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read 20024 B against a cohort median of 65288 B (-45264 B, -69.3%), past the ±25% leg tolerance (±16322 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 110080 B against a cohort median of 65288 B (+44792 B, 68.6%), past the ±25% leg tolerance (±16322 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read 20496 B against a cohort median of 65288 B (-44792 B, -68.6%), past the ±25% leg tolerance (±16322 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 3 of 6 read 392272 B against a cohort median of 65288 B (+326984 B, 500.8%), past the ±25% leg tolerance (±16322 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read 19772 B against a cohort median of 65288 B (-45516 B, -69.7%), past the ±25% leg tolerance (±16322 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 5 of 6 read 279208 B against a cohort median of 65288 B (+213920 B, 327.7%), past the ±25% leg tolerance (±16322 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read 20024 B against a cohort median of 65288 B (-45264 B, -69.3%), past the ±25% leg tolerance (±16322 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26692
+            ],
+            "primeExcess": -38596,
+            "perWrite": 140324.66666666666,
+            "perBoundaryPerWrite": 5846.86111111111,
+            "cdpBracket": 192668,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5183023,
+              5183039,
+              5209731,
+              5209747,
+              5319827,
+              5319843,
+              5340339,
+              5340355,
+              5732627,
+              5732643,
+              5752415,
+              5752431,
+              6031639,
+              6031655,
+              6051679
+            ],
+            "tick0": 77,
+            "tick": 84,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 220460,
+            "fall": 98096,
+            "falls": 1,
+            "maxStep": 121856,
+            "endpoints": 122364,
+            "legs": [
+              19244,
+              19256,
+              19256,
+              121856,
+              21584,
+              19184
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              -98096,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": 5.328209389281263,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 121856 B against a cohort median of 19256 B (+102600 B, 532.8%), past the ±25% leg tolerance (±4814 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 121856 B against a cohort median of 19256 B (+102600 B, 532.8%), past the ±25% leg tolerance (±4814 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 36743.333333333336,
+            "perBoundaryPerWrite": 1530.9722222222224,
+            "cdpBracket": 177552,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5290747,
+              5290763,
+              5316803,
+              5316819,
+              5336063,
+              5336079,
+              5355335,
+              5355351,
+              5374607,
+              5374623,
+              5496479,
+              5398383,
+              5419967,
+              5419983,
+              5439167
+            ],
+            "tick0": 105,
+            "tick": 112,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 2,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5254211,
+              5254227,
+              5254243,
+              5254259,
+              5254275,
+              5254291,
+              5254307,
+              5254323,
+              5254339,
+              5254355,
+              5254371,
+              5254387,
+              5254403,
+              5254419,
+              5254435
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85088,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5262235,
+              5262251,
+              5270315,
+              5270331,
+              5278395,
+              5278411,
+              5286475,
+              5286491,
+              5294555,
+              5294571,
+              5302635,
+              5302651,
+              5310715,
+              5310731,
+              5318795
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5257435,
+              5257451,
+              5260715,
+              5260731,
+              5263995,
+              5264011,
+              5267275,
+              5267291,
+              5270555,
+              5270571,
+              5273835,
+              5273851,
+              5277115,
+              5277131,
+              5280395
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 142332,
+            "fall": 26236,
+            "falls": 1,
+            "maxStep": 46020,
+            "endpoints": 116096,
+            "legs": [
+              19256,
+              -26236,
+              19220,
+              19244,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              46020,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19250,
+            "legWorstDeviation": -2.362909090909091,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read -26236 B against a cohort median of 19250 B (-45486 B, -236.3%), past the ±25% leg tolerance (±4812.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read -26236 B against a cohort median of 19250 B (-45486 B, -236.3%), past the ±25% leg tolerance (±4812.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6790,
+            "perWrite": 23722,
+            "perBoundaryPerWrite": 988.4166666666666,
+            "cdpBracket": 173196,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5343627,
+              5343643,
+              5369683,
+              5369699,
+              5388955,
+              5434975,
+              5408739,
+              5408755,
+              5427975,
+              5427991,
+              5447235,
+              5447251,
+              5466507,
+              5466523,
+              5485779
+            ],
+            "tick0": 133,
+            "tick": 140,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 592596,
+            "fall": 470096,
+            "falls": 1,
+            "maxStep": 463876,
+            "endpoints": 122500,
+            "legs": [
+              19696,
+              19696,
+              50036,
+              -470096,
+              19624,
+              19588
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              463876,
+              16,
+              16
+            ],
+            "legMedian": 19660,
+            "legWorstDeviation": -24.911291963377415,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 50036 B against a cohort median of 19660 B (+30376 B, 154.5%), past the ±25% leg tolerance (±4915 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -470096 B against a cohort median of 19660 B (-489756 B, -2491.1%), past the ±25% leg tolerance (±4915 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 50036 B against a cohort median of 19660 B (+30376 B, 154.5%), past the ±25% leg tolerance (±4915 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -470096 B against a cohort median of 19660 B (-489756 B, -2491.1%), past the ±25% leg tolerance (±4915 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6884,
+            "perWrite": 98766,
+            "perBoundaryPerWrite": 4115.25,
+            "cdpBracket": 177024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5419195,
+              5419211,
+              5445755,
+              5445771,
+              5465467,
+              5465483,
+              5485179,
+              5485195,
+              5535231,
+              5999107,
+              5529011,
+              5529027,
+              5548651,
+              5548667,
+              5568255
+            ],
+            "tick0": 161,
+            "tick": 168,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 3,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 29120,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5380263,
+              5380279,
+              5380295,
+              5380311,
+              5380327,
+              5380343,
+              5380359,
+              5380375,
+              5380391,
+              5380407,
+              5380423,
+              5380439,
+              5380455,
+              5380471,
+              5380487
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5389199,
+              5389215,
+              5397279,
+              5397295,
+              5405359,
+              5405375,
+              5413439,
+              5413455,
+              5421519,
+              5421535,
+              5429599,
+              5429615,
+              5437679,
+              5437695,
+              5445759
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5384399,
+              5384415,
+              5387679,
+              5387695,
+              5390959,
+              5390975,
+              5394239,
+              5394255,
+              5397519,
+              5397535,
+              5400799,
+              5400815,
+              5404079,
+              5404095,
+              5407359
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118272,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19696,
+            "endpoints": 118272,
+            "legs": [
+              19696,
+              19696,
+              19696,
+              19696,
+              19696,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26532
+            ],
+            "primeExcess": 6836,
+            "perWrite": 19712,
+            "perBoundaryPerWrite": 821.3333333333334,
+            "cdpBracket": 172784,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5452291,
+              5452307,
+              5478839,
+              5478855,
+              5498551,
+              5498567,
+              5518263,
+              5518279,
+              5537975,
+              5537991,
+              5557687,
+              5557703,
+              5577399,
+              5577415,
+              5597111
+            ],
+            "tick0": 189,
+            "tick": 196,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117780,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21692,
+            "endpoints": 117780,
+            "legs": [
+              19256,
+              21692,
+              19184,
+              19184,
+              19184,
+              19184
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19184,
+            "legWorstDeviation": 0.13073394495412843,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26028
+            ],
+            "primeExcess": 6844,
+            "perWrite": 19630,
+            "perBoundaryPerWrite": 817.9166666666666,
+            "cdpBracket": 171768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5480623,
+              5480639,
+              5506667,
+              5506683,
+              5525939,
+              5525955,
+              5547647,
+              5547663,
+              5566847,
+              5566863,
+              5586047,
+              5586063,
+              5605247,
+              5605263,
+              5624447
+            ],
+            "tick0": 217,
+            "tick": 224,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 4,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5439715,
+              5439731,
+              5439747,
+              5439763,
+              5439779,
+              5439795,
+              5439811,
+              5439827,
+              5439843,
+              5439859,
+              5439875,
+              5439891,
+              5439907,
+              5439923,
+              5439939
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5447723,
+              5447739,
+              5455803,
+              5455819,
+              5463883,
+              5463899,
+              5471963,
+              5471979,
+              5480043,
+              5480059,
+              5488123,
+              5488139,
+              5496203,
+              5496219,
+              5504283
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5442923,
+              5442939,
+              5446203,
+              5446219,
+              5449483,
+              5449499,
+              5452763,
+              5452779,
+              5456043,
+              5456059,
+              5459323,
+              5459339,
+              5462603,
+              5462619,
+              5465883
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 103264,
+            "fall": 288920,
+            "falls": 1,
+            "maxStep": 22476,
+            "endpoints": -185656,
+            "legs": [
+              20460,
+              22476,
+              -288920,
+              19448,
+              21372,
+              19412
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19954,
+            "legWorstDeviation": -15.479302395509672,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read -288920 B against a cohort median of 19954 B (-308874 B, -1547.9%), past the ±25% leg tolerance (±4988.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read -288920 B against a cohort median of 19954 B (-308874 B, -1547.9%), past the ±25% leg tolerance (±4988.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              342712
+            ],
+            "primeExcess": 322758,
+            "perWrite": 17210.666666666668,
+            "perBoundaryPerWrite": 717.1111111111112,
+            "cdpBracket": 185144,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5614059,
+              5614075,
+              5956787,
+              5956803,
+              5977263,
+              5977279,
+              5999755,
+              5999771,
+              5710851,
+              5710867,
+              5730315,
+              5730331,
+              5751703,
+              5751719,
+              5771131
+            ],
+            "tick0": 245,
+            "tick": 252,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122036,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22580,
+            "endpoints": 122036,
+            "legs": [
+              19872,
+              19872,
+              19872,
+              22580,
+              19872,
+              19872
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19872,
+            "legWorstDeviation": 0.1362721417069243,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26724
+            ],
+            "primeExcess": 6852,
+            "perWrite": 20339.333333333332,
+            "perBoundaryPerWrite": 847.4722222222222,
+            "cdpBracket": 176740,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5704111,
+              5704127,
+              5730851,
+              5730867,
+              5750739,
+              5750755,
+              5770627,
+              5770643,
+              5790515,
+              5790531,
+              5813111,
+              5813127,
+              5832999,
+              5833015,
+              5852887
+            ],
+            "tick0": 273,
+            "tick": 280,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 5,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5664463,
+              5664479,
+              5664495,
+              5664511,
+              5664527,
+              5664543,
+              5664559,
+              5664575,
+              5664591,
+              5664607,
+              5664623,
+              5664639,
+              5664655,
+              5664671,
+              5664687
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5672471,
+              5672487,
+              5680551,
+              5680567,
+              5688631,
+              5688647,
+              5696711,
+              5696727,
+              5704791,
+              5704807,
+              5712871,
+              5712887,
+              5720951,
+              5720967,
+              5729031
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5667671,
+              5667687,
+              5670951,
+              5670967,
+              5674231,
+              5674247,
+              5677511,
+              5677527,
+              5680791,
+              5680807,
+              5684071,
+              5684087,
+              5687351,
+              5687367,
+              5690631
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122608,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21220,
+            "endpoints": 122608,
+            "legs": [
+              19872,
+              19872,
+              17576,
+              19872,
+              21220,
+              19872
+            ],
+            "gaps": [
+              16,
+              16,
+              3496,
+              764,
+              16,
+              16
+            ],
+            "legMedian": 19872,
+            "legWorstDeviation": -0.11553945249597423,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26736
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20434.666666666668,
+            "perBoundaryPerWrite": 851.4444444444445,
+            "cdpBracket": 177324,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5723691,
+              5723707,
+              5750443,
+              5750459,
+              5770331,
+              5770347,
+              5790219,
+              5793715,
+              5811291,
+              5812055,
+              5831927,
+              5831943,
+              5853163,
+              5853179,
+              5873051
+            ],
+            "tick0": 301,
+            "tick": 308,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116580,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19416,
+            "endpoints": 116580,
+            "legs": [
+              19416,
+              19404,
+              19416,
+              19416,
+              19416,
+              19416
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19416,
+            "legWorstDeviation": -0.0006180469715698393,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26216
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19430,
+            "perBoundaryPerWrite": 809.5833333333334,
+            "cdpBracket": 170756,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5741939,
+              5741955,
+              5768171,
+              5768187,
+              5787603,
+              5787619,
+              5807023,
+              5807039,
+              5826455,
+              5826471,
+              5845887,
+              5845903,
+              5865319,
+              5865335,
+              5884751
+            ],
+            "tick0": 329,
+            "tick": 336,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 6,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5703107,
+              5703123,
+              5703139,
+              5703155,
+              5703171,
+              5703187,
+              5703203,
+              5703219,
+              5703235,
+              5703251,
+              5703267,
+              5703283,
+              5703299,
+              5703315,
+              5703331
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5711115,
+              5711131,
+              5719195,
+              5719211,
+              5727275,
+              5727291,
+              5735355,
+              5735371,
+              5743435,
+              5743451,
+              5751515,
+              5751531,
+              5759595,
+              5759611,
+              5767675
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5706315,
+              5706331,
+              5709595,
+              5709611,
+              5712875,
+              5712891,
+              5716155,
+              5716171,
+              5719435,
+              5719451,
+              5722715,
+              5722731,
+              5725995,
+              5726011,
+              5729275
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 118808,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20864,
+            "endpoints": 118808,
+            "legs": [
+              19400,
+              19812,
+              19836,
+              19400,
+              20864,
+              19400
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19606,
+            "legWorstDeviation": 0.06416403141895338,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26188
+            ],
+            "primeExcess": 6582,
+            "perWrite": 19801.333333333332,
+            "perBoundaryPerWrite": 825.0555555555555,
+            "cdpBracket": 173084,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5766143,
+              5766159,
+              5792347,
+              5792363,
+              5811763,
+              5811779,
+              5831591,
+              5831607,
+              5851443,
+              5851459,
+              5870859,
+              5870875,
+              5891739,
+              5891755,
+              5911155
+            ],
+            "tick0": 357,
+            "tick": 364,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119124,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19840,
+            "endpoints": 119124,
+            "legs": [
+              19828,
+              19840,
+              19840,
+              19840,
+              19840,
+              19840
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19840,
+            "legWorstDeviation": -0.0006048387096774194,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26692
+            ],
+            "primeExcess": 6852,
+            "perWrite": 19854,
+            "perBoundaryPerWrite": 827.25,
+            "cdpBracket": 173796,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5792671,
+              5792687,
+              5819379,
+              5819395,
+              5839223,
+              5839239,
+              5859079,
+              5859095,
+              5878935,
+              5878951,
+              5898791,
+              5898807,
+              5918647,
+              5918663,
+              5938503
+            ],
+            "tick0": 385,
+            "tick": 392,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 7,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5751695,
+              5751711,
+              5751727,
+              5751743,
+              5751759,
+              5751775,
+              5751791,
+              5751807,
+              5751823,
+              5751839,
+              5751855,
+              5751871,
+              5751887,
+              5751903,
+              5751919
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48988,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48988,
+            "legs": [
+              8064,
+              8064,
+              6036,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              2552,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": -0.25148809523809523,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 6036 B against a cohort median of 8064 B (-2028 B, -25.1%), past the ±25% leg tolerance (±2016 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 6036 B against a cohort median of 8064 B (-2028 B, -25.1%), past the ±25% leg tolerance (±2016 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8164.666666666667,
+            "cdpBracket": 85132,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5759703,
+              5759719,
+              5767783,
+              5767799,
+              5775863,
+              5775879,
+              5783943,
+              5786495,
+              5792531,
+              5792547,
+              5800611,
+              5800627,
+              5808691,
+              5808707,
+              5816771
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5755411,
+              5755427,
+              5758691,
+              5758707,
+              5761971,
+              5761987,
+              5765251,
+              5765267,
+              5768531,
+              5768547,
+              5771811,
+              5771827,
+              5775091,
+              5775107,
+              5778371
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122736,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23516,
+            "endpoints": 122736,
+            "legs": [
+              19820,
+              19820,
+              19832,
+              19832,
+              19820,
+              23516
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19826,
+            "legWorstDeviation": 0.18611923736507616,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26684
+            ],
+            "primeExcess": 6858,
+            "perWrite": 20456,
+            "perBoundaryPerWrite": 852.3333333333334,
+            "cdpBracket": 184324,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5825027,
+              5825043,
+              5851727,
+              5851743,
+              5871563,
+              5871579,
+              5891399,
+              5891415,
+              5911247,
+              5911263,
+              5931095,
+              5931111,
+              5950931,
+              5950947,
+              5974463
+            ],
+            "tick0": 413,
+            "tick": 420,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116400,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19392,
+            "endpoints": 116400,
+            "legs": [
+              19392,
+              19392,
+              19380,
+              19380,
+              19380,
+              19380
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19380,
+            "legWorstDeviation": 0.0006191950464396285,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26192
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19400,
+            "perBoundaryPerWrite": 808.3333333333334,
+            "cdpBracket": 174420,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5841915,
+              5841931,
+              5868123,
+              5868139,
+              5887531,
+              5887547,
+              5906939,
+              5906955,
+              5926335,
+              5926351,
+              5945731,
+              5945747,
+              5965127,
+              5965143,
+              5984523
+            ],
+            "tick0": 441,
+            "tick": 448,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 8,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5804895,
+              5804911,
+              5804927,
+              5804943,
+              5804959,
+              5804975,
+              5804991,
+              5805007,
+              5805023,
+              5805039,
+              5805055,
+              5805071,
+              5805087,
+              5805103,
+              5805119
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5812903,
+              5812919,
+              5820983,
+              5820999,
+              5829063,
+              5829079,
+              5837143,
+              5837159,
+              5845223,
+              5845239,
+              5853303,
+              5853319,
+              5861383,
+              5861399,
+              5869463
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5808103,
+              5808119,
+              5811383,
+              5811399,
+              5814663,
+              5814679,
+              5817943,
+              5817959,
+              5821223,
+              5821239,
+              5824503,
+              5824519,
+              5827783,
+              5827799,
+              5831063
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 118884,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21104,
+            "endpoints": 118884,
+            "legs": [
+              19392,
+              21104,
+              19380,
+              19380,
+              19392,
+              20140
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19392,
+            "legWorstDeviation": 0.08828382838283828,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26192
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19814,
+            "perBoundaryPerWrite": 825.5833333333334,
+            "cdpBracket": 173164,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5874727,
+              5874743,
+              5900935,
+              5900951,
+              5920343,
+              5920359,
+              5941463,
+              5941479,
+              5960859,
+              5960875,
+              5980255,
+              5980271,
+              5999663,
+              5999679,
+              6019819
+            ],
+            "tick0": 469,
+            "tick": 476,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 127176,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 28952,
+            "endpoints": 127176,
+            "legs": [
+              19820,
+              19832,
+              28952,
+              15844,
+              19820,
+              19820
+            ],
+            "gaps": [
+              16,
+              16,
+              3008,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19820,
+            "legWorstDeviation": 0.4607467204843592,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 28952 B against a cohort median of 19820 B (+9132 B, 46.1%), past the ±25% leg tolerance (±4955 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 28952 B against a cohort median of 19820 B (+9132 B, 46.1%), past the ±25% leg tolerance (±4955 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26684
+            ],
+            "primeExcess": 6864,
+            "perWrite": 21196,
+            "perBoundaryPerWrite": 883.1666666666666,
+            "cdpBracket": 181840,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5908079,
+              5908095,
+              5934779,
+              5934795,
+              5954615,
+              5954631,
+              5974463,
+              5977471,
+              6006423,
+              6006439,
+              6022283,
+              6022299,
+              6042119,
+              6042135,
+              6061955
+            ],
+            "tick0": 497,
+            "tick": 504,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 9,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5874647,
+              5874663,
+              5874679,
+              5874695,
+              5874711,
+              5874727,
+              5874743,
+              5874759,
+              5874775,
+              5874791,
+              5874807,
+              5874823,
+              5874839,
+              5874855,
+              5874871
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5882655,
+              5882671,
+              5890735,
+              5890751,
+              5898815,
+              5898831,
+              5906895,
+              5906911,
+              5914975,
+              5914991,
+              5923055,
+              5923071,
+              5931135,
+              5931151,
+              5939215
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5877855,
+              5877871,
+              5881135,
+              5881151,
+              5884415,
+              5884431,
+              5887695,
+              5887711,
+              5890975,
+              5890991,
+              5894255,
+              5894271,
+              5897535,
+              5897551,
+              5900815
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 123932,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24752,
+            "endpoints": 123932,
+            "legs": [
+              19824,
+              19824,
+              19812,
+              19812,
+              19812,
+              24752
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 0.24896558684024625,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6870,
+            "perWrite": 20655.333333333332,
+            "perBoundaryPerWrite": 860.6388888888888,
+            "cdpBracket": 178600,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5950287,
+              5950303,
+              5976991,
+              5977007,
+              5996831,
+              5996847,
+              6016671,
+              6016687,
+              6036499,
+              6036515,
+              6056327,
+              6056343,
+              6076155,
+              6076171,
+              6100923
+            ],
+            "tick0": 525,
+            "tick": 532,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116340,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116340,
+            "legs": [
+              19372,
+              19372,
+              19384,
+              19372,
+              19372,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0006194507536650836,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19390,
+            "perBoundaryPerWrite": 807.9166666666666,
+            "cdpBracket": 177740,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5955355,
+              5955371,
+              5981543,
+              5981559,
+              6000931,
+              6000947,
+              6020319,
+              6020335,
+              6039719,
+              6039735,
+              6059107,
+              6059123,
+              6078495,
+              6078511,
+              6097883
+            ],
+            "tick0": 553,
+            "tick": 560,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 10,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5921063,
+              5921079,
+              5921095,
+              5921111,
+              5921127,
+              5921143,
+              5921159,
+              5921175,
+              5921191,
+              5921207,
+              5921223,
+              5921239,
+              5921255,
+              5921271,
+              5921287
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5929071,
+              5929087,
+              5937151,
+              5937167,
+              5945231,
+              5945247,
+              5953311,
+              5953327,
+              5961391,
+              5961407,
+              5969471,
+              5969487,
+              5977551,
+              5977567,
+              5985631
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5924271,
+              5924287,
+              5927551,
+              5927567,
+              5930831,
+              5930847,
+              5934111,
+              5934127,
+              5937391,
+              5937407,
+              5940671,
+              5940687,
+              5943951,
+              5943967,
+              5947231
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116352,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116352,
+            "legs": [
+              19372,
+              19384,
+              19372,
+              19384,
+              19372,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0006194507536650836,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19392,
+            "perBoundaryPerWrite": 808,
+            "cdpBracket": 171332,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5981755,
+              5981771,
+              6007943,
+              6007959,
+              6027331,
+              6027347,
+              6046731,
+              6046747,
+              6066119,
+              6066135,
+              6085519,
+              6085535,
+              6104907,
+              6104923,
+              6124295
+            ],
+            "tick0": 581,
+            "tick": 588,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118992,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 118992,
+            "legs": [
+              19788,
+              19824,
+              19824,
+              19824,
+              19824,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": -0.0018159806295399517,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19832,
+            "perBoundaryPerWrite": 826.3333333333334,
+            "cdpBracket": 175152,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5993727,
+              5993743,
+              6020431,
+              6020447,
+              6040235,
+              6040251,
+              6060075,
+              6060091,
+              6079915,
+              6079931,
+              6099755,
+              6099771,
+              6119595,
+              6119611,
+              6139423
+            ],
+            "tick0": 609,
+            "tick": 616,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 11,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5952763,
+              5952779,
+              5952795,
+              5952811,
+              5952827,
+              5952843,
+              5952859,
+              5952875,
+              5952891,
+              5952907,
+              5952923,
+              5952939,
+              5952955,
+              5952971,
+              5952987
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5960771,
+              5960787,
+              5968851,
+              5968867,
+              5976931,
+              5976947,
+              5985011,
+              5985027,
+              5993091,
+              5993107,
+              6001171,
+              6001187,
+              6009251,
+              6009267,
+              6017331
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5955971,
+              5955987,
+              5959251,
+              5959267,
+              5962531,
+              5962547,
+              5965811,
+              5965827,
+              5969091,
+              5969107,
+              5972371,
+              5972387,
+              5975651,
+              5975667,
+              5978931
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119824,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20580,
+            "endpoints": 119824,
+            "legs": [
+              19832,
+              19820,
+              19832,
+              19832,
+              19832,
+              20580
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19832,
+            "legWorstDeviation": 0.03771682129891085,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26696
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19970.666666666668,
+            "perBoundaryPerWrite": 832.1111111111112,
+            "cdpBracket": 174500,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6000775,
+              6000791,
+              6027487,
+              6027503,
+              6047335,
+              6047351,
+              6067171,
+              6067187,
+              6087019,
+              6087035,
+              6106867,
+              6106883,
+              6126715,
+              6126731,
+              6147311
+            ],
+            "tick0": 637,
+            "tick": 644,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 273760,
+            "fall": 151948,
+            "falls": 1,
+            "maxStep": 176820,
+            "endpoints": 121812,
+            "legs": [
+              19384,
+              -151948,
+              19372,
+              19372,
+              19384,
+              19348
+            ],
+            "gaps": [
+              16,
+              176820,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": -8.843691926491845,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read -151948 B against a cohort median of 19372 B (-171320 B, -884.4%), past the ±25% leg tolerance (±4843 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read -151948 B against a cohort median of 19372 B (-171320 B, -884.4%), past the ±25% leg tolerance (±4843 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 45626.666666666664,
+            "perBoundaryPerWrite": 1901.111111111111,
+            "cdpBracket": 177168,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6024867,
+              6024883,
+              6051067,
+              6051083,
+              6070467,
+              6247287,
+              6095339,
+              6095355,
+              6114727,
+              6114743,
+              6134115,
+              6134131,
+              6153515,
+              6153531,
+              6172879
+            ],
+            "tick0": 665,
+            "tick": 672,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 12,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5989275,
+              5989291,
+              5989307,
+              5989323,
+              5989339,
+              5989355,
+              5989371,
+              5989387,
+              5989403,
+              5989419,
+              5989435,
+              5989451,
+              5989467,
+              5989483,
+              5989499
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5997283,
+              5997299,
+              6005363,
+              6005379,
+              6013443,
+              6013459,
+              6021523,
+              6021539,
+              6029603,
+              6029619,
+              6037683,
+              6037699,
+              6045763,
+              6045779,
+              6053843
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5992483,
+              5992499,
+              5995763,
+              5995779,
+              5999043,
+              5999059,
+              6002323,
+              6002339,
+              6005603,
+              6005619,
+              6008883,
+              6008899,
+              6012163,
+              6012179,
+              6015443
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116340,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116340,
+            "legs": [
+              19372,
+              19384,
+              19372,
+              19372,
+              19372,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0006194507536650836,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19390,
+            "perBoundaryPerWrite": 807.9166666666666,
+            "cdpBracket": 171344,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6058703,
+              6058719,
+              6084903,
+              6084919,
+              6104291,
+              6104307,
+              6123691,
+              6123707,
+              6143079,
+              6143095,
+              6162467,
+              6162483,
+              6181855,
+              6181871,
+              6201243
+            ],
+            "tick0": 693,
+            "tick": 700,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118956,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 118956,
+            "legs": [
+              19812,
+              19824,
+              19812,
+              19788,
+              19812,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": -0.0012113870381586917,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6876,
+            "perWrite": 19826,
+            "perBoundaryPerWrite": 826.0833333333334,
+            "cdpBracket": 173608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6087599,
+              6087615,
+              6114303,
+              6114319,
+              6134131,
+              6134147,
+              6153971,
+              6153987,
+              6173799,
+              6173815,
+              6193603,
+              6193619,
+              6213431,
+              6213447,
+              6233259
+            ],
+            "tick0": 721,
+            "tick": 728,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 13,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 31952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6046635,
+              6046651,
+              6046667,
+              6046683,
+              6046699,
+              6046715,
+              6046731,
+              6046747,
+              6046763,
+              6046779,
+              6046795,
+              6046811,
+              6046827,
+              6046843,
+              6046859
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6058663,
+              6058679,
+              6066743,
+              6066759,
+              6074823,
+              6074839,
+              6082903,
+              6082919,
+              6090983,
+              6090999,
+              6099063,
+              6099079,
+              6107143,
+              6107159,
+              6115223
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6053863,
+              6053879,
+              6057143,
+              6057159,
+              6060423,
+              6060439,
+              6063703,
+              6063719,
+              6066983,
+              6066999,
+              6070263,
+              6070279,
+              6073543,
+              6073559,
+              6076823
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119752,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20572,
+            "endpoints": 119752,
+            "legs": [
+              19812,
+              19812,
+              19824,
+              19812,
+              19824,
+              20572
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 0.03804622060752851,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26676
+            ],
+            "primeExcess": 6858,
+            "perWrite": 19958.666666666668,
+            "perBoundaryPerWrite": 831.6111111111112,
+            "cdpBracket": 174392,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6101239,
+              6101255,
+              6127931,
+              6127947,
+              6147759,
+              6147775,
+              6167587,
+              6167603,
+              6187427,
+              6187443,
+              6207255,
+              6207271,
+              6227095,
+              6227111,
+              6247683
+            ],
+            "tick0": 749,
+            "tick": 756,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116364,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116364,
+            "legs": [
+              19384,
+              19384,
+              19372,
+              19372,
+              19384,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.0003096294767261843,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6794,
+            "perWrite": 19394,
+            "perBoundaryPerWrite": 808.0833333333334,
+            "cdpBracket": 170480,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6104279,
+              6104295,
+              6130467,
+              6130483,
+              6149867,
+              6149883,
+              6169267,
+              6169283,
+              6188655,
+              6188671,
+              6208043,
+              6208059,
+              6227443,
+              6227459,
+              6246831
+            ],
+            "tick0": 777,
+            "tick": 784,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 14,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6063335,
+              6063351,
+              6063367,
+              6063383,
+              6063399,
+              6063415,
+              6063431,
+              6063447,
+              6063463,
+              6063479,
+              6063495,
+              6063511,
+              6063527,
+              6063543,
+              6063559
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6071343,
+              6071359,
+              6079423,
+              6079439,
+              6087503,
+              6087519,
+              6095583,
+              6095599,
+              6103663,
+              6103679,
+              6111743,
+              6111759,
+              6119823,
+              6119839,
+              6127903
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6066543,
+              6066559,
+              6069823,
+              6069839,
+              6073103,
+              6073119,
+              6076383,
+              6076399,
+              6079663,
+              6079679,
+              6082943,
+              6082959,
+              6086223,
+              6086239,
+              6089503
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117828,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20848,
+            "endpoints": 117828,
+            "legs": [
+              19384,
+              19372,
+              19372,
+              19372,
+              19384,
+              20848
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.07585922179791516,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19638,
+            "perBoundaryPerWrite": 818.25,
+            "cdpBracket": 174684,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6113447,
+              6113463,
+              6139647,
+              6139663,
+              6159047,
+              6159063,
+              6178435,
+              6178451,
+              6197823,
+              6197839,
+              6217211,
+              6217227,
+              6236611,
+              6236627,
+              6257475
+            ],
+            "tick0": 805,
+            "tick": 812,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119004,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 119004,
+            "legs": [
+              19812,
+              19824,
+              19824,
+              19812,
+              19824,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": -0.0003027550711474417,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6870,
+            "perWrite": 19834,
+            "perBoundaryPerWrite": 826.4166666666666,
+            "cdpBracket": 173656,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6130155,
+              6130171,
+              6156859,
+              6156875,
+              6176687,
+              6176703,
+              6196527,
+              6196543,
+              6216367,
+              6216383,
+              6236195,
+              6236211,
+              6256035,
+              6256051,
+              6275863
+            ],
+            "tick0": 833,
+            "tick": 840,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 15,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6089191,
+              6089207,
+              6089223,
+              6089239,
+              6089255,
+              6089271,
+              6089287,
+              6089303,
+              6089319,
+              6089335,
+              6089351,
+              6089367,
+              6089383,
+              6089399,
+              6089415
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6097199,
+              6097215,
+              6105279,
+              6105295,
+              6113359,
+              6113375,
+              6121439,
+              6121455,
+              6129519,
+              6129535,
+              6137599,
+              6137615,
+              6145679,
+              6145695,
+              6153759
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6092399,
+              6092415,
+              6095679,
+              6095695,
+              6098959,
+              6098975,
+              6102239,
+              6102255,
+              6105519,
+              6105535,
+              6108799,
+              6108815,
+              6112079,
+              6112095,
+              6115359
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120468,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20556,
+            "endpoints": 120468,
+            "legs": [
+              19824,
+              19812,
+              19824,
+              20556,
+              20544,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.036924939467312345,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20078,
+            "perBoundaryPerWrite": 836.5833333333334,
+            "cdpBracket": 175120,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6144475,
+              6144491,
+              6171179,
+              6171195,
+              6191019,
+              6191035,
+              6210847,
+              6210863,
+              6230687,
+              6230703,
+              6251259,
+              6251275,
+              6271819,
+              6271835,
+              6291647
+            ],
+            "tick0": 861,
+            "tick": 868,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116328,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116328,
+            "legs": [
+              19384,
+              19372,
+              19348,
+              19372,
+              19372,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": -0.0012389015073301672,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19388,
+            "perBoundaryPerWrite": 807.8333333333334,
+            "cdpBracket": 170456,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6157891,
+              6157907,
+              6184091,
+              6184107,
+              6203491,
+              6203507,
+              6222879,
+              6222895,
+              6242243,
+              6242259,
+              6261631,
+              6261647,
+              6281019,
+              6281035,
+              6300419
+            ],
+            "tick0": 889,
+            "tick": 896,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 16,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6111831,
+              6111847,
+              6111863,
+              6111879,
+              6111895,
+              6111911,
+              6111927,
+              6111943,
+              6111959,
+              6111975,
+              6111991,
+              6112007,
+              6112023,
+              6112039,
+              6112055
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6119839,
+              6119855,
+              6127919,
+              6127935,
+              6135999,
+              6136015,
+              6144079,
+              6144095,
+              6152159,
+              6152175,
+              6160239,
+              6160255,
+              6168319,
+              6168335,
+              6176399
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6115039,
+              6115055,
+              6118319,
+              6118335,
+              6121599,
+              6121615,
+              6124879,
+              6124895,
+              6128159,
+              6128175,
+              6131439,
+              6131455,
+              6134719,
+              6134735,
+              6137999
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117816,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20128,
+            "endpoints": 117816,
+            "legs": [
+              19384,
+              19384,
+              19348,
+              19372,
+              20128,
+              20104
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19384,
+            "legWorstDeviation": 0.03838217086256707,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19636,
+            "perBoundaryPerWrite": 818.1666666666666,
+            "cdpBracket": 172072,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6154987,
+              6155003,
+              6181187,
+              6181203,
+              6200587,
+              6200603,
+              6219987,
+              6220003,
+              6239351,
+              6239367,
+              6258739,
+              6258755,
+              6278883,
+              6278899,
+              6299003
+            ],
+            "tick0": 917,
+            "tick": 924,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122648,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22424,
+            "endpoints": 122648,
+            "legs": [
+              19812,
+              19812,
+              22424,
+              19824,
+              20868,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 0.13149661923503886,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28024
+            ],
+            "primeExcess": 8206,
+            "perWrite": 20441.333333333332,
+            "perBoundaryPerWrite": 851.7222222222222,
+            "cdpBracket": 178636,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6171475,
+              6171491,
+              6199515,
+              6199531,
+              6219343,
+              6219359,
+              6239171,
+              6239187,
+              6261611,
+              6261627,
+              6281451,
+              6281467,
+              6302335,
+              6302351,
+              6322163
+            ],
+            "tick0": 945,
+            "tick": 952,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 17,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6128919,
+              6128935,
+              6128951,
+              6128967,
+              6128983,
+              6128999,
+              6129015,
+              6129031,
+              6129047,
+              6129063,
+              6129079,
+              6129095,
+              6129111,
+              6129127,
+              6129143
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6136927,
+              6136943,
+              6145007,
+              6145023,
+              6153087,
+              6153103,
+              6161167,
+              6161183,
+              6169247,
+              6169263,
+              6177327,
+              6177343,
+              6185407,
+              6185423,
+              6193487
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6132127,
+              6132143,
+              6135407,
+              6135423,
+              6138687,
+              6138703,
+              6141967,
+              6141983,
+              6145247,
+              6145263,
+              6148527,
+              6148543,
+              6151807,
+              6151823,
+              6155087
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119016,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19828,
+            "endpoints": 119016,
+            "legs": [
+              19816,
+              19816,
+              19828,
+              19816,
+              19828,
+              19816
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19816,
+            "legWorstDeviation": 0.0006055712555510698,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26692
+            ],
+            "primeExcess": 6876,
+            "perWrite": 19836,
+            "perBoundaryPerWrite": 826.5,
+            "cdpBracket": 174392,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6188935,
+              6188951,
+              6215643,
+              6215659,
+              6235475,
+              6235491,
+              6255307,
+              6255323,
+              6275151,
+              6275167,
+              6294983,
+              6294999,
+              6314827,
+              6314843,
+              6334659
+            ],
+            "tick0": 973,
+            "tick": 980,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116352,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116352,
+            "legs": [
+              19372,
+              19384,
+              19384,
+              19372,
+              19372,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0006194507536650836,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19392,
+            "perBoundaryPerWrite": 808,
+            "cdpBracket": 170480,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6193531,
+              6193547,
+              6219731,
+              6219747,
+              6239119,
+              6239135,
+              6258519,
+              6258535,
+              6277919,
+              6277935,
+              6297307,
+              6297323,
+              6316695,
+              6316711,
+              6336083
+            ],
+            "tick0": 1001,
+            "tick": 1008,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      }
+    ],
+    "allocFits": {
+      "perRound": {},
+      "mean": {}
+    },
+    "writeDriven": true,
+    "writeProvenance": {
+      "windows": 36,
+      "pairs": 36,
+      "unnamed": [],
+      "incomplete": [],
+      "ok": true
+    },
+    "controlVerdict": {
+      "ok": true,
+      "perDouble": 8.085592592592592,
+      "differential": 8.00932098765432
+    },
+    "fallsInMeasuredWindows": 7,
+    "refusedWindows": 9,
+    "refusalReasons": 18
+  },
+  "box": {
+    "bead": "rf2-24o2z",
+    "chromium": "chromium/147.0.7727.15",
+    "node": "v24.13.0",
+    "platform": "win32/x64/10.0.26200",
+    "load": {
+      "open": {
+        "at": "2026-08-20T20:26:01.699Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13472648835,
+        "cpuBusyMs": 3626227081,
+        "freeMemB": 16167792640,
+        "totalMemB": 68112736256,
+        "uptimeS": 708724.5
+      },
+      "close": {
+        "at": "2026-08-20T20:26:27.849Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13473145739,
+        "cpuBusyMs": 3626360596,
+        "freeMemB": 16257351680,
+        "totalMemB": 68112736256,
+        "uptimeS": 708750.656
+      },
+      "busyFraction": 0.21178771578902286
+    },
+    "session": {
+      "startedAt": "2026-08-20T20:25:27.340Z",
+      "sessionStartedAt": "2026-08-20T19:39:26.627Z",
+      "runsInSession": 5,
+      "sessionGapMs": 3600000,
+      "previousRun": {
+        "startedAt": "2026-08-20T20:24:20.291Z",
+        "endedAt": "2026-08-20T20:25:27.200Z",
+        "sinceStartMs": 67049,
+        "sinceEndMs": 140,
+        "sameSession": true
+      }
+    }
+  }
+}

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/parity-2.json
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/parity-2.json
@@ -1,0 +1,7553 @@
+{
+  "generatedAt": "2026-08-20T20:29:09.400Z",
+  "build": "hicasso-bench",
+  "initFn": "re-frame.bench.p0-app/-main",
+  "alloc": {
+    "benchmark": "P0:steady-state-allocation-slope",
+    "bead": "rf2-2rtt6.76",
+    "roots": 4,
+    "perRoot": {
+      "list": 300,
+      "grid": 6
+    },
+    "publishedPerRoot": {
+      "list": 300,
+      "grid": 300
+    },
+    "arm": {
+      "cells": 6,
+      "roots": 4,
+      "boundaries": 24,
+      "writes": 6,
+      "refusals": [],
+      "admissible": true
+    },
+    "boundaries": 24,
+    "writes": 6,
+    "primeWrites": 1,
+    "windowWrites": 7,
+    "bySite": false,
+    "sites": 2,
+    "siteNames": [
+      "dispatch",
+      "drain"
+    ],
+    "warmups": 3,
+    "rounds": 18,
+    "preciseMemory": true,
+    "controlDoubles": {
+      "d1": 1000,
+      "d2": 400
+    },
+    "controlSlack": 0.75,
+    "writeSelector": "all",
+    "writeLegs": [
+      "all"
+    ],
+    "writePaired": false,
+    "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+    "plan": {
+      "name": "floor",
+      "arms": true,
+      "rungs": false,
+      "fits": false
+    },
+    "segOrder": "parity",
+    "passOrder": "parity",
+    "passSeed": "1787257712651",
+    "passSchedule": {
+      "flips": [
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false
+      ],
+      "attempts": 1,
+      "parityTied": false
+    },
+    "controlSlot": "first",
+    "instrument": "in-page performance.memory.usedJSHeapSize sampled at every leg boundary, rising steps accumulated separately from falling ones; --enable-precise-memory-info. A falling step is a collection this counter SAW; a leg that deviates from its cohort median by more than the leg tolerance is a work unit that is not one; and under the by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the other two can see. TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg has no interior reading and so no site step to be negative, and the intra-leg gate returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with these (see `bySite`), so a witness comparing byte for byte against a figure published at stride 2 can never be screened by all three",
+    "fallThresholdB": 600000,
+    "legTolerance": 0.25,
+    "verification": {
+      "unverified": 0,
+      "detail": []
+    },
+    "workCount": false,
+    "workVerification": {
+      "counted": false
+    },
+    "perRound": [
+      {
+        "round": 0,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 524,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              524
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 116.66666666666667,
+            "cdpBracket": 46232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3840294,
+              3840310,
+              3840326,
+              3840342,
+              3840358,
+              3840374,
+              3840390,
+              3840406,
+              3840422,
+              3840438,
+              3840454,
+              3840470,
+              3840486,
+              3841010,
+              3841026
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48576,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8144,
+            "endpoints": 48576,
+            "legs": [
+              8144,
+              8080,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.00992063492063492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8096,
+            "cdpBracket": 87388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3853918,
+              3853934,
+              3861998,
+              3862014,
+              3870158,
+              3870174,
+              3878254,
+              3878270,
+              3886334,
+              3886350,
+              3894414,
+              3894430,
+              3902494,
+              3902510,
+              3910574
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 52328,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3850018,
+              3850034,
+              3853298,
+              3853314,
+              3856578,
+              3856594,
+              3859858,
+              3859874,
+              3863138,
+              3863154,
+              3866418,
+              3866434,
+              3869698,
+              3869714,
+              3872978
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 356244,
+            "fall": 224896,
+            "falls": 1,
+            "maxStep": 254036,
+            "endpoints": 131348,
+            "legs": [
+              20408,
+              19692,
+              19764,
+              -224896,
+              19692,
+              22572
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              254036,
+              16,
+              16
+            ],
+            "legMedian": 19728,
+            "legWorstDeviation": -12.399837793998378,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read -224896 B against a cohort median of 19728 B (-244624 B, -1240.0%), past the ±25% leg tolerance (±4932 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read -224896 B against a cohort median of 19728 B (-244624 B, -1240.0%), past the ±25% leg tolerance (±4932 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              27388
+            ],
+            "primeExcess": 7660,
+            "perWrite": 59374,
+            "perBoundaryPerWrite": 2473.9166666666665,
+            "cdpBracket": 187136,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              4783239,
+              4783255,
+              4810643,
+              4810659,
+              4831067,
+              4831083,
+              4850775,
+              4850791,
+              4870555,
+              5124591,
+              4899695,
+              4899711,
+              4919403,
+              4919419,
+              4941991
+            ],
+            "tick0": 21,
+            "tick": 28,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 452484,
+            "fall": 215072,
+            "falls": 1,
+            "maxStep": 260892,
+            "endpoints": 237412,
+            "legs": [
+              19916,
+              260892,
+              22124,
+              20428,
+              -215072,
+              128980
+            ],
+            "gaps": [
+              16,
+              16,
+              64,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21276,
+            "legWorstDeviation": 11.262267343485618,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 260892 B against a cohort median of 21276 B (+239616 B, 1126.2%), past the ±25% leg tolerance (±5319 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -215072 B against a cohort median of 21276 B (-236348 B, -1110.9%), past the ±25% leg tolerance (±5319 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 6 of 6 read 128980 B against a cohort median of 21276 B (+107704 B, 506.2%), past the ±25% leg tolerance (±5319 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 260892 B against a cohort median of 21276 B (+239616 B, 1126.2%), past the ±25% leg tolerance (±5319 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -215072 B against a cohort median of 21276 B (-236348 B, -1110.9%), past the ±25% leg tolerance (±5319 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 6 of 6 read 128980 B against a cohort median of 21276 B (+107704 B, 506.2%), past the ±25% leg tolerance (±5319 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26764
+            ],
+            "primeExcess": 5488,
+            "perWrite": 75414,
+            "perBoundaryPerWrite": 3142.25,
+            "cdpBracket": 201444,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5077563,
+              5077579,
+              5104343,
+              5104359,
+              5124275,
+              5124291,
+              5385183,
+              5385247,
+              5407371,
+              5407387,
+              5427815,
+              5427831,
+              5212759,
+              5212775,
+              5341755
+            ],
+            "tick0": 49,
+            "tick": 56,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 1,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5063939,
+              5063955,
+              5063971,
+              5063987,
+              5064003,
+              5064019,
+              5064035,
+              5064051,
+              5064067,
+              5064083,
+              5064099,
+              5064115,
+              5064131,
+              5064147,
+              5064163
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 87716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5071947,
+              5071963,
+              5080027,
+              5080043,
+              5088107,
+              5088123,
+              5096187,
+              5096203,
+              5104267,
+              5104283,
+              5112347,
+              5112363,
+              5120427,
+              5120443,
+              5128507
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5069391,
+              5069407,
+              5072671,
+              5072687,
+              5075951,
+              5075967,
+              5079231,
+              5079247,
+              5082511,
+              5082527,
+              5085791,
+              5085807,
+              5089071,
+              5089087,
+              5092351
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 591520,
+            "fall": 471984,
+            "falls": 2,
+            "maxStep": 356572,
+            "endpoints": 119536,
+            "legs": [
+              356572,
+              -315796,
+              20588,
+              19760,
+              22172,
+              172348
+            ],
+            "gaps": [
+              -156188,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21380,
+            "legWorstDeviation": -15.770626753975678,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 356572 B against a cohort median of 21380 B (+335192 B, 1567.8%), past the ±25% leg tolerance (±5345 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -315796 B against a cohort median of 21380 B (-337176 B, -1577.1%), past the ±25% leg tolerance (±5345 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 6 of 6 read 172348 B against a cohort median of 21380 B (+150968 B, 706.1%), past the ±25% leg tolerance (±5345 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 356572 B against a cohort median of 21380 B (+335192 B, 1567.8%), past the ±25% leg tolerance (±5345 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -315796 B against a cohort median of 21380 B (-337176 B, -1577.1%), past the ±25% leg tolerance (±5345 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 6 of 6 read 172348 B against a cohort median of 21380 B (+150968 B, 706.1%), past the ±25% leg tolerance (±5345 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              187180
+            ],
+            "primeExcess": 165800,
+            "perWrite": 98586.66666666667,
+            "perBoundaryPerWrite": 4107.777777777778,
+            "cdpBracket": 187656,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5198083,
+              5198099,
+              5385279,
+              5229091,
+              5585663,
+              5585679,
+              5269883,
+              5269899,
+              5290487,
+              5290503,
+              5310263,
+              5310279,
+              5332451,
+              5332467,
+              5504815
+            ],
+            "tick0": 77,
+            "tick": 84,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 169108,
+            "fall": 46136,
+            "falls": 1,
+            "maxStep": 69224,
+            "endpoints": 122972,
+            "legs": [
+              19256,
+              19244,
+              21604,
+              20516,
+              -46136,
+              19184
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              69224,
+              16
+            ],
+            "legMedian": 19250,
+            "legWorstDeviation": -3.3966753246753245,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read -46136 B against a cohort median of 19250 B (-65386 B, -339.7%), past the ±25% leg tolerance (±4812.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read -46136 B against a cohort median of 19250 B (-65386 B, -339.7%), past the ±25% leg tolerance (±4812.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6790,
+            "perWrite": 28184.666666666668,
+            "perBoundaryPerWrite": 1174.361111111111,
+            "cdpBracket": 177428,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5300531,
+              5300547,
+              5326587,
+              5326603,
+              5345859,
+              5345875,
+              5365119,
+              5365135,
+              5386739,
+              5386755,
+              5407271,
+              5476495,
+              5430359,
+              5430375,
+              5449559
+            ],
+            "tick0": 105,
+            "tick": 112,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 2,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5264007,
+              5264023,
+              5264039,
+              5264055,
+              5264071,
+              5264087,
+              5264103,
+              5264119,
+              5264135,
+              5264151,
+              5264167,
+              5264183,
+              5264199,
+              5264215,
+              5264231
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85088,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5272031,
+              5272047,
+              5280111,
+              5280127,
+              5288191,
+              5288207,
+              5296271,
+              5296287,
+              5304351,
+              5304367,
+              5312431,
+              5312447,
+              5320511,
+              5320527,
+              5328591
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5267231,
+              5267247,
+              5270511,
+              5270527,
+              5273791,
+              5273807,
+              5277071,
+              5277087,
+              5280351,
+              5280367,
+              5283631,
+              5283647,
+              5286911,
+              5286927,
+              5290191
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116132,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19768,
+            "endpoints": 116132,
+            "legs": [
+              19768,
+              19256,
+              19256,
+              19244,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": 0.02658911508101371,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19355.333333333332,
+            "perBoundaryPerWrite": 806.4722222222222,
+            "cdpBracket": 173316,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5353159,
+              5353175,
+              5379215,
+              5379231,
+              5398999,
+              5399015,
+              5418271,
+              5418287,
+              5437543,
+              5437559,
+              5456803,
+              5456819,
+              5476075,
+              5476091,
+              5495347
+            ],
+            "tick0": 133,
+            "tick": 140,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122380,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22096,
+            "endpoints": 122380,
+            "legs": [
+              19696,
+              22096,
+              21632,
+              19624,
+              19612,
+              19624
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19660,
+            "legWorstDeviation": 0.12390640895218719,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6884,
+            "perWrite": 20396.666666666668,
+            "perBoundaryPerWrite": 849.8611111111112,
+            "cdpBracket": 176904,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5426755,
+              5426771,
+              5453315,
+              5453331,
+              5473027,
+              5473043,
+              5495139,
+              5495155,
+              5516787,
+              5516803,
+              5536427,
+              5536443,
+              5556055,
+              5556071,
+              5575695
+            ],
+            "tick0": 161,
+            "tick": 168,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 3,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 29232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5387823,
+              5387839,
+              5387855,
+              5387871,
+              5387887,
+              5387903,
+              5387919,
+              5387935,
+              5387951,
+              5387967,
+              5387983,
+              5387999,
+              5388015,
+              5388031,
+              5388047
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5396759,
+              5396775,
+              5404839,
+              5404855,
+              5412919,
+              5412935,
+              5420999,
+              5421015,
+              5429079,
+              5429095,
+              5437159,
+              5437175,
+              5445239,
+              5445255,
+              5453319
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5391959,
+              5391975,
+              5395239,
+              5395255,
+              5398519,
+              5398535,
+              5401799,
+              5401815,
+              5405079,
+              5405095,
+              5408359,
+              5408375,
+              5411639,
+              5411655,
+              5414919
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118272,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19696,
+            "endpoints": 118272,
+            "legs": [
+              19696,
+              19696,
+              19696,
+              19696,
+              19696,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26532
+            ],
+            "primeExcess": 6836,
+            "perWrite": 19712,
+            "perBoundaryPerWrite": 821.3333333333334,
+            "cdpBracket": 172784,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5459755,
+              5459771,
+              5486303,
+              5486319,
+              5506015,
+              5506031,
+              5525727,
+              5525743,
+              5545439,
+              5545455,
+              5565151,
+              5565167,
+              5584863,
+              5584879,
+              5604575
+            ],
+            "tick0": 189,
+            "tick": 196,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 115608,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19256,
+            "endpoints": 115608,
+            "legs": [
+              19256,
+              19256,
+              19256,
+              19256,
+              19244,
+              19244
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": -0.0006231823847112588,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19268,
+            "perBoundaryPerWrite": 802.8333333333334,
+            "cdpBracket": 169608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5487563,
+              5487579,
+              5513619,
+              5513635,
+              5532891,
+              5532907,
+              5552163,
+              5552179,
+              5571435,
+              5571451,
+              5590707,
+              5590723,
+              5609967,
+              5609983,
+              5629227
+            ],
+            "tick0": 217,
+            "tick": 224,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 4,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5446619,
+              5446635,
+              5446651,
+              5446667,
+              5446683,
+              5446699,
+              5446715,
+              5446731,
+              5446747,
+              5446763,
+              5446779,
+              5446795,
+              5446811,
+              5446827,
+              5446843
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5454627,
+              5454643,
+              5462707,
+              5462723,
+              5470787,
+              5470803,
+              5478867,
+              5478883,
+              5486947,
+              5486963,
+              5495027,
+              5495043,
+              5503107,
+              5503123,
+              5511187
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5449827,
+              5449843,
+              5453107,
+              5453123,
+              5456387,
+              5456403,
+              5459667,
+              5459683,
+              5462947,
+              5462963,
+              5466227,
+              5466243,
+              5469507,
+              5469523,
+              5472787
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 424580,
+            "fall": 274508,
+            "falls": 2,
+            "maxStep": 330048,
+            "endpoints": 150072,
+            "legs": [
+              23132,
+              330048,
+              -273636,
+              23132,
+              25056,
+              23132
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              -872,
+              16,
+              16
+            ],
+            "legMedian": 23132,
+            "legWorstDeviation": 13.268026975618191,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 330048 B against a cohort median of 23132 B (+306916 B, 1326.8%), past the ±25% leg tolerance (±5783 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -273636 B against a cohort median of 23132 B (-296768 B, -1282.9%), past the ±25% leg tolerance (±5783 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 330048 B against a cohort median of 23132 B (+306916 B, 1326.8%), past the ±25% leg tolerance (±5783 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -273636 B against a cohort median of 23132 B (-296768 B, -1282.9%), past the ±25% leg tolerance (±5783 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              31708
+            ],
+            "primeExcess": 8576,
+            "perWrite": 70763.33333333333,
+            "perBoundaryPerWrite": 2948.472222222222,
+            "cdpBracket": 210616,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5624443,
+              5624459,
+              5656167,
+              5656183,
+              5679315,
+              5679331,
+              6009379,
+              6009395,
+              5735759,
+              5734887,
+              5758019,
+              5758035,
+              5783091,
+              5783107,
+              5806239
+            ],
+            "tick0": 245,
+            "tick": 252,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 146220,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 26264,
+            "endpoints": 146220,
+            "legs": [
+              23556,
+              23544,
+              26264,
+              23556,
+              25684,
+              23520
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23556,
+            "legWorstDeviation": 0.11496009509254543,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30436
+            ],
+            "primeExcess": 6880,
+            "perWrite": 24370,
+            "perBoundaryPerWrite": 1015.4166666666666,
+            "cdpBracket": 204636,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5714371,
+              5714387,
+              5744823,
+              5744839,
+              5768395,
+              5768411,
+              5791955,
+              5791971,
+              5818235,
+              5818251,
+              5841807,
+              5841823,
+              5867507,
+              5867523,
+              5891043
+            ],
+            "tick0": 273,
+            "tick": 280,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 5,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5673939,
+              5673955,
+              5673971,
+              5673987,
+              5674003,
+              5674019,
+              5674035,
+              5674051,
+              5674067,
+              5674083,
+              5674099,
+              5674115,
+              5674131,
+              5674147,
+              5674163
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5681947,
+              5681963,
+              5690027,
+              5690043,
+              5698107,
+              5698123,
+              5706187,
+              5706203,
+              5714267,
+              5714283,
+              5722347,
+              5722363,
+              5730427,
+              5730443,
+              5738507
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5677147,
+              5677163,
+              5680427,
+              5680443,
+              5683707,
+              5683723,
+              5686987,
+              5687003,
+              5690267,
+              5690283,
+              5693547,
+              5693563,
+              5696827,
+              5696843,
+              5700107
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 144124,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 25652,
+            "endpoints": 144124,
+            "legs": [
+              23556,
+              24164,
+              23556,
+              23544,
+              23556,
+              25652
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23556,
+            "legWorstDeviation": 0.08897945321786381,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30436
+            ],
+            "primeExcess": 6880,
+            "perWrite": 24020.666666666668,
+            "perBoundaryPerWrite": 1000.8611111111112,
+            "cdpBracket": 202540,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5732679,
+              5732695,
+              5763131,
+              5763147,
+              5786703,
+              5786719,
+              5810883,
+              5810899,
+              5834455,
+              5834471,
+              5858015,
+              5858031,
+              5881587,
+              5881603,
+              5907255
+            ],
+            "tick0": 301,
+            "tick": 308,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 138768,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23116,
+            "endpoints": 138768,
+            "legs": [
+              23104,
+              23104,
+              23116,
+              23116,
+              23116,
+              23116
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23116,
+            "legWorstDeviation": -0.0005191209551825575,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29932
+            ],
+            "primeExcess": 6816,
+            "perWrite": 23128,
+            "perBoundaryPerWrite": 963.6666666666666,
+            "cdpBracket": 196660,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5748195,
+              5748211,
+              5778143,
+              5778159,
+              5801263,
+              5801279,
+              5824383,
+              5824399,
+              5847515,
+              5847531,
+              5870647,
+              5870663,
+              5893779,
+              5893795,
+              5916911
+            ],
+            "tick0": 329,
+            "tick": 336,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 6,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5707239,
+              5707255,
+              5707271,
+              5707287,
+              5707303,
+              5707319,
+              5707335,
+              5707351,
+              5707367,
+              5707383,
+              5707399,
+              5707415,
+              5707431,
+              5707447,
+              5707463
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5715247,
+              5715263,
+              5723327,
+              5723343,
+              5731407,
+              5731423,
+              5739487,
+              5739503,
+              5747567,
+              5747583,
+              5755647,
+              5755663,
+              5763727,
+              5763743,
+              5771807
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5710447,
+              5710463,
+              5713727,
+              5713743,
+              5717007,
+              5717023,
+              5720287,
+              5720303,
+              5723567,
+              5723583,
+              5726847,
+              5726863,
+              5730127,
+              5730143,
+              5733407
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 547920,
+            "fall": 406936,
+            "falls": 1,
+            "maxStep": 454600,
+            "endpoints": 140984,
+            "legs": [
+              23100,
+              23500,
+              23524,
+              23100,
+              454600,
+              -406936
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23300,
+            "legWorstDeviation": 18.510729613733904,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read 454600 B against a cohort median of 23300 B (+431300 B, 1851.1%), past the ±25% leg tolerance (±5825 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read -406936 B against a cohort median of 23300 B (-430236 B, -1846.5%), past the ±25% leg tolerance (±5825 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read 454600 B against a cohort median of 23300 B (+431300 B, 1851.1%), past the ±25% leg tolerance (±5825 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read -406936 B against a cohort median of 23300 B (-430236 B, -1846.5%), past the ±25% leg tolerance (±5825 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29916
+            ],
+            "primeExcess": 6616,
+            "perWrite": 91320,
+            "perBoundaryPerWrite": 3805,
+            "cdpBracket": 198988,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5771539,
+              5771555,
+              5801471,
+              5801487,
+              5824587,
+              5824603,
+              5848103,
+              5848119,
+              5871643,
+              5871659,
+              5894759,
+              5894775,
+              6349375,
+              6349391,
+              5942455
+            ],
+            "tick0": 357,
+            "tick": 364,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 141324,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23540,
+            "endpoints": 141324,
+            "legs": [
+              23540,
+              23540,
+              23540,
+              23528,
+              23540,
+              23540
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23540,
+            "legWorstDeviation": -0.0005097706032285472,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30420
+            ],
+            "primeExcess": 6880,
+            "perWrite": 23554,
+            "perBoundaryPerWrite": 981.4166666666666,
+            "cdpBracket": 199724,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5795295,
+              5795311,
+              5825731,
+              5825747,
+              5849287,
+              5849303,
+              5872843,
+              5872859,
+              5896399,
+              5896415,
+              5919943,
+              5919959,
+              5943499,
+              5943515,
+              5967055
+            ],
+            "tick0": 385,
+            "tick": 392,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 7,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5754319,
+              5754335,
+              5754351,
+              5754367,
+              5754383,
+              5754399,
+              5754415,
+              5754431,
+              5754447,
+              5754463,
+              5754479,
+              5754495,
+              5754511,
+              5754527,
+              5754543
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 273844,
+            "fall": 224856,
+            "falls": 1,
+            "maxStep": 229904,
+            "endpoints": 48988,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              229904,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              3556,
+              -224856
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 27.509920634920636,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read 229904 B against a cohort median of 8064 B (+221840 B, 2751.0%), past the ±25% leg tolerance (±2016 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read 229904 B against a cohort median of 8064 B (+221840 B, 2751.0%), past the ±25% leg tolerance (±2016 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 45640.666666666664,
+            "cdpBracket": 85132,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5762327,
+              5762343,
+              5770407,
+              5770423,
+              5778487,
+              5778503,
+              5786567,
+              5786583,
+              5794647,
+              5794663,
+              5802727,
+              5806283,
+              6036187,
+              5811331,
+              5819395
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5758035,
+              5758051,
+              5761315,
+              5761331,
+              5764595,
+              5764611,
+              5767875,
+              5767891,
+              5771155,
+              5771171,
+              5774435,
+              5774451,
+              5777715,
+              5777731,
+              5780995
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 145200,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 27480,
+            "endpoints": 145200,
+            "legs": [
+              23520,
+              23532,
+              23532,
+              23520,
+              23520,
+              27480
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23526,
+            "legWorstDeviation": 0.16806937005865852,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30412
+            ],
+            "primeExcess": 6886,
+            "perWrite": 24200,
+            "perBoundaryPerWrite": 1008.3333333333334,
+            "cdpBracket": 203592,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5827747,
+              5827763,
+              5858175,
+              5858191,
+              5881711,
+              5881727,
+              5905259,
+              5905275,
+              5928807,
+              5928823,
+              5952343,
+              5952359,
+              5975879,
+              5975895,
+              6003375
+            ],
+            "tick0": 413,
+            "tick": 420,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 354472,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 238952,
+            "endpoints": 354472,
+            "legs": [
+              23080,
+              23092,
+              23092,
+              23080,
+              23080,
+              238952
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23086,
+            "legWorstDeviation": 9.350515463917526,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 238952 B against a cohort median of 23086 B (+215866 B, 935.1%), past the ±25% leg tolerance (±5771.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 238952 B against a cohort median of 23086 B (+215866 B, 935.1%), past the ±25% leg tolerance (±5771.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29896
+            ],
+            "primeExcess": 6810,
+            "perWrite": 59078.666666666664,
+            "perBoundaryPerWrite": 2461.611111111111,
+            "cdpBracket": 200380,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5843911,
+              5843927,
+              5873823,
+              5873839,
+              5896919,
+              5896935,
+              5920027,
+              5920043,
+              5943135,
+              5943151,
+              5966231,
+              5966247,
+              5989327,
+              5989343,
+              6228295
+            ],
+            "tick0": 441,
+            "tick": 448,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 8,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5806891,
+              5806907,
+              5806923,
+              5806939,
+              5806955,
+              5806971,
+              5806987,
+              5807003,
+              5807019,
+              5807035,
+              5807051,
+              5807067,
+              5807083,
+              5807099,
+              5807115
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5814899,
+              5814915,
+              5822979,
+              5822995,
+              5831059,
+              5831075,
+              5839139,
+              5839155,
+              5847219,
+              5847235,
+              5855299,
+              5855315,
+              5863379,
+              5863395,
+              5871459
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5810099,
+              5810115,
+              5813379,
+              5813395,
+              5816659,
+              5816675,
+              5819939,
+              5819955,
+              5823219,
+              5823235,
+              5826499,
+              5826515,
+              5829779,
+              5829795,
+              5833059
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 141036,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24804,
+            "endpoints": 141036,
+            "legs": [
+              23080,
+              24804,
+              23056,
+              23080,
+              23092,
+              23080
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              764
+            ],
+            "legMedian": 23080,
+            "legWorstDeviation": 0.07469670710571924,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29908
+            ],
+            "primeExcess": 6828,
+            "perWrite": 23506,
+            "perBoundaryPerWrite": 979.4166666666666,
+            "cdpBracket": 199032,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5876907,
+              5876923,
+              5906831,
+              5906847,
+              5929927,
+              5929943,
+              5954747,
+              5954763,
+              5977819,
+              5977835,
+              6000915,
+              6000931,
+              6024023,
+              6024787,
+              6047867
+            ],
+            "tick0": 469,
+            "tick": 476,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 150900,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 43348,
+            "endpoints": 150900,
+            "legs": [
+              23520,
+              43348,
+              13376,
+              23520,
+              23520,
+              23520
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23520,
+            "legWorstDeviation": 0.8430272108843537,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 43348 B against a cohort median of 23520 B (+19828 B, 84.3%), past the ±25% leg tolerance (±5880 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read 13376 B against a cohort median of 23520 B (-10144 B, -43.1%), past the ±25% leg tolerance (±5880 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 43348 B against a cohort median of 23520 B (+19828 B, 84.3%), past the ±25% leg tolerance (±5880 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read 13376 B against a cohort median of 23520 B (-10144 B, -43.1%), past the ±25% leg tolerance (±5880 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30412
+            ],
+            "primeExcess": 6892,
+            "perWrite": 25150,
+            "perBoundaryPerWrite": 1047.9166666666667,
+            "cdpBracket": 209292,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5911467,
+              5911483,
+              5941895,
+              5941911,
+              5965431,
+              5965447,
+              6008795,
+              6008811,
+              6022187,
+              6022203,
+              6045723,
+              6045739,
+              6069259,
+              6069275,
+              6092795
+            ],
+            "tick0": 497,
+            "tick": 504,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 9,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5878551,
+              5878567,
+              5878583,
+              5878599,
+              5878615,
+              5878631,
+              5878647,
+              5878663,
+              5878679,
+              5878695,
+              5878711,
+              5878727,
+              5878743,
+              5878759,
+              5878775
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5886559,
+              5886575,
+              5894639,
+              5894655,
+              5902719,
+              5902735,
+              5910799,
+              5910815,
+              5918879,
+              5918895,
+              5926959,
+              5926975,
+              5935039,
+              5935055,
+              5943119
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5881759,
+              5881775,
+              5885039,
+              5885055,
+              5888319,
+              5888335,
+              5891599,
+              5891615,
+              5894879,
+              5894895,
+              5898159,
+              5898175,
+              5901439,
+              5901455,
+              5904719
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 146108,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 28440,
+            "endpoints": 146108,
+            "legs": [
+              23524,
+              23512,
+              23512,
+              23512,
+              28440,
+              23512
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23512,
+            "legWorstDeviation": 0.20959510037427698,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30404
+            ],
+            "primeExcess": 6892,
+            "perWrite": 24351.333333333332,
+            "perBoundaryPerWrite": 1014.6388888888888,
+            "cdpBracket": 204492,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5954215,
+              5954231,
+              5984635,
+              5984651,
+              6008175,
+              6008191,
+              6031703,
+              6031719,
+              6055231,
+              6055247,
+              6078759,
+              6078775,
+              6107215,
+              6107231,
+              6130743
+            ],
+            "tick0": 525,
+            "tick": 532,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 145156,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 29664,
+            "endpoints": 145156,
+            "legs": [
+              23072,
+              23084,
+              23084,
+              23072,
+              29664,
+              23084
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23084,
+            "legWorstDeviation": 0.2850459192514296,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read 29664 B against a cohort median of 23084 B (+6580 B, 28.5%), past the ±25% leg tolerance (±5771 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read 29664 B against a cohort median of 23084 B (+6580 B, 28.5%), past the ±25% leg tolerance (±5771 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29900
+            ],
+            "primeExcess": 6816,
+            "perWrite": 24192.666666666668,
+            "perBoundaryPerWrite": 1008.0277777777778,
+            "cdpBracket": 203016,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5959351,
+              5959367,
+              5989267,
+              5989283,
+              6012355,
+              6012371,
+              6035455,
+              6035471,
+              6058555,
+              6058571,
+              6081643,
+              6081659,
+              6111323,
+              6111339,
+              6134423
+            ],
+            "tick0": 553,
+            "tick": 560,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 10,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5924987,
+              5925003,
+              5925019,
+              5925035,
+              5925051,
+              5925067,
+              5925083,
+              5925099,
+              5925115,
+              5925131,
+              5925147,
+              5925163,
+              5925179,
+              5925195,
+              5925211
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5932995,
+              5933011,
+              5941075,
+              5941091,
+              5949155,
+              5949171,
+              5957235,
+              5957251,
+              5965315,
+              5965331,
+              5973395,
+              5973411,
+              5981475,
+              5981491,
+              5989555
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5928195,
+              5928211,
+              5931475,
+              5931491,
+              5934755,
+              5934771,
+              5938035,
+              5938051,
+              5941315,
+              5941331,
+              5944595,
+              5944611,
+              5947875,
+              5947891,
+              5951155
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 139324,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23832,
+            "endpoints": 139324,
+            "legs": [
+              23072,
+              23072,
+              23084,
+              23084,
+              23832,
+              23084
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23084,
+            "legWorstDeviation": 0.032403396291803846,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29900
+            ],
+            "primeExcess": 6816,
+            "perWrite": 23220.666666666668,
+            "perBoundaryPerWrite": 967.5277777777778,
+            "cdpBracket": 199824,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5985703,
+              5985719,
+              6015619,
+              6015635,
+              6038707,
+              6038723,
+              6061795,
+              6061811,
+              6084895,
+              6084911,
+              6107995,
+              6108011,
+              6131843,
+              6131859,
+              6154943
+            ],
+            "tick0": 581,
+            "tick": 588,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 143836,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 25008,
+            "endpoints": 143836,
+            "legs": [
+              24692,
+              23516,
+              23516,
+              23504,
+              23504,
+              25008
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23516,
+            "legWorstDeviation": 0.06344616431365878,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30396
+            ],
+            "primeExcess": 6880,
+            "perWrite": 23972.666666666668,
+            "perBoundaryPerWrite": 998.8611111111112,
+            "cdpBracket": 202212,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5998787,
+              5998803,
+              6029199,
+              6029215,
+              6053907,
+              6053923,
+              6077439,
+              6077455,
+              6100971,
+              6100987,
+              6124491,
+              6124507,
+              6148011,
+              6148027,
+              6173035
+            ],
+            "tick0": 609,
+            "tick": 616,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 11,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5957579,
+              5957595,
+              5957611,
+              5957627,
+              5957643,
+              5957659,
+              5957675,
+              5957691,
+              5957707,
+              5957723,
+              5957739,
+              5957755,
+              5957771,
+              5957787,
+              5957803
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5965587,
+              5965603,
+              5973667,
+              5973683,
+              5981747,
+              5981763,
+              5989827,
+              5989843,
+              5997907,
+              5997923,
+              6005987,
+              6006003,
+              6014067,
+              6014083,
+              6022147
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5960787,
+              5960803,
+              5964067,
+              5964083,
+              5967347,
+              5967363,
+              5970627,
+              5970643,
+              5973907,
+              5973923,
+              5977187,
+              5977203,
+              5980467,
+              5980483,
+              5983747
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 141096,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23508,
+            "endpoints": 141096,
+            "legs": [
+              23496,
+              23508,
+              23496,
+              23496,
+              23508,
+              23496
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23496,
+            "legWorstDeviation": 0.0005107252298263534,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30388
+            ],
+            "primeExcess": 6892,
+            "perWrite": 23516,
+            "perBoundaryPerWrite": 979.8333333333334,
+            "cdpBracket": 200184,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6008895,
+              6008911,
+              6039299,
+              6039315,
+              6062811,
+              6062827,
+              6086335,
+              6086351,
+              6109847,
+              6109863,
+              6133359,
+              6133375,
+              6156883,
+              6156899,
+              6180395
+            ],
+            "tick0": 637,
+            "tick": 644,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 138468,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23068,
+            "endpoints": 138468,
+            "legs": [
+              23068,
+              23068,
+              23068,
+              23032,
+              23068,
+              23068
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23068,
+            "legWorstDeviation": -0.0015606034333275533,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              35356
+            ],
+            "primeExcess": 12288,
+            "perWrite": 23078,
+            "perBoundaryPerWrite": 961.5833333333334,
+            "cdpBracket": 202996,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6029139,
+              6029155,
+              6064511,
+              6064527,
+              6087595,
+              6087611,
+              6110679,
+              6110695,
+              6133763,
+              6133779,
+              6156811,
+              6156827,
+              6179895,
+              6179911,
+              6202979
+            ],
+            "tick0": 665,
+            "tick": 672,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 12,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5993547,
+              5993563,
+              5993579,
+              5993595,
+              5993611,
+              5993627,
+              5993643,
+              5993659,
+              5993675,
+              5993691,
+              5993707,
+              5993723,
+              5993739,
+              5993755,
+              5993771
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6001555,
+              6001571,
+              6009635,
+              6009651,
+              6017715,
+              6017731,
+              6025795,
+              6025811,
+              6033875,
+              6033891,
+              6041955,
+              6041971,
+              6050035,
+              6050051,
+              6058115
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5996755,
+              5996771,
+              6000035,
+              6000051,
+              6003315,
+              6003331,
+              6006595,
+              6006611,
+              6009875,
+              6009891,
+              6013155,
+              6013171,
+              6016435,
+              6016451,
+              6019715
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 139240,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23816,
+            "endpoints": 139240,
+            "legs": [
+              23068,
+              23068,
+              23068,
+              23056,
+              23816,
+              23068
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23068,
+            "legWorstDeviation": 0.03242587133691694,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29872
+            ],
+            "primeExcess": 6804,
+            "perWrite": 23206.666666666668,
+            "perBoundaryPerWrite": 966.9444444444445,
+            "cdpBracket": 197184,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6062783,
+              6062799,
+              6092671,
+              6092687,
+              6115755,
+              6115771,
+              6138839,
+              6138855,
+              6161923,
+              6161939,
+              6184995,
+              6185011,
+              6208827,
+              6208843,
+              6231911
+            ],
+            "tick0": 693,
+            "tick": 700,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 141108,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23508,
+            "endpoints": 141108,
+            "legs": [
+              23496,
+              23508,
+              23496,
+              23508,
+              23508,
+              23496
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23502,
+            "legWorstDeviation": -0.0002552974214960429,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30388
+            ],
+            "primeExcess": 6886,
+            "perWrite": 23518,
+            "perBoundaryPerWrite": 979.9166666666666,
+            "cdpBracket": 199460,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6091751,
+              6091767,
+              6122155,
+              6122171,
+              6145667,
+              6145683,
+              6169191,
+              6169207,
+              6192703,
+              6192719,
+              6216227,
+              6216243,
+              6239751,
+              6239767,
+              6263263
+            ],
+            "tick0": 721,
+            "tick": 728,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 13,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 31952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6050787,
+              6050803,
+              6050819,
+              6050835,
+              6050851,
+              6050867,
+              6050883,
+              6050899,
+              6050915,
+              6050931,
+              6050947,
+              6050963,
+              6050979,
+              6050995,
+              6051011
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6062815,
+              6062831,
+              6070895,
+              6070911,
+              6078975,
+              6078991,
+              6087055,
+              6087071,
+              6095135,
+              6095151,
+              6103215,
+              6103231,
+              6111295,
+              6111311,
+              6119375
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6058015,
+              6058031,
+              6061295,
+              6061311,
+              6064575,
+              6064591,
+              6067855,
+              6067871,
+              6071135,
+              6071151,
+              6074415,
+              6074431,
+              6077695,
+              6077711,
+              6080975
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 141868,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24244,
+            "endpoints": 141868,
+            "legs": [
+              23508,
+              23508,
+              23508,
+              23496,
+              24244,
+              23508
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23508,
+            "legWorstDeviation": 0.031308490726561174,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30376
+            ],
+            "primeExcess": 6868,
+            "perWrite": 23644.666666666668,
+            "perBoundaryPerWrite": 985.1944444444445,
+            "cdpBracket": 202468,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6105391,
+              6105407,
+              6135783,
+              6135799,
+              6159307,
+              6159323,
+              6182831,
+              6182847,
+              6206355,
+              6206371,
+              6229867,
+              6229883,
+              6254127,
+              6254143,
+              6277651
+            ],
+            "tick0": 749,
+            "tick": 756,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 138480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23068,
+            "endpoints": 138480,
+            "legs": [
+              23068,
+              23068,
+              23068,
+              23056,
+              23056,
+              23068
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23068,
+            "legWorstDeviation": -0.0005202011444425178,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29884
+            ],
+            "primeExcess": 6816,
+            "perWrite": 23080,
+            "perBoundaryPerWrite": 961.6666666666666,
+            "cdpBracket": 196308,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6108227,
+              6108243,
+              6138127,
+              6138143,
+              6161211,
+              6161227,
+              6184295,
+              6184311,
+              6207379,
+              6207395,
+              6230451,
+              6230467,
+              6253523,
+              6253539,
+              6276607
+            ],
+            "tick0": 777,
+            "tick": 784,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 14,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6067283,
+              6067299,
+              6067315,
+              6067331,
+              6067347,
+              6067363,
+              6067379,
+              6067395,
+              6067411,
+              6067427,
+              6067443,
+              6067459,
+              6067475,
+              6067491,
+              6067507
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6075291,
+              6075307,
+              6083371,
+              6083387,
+              6091451,
+              6091467,
+              6099531,
+              6099547,
+              6107611,
+              6107627,
+              6115691,
+              6115707,
+              6123771,
+              6123787,
+              6131851
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6070491,
+              6070507,
+              6073771,
+              6073787,
+              6077051,
+              6077067,
+              6080331,
+              6080347,
+              6083611,
+              6083627,
+              6086891,
+              6086907,
+              6090171,
+              6090187,
+              6093451
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 310196,
+            "fall": 161440,
+            "falls": 1,
+            "maxStep": 190748,
+            "endpoints": 148756,
+            "legs": [
+              23068,
+              23056,
+              23068,
+              24676,
+              190748,
+              25500
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              -161440
+            ],
+            "legMedian": 23872,
+            "legWorstDeviation": 6.990449061662199,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read 190748 B against a cohort median of 23872 B (+166876 B, 699.0%), past the ±25% leg tolerance (±5968 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read 190748 B against a cohort median of 23872 B (+166876 B, 699.0%), past the ±25% leg tolerance (±5968 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29884
+            ],
+            "primeExcess": 6012,
+            "perWrite": 51699.333333333336,
+            "perBoundaryPerWrite": 2154.138888888889,
+            "cdpBracket": 206712,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6117395,
+              6117411,
+              6147295,
+              6147311,
+              6170379,
+              6170395,
+              6193451,
+              6193467,
+              6216535,
+              6216551,
+              6241227,
+              6241243,
+              6431991,
+              6270551,
+              6296051
+            ],
+            "tick0": 805,
+            "tick": 812,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 141108,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23508,
+            "endpoints": 141108,
+            "legs": [
+              23508,
+              23508,
+              23508,
+              23496,
+              23496,
+              23496
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23502,
+            "legWorstDeviation": 0.0002552974214960429,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30388
+            ],
+            "primeExcess": 6886,
+            "perWrite": 23518,
+            "perBoundaryPerWrite": 979.9166666666666,
+            "cdpBracket": 199460,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6134595,
+              6134611,
+              6164999,
+              6165015,
+              6188523,
+              6188539,
+              6212047,
+              6212063,
+              6235571,
+              6235587,
+              6259083,
+              6259099,
+              6282595,
+              6282611,
+              6306107
+            ],
+            "tick0": 833,
+            "tick": 840,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 15,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6093631,
+              6093647,
+              6093663,
+              6093679,
+              6093695,
+              6093711,
+              6093727,
+              6093743,
+              6093759,
+              6093775,
+              6093791,
+              6093807,
+              6093823,
+              6093839,
+              6093855
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6101639,
+              6101655,
+              6109719,
+              6109735,
+              6117799,
+              6117815,
+              6125879,
+              6125895,
+              6133959,
+              6133975,
+              6142039,
+              6142055,
+              6150119,
+              6150135,
+              6158199
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6096839,
+              6096855,
+              6100119,
+              6100135,
+              6103399,
+              6103415,
+              6106679,
+              6106695,
+              6109959,
+              6109975,
+              6113239,
+              6113255,
+              6116519,
+              6116535,
+              6119799
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 144084,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23508,
+            "endpoints": 144084,
+            "legs": [
+              23508,
+              23496,
+              23496,
+              23508,
+              21116,
+              23424
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              5456,
+              16
+            ],
+            "legMedian": 23496,
+            "legWorstDeviation": -0.10129383724889343,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30376
+            ],
+            "primeExcess": 6880,
+            "perWrite": 24014,
+            "perBoundaryPerWrite": 1000.5833333333334,
+            "cdpBracket": 202424,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6148699,
+              6148715,
+              6179091,
+              6179107,
+              6202615,
+              6202631,
+              6226127,
+              6226143,
+              6249639,
+              6249655,
+              6273163,
+              6278619,
+              6299735,
+              6299751,
+              6323175
+            ],
+            "tick0": 861,
+            "tick": 868,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 138432,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23068,
+            "endpoints": 138432,
+            "legs": [
+              23032,
+              23068,
+              23056,
+              23068,
+              23056,
+              23056
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23056,
+            "legWorstDeviation": -0.001040943789035392,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29872
+            ],
+            "primeExcess": 6816,
+            "perWrite": 23072,
+            "perBoundaryPerWrite": 961.3333333333334,
+            "cdpBracket": 196936,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6161987,
+              6162003,
+              6191875,
+              6191891,
+              6214923,
+              6214939,
+              6238007,
+              6238023,
+              6261079,
+              6261095,
+              6284163,
+              6284179,
+              6307235,
+              6307251,
+              6330307
+            ],
+            "tick0": 889,
+            "tick": 896,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 16,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6115939,
+              6115955,
+              6115971,
+              6115987,
+              6116003,
+              6116019,
+              6116035,
+              6116051,
+              6116067,
+              6116083,
+              6116099,
+              6116115,
+              6116131,
+              6116147,
+              6116163
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6123947,
+              6123963,
+              6132027,
+              6132043,
+              6140107,
+              6140123,
+              6148187,
+              6148203,
+              6156267,
+              6156283,
+              6164347,
+              6164363,
+              6172427,
+              6172443,
+              6180507
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6119147,
+              6119163,
+              6122427,
+              6122443,
+              6125707,
+              6125723,
+              6128987,
+              6129003,
+              6132267,
+              6132283,
+              6135547,
+              6135563,
+              6138827,
+              6138843,
+              6142107
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 141348,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 25384,
+            "endpoints": 141348,
+            "legs": [
+              23068,
+              23056,
+              23056,
+              25384,
+              22984,
+              23704
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23062,
+            "legWorstDeviation": 0.10068510970427544,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29884
+            ],
+            "primeExcess": 6822,
+            "perWrite": 23558,
+            "perBoundaryPerWrite": 981.5833333333334,
+            "cdpBracket": 199304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6159095,
+              6159111,
+              6188995,
+              6189011,
+              6212079,
+              6212095,
+              6235151,
+              6235167,
+              6258223,
+              6258239,
+              6283623,
+              6283639,
+              6306623,
+              6306639,
+              6330343
+            ],
+            "tick0": 917,
+            "tick": 924,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 147776,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 26288,
+            "endpoints": 147776,
+            "legs": [
+              23496,
+              24844,
+              26108,
+              26288,
+              23472,
+              23472
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 24170,
+            "legWorstDeviation": 0.08762929251137774,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30388
+            ],
+            "primeExcess": 6218,
+            "perWrite": 24629.333333333332,
+            "perBoundaryPerWrite": 1026.2222222222222,
+            "cdpBracket": 206128,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6175643,
+              6175659,
+              6206047,
+              6206063,
+              6229559,
+              6229575,
+              6254419,
+              6254435,
+              6280543,
+              6280559,
+              6306847,
+              6306863,
+              6330335,
+              6330351,
+              6353823
+            ],
+            "tick0": 945,
+            "tick": 952,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 17,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6132959,
+              6132975,
+              6132991,
+              6133007,
+              6133023,
+              6133039,
+              6133055,
+              6133071,
+              6133087,
+              6133103,
+              6133119,
+              6133135,
+              6133151,
+              6133167,
+              6133183
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6140967,
+              6140983,
+              6149047,
+              6149063,
+              6157127,
+              6157143,
+              6165207,
+              6165223,
+              6173287,
+              6173303,
+              6181367,
+              6181383,
+              6189447,
+              6189463,
+              6197527
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6136167,
+              6136183,
+              6139447,
+              6139463,
+              6142727,
+              6142743,
+              6146007,
+              6146023,
+              6149287,
+              6149303,
+              6152567,
+              6152583,
+              6155847,
+              6155863,
+              6159127
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 143908,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 25868,
+            "endpoints": 143908,
+            "legs": [
+              23500,
+              25868,
+              23440,
+              23428,
+              23428,
+              24148
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23470,
+            "legWorstDeviation": 0.10217298679164892,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30380
+            ],
+            "primeExcess": 6910,
+            "perWrite": 23984.666666666668,
+            "perBoundaryPerWrite": 999.3611111111112,
+            "cdpBracket": 202252,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6193159,
+              6193175,
+              6223555,
+              6223571,
+              6247071,
+              6247087,
+              6272955,
+              6272971,
+              6296411,
+              6296427,
+              6319855,
+              6319871,
+              6343299,
+              6343315,
+              6367463
+            ],
+            "tick0": 973,
+            "tick": 980,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 138468,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23068,
+            "endpoints": 138468,
+            "legs": [
+              23056,
+              23068,
+              23068,
+              23056,
+              23056,
+              23068
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 23062,
+            "legWorstDeviation": -0.00026016824212991065,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29872
+            ],
+            "primeExcess": 6810,
+            "perWrite": 23078,
+            "perBoundaryPerWrite": 961.5833333333334,
+            "cdpBracket": 196284,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6197955,
+              6197971,
+              6227843,
+              6227859,
+              6250915,
+              6250931,
+              6273999,
+              6274015,
+              6297083,
+              6297099,
+              6320155,
+              6320171,
+              6343227,
+              6343243,
+              6366311
+            ],
+            "tick0": 1001,
+            "tick": 1008,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      }
+    ],
+    "allocFits": {
+      "perRound": {},
+      "mean": {}
+    },
+    "writeDriven": true,
+    "writeProvenance": {
+      "windows": 36,
+      "pairs": 36,
+      "unnamed": [],
+      "incomplete": [],
+      "ok": true
+    },
+    "controlVerdict": {
+      "ok": true,
+      "perDouble": 10.167592592592591,
+      "differential": 11.479320987654319
+    },
+    "fallsInMeasuredWindows": 9,
+    "refusedWindows": 10,
+    "refusalReasons": 17
+  },
+  "box": {
+    "bead": "rf2-24o2z",
+    "chromium": "chromium/147.0.7727.15",
+    "node": "v24.13.0",
+    "platform": "win32/x64/10.0.26200",
+    "load": {
+      "open": {
+        "at": "2026-08-20T20:29:09.475Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13475885272,
+        "cpuBusyMs": 3627529548,
+        "freeMemB": 16216432640,
+        "totalMemB": 68112736256,
+        "uptimeS": 708912.281
+      },
+      "close": {
+        "at": "2026-08-20T20:29:35.705Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13476424582,
+        "cpuBusyMs": 3627621501,
+        "freeMemB": 16229462016,
+        "totalMemB": 68112736256,
+        "uptimeS": 708938.5
+      },
+      "busyFraction": 0.14566511897576762
+    },
+    "session": {
+      "startedAt": "2026-08-20T20:28:32.649Z",
+      "sessionStartedAt": "2026-08-20T19:39:26.627Z",
+      "runsInSession": 8,
+      "sessionGapMs": 3600000,
+      "previousRun": {
+        "startedAt": "2026-08-20T20:27:29.240Z",
+        "endedAt": "2026-08-20T20:28:32.258Z",
+        "sinceStartMs": 63409,
+        "sinceEndMs": 391,
+        "sameSession": true
+      }
+    }
+  }
+}

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/parity-3.json
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/parity-3.json
@@ -1,0 +1,7543 @@
+{
+  "generatedAt": "2026-08-20T20:32:15.807Z",
+  "build": "hicasso-bench",
+  "initFn": "re-frame.bench.p0-app/-main",
+  "alloc": {
+    "benchmark": "P0:steady-state-allocation-slope",
+    "bead": "rf2-2rtt6.76",
+    "roots": 4,
+    "perRoot": {
+      "list": 300,
+      "grid": 6
+    },
+    "publishedPerRoot": {
+      "list": 300,
+      "grid": 300
+    },
+    "arm": {
+      "cells": 6,
+      "roots": 4,
+      "boundaries": 24,
+      "writes": 6,
+      "refusals": [],
+      "admissible": true
+    },
+    "boundaries": 24,
+    "writes": 6,
+    "primeWrites": 1,
+    "windowWrites": 7,
+    "bySite": false,
+    "sites": 2,
+    "siteNames": [
+      "dispatch",
+      "drain"
+    ],
+    "warmups": 3,
+    "rounds": 18,
+    "preciseMemory": true,
+    "controlDoubles": {
+      "d1": 1000,
+      "d2": 400
+    },
+    "controlSlack": 0.75,
+    "writeSelector": "all",
+    "writeLegs": [
+      "all"
+    ],
+    "writePaired": false,
+    "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+    "plan": {
+      "name": "floor",
+      "arms": true,
+      "rungs": false,
+      "fits": false
+    },
+    "segOrder": "parity",
+    "passOrder": "parity",
+    "passSeed": "1787257897774",
+    "passSchedule": {
+      "flips": [
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        true,
+        true
+      ],
+      "attempts": 1,
+      "parityTied": false
+    },
+    "controlSlot": "first",
+    "instrument": "in-page performance.memory.usedJSHeapSize sampled at every leg boundary, rising steps accumulated separately from falling ones; --enable-precise-memory-info. A falling step is a collection this counter SAW; a leg that deviates from its cohort median by more than the leg tolerance is a work unit that is not one; and under the by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the other two can see. TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg has no interior reading and so no site step to be negative, and the intra-leg gate returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with these (see `bySite`), so a witness comparing byte for byte against a figure published at stride 2 can never be screened by all three",
+    "fallThresholdB": 600000,
+    "legTolerance": 0.25,
+    "verification": {
+      "unverified": 0,
+      "detail": []
+    },
+    "workCount": false,
+    "workVerification": {
+      "counted": false
+    },
+    "perRound": [
+      {
+        "round": 0,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 524,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              524
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 116.66666666666667,
+            "cdpBracket": 46232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3840294,
+              3840310,
+              3840326,
+              3840342,
+              3840358,
+              3840374,
+              3840390,
+              3840406,
+              3840422,
+              3840438,
+              3840454,
+              3840470,
+              3840486,
+              3841010,
+              3841026
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48576,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8144,
+            "endpoints": 48576,
+            "legs": [
+              8144,
+              8080,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.00992063492063492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8096,
+            "cdpBracket": 87388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3853918,
+              3853934,
+              3861998,
+              3862014,
+              3870158,
+              3870174,
+              3878254,
+              3878270,
+              3886334,
+              3886350,
+              3894414,
+              3894430,
+              3902494,
+              3902510,
+              3910574
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 52328,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3850018,
+              3850034,
+              3853298,
+              3853314,
+              3856578,
+              3856594,
+              3859858,
+              3859874,
+              3863138,
+              3863154,
+              3866418,
+              3866434,
+              3869698,
+              3869714,
+              3872978
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 131324,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 27300,
+            "endpoints": 131324,
+            "legs": [
+              20408,
+              19680,
+              27300,
+              21588,
+              22560,
+              19692
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20998,
+            "legWorstDeviation": 0.3001238213163158,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 27300 B against a cohort median of 20998 B (+6302 B, 30.0%), past the ±25% leg tolerance (±5249.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 27300 B against a cohort median of 20998 B (+6302 B, 30.0%), past the ±25% leg tolerance (±5249.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              27388
+            ],
+            "primeExcess": 6390,
+            "perWrite": 21887.333333333332,
+            "perBoundaryPerWrite": 911.9722222222222,
+            "cdpBracket": 187112,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              4782603,
+              4782619,
+              4810007,
+              4810023,
+              4830431,
+              4830447,
+              4850127,
+              4850143,
+              4877443,
+              4877459,
+              4899047,
+              4899063,
+              4921623,
+              4921639,
+              4941331
+            ],
+            "tick0": 21,
+            "tick": 28,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 216712,
+            "fall": 87728,
+            "falls": 1,
+            "maxStep": 133492,
+            "endpoints": 128984,
+            "legs": [
+              19916,
+              133492,
+              23520,
+              -87728,
+              19844,
+              19844
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19880,
+            "legWorstDeviation": 5.714889336016096,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 133492 B against a cohort median of 19880 B (+113612 B, 571.5%), past the ±25% leg tolerance (±4970 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -87728 B against a cohort median of 19880 B (-107608 B, -541.3%), past the ±25% leg tolerance (±4970 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 133492 B against a cohort median of 19880 B (+113612 B, 571.5%), past the ±25% leg tolerance (±4970 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -87728 B against a cohort median of 19880 B (-107608 B, -541.3%), past the ±25% leg tolerance (±4970 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26764
+            ],
+            "primeExcess": 6884,
+            "perWrite": 36118.666666666664,
+            "perBoundaryPerWrite": 1504.9444444444443,
+            "cdpBracket": 204404,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5059159,
+              5059175,
+              5085939,
+              5085955,
+              5105871,
+              5105887,
+              5239379,
+              5239395,
+              5262915,
+              5262931,
+              5175203,
+              5175219,
+              5195063,
+              5195079,
+              5214923
+            ],
+            "tick0": 49,
+            "tick": 56,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 1,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5046495,
+              5046511,
+              5046527,
+              5046543,
+              5046559,
+              5046575,
+              5046591,
+              5046607,
+              5046623,
+              5046639,
+              5046655,
+              5046671,
+              5046687,
+              5046703,
+              5046719
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 87716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5054503,
+              5054519,
+              5062583,
+              5062599,
+              5070663,
+              5070679,
+              5078743,
+              5078759,
+              5086823,
+              5086839,
+              5094903,
+              5094919,
+              5102983,
+              5102999,
+              5111063
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5051947,
+              5051963,
+              5055227,
+              5055243,
+              5058507,
+              5058523,
+              5061787,
+              5061803,
+              5065067,
+              5065083,
+              5068347,
+              5068363,
+              5071627,
+              5071643,
+              5074907
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 1023732,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 724724,
+            "endpoints": 1023732,
+            "legs": [
+              24636,
+              20496,
+              19772,
+              214236,
+              19772,
+              724724
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22566,
+            "legWorstDeviation": 31.115749357440396,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 214236 B against a cohort median of 22566 B (+191670 B, 849.4%), past the ±25% leg tolerance (±5641.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read 724724 B against a cohort median of 22566 B (+702158 B, 3111.6%), past the ±25% leg tolerance (±5641.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 214236 B against a cohort median of 22566 B (+191670 B, 849.4%), past the ±25% leg tolerance (±5641.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read 724724 B against a cohort median of 22566 B (+702158 B, 3111.6%), past the ±25% leg tolerance (±5641.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26656
+            ],
+            "primeExcess": 4090,
+            "perWrite": 170622,
+            "perBoundaryPerWrite": 7109.25,
+            "cdpBracket": 192632,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5181159,
+              5181175,
+              5207831,
+              5207847,
+              5232483,
+              5232499,
+              5252995,
+              5253011,
+              5272783,
+              5272799,
+              5487035,
+              5487051,
+              5506823,
+              5506839,
+              6231563
+            ],
+            "tick0": 77,
+            "tick": 84,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 155388,
+            "fall": 33156,
+            "falls": 1,
+            "maxStep": 54756,
+            "endpoints": 122232,
+            "legs": [
+              19256,
+              19256,
+              -33156,
+              23672,
+              19184,
+              19184
+            ],
+            "gaps": [
+              16,
+              16,
+              54756,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19220,
+            "legWorstDeviation": -2.7250780437044746,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read -33156 B against a cohort median of 19220 B (-52376 B, -272.5%), past the ±25% leg tolerance (±4805 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read -33156 B against a cohort median of 19220 B (-52376 B, -272.5%), past the ±25% leg tolerance (±4805 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6820,
+            "perWrite": 25898,
+            "perBoundaryPerWrite": 1079.0833333333333,
+            "cdpBracket": 177420,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5290747,
+              5290763,
+              5316803,
+              5316819,
+              5336075,
+              5336091,
+              5355347,
+              5410103,
+              5376947,
+              5376963,
+              5400635,
+              5400651,
+              5419835,
+              5419851,
+              5439035
+            ],
+            "tick0": 105,
+            "tick": 112,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 2,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5254211,
+              5254227,
+              5254243,
+              5254259,
+              5254275,
+              5254291,
+              5254307,
+              5254323,
+              5254339,
+              5254355,
+              5254371,
+              5254387,
+              5254403,
+              5254419,
+              5254435
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85088,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5262235,
+              5262251,
+              5270315,
+              5270331,
+              5278395,
+              5278411,
+              5286475,
+              5286491,
+              5294555,
+              5294571,
+              5302635,
+              5302651,
+              5310715,
+              5310731,
+              5318795
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5257435,
+              5257451,
+              5260715,
+              5260731,
+              5263995,
+              5264011,
+              5267275,
+              5267291,
+              5270555,
+              5270571,
+              5273835,
+              5273851,
+              5277115,
+              5277131,
+              5280395
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116120,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19768,
+            "endpoints": 116120,
+            "legs": [
+              19768,
+              19256,
+              19256,
+              19256,
+              19244,
+              19244
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": 0.02658911508101371,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19353.333333333332,
+            "perBoundaryPerWrite": 806.3888888888888,
+            "cdpBracket": 173220,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5343139,
+              5343155,
+              5369195,
+              5369211,
+              5388979,
+              5388995,
+              5408251,
+              5408267,
+              5427523,
+              5427539,
+              5446795,
+              5446811,
+              5466055,
+              5466071,
+              5485315
+            ],
+            "tick0": 133,
+            "tick": 140,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 372408,
+            "fall": 249980,
+            "falls": 1,
+            "maxStep": 271592,
+            "endpoints": 122428,
+            "legs": [
+              19696,
+              22168,
+              271592,
+              19624,
+              19624,
+              19624
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              -249980,
+              16,
+              16
+            ],
+            "legMedian": 19660,
+            "legWorstDeviation": 12.814445574771108,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 271592 B against a cohort median of 19660 B (+251932 B, 1281.4%), past the ±25% leg tolerance (±4915 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 271592 B against a cohort median of 19660 B (+251932 B, 1281.4%), past the ±25% leg tolerance (±4915 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6884,
+            "perWrite": 62068,
+            "perBoundaryPerWrite": 2586.1666666666665,
+            "cdpBracket": 176952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5419195,
+              5419211,
+              5445755,
+              5445771,
+              5465467,
+              5465483,
+              5487651,
+              5487667,
+              5759259,
+              5509279,
+              5528903,
+              5528919,
+              5548543,
+              5548559,
+              5568183
+            ],
+            "tick0": 161,
+            "tick": 168,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 3,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 29120,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5380263,
+              5380279,
+              5380295,
+              5380311,
+              5380327,
+              5380343,
+              5380359,
+              5380375,
+              5380391,
+              5380407,
+              5380423,
+              5380439,
+              5380455,
+              5380471,
+              5380487
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5389199,
+              5389215,
+              5397279,
+              5397295,
+              5405359,
+              5405375,
+              5413439,
+              5413455,
+              5421519,
+              5421535,
+              5429599,
+              5429615,
+              5437679,
+              5437695,
+              5445759
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5384399,
+              5384415,
+              5387679,
+              5387695,
+              5390959,
+              5390975,
+              5394239,
+              5394255,
+              5397519,
+              5397535,
+              5400799,
+              5400815,
+              5404079,
+              5404095,
+              5407359
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118248,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19696,
+            "endpoints": 118248,
+            "legs": [
+              19684,
+              19696,
+              19696,
+              19684,
+              19696,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": -0.0006092607636068237,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6848,
+            "perWrite": 19708,
+            "perBoundaryPerWrite": 821.1666666666666,
+            "cdpBracket": 172772,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5452279,
+              5452295,
+              5478839,
+              5478855,
+              5498539,
+              5498555,
+              5518251,
+              5518267,
+              5537963,
+              5537979,
+              5557663,
+              5557679,
+              5577375,
+              5577391,
+              5597087
+            ],
+            "tick0": 189,
+            "tick": 196,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117780,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21692,
+            "endpoints": 117780,
+            "legs": [
+              19256,
+              21692,
+              19184,
+              19184,
+              19184,
+              19184
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19184,
+            "legWorstDeviation": 0.13073394495412843,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6856,
+            "perWrite": 19630,
+            "perBoundaryPerWrite": 817.9166666666666,
+            "cdpBracket": 171780,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5480623,
+              5480639,
+              5506679,
+              5506695,
+              5525951,
+              5525967,
+              5547659,
+              5547675,
+              5566859,
+              5566875,
+              5586059,
+              5586075,
+              5605259,
+              5605275,
+              5624459
+            ],
+            "tick0": 217,
+            "tick": 224,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 4,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5439703,
+              5439719,
+              5439735,
+              5439751,
+              5439767,
+              5439783,
+              5439799,
+              5439815,
+              5439831,
+              5439847,
+              5439863,
+              5439879,
+              5439895,
+              5439911,
+              5439927
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5447711,
+              5447727,
+              5455791,
+              5455807,
+              5463871,
+              5463887,
+              5471951,
+              5471967,
+              5480031,
+              5480047,
+              5488111,
+              5488127,
+              5496191,
+              5496207,
+              5504271
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5442911,
+              5442927,
+              5446191,
+              5446207,
+              5449471,
+              5449487,
+              5452751,
+              5452767,
+              5456031,
+              5456047,
+              5459311,
+              5459327,
+              5462591,
+              5462607,
+              5465871
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 401100,
+            "fall": 599732,
+            "falls": 2,
+            "maxStep": 321316,
+            "endpoints": -198632,
+            "legs": [
+              -301432,
+              -298300,
+              19448,
+              19436,
+              21372,
+              19448
+            ],
+            "gaps": [
+              16,
+              321316,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19442,
+            "legWorstDeviation": -16.504166238041353,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read -301432 B against a cohort median of 19442 B (-320874 B, -1650.4%), past the ±25% leg tolerance (±4860.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 2 of 6 read -298300 B against a cohort median of 19442 B (-317742 B, -1634.3%), past the ±25% leg tolerance (±4860.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read -301432 B against a cohort median of 19442 B (-320874 B, -1650.4%), past the ±25% leg tolerance (±4860.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 2 of 6 read -298300 B against a cohort median of 19442 B (-317742 B, -1634.3%), past the ±25% leg tolerance (±4860.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              355712
+            ],
+            "primeExcess": 336270,
+            "perWrite": 66850,
+            "perBoundaryPerWrite": 2785.4166666666665,
+            "cdpBracket": 185168,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5614059,
+              5614075,
+              5969787,
+              5969803,
+              5668371,
+              5989687,
+              5691387,
+              5691403,
+              5710851,
+              5710867,
+              5730303,
+              5730319,
+              5751691,
+              5751707,
+              5771155
+            ],
+            "tick0": 245,
+            "tick": 252,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122888,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23444,
+            "endpoints": 122888,
+            "legs": [
+              19872,
+              19872,
+              19860,
+              23444,
+              19872,
+              19872
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19872,
+            "legWorstDeviation": 0.17975040257648953,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26736
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20481.333333333332,
+            "perBoundaryPerWrite": 853.3888888888888,
+            "cdpBracket": 177604,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5703823,
+              5703839,
+              5730575,
+              5730591,
+              5750463,
+              5750479,
+              5770351,
+              5770367,
+              5790227,
+              5790243,
+              5813687,
+              5813703,
+              5833575,
+              5833591,
+              5853463
+            ],
+            "tick0": 273,
+            "tick": 280,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 5,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5664463,
+              5664479,
+              5664495,
+              5664511,
+              5664527,
+              5664543,
+              5664559,
+              5664575,
+              5664591,
+              5664607,
+              5664623,
+              5664639,
+              5664655,
+              5664671,
+              5664687
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5672471,
+              5672487,
+              5680551,
+              5680567,
+              5688631,
+              5688647,
+              5696711,
+              5696727,
+              5704791,
+              5704807,
+              5712871,
+              5712887,
+              5720951,
+              5720967,
+              5729031
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5667671,
+              5667687,
+              5670951,
+              5670967,
+              5674231,
+              5674247,
+              5677511,
+              5677527,
+              5680791,
+              5680807,
+              5684071,
+              5684087,
+              5687351,
+              5687367,
+              5690631
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122608,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21220,
+            "endpoints": 122608,
+            "legs": [
+              19872,
+              21056,
+              20620,
+              19872,
+              19872,
+              21220
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20246,
+            "legWorstDeviation": 0.04810826829991109,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26724
+            ],
+            "primeExcess": 6478,
+            "perWrite": 20434.666666666668,
+            "perBoundaryPerWrite": 851.4444444444445,
+            "cdpBracket": 177312,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5723679,
+              5723695,
+              5750419,
+              5750435,
+              5770307,
+              5770323,
+              5791379,
+              5791395,
+              5812015,
+              5812031,
+              5831903,
+              5831919,
+              5851791,
+              5851807,
+              5873027
+            ],
+            "tick0": 301,
+            "tick": 308,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116688,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19432,
+            "endpoints": 116688,
+            "legs": [
+              19432,
+              19432,
+              19432,
+              19432,
+              19432,
+              19432
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19432,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26232
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19448,
+            "perBoundaryPerWrite": 810.3333333333334,
+            "cdpBracket": 170880,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5739303,
+              5739319,
+              5765551,
+              5765567,
+              5784999,
+              5785015,
+              5804447,
+              5804463,
+              5823895,
+              5823911,
+              5843343,
+              5843359,
+              5862791,
+              5862807,
+              5882239
+            ],
+            "tick0": 329,
+            "tick": 336,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 6,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5700471,
+              5700487,
+              5700503,
+              5700519,
+              5700535,
+              5700551,
+              5700567,
+              5700583,
+              5700599,
+              5700615,
+              5700631,
+              5700647,
+              5700663,
+              5700679,
+              5700695
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5708479,
+              5708495,
+              5716559,
+              5716575,
+              5724639,
+              5724655,
+              5732719,
+              5732735,
+              5740799,
+              5740815,
+              5748879,
+              5748895,
+              5756959,
+              5756975,
+              5765039
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5703679,
+              5703695,
+              5706959,
+              5706975,
+              5710239,
+              5710255,
+              5713519,
+              5713535,
+              5716799,
+              5716815,
+              5720079,
+              5720095,
+              5723359,
+              5723375,
+              5726639
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 118152,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20264,
+            "endpoints": 118152,
+            "legs": [
+              19416,
+              20264,
+              19416,
+              20164,
+              19380,
+              19416
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19416,
+            "legWorstDeviation": 0.043675319324268644,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26216
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19692,
+            "perBoundaryPerWrite": 820.5,
+            "cdpBracket": 173172,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5763399,
+              5763415,
+              5789631,
+              5789647,
+              5809063,
+              5809079,
+              5829343,
+              5829359,
+              5848775,
+              5848791,
+              5868955,
+              5868971,
+              5888351,
+              5888367,
+              5907783
+            ],
+            "tick0": 357,
+            "tick": 364,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119232,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19856,
+            "endpoints": 119232,
+            "legs": [
+              19856,
+              19856,
+              19856,
+              19856,
+              19856,
+              19856
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19856,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26720
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19872,
+            "perBoundaryPerWrite": 828,
+            "cdpBracket": 173932,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5789927,
+              5789943,
+              5816663,
+              5816679,
+              5836535,
+              5836551,
+              5856407,
+              5856423,
+              5876279,
+              5876295,
+              5896151,
+              5896167,
+              5916023,
+              5916039,
+              5935895
+            ],
+            "tick0": 385,
+            "tick": 392,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 7,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5748963,
+              5748979,
+              5748995,
+              5749011,
+              5749027,
+              5749043,
+              5749059,
+              5749075,
+              5749091,
+              5749107,
+              5749123,
+              5749139,
+              5749155,
+              5749171,
+              5749187
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 51216,
+            "fall": 2228,
+            "falls": 1,
+            "maxStep": 10816,
+            "endpoints": 48988,
+            "legs": [
+              8064,
+              8064,
+              10816,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              -2228,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.3412698412698413,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 10816 B against a cohort median of 8064 B (+2752 B, 34.1%), past the ±25% leg tolerance (±2016 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 10816 B against a cohort median of 8064 B (+2752 B, 34.1%), past the ±25% leg tolerance (±2016 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8536,
+            "cdpBracket": 85132,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5756971,
+              5756987,
+              5765051,
+              5765067,
+              5773131,
+              5773147,
+              5781211,
+              5781227,
+              5792043,
+              5789815,
+              5797879,
+              5797895,
+              5805959,
+              5805975,
+              5814039
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5752679,
+              5752695,
+              5755959,
+              5755975,
+              5759239,
+              5759255,
+              5762519,
+              5762535,
+              5765799,
+              5765815,
+              5769079,
+              5769095,
+              5772359,
+              5772375,
+              5775639
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 121524,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21488,
+            "endpoints": 121524,
+            "legs": [
+              19836,
+              19836,
+              19848,
+              19836,
+              21488,
+              20584
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19842,
+            "legWorstDeviation": 0.08295534724322146,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26712
+            ],
+            "primeExcess": 6870,
+            "perWrite": 20254,
+            "perBoundaryPerWrite": 843.9166666666666,
+            "cdpBracket": 183140,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5822499,
+              5822515,
+              5849227,
+              5849243,
+              5869079,
+              5869095,
+              5888931,
+              5888947,
+              5908795,
+              5908811,
+              5928647,
+              5928663,
+              5950151,
+              5950167,
+              5970751
+            ],
+            "tick0": 413,
+            "tick": 420,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116448,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19396,
+            "endpoints": 116448,
+            "legs": [
+              19396,
+              19396,
+              19372,
+              19396,
+              19396,
+              19396
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19396,
+            "legWorstDeviation": -0.0012373685295937306,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26208
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19408,
+            "perBoundaryPerWrite": 808.6666666666666,
+            "cdpBracket": 174484,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5839315,
+              5839331,
+              5865539,
+              5865555,
+              5884951,
+              5884967,
+              5904363,
+              5904379,
+              5923751,
+              5923767,
+              5943163,
+              5943179,
+              5962575,
+              5962591,
+              5981987
+            ],
+            "tick0": 441,
+            "tick": 448,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 8,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5802295,
+              5802311,
+              5802327,
+              5802343,
+              5802359,
+              5802375,
+              5802391,
+              5802407,
+              5802423,
+              5802439,
+              5802455,
+              5802471,
+              5802487,
+              5802503,
+              5802519
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5810303,
+              5810319,
+              5818383,
+              5818399,
+              5826463,
+              5826479,
+              5834543,
+              5834559,
+              5842623,
+              5842639,
+              5850703,
+              5850719,
+              5858783,
+              5858799,
+              5866863
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5805503,
+              5805519,
+              5808783,
+              5808799,
+              5812063,
+              5812079,
+              5815343,
+              5815359,
+              5818623,
+              5818639,
+              5821903,
+              5821919,
+              5825183,
+              5825199,
+              5828463
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 118956,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21132,
+            "endpoints": 118956,
+            "legs": [
+              21132,
+              19396,
+              19408,
+              19372,
+              19396,
+              20156
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19402,
+            "legWorstDeviation": 0.0891660653540872,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26196
+            ],
+            "primeExcess": 6794,
+            "perWrite": 19826,
+            "perBoundaryPerWrite": 826.0833333333334,
+            "cdpBracket": 173240,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5872119,
+              5872135,
+              5898331,
+              5898347,
+              5919479,
+              5919495,
+              5938891,
+              5938907,
+              5958315,
+              5958331,
+              5977703,
+              5977719,
+              5997115,
+              5997131,
+              6017287
+            ],
+            "tick0": 469,
+            "tick": 476,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 193496,
+            "fall": 65792,
+            "falls": 1,
+            "maxStep": 89024,
+            "endpoints": 127704,
+            "legs": [
+              19848,
+              89024,
+              25036,
+              19836,
+              19836,
+              19836
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              -65792,
+              16,
+              16
+            ],
+            "legMedian": 19842,
+            "legWorstDeviation": 3.4866444914827133,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 89024 B against a cohort median of 19842 B (+69182 B, 348.7%), past the ±25% leg tolerance (±4960.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read 25036 B against a cohort median of 19842 B (+5194 B, 26.2%), past the ±25% leg tolerance (±4960.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 89024 B against a cohort median of 19842 B (+69182 B, 348.7%), past the ±25% leg tolerance (±4960.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read 25036 B against a cohort median of 19842 B (+5194 B, 26.2%), past the ±25% leg tolerance (±4960.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26712
+            ],
+            "primeExcess": 6870,
+            "perWrite": 32249.333333333332,
+            "perBoundaryPerWrite": 1343.7222222222222,
+            "cdpBracket": 182396,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5907451,
+              5907467,
+              5934179,
+              5934195,
+              5954043,
+              5954059,
+              6043083,
+              6043099,
+              6068135,
+              6002343,
+              6022179,
+              6022195,
+              6042031,
+              6042047,
+              6061883
+            ],
+            "tick0": 497,
+            "tick": 504,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 9,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5874163,
+              5874179,
+              5874195,
+              5874211,
+              5874227,
+              5874243,
+              5874259,
+              5874275,
+              5874291,
+              5874307,
+              5874323,
+              5874339,
+              5874355,
+              5874371,
+              5874387
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5882171,
+              5882187,
+              5890251,
+              5890267,
+              5898331,
+              5898347,
+              5906411,
+              5906427,
+              5914491,
+              5914507,
+              5922571,
+              5922587,
+              5930651,
+              5930667,
+              5938731
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5877371,
+              5877387,
+              5880651,
+              5880667,
+              5883931,
+              5883947,
+              5887211,
+              5887227,
+              5890491,
+              5890507,
+              5893771,
+              5893787,
+              5897051,
+              5897067,
+              5900331
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 124052,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24768,
+            "endpoints": 124052,
+            "legs": [
+              19840,
+              19840,
+              19828,
+              19840,
+              24768,
+              19840
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19840,
+            "legWorstDeviation": 0.24838709677419354,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26704
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20675.333333333332,
+            "perBoundaryPerWrite": 861.4722222222222,
+            "cdpBracket": 178736,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5950103,
+              5950119,
+              5976823,
+              5976839,
+              5996679,
+              5996695,
+              6016535,
+              6016551,
+              6036379,
+              6036395,
+              6056235,
+              6056251,
+              6081019,
+              6081035,
+              6100875
+            ],
+            "tick0": 525,
+            "tick": 532,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 123304,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 26232,
+            "endpoints": 123304,
+            "legs": [
+              19388,
+              19388,
+              19400,
+              19400,
+              19400,
+              26232
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19400,
+            "legWorstDeviation": 0.35216494845360824,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 26232 B against a cohort median of 19400 B (+6832 B, 35.2%), past the ±25% leg tolerance (±4850 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 26232 B against a cohort median of 19400 B (+6832 B, 35.2%), past the ±25% leg tolerance (±4850 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26200
+            ],
+            "primeExcess": 6800,
+            "perWrite": 20550.666666666668,
+            "perBoundaryPerWrite": 856.2777777777778,
+            "cdpBracket": 177464,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5955191,
+              5955207,
+              5981407,
+              5981423,
+              6000811,
+              6000827,
+              6020215,
+              6020231,
+              6039631,
+              6039647,
+              6059047,
+              6059063,
+              6078463,
+              6078479,
+              6104711
+            ],
+            "tick0": 553,
+            "tick": 560,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 10,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5920911,
+              5920927,
+              5920943,
+              5920959,
+              5920975,
+              5920991,
+              5921007,
+              5921023,
+              5921039,
+              5921055,
+              5921071,
+              5921087,
+              5921103,
+              5921119,
+              5921135
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5928919,
+              5928935,
+              5936999,
+              5937015,
+              5945079,
+              5945095,
+              5953159,
+              5953175,
+              5961239,
+              5961255,
+              5969319,
+              5969335,
+              5977399,
+              5977415,
+              5985479
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5924119,
+              5924135,
+              5927399,
+              5927415,
+              5930679,
+              5930695,
+              5933959,
+              5933975,
+              5937239,
+              5937255,
+              5940519,
+              5940535,
+              5943799,
+              5943815,
+              5947079
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116460,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19400,
+            "endpoints": 116460,
+            "legs": [
+              19388,
+              19388,
+              19400,
+              19388,
+              19400,
+              19400
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19394,
+            "legWorstDeviation": -0.00030937403320614623,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26200
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19410,
+            "perBoundaryPerWrite": 808.75,
+            "cdpBracket": 174008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5981639,
+              5981655,
+              6007855,
+              6007871,
+              6027259,
+              6027275,
+              6046663,
+              6046679,
+              6066079,
+              6066095,
+              6085483,
+              6085499,
+              6104899,
+              6104915,
+              6124315
+            ],
+            "tick0": 581,
+            "tick": 588,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118992,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 118992,
+            "legs": [
+              19824,
+              19812,
+              19812,
+              19824,
+              19812,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": 0.0006056935190793458,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6876,
+            "perWrite": 19832,
+            "perBoundaryPerWrite": 826.3333333333334,
+            "cdpBracket": 175152,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5995931,
+              5995947,
+              6022635,
+              6022651,
+              6042475,
+              6042491,
+              6062303,
+              6062319,
+              6082131,
+              6082147,
+              6101971,
+              6101987,
+              6121799,
+              6121815,
+              6141627
+            ],
+            "tick0": 609,
+            "tick": 616,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 11,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5954967,
+              5954983,
+              5954999,
+              5955015,
+              5955031,
+              5955047,
+              5955063,
+              5955079,
+              5955095,
+              5955111,
+              5955127,
+              5955143,
+              5955159,
+              5955175,
+              5955191
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5962975,
+              5962991,
+              5971055,
+              5971071,
+              5979135,
+              5979151,
+              5987215,
+              5987231,
+              5995295,
+              5995311,
+              6003375,
+              6003391,
+              6011455,
+              6011471,
+              6019535
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5958175,
+              5958191,
+              5961455,
+              5961471,
+              5964735,
+              5964751,
+              5968015,
+              5968031,
+              5971295,
+              5971311,
+              5974575,
+              5974591,
+              5977855,
+              5977871,
+              5981135
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119776,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20580,
+            "endpoints": 119776,
+            "legs": [
+              19820,
+              19796,
+              19832,
+              19820,
+              19832,
+              20580
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19826,
+            "legWorstDeviation": 0.038030868556441035,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26696
+            ],
+            "primeExcess": 6870,
+            "perWrite": 19962.666666666668,
+            "perBoundaryPerWrite": 831.7777777777778,
+            "cdpBracket": 174452,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6003271,
+              6003287,
+              6029983,
+              6029999,
+              6049819,
+              6049835,
+              6069631,
+              6069647,
+              6089479,
+              6089495,
+              6109315,
+              6109331,
+              6129163,
+              6129179,
+              6149759
+            ],
+            "tick0": 637,
+            "tick": 644,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116352,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116352,
+            "legs": [
+              19384,
+              19372,
+              19384,
+              19384,
+              19384,
+              19348
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19384,
+            "legWorstDeviation": -0.0018572018159306646,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              31668
+            ],
+            "primeExcess": 12284,
+            "perWrite": 19392,
+            "perBoundaryPerWrite": 808,
+            "cdpBracket": 177192,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6024979,
+              6024995,
+              6056663,
+              6056679,
+              6076063,
+              6076079,
+              6095451,
+              6095467,
+              6114851,
+              6114867,
+              6134251,
+              6134267,
+              6153651,
+              6153667,
+              6173015
+            ],
+            "tick0": 665,
+            "tick": 672,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 12,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5989387,
+              5989403,
+              5989419,
+              5989435,
+              5989451,
+              5989467,
+              5989483,
+              5989499,
+              5989515,
+              5989531,
+              5989547,
+              5989563,
+              5989579,
+              5989595,
+              5989611
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5997395,
+              5997411,
+              6005475,
+              6005491,
+              6013555,
+              6013571,
+              6021635,
+              6021651,
+              6029715,
+              6029731,
+              6037795,
+              6037811,
+              6045875,
+              6045891,
+              6053955
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5992595,
+              5992611,
+              5995875,
+              5995891,
+              5999155,
+              5999171,
+              6002435,
+              6002451,
+              6005715,
+              6005731,
+              6008995,
+              6009011,
+              6012275,
+              6012291,
+              6015555
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117088,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20132,
+            "endpoints": 117088,
+            "legs": [
+              19372,
+              19372,
+              19372,
+              19372,
+              19372,
+              20132
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0392318810654553,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19514.666666666668,
+            "perBoundaryPerWrite": 813.1111111111112,
+            "cdpBracket": 171344,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6058815,
+              6058831,
+              6085015,
+              6085031,
+              6104403,
+              6104419,
+              6123791,
+              6123807,
+              6143179,
+              6143195,
+              6162567,
+              6162583,
+              6181955,
+              6181971,
+              6202103
+            ],
+            "tick0": 693,
+            "tick": 700,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118968,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 118968,
+            "legs": [
+              19812,
+              19812,
+              19812,
+              19824,
+              19824,
+              19788
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": -0.0012113870381586917,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6876,
+            "perWrite": 19828,
+            "perBoundaryPerWrite": 826.1666666666666,
+            "cdpBracket": 173620,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6087711,
+              6087727,
+              6114415,
+              6114431,
+              6134243,
+              6134259,
+              6154071,
+              6154087,
+              6173899,
+              6173915,
+              6193739,
+              6193755,
+              6213579,
+              6213595,
+              6233383
+            ],
+            "tick0": 721,
+            "tick": 728,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 13,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 31952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6046747,
+              6046763,
+              6046779,
+              6046795,
+              6046811,
+              6046827,
+              6046843,
+              6046859,
+              6046875,
+              6046891,
+              6046907,
+              6046923,
+              6046939,
+              6046955,
+              6046971
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6058775,
+              6058791,
+              6066855,
+              6066871,
+              6074935,
+              6074951,
+              6083015,
+              6083031,
+              6091095,
+              6091111,
+              6099175,
+              6099191,
+              6107255,
+              6107271,
+              6115335
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6053975,
+              6053991,
+              6057255,
+              6057271,
+              6060535,
+              6060551,
+              6063815,
+              6063831,
+              6067095,
+              6067111,
+              6070375,
+              6070391,
+              6073655,
+              6073671,
+              6076935
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119752,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20572,
+            "endpoints": 119752,
+            "legs": [
+              19812,
+              19812,
+              19812,
+              19824,
+              19824,
+              20572
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 0.03804622060752851,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6870,
+            "perWrite": 19958.666666666668,
+            "perBoundaryPerWrite": 831.6111111111112,
+            "cdpBracket": 174404,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6101351,
+              6101367,
+              6128055,
+              6128071,
+              6147883,
+              6147899,
+              6167711,
+              6167727,
+              6187539,
+              6187555,
+              6207379,
+              6207395,
+              6227219,
+              6227235,
+              6247807
+            ],
+            "tick0": 749,
+            "tick": 756,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116316,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116316,
+            "legs": [
+              19384,
+              19372,
+              19348,
+              19372,
+              19372,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": -0.0012389015073301672,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19386,
+            "perBoundaryPerWrite": 807.75,
+            "cdpBracket": 170432,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6104379,
+              6104395,
+              6130567,
+              6130583,
+              6149967,
+              6149983,
+              6169355,
+              6169371,
+              6188719,
+              6188735,
+              6208107,
+              6208123,
+              6227495,
+              6227511,
+              6246883
+            ],
+            "tick0": 777,
+            "tick": 784,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 14,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6063447,
+              6063463,
+              6063479,
+              6063495,
+              6063511,
+              6063527,
+              6063543,
+              6063559,
+              6063575,
+              6063591,
+              6063607,
+              6063623,
+              6063639,
+              6063655,
+              6063671
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6071455,
+              6071471,
+              6079535,
+              6079551,
+              6087615,
+              6087631,
+              6095695,
+              6095711,
+              6103775,
+              6103791,
+              6111855,
+              6111871,
+              6119935,
+              6119951,
+              6128015
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6066655,
+              6066671,
+              6069935,
+              6069951,
+              6073215,
+              6073231,
+              6076495,
+              6076511,
+              6079775,
+              6079791,
+              6083055,
+              6083071,
+              6086335,
+              6086351,
+              6089615
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117100,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20132,
+            "endpoints": 117100,
+            "legs": [
+              19384,
+              19384,
+              19348,
+              19372,
+              19384,
+              20132
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19384,
+            "legWorstDeviation": 0.0385885266198927,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19516.666666666668,
+            "perBoundaryPerWrite": 813.1944444444445,
+            "cdpBracket": 173872,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6113559,
+              6113575,
+              6139759,
+              6139775,
+              6159159,
+              6159175,
+              6178559,
+              6178575,
+              6197923,
+              6197939,
+              6217311,
+              6217327,
+              6236711,
+              6236727,
+              6256859
+            ],
+            "tick0": 805,
+            "tick": 812,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119004,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 119004,
+            "legs": [
+              19812,
+              19824,
+              19812,
+              19824,
+              19824,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": -0.0003027550711474417,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26676
+            ],
+            "primeExcess": 6858,
+            "perWrite": 19834,
+            "perBoundaryPerWrite": 826.4166666666666,
+            "cdpBracket": 173644,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6130267,
+              6130283,
+              6156959,
+              6156975,
+              6176787,
+              6176803,
+              6196627,
+              6196643,
+              6216455,
+              6216471,
+              6236295,
+              6236311,
+              6256135,
+              6256151,
+              6275963
+            ],
+            "tick0": 833,
+            "tick": 840,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 15,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6089303,
+              6089319,
+              6089335,
+              6089351,
+              6089367,
+              6089383,
+              6089399,
+              6089415,
+              6089431,
+              6089447,
+              6089463,
+              6089479,
+              6089495,
+              6089511,
+              6089527
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6097311,
+              6097327,
+              6105391,
+              6105407,
+              6113471,
+              6113487,
+              6121551,
+              6121567,
+              6129631,
+              6129647,
+              6137711,
+              6137727,
+              6145791,
+              6145807,
+              6153871
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6092511,
+              6092527,
+              6095791,
+              6095807,
+              6099071,
+              6099087,
+              6102351,
+              6102367,
+              6105631,
+              6105647,
+              6108911,
+              6108927,
+              6112191,
+              6112207,
+              6115471
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122124,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22908,
+            "endpoints": 122124,
+            "legs": [
+              19824,
+              19824,
+              19824,
+              19824,
+              19824,
+              22908
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.15556900726392253,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20354,
+            "perBoundaryPerWrite": 848.0833333333334,
+            "cdpBracket": 176776,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6144227,
+              6144243,
+              6170931,
+              6170947,
+              6190771,
+              6190787,
+              6210611,
+              6210627,
+              6230451,
+              6230467,
+              6250291,
+              6250307,
+              6270131,
+              6270147,
+              6293055
+            ],
+            "tick0": 861,
+            "tick": 868,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116376,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116376,
+            "legs": [
+              19372,
+              19384,
+              19384,
+              19372,
+              19384,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19384,
+            "legWorstDeviation": -0.0006190672719768881,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19396,
+            "perBoundaryPerWrite": 808.1666666666666,
+            "cdpBracket": 170504,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6155539,
+              6155555,
+              6181739,
+              6181755,
+              6201127,
+              6201143,
+              6220527,
+              6220543,
+              6239927,
+              6239943,
+              6259315,
+              6259331,
+              6278715,
+              6278731,
+              6298115
+            ],
+            "tick0": 889,
+            "tick": 896,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 16,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6109479,
+              6109495,
+              6109511,
+              6109527,
+              6109543,
+              6109559,
+              6109575,
+              6109591,
+              6109607,
+              6109623,
+              6109639,
+              6109655,
+              6109671,
+              6109687,
+              6109703
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6117487,
+              6117503,
+              6125567,
+              6125583,
+              6133647,
+              6133663,
+              6141727,
+              6141743,
+              6149807,
+              6149823,
+              6157887,
+              6157903,
+              6165967,
+              6165983,
+              6174047
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6112687,
+              6112703,
+              6115967,
+              6115983,
+              6119247,
+              6119263,
+              6122527,
+              6122543,
+              6125807,
+              6125823,
+              6129087,
+              6129103,
+              6132367,
+              6132383,
+              6135647
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 119268,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21712,
+            "endpoints": 119268,
+            "legs": [
+              19372,
+              19384,
+              19384,
+              21712,
+              20020,
+              19300
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19384,
+            "legWorstDeviation": 0.1200990507635163,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19878,
+            "perBoundaryPerWrite": 828.25,
+            "cdpBracket": 173524,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6152635,
+              6152651,
+              6178835,
+              6178851,
+              6198223,
+              6198239,
+              6217623,
+              6217639,
+              6237023,
+              6237039,
+              6258751,
+              6258767,
+              6278787,
+              6278803,
+              6298103
+            ],
+            "tick0": 917,
+            "tick": 924,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 217936,
+            "fall": 93952,
+            "falls": 1,
+            "maxStep": 117448,
+            "endpoints": 123984,
+            "legs": [
+              19824,
+              21136,
+              19812,
+              117448,
+              19812,
+              19824
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              -93952,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 4.92453591606134,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 117448 B against a cohort median of 19824 B (+97624 B, 492.5%), past the ±25% leg tolerance (±4956 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 117448 B against a cohort median of 19824 B (+97624 B, 492.5%), past the ±25% leg tolerance (±4956 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26676
+            ],
+            "primeExcess": 6852,
+            "perWrite": 36322.666666666664,
+            "perBoundaryPerWrite": 1513.4444444444443,
+            "cdpBracket": 178624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6171423,
+              6171439,
+              6198115,
+              6198131,
+              6217955,
+              6217971,
+              6239107,
+              6239123,
+              6258935,
+              6258951,
+              6376399,
+              6282447,
+              6302259,
+              6302275,
+              6322099
+            ],
+            "tick0": 945,
+            "tick": 952,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 17,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6128867,
+              6128883,
+              6128899,
+              6128915,
+              6128931,
+              6128947,
+              6128963,
+              6128979,
+              6128995,
+              6129011,
+              6129027,
+              6129043,
+              6129059,
+              6129075,
+              6129091
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6136875,
+              6136891,
+              6144955,
+              6144971,
+              6153035,
+              6153051,
+              6161115,
+              6161131,
+              6169195,
+              6169211,
+              6177275,
+              6177291,
+              6185355,
+              6185371,
+              6193435
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6132075,
+              6132091,
+              6135355,
+              6135371,
+              6138635,
+              6138651,
+              6141915,
+              6141931,
+              6145195,
+              6145211,
+              6148475,
+              6148491,
+              6151755,
+              6151771,
+              6155035
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 121852,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22208,
+            "endpoints": 121852,
+            "legs": [
+              19816,
+              22208,
+              19756,
+              19744,
+              19756,
+              20476
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19786,
+            "legWorstDeviation": 0.12240978469624987,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26680
+            ],
+            "primeExcess": 6894,
+            "perWrite": 20308.666666666668,
+            "perBoundaryPerWrite": 846.1944444444445,
+            "cdpBracket": 176496,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6188959,
+              6188975,
+              6215655,
+              6215671,
+              6235487,
+              6235503,
+              6257711,
+              6257727,
+              6277483,
+              6277499,
+              6297243,
+              6297259,
+              6317015,
+              6317031,
+              6337507
+            ],
+            "tick0": 973,
+            "tick": 980,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116376,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116376,
+            "legs": [
+              19384,
+              19384,
+              19372,
+              19384,
+              19384,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19384,
+            "legWorstDeviation": -0.0006190672719768881,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19396,
+            "perBoundaryPerWrite": 808.1666666666666,
+            "cdpBracket": 170504,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6193743,
+              6193759,
+              6219943,
+              6219959,
+              6239343,
+              6239359,
+              6258743,
+              6258759,
+              6278131,
+              6278147,
+              6297531,
+              6297547,
+              6316931,
+              6316947,
+              6336319
+            ],
+            "tick0": 1001,
+            "tick": 1008,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      }
+    ],
+    "allocFits": {
+      "perRound": {},
+      "mean": {}
+    },
+    "writeDriven": true,
+    "writeProvenance": {
+      "windows": 36,
+      "pairs": 36,
+      "unnamed": [],
+      "incomplete": [],
+      "ok": true
+    },
+    "controlVerdict": {
+      "ok": true,
+      "perDouble": 8.106222222222222,
+      "differential": 8.043703703703704
+    },
+    "fallsInMeasuredWindows": 7,
+    "refusedWindows": 9,
+    "refusalReasons": 13
+  },
+  "box": {
+    "bead": "rf2-24o2z",
+    "chromium": "chromium/147.0.7727.15",
+    "node": "v24.13.0",
+    "platform": "win32/x64/10.0.26200",
+    "load": {
+      "open": {
+        "at": "2026-08-20T20:32:15.884Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13478985051,
+        "cpuBusyMs": 3628934731,
+        "freeMemB": 15455260672,
+        "totalMemB": 68112736256,
+        "uptimeS": 709098.687
+      },
+      "close": {
+        "at": "2026-08-20T20:32:42.036Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13479476836,
+        "cpuBusyMs": 3629073237,
+        "freeMemB": 15617679360,
+        "totalMemB": 68112736256,
+        "uptimeS": 709124.843
+      },
+      "busyFraction": 0.2197492904071294
+    },
+    "session": {
+      "startedAt": "2026-08-20T20:31:37.772Z",
+      "sessionStartedAt": "2026-08-20T19:39:26.627Z",
+      "runsInSession": 11,
+      "sessionGapMs": 3600000,
+      "previousRun": {
+        "startedAt": "2026-08-20T20:30:37.666Z",
+        "endedAt": "2026-08-20T20:31:37.022Z",
+        "sinceStartMs": 60106,
+        "sinceEndMs": 750,
+        "sameSession": true
+      }
+    }
+  }
+}

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/parity-4.json
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/parity-4.json
@@ -1,0 +1,7559 @@
+{
+  "generatedAt": "2026-08-20T20:35:39.281Z",
+  "build": "hicasso-bench",
+  "initFn": "re-frame.bench.p0-app/-main",
+  "alloc": {
+    "benchmark": "P0:steady-state-allocation-slope",
+    "bead": "rf2-2rtt6.76",
+    "roots": 4,
+    "perRoot": {
+      "list": 300,
+      "grid": 6
+    },
+    "publishedPerRoot": {
+      "list": 300,
+      "grid": 300
+    },
+    "arm": {
+      "cells": 6,
+      "roots": 4,
+      "boundaries": 24,
+      "writes": 6,
+      "refusals": [],
+      "admissible": true
+    },
+    "boundaries": 24,
+    "writes": 6,
+    "primeWrites": 1,
+    "windowWrites": 7,
+    "bySite": false,
+    "sites": 2,
+    "siteNames": [
+      "dispatch",
+      "drain"
+    ],
+    "warmups": 3,
+    "rounds": 18,
+    "preciseMemory": true,
+    "controlDoubles": {
+      "d1": 1000,
+      "d2": 400
+    },
+    "controlSlack": 0.75,
+    "writeSelector": "all",
+    "writeLegs": [
+      "all"
+    ],
+    "writePaired": false,
+    "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+    "plan": {
+      "name": "floor",
+      "arms": true,
+      "rungs": false,
+      "fits": false
+    },
+    "segOrder": "parity",
+    "passOrder": "parity",
+    "passSeed": "1787258103039",
+    "passSchedule": {
+      "flips": [
+        true,
+        false,
+        true,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "attempts": 1,
+      "parityTied": false
+    },
+    "controlSlot": "first",
+    "instrument": "in-page performance.memory.usedJSHeapSize sampled at every leg boundary, rising steps accumulated separately from falling ones; --enable-precise-memory-info. A falling step is a collection this counter SAW; a leg that deviates from its cohort median by more than the leg tolerance is a work unit that is not one; and under the by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the other two can see. TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg has no interior reading and so no site step to be negative, and the intra-leg gate returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with these (see `bySite`), so a witness comparing byte for byte against a figure published at stride 2 can never be screened by all three",
+    "fallThresholdB": 600000,
+    "legTolerance": 0.25,
+    "verification": {
+      "unverified": 0,
+      "detail": []
+    },
+    "workCount": false,
+    "workVerification": {
+      "counted": false
+    },
+    "perRound": [
+      {
+        "round": 0,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 524,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              524
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 116.66666666666667,
+            "cdpBracket": 46232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3840262,
+              3840278,
+              3840294,
+              3840310,
+              3840326,
+              3840342,
+              3840358,
+              3840374,
+              3840390,
+              3840406,
+              3840422,
+              3840438,
+              3840454,
+              3840978,
+              3840994
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48576,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8144,
+            "endpoints": 48576,
+            "legs": [
+              8144,
+              8080,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.00992063492063492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8096,
+            "cdpBracket": 87388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3853886,
+              3853902,
+              3861966,
+              3861982,
+              3870126,
+              3870142,
+              3878222,
+              3878238,
+              3886302,
+              3886318,
+              3894382,
+              3894398,
+              3902462,
+              3902478,
+              3910542
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 52328,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3849986,
+              3850002,
+              3853266,
+              3853282,
+              3856546,
+              3856562,
+              3859826,
+              3859842,
+              3863106,
+              3863122,
+              3866386,
+              3866402,
+              3869666,
+              3869682,
+              3872946
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 908356,
+            "fall": 499180,
+            "falls": 1,
+            "maxStep": 546304,
+            "endpoints": 409176,
+            "legs": [
+              21336,
+              19692,
+              19764,
+              298332,
+              546304,
+              -499180
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              2848,
+              16
+            ],
+            "legMedian": 20550,
+            "legWorstDeviation": 25.58413625304136,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 298332 B against a cohort median of 20550 B (+277782 B, 1351.7%), past the ±25% leg tolerance (±5137.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read 546304 B against a cohort median of 20550 B (+525754 B, 2558.4%), past the ±25% leg tolerance (±5137.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read -499180 B against a cohort median of 20550 B (-519730 B, -2529.1%), past the ±25% leg tolerance (±5137.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 298332 B against a cohort median of 20550 B (+277782 B, 1351.7%), past the ±25% leg tolerance (±5137.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read 546304 B against a cohort median of 20550 B (+525754 B, 2558.4%), past the ±25% leg tolerance (±5137.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read -499180 B against a cohort median of 20550 B (-519730 B, -2529.1%), past the ±25% leg tolerance (±5137.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26460
+            ],
+            "primeExcess": 5910,
+            "perWrite": 151392.66666666666,
+            "perBoundaryPerWrite": 6308.027777777777,
+            "cdpBracket": 192940,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              4777587,
+              4777603,
+              4804063,
+              4804079,
+              4825415,
+              4825431,
+              4845123,
+              4845139,
+              4864903,
+              4864919,
+              5163251,
+              5166099,
+              5712403,
+              5712419,
+              5213239
+            ],
+            "tick0": 21,
+            "tick": 28,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 1101308,
+            "fall": 283524,
+            "falls": 1,
+            "maxStep": 444360,
+            "endpoints": 817784,
+            "legs": [
+              125776,
+              -283524,
+              22160,
+              20428,
+              444360,
+              286556
+            ],
+            "gaps": [
+              16,
+              201948,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 73968,
+            "legWorstDeviation": 5.007462686567164,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 125776 B against a cohort median of 73968 B (+51808 B, 70.0%), past the ±25% leg tolerance (±18492 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -283524 B against a cohort median of 73968 B (-357492 B, -483.3%), past the ±25% leg tolerance (±18492 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 3 of 6 read 22160 B against a cohort median of 73968 B (-51808 B, -70.0%), past the ±25% leg tolerance (±18492 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 4 of 6 read 20428 B against a cohort median of 73968 B (-53540 B, -72.4%), past the ±25% leg tolerance (±18492 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 5 of 6 read 444360 B against a cohort median of 73968 B (+370392 B, 500.7%), past the ±25% leg tolerance (±18492 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read 286556 B against a cohort median of 73968 B (+212588 B, 287.4%), past the ±25% leg tolerance (±18492 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 125776 B against a cohort median of 73968 B (+51808 B, 70.0%), past the ±25% leg tolerance (±18492 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -283524 B against a cohort median of 73968 B (-357492 B, -483.3%), past the ±25% leg tolerance (±18492 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 3 of 6 read 22160 B against a cohort median of 73968 B (-51808 B, -70.0%), past the ±25% leg tolerance (±18492 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 4 of 6 read 20428 B against a cohort median of 73968 B (-53540 B, -72.4%), past the ±25% leg tolerance (±18492 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 5 of 6 read 444360 B against a cohort median of 73968 B (+370392 B, 500.7%), past the ±25% leg tolerance (±18492 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read 286556 B against a cohort median of 73968 B (+212588 B, 287.4%), past the ±25% leg tolerance (±18492 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26764
+            ],
+            "primeExcess": -47204,
+            "perWrite": 183551.33333333334,
+            "perBoundaryPerWrite": 7647.972222222223,
+            "cdpBracket": 873768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5062815,
+              5062831,
+              5089595,
+              5089611,
+              5215387,
+              5417335,
+              5133811,
+              5133827,
+              5155987,
+              5156003,
+              5176431,
+              5176447,
+              5620807,
+              5620823,
+              5907379
+            ],
+            "tick0": 49,
+            "tick": 56,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 1,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5050923,
+              5050939,
+              5050955,
+              5050971,
+              5050987,
+              5051003,
+              5051019,
+              5051035,
+              5051051,
+              5051067,
+              5051083,
+              5051099,
+              5051115,
+              5051131,
+              5051147
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 87716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5058931,
+              5058947,
+              5067011,
+              5067027,
+              5075091,
+              5075107,
+              5083171,
+              5083187,
+              5091251,
+              5091267,
+              5099331,
+              5099347,
+              5107411,
+              5107427,
+              5115491
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5056375,
+              5056391,
+              5059655,
+              5059671,
+              5062935,
+              5062951,
+              5066215,
+              5066231,
+              5069495,
+              5069511,
+              5072775,
+              5072791,
+              5076055,
+              5076071,
+              5079335
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 851796,
+            "fall": 721780,
+            "falls": 2,
+            "maxStep": 396172,
+            "endpoints": 130016,
+            "legs": [
+              20280,
+              -353528,
+              396172,
+              19772,
+              19772,
+              21696
+            ],
+            "gaps": [
+              16,
+              374040,
+              16,
+              -368252,
+              16,
+              16
+            ],
+            "legMedian": 20026,
+            "legWorstDeviation": 18.78288225307101,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read -353528 B against a cohort median of 20026 B (-373554 B, -1865.3%), past the ±25% leg tolerance (±5006.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 3 of 6 read 396172 B against a cohort median of 20026 B (+376146 B, 1878.3%), past the ±25% leg tolerance (±5006.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read -353528 B against a cohort median of 20026 B (-373554 B, -1865.3%), past the ±25% leg tolerance (±5006.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 3 of 6 read 396172 B against a cohort median of 20026 B (+376146 B, 1878.3%), past the ±25% leg tolerance (±5006.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30976
+            ],
+            "primeExcess": 10950,
+            "perWrite": 141966,
+            "perBoundaryPerWrite": 5915.25,
+            "cdpBracket": 193312,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5182967,
+              5182983,
+              5213959,
+              5213975,
+              5234255,
+              5608295,
+              5254767,
+              5254783,
+              5650955,
+              5282703,
+              5302475,
+              5302491,
+              5322263,
+              5322279,
+              5343975
+            ],
+            "tick0": 77,
+            "tick": 84,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 123032,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 26812,
+            "endpoints": 123032,
+            "legs": [
+              19256,
+              19244,
+              19256,
+              26812,
+              19184,
+              19184
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19250,
+            "legWorstDeviation": 0.3928311688311688,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 26812 B against a cohort median of 19250 B (+7562 B, 39.3%), past the ±25% leg tolerance (±4812.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 26812 B against a cohort median of 19250 B (+7562 B, 39.3%), past the ±25% leg tolerance (±4812.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6790,
+            "perWrite": 20505.333333333332,
+            "perBoundaryPerWrite": 854.3888888888888,
+            "cdpBracket": 177488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5292567,
+              5292583,
+              5318623,
+              5318639,
+              5337895,
+              5337911,
+              5357155,
+              5357171,
+              5376427,
+              5376443,
+              5403255,
+              5403271,
+              5422455,
+              5422471,
+              5441655
+            ],
+            "tick0": 105,
+            "tick": 112,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 2,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5256031,
+              5256047,
+              5256063,
+              5256079,
+              5256095,
+              5256111,
+              5256127,
+              5256143,
+              5256159,
+              5256175,
+              5256191,
+              5256207,
+              5256223,
+              5256239,
+              5256255
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85088,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5264055,
+              5264071,
+              5272135,
+              5272151,
+              5280215,
+              5280231,
+              5288295,
+              5288311,
+              5296375,
+              5296391,
+              5304455,
+              5304471,
+              5312535,
+              5312551,
+              5320615
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5259255,
+              5259271,
+              5262535,
+              5262551,
+              5265815,
+              5265831,
+              5269095,
+              5269111,
+              5272375,
+              5272391,
+              5275655,
+              5275671,
+              5278935,
+              5278951,
+              5282215
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116132,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19768,
+            "endpoints": 116132,
+            "legs": [
+              19244,
+              19768,
+              19256,
+              19256,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": 0.02658911508101371,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19355.333333333332,
+            "perBoundaryPerWrite": 806.4722222222222,
+            "cdpBracket": 173232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5345259,
+              5345275,
+              5371315,
+              5371331,
+              5390575,
+              5390591,
+              5410359,
+              5410375,
+              5429631,
+              5429647,
+              5448903,
+              5448919,
+              5468175,
+              5468191,
+              5487447
+            ],
+            "tick0": 133,
+            "tick": 140,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 338656,
+            "fall": 216228,
+            "falls": 1,
+            "maxStep": 259920,
+            "endpoints": 122428,
+            "legs": [
+              19696,
+              19696,
+              259920,
+              -216228,
+              19624,
+              19624
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19660,
+            "legWorstDeviation": 12.220752797558495,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 259920 B against a cohort median of 19660 B (+240260 B, 1222.1%), past the ±25% leg tolerance (±4915 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -216228 B against a cohort median of 19660 B (-235888 B, -1199.8%), past the ±25% leg tolerance (±4915 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 259920 B against a cohort median of 19660 B (+240260 B, 1222.1%), past the ±25% leg tolerance (±4915 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -216228 B against a cohort median of 19660 B (-235888 B, -1199.8%), past the ±25% leg tolerance (±4915 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6884,
+            "perWrite": 56442.666666666664,
+            "perBoundaryPerWrite": 2351.777777777778,
+            "cdpBracket": 176952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5421007,
+              5421023,
+              5447567,
+              5447583,
+              5467279,
+              5467295,
+              5486991,
+              5487007,
+              5746927,
+              5746943,
+              5530715,
+              5530731,
+              5550355,
+              5550371,
+              5569995
+            ],
+            "tick0": 161,
+            "tick": 168,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 3,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 29120,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5382075,
+              5382091,
+              5382107,
+              5382123,
+              5382139,
+              5382155,
+              5382171,
+              5382187,
+              5382203,
+              5382219,
+              5382235,
+              5382251,
+              5382267,
+              5382283,
+              5382299
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5391011,
+              5391027,
+              5399091,
+              5399107,
+              5407171,
+              5407187,
+              5415251,
+              5415267,
+              5423331,
+              5423347,
+              5431411,
+              5431427,
+              5439491,
+              5439507,
+              5447571
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5386211,
+              5386227,
+              5389491,
+              5389507,
+              5392771,
+              5392787,
+              5396051,
+              5396067,
+              5399331,
+              5399347,
+              5402611,
+              5402627,
+              5405891,
+              5405907,
+              5409171
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118272,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19696,
+            "endpoints": 118272,
+            "legs": [
+              19696,
+              19696,
+              19696,
+              19696,
+              19696,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26532
+            ],
+            "primeExcess": 6836,
+            "perWrite": 19712,
+            "perBoundaryPerWrite": 821.3333333333334,
+            "cdpBracket": 172784,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5454115,
+              5454131,
+              5480663,
+              5480679,
+              5500375,
+              5500391,
+              5520087,
+              5520103,
+              5539799,
+              5539815,
+              5559511,
+              5559527,
+              5579223,
+              5579239,
+              5598935
+            ],
+            "tick0": 189,
+            "tick": 196,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117852,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21692,
+            "endpoints": 117852,
+            "legs": [
+              19256,
+              19256,
+              21692,
+              19184,
+              19184,
+              19184
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19220,
+            "legWorstDeviation": 0.12861602497398544,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6820,
+            "perWrite": 19642,
+            "perBoundaryPerWrite": 818.4166666666666,
+            "cdpBracket": 171852,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5479019,
+              5479035,
+              5505075,
+              5505091,
+              5524347,
+              5524363,
+              5543619,
+              5543635,
+              5565327,
+              5565343,
+              5584527,
+              5584543,
+              5603727,
+              5603743,
+              5622927
+            ],
+            "tick0": 217,
+            "tick": 224,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 4,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5438111,
+              5438127,
+              5438143,
+              5438159,
+              5438175,
+              5438191,
+              5438207,
+              5438223,
+              5438239,
+              5438255,
+              5438271,
+              5438287,
+              5438303,
+              5438319,
+              5438335
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5446119,
+              5446135,
+              5454199,
+              5454215,
+              5462279,
+              5462295,
+              5470359,
+              5470375,
+              5478439,
+              5478455,
+              5486519,
+              5486535,
+              5494599,
+              5494615,
+              5502679
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5441319,
+              5441335,
+              5444599,
+              5444615,
+              5447879,
+              5447895,
+              5451159,
+              5451175,
+              5454439,
+              5454455,
+              5457719,
+              5457735,
+              5460999,
+              5461015,
+              5464279
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 99336,
+            "fall": 295600,
+            "falls": 1,
+            "maxStep": 21336,
+            "endpoints": -196264,
+            "legs": [
+              19596,
+              19448,
+              -295600,
+              19412,
+              21336,
+              19448
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19448,
+            "legWorstDeviation": -16.199506375976963,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read -295600 B against a cohort median of 19448 B (-315048 B, -1620.0%), past the ±25% leg tolerance (±4862 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read -295600 B against a cohort median of 19448 B (-315048 B, -1620.0%), past the ±25% leg tolerance (±4862 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              353032
+            ],
+            "primeExcess": 333584,
+            "perWrite": 16556,
+            "perBoundaryPerWrite": 689.8333333333334,
+            "cdpBracket": 184856,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5615659,
+              5615675,
+              5968707,
+              5968723,
+              5988319,
+              5988335,
+              6007783,
+              6007799,
+              5712199,
+              5712215,
+              5731627,
+              5731643,
+              5752979,
+              5752995,
+              5772443
+            ],
+            "tick0": 245,
+            "tick": 252,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 124040,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22508,
+            "endpoints": 124040,
+            "legs": [
+              19872,
+              22200,
+              22508,
+              19800,
+              19800,
+              19764
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19836,
+            "legWorstDeviation": 0.1347045775357935,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26736
+            ],
+            "primeExcess": 6900,
+            "perWrite": 20673.333333333332,
+            "perBoundaryPerWrite": 861.3888888888888,
+            "cdpBracket": 178756,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5705335,
+              5705351,
+              5732087,
+              5732103,
+              5751975,
+              5751991,
+              5774191,
+              5774207,
+              5796715,
+              5796731,
+              5816531,
+              5816547,
+              5836347,
+              5836363,
+              5856127
+            ],
+            "tick0": 273,
+            "tick": 280,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 5,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5665711,
+              5665727,
+              5665743,
+              5665759,
+              5665775,
+              5665791,
+              5665807,
+              5665823,
+              5665839,
+              5665855,
+              5665871,
+              5665887,
+              5665903,
+              5665919,
+              5665935
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5673719,
+              5673735,
+              5681799,
+              5681815,
+              5689879,
+              5689895,
+              5697959,
+              5697975,
+              5706039,
+              5706055,
+              5714119,
+              5714135,
+              5722199,
+              5722215,
+              5730279
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5668919,
+              5668935,
+              5672199,
+              5672215,
+              5675479,
+              5675495,
+              5678759,
+              5678775,
+              5682039,
+              5682055,
+              5685319,
+              5685335,
+              5688599,
+              5688615,
+              5691879
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122596,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21220,
+            "endpoints": 122596,
+            "legs": [
+              19872,
+              21056,
+              20620,
+              19860,
+              19872,
+              21220
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20246,
+            "legWorstDeviation": 0.04810826829991109,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26724
+            ],
+            "primeExcess": 6478,
+            "perWrite": 20432.666666666668,
+            "perBoundaryPerWrite": 851.3611111111112,
+            "cdpBracket": 177300,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5725227,
+              5725243,
+              5751967,
+              5751983,
+              5771855,
+              5771871,
+              5792927,
+              5792943,
+              5813563,
+              5813579,
+              5833439,
+              5833455,
+              5853327,
+              5853343,
+              5874563
+            ],
+            "tick0": 301,
+            "tick": 308,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116592,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19416,
+            "endpoints": 116592,
+            "legs": [
+              19416,
+              19416,
+              19416,
+              19416,
+              19416,
+              19416
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19416,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26180
+            ],
+            "primeExcess": 6764,
+            "perWrite": 19432,
+            "perBoundaryPerWrite": 809.6666666666666,
+            "cdpBracket": 170732,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5744443,
+              5744459,
+              5770639,
+              5770655,
+              5790071,
+              5790087,
+              5809503,
+              5809519,
+              5828935,
+              5828951,
+              5848367,
+              5848383,
+              5867799,
+              5867815,
+              5887231
+            ],
+            "tick0": 329,
+            "tick": 336,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 6,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5703499,
+              5703515,
+              5703531,
+              5703547,
+              5703563,
+              5703579,
+              5703595,
+              5703611,
+              5703627,
+              5703643,
+              5703659,
+              5703675,
+              5703691,
+              5703707,
+              5703723
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5711507,
+              5711523,
+              5719587,
+              5719603,
+              5727667,
+              5727683,
+              5735747,
+              5735763,
+              5743827,
+              5743843,
+              5751907,
+              5751923,
+              5759987,
+              5760003,
+              5768067
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5706707,
+              5706723,
+              5709987,
+              5710003,
+              5713267,
+              5713283,
+              5716547,
+              5716563,
+              5719827,
+              5719843,
+              5723107,
+              5723123,
+              5726387,
+              5726403,
+              5729667
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 118784,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20248,
+            "endpoints": 118784,
+            "legs": [
+              19400,
+              20248,
+              19400,
+              20136,
+              20104,
+              19400
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19752,
+            "legWorstDeviation": 0.025111381125961927,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26200
+            ],
+            "primeExcess": 6448,
+            "perWrite": 19797.333333333332,
+            "perBoundaryPerWrite": 824.8888888888888,
+            "cdpBracket": 173072,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5768527,
+              5768543,
+              5794743,
+              5794759,
+              5814159,
+              5814175,
+              5834423,
+              5834439,
+              5853839,
+              5853855,
+              5873991,
+              5874007,
+              5894111,
+              5894127,
+              5913527
+            ],
+            "tick0": 357,
+            "tick": 364,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119124,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19840,
+            "endpoints": 119124,
+            "legs": [
+              19840,
+              19828,
+              19840,
+              19840,
+              19840,
+              19840
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19840,
+            "legWorstDeviation": -0.0006048387096774194,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26704
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19854,
+            "perBoundaryPerWrite": 827.25,
+            "cdpBracket": 173808,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5795539,
+              5795555,
+              5822259,
+              5822275,
+              5842115,
+              5842131,
+              5861959,
+              5861975,
+              5881815,
+              5881831,
+              5901671,
+              5901687,
+              5921527,
+              5921543,
+              5941383
+            ],
+            "tick0": 385,
+            "tick": 392,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 7,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5754563,
+              5754579,
+              5754595,
+              5754611,
+              5754627,
+              5754643,
+              5754659,
+              5754675,
+              5754691,
+              5754707,
+              5754723,
+              5754739,
+              5754755,
+              5754771,
+              5754787
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5762571,
+              5762587,
+              5770651,
+              5770667,
+              5778731,
+              5778747,
+              5786811,
+              5786827,
+              5794891,
+              5794907,
+              5802971,
+              5802987,
+              5811051,
+              5811067,
+              5819131
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5757771,
+              5757787,
+              5761051,
+              5761067,
+              5764331,
+              5764347,
+              5767611,
+              5767627,
+              5770891,
+              5770907,
+              5774171,
+              5774187,
+              5777451,
+              5777467,
+              5780731
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122724,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23516,
+            "endpoints": 122724,
+            "legs": [
+              19832,
+              19820,
+              19820,
+              19820,
+              23516,
+              19820
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19820,
+            "legWorstDeviation": 0.18647830474268415,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26696
+            ],
+            "primeExcess": 6876,
+            "perWrite": 20454,
+            "perBoundaryPerWrite": 852.25,
+            "cdpBracket": 184324,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5827083,
+              5827099,
+              5853795,
+              5853811,
+              5873643,
+              5873659,
+              5893479,
+              5893495,
+              5913315,
+              5913331,
+              5933151,
+              5933167,
+              5956683,
+              5956699,
+              5976519
+            ],
+            "tick0": 413,
+            "tick": 420,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116388,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19392,
+            "endpoints": 116388,
+            "legs": [
+              19380,
+              19380,
+              19380,
+              19392,
+              19380,
+              19380
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19380,
+            "legWorstDeviation": 0.0006191950464396285,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26192
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19398,
+            "perBoundaryPerWrite": 808.25,
+            "cdpBracket": 174408,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5843971,
+              5843987,
+              5870179,
+              5870195,
+              5889575,
+              5889591,
+              5908971,
+              5908987,
+              5928367,
+              5928383,
+              5947775,
+              5947791,
+              5967171,
+              5967187,
+              5986567
+            ],
+            "tick0": 441,
+            "tick": 448,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 8,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5806939,
+              5806955,
+              5806971,
+              5806987,
+              5807003,
+              5807019,
+              5807035,
+              5807051,
+              5807067,
+              5807083,
+              5807099,
+              5807115,
+              5807131,
+              5807147,
+              5807163
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5814947,
+              5814963,
+              5823027,
+              5823043,
+              5831107,
+              5831123,
+              5839187,
+              5839203,
+              5847267,
+              5847283,
+              5855347,
+              5855363,
+              5863427,
+              5863443,
+              5871507
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5810147,
+              5810163,
+              5813427,
+              5813443,
+              5816707,
+              5816723,
+              5819987,
+              5820003,
+              5823267,
+              5823283,
+              5826547,
+              5826563,
+              5829827,
+              5829843,
+              5833107
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 287240,
+            "fall": 168356,
+            "falls": 1,
+            "maxStep": 188512,
+            "endpoints": 118884,
+            "legs": [
+              19392,
+              21104,
+              19380,
+              -168356,
+              19392,
+              19380
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              188512,
+              16,
+              16
+            ],
+            "legMedian": 19386,
+            "legWorstDeviation": -9.684411430929536,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read -168356 B against a cohort median of 19386 B (-187742 B, -968.4%), past the ±25% leg tolerance (±4846.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read -168356 B against a cohort median of 19386 B (-187742 B, -968.4%), past the ±25% leg tolerance (±4846.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26192
+            ],
+            "primeExcess": 6806,
+            "perWrite": 47873.333333333336,
+            "perBoundaryPerWrite": 1994.7222222222224,
+            "cdpBracket": 173164,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5876759,
+              5876775,
+              5902967,
+              5902983,
+              5922375,
+              5922391,
+              5943495,
+              5943511,
+              5962891,
+              6151403,
+              5983047,
+              5983063,
+              6002455,
+              6002471,
+              6021851
+            ],
+            "tick0": 469,
+            "tick": 476,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 127860,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 28336,
+            "endpoints": 127860,
+            "legs": [
+              19832,
+              28336,
+              20148,
+              19820,
+              19796,
+              19832
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19832,
+            "legWorstDeviation": 0.4288019362646228,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 28336 B against a cohort median of 19832 B (+8504 B, 42.9%), past the ±25% leg tolerance (±4958 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 28336 B against a cohort median of 19832 B (+8504 B, 42.9%), past the ±25% leg tolerance (±4958 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26696
+            ],
+            "primeExcess": 6864,
+            "perWrite": 21310,
+            "perBoundaryPerWrite": 887.9166666666666,
+            "cdpBracket": 182536,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5914283,
+              5914299,
+              5940995,
+              5941011,
+              5960843,
+              5960859,
+              5989195,
+              5989211,
+              6009359,
+              6009375,
+              6029195,
+              6029211,
+              6049007,
+              6049023,
+              6068855
+            ],
+            "tick0": 497,
+            "tick": 504,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 9,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5881079,
+              5881095,
+              5881111,
+              5881127,
+              5881143,
+              5881159,
+              5881175,
+              5881191,
+              5881207,
+              5881223,
+              5881239,
+              5881255,
+              5881271,
+              5881287,
+              5881303
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5889087,
+              5889103,
+              5897167,
+              5897183,
+              5905247,
+              5905263,
+              5913327,
+              5913343,
+              5921407,
+              5921423,
+              5929487,
+              5929503,
+              5937567,
+              5937583,
+              5945647
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5884287,
+              5884303,
+              5887567,
+              5887583,
+              5890847,
+              5890863,
+              5894127,
+              5894143,
+              5897407,
+              5897423,
+              5900687,
+              5900703,
+              5903967,
+              5903983,
+              5907247
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119764,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20572,
+            "endpoints": 119764,
+            "legs": [
+              19824,
+              19824,
+              19824,
+              19812,
+              20572,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.0377320419693301,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19960.666666666668,
+            "perBoundaryPerWrite": 831.6944444444445,
+            "cdpBracket": 178612,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5956587,
+              5956603,
+              5983291,
+              5983307,
+              6003131,
+              6003147,
+              6022971,
+              6022987,
+              6042811,
+              6042827,
+              6062639,
+              6062655,
+              6083227,
+              6083243,
+              6103055
+            ],
+            "tick0": 525,
+            "tick": 532,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116316,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116316,
+            "legs": [
+              19372,
+              19372,
+              19348,
+              19372,
+              19372,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": -0.0012389015073301672,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19386,
+            "perBoundaryPerWrite": 807.75,
+            "cdpBracket": 177784,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5961759,
+              5961775,
+              5987959,
+              5987975,
+              6007347,
+              6007363,
+              6026735,
+              6026751,
+              6046099,
+              6046115,
+              6065487,
+              6065503,
+              6084875,
+              6084891,
+              6104275
+            ],
+            "tick0": 553,
+            "tick": 560,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 10,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5927395,
+              5927411,
+              5927427,
+              5927443,
+              5927459,
+              5927475,
+              5927491,
+              5927507,
+              5927523,
+              5927539,
+              5927555,
+              5927571,
+              5927587,
+              5927603,
+              5927619
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5935403,
+              5935419,
+              5943483,
+              5943499,
+              5951563,
+              5951579,
+              5959643,
+              5959659,
+              5967723,
+              5967739,
+              5975803,
+              5975819,
+              5983883,
+              5983899,
+              5991963
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5930603,
+              5930619,
+              5933883,
+              5933899,
+              5937163,
+              5937179,
+              5940443,
+              5940459,
+              5943723,
+              5943739,
+              5947003,
+              5947019,
+              5950283,
+              5950299,
+              5953563
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116352,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116352,
+            "legs": [
+              19372,
+              19384,
+              19372,
+              19372,
+              19372,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0006194507536650836,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19392,
+            "perBoundaryPerWrite": 808,
+            "cdpBracket": 171360,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5988123,
+              5988139,
+              6014311,
+              6014327,
+              6033699,
+              6033715,
+              6053099,
+              6053115,
+              6072487,
+              6072503,
+              6091875,
+              6091891,
+              6111263,
+              6111279,
+              6130663
+            ],
+            "tick0": 581,
+            "tick": 588,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 276776,
+            "fall": 155816,
+            "falls": 1,
+            "maxStep": 176396,
+            "endpoints": 120960,
+            "legs": [
+              19832,
+              20996,
+              19832,
+              176396,
+              19820,
+              19820
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              -155816,
+              16
+            ],
+            "legMedian": 19832,
+            "legWorstDeviation": 7.8945139169019765,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 176396 B against a cohort median of 19832 B (+156564 B, 789.5%), past the ±25% leg tolerance (±4958 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 176396 B against a cohort median of 19832 B (+156564 B, 789.5%), past the ±25% leg tolerance (±4958 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26696
+            ],
+            "primeExcess": 6864,
+            "perWrite": 46129.333333333336,
+            "perBoundaryPerWrite": 1922.0555555555557,
+            "cdpBracket": 177128,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6001351,
+              6001367,
+              6028063,
+              6028079,
+              6047911,
+              6047927,
+              6068923,
+              6068939,
+              6088771,
+              6088787,
+              6265183,
+              6109367,
+              6129187,
+              6129203,
+              6149023
+            ],
+            "tick0": 609,
+            "tick": 616,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 11,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5960143,
+              5960159,
+              5960175,
+              5960191,
+              5960207,
+              5960223,
+              5960239,
+              5960255,
+              5960271,
+              5960287,
+              5960303,
+              5960319,
+              5960335,
+              5960351,
+              5960367
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5968151,
+              5968167,
+              5976231,
+              5976247,
+              5984311,
+              5984327,
+              5992391,
+              5992407,
+              6000471,
+              6000487,
+              6008551,
+              6008567,
+              6016631,
+              6016647,
+              6024711
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5963351,
+              5963367,
+              5966631,
+              5966647,
+              5969911,
+              5969927,
+              5973191,
+              5973207,
+              5976471,
+              5976487,
+              5979751,
+              5979767,
+              5983031,
+              5983047,
+              5986311
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119740,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20560,
+            "endpoints": 119740,
+            "legs": [
+              19812,
+              19824,
+              19812,
+              19812,
+              19824,
+              20560
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 0.037440710465233625,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6870,
+            "perWrite": 19956.666666666668,
+            "perBoundaryPerWrite": 831.5277777777778,
+            "cdpBracket": 174408,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6011291,
+              6011307,
+              6037995,
+              6038011,
+              6057823,
+              6057839,
+              6077663,
+              6077679,
+              6097491,
+              6097507,
+              6117319,
+              6117335,
+              6137159,
+              6137175,
+              6157735
+            ],
+            "tick0": 637,
+            "tick": 644,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117060,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20116,
+            "endpoints": 117060,
+            "legs": [
+              19372,
+              19348,
+              19372,
+              19384,
+              20116,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.038405946727235185,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              31416
+            ],
+            "primeExcess": 12044,
+            "perWrite": 19510,
+            "perBoundaryPerWrite": 812.9166666666666,
+            "cdpBracket": 177648,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6021443,
+              6021459,
+              6052875,
+              6052891,
+              6072263,
+              6072279,
+              6091627,
+              6091643,
+              6111015,
+              6111031,
+              6130415,
+              6130431,
+              6150547,
+              6150563,
+              6169935
+            ],
+            "tick0": 665,
+            "tick": 672,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 12,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5985767,
+              5985783,
+              5985799,
+              5985815,
+              5985831,
+              5985847,
+              5985863,
+              5985879,
+              5985895,
+              5985911,
+              5985927,
+              5985943,
+              5985959,
+              5985975,
+              5985991
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5993775,
+              5993791,
+              6001855,
+              6001871,
+              6009935,
+              6009951,
+              6018015,
+              6018031,
+              6026095,
+              6026111,
+              6034175,
+              6034191,
+              6042255,
+              6042271,
+              6050335
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5988975,
+              5988991,
+              5992255,
+              5992271,
+              5995535,
+              5995551,
+              5998815,
+              5998831,
+              6002095,
+              6002111,
+              6005375,
+              6005391,
+              6008655,
+              6008671,
+              6011935
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 132064,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 35096,
+            "endpoints": 132064,
+            "legs": [
+              19372,
+              19372,
+              19372,
+              19372,
+              19384,
+              35096
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.8116869708858145,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 35096 B against a cohort median of 19372 B (+15724 B, 81.2%), past the ±25% leg tolerance (±4843 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 35096 B against a cohort median of 19372 B (+15724 B, 81.2%), past the ±25% leg tolerance (±4843 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 22010.666666666668,
+            "perBoundaryPerWrite": 917.1111111111112,
+            "cdpBracket": 171356,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6055239,
+              6055255,
+              6081439,
+              6081455,
+              6100827,
+              6100843,
+              6120215,
+              6120231,
+              6139603,
+              6139619,
+              6158991,
+              6159007,
+              6178391,
+              6178407,
+              6213503
+            ],
+            "tick0": 693,
+            "tick": 700,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118992,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 118992,
+            "legs": [
+              19824,
+              19812,
+              19812,
+              19812,
+              19812,
+              19824
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": 0.0006056935190793458,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6876,
+            "perWrite": 19832,
+            "perBoundaryPerWrite": 826.3333333333334,
+            "cdpBracket": 174332,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6084219,
+              6084235,
+              6110923,
+              6110939,
+              6130763,
+              6130779,
+              6150591,
+              6150607,
+              6170419,
+              6170435,
+              6190247,
+              6190263,
+              6210075,
+              6210091,
+              6229915
+            ],
+            "tick0": 721,
+            "tick": 728,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 13,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 31952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6043255,
+              6043271,
+              6043287,
+              6043303,
+              6043319,
+              6043335,
+              6043351,
+              6043367,
+              6043383,
+              6043399,
+              6043415,
+              6043431,
+              6043447,
+              6043463,
+              6043479
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6055283,
+              6055299,
+              6063363,
+              6063379,
+              6071443,
+              6071459,
+              6079523,
+              6079539,
+              6087603,
+              6087619,
+              6095683,
+              6095699,
+              6103763,
+              6103779,
+              6111843
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6050483,
+              6050499,
+              6053763,
+              6053779,
+              6057043,
+              6057059,
+              6060323,
+              6060339,
+              6063603,
+              6063619,
+              6066883,
+              6066899,
+              6070163,
+              6070179,
+              6073443
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118992,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 118992,
+            "legs": [
+              19812,
+              19824,
+              19824,
+              19812,
+              19812,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": 0.0006056935190793458,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6876,
+            "perWrite": 19832,
+            "perBoundaryPerWrite": 826.3333333333334,
+            "cdpBracket": 174392,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6097859,
+              6097875,
+              6124563,
+              6124579,
+              6144391,
+              6144407,
+              6164231,
+              6164247,
+              6184071,
+              6184087,
+              6203899,
+              6203915,
+              6223727,
+              6223743,
+              6243555
+            ],
+            "tick0": 749,
+            "tick": 756,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116364,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116364,
+            "legs": [
+              19372,
+              19372,
+              19384,
+              19384,
+              19372,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": -0.0003096294767261843,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19394,
+            "perBoundaryPerWrite": 808.0833333333334,
+            "cdpBracket": 171180,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6110883,
+              6110899,
+              6137083,
+              6137099,
+              6156471,
+              6156487,
+              6175859,
+              6175875,
+              6195259,
+              6195275,
+              6214659,
+              6214675,
+              6234047,
+              6234063,
+              6253447
+            ],
+            "tick0": 777,
+            "tick": 784,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 14,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6069939,
+              6069955,
+              6069971,
+              6069987,
+              6070003,
+              6070019,
+              6070035,
+              6070051,
+              6070067,
+              6070083,
+              6070099,
+              6070115,
+              6070131,
+              6070147,
+              6070163
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6077947,
+              6077963,
+              6086027,
+              6086043,
+              6094107,
+              6094123,
+              6102187,
+              6102203,
+              6110267,
+              6110283,
+              6118347,
+              6118363,
+              6126427,
+              6126443,
+              6134507
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6073147,
+              6073163,
+              6076427,
+              6076443,
+              6079707,
+              6079723,
+              6082987,
+              6083003,
+              6086267,
+              6086283,
+              6089547,
+              6089563,
+              6092827,
+              6092843,
+              6096107
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116364,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116364,
+            "legs": [
+              19384,
+              19384,
+              19372,
+              19372,
+              19372,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.0003096294767261843,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6794,
+            "perWrite": 19394,
+            "perBoundaryPerWrite": 808.0833333333334,
+            "cdpBracket": 173844,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6120051,
+              6120067,
+              6146239,
+              6146255,
+              6165639,
+              6165655,
+              6185039,
+              6185055,
+              6204427,
+              6204443,
+              6223815,
+              6223831,
+              6243203,
+              6243219,
+              6262603
+            ],
+            "tick0": 805,
+            "tick": 812,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118968,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19812,
+            "endpoints": 118968,
+            "legs": [
+              19812,
+              19812,
+              19812,
+              19812,
+              19812,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6876,
+            "perWrite": 19828,
+            "perBoundaryPerWrite": 826.1666666666666,
+            "cdpBracket": 173620,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6137011,
+              6137027,
+              6163715,
+              6163731,
+              6183543,
+              6183559,
+              6203371,
+              6203387,
+              6223199,
+              6223215,
+              6243027,
+              6243043,
+              6262855,
+              6262871,
+              6282683
+            ],
+            "tick0": 833,
+            "tick": 840,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 15,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6096047,
+              6096063,
+              6096079,
+              6096095,
+              6096111,
+              6096127,
+              6096143,
+              6096159,
+              6096175,
+              6096191,
+              6096207,
+              6096223,
+              6096239,
+              6096255,
+              6096271
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6104055,
+              6104071,
+              6112135,
+              6112151,
+              6120215,
+              6120231,
+              6128295,
+              6128311,
+              6136375,
+              6136391,
+              6144455,
+              6144471,
+              6152535,
+              6152551,
+              6160615
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6099255,
+              6099271,
+              6102535,
+              6102551,
+              6105815,
+              6105831,
+              6109095,
+              6109111,
+              6112375,
+              6112391,
+              6115655,
+              6115671,
+              6118935,
+              6118951,
+              6122215
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119764,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20572,
+            "endpoints": 119764,
+            "legs": [
+              19812,
+              19824,
+              19824,
+              19812,
+              19824,
+              20572
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.0377320419693301,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19960.666666666668,
+            "perBoundaryPerWrite": 831.6944444444445,
+            "cdpBracket": 174416,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6151135,
+              6151151,
+              6177839,
+              6177855,
+              6197667,
+              6197683,
+              6217507,
+              6217523,
+              6237347,
+              6237363,
+              6257175,
+              6257191,
+              6277015,
+              6277031,
+              6297603
+            ],
+            "tick0": 861,
+            "tick": 868,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116340,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116340,
+            "legs": [
+              19372,
+              19384,
+              19372,
+              19372,
+              19372,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0006194507536650836,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19390,
+            "perBoundaryPerWrite": 807.9166666666666,
+            "cdpBracket": 170468,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6159947,
+              6159963,
+              6186147,
+              6186163,
+              6205535,
+              6205551,
+              6224935,
+              6224951,
+              6244323,
+              6244339,
+              6263711,
+              6263727,
+              6283099,
+              6283115,
+              6302487
+            ],
+            "tick0": 889,
+            "tick": 896,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 16,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6113875,
+              6113891,
+              6113907,
+              6113923,
+              6113939,
+              6113955,
+              6113971,
+              6113987,
+              6114003,
+              6114019,
+              6114035,
+              6114051,
+              6114067,
+              6114083,
+              6114099
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6121883,
+              6121899,
+              6129963,
+              6129979,
+              6138043,
+              6138059,
+              6146123,
+              6146139,
+              6154203,
+              6154219,
+              6162283,
+              6162299,
+              6170363,
+              6170379,
+              6178443
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6117083,
+              6117099,
+              6120363,
+              6120379,
+              6123643,
+              6123659,
+              6126923,
+              6126939,
+              6130203,
+              6130219,
+              6133483,
+              6133499,
+              6136763,
+              6136779,
+              6140043
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116328,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116328,
+            "legs": [
+              19384,
+              19372,
+              19372,
+              19348,
+              19384,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": -0.0012389015073301672,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19388,
+            "perBoundaryPerWrite": 807.8333333333334,
+            "cdpBracket": 171304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6157043,
+              6157059,
+              6183243,
+              6183259,
+              6202643,
+              6202659,
+              6222031,
+              6222047,
+              6241419,
+              6241435,
+              6260783,
+              6260799,
+              6280183,
+              6280199,
+              6299571
+            ],
+            "tick0": 917,
+            "tick": 924,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 253812,
+            "fall": 129816,
+            "falls": 1,
+            "maxStep": 173096,
+            "endpoints": 123996,
+            "legs": [
+              19812,
+              21172,
+              173096,
+              -129816,
+              19824,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 7.734281965889595,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 173096 B against a cohort median of 19818 B (+153278 B, 773.4%), past the ±25% leg tolerance (±4954.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -129816 B against a cohort median of 19818 B (-149634 B, -755.0%), past the ±25% leg tolerance (±4954.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 173096 B against a cohort median of 19818 B (+153278 B, 773.4%), past the ±25% leg tolerance (±4954.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -129816 B against a cohort median of 19818 B (-149634 B, -755.0%), past the ±25% leg tolerance (±4954.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26676
+            ],
+            "primeExcess": 6858,
+            "perWrite": 42302,
+            "perBoundaryPerWrite": 1762.5833333333333,
+            "cdpBracket": 184936,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6173543,
+              6173559,
+              6200235,
+              6200251,
+              6220063,
+              6220079,
+              6241251,
+              6241267,
+              6414363,
+              6414379,
+              6284563,
+              6284579,
+              6304403,
+              6304419,
+              6324231
+            ],
+            "tick0": 945,
+            "tick": 952,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 17,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6137287,
+              6137303,
+              6137319,
+              6137335,
+              6137351,
+              6137367,
+              6137383,
+              6137399,
+              6137415,
+              6137431,
+              6137447,
+              6137463,
+              6137479,
+              6137495,
+              6137511
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6145295,
+              6145311,
+              6153375,
+              6153391,
+              6161455,
+              6161471,
+              6169535,
+              6169551,
+              6177615,
+              6177631,
+              6185695,
+              6185711,
+              6193775,
+              6193791,
+              6201855
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6140495,
+              6140511,
+              6143775,
+              6143791,
+              6147055,
+              6147071,
+              6150335,
+              6150351,
+              6153615,
+              6153631,
+              6156895,
+              6156911,
+              6160175,
+              6160191,
+              6163455
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119776,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20576,
+            "endpoints": 119776,
+            "legs": [
+              19828,
+              19816,
+              19828,
+              19816,
+              20576,
+              19816
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19822,
+            "legWorstDeviation": 0.038038543032993644,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26692
+            ],
+            "primeExcess": 6870,
+            "perWrite": 19962.666666666668,
+            "perBoundaryPerWrite": 831.7777777777778,
+            "cdpBracket": 176692,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6191099,
+              6191115,
+              6217807,
+              6217823,
+              6237651,
+              6237667,
+              6257483,
+              6257499,
+              6277327,
+              6277343,
+              6297159,
+              6297175,
+              6317751,
+              6317767,
+              6337583
+            ],
+            "tick0": 973,
+            "tick": 980,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116352,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116352,
+            "legs": [
+              19372,
+              19372,
+              19372,
+              19384,
+              19372,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0006194507536650836,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19392,
+            "perBoundaryPerWrite": 808,
+            "cdpBracket": 170468,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6195695,
+              6195711,
+              6221883,
+              6221899,
+              6241271,
+              6241287,
+              6260659,
+              6260675,
+              6280047,
+              6280063,
+              6299447,
+              6299463,
+              6318835,
+              6318851,
+              6338235
+            ],
+            "tick0": 1001,
+            "tick": 1008,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      }
+    ],
+    "allocFits": {
+      "perRound": {},
+      "mean": {}
+    },
+    "writeDriven": true,
+    "writeProvenance": {
+      "windows": 36,
+      "pairs": 36,
+      "unnamed": [],
+      "incomplete": [],
+      "ok": true
+    },
+    "controlVerdict": {
+      "ok": true,
+      "perDouble": 8.08088888888889,
+      "differential": 8.00148148148148
+    },
+    "fallsInMeasuredWindows": 9,
+    "refusedWindows": 11,
+    "refusalReasons": 21
+  },
+  "box": {
+    "bead": "rf2-24o2z",
+    "chromium": "chromium/147.0.7727.15",
+    "node": "v24.13.0",
+    "platform": "win32/x64/10.0.26200",
+    "load": {
+      "open": {
+        "at": "2026-08-20T20:35:39.356Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13482169895,
+        "cpuBusyMs": 3630669220,
+        "freeMemB": 16031236096,
+        "totalMemB": 68112736256,
+        "uptimeS": 709302.156
+      },
+      "close": {
+        "at": "2026-08-20T20:36:05.465Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13482653083,
+        "cpuBusyMs": 3630815675,
+        "freeMemB": 15584284672,
+        "totalMemB": 68112736256,
+        "uptimeS": 709328.265
+      },
+      "busyFraction": 0.23260006066929992
+    },
+    "session": {
+      "startedAt": "2026-08-20T20:35:03.038Z",
+      "sessionStartedAt": "2026-08-20T19:39:26.627Z",
+      "runsInSession": 14,
+      "sessionGapMs": 3600000,
+      "previousRun": {
+        "startedAt": "2026-08-20T20:33:49.570Z",
+        "endedAt": "2026-08-20T20:35:02.662Z",
+        "sinceStartMs": 73468,
+        "sinceEndMs": 376,
+        "sameSession": true
+      }
+    }
+  }
+}

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/parity-5.json
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/parity-5.json
@@ -1,0 +1,7561 @@
+{
+  "generatedAt": "2026-08-20T20:39:01.043Z",
+  "build": "hicasso-bench",
+  "initFn": "re-frame.bench.p0-app/-main",
+  "alloc": {
+    "benchmark": "P0:steady-state-allocation-slope",
+    "bead": "rf2-2rtt6.76",
+    "roots": 4,
+    "perRoot": {
+      "list": 300,
+      "grid": 6
+    },
+    "publishedPerRoot": {
+      "list": 300,
+      "grid": 300
+    },
+    "arm": {
+      "cells": 6,
+      "roots": 4,
+      "boundaries": 24,
+      "writes": 6,
+      "refusals": [],
+      "admissible": true
+    },
+    "boundaries": 24,
+    "writes": 6,
+    "primeWrites": 1,
+    "windowWrites": 7,
+    "bySite": false,
+    "sites": 2,
+    "siteNames": [
+      "dispatch",
+      "drain"
+    ],
+    "warmups": 3,
+    "rounds": 18,
+    "preciseMemory": true,
+    "controlDoubles": {
+      "d1": 1000,
+      "d2": 400
+    },
+    "controlSlack": 0.75,
+    "writeSelector": "all",
+    "writeLegs": [
+      "all"
+    ],
+    "writePaired": false,
+    "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+    "plan": {
+      "name": "floor",
+      "arms": true,
+      "rungs": false,
+      "fits": false
+    },
+    "segOrder": "parity",
+    "passOrder": "parity",
+    "passSeed": "1787258299933",
+    "passSchedule": {
+      "flips": [
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false
+      ],
+      "attempts": 1,
+      "parityTied": false
+    },
+    "controlSlot": "first",
+    "instrument": "in-page performance.memory.usedJSHeapSize sampled at every leg boundary, rising steps accumulated separately from falling ones; --enable-precise-memory-info. A falling step is a collection this counter SAW; a leg that deviates from its cohort median by more than the leg tolerance is a work unit that is not one; and under the by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the other two can see. TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg has no interior reading and so no site step to be negative, and the intra-leg gate returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with these (see `bySite`), so a witness comparing byte for byte against a figure published at stride 2 can never be screened by all three",
+    "fallThresholdB": 600000,
+    "legTolerance": 0.25,
+    "verification": {
+      "unverified": 0,
+      "detail": []
+    },
+    "workCount": false,
+    "workVerification": {
+      "counted": false
+    },
+    "perRound": [
+      {
+        "round": 0,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 524,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              524
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 116.66666666666667,
+            "cdpBracket": 46232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3904806,
+              3904822,
+              3904838,
+              3904854,
+              3904870,
+              3904886,
+              3904902,
+              3904918,
+              3904934,
+              3904950,
+              3904966,
+              3904982,
+              3904998,
+              3905522,
+              3905538
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48576,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8144,
+            "endpoints": 48576,
+            "legs": [
+              8144,
+              8080,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.00992063492063492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8096,
+            "cdpBracket": 87388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3918430,
+              3918446,
+              3926510,
+              3926526,
+              3934670,
+              3934686,
+              3942766,
+              3942782,
+              3950846,
+              3950862,
+              3958926,
+              3958942,
+              3967006,
+              3967022,
+              3975086
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 52328,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3914530,
+              3914546,
+              3917810,
+              3917826,
+              3921090,
+              3921106,
+              3924370,
+              3924386,
+              3927650,
+              3927666,
+              3930930,
+              3930946,
+              3934210,
+              3934226,
+              3937490
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 131320,
+            "fall": 252956,
+            "falls": 1,
+            "maxStep": 27300,
+            "endpoints": -121636,
+            "legs": [
+              20408,
+              19692,
+              27300,
+              21576,
+              20952,
+              21312
+            ],
+            "gaps": [
+              -252956,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21132,
+            "legWorstDeviation": 0.2918796138557638,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 27300 B against a cohort median of 21132 B (+6168 B, 29.2%), past the ±25% leg tolerance (±5283 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 27300 B against a cohort median of 21132 B (+6168 B, 29.2%), past the ±25% leg tolerance (±5283 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              280360
+            ],
+            "primeExcess": 259228,
+            "perWrite": 21886.666666666668,
+            "perBoundaryPerWrite": 911.9444444444445,
+            "cdpBracket": 187124,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              4782631,
+              4782647,
+              5063007,
+              4810051,
+              4830459,
+              4830475,
+              4850167,
+              4850183,
+              4877483,
+              4877499,
+              4899075,
+              4899091,
+              4920043,
+              4920059,
+              4941371
+            ],
+            "tick0": 21,
+            "tick": 28,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 532272,
+            "fall": 140604,
+            "falls": 1,
+            "maxStep": 285540,
+            "endpoints": 391668,
+            "legs": [
+              19916,
+              187032,
+              -140604,
+              285540,
+              19844,
+              19844
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19880,
+            "legWorstDeviation": 13.36317907444668,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 187032 B against a cohort median of 19880 B (+167152 B, 840.8%), past the ±25% leg tolerance (±4970 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -140604 B against a cohort median of 19880 B (-160484 B, -807.3%), past the ±25% leg tolerance (±4970 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 4 of 6 read 285540 B against a cohort median of 19880 B (+265660 B, 1336.3%), past the ±25% leg tolerance (±4970 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 187032 B against a cohort median of 19880 B (+167152 B, 840.8%), past the ±25% leg tolerance (±4970 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -140604 B against a cohort median of 19880 B (-160484 B, -807.3%), past the ±25% leg tolerance (±4970 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 4 of 6 read 285540 B against a cohort median of 19880 B (+265660 B, 1336.3%), past the ±25% leg tolerance (±4970 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26752
+            ],
+            "primeExcess": 6872,
+            "perWrite": 88712,
+            "perBoundaryPerWrite": 3696.3333333333335,
+            "cdpBracket": 204392,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5059159,
+              5059175,
+              5085927,
+              5085943,
+              5105859,
+              5105875,
+              5292907,
+              5292923,
+              5152319,
+              5152335,
+              5437875,
+              5437891,
+              5457735,
+              5457751,
+              5477595
+            ],
+            "tick0": 49,
+            "tick": 56,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 1,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5046495,
+              5046511,
+              5046527,
+              5046543,
+              5046559,
+              5046575,
+              5046591,
+              5046607,
+              5046623,
+              5046639,
+              5046655,
+              5046671,
+              5046687,
+              5046703,
+              5046719
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 87716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5054503,
+              5054519,
+              5062583,
+              5062599,
+              5070663,
+              5070679,
+              5078743,
+              5078759,
+              5086823,
+              5086839,
+              5094903,
+              5094919,
+              5102983,
+              5102999,
+              5111063
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5051947,
+              5051963,
+              5055227,
+              5055243,
+              5058507,
+              5058523,
+              5061787,
+              5061803,
+              5065067,
+              5065083,
+              5068347,
+              5068363,
+              5071627,
+              5071643,
+              5074907
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 558328,
+            "fall": 428276,
+            "falls": 2,
+            "maxStep": 314656,
+            "endpoints": 130052,
+            "legs": [
+              182328,
+              19772,
+              314656,
+              -266968,
+              19772,
+              21720
+            ],
+            "gaps": [
+              16,
+              -161308,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20746,
+            "legWorstDeviation": 14.167068350525403,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 182328 B against a cohort median of 20746 B (+161582 B, 778.9%), past the ±25% leg tolerance (±5186.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read 314656 B against a cohort median of 20746 B (+293910 B, 1416.7%), past the ±25% leg tolerance (±5186.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -266968 B against a cohort median of 20746 B (-287714 B, -1386.8%), past the ±25% leg tolerance (±5186.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 182328 B against a cohort median of 20746 B (+161582 B, 778.9%), past the ±25% leg tolerance (±5186.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read 314656 B against a cohort median of 20746 B (+293910 B, 1416.7%), past the ±25% leg tolerance (±5186.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -266968 B against a cohort median of 20746 B (-287714 B, -1386.8%), past the ±25% leg tolerance (±5186.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30976
+            ],
+            "primeExcess": 10230,
+            "perWrite": 93054.66666666667,
+            "perBoundaryPerWrite": 3877.277777777778,
+            "cdpBracket": 192964,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5181159,
+              5181175,
+              5212151,
+              5212167,
+              5394495,
+              5233187,
+              5252959,
+              5252975,
+              5567631,
+              5567647,
+              5300679,
+              5300695,
+              5320467,
+              5320483,
+              5342203
+            ],
+            "tick0": 77,
+            "tick": 84,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 122964,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24404,
+            "endpoints": 122964,
+            "legs": [
+              19256,
+              21656,
+              19184,
+              24404,
+              19184,
+              19184
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19220,
+            "legWorstDeviation": 0.2697190426638918,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 24404 B against a cohort median of 19220 B (+5184 B, 27.0%), past the ±25% leg tolerance (±4805 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 24404 B against a cohort median of 19220 B (+5184 B, 27.0%), past the ±25% leg tolerance (±4805 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6820,
+            "perWrite": 20494,
+            "perBoundaryPerWrite": 853.9166666666666,
+            "cdpBracket": 177420,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5290735,
+              5290751,
+              5316791,
+              5316807,
+              5336063,
+              5336079,
+              5357735,
+              5357751,
+              5376935,
+              5376951,
+              5401355,
+              5401371,
+              5420555,
+              5420571,
+              5439755
+            ],
+            "tick0": 105,
+            "tick": 112,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 2,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5254211,
+              5254227,
+              5254243,
+              5254259,
+              5254275,
+              5254291,
+              5254307,
+              5254323,
+              5254339,
+              5254355,
+              5254371,
+              5254387,
+              5254403,
+              5254419,
+              5254435
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85088,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5262235,
+              5262251,
+              5270315,
+              5270331,
+              5278395,
+              5278411,
+              5286475,
+              5286491,
+              5294555,
+              5294571,
+              5302635,
+              5302651,
+              5310715,
+              5310731,
+              5318795
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5257435,
+              5257451,
+              5260715,
+              5260731,
+              5263995,
+              5264011,
+              5267275,
+              5267291,
+              5270555,
+              5270571,
+              5273835,
+              5273851,
+              5277115,
+              5277131,
+              5280395
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116132,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19768,
+            "endpoints": 116132,
+            "legs": [
+              19256,
+              19768,
+              19244,
+              19256,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": 0.02658911508101371,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19355.333333333332,
+            "perBoundaryPerWrite": 806.4722222222222,
+            "cdpBracket": 173232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5343435,
+              5343451,
+              5369491,
+              5369507,
+              5388763,
+              5388779,
+              5408547,
+              5408563,
+              5427807,
+              5427823,
+              5447079,
+              5447095,
+              5466351,
+              5466367,
+              5485623
+            ],
+            "tick0": 133,
+            "tick": 140,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 131052,
+            "fall": 8708,
+            "falls": 1,
+            "maxStep": 30820,
+            "endpoints": 122344,
+            "legs": [
+              19696,
+              -8708,
+              21632,
+              19624,
+              19612,
+              19588
+            ],
+            "gaps": [
+              16,
+              30820,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19618,
+            "legWorstDeviation": -1.4438780711591395,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read -8708 B against a cohort median of 19618 B (-28326 B, -144.4%), past the ±25% leg tolerance (±4904.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read -8708 B against a cohort median of 19618 B (-28326 B, -144.4%), past the ±25% leg tolerance (±4904.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6926,
+            "perWrite": 21842,
+            "perBoundaryPerWrite": 910.0833333333334,
+            "cdpBracket": 176868,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5419195,
+              5419211,
+              5445755,
+              5445771,
+              5465467,
+              5496287,
+              5487579,
+              5487595,
+              5509227,
+              5509243,
+              5528867,
+              5528883,
+              5548495,
+              5548511,
+              5568099
+            ],
+            "tick0": 161,
+            "tick": 168,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 3,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 1120,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 944,
+            "endpoints": 1120,
+            "legs": [
+              16,
+              16,
+              944,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 58,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 944 B against a cohort median of 16 B (+928 B, 5800.0%), past the ±25% leg tolerance (±4 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 944 B against a cohort median of 16 B (+928 B, 5800.0%), past the ±25% leg tolerance (±4 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 186.66666666666666,
+            "cdpBracket": 29232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5380263,
+              5380279,
+              5380295,
+              5380311,
+              5380327,
+              5380343,
+              5380359,
+              5380375,
+              5381319,
+              5381335,
+              5381351,
+              5381367,
+              5381383,
+              5381399,
+              5381415
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5389199,
+              5389215,
+              5397279,
+              5397295,
+              5405359,
+              5405375,
+              5413439,
+              5413455,
+              5421519,
+              5421535,
+              5429599,
+              5429615,
+              5437679,
+              5437695,
+              5445759
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5384399,
+              5384415,
+              5387679,
+              5387695,
+              5390959,
+              5390975,
+              5394239,
+              5394255,
+              5397519,
+              5397535,
+              5400799,
+              5400815,
+              5404079,
+              5404095,
+              5407359
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118248,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19696,
+            "endpoints": 118248,
+            "legs": [
+              19684,
+              19684,
+              19696,
+              19696,
+              19696,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": -0.0006092607636068237,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6848,
+            "perWrite": 19708,
+            "perBoundaryPerWrite": 821.1666666666666,
+            "cdpBracket": 172772,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5452279,
+              5452295,
+              5478839,
+              5478855,
+              5498539,
+              5498555,
+              5518239,
+              5518255,
+              5537951,
+              5537967,
+              5557663,
+              5557679,
+              5577375,
+              5577391,
+              5597087
+            ],
+            "tick0": 189,
+            "tick": 196,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 115596,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19256,
+            "endpoints": 115596,
+            "legs": [
+              19256,
+              19256,
+              19220,
+              19256,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": -0.0018695471541337765,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19266,
+            "perBoundaryPerWrite": 802.75,
+            "cdpBracket": 169596,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5480415,
+              5480431,
+              5506471,
+              5506487,
+              5525743,
+              5525759,
+              5545015,
+              5545031,
+              5564251,
+              5564267,
+              5583523,
+              5583539,
+              5602795,
+              5602811,
+              5622067
+            ],
+            "tick0": 217,
+            "tick": 224,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 4,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5439471,
+              5439487,
+              5439503,
+              5439519,
+              5439535,
+              5439551,
+              5439567,
+              5439583,
+              5439599,
+              5439615,
+              5439631,
+              5439647,
+              5439663,
+              5439679,
+              5439695
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5447479,
+              5447495,
+              5455559,
+              5455575,
+              5463639,
+              5463655,
+              5471719,
+              5471735,
+              5479799,
+              5479815,
+              5487879,
+              5487895,
+              5495959,
+              5495975,
+              5504039
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5442679,
+              5442695,
+              5445959,
+              5445975,
+              5449239,
+              5449255,
+              5452519,
+              5452535,
+              5455799,
+              5455815,
+              5459079,
+              5459095,
+              5462359,
+              5462375,
+              5465639
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 417568,
+            "fall": 288496,
+            "falls": 1,
+            "maxStep": 335284,
+            "endpoints": 129072,
+            "legs": [
+              335284,
+              -288496,
+              21920,
+              19448,
+              19448,
+              21372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20410,
+            "legWorstDeviation": 15.427437530622244,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 335284 B against a cohort median of 20410 B (+314874 B, 1542.7%), past the ±25% leg tolerance (±5102.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -288496 B against a cohort median of 20410 B (-308906 B, -1513.5%), past the ±25% leg tolerance (±5102.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 335284 B against a cohort median of 20410 B (+314874 B, 1542.7%), past the ±25% leg tolerance (±5102.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -288496 B against a cohort median of 20410 B (-308906 B, -1513.5%), past the ±25% leg tolerance (±5102.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28008
+            ],
+            "primeExcess": 7598,
+            "perWrite": 69594.66666666667,
+            "perBoundaryPerWrite": 2899.777777777778,
+            "cdpBracket": 185168,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5613879,
+              5613895,
+              5641903,
+              5641919,
+              5977203,
+              5977219,
+              5688723,
+              5688739,
+              5710659,
+              5710675,
+              5730123,
+              5730139,
+              5749587,
+              5749603,
+              5770975
+            ],
+            "tick0": 245,
+            "tick": 252,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122864,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23408,
+            "endpoints": 122864,
+            "legs": [
+              19872,
+              19872,
+              19872,
+              23408,
+              19872,
+              19872
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19872,
+            "legWorstDeviation": 0.177938808373591,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26736
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20477.333333333332,
+            "perBoundaryPerWrite": 853.2222222222222,
+            "cdpBracket": 177580,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5703579,
+              5703595,
+              5730331,
+              5730347,
+              5750219,
+              5750235,
+              5770107,
+              5770123,
+              5789995,
+              5790011,
+              5813419,
+              5813435,
+              5833307,
+              5833323,
+              5853195
+            ],
+            "tick0": 273,
+            "tick": 280,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 5,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5664219,
+              5664235,
+              5664251,
+              5664267,
+              5664283,
+              5664299,
+              5664315,
+              5664331,
+              5664347,
+              5664363,
+              5664379,
+              5664395,
+              5664411,
+              5664427,
+              5664443
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5672227,
+              5672243,
+              5680307,
+              5680323,
+              5688387,
+              5688403,
+              5696467,
+              5696483,
+              5704547,
+              5704563,
+              5712627,
+              5712643,
+              5720707,
+              5720723,
+              5728787
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5667427,
+              5667443,
+              5670707,
+              5670723,
+              5673987,
+              5674003,
+              5677267,
+              5677283,
+              5680547,
+              5680563,
+              5683827,
+              5683843,
+              5687107,
+              5687123,
+              5690387
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122608,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21220,
+            "endpoints": 122608,
+            "legs": [
+              19872,
+              21056,
+              19872,
+              20620,
+              19872,
+              21220
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20246,
+            "legWorstDeviation": 0.04810826829991109,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26724
+            ],
+            "primeExcess": 6478,
+            "perWrite": 20434.666666666668,
+            "perBoundaryPerWrite": 851.4444444444445,
+            "cdpBracket": 177312,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5723447,
+              5723463,
+              5750187,
+              5750203,
+              5770075,
+              5770091,
+              5791147,
+              5791163,
+              5811035,
+              5811051,
+              5831671,
+              5831687,
+              5851559,
+              5851575,
+              5872795
+            ],
+            "tick0": 301,
+            "tick": 308,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116580,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19416,
+            "endpoints": 116580,
+            "legs": [
+              19404,
+              19416,
+              19416,
+              19416,
+              19416,
+              19416
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19416,
+            "legWorstDeviation": -0.0006180469715698393,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26216
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19430,
+            "perBoundaryPerWrite": 809.5833333333334,
+            "cdpBracket": 170756,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5742663,
+              5742679,
+              5768895,
+              5768911,
+              5788315,
+              5788331,
+              5807747,
+              5807763,
+              5827179,
+              5827195,
+              5846611,
+              5846627,
+              5866043,
+              5866059,
+              5885475
+            ],
+            "tick0": 329,
+            "tick": 336,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 6,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5701719,
+              5701735,
+              5701751,
+              5701767,
+              5701783,
+              5701799,
+              5701815,
+              5701831,
+              5701847,
+              5701863,
+              5701879,
+              5701895,
+              5701911,
+              5701927,
+              5701943
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5709727,
+              5709743,
+              5717807,
+              5717823,
+              5725887,
+              5725903,
+              5733967,
+              5733983,
+              5742047,
+              5742063,
+              5750127,
+              5750143,
+              5758207,
+              5758223,
+              5766287
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5704927,
+              5704943,
+              5708207,
+              5708223,
+              5711487,
+              5711503,
+              5714767,
+              5714783,
+              5718047,
+              5718063,
+              5721327,
+              5721343,
+              5724607,
+              5724623,
+              5727887
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 118808,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20864,
+            "endpoints": 118808,
+            "legs": [
+              19400,
+              19812,
+              19836,
+              20864,
+              19400,
+              19400
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19606,
+            "legWorstDeviation": 0.06416403141895338,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26188
+            ],
+            "primeExcess": 6582,
+            "perWrite": 19801.333333333332,
+            "perBoundaryPerWrite": 825.0555555555555,
+            "cdpBracket": 173084,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5766867,
+              5766883,
+              5793071,
+              5793087,
+              5812487,
+              5812503,
+              5832315,
+              5832331,
+              5852167,
+              5852183,
+              5873047,
+              5873063,
+              5892463,
+              5892479,
+              5911879
+            ],
+            "tick0": 357,
+            "tick": 364,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119124,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19840,
+            "endpoints": 119124,
+            "legs": [
+              19840,
+              19828,
+              19840,
+              19840,
+              19840,
+              19840
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19840,
+            "legWorstDeviation": -0.0006048387096774194,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26704
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19854,
+            "perBoundaryPerWrite": 827.25,
+            "cdpBracket": 173808,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5793395,
+              5793411,
+              5820115,
+              5820131,
+              5839971,
+              5839987,
+              5859815,
+              5859831,
+              5879671,
+              5879687,
+              5899527,
+              5899543,
+              5919383,
+              5919399,
+              5939239
+            ],
+            "tick0": 385,
+            "tick": 392,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 7,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5752431,
+              5752447,
+              5752463,
+              5752479,
+              5752495,
+              5752511,
+              5752527,
+              5752543,
+              5752559,
+              5752575,
+              5752591,
+              5752607,
+              5752623,
+              5752639,
+              5752655
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 268868,
+            "fall": 219880,
+            "falls": 1,
+            "maxStep": 226260,
+            "endpoints": 48988,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              10272,
+              -219880,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              226260,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": -28.26686507936508,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 10272 B against a cohort median of 8064 B (+2208 B, 27.4%), past the ±25% leg tolerance (±2016 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -219880 B against a cohort median of 8064 B (-227944 B, -2826.7%), past the ±25% leg tolerance (±2016 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 10272 B against a cohort median of 8064 B (+2208 B, 27.4%), past the ±25% leg tolerance (±2016 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -219880 B against a cohort median of 8064 B (-227944 B, -2826.7%), past the ±25% leg tolerance (±2016 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 44811.333333333336,
+            "cdpBracket": 85132,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5760439,
+              5760455,
+              5768519,
+              5768535,
+              5776599,
+              5776615,
+              5784679,
+              5784695,
+              5792759,
+              5792775,
+              5803047,
+              6029307,
+              5809427,
+              5809443,
+              5817507
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5756147,
+              5756163,
+              5759427,
+              5759443,
+              5762707,
+              5762723,
+              5765987,
+              5766003,
+              5769267,
+              5769283,
+              5772547,
+              5772563,
+              5775827,
+              5775843,
+              5779107
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 510848,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 410868,
+            "endpoints": 510848,
+            "legs": [
+              19832,
+              19820,
+              19820,
+              19832,
+              20580,
+              410868
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19832,
+            "legWorstDeviation": 19.717426381605485,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 410868 B against a cohort median of 19832 B (+391036 B, 1971.7%), past the ±25% leg tolerance (±4958 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 410868 B against a cohort median of 19832 B (+391036 B, 1971.7%), past the ±25% leg tolerance (±4958 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26696
+            ],
+            "primeExcess": 6864,
+            "perWrite": 85141.33333333333,
+            "perBoundaryPerWrite": 3547.555555555555,
+            "cdpBracket": 183064,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5825375,
+              5825391,
+              5852087,
+              5852103,
+              5871935,
+              5871951,
+              5891771,
+              5891787,
+              5911607,
+              5911623,
+              5931455,
+              5931471,
+              5952051,
+              5952067,
+              6362935
+            ],
+            "tick0": 413,
+            "tick": 420,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116352,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19380,
+            "endpoints": 116352,
+            "legs": [
+              19380,
+              19380,
+              19380,
+              19380,
+              19380,
+              19356
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19380,
+            "legWorstDeviation": -0.001238390092879257,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26192
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19392,
+            "perBoundaryPerWrite": 808,
+            "cdpBracket": 174428,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5842239,
+              5842255,
+              5868447,
+              5868463,
+              5887843,
+              5887859,
+              5907239,
+              5907255,
+              5926635,
+              5926651,
+              5946031,
+              5946047,
+              5965427,
+              5965443,
+              5984799
+            ],
+            "tick0": 441,
+            "tick": 448,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 8,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5805219,
+              5805235,
+              5805251,
+              5805267,
+              5805283,
+              5805299,
+              5805315,
+              5805331,
+              5805347,
+              5805363,
+              5805379,
+              5805395,
+              5805411,
+              5805427,
+              5805443
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5813227,
+              5813243,
+              5821307,
+              5821323,
+              5829387,
+              5829403,
+              5837467,
+              5837483,
+              5845547,
+              5845563,
+              5853627,
+              5853643,
+              5861707,
+              5861723,
+              5869787
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5808427,
+              5808443,
+              5811707,
+              5811723,
+              5814987,
+              5815003,
+              5818267,
+              5818283,
+              5821547,
+              5821563,
+              5824827,
+              5824843,
+              5828107,
+              5828123,
+              5831387
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 118896,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21104,
+            "endpoints": 118896,
+            "legs": [
+              21104,
+              19392,
+              19392,
+              19392,
+              20128,
+              19392
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19392,
+            "legWorstDeviation": 0.08828382838283828,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26192
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19816,
+            "perBoundaryPerWrite": 825.6666666666666,
+            "cdpBracket": 173176,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5875051,
+              5875067,
+              5901259,
+              5901275,
+              5922379,
+              5922395,
+              5941787,
+              5941803,
+              5961195,
+              5961211,
+              5980603,
+              5980619,
+              6000747,
+              6000763,
+              6020155
+            ],
+            "tick0": 469,
+            "tick": 476,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 466124,
+            "fall": 337688,
+            "falls": 2,
+            "maxStep": 212156,
+            "endpoints": 128436,
+            "legs": [
+              19820,
+              22320,
+              20204,
+              20732,
+              212156,
+              -332392
+            ],
+            "gaps": [
+              16,
+              16,
+              5776,
+              16,
+              -5296,
+              165068
+            ],
+            "legMedian": 20468,
+            "legWorstDeviation": -17.239593511823333,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read 212156 B against a cohort median of 20468 B (+191688 B, 936.5%), past the ±25% leg tolerance (±5117 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read -332392 B against a cohort median of 20468 B (-352860 B, -1724.0%), past the ±25% leg tolerance (±5117 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read 212156 B against a cohort median of 20468 B (+191688 B, 936.5%), past the ±25% leg tolerance (±5117 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read -332392 B against a cohort median of 20468 B (-352860 B, -1724.0%), past the ±25% leg tolerance (±5117 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26696
+            ],
+            "primeExcess": 6228,
+            "perWrite": 77687.33333333333,
+            "perBoundaryPerWrite": 3236.972222222222,
+            "cdpBracket": 183112,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5910411,
+              5910427,
+              5937123,
+              5937139,
+              5956959,
+              5956975,
+              5979295,
+              5985071,
+              6005275,
+              6005291,
+              6026023,
+              6020727,
+              6232883,
+              6397951,
+              6065559
+            ],
+            "tick0": 497,
+            "tick": 504,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 9,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5877411,
+              5877427,
+              5877443,
+              5877459,
+              5877475,
+              5877491,
+              5877507,
+              5877523,
+              5877539,
+              5877555,
+              5877571,
+              5877587,
+              5877603,
+              5877619,
+              5877635
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5885419,
+              5885435,
+              5893499,
+              5893515,
+              5901579,
+              5901595,
+              5909659,
+              5909675,
+              5917739,
+              5917755,
+              5925819,
+              5925835,
+              5933899,
+              5933915,
+              5941979
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5880619,
+              5880635,
+              5883899,
+              5883915,
+              5887179,
+              5887195,
+              5890459,
+              5890475,
+              5893739,
+              5893755,
+              5897019,
+              5897035,
+              5900299,
+              5900315,
+              5903579
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 123932,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24740,
+            "endpoints": 123932,
+            "legs": [
+              19824,
+              19824,
+              19812,
+              19812,
+              24740,
+              19824
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.24798224374495562,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20655.333333333332,
+            "perBoundaryPerWrite": 860.6388888888888,
+            "cdpBracket": 178600,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5953003,
+              5953019,
+              5979707,
+              5979723,
+              5999547,
+              5999563,
+              6019387,
+              6019403,
+              6039215,
+              6039231,
+              6059043,
+              6059059,
+              6083799,
+              6083815,
+              6103639
+            ],
+            "tick0": 525,
+            "tick": 532,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116364,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116364,
+            "legs": [
+              19372,
+              19384,
+              19384,
+              19372,
+              19372,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": -0.0003096294767261843,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6794,
+            "perWrite": 19394,
+            "perBoundaryPerWrite": 808.0833333333334,
+            "cdpBracket": 177076,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5958091,
+              5958107,
+              5984279,
+              5984295,
+              6003667,
+              6003683,
+              6023067,
+              6023083,
+              6042467,
+              6042483,
+              6061855,
+              6061871,
+              6081243,
+              6081259,
+              6100643
+            ],
+            "tick0": 553,
+            "tick": 560,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 10,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5923811,
+              5923827,
+              5923843,
+              5923859,
+              5923875,
+              5923891,
+              5923907,
+              5923923,
+              5923939,
+              5923955,
+              5923971,
+              5923987,
+              5924003,
+              5924019,
+              5924035
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5931819,
+              5931835,
+              5939899,
+              5939915,
+              5947979,
+              5947995,
+              5956059,
+              5956075,
+              5964139,
+              5964155,
+              5972219,
+              5972235,
+              5980299,
+              5980315,
+              5988379
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5927019,
+              5927035,
+              5930299,
+              5930315,
+              5933579,
+              5933595,
+              5936859,
+              5936875,
+              5940139,
+              5940155,
+              5943419,
+              5943435,
+              5946699,
+              5946715,
+              5949979
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117124,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20120,
+            "endpoints": 117124,
+            "legs": [
+              19384,
+              19372,
+              19384,
+              19384,
+              20120,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19384,
+            "legWorstDeviation": 0.037969459347915804,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19520.666666666668,
+            "perBoundaryPerWrite": 813.3611111111112,
+            "cdpBracket": 171396,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5984539,
+              5984555,
+              6010739,
+              6010755,
+              6030139,
+              6030155,
+              6049527,
+              6049543,
+              6068927,
+              6068943,
+              6088327,
+              6088343,
+              6108463,
+              6108479,
+              6127863
+            ],
+            "tick0": 581,
+            "tick": 588,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119064,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19832,
+            "endpoints": 119064,
+            "legs": [
+              19832,
+              19832,
+              19832,
+              19832,
+              19820,
+              19820
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19832,
+            "legWorstDeviation": -0.0006050826946349334,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26696
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19844,
+            "perBoundaryPerWrite": 826.8333333333334,
+            "cdpBracket": 175232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5995143,
+              5995159,
+              6021855,
+              6021871,
+              6041703,
+              6041719,
+              6061551,
+              6061567,
+              6081399,
+              6081415,
+              6101247,
+              6101263,
+              6121083,
+              6121099,
+              6140919
+            ],
+            "tick0": 609,
+            "tick": 616,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 11,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5954179,
+              5954195,
+              5954211,
+              5954227,
+              5954243,
+              5954259,
+              5954275,
+              5954291,
+              5954307,
+              5954323,
+              5954339,
+              5954355,
+              5954371,
+              5954387,
+              5954403
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5962187,
+              5962203,
+              5970267,
+              5970283,
+              5978347,
+              5978363,
+              5986427,
+              5986443,
+              5994507,
+              5994523,
+              6002587,
+              6002603,
+              6010667,
+              6010683,
+              6018747
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5957387,
+              5957403,
+              5960667,
+              5960683,
+              5963947,
+              5963963,
+              5967227,
+              5967243,
+              5970507,
+              5970523,
+              5973787,
+              5973803,
+              5977067,
+              5977083,
+              5980347
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119776,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20572,
+            "endpoints": 119776,
+            "legs": [
+              19812,
+              19824,
+              19824,
+              19824,
+              20572,
+              19824
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.0377320419693301,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26676
+            ],
+            "primeExcess": 6852,
+            "perWrite": 19962.666666666668,
+            "perBoundaryPerWrite": 831.7777777777778,
+            "cdpBracket": 174432,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6005083,
+              6005099,
+              6031775,
+              6031791,
+              6051603,
+              6051619,
+              6071443,
+              6071459,
+              6091283,
+              6091299,
+              6111123,
+              6111139,
+              6131711,
+              6131727,
+              6151551
+            ],
+            "tick0": 637,
+            "tick": 644,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116328,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116328,
+            "legs": [
+              19372,
+              19372,
+              19372,
+              19384,
+              19384,
+              19348
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": -0.0012389015073301672,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              31668
+            ],
+            "primeExcess": 12296,
+            "perWrite": 19388,
+            "perBoundaryPerWrite": 807.8333333333334,
+            "cdpBracket": 177168,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6025171,
+              6025187,
+              6056855,
+              6056871,
+              6076243,
+              6076259,
+              6095631,
+              6095647,
+              6115019,
+              6115035,
+              6134419,
+              6134435,
+              6153819,
+              6153835,
+              6173183
+            ],
+            "tick0": 665,
+            "tick": 672,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 12,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5989579,
+              5989595,
+              5989611,
+              5989627,
+              5989643,
+              5989659,
+              5989675,
+              5989691,
+              5989707,
+              5989723,
+              5989739,
+              5989755,
+              5989771,
+              5989787,
+              5989803
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5997587,
+              5997603,
+              6005667,
+              6005683,
+              6013747,
+              6013763,
+              6021827,
+              6021843,
+              6029907,
+              6029923,
+              6037987,
+              6038003,
+              6046067,
+              6046083,
+              6054147
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5992787,
+              5992803,
+              5996067,
+              5996083,
+              5999347,
+              5999363,
+              6002627,
+              6002643,
+              6005907,
+              6005923,
+              6009187,
+              6009203,
+              6012467,
+              6012483,
+              6015747
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 261724,
+            "fall": 144636,
+            "falls": 1,
+            "maxStep": 164772,
+            "endpoints": 117088,
+            "legs": [
+              19372,
+              19384,
+              19372,
+              19372,
+              19372,
+              -144636
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              164772
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": -8.466239933925253,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read -144636 B against a cohort median of 19372 B (-164008 B, -846.6%), past the ±25% leg tolerance (±4843 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read -144636 B against a cohort median of 19372 B (-164008 B, -846.6%), past the ±25% leg tolerance (±4843 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 43620.666666666664,
+            "perBoundaryPerWrite": 1817.5277777777776,
+            "cdpBracket": 171344,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6059095,
+              6059111,
+              6085295,
+              6085311,
+              6104683,
+              6104699,
+              6124083,
+              6124099,
+              6143471,
+              6143487,
+              6162859,
+              6162875,
+              6182247,
+              6347019,
+              6202383
+            ],
+            "tick0": 693,
+            "tick": 700,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118968,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 118968,
+            "legs": [
+              19812,
+              19824,
+              19812,
+              19824,
+              19788,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": -0.0012113870381586917,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6876,
+            "perWrite": 19828,
+            "perBoundaryPerWrite": 826.1666666666666,
+            "cdpBracket": 173620,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6087991,
+              6088007,
+              6114695,
+              6114711,
+              6134523,
+              6134539,
+              6154363,
+              6154379,
+              6174191,
+              6174207,
+              6194031,
+              6194047,
+              6213835,
+              6213851,
+              6233663
+            ],
+            "tick0": 721,
+            "tick": 728,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 13,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 31952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6047027,
+              6047043,
+              6047059,
+              6047075,
+              6047091,
+              6047107,
+              6047123,
+              6047139,
+              6047155,
+              6047171,
+              6047187,
+              6047203,
+              6047219,
+              6047235,
+              6047251
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6059055,
+              6059071,
+              6067135,
+              6067151,
+              6075215,
+              6075231,
+              6083295,
+              6083311,
+              6091375,
+              6091391,
+              6099455,
+              6099471,
+              6107535,
+              6107551,
+              6115615
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6054255,
+              6054271,
+              6057535,
+              6057551,
+              6060815,
+              6060831,
+              6064095,
+              6064111,
+              6067375,
+              6067391,
+              6070655,
+              6070671,
+              6073935,
+              6073951,
+              6077215
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119740,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20560,
+            "endpoints": 119740,
+            "legs": [
+              19824,
+              19812,
+              19812,
+              19812,
+              19824,
+              20560
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 0.037440710465233625,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6870,
+            "perWrite": 19956.666666666668,
+            "perBoundaryPerWrite": 831.5277777777778,
+            "cdpBracket": 174392,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6101631,
+              6101647,
+              6128335,
+              6128351,
+              6148175,
+              6148191,
+              6168003,
+              6168019,
+              6187831,
+              6187847,
+              6207659,
+              6207675,
+              6227499,
+              6227515,
+              6248075
+            ],
+            "tick0": 749,
+            "tick": 756,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116352,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116352,
+            "legs": [
+              19372,
+              19372,
+              19372,
+              19384,
+              19384,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0006194507536650836,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19392,
+            "perBoundaryPerWrite": 808,
+            "cdpBracket": 170480,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6104671,
+              6104687,
+              6130871,
+              6130887,
+              6150259,
+              6150275,
+              6169647,
+              6169663,
+              6189035,
+              6189051,
+              6208435,
+              6208451,
+              6227835,
+              6227851,
+              6247223
+            ],
+            "tick0": 777,
+            "tick": 784,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 14,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6063715,
+              6063731,
+              6063747,
+              6063763,
+              6063779,
+              6063795,
+              6063811,
+              6063827,
+              6063843,
+              6063859,
+              6063875,
+              6063891,
+              6063907,
+              6063923,
+              6063939
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6071723,
+              6071739,
+              6079803,
+              6079819,
+              6087883,
+              6087899,
+              6095963,
+              6095979,
+              6104043,
+              6104059,
+              6112123,
+              6112139,
+              6120203,
+              6120219,
+              6128283
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6066923,
+              6066939,
+              6070203,
+              6070219,
+              6073483,
+              6073499,
+              6076763,
+              6076779,
+              6080043,
+              6080059,
+              6083323,
+              6083339,
+              6086603,
+              6086619,
+              6089883
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 268876,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 171896,
+            "endpoints": 268876,
+            "legs": [
+              19372,
+              19372,
+              19384,
+              19384,
+              19372,
+              171896
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 7.870678088554031,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 171896 B against a cohort median of 19378 B (+152518 B, 787.1%), past the ±25% leg tolerance (±4844.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 171896 B against a cohort median of 19378 B (+152518 B, 787.1%), past the ±25% leg tolerance (±4844.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6806,
+            "perWrite": 44812.666666666664,
+            "perBoundaryPerWrite": 1867.1944444444443,
+            "cdpBracket": 176108,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6113827,
+              6113843,
+              6140027,
+              6140043,
+              6159415,
+              6159431,
+              6178803,
+              6178819,
+              6198203,
+              6198219,
+              6217603,
+              6217619,
+              6236991,
+              6237007,
+              6408903
+            ],
+            "tick0": 805,
+            "tick": 812,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119016,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 119016,
+            "legs": [
+              19812,
+              19824,
+              19824,
+              19824,
+              19812,
+              19824
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": -0.0006053268765133172,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26676
+            ],
+            "primeExcess": 6852,
+            "perWrite": 19836,
+            "perBoundaryPerWrite": 826.5,
+            "cdpBracket": 173656,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6130535,
+              6130551,
+              6157227,
+              6157243,
+              6177055,
+              6177071,
+              6196895,
+              6196911,
+              6216735,
+              6216751,
+              6236575,
+              6236591,
+              6256403,
+              6256419,
+              6276243
+            ],
+            "tick0": 833,
+            "tick": 840,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 15,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6089571,
+              6089587,
+              6089603,
+              6089619,
+              6089635,
+              6089651,
+              6089667,
+              6089683,
+              6089699,
+              6089715,
+              6089731,
+              6089747,
+              6089763,
+              6089779,
+              6089795
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6097579,
+              6097595,
+              6105659,
+              6105675,
+              6113739,
+              6113755,
+              6121819,
+              6121835,
+              6129899,
+              6129915,
+              6137979,
+              6137995,
+              6146059,
+              6146075,
+              6154139
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6092779,
+              6092795,
+              6096059,
+              6096075,
+              6099339,
+              6099355,
+              6102619,
+              6102635,
+              6105899,
+              6105915,
+              6109179,
+              6109195,
+              6112459,
+              6112475,
+              6115739
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 355432,
+            "fall": 231780,
+            "falls": 1,
+            "maxStep": 253936,
+            "endpoints": 123652,
+            "legs": [
+              19824,
+              19812,
+              19812,
+              19824,
+              253936,
+              22144
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              -231780
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 11.80952380952381,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read 253936 B against a cohort median of 19824 B (+234112 B, 1181.0%), past the ±25% leg tolerance (±4956 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read 253936 B against a cohort median of 19824 B (+234112 B, 1181.0%), past the ±25% leg tolerance (±4956 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 59238.666666666664,
+            "perBoundaryPerWrite": 2468.277777777778,
+            "cdpBracket": 178304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6144219,
+              6144235,
+              6170923,
+              6170939,
+              6190763,
+              6190779,
+              6210591,
+              6210607,
+              6230419,
+              6230435,
+              6250259,
+              6250275,
+              6504211,
+              6272431,
+              6294575
+            ],
+            "tick0": 861,
+            "tick": 868,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116328,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116328,
+            "legs": [
+              19384,
+              19372,
+              19384,
+              19372,
+              19348,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": -0.0012389015073301672,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19388,
+            "perBoundaryPerWrite": 807.8333333333334,
+            "cdpBracket": 170456,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6153787,
+              6153803,
+              6179987,
+              6180003,
+              6199387,
+              6199403,
+              6218775,
+              6218791,
+              6238175,
+              6238191,
+              6257563,
+              6257579,
+              6276927,
+              6276943,
+              6296315
+            ],
+            "tick0": 889,
+            "tick": 896,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 16,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6107727,
+              6107743,
+              6107759,
+              6107775,
+              6107791,
+              6107807,
+              6107823,
+              6107839,
+              6107855,
+              6107871,
+              6107887,
+              6107903,
+              6107919,
+              6107935,
+              6107951
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6115735,
+              6115751,
+              6123815,
+              6123831,
+              6131895,
+              6131911,
+              6139975,
+              6139991,
+              6148055,
+              6148071,
+              6156135,
+              6156151,
+              6164215,
+              6164231,
+              6172295
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6110935,
+              6110951,
+              6114215,
+              6114231,
+              6117495,
+              6117511,
+              6120775,
+              6120791,
+              6124055,
+              6124071,
+              6127335,
+              6127351,
+              6130615,
+              6130631,
+              6133895
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 119316,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 119316,
+            "legs": [
+              19372,
+              19384,
+              19372,
+              19372,
+              17968,
+              19300
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              4468,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": -0.07247573817881478,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19886,
+            "perBoundaryPerWrite": 828.5833333333334,
+            "cdpBracket": 173560,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6150883,
+              6150899,
+              6177071,
+              6177087,
+              6196459,
+              6196475,
+              6215859,
+              6215875,
+              6235247,
+              6235263,
+              6254635,
+              6259103,
+              6277071,
+              6277087,
+              6296387
+            ],
+            "tick0": 917,
+            "tick": 924,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 124260,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23720,
+            "endpoints": 124260,
+            "legs": [
+              21172,
+              19824,
+              23720,
+              19824,
+              19812,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.19652945924132365,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20710,
+            "perBoundaryPerWrite": 862.9166666666666,
+            "cdpBracket": 179656,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6169743,
+              6169759,
+              6196447,
+              6196463,
+              6217635,
+              6217651,
+              6237475,
+              6237491,
+              6261211,
+              6261227,
+              6281051,
+              6281067,
+              6300879,
+              6300895,
+              6320707
+            ],
+            "tick0": 945,
+            "tick": 952,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "reagent-subs",
+          "uix-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "reagent-subs|grid/floor",
+          "uix-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 17,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6127271,
+              6127287,
+              6127303,
+              6127319,
+              6127335,
+              6127351,
+              6127367,
+              6127383,
+              6127399,
+              6127415,
+              6127431,
+              6127447,
+              6127463,
+              6127479,
+              6127495
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6135279,
+              6135295,
+              6143359,
+              6143375,
+              6151439,
+              6151455,
+              6159519,
+              6159535,
+              6167599,
+              6167615,
+              6175679,
+              6175695,
+              6183759,
+              6183775,
+              6191839
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6130479,
+              6130495,
+              6133759,
+              6133775,
+              6137039,
+              6137055,
+              6140319,
+              6140335,
+              6143599,
+              6143615,
+              6146879,
+              6146895,
+              6150159,
+              6150175,
+              6153439
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122496,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22720,
+            "endpoints": 122496,
+            "legs": [
+              19828,
+              19816,
+              19828,
+              22720,
+              20464,
+              19744
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19828,
+            "legWorstDeviation": 0.14585434738753278,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26680
+            ],
+            "primeExcess": 6852,
+            "perWrite": 20416,
+            "perBoundaryPerWrite": 850.6666666666666,
+            "cdpBracket": 177140,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6187107,
+              6187123,
+              6213803,
+              6213819,
+              6233647,
+              6233663,
+              6253479,
+              6253495,
+              6273323,
+              6273339,
+              6296059,
+              6296075,
+              6316539,
+              6316555,
+              6336299
+            ],
+            "tick0": 973,
+            "tick": 980,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116400,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116400,
+            "legs": [
+              19384,
+              19384,
+              19384,
+              19384,
+              19384,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19384,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6788,
+            "perWrite": 19400,
+            "perBoundaryPerWrite": 808.3333333333334,
+            "cdpBracket": 170516,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6191895,
+              6191911,
+              6218083,
+              6218099,
+              6237483,
+              6237499,
+              6256883,
+              6256899,
+              6276283,
+              6276299,
+              6295683,
+              6295699,
+              6315083,
+              6315099,
+              6334483
+            ],
+            "tick0": 1001,
+            "tick": 1008,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      }
+    ],
+    "allocFits": {
+      "perRound": {},
+      "mean": {}
+    },
+    "writeDriven": true,
+    "writeProvenance": {
+      "windows": 36,
+      "pairs": 36,
+      "unnamed": [],
+      "incomplete": [],
+      "ok": true
+    },
+    "controlVerdict": {
+      "ok": true,
+      "perDouble": 10.121518518518519,
+      "differential": 11.40253086419753
+    },
+    "fallsInMeasuredWindows": 10,
+    "refusedWindows": 11,
+    "refusalReasons": 17
+  },
+  "box": {
+    "bead": "rf2-24o2z",
+    "chromium": "chromium/147.0.7727.15",
+    "node": "v24.13.0",
+    "platform": "win32/x64/10.0.26200",
+    "load": {
+      "open": {
+        "at": "2026-08-20T20:39:01.121Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13485506769,
+        "cpuBusyMs": 3632206327,
+        "freeMemB": 16139333632,
+        "totalMemB": 68112736256,
+        "uptimeS": 709503.921
+      },
+      "close": {
+        "at": "2026-08-20T20:39:27.357Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13486002349,
+        "cpuBusyMs": 3632343318,
+        "freeMemB": 15709028352,
+        "totalMemB": 68112736256,
+        "uptimeS": 709530.156
+      },
+      "busyFraction": 0.21656225151010716
+    },
+    "session": {
+      "startedAt": "2026-08-20T20:38:19.932Z",
+      "sessionStartedAt": "2026-08-20T19:39:26.627Z",
+      "runsInSession": 17,
+      "sessionGapMs": 3600000,
+      "previousRun": {
+        "startedAt": "2026-08-20T20:37:12.274Z",
+        "endedAt": "2026-08-20T20:38:19.525Z",
+        "sinceStartMs": 67658,
+        "sinceEndMs": 407,
+        "sameSession": true
+      }
+    }
+  }
+}

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/reversed-1.json
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/reversed-1.json
@@ -1,0 +1,7523 @@
+{
+  "generatedAt": "2026-08-20T20:23:50.008Z",
+  "build": "hicasso-bench",
+  "initFn": "re-frame.bench.p0-app/-main",
+  "alloc": {
+    "benchmark": "P0:steady-state-allocation-slope",
+    "bead": "rf2-2rtt6.76",
+    "roots": 4,
+    "perRoot": {
+      "list": 300,
+      "grid": 6
+    },
+    "publishedPerRoot": {
+      "list": 300,
+      "grid": 300
+    },
+    "arm": {
+      "cells": 6,
+      "roots": 4,
+      "boundaries": 24,
+      "writes": 6,
+      "refusals": [],
+      "admissible": true
+    },
+    "boundaries": 24,
+    "writes": 6,
+    "primeWrites": 1,
+    "windowWrites": 7,
+    "bySite": false,
+    "sites": 2,
+    "siteNames": [
+      "dispatch",
+      "drain"
+    ],
+    "warmups": 3,
+    "rounds": 18,
+    "preciseMemory": true,
+    "controlDoubles": {
+      "d1": 1000,
+      "d2": 400
+    },
+    "controlSlack": 0.75,
+    "writeSelector": "all",
+    "writeLegs": [
+      "all"
+    ],
+    "writePaired": false,
+    "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+    "plan": {
+      "name": "floor",
+      "arms": true,
+      "rungs": false,
+      "fits": false
+    },
+    "segOrder": "fixed-reversed",
+    "passOrder": "parity",
+    "passSeed": "1787257386057",
+    "passSchedule": {
+      "flips": [
+        true,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true
+      ],
+      "attempts": 1,
+      "parityTied": false
+    },
+    "controlSlot": "first",
+    "instrument": "in-page performance.memory.usedJSHeapSize sampled at every leg boundary, rising steps accumulated separately from falling ones; --enable-precise-memory-info. A falling step is a collection this counter SAW; a leg that deviates from its cohort median by more than the leg tolerance is a work unit that is not one; and under the by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the other two can see. TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg has no interior reading and so no site step to be negative, and the intra-leg gate returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with these (see `bySite`), so a witness comparing byte for byte against a figure published at stride 2 can never be screened by all three",
+    "fallThresholdB": 600000,
+    "legTolerance": 0.25,
+    "verification": {
+      "unverified": 0,
+      "detail": []
+    },
+    "workCount": false,
+    "workVerification": {
+      "counted": false
+    },
+    "perRound": [
+      {
+        "round": 0,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 524,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              524
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 116.66666666666667,
+            "cdpBracket": 46232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3840294,
+              3840310,
+              3840326,
+              3840342,
+              3840358,
+              3840374,
+              3840390,
+              3840406,
+              3840422,
+              3840438,
+              3840454,
+              3840470,
+              3840486,
+              3841010,
+              3841026
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48576,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8144,
+            "endpoints": 48576,
+            "legs": [
+              8144,
+              8080,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.00992063492063492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8096,
+            "cdpBracket": 87388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3853918,
+              3853934,
+              3861998,
+              3862014,
+              3870158,
+              3870174,
+              3878254,
+              3878270,
+              3886334,
+              3886350,
+              3894414,
+              3894430,
+              3902494,
+              3902510,
+              3910574
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 52328,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3850018,
+              3850034,
+              3853298,
+              3853314,
+              3856578,
+              3856594,
+              3859858,
+              3859874,
+              3863138,
+              3863154,
+              3866418,
+              3866434,
+              3869698,
+              3869714,
+              3872978
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 366988,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 253972,
+            "endpoints": 366988,
+            "legs": [
+              20908,
+              20132,
+              28220,
+              20648,
+              23012,
+              253972
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21960,
+            "legWorstDeviation": 10.565209471766849,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 28220 B against a cohort median of 21960 B (+6260 B, 28.5%), past the ±25% leg tolerance (±5490 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read 253972 B against a cohort median of 21960 B (+232012 B, 1056.5%), past the ±25% leg tolerance (±5490 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 28220 B against a cohort median of 21960 B (+6260 B, 28.5%), past the ±25% leg tolerance (±5490 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read 253972 B against a cohort median of 21960 B (+232012 B, 1056.5%), past the ±25% leg tolerance (±5490 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28792
+            ],
+            "primeExcess": 6832,
+            "perWrite": 61164.666666666664,
+            "perBoundaryPerWrite": 2548.527777777778,
+            "cdpBracket": 190860,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              4798939,
+              4798955,
+              4827747,
+              4827763,
+              4848671,
+              4848687,
+              4868819,
+              4868835,
+              4897055,
+              4897071,
+              4917719,
+              4917735,
+              4940747,
+              4940763,
+              5194735
+            ],
+            "tick0": 21,
+            "tick": 28,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 549868,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 442544,
+            "endpoints": 549868,
+            "legs": [
+              24048,
+              20124,
+              21792,
+              21860,
+              19404,
+              442544
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21826,
+            "legWorstDeviation": 19.276001099605974,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 442544 B against a cohort median of 21826 B (+420718 B, 1927.6%), past the ±25% leg tolerance (±5456.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 442544 B against a cohort median of 21826 B (+420718 B, 1927.6%), past the ±25% leg tolerance (±5456.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26276
+            ],
+            "primeExcess": 4450,
+            "perWrite": 91644.66666666667,
+            "perBoundaryPerWrite": 3818.527777777778,
+            "cdpBracket": 194728,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5067171,
+              5067187,
+              5093463,
+              5093479,
+              5117527,
+              5117543,
+              5137667,
+              5137683,
+              5159475,
+              5159491,
+              5181351,
+              5181367,
+              5200771,
+              5200787,
+              5643331
+            ],
+            "tick0": 49,
+            "tick": 56,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 1,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5065919,
+              5065935,
+              5065951,
+              5065967,
+              5065983,
+              5065999,
+              5066015,
+              5066031,
+              5066047,
+              5066063,
+              5066079,
+              5066095,
+              5066111,
+              5066127,
+              5066143
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 87716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5073927,
+              5073943,
+              5082007,
+              5082023,
+              5090087,
+              5090103,
+              5098167,
+              5098183,
+              5106247,
+              5106263,
+              5114327,
+              5114343,
+              5122407,
+              5122423,
+              5130487
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5071371,
+              5071387,
+              5074651,
+              5074667,
+              5077931,
+              5077947,
+              5081211,
+              5081227,
+              5084491,
+              5084507,
+              5087771,
+              5087787,
+              5091051,
+              5091067,
+              5094331
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 732620,
+            "fall": 348384,
+            "falls": 1,
+            "maxStep": 369392,
+            "endpoints": 384236,
+            "legs": [
+              369392,
+              19772,
+              20588,
+              19772,
+              19772,
+              280700
+            ],
+            "gaps": [
+              16,
+              -348384,
+              16,
+              2560,
+              16,
+              16
+            ],
+            "legMedian": 20180,
+            "legWorstDeviation": 17.304856293359762,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 369392 B against a cohort median of 20180 B (+349212 B, 1730.5%), past the ±25% leg tolerance (±5045 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read 280700 B against a cohort median of 20180 B (+260520 B, 1291.0%), past the ±25% leg tolerance (±5045 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 369392 B against a cohort median of 20180 B (+349212 B, 1730.5%), past the ±25% leg tolerance (±5045 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 6 of 6 read 280700 B against a cohort median of 20180 B (+260520 B, 1291.0%), past the ±25% leg tolerance (±5045 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30976
+            ],
+            "primeExcess": 10796,
+            "perWrite": 122103.33333333333,
+            "perBoundaryPerWrite": 5087.638888888889,
+            "cdpBracket": 187760,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5200355,
+              5200371,
+              5231347,
+              5231363,
+              5600755,
+              5252371,
+              5272143,
+              5272159,
+              5292747,
+              5295307,
+              5315079,
+              5315095,
+              5334867,
+              5334883,
+              5615583
+            ],
+            "tick0": 77,
+            "tick": 84,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 122100,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23660,
+            "endpoints": 122100,
+            "legs": [
+              21608,
+              19184,
+              23660,
+              19184,
+              19184,
+              19184
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19184,
+            "legWorstDeviation": 0.23331943286071727,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6856,
+            "perWrite": 20350,
+            "perBoundaryPerWrite": 847.9166666666666,
+            "cdpBracket": 176556,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5302675,
+              5302691,
+              5328731,
+              5328747,
+              5350355,
+              5350371,
+              5369555,
+              5369571,
+              5393231,
+              5393247,
+              5412431,
+              5412447,
+              5431631,
+              5431647,
+              5450831
+            ],
+            "tick0": 105,
+            "tick": 112,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 2,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5266139,
+              5266155,
+              5266171,
+              5266187,
+              5266203,
+              5266219,
+              5266235,
+              5266251,
+              5266267,
+              5266283,
+              5266299,
+              5266315,
+              5266331,
+              5266347,
+              5266363
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85088,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5274163,
+              5274179,
+              5282243,
+              5282259,
+              5290323,
+              5290339,
+              5298403,
+              5298419,
+              5306483,
+              5306499,
+              5314563,
+              5314579,
+              5322643,
+              5322659,
+              5330723
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5269363,
+              5269379,
+              5272643,
+              5272659,
+              5275923,
+              5275939,
+              5279203,
+              5279219,
+              5282483,
+              5282499,
+              5285763,
+              5285779,
+              5289043,
+              5289059,
+              5292323
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119004,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20440,
+            "endpoints": 119004,
+            "legs": [
+              19696,
+              19696,
+              20440,
+              19696,
+              19696,
+              19684
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": 0.03777416734362307,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6848,
+            "perWrite": 19834,
+            "perBoundaryPerWrite": 826.4166666666666,
+            "cdpBracket": 176628,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5370031,
+              5370047,
+              5396591,
+              5396607,
+              5416303,
+              5416319,
+              5436015,
+              5436031,
+              5456471,
+              5456487,
+              5476183,
+              5476199,
+              5495895,
+              5495911,
+              5515595
+            ],
+            "tick0": 133,
+            "tick": 140,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117676,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20824,
+            "endpoints": 117676,
+            "legs": [
+              19768,
+              19256,
+              20824,
+              19220,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": 0.08142916493560448,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19612.666666666668,
+            "perBoundaryPerWrite": 817.1944444444445,
+            "cdpBracket": 171676,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5427743,
+              5427759,
+              5453799,
+              5453815,
+              5473583,
+              5473599,
+              5492855,
+              5492871,
+              5513695,
+              5513711,
+              5532931,
+              5532947,
+              5552203,
+              5552219,
+              5571475
+            ],
+            "tick0": 161,
+            "tick": 168,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 3,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 29120,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5388867,
+              5388883,
+              5388899,
+              5388915,
+              5388931,
+              5388947,
+              5388963,
+              5388979,
+              5388995,
+              5389011,
+              5389027,
+              5389043,
+              5389059,
+              5389075,
+              5389091
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5397803,
+              5397819,
+              5405883,
+              5405899,
+              5413963,
+              5413979,
+              5422043,
+              5422059,
+              5430123,
+              5430139,
+              5438203,
+              5438219,
+              5446283,
+              5446299,
+              5454363
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5393003,
+              5393019,
+              5396283,
+              5396299,
+              5399563,
+              5399579,
+              5402843,
+              5402859,
+              5406123,
+              5406139,
+              5409403,
+              5409419,
+              5412683,
+              5412699,
+              5415963
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118236,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19696,
+            "endpoints": 118236,
+            "legs": [
+              19660,
+              19696,
+              19696,
+              19696,
+              19696,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": -0.0018277822908204712,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6848,
+            "perWrite": 19706,
+            "perBoundaryPerWrite": 821.0833333333334,
+            "cdpBracket": 172760,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5454427,
+              5454443,
+              5480987,
+              5481003,
+              5500663,
+              5500679,
+              5520375,
+              5520391,
+              5540087,
+              5540103,
+              5559799,
+              5559815,
+              5579511,
+              5579527,
+              5599223
+            ],
+            "tick0": 189,
+            "tick": 196,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 115596,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19256,
+            "endpoints": 115596,
+            "legs": [
+              19256,
+              19256,
+              19256,
+              19256,
+              19220,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": -0.0018695471541337765,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19266,
+            "perBoundaryPerWrite": 802.75,
+            "cdpBracket": 169596,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5488947,
+              5488963,
+              5515003,
+              5515019,
+              5534275,
+              5534291,
+              5553547,
+              5553563,
+              5572819,
+              5572835,
+              5592091,
+              5592107,
+              5611327,
+              5611343,
+              5630599
+            ],
+            "tick0": 217,
+            "tick": 224,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 4,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5448003,
+              5448019,
+              5448035,
+              5448051,
+              5448067,
+              5448083,
+              5448099,
+              5448115,
+              5448131,
+              5448147,
+              5448163,
+              5448179,
+              5448195,
+              5448211,
+              5448227
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5456011,
+              5456027,
+              5464091,
+              5464107,
+              5472171,
+              5472187,
+              5480251,
+              5480267,
+              5488331,
+              5488347,
+              5496411,
+              5496427,
+              5504491,
+              5504507,
+              5512571
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5451211,
+              5451227,
+              5454491,
+              5454507,
+              5457771,
+              5457787,
+              5461051,
+              5461067,
+              5464331,
+              5464347,
+              5467611,
+              5467627,
+              5470891,
+              5470907,
+              5474171
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 135264,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 26592,
+            "endpoints": 135264,
+            "legs": [
+              26592,
+              24184,
+              20632,
+              20620,
+              22532,
+              20608
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21582,
+            "legWorstDeviation": 0.23213789268835142,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29244
+            ],
+            "primeExcess": 7662,
+            "perWrite": 22544,
+            "perBoundaryPerWrite": 939.3333333333334,
+            "cdpBracket": 192616,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5627927,
+              5627943,
+              5657187,
+              5657203,
+              5683795,
+              5683811,
+              5707995,
+              5708011,
+              5728643,
+              5728659,
+              5749279,
+              5749295,
+              5771827,
+              5771843,
+              5792451
+            ],
+            "tick0": 245,
+            "tick": 252,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 123680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22860,
+            "endpoints": 123680,
+            "legs": [
+              20152,
+              20152,
+              20152,
+              22860,
+              20152,
+              20116
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20152,
+            "legWorstDeviation": 0.13437872171496626,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26940
+            ],
+            "primeExcess": 6788,
+            "perWrite": 20613.333333333332,
+            "perBoundaryPerWrite": 858.8888888888888,
+            "cdpBracket": 179324,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5711407,
+              5711423,
+              5738363,
+              5738379,
+              5758531,
+              5758547,
+              5778699,
+              5778715,
+              5798867,
+              5798883,
+              5821743,
+              5821759,
+              5841911,
+              5841927,
+              5862043
+            ],
+            "tick0": 273,
+            "tick": 280,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 5,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5671191,
+              5671207,
+              5671223,
+              5671239,
+              5671255,
+              5671271,
+              5671287,
+              5671303,
+              5671319,
+              5671335,
+              5671351,
+              5671367,
+              5671383,
+              5671399,
+              5671415
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5679199,
+              5679215,
+              5687279,
+              5687295,
+              5695359,
+              5695375,
+              5703439,
+              5703455,
+              5711519,
+              5711535,
+              5719599,
+              5719615,
+              5727679,
+              5727695,
+              5735759
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5674399,
+              5674415,
+              5677679,
+              5677695,
+              5680959,
+              5680975,
+              5684239,
+              5684255,
+              5687519,
+              5687535,
+              5690799,
+              5690815,
+              5694079,
+              5694095,
+              5697359
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 126340,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21940,
+            "endpoints": 126340,
+            "legs": [
+              20592,
+              21200,
+              20580,
+              20592,
+              20592,
+              21940
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              764,
+              16,
+              16
+            ],
+            "legMedian": 20592,
+            "legWorstDeviation": 0.06546231546231546,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              27456
+            ],
+            "primeExcess": 6864,
+            "perWrite": 21056.666666666668,
+            "perBoundaryPerWrite": 877.3611111111112,
+            "cdpBracket": 181776,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5734615,
+              5734631,
+              5762087,
+              5762103,
+              5782695,
+              5782711,
+              5803911,
+              5803927,
+              5824507,
+              5825271,
+              5845863,
+              5845879,
+              5866471,
+              5866487,
+              5888427
+            ],
+            "tick0": 301,
+            "tick": 308,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 121644,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20880,
+            "endpoints": 121644,
+            "legs": [
+              20136,
+              20880,
+              20136,
+              20136,
+              20124,
+              20136
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20136,
+            "legWorstDeviation": 0.03694874851013111,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26936
+            ],
+            "primeExcess": 6800,
+            "perWrite": 20274,
+            "perBoundaryPerWrite": 844.75,
+            "cdpBracket": 176540,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5753623,
+              5753639,
+              5780575,
+              5780591,
+              5800727,
+              5800743,
+              5821623,
+              5821639,
+              5841775,
+              5841791,
+              5861927,
+              5861943,
+              5882067,
+              5882083,
+              5902219
+            ],
+            "tick0": 329,
+            "tick": 336,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 6,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5712679,
+              5712695,
+              5712711,
+              5712727,
+              5712743,
+              5712759,
+              5712775,
+              5712791,
+              5712807,
+              5712823,
+              5712839,
+              5712855,
+              5712871,
+              5712887,
+              5712903
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5720687,
+              5720703,
+              5728767,
+              5728783,
+              5736847,
+              5736863,
+              5744927,
+              5744943,
+              5753007,
+              5753023,
+              5761087,
+              5761103,
+              5769167,
+              5769183,
+              5777247
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5715887,
+              5715903,
+              5719167,
+              5719183,
+              5722447,
+              5722463,
+              5725727,
+              5725743,
+              5729007,
+              5729023,
+              5732287,
+              5732303,
+              5735567,
+              5735583,
+              5738847
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 136260,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23168,
+            "endpoints": 136260,
+            "legs": [
+              22432,
+              22844,
+              22856,
+              23168,
+              22432,
+              22432
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22638,
+            "legWorstDeviation": 0.023411962187472393,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29296
+            ],
+            "primeExcess": 6658,
+            "perWrite": 22710,
+            "perBoundaryPerWrite": 946.25,
+            "cdpBracket": 193664,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5783511,
+              5783527,
+              5812823,
+              5812839,
+              5835271,
+              5835287,
+              5858131,
+              5858147,
+              5881003,
+              5881019,
+              5904187,
+              5904203,
+              5926635,
+              5926651,
+              5949083
+            ],
+            "tick0": 357,
+            "tick": 364,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 132012,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21992,
+            "endpoints": 132012,
+            "legs": [
+              21992,
+              21992,
+              21992,
+              21992,
+              21956,
+              21992
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21992,
+            "legWorstDeviation": -0.001636958894143325,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28792
+            ],
+            "primeExcess": 6800,
+            "perWrite": 22002,
+            "perBoundaryPerWrite": 916.75,
+            "cdpBracket": 188764,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5793375,
+              5793391,
+              5822183,
+              5822199,
+              5844191,
+              5844207,
+              5866199,
+              5866215,
+              5888207,
+              5888223,
+              5910215,
+              5910231,
+              5932187,
+              5932203,
+              5954195
+            ],
+            "tick0": 385,
+            "tick": 392,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 7,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5752431,
+              5752447,
+              5752463,
+              5752479,
+              5752495,
+              5752511,
+              5752527,
+              5752543,
+              5752559,
+              5752575,
+              5752591,
+              5752607,
+              5752623,
+              5752639,
+              5752655
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5760439,
+              5760455,
+              5768519,
+              5768535,
+              5776599,
+              5776615,
+              5784679,
+              5784695,
+              5792759,
+              5792775,
+              5800839,
+              5800855,
+              5808919,
+              5808935,
+              5816999
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5755639,
+              5755655,
+              5758919,
+              5758935,
+              5762199,
+              5762215,
+              5765479,
+              5765495,
+              5768759,
+              5768775,
+              5772039,
+              5772055,
+              5775319,
+              5775335,
+              5778599
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 138288,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 25360,
+            "endpoints": 138288,
+            "legs": [
+              22424,
+              22412,
+              22424,
+              23160,
+              25360,
+              22412
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22424,
+            "legWorstDeviation": 0.13093114520156976,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29276
+            ],
+            "primeExcess": 6852,
+            "perWrite": 23048,
+            "perBoundaryPerWrite": 960.3333333333334,
+            "cdpBracket": 202468,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5829435,
+              5829451,
+              5858727,
+              5858743,
+              5881167,
+              5881183,
+              5903595,
+              5903611,
+              5926035,
+              5926051,
+              5949211,
+              5949227,
+              5974587,
+              5974603,
+              5997015
+            ],
+            "tick0": 413,
+            "tick": 420,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 131964,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21984,
+            "endpoints": 131964,
+            "legs": [
+              21972,
+              21984,
+              21972,
+              21972,
+              21984,
+              21984
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21978,
+            "legWorstDeviation": -0.000273000273000273,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28784
+            ],
+            "primeExcess": 6806,
+            "perWrite": 21994,
+            "perBoundaryPerWrite": 916.4166666666666,
+            "cdpBracket": 192632,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5846319,
+              5846335,
+              5875119,
+              5875135,
+              5897107,
+              5897123,
+              5919107,
+              5919123,
+              5941095,
+              5941111,
+              5963083,
+              5963099,
+              5985083,
+              5985099,
+              6007083
+            ],
+            "tick0": 441,
+            "tick": 448,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 8,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5809311,
+              5809327,
+              5809343,
+              5809359,
+              5809375,
+              5809391,
+              5809407,
+              5809423,
+              5809439,
+              5809455,
+              5809471,
+              5809487,
+              5809503,
+              5809519,
+              5809535
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5817319,
+              5817335,
+              5825399,
+              5825415,
+              5833479,
+              5833495,
+              5841559,
+              5841575,
+              5849639,
+              5849655,
+              5857719,
+              5857735,
+              5865799,
+              5865815,
+              5873879
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5812519,
+              5812535,
+              5815799,
+              5815815,
+              5819079,
+              5819095,
+              5822359,
+              5822375,
+              5825639,
+              5825655,
+              5828919,
+              5828935,
+              5832199,
+              5832215,
+              5835479
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 534460,
+            "fall": 391592,
+            "falls": 2,
+            "maxStep": 246204,
+            "endpoints": 142868,
+            "legs": [
+              -198172,
+              246204,
+              -193420,
+              22400,
+              22388,
+              22388
+            ],
+            "gaps": [
+              221000,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22388,
+            "legWorstDeviation": 9.997141325710201,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read -198172 B against a cohort median of 22388 B (-220560 B, -985.2%), past the ±25% leg tolerance (±5597 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 2 of 6 read 246204 B against a cohort median of 22388 B (+223816 B, 999.7%), past the ±25% leg tolerance (±5597 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -193420 B against a cohort median of 22388 B (-215808 B, -963.9%), past the ±25% leg tolerance (±5597 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read -198172 B against a cohort median of 22388 B (-220560 B, -985.2%), past the ±25% leg tolerance (±5597 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 2 of 6 read 246204 B against a cohort median of 22388 B (+223816 B, 999.7%), past the ±25% leg tolerance (±5597 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -193420 B against a cohort median of 22388 B (-215808 B, -963.9%), past the ±25% leg tolerance (±5597 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29264
+            ],
+            "primeExcess": 6876,
+            "perWrite": 89076.66666666667,
+            "perBoundaryPerWrite": 3711.527777777778,
+            "cdpBracket": 200240,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5882467,
+              5882483,
+              5911747,
+              6132747,
+              5934575,
+              5934591,
+              6180795,
+              6180811,
+              5987391,
+              5987407,
+              6009807,
+              6009823,
+              6032211,
+              6032227,
+              6054615
+            ],
+            "tick0": 469,
+            "tick": 476,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 132036,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22620,
+            "endpoints": 132036,
+            "legs": [
+              21840,
+              22620,
+              21864,
+              21876,
+              21864,
+              21876
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21870,
+            "legWorstDeviation": 0.03429355281207133,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28676
+            ],
+            "primeExcess": 6806,
+            "perWrite": 22006,
+            "perBoundaryPerWrite": 916.9166666666666,
+            "cdpBracket": 188672,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5919959,
+              5919975,
+              5948651,
+              5948667,
+              5970507,
+              5970523,
+              5993143,
+              5993159,
+              6015023,
+              6015039,
+              6036915,
+              6036931,
+              6058795,
+              6058811,
+              6080687
+            ],
+            "tick0": 497,
+            "tick": 504,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 9,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5879003,
+              5879019,
+              5879035,
+              5879051,
+              5879067,
+              5879083,
+              5879099,
+              5879115,
+              5879131,
+              5879147,
+              5879163,
+              5879179,
+              5879195,
+              5879211,
+              5879227
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5887011,
+              5887027,
+              5895091,
+              5895107,
+              5903171,
+              5903187,
+              5911251,
+              5911267,
+              5919331,
+              5919347,
+              5927411,
+              5927427,
+              5935491,
+              5935507,
+              5943571
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5882211,
+              5882227,
+              5885491,
+              5885507,
+              5888771,
+              5888787,
+              5892051,
+              5892067,
+              5895331,
+              5895347,
+              5898611,
+              5898627,
+              5901891,
+              5901907,
+              5905171
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 134500,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23032,
+            "endpoints": 134500,
+            "legs": [
+              22272,
+              22272,
+              22272,
+              23032,
+              22284,
+              22272
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22272,
+            "legWorstDeviation": 0.03412356321839081,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29136
+            ],
+            "primeExcess": 6864,
+            "perWrite": 22416.666666666668,
+            "perBoundaryPerWrite": 934.0277777777778,
+            "cdpBracket": 195796,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5952391,
+              5952407,
+              5981543,
+              5981559,
+              6003831,
+              6003847,
+              6026119,
+              6026135,
+              6048407,
+              6048423,
+              6071455,
+              6071471,
+              6093755,
+              6093771,
+              6116043
+            ],
+            "tick0": 525,
+            "tick": 532,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 131112,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21844,
+            "endpoints": 131112,
+            "legs": [
+              21844,
+              21832,
+              21832,
+              21832,
+              21832,
+              21844
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21832,
+            "legWorstDeviation": 0.0005496518871381459,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28632
+            ],
+            "primeExcess": 6800,
+            "perWrite": 21852,
+            "perBoundaryPerWrite": 910.5,
+            "cdpBracket": 195280,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5963167,
+              5963183,
+              5991815,
+              5991831,
+              6013675,
+              6013691,
+              6035523,
+              6035539,
+              6057371,
+              6057387,
+              6079219,
+              6079235,
+              6101067,
+              6101083,
+              6122927
+            ],
+            "tick0": 553,
+            "tick": 560,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 10,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5928887,
+              5928903,
+              5928919,
+              5928935,
+              5928951,
+              5928967,
+              5928983,
+              5928999,
+              5929015,
+              5929031,
+              5929047,
+              5929063,
+              5929079,
+              5929095,
+              5929111
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5936895,
+              5936911,
+              5944975,
+              5944991,
+              5953055,
+              5953071,
+              5961135,
+              5961151,
+              5969215,
+              5969231,
+              5977295,
+              5977311,
+              5985375,
+              5985391,
+              5993455
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5932095,
+              5932111,
+              5935375,
+              5935391,
+              5938655,
+              5938671,
+              5941935,
+              5941951,
+              5945215,
+              5945231,
+              5948495,
+              5948511,
+              5951775,
+              5951791,
+              5955055
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 134512,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23032,
+            "endpoints": 134512,
+            "legs": [
+              22272,
+              22272,
+              22284,
+              23032,
+              22272,
+              22284
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22278,
+            "legWorstDeviation": 0.03384504892719275,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29148
+            ],
+            "primeExcess": 6870,
+            "perWrite": 22418.666666666668,
+            "perBoundaryPerWrite": 934.1111111111112,
+            "cdpBracket": 191768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5993319,
+              5993335,
+              6022483,
+              6022499,
+              6044771,
+              6044787,
+              6067059,
+              6067075,
+              6089359,
+              6089375,
+              6112407,
+              6112423,
+              6134695,
+              6134711,
+              6156995
+            ],
+            "tick0": 581,
+            "tick": 588,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 133284,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23344,
+            "endpoints": 133284,
+            "legs": [
+              21852,
+              21852,
+              21852,
+              22448,
+              21840,
+              23344
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21852,
+            "legWorstDeviation": 0.06827750320336812,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28652
+            ],
+            "primeExcess": 6800,
+            "perWrite": 22214,
+            "perBoundaryPerWrite": 925.5833333333334,
+            "cdpBracket": 189896,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5994879,
+              5994895,
+              6023547,
+              6023563,
+              6045415,
+              6045431,
+              6067283,
+              6067299,
+              6089151,
+              6089167,
+              6111615,
+              6111631,
+              6133471,
+              6133487,
+              6156831
+            ],
+            "tick0": 609,
+            "tick": 616,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 11,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5954543,
+              5954559,
+              5954575,
+              5954591,
+              5954607,
+              5954623,
+              5954639,
+              5954655,
+              5954671,
+              5954687,
+              5954703,
+              5954719,
+              5954735,
+              5954751,
+              5954767
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5962551,
+              5962567,
+              5970631,
+              5970647,
+              5978711,
+              5978727,
+              5986791,
+              5986807,
+              5994871,
+              5994887,
+              6002951,
+              6002967,
+              6011031,
+              6011047,
+              6019111
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5957751,
+              5957767,
+              5961031,
+              5961047,
+              5964311,
+              5964327,
+              5967591,
+              5967607,
+              5970871,
+              5970887,
+              5974151,
+              5974167,
+              5977431,
+              5977447,
+              5980711
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 145572,
+            "fall": 8784,
+            "falls": 1,
+            "maxStep": 33444,
+            "endpoints": 136788,
+            "legs": [
+              22272,
+              22284,
+              22272,
+              23020,
+              33444,
+              22200
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              -8784
+            ],
+            "legMedian": 22278,
+            "legWorstDeviation": 0.5012119579854565,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read 33444 B against a cohort median of 22278 B (+11166 B, 50.1%), past the ±25% leg tolerance (±5569.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read 33444 B against a cohort median of 22278 B (+11166 B, 50.1%), past the ±25% leg tolerance (±5569.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29148
+            ],
+            "primeExcess": 6870,
+            "perWrite": 24262,
+            "perBoundaryPerWrite": 1010.9166666666666,
+            "cdpBracket": 193916,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6011535,
+              6011551,
+              6040699,
+              6040715,
+              6062987,
+              6063003,
+              6085287,
+              6085303,
+              6107575,
+              6107591,
+              6130611,
+              6130627,
+              6164071,
+              6155287,
+              6177487
+            ],
+            "tick0": 637,
+            "tick": 644,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 131124,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21844,
+            "endpoints": 131124,
+            "legs": [
+              21832,
+              21844,
+              21832,
+              21832,
+              21844,
+              21844
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21838,
+            "legWorstDeviation": -0.0002747504350215221,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              35808
+            ],
+            "primeExcess": 13970,
+            "perWrite": 21854,
+            "perBoundaryPerWrite": 910.5833333333334,
+            "cdpBracket": 196104,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6029583,
+              6029599,
+              6065407,
+              6065423,
+              6087255,
+              6087271,
+              6109115,
+              6109131,
+              6130963,
+              6130979,
+              6152811,
+              6152827,
+              6174671,
+              6174687,
+              6196531
+            ],
+            "tick0": 665,
+            "tick": 672,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 12,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5994555,
+              5994571,
+              5994587,
+              5994603,
+              5994619,
+              5994635,
+              5994651,
+              5994667,
+              5994683,
+              5994699,
+              5994715,
+              5994731,
+              5994747,
+              5994763,
+              5994779
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6002563,
+              6002579,
+              6010643,
+              6010659,
+              6018723,
+              6018739,
+              6026803,
+              6026819,
+              6034883,
+              6034899,
+              6042963,
+              6042979,
+              6051043,
+              6051059,
+              6059123
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5997763,
+              5997779,
+              6001043,
+              6001059,
+              6004323,
+              6004339,
+              6007603,
+              6007619,
+              6010883,
+              6010899,
+              6014163,
+              6014179,
+              6017443,
+              6017459,
+              6020723
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 136632,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24576,
+            "endpoints": 136632,
+            "legs": [
+              22272,
+              22284,
+              22272,
+              24576,
+              22932,
+              22200
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22278,
+            "legWorstDeviation": 0.10315109076218691,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29148
+            ],
+            "primeExcess": 6870,
+            "perWrite": 22772,
+            "perBoundaryPerWrite": 948.8333333333334,
+            "cdpBracket": 193872,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6068575,
+              6068591,
+              6097739,
+              6097755,
+              6120027,
+              6120043,
+              6142327,
+              6142343,
+              6164615,
+              6164631,
+              6189207,
+              6189223,
+              6212155,
+              6212171,
+              6234371
+            ],
+            "tick0": 693,
+            "tick": 700,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 131160,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21844,
+            "endpoints": 131160,
+            "legs": [
+              21844,
+              21844,
+              21844,
+              21844,
+              21844,
+              21844
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21844,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28644
+            ],
+            "primeExcess": 6800,
+            "perWrite": 21860,
+            "perBoundaryPerWrite": 910.8333333333334,
+            "cdpBracket": 187748,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6088691,
+              6088707,
+              6117351,
+              6117367,
+              6139211,
+              6139227,
+              6161071,
+              6161087,
+              6182931,
+              6182947,
+              6204791,
+              6204807,
+              6226651,
+              6226667,
+              6248511
+            ],
+            "tick0": 721,
+            "tick": 728,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 13,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 31952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6047747,
+              6047763,
+              6047779,
+              6047795,
+              6047811,
+              6047827,
+              6047843,
+              6047859,
+              6047875,
+              6047891,
+              6047907,
+              6047923,
+              6047939,
+              6047955,
+              6047971
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6059775,
+              6059791,
+              6067855,
+              6067871,
+              6075935,
+              6075951,
+              6084015,
+              6084031,
+              6092095,
+              6092111,
+              6100175,
+              6100191,
+              6108255,
+              6108271,
+              6116335
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6054975,
+              6054991,
+              6058255,
+              6058271,
+              6061535,
+              6061551,
+              6064815,
+              6064831,
+              6068095,
+              6068111,
+              6071375,
+              6071391,
+              6074655,
+              6074671,
+              6077935
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 137224,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 25288,
+            "endpoints": 137224,
+            "legs": [
+              22272,
+              25288,
+              22200,
+              22200,
+              22968,
+              22200
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22236,
+            "legWorstDeviation": 0.13725490196078433,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29148
+            ],
+            "primeExcess": 6912,
+            "perWrite": 22870.666666666668,
+            "perBoundaryPerWrite": 952.9444444444445,
+            "cdpBracket": 194336,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6106919,
+              6106935,
+              6136083,
+              6136099,
+              6158371,
+              6158387,
+              6183675,
+              6183691,
+              6205891,
+              6205907,
+              6228107,
+              6228123,
+              6251091,
+              6251107,
+              6273307
+            ],
+            "tick0": 749,
+            "tick": 756,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 131136,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21844,
+            "endpoints": 131136,
+            "legs": [
+              21844,
+              21832,
+              21844,
+              21844,
+              21844,
+              21832
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21844,
+            "legWorstDeviation": -0.0005493499359091741,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28644
+            ],
+            "primeExcess": 6800,
+            "perWrite": 21856,
+            "perBoundaryPerWrite": 910.6666666666666,
+            "cdpBracket": 187724,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6109763,
+              6109779,
+              6138423,
+              6138439,
+              6160283,
+              6160299,
+              6182131,
+              6182147,
+              6203991,
+              6204007,
+              6225851,
+              6225867,
+              6247711,
+              6247727,
+              6269559
+            ],
+            "tick0": 777,
+            "tick": 784,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 14,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6068819,
+              6068835,
+              6068851,
+              6068867,
+              6068883,
+              6068899,
+              6068915,
+              6068931,
+              6068947,
+              6068963,
+              6068979,
+              6068995,
+              6069011,
+              6069027,
+              6069043
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6076827,
+              6076843,
+              6084907,
+              6084923,
+              6092987,
+              6093003,
+              6101067,
+              6101083,
+              6109147,
+              6109163,
+              6117227,
+              6117243,
+              6125307,
+              6125323,
+              6133387
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6072027,
+              6072043,
+              6075307,
+              6075323,
+              6078587,
+              6078603,
+              6081867,
+              6081883,
+              6085147,
+              6085163,
+              6088427,
+              6088443,
+              6091707,
+              6091723,
+              6094987
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 136512,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24612,
+            "endpoints": 136512,
+            "legs": [
+              22284,
+              24612,
+              22200,
+              22200,
+              22920,
+              22200
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22242,
+            "legWorstDeviation": 0.10655516590234691,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29148
+            ],
+            "primeExcess": 6906,
+            "perWrite": 22752,
+            "perBoundaryPerWrite": 948,
+            "cdpBracket": 196268,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6125523,
+              6125539,
+              6154687,
+              6154703,
+              6176987,
+              6177003,
+              6201615,
+              6201631,
+              6223831,
+              6223847,
+              6246047,
+              6246063,
+              6268983,
+              6268999,
+              6291199
+            ],
+            "tick0": 805,
+            "tick": 812,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 131112,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21844,
+            "endpoints": 131112,
+            "legs": [
+              21844,
+              21832,
+              21832,
+              21832,
+              21832,
+              21844
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21832,
+            "legWorstDeviation": 0.0005496518871381459,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28644
+            ],
+            "primeExcess": 6812,
+            "perWrite": 21852,
+            "perBoundaryPerWrite": 910.5,
+            "cdpBracket": 187700,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6131651,
+              6131667,
+              6160311,
+              6160327,
+              6182171,
+              6182187,
+              6204019,
+              6204035,
+              6225867,
+              6225883,
+              6247715,
+              6247731,
+              6269563,
+              6269579,
+              6291423
+            ],
+            "tick0": 833,
+            "tick": 840,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 15,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6090707,
+              6090723,
+              6090739,
+              6090755,
+              6090771,
+              6090787,
+              6090803,
+              6090819,
+              6090835,
+              6090851,
+              6090867,
+              6090883,
+              6090899,
+              6090915,
+              6090931
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6098715,
+              6098731,
+              6106795,
+              6106811,
+              6114875,
+              6114891,
+              6122955,
+              6122971,
+              6131035,
+              6131051,
+              6139115,
+              6139131,
+              6147195,
+              6147211,
+              6155275
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6093915,
+              6093931,
+              6097195,
+              6097211,
+              6100475,
+              6100491,
+              6103755,
+              6103771,
+              6107035,
+              6107051,
+              6110315,
+              6110331,
+              6113595,
+              6113611,
+              6116875
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 137628,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24684,
+            "endpoints": 137628,
+            "legs": [
+              22284,
+              24684,
+              22200,
+              23256,
+              22212,
+              22176
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              736
+            ],
+            "legMedian": 22248,
+            "legWorstDeviation": 0.10949298813376483,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29148
+            ],
+            "primeExcess": 6900,
+            "perWrite": 22938,
+            "perBoundaryPerWrite": 955.75,
+            "cdpBracket": 194740,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6151627,
+              6151643,
+              6180791,
+              6180807,
+              6203091,
+              6203107,
+              6227791,
+              6227807,
+              6250007,
+              6250023,
+              6273279,
+              6273295,
+              6295507,
+              6296243,
+              6318419
+            ],
+            "tick0": 861,
+            "tick": 868,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 131040,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21832,
+            "endpoints": 131040,
+            "legs": [
+              21820,
+              21832,
+              21832,
+              21796,
+              21832,
+              21832
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21832,
+            "legWorstDeviation": -0.0016489556614144375,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28620
+            ],
+            "primeExcess": 6788,
+            "perWrite": 21840,
+            "perBoundaryPerWrite": 910,
+            "cdpBracket": 187604,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6164167,
+              6164183,
+              6192803,
+              6192819,
+              6214639,
+              6214655,
+              6236487,
+              6236503,
+              6258335,
+              6258351,
+              6280147,
+              6280163,
+              6301995,
+              6302011,
+              6323843
+            ],
+            "tick0": 889,
+            "tick": 896,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 16,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6118107,
+              6118123,
+              6118139,
+              6118155,
+              6118171,
+              6118187,
+              6118203,
+              6118219,
+              6118235,
+              6118251,
+              6118267,
+              6118283,
+              6118299,
+              6118315,
+              6118331
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6126115,
+              6126131,
+              6134195,
+              6134211,
+              6142275,
+              6142291,
+              6150355,
+              6150371,
+              6158435,
+              6158451,
+              6166515,
+              6166531,
+              6174595,
+              6174611,
+              6182675
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6121315,
+              6121331,
+              6124595,
+              6124611,
+              6127875,
+              6127891,
+              6131155,
+              6131171,
+              6134435,
+              6134451,
+              6137715,
+              6137731,
+              6140995,
+              6141011,
+              6144275
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 136508,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24656,
+            "endpoints": 136508,
+            "legs": [
+              22272,
+              24656,
+              22200,
+              22188,
+              22188,
+              22908
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22236,
+            "legWorstDeviation": 0.10883252383522216,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29124
+            ],
+            "primeExcess": 6888,
+            "perWrite": 22751.333333333332,
+            "perBoundaryPerWrite": 947.9722222222222,
+            "cdpBracket": 193724,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6165851,
+              6165867,
+              6194991,
+              6195007,
+              6217279,
+              6217295,
+              6241951,
+              6241967,
+              6264167,
+              6264183,
+              6286371,
+              6286387,
+              6308575,
+              6308591,
+              6331499
+            ],
+            "tick0": 917,
+            "tick": 924,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 133688,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24432,
+            "endpoints": 133688,
+            "legs": [
+              21832,
+              21832,
+              24432,
+              21832,
+              21832,
+              21832
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21832,
+            "legWorstDeviation": 0.11909124221326493,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29968
+            ],
+            "primeExcess": 8136,
+            "perWrite": 22281.333333333332,
+            "perBoundaryPerWrite": 928.3888888888888,
+            "cdpBracket": 191600,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6173167,
+              6173183,
+              6203151,
+              6203167,
+              6224999,
+              6225015,
+              6246847,
+              6246863,
+              6271295,
+              6271311,
+              6293143,
+              6293159,
+              6314991,
+              6315007,
+              6336839
+            ],
+            "tick0": 945,
+            "tick": 952,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 17,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6129587,
+              6129603,
+              6129619,
+              6129635,
+              6129651,
+              6129667,
+              6129683,
+              6129699,
+              6129715,
+              6129731,
+              6129747,
+              6129763,
+              6129779,
+              6129795,
+              6129811
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6137595,
+              6137611,
+              6145675,
+              6145691,
+              6153755,
+              6153771,
+              6161835,
+              6161851,
+              6169915,
+              6169931,
+              6177995,
+              6178011,
+              6186075,
+              6186091,
+              6194155
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6132795,
+              6132811,
+              6136075,
+              6136091,
+              6139355,
+              6139371,
+              6142635,
+              6142651,
+              6145915,
+              6145931,
+              6149195,
+              6149211,
+              6152475,
+              6152491,
+              6155755
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 138280,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 25364,
+            "endpoints": 138280,
+            "legs": [
+              25364,
+              22192,
+              22192,
+              23260,
+              22972,
+              22204
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 22588,
+            "legWorstDeviation": 0.12289711351159908,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29140
+            ],
+            "primeExcess": 6552,
+            "perWrite": 23046.666666666668,
+            "perBoundaryPerWrite": 960.2777777777778,
+            "cdpBracket": 195384,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6195735,
+              6195751,
+              6224891,
+              6224907,
+              6250271,
+              6250287,
+              6272479,
+              6272495,
+              6294687,
+              6294703,
+              6317963,
+              6317979,
+              6340951,
+              6340967,
+              6363171
+            ],
+            "tick0": 973,
+            "tick": 980,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 131064,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21832,
+            "endpoints": 131064,
+            "legs": [
+              21832,
+              21832,
+              21832,
+              21820,
+              21832,
+              21820
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21832,
+            "legWorstDeviation": -0.0005496518871381459,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28620
+            ],
+            "primeExcess": 6788,
+            "perWrite": 21844,
+            "perBoundaryPerWrite": 910.1666666666666,
+            "cdpBracket": 187628,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6200535,
+              6200551,
+              6229171,
+              6229187,
+              6251019,
+              6251035,
+              6272867,
+              6272883,
+              6294715,
+              6294731,
+              6316551,
+              6316567,
+              6338399,
+              6338415,
+              6360235
+            ],
+            "tick0": 1001,
+            "tick": 1008,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      }
+    ],
+    "allocFits": {
+      "perRound": {},
+      "mean": {}
+    },
+    "writeDriven": true,
+    "writeProvenance": {
+      "windows": 36,
+      "pairs": 36,
+      "unnamed": [],
+      "incomplete": [],
+      "ok": true
+    },
+    "controlVerdict": {
+      "ok": true,
+      "perDouble": 8.08088888888889,
+      "differential": 8.00148148148148
+    },
+    "fallsInMeasuredWindows": 4,
+    "refusedWindows": 5,
+    "refusalReasons": 9
+  },
+  "box": {
+    "bead": "rf2-24o2z",
+    "chromium": "chromium/147.0.7727.15",
+    "node": "v24.13.0",
+    "platform": "win32/x64/10.0.26200",
+    "load": {
+      "open": {
+        "at": "2026-08-20T20:23:50.105Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13470480864,
+        "cpuBusyMs": 3625213921,
+        "freeMemB": 15449464832,
+        "totalMemB": 68112736256,
+        "uptimeS": 708592.906
+      },
+      "close": {
+        "at": "2026-08-20T20:24:16.447Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13470957192,
+        "cpuBusyMs": 3625374218,
+        "freeMemB": 15471288320,
+        "totalMemB": 68112736256,
+        "uptimeS": 708619.25
+      },
+      "busyFraction": 0.2517918711957589
+    },
+    "session": {
+      "startedAt": "2026-08-20T20:23:06.056Z",
+      "sessionStartedAt": "2026-08-20T19:39:26.627Z",
+      "runsInSession": 3,
+      "sessionGapMs": 3600000,
+      "previousRun": {
+        "startedAt": "2026-08-20T19:42:03.630Z",
+        "endedAt": "2026-08-20T19:44:03.461Z",
+        "sinceStartMs": 2462426,
+        "sinceEndMs": 2342595,
+        "sameSession": true
+      }
+    }
+  }
+}

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/reversed-2.json
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/reversed-2.json
@@ -1,0 +1,7559 @@
+{
+  "generatedAt": "2026-08-20T20:27:02.630Z",
+  "build": "hicasso-bench",
+  "initFn": "re-frame.bench.p0-app/-main",
+  "alloc": {
+    "benchmark": "P0:steady-state-allocation-slope",
+    "bead": "rf2-2rtt6.76",
+    "roots": 4,
+    "perRoot": {
+      "list": 300,
+      "grid": 6
+    },
+    "publishedPerRoot": {
+      "list": 300,
+      "grid": 300
+    },
+    "arm": {
+      "cells": 6,
+      "roots": 4,
+      "boundaries": 24,
+      "writes": 6,
+      "refusals": [],
+      "admissible": true
+    },
+    "boundaries": 24,
+    "writes": 6,
+    "primeWrites": 1,
+    "windowWrites": 7,
+    "bySite": false,
+    "sites": 2,
+    "siteNames": [
+      "dispatch",
+      "drain"
+    ],
+    "warmups": 3,
+    "rounds": 18,
+    "preciseMemory": true,
+    "controlDoubles": {
+      "d1": 1000,
+      "d2": 400
+    },
+    "controlSlack": 0.75,
+    "writeSelector": "all",
+    "writeLegs": [
+      "all"
+    ],
+    "writePaired": false,
+    "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+    "plan": {
+      "name": "floor",
+      "arms": true,
+      "rungs": false,
+      "fits": false
+    },
+    "segOrder": "fixed-reversed",
+    "passOrder": "parity",
+    "passSeed": "1787257587997",
+    "passSchedule": {
+      "flips": [
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true
+      ],
+      "attempts": 1,
+      "parityTied": false
+    },
+    "controlSlot": "first",
+    "instrument": "in-page performance.memory.usedJSHeapSize sampled at every leg boundary, rising steps accumulated separately from falling ones; --enable-precise-memory-info. A falling step is a collection this counter SAW; a leg that deviates from its cohort median by more than the leg tolerance is a work unit that is not one; and under the by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the other two can see. TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg has no interior reading and so no site step to be negative, and the intra-leg gate returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with these (see `bySite`), so a witness comparing byte for byte against a figure published at stride 2 can never be screened by all three",
+    "fallThresholdB": 600000,
+    "legTolerance": 0.25,
+    "verification": {
+      "unverified": 0,
+      "detail": []
+    },
+    "workCount": false,
+    "workVerification": {
+      "counted": false
+    },
+    "perRound": [
+      {
+        "round": 0,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 524,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              524
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 116.66666666666667,
+            "cdpBracket": 46232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3839770,
+              3839786,
+              3839802,
+              3839818,
+              3839834,
+              3839850,
+              3839866,
+              3839882,
+              3839898,
+              3839914,
+              3839930,
+              3839946,
+              3839962,
+              3840486,
+              3840502
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48576,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8144,
+            "endpoints": 48576,
+            "legs": [
+              8144,
+              8080,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.00992063492063492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8096,
+            "cdpBracket": 87388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3853394,
+              3853410,
+              3861474,
+              3861490,
+              3869634,
+              3869650,
+              3877730,
+              3877746,
+              3885810,
+              3885826,
+              3893890,
+              3893906,
+              3901970,
+              3901986,
+              3910050
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 52328,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3849494,
+              3849510,
+              3852774,
+              3852790,
+              3856054,
+              3856070,
+              3859334,
+              3859350,
+              3862614,
+              3862630,
+              3865894,
+              3865910,
+              3869174,
+              3869190,
+              3872454
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 134588,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 28292,
+            "endpoints": 134588,
+            "legs": [
+              21776,
+              20132,
+              28292,
+              20648,
+              23000,
+              20644
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21212,
+            "legWorstDeviation": 0.3337733358476334,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 28292 B against a cohort median of 21212 B (+7080 B, 33.4%), past the ±25% leg tolerance (±5303 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 28292 B against a cohort median of 21212 B (+7080 B, 33.4%), past the ±25% leg tolerance (±5303 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28720
+            ],
+            "primeExcess": 7508,
+            "perWrite": 22431.333333333332,
+            "perBoundaryPerWrite": 934.6388888888888,
+            "cdpBracket": 197532,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              4791439,
+              4791455,
+              4820175,
+              4820191,
+              4841967,
+              4841983,
+              4862115,
+              4862131,
+              4890423,
+              4890439,
+              4911087,
+              4911103,
+              4934103,
+              4934119,
+              4954763
+            ],
+            "tick0": 21,
+            "tick": 28,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 547280,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 444468,
+            "endpoints": 547280,
+            "legs": [
+              22468,
+              19476,
+              21964,
+              19404,
+              19404,
+              444468
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20720,
+            "legWorstDeviation": 20.4511583011583,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 444468 B against a cohort median of 20720 B (+423748 B, 2045.1%), past the ±25% leg tolerance (±5180 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 444468 B against a cohort median of 20720 B (+423748 B, 2045.1%), past the ±25% leg tolerance (±5180 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30800
+            ],
+            "primeExcess": 10080,
+            "perWrite": 91213.33333333333,
+            "perBoundaryPerWrite": 3800.555555555555,
+            "cdpBracket": 192520,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5063343,
+              5063359,
+              5094159,
+              5094175,
+              5116643,
+              5116659,
+              5136135,
+              5136151,
+              5158115,
+              5158131,
+              5177535,
+              5177551,
+              5196955,
+              5196971,
+              5641439
+            ],
+            "tick0": 49,
+            "tick": 56,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 1,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5048703,
+              5048719,
+              5048735,
+              5048751,
+              5048767,
+              5048783,
+              5048799,
+              5048815,
+              5048831,
+              5048847,
+              5048863,
+              5048879,
+              5048895,
+              5048911,
+              5048927
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 87716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5056711,
+              5056727,
+              5064791,
+              5064807,
+              5072871,
+              5072887,
+              5080951,
+              5080967,
+              5089031,
+              5089047,
+              5097111,
+              5097127,
+              5105191,
+              5105207,
+              5113271
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5054155,
+              5054171,
+              5057435,
+              5057451,
+              5060715,
+              5060731,
+              5063995,
+              5064011,
+              5067275,
+              5067291,
+              5070555,
+              5070571,
+              5073835,
+              5073851,
+              5077115
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 572572,
+            "fall": 276372,
+            "falls": 1,
+            "maxStep": 321648,
+            "endpoints": 296200,
+            "legs": [
+              321648,
+              -276372,
+              20660,
+              19844,
+              190312,
+              19844
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              184
+            ],
+            "legMedian": 20252,
+            "legWorstDeviation": 14.882283231285799,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 321648 B against a cohort median of 20252 B (+301396 B, 1488.2%), past the ±25% leg tolerance (±5063 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -276372 B against a cohort median of 20252 B (-296624 B, -1464.7%), past the ±25% leg tolerance (±5063 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 5 of 6 read 190312 B against a cohort median of 20252 B (+170060 B, 839.7%), past the ±25% leg tolerance (±5063 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 321648 B against a cohort median of 20252 B (+301396 B, 1488.2%), past the ±25% leg tolerance (±5063 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -276372 B against a cohort median of 20252 B (-296624 B, -1464.7%), past the ±25% leg tolerance (±5063 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 5 of 6 read 190312 B against a cohort median of 20252 B (+170060 B, 839.7%), past the ±25% leg tolerance (±5063 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26752
+            ],
+            "primeExcess": 6500,
+            "perWrite": 95428.66666666667,
+            "perBoundaryPerWrite": 3976.194444444445,
+            "cdpBracket": 195140,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5183251,
+              5183267,
+              5210019,
+              5210035,
+              5531683,
+              5531699,
+              5255327,
+              5255343,
+              5276003,
+              5276019,
+              5295863,
+              5295879,
+              5486191,
+              5486375,
+              5506219
+            ],
+            "tick0": 77,
+            "tick": 84,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 175308,
+            "fall": 53184,
+            "falls": 1,
+            "maxStep": 76872,
+            "endpoints": 122124,
+            "legs": [
+              19256,
+              21548,
+              19184,
+              -53184,
+              19184,
+              19184
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              76872,
+              16,
+              16
+            ],
+            "legMedian": 19184,
+            "legWorstDeviation": -3.772310258548791,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read -53184 B against a cohort median of 19184 B (-72368 B, -377.2%), past the ±25% leg tolerance (±4796 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read -53184 B against a cohort median of 19184 B (-72368 B, -377.2%), past the ±25% leg tolerance (±4796 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6856,
+            "perWrite": 29218,
+            "perBoundaryPerWrite": 1217.4166666666667,
+            "cdpBracket": 176580,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5294223,
+              5294239,
+              5320279,
+              5320295,
+              5339551,
+              5339567,
+              5361115,
+              5361131,
+              5380315,
+              5457187,
+              5404003,
+              5404019,
+              5423203,
+              5423219,
+              5442403
+            ],
+            "tick0": 105,
+            "tick": 112,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 2,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5257687,
+              5257703,
+              5257719,
+              5257735,
+              5257751,
+              5257767,
+              5257783,
+              5257799,
+              5257815,
+              5257831,
+              5257847,
+              5257863,
+              5257879,
+              5257895,
+              5257911
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85088,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5265711,
+              5265727,
+              5273791,
+              5273807,
+              5281871,
+              5281887,
+              5289951,
+              5289967,
+              5298031,
+              5298047,
+              5306111,
+              5306127,
+              5314191,
+              5314207,
+              5322271
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5260911,
+              5260927,
+              5264191,
+              5264207,
+              5267471,
+              5267487,
+              5270751,
+              5270767,
+              5274031,
+              5274047,
+              5277311,
+              5277327,
+              5280591,
+              5280607,
+              5283871
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118224,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19696,
+            "endpoints": 118224,
+            "legs": [
+              19684,
+              19696,
+              19696,
+              19696,
+              19696,
+              19660
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": -0.0018277822908204712,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              27288
+            ],
+            "primeExcess": 7592,
+            "perWrite": 19704,
+            "perBoundaryPerWrite": 821,
+            "cdpBracket": 174076,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5361547,
+              5361563,
+              5388851,
+              5388867,
+              5408551,
+              5408567,
+              5428263,
+              5428279,
+              5447975,
+              5447991,
+              5467687,
+              5467703,
+              5487399,
+              5487415,
+              5507075
+            ],
+            "tick0": 133,
+            "tick": 140,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20824,
+            "endpoints": 117700,
+            "legs": [
+              19768,
+              19244,
+              20824,
+              19256,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": 0.08142916493560448,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19616.666666666668,
+            "perBoundaryPerWrite": 817.3611111111112,
+            "cdpBracket": 171700,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5420771,
+              5420787,
+              5446827,
+              5446843,
+              5466611,
+              5466627,
+              5485871,
+              5485887,
+              5506711,
+              5506727,
+              5525983,
+              5525999,
+              5545255,
+              5545271,
+              5564527
+            ],
+            "tick0": 161,
+            "tick": 168,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 3,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 29120,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5381907,
+              5381923,
+              5381939,
+              5381955,
+              5381971,
+              5381987,
+              5382003,
+              5382019,
+              5382035,
+              5382051,
+              5382067,
+              5382083,
+              5382099,
+              5382115,
+              5382131
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5390843,
+              5390859,
+              5398923,
+              5398939,
+              5407003,
+              5407019,
+              5415083,
+              5415099,
+              5423163,
+              5423179,
+              5431243,
+              5431259,
+              5439323,
+              5439339,
+              5447403
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5386043,
+              5386059,
+              5389323,
+              5389339,
+              5392603,
+              5392619,
+              5395883,
+              5395899,
+              5399163,
+              5399179,
+              5402443,
+              5402459,
+              5405723,
+              5405739,
+              5409003
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118272,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19696,
+            "endpoints": 118272,
+            "legs": [
+              19696,
+              19696,
+              19696,
+              19696,
+              19696,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26532
+            ],
+            "primeExcess": 6836,
+            "perWrite": 19712,
+            "perBoundaryPerWrite": 821.3333333333334,
+            "cdpBracket": 172784,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5447467,
+              5447483,
+              5474015,
+              5474031,
+              5493727,
+              5493743,
+              5513439,
+              5513455,
+              5533151,
+              5533167,
+              5552863,
+              5552879,
+              5572575,
+              5572591,
+              5592287
+            ],
+            "tick0": 189,
+            "tick": 196,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 115620,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19256,
+            "endpoints": 115620,
+            "legs": [
+              19256,
+              19256,
+              19244,
+              19256,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": -0.0006231823847112588,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19270,
+            "perBoundaryPerWrite": 802.9166666666666,
+            "cdpBracket": 169620,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5481831,
+              5481847,
+              5507887,
+              5507903,
+              5527159,
+              5527175,
+              5546431,
+              5546447,
+              5565691,
+              5565707,
+              5584963,
+              5584979,
+              5604235,
+              5604251,
+              5623507
+            ],
+            "tick0": 217,
+            "tick": 224,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 4,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5440247,
+              5440263,
+              5440279,
+              5440295,
+              5440311,
+              5440327,
+              5440343,
+              5440359,
+              5440375,
+              5440391,
+              5440407,
+              5440423,
+              5440439,
+              5440455,
+              5440471
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5448255,
+              5448271,
+              5456335,
+              5456351,
+              5464415,
+              5464431,
+              5472495,
+              5472511,
+              5480575,
+              5480591,
+              5488655,
+              5488671,
+              5496735,
+              5496751,
+              5504815
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5443455,
+              5443471,
+              5446735,
+              5446751,
+              5450015,
+              5450031,
+              5453295,
+              5453311,
+              5456575,
+              5456591,
+              5459855,
+              5459871,
+              5463135,
+              5463151,
+              5466415
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 409332,
+            "fall": 276300,
+            "falls": 1,
+            "maxStep": 252164,
+            "endpoints": 133032,
+            "legs": [
+              252164,
+              -276300,
+              19888,
+              19888,
+              23984,
+              19888
+            ],
+            "gaps": [
+              16,
+              73440,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19888,
+            "legWorstDeviation": -14.892799678197909,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 252164 B against a cohort median of 19888 B (+232276 B, 1167.9%), past the ±25% leg tolerance (±4972 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -276300 B against a cohort median of 19888 B (-296188 B, -1489.3%), past the ±25% leg tolerance (±4972 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 252164 B against a cohort median of 19888 B (+232276 B, 1167.9%), past the ±25% leg tolerance (±4972 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -276300 B against a cohort median of 19888 B (-296188 B, -1489.3%), past the ±25% leg tolerance (±4972 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28500
+            ],
+            "primeExcess": 8612,
+            "perWrite": 68222,
+            "perBoundaryPerWrite": 2842.5833333333335,
+            "cdpBracket": 189640,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5620631,
+              5620647,
+              5649147,
+              5649163,
+              5901327,
+              5974767,
+              5698467,
+              5698483,
+              5718371,
+              5718387,
+              5738275,
+              5738291,
+              5762275,
+              5762291,
+              5782179
+            ],
+            "tick0": 245,
+            "tick": 252,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 151612,
+            "fall": 31364,
+            "falls": 1,
+            "maxStep": 54384,
+            "endpoints": 120248,
+            "legs": [
+              19432,
+              19432,
+              19432,
+              54384,
+              19420,
+              19432
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              -31364,
+              16
+            ],
+            "legMedian": 19432,
+            "legWorstDeviation": 1.7986825854261013,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 54384 B against a cohort median of 19432 B (+34952 B, 179.9%), past the ±25% leg tolerance (±4858 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 54384 B against a cohort median of 19432 B (+34952 B, 179.9%), past the ±25% leg tolerance (±4858 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26232
+            ],
+            "primeExcess": 6800,
+            "perWrite": 25268.666666666668,
+            "perBoundaryPerWrite": 1052.861111111111,
+            "cdpBracket": 174440,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5701167,
+              5701183,
+              5727415,
+              5727431,
+              5746863,
+              5746879,
+              5766311,
+              5766327,
+              5785759,
+              5785775,
+              5840159,
+              5808795,
+              5828215,
+              5828231,
+              5847663
+            ],
+            "tick0": 273,
+            "tick": 280,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 5,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5661827,
+              5661843,
+              5661859,
+              5661875,
+              5661891,
+              5661907,
+              5661923,
+              5661939,
+              5661955,
+              5661971,
+              5661987,
+              5662003,
+              5662019,
+              5662035,
+              5662051
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5669835,
+              5669851,
+              5677915,
+              5677931,
+              5685995,
+              5686011,
+              5694075,
+              5694091,
+              5702155,
+              5702171,
+              5710235,
+              5710251,
+              5718315,
+              5718331,
+              5726395
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5665035,
+              5665051,
+              5668315,
+              5668331,
+              5671595,
+              5671611,
+              5674875,
+              5674891,
+              5678155,
+              5678171,
+              5681435,
+              5681451,
+              5684715,
+              5684731,
+              5687995
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122560,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21968,
+            "endpoints": 122560,
+            "legs": [
+              19872,
+              21056,
+              19860,
+              19836,
+              19872,
+              21968
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19872,
+            "legWorstDeviation": 0.10547504025764895,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26736
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20426.666666666668,
+            "perBoundaryPerWrite": 851.1111111111112,
+            "cdpBracket": 177276,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5725059,
+              5725075,
+              5751811,
+              5751827,
+              5771699,
+              5771715,
+              5792771,
+              5792787,
+              5812647,
+              5812663,
+              5832499,
+              5832515,
+              5852387,
+              5852403,
+              5874371
+            ],
+            "tick0": 301,
+            "tick": 308,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116688,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19432,
+            "endpoints": 116688,
+            "legs": [
+              19432,
+              19432,
+              19432,
+              19432,
+              19432,
+              19432
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19432,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26220
+            ],
+            "primeExcess": 6788,
+            "perWrite": 19448,
+            "perBoundaryPerWrite": 810.3333333333334,
+            "cdpBracket": 170868,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5740607,
+              5740623,
+              5766843,
+              5766859,
+              5786291,
+              5786307,
+              5805739,
+              5805755,
+              5825187,
+              5825203,
+              5844635,
+              5844651,
+              5864083,
+              5864099,
+              5883531
+            ],
+            "tick0": 329,
+            "tick": 336,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 6,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5701763,
+              5701779,
+              5701795,
+              5701811,
+              5701827,
+              5701843,
+              5701859,
+              5701875,
+              5701891,
+              5701907,
+              5701923,
+              5701939,
+              5701955,
+              5701971,
+              5701987
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5709771,
+              5709787,
+              5717851,
+              5717867,
+              5725931,
+              5725947,
+              5734011,
+              5734027,
+              5742091,
+              5742107,
+              5750171,
+              5750187,
+              5758251,
+              5758267,
+              5766331
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5704971,
+              5704987,
+              5708251,
+              5708267,
+              5711531,
+              5711547,
+              5714811,
+              5714827,
+              5718091,
+              5718107,
+              5721371,
+              5721387,
+              5724651,
+              5724667,
+              5727931
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120828,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20604,
+            "endpoints": 120828,
+            "legs": [
+              19856,
+              20268,
+              20292,
+              19856,
+              20604,
+              19856
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20062,
+            "legWorstDeviation": 0.02701624962615891,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26720
+            ],
+            "primeExcess": 6658,
+            "perWrite": 20138,
+            "perBoundaryPerWrite": 839.0833333333334,
+            "cdpBracket": 175656,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5770903,
+              5770919,
+              5797639,
+              5797655,
+              5817511,
+              5817527,
+              5837795,
+              5837811,
+              5858103,
+              5858119,
+              5877975,
+              5877991,
+              5898595,
+              5898611,
+              5918467
+            ],
+            "tick0": 357,
+            "tick": 364,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116580,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19416,
+            "endpoints": 116580,
+            "legs": [
+              19404,
+              19416,
+              19416,
+              19416,
+              19416,
+              19416
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19416,
+            "legWorstDeviation": -0.0006180469715698393,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26216
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19430,
+            "perBoundaryPerWrite": 809.5833333333334,
+            "cdpBracket": 170756,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5783575,
+              5783591,
+              5809807,
+              5809823,
+              5829227,
+              5829243,
+              5848659,
+              5848675,
+              5868091,
+              5868107,
+              5887523,
+              5887539,
+              5906955,
+              5906971,
+              5926387
+            ],
+            "tick0": 385,
+            "tick": 392,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 7,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5742631,
+              5742647,
+              5742663,
+              5742679,
+              5742695,
+              5742711,
+              5742727,
+              5742743,
+              5742759,
+              5742775,
+              5742791,
+              5742807,
+              5742823,
+              5742839,
+              5742855
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5750639,
+              5750655,
+              5758719,
+              5758735,
+              5766799,
+              5766815,
+              5774879,
+              5774895,
+              5782959,
+              5782975,
+              5791039,
+              5791055,
+              5799119,
+              5799135,
+              5807199
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5745839,
+              5745855,
+              5749119,
+              5749135,
+              5752399,
+              5752415,
+              5755679,
+              5755695,
+              5758959,
+              5758975,
+              5762239,
+              5762255,
+              5765519,
+              5765535,
+              5768799
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 523712,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 424400,
+            "endpoints": 523712,
+            "legs": [
+              19836,
+              19848,
+              19836,
+              19848,
+              19848,
+              424400
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19848,
+            "legWorstDeviation": 20.382507053607416,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 424400 B against a cohort median of 19848 B (+404552 B, 2038.3%), past the ±25% leg tolerance (±4962 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 424400 B against a cohort median of 19848 B (+404552 B, 2038.3%), past the ±25% leg tolerance (±4962 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26712
+            ],
+            "primeExcess": 6864,
+            "perWrite": 87285.33333333333,
+            "perBoundaryPerWrite": 3636.8888888888887,
+            "cdpBracket": 184060,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5820179,
+              5820195,
+              5846907,
+              5846923,
+              5866759,
+              5866775,
+              5886623,
+              5886639,
+              5906475,
+              5906491,
+              5926339,
+              5926355,
+              5946203,
+              5946219,
+              6370619
+            ],
+            "tick0": 413,
+            "tick": 420,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116472,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19408,
+            "endpoints": 116472,
+            "legs": [
+              19396,
+              19408,
+              19396,
+              19372,
+              19396,
+              19408
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19396,
+            "legWorstDeviation": -0.0012373685295937306,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26208
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19412,
+            "perBoundaryPerWrite": 808.8333333333334,
+            "cdpBracket": 174564,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5837039,
+              5837055,
+              5863263,
+              5863279,
+              5882675,
+              5882691,
+              5902099,
+              5902115,
+              5921511,
+              5921527,
+              5940899,
+              5940915,
+              5960311,
+              5960327,
+              5979735
+            ],
+            "tick0": 441,
+            "tick": 448,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 8,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5800019,
+              5800035,
+              5800051,
+              5800067,
+              5800083,
+              5800099,
+              5800115,
+              5800131,
+              5800147,
+              5800163,
+              5800179,
+              5800195,
+              5800211,
+              5800227,
+              5800243
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5808027,
+              5808043,
+              5816107,
+              5816123,
+              5824187,
+              5824203,
+              5832267,
+              5832283,
+              5840347,
+              5840363,
+              5848427,
+              5848443,
+              5856507,
+              5856523,
+              5864587
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5803227,
+              5803243,
+              5806507,
+              5806523,
+              5809787,
+              5809803,
+              5813067,
+              5813083,
+              5816347,
+              5816363,
+              5819627,
+              5819643,
+              5822907,
+              5822923,
+              5826187
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 714148,
+            "fall": 585864,
+            "falls": 2,
+            "maxStep": 441912,
+            "endpoints": 128284,
+            "legs": [
+              20248,
+              212236,
+              19836,
+              441912,
+              -167812,
+              19836
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              -418052,
+              16
+            ],
+            "legMedian": 20042,
+            "legWorstDeviation": 21.049296477397466,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 212236 B against a cohort median of 20042 B (+192194 B, 959.0%), past the ±25% leg tolerance (±5010.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read 441912 B against a cohort median of 20042 B (+421870 B, 2104.9%), past the ±25% leg tolerance (±5010.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -167812 B against a cohort median of 20042 B (-187854 B, -937.3%), past the ±25% leg tolerance (±5010.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 212236 B against a cohort median of 20042 B (+192194 B, 959.0%), past the ±25% leg tolerance (±5010.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read 441912 B against a cohort median of 20042 B (+421870 B, 2104.9%), past the ±25% leg tolerance (±5010.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -167812 B against a cohort median of 20042 B (-187854 B, -937.3%), past the ±25% leg tolerance (±5010.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26712
+            ],
+            "primeExcess": 6670,
+            "perWrite": 119024.66666666667,
+            "perBoundaryPerWrite": 4959.361111111111,
+            "cdpBracket": 183104,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5872963,
+              5872979,
+              5899691,
+              5899707,
+              5919955,
+              5919971,
+              6132207,
+              6132223,
+              6152059,
+              6152075,
+              6593987,
+              6175935,
+              6008123,
+              6008139,
+              6027975
+            ],
+            "tick0": 469,
+            "tick": 476,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116496,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19408,
+            "endpoints": 116496,
+            "legs": [
+              19408,
+              19396,
+              19408,
+              19396,
+              19396,
+              19396
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19396,
+            "legWorstDeviation": 0.0006186842647968653,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26208
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19416,
+            "perBoundaryPerWrite": 809,
+            "cdpBracket": 170664,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5910719,
+              5910735,
+              5936943,
+              5936959,
+              5956367,
+              5956383,
+              5975779,
+              5975795,
+              5995203,
+              5995219,
+              6014615,
+              6014631,
+              6034027,
+              6034043,
+              6053439
+            ],
+            "tick0": 497,
+            "tick": 504,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 9,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5869763,
+              5869779,
+              5869795,
+              5869811,
+              5869827,
+              5869843,
+              5869859,
+              5869875,
+              5869891,
+              5869907,
+              5869923,
+              5869939,
+              5869955,
+              5869971,
+              5869987
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5877771,
+              5877787,
+              5885851,
+              5885867,
+              5893931,
+              5893947,
+              5902011,
+              5902027,
+              5910091,
+              5910107,
+              5918171,
+              5918187,
+              5926251,
+              5926267,
+              5934331
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5872971,
+              5872987,
+              5876251,
+              5876267,
+              5879531,
+              5879547,
+              5882811,
+              5882827,
+              5886091,
+              5886107,
+              5889371,
+              5889387,
+              5892651,
+              5892667,
+              5895931
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 124684,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 25464,
+            "endpoints": 124684,
+            "legs": [
+              19832,
+              19820,
+              19820,
+              19820,
+              19832,
+              25464
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19826,
+            "legWorstDeviation": 0.2843740542721679,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 25464 B against a cohort median of 19826 B (+5638 B, 28.4%), past the ±25% leg tolerance (±4956.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 25464 B against a cohort median of 19826 B (+5638 B, 28.4%), past the ±25% leg tolerance (±4956.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26696
+            ],
+            "primeExcess": 6870,
+            "perWrite": 20780.666666666668,
+            "perBoundaryPerWrite": 865.8611111111112,
+            "cdpBracket": 179360,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5947031,
+              5947047,
+              5973743,
+              5973759,
+              5993591,
+              5993607,
+              6013427,
+              6013443,
+              6033263,
+              6033279,
+              6053099,
+              6053115,
+              6072947,
+              6072963,
+              6098427
+            ],
+            "tick0": 525,
+            "tick": 532,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116412,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19392,
+            "endpoints": 116412,
+            "legs": [
+              19392,
+              19380,
+              19380,
+              19392,
+              19392,
+              19380
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19386,
+            "legWorstDeviation": 0.00030950170225936243,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26180
+            ],
+            "primeExcess": 6794,
+            "perWrite": 19402,
+            "perBoundaryPerWrite": 808.4166666666666,
+            "cdpBracket": 177132,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5957807,
+              5957823,
+              5984003,
+              5984019,
+              6003411,
+              6003427,
+              6022807,
+              6022823,
+              6042203,
+              6042219,
+              6061611,
+              6061627,
+              6081019,
+              6081035,
+              6100415
+            ],
+            "tick0": 553,
+            "tick": 560,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 10,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5923455,
+              5923471,
+              5923487,
+              5923503,
+              5923519,
+              5923535,
+              5923551,
+              5923567,
+              5923583,
+              5923599,
+              5923615,
+              5923631,
+              5923647,
+              5923663,
+              5923679
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5931463,
+              5931479,
+              5939543,
+              5939559,
+              5947623,
+              5947639,
+              5955703,
+              5955719,
+              5963783,
+              5963799,
+              5971863,
+              5971879,
+              5979943,
+              5979959,
+              5988023
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5926663,
+              5926679,
+              5929943,
+              5929959,
+              5933223,
+              5933239,
+              5936503,
+              5936519,
+              5939783,
+              5939799,
+              5943063,
+              5943079,
+              5946343,
+              5946359,
+              5949623
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119824,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20580,
+            "endpoints": 119824,
+            "legs": [
+              19832,
+              19832,
+              19820,
+              19832,
+              19832,
+              20580
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19832,
+            "legWorstDeviation": 0.03771682129891085,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26684
+            ],
+            "primeExcess": 6852,
+            "perWrite": 19970.666666666668,
+            "perBoundaryPerWrite": 832.1111111111112,
+            "cdpBracket": 177128,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5989747,
+              5989763,
+              6016447,
+              6016463,
+              6036295,
+              6036311,
+              6056143,
+              6056159,
+              6075979,
+              6075995,
+              6095827,
+              6095843,
+              6115675,
+              6115691,
+              6136271
+            ],
+            "tick0": 581,
+            "tick": 588,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117372,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20432,
+            "endpoints": 117372,
+            "legs": [
+              19376,
+              19376,
+              19364,
+              19364,
+              19364,
+              20432
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19370,
+            "legWorstDeviation": 0.05482705214248838,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26140
+            ],
+            "primeExcess": 6770,
+            "perWrite": 19562,
+            "perBoundaryPerWrite": 815.0833333333334,
+            "cdpBracket": 172964,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5995183,
+              5995199,
+              6021339,
+              6021355,
+              6040731,
+              6040747,
+              6060123,
+              6060139,
+              6079503,
+              6079519,
+              6098883,
+              6098899,
+              6118263,
+              6118279,
+              6138711
+            ],
+            "tick0": 609,
+            "tick": 616,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 11,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5953959,
+              5953975,
+              5953991,
+              5954007,
+              5954023,
+              5954039,
+              5954055,
+              5954071,
+              5954087,
+              5954103,
+              5954119,
+              5954135,
+              5954151,
+              5954167,
+              5954183
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5961967,
+              5961983,
+              5970047,
+              5970063,
+              5978127,
+              5978143,
+              5986207,
+              5986223,
+              5994287,
+              5994303,
+              6002367,
+              6002383,
+              6010447,
+              6010463,
+              6018527
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5957167,
+              5957183,
+              5960447,
+              5960463,
+              5963727,
+              5963743,
+              5967007,
+              5967023,
+              5970287,
+              5970303,
+              5973567,
+              5973583,
+              5976847,
+              5976863,
+              5980127
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119752,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20560,
+            "endpoints": 119752,
+            "legs": [
+              19812,
+              19824,
+              19824,
+              19812,
+              19824,
+              20560
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.03712671509281679,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19958.666666666668,
+            "perBoundaryPerWrite": 831.6111111111112,
+            "cdpBracket": 174420,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6008611,
+              6008627,
+              6035315,
+              6035331,
+              6055143,
+              6055159,
+              6074983,
+              6074999,
+              6094823,
+              6094839,
+              6114651,
+              6114667,
+              6134491,
+              6134507,
+              6155067
+            ],
+            "tick0": 637,
+            "tick": 644,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116292,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19376,
+            "endpoints": 116292,
+            "legs": [
+              19376,
+              19364,
+              19376,
+              19364,
+              19340,
+              19376
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19370,
+            "legWorstDeviation": -0.0015487867836861124,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              31660
+            ],
+            "primeExcess": 12290,
+            "perWrite": 19382,
+            "perBoundaryPerWrite": 807.5833333333334,
+            "cdpBracket": 177124,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6018511,
+              6018527,
+              6050187,
+              6050203,
+              6069579,
+              6069595,
+              6088959,
+              6088975,
+              6108351,
+              6108367,
+              6127731,
+              6127747,
+              6147087,
+              6147103,
+              6166479
+            ],
+            "tick0": 665,
+            "tick": 672,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 12,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5982919,
+              5982935,
+              5982951,
+              5982967,
+              5982983,
+              5982999,
+              5983015,
+              5983031,
+              5983047,
+              5983063,
+              5983079,
+              5983095,
+              5983111,
+              5983127,
+              5983143
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5990927,
+              5990943,
+              5999007,
+              5999023,
+              6007087,
+              6007103,
+              6015167,
+              6015183,
+              6023247,
+              6023263,
+              6031327,
+              6031343,
+              6039407,
+              6039423,
+              6047487
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5986127,
+              5986143,
+              5989407,
+              5989423,
+              5992687,
+              5992703,
+              5995967,
+              5995983,
+              5999247,
+              5999263,
+              6002527,
+              6002543,
+              6005807,
+              6005823,
+              6009087
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 279872,
+            "fall": 160180,
+            "falls": 1,
+            "maxStep": 180760,
+            "endpoints": 119692,
+            "legs": [
+              19816,
+              19804,
+              19804,
+              19804,
+              19804,
+              -160180
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              180760
+            ],
+            "legMedian": 19804,
+            "legWorstDeviation": -9.08826499697031,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read -160180 B against a cohort median of 19804 B (-179984 B, -908.8%), past the ±25% leg tolerance (±4951 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read -160180 B against a cohort median of 19804 B (-179984 B, -908.8%), past the ±25% leg tolerance (±4951 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26668
+            ],
+            "primeExcess": 6864,
+            "perWrite": 46645.333333333336,
+            "perBoundaryPerWrite": 1943.5555555555557,
+            "cdpBracket": 174452,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6057211,
+              6057227,
+              6083895,
+              6083911,
+              6103727,
+              6103743,
+              6123547,
+              6123563,
+              6143367,
+              6143383,
+              6163187,
+              6163203,
+              6183007,
+              6363767,
+              6203587
+            ],
+            "tick0": 693,
+            "tick": 700,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116316,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19376,
+            "endpoints": 116316,
+            "legs": [
+              19364,
+              19364,
+              19376,
+              19364,
+              19376,
+              19376
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19370,
+            "legWorstDeviation": -0.0003097573567372225,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26176
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19386,
+            "perBoundaryPerWrite": 807.75,
+            "cdpBracket": 170436,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6077447,
+              6077463,
+              6103639,
+              6103655,
+              6123019,
+              6123035,
+              6142399,
+              6142415,
+              6161791,
+              6161807,
+              6181171,
+              6181187,
+              6200563,
+              6200579,
+              6219955
+            ],
+            "tick0": 721,
+            "tick": 728,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 13,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 31952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6036503,
+              6036519,
+              6036535,
+              6036551,
+              6036567,
+              6036583,
+              6036599,
+              6036615,
+              6036631,
+              6036647,
+              6036663,
+              6036679,
+              6036695,
+              6036711,
+              6036727
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6048531,
+              6048547,
+              6056611,
+              6056627,
+              6064691,
+              6064707,
+              6072771,
+              6072787,
+              6080851,
+              6080867,
+              6088931,
+              6088947,
+              6097011,
+              6097027,
+              6105091
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6043731,
+              6043747,
+              6047011,
+              6047027,
+              6050291,
+              6050307,
+              6053571,
+              6053587,
+              6056851,
+              6056867,
+              6060131,
+              6060147,
+              6063411,
+              6063427,
+              6066691
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119704,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20552,
+            "endpoints": 119704,
+            "legs": [
+              19804,
+              19816,
+              19804,
+              19816,
+              19816,
+              20552
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19816,
+            "legWorstDeviation": 0.03714170367379895,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26668
+            ],
+            "primeExcess": 6852,
+            "perWrite": 19950.666666666668,
+            "perBoundaryPerWrite": 831.2777777777778,
+            "cdpBracket": 174336,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6095699,
+              6095715,
+              6122383,
+              6122399,
+              6142203,
+              6142219,
+              6162035,
+              6162051,
+              6181855,
+              6181871,
+              6201687,
+              6201703,
+              6221519,
+              6221535,
+              6242087
+            ],
+            "tick0": 749,
+            "tick": 756,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117024,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20108,
+            "endpoints": 117024,
+            "legs": [
+              19364,
+              19364,
+              19364,
+              19364,
+              19364,
+              20108
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19364,
+            "legWorstDeviation": 0.03842181367486057,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26176
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19504,
+            "perBoundaryPerWrite": 812.6666666666666,
+            "cdpBracket": 171144,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6109127,
+              6109143,
+              6135319,
+              6135335,
+              6154699,
+              6154715,
+              6174079,
+              6174095,
+              6193459,
+              6193475,
+              6212839,
+              6212855,
+              6232219,
+              6232235,
+              6252343
+            ],
+            "tick0": 777,
+            "tick": 784,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 14,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6068183,
+              6068199,
+              6068215,
+              6068231,
+              6068247,
+              6068263,
+              6068279,
+              6068295,
+              6068311,
+              6068327,
+              6068343,
+              6068359,
+              6068375,
+              6068391,
+              6068407
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6076191,
+              6076207,
+              6084271,
+              6084287,
+              6092351,
+              6092367,
+              6100431,
+              6100447,
+              6108511,
+              6108527,
+              6116591,
+              6116607,
+              6124671,
+              6124687,
+              6132751
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6071391,
+              6071407,
+              6074671,
+              6074687,
+              6077951,
+              6077967,
+              6081231,
+              6081247,
+              6084511,
+              6084527,
+              6087791,
+              6087807,
+              6091071,
+              6091087,
+              6094351
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 180228,
+            "fall": 58284,
+            "falls": 1,
+            "maxStep": 78764,
+            "endpoints": 121944,
+            "legs": [
+              19816,
+              19804,
+              19804,
+              19816,
+              22144,
+              -58284
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              78764
+            ],
+            "legMedian": 19810,
+            "legWorstDeviation": -3.942150429076224,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read -58284 B against a cohort median of 19810 B (-78094 B, -394.2%), past the ±25% leg tolerance (±4952.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read -58284 B against a cohort median of 19810 B (-78094 B, -394.2%), past the ±25% leg tolerance (±4952.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26668
+            ],
+            "primeExcess": 6858,
+            "perWrite": 30038,
+            "perBoundaryPerWrite": 1251.5833333333333,
+            "cdpBracket": 179220,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6124899,
+              6124915,
+              6151583,
+              6151599,
+              6171415,
+              6171431,
+              6191235,
+              6191251,
+              6211055,
+              6211071,
+              6230887,
+              6230903,
+              6253047,
+              6331811,
+              6273527
+            ],
+            "tick0": 805,
+            "tick": 812,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116304,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19376,
+            "endpoints": 116304,
+            "legs": [
+              19376,
+              19364,
+              19364,
+              19364,
+              19364,
+              19376
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19364,
+            "legWorstDeviation": 0.0006197066721751704,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26164
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19384,
+            "perBoundaryPerWrite": 807.6666666666666,
+            "cdpBracket": 170412,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6129015,
+              6129031,
+              6155195,
+              6155211,
+              6174587,
+              6174603,
+              6193967,
+              6193983,
+              6213347,
+              6213363,
+              6232727,
+              6232743,
+              6252107,
+              6252123,
+              6271499
+            ],
+            "tick0": 833,
+            "tick": 840,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 15,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6088071,
+              6088087,
+              6088103,
+              6088119,
+              6088135,
+              6088151,
+              6088167,
+              6088183,
+              6088199,
+              6088215,
+              6088231,
+              6088247,
+              6088263,
+              6088279,
+              6088295
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6096079,
+              6096095,
+              6104159,
+              6104175,
+              6112239,
+              6112255,
+              6120319,
+              6120335,
+              6128399,
+              6128415,
+              6136479,
+              6136495,
+              6144559,
+              6144575,
+              6152639
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6091279,
+              6091295,
+              6094559,
+              6094575,
+              6097839,
+              6097855,
+              6101119,
+              6101135,
+              6104399,
+              6104415,
+              6107679,
+              6107695,
+              6110959,
+              6110975,
+              6114239
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 260172,
+            "fall": 135360,
+            "falls": 2,
+            "maxStep": 119904,
+            "endpoints": 124812,
+            "legs": [
+              19816,
+              19816,
+              19816,
+              -94756,
+              19708,
+              -40604
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              119904,
+              16,
+              61048
+            ],
+            "legMedian": 19762,
+            "legWorstDeviation": -5.794858819957494,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read -94756 B against a cohort median of 19762 B (-114518 B, -579.5%), past the ±25% leg tolerance (±4940.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 6 of 6 read -40604 B against a cohort median of 19762 B (-60366 B, -305.5%), past the ±25% leg tolerance (±4940.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read -94756 B against a cohort median of 19762 B (-114518 B, -579.5%), past the ±25% leg tolerance (±4940.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 6 of 6 read -40604 B against a cohort median of 19762 B (-60366 B, -305.5%), past the ±25% leg tolerance (±4940.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26680
+            ],
+            "primeExcess": 6918,
+            "perWrite": 43362,
+            "perBoundaryPerWrite": 1806.75,
+            "cdpBracket": 179456,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6149291,
+              6149307,
+              6175987,
+              6176003,
+              6195819,
+              6195835,
+              6215651,
+              6215667,
+              6235483,
+              6355387,
+              6260631,
+              6260647,
+              6280355,
+              6341403,
+              6300799
+            ],
+            "tick0": 861,
+            "tick": 868,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 119152,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22212,
+            "endpoints": 119152,
+            "legs": [
+              19376,
+              19364,
+              22212,
+              19376,
+              19364,
+              19364
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19370,
+            "legWorstDeviation": 0.14672173464119773,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26176
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19858.666666666668,
+            "perBoundaryPerWrite": 827.4444444444445,
+            "cdpBracket": 173272,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6159815,
+              6159831,
+              6186007,
+              6186023,
+              6205399,
+              6205415,
+              6224779,
+              6224795,
+              6247007,
+              6247023,
+              6266399,
+              6266415,
+              6285779,
+              6285795,
+              6305159
+            ],
+            "tick0": 889,
+            "tick": 896,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 16,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6115667,
+              6115683,
+              6115699,
+              6115715,
+              6115731,
+              6115747,
+              6115763,
+              6115779,
+              6115795,
+              6115811,
+              6115827,
+              6115843,
+              6115859,
+              6115875,
+              6115891
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6123675,
+              6123691,
+              6131755,
+              6131771,
+              6139835,
+              6139851,
+              6147915,
+              6147931,
+              6155995,
+              6156011,
+              6164075,
+              6164091,
+              6172155,
+              6172171,
+              6180235
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6118875,
+              6118891,
+              6122155,
+              6122171,
+              6125435,
+              6125451,
+              6128715,
+              6128731,
+              6131995,
+              6132011,
+              6135275,
+              6135291,
+              6138555,
+              6138571,
+              6141835
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 121764,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22216,
+            "endpoints": 121764,
+            "legs": [
+              19816,
+              22216,
+              19708,
+              19732,
+              19732,
+              20464
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19774,
+            "legWorstDeviation": 0.12349549914028522,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26680
+            ],
+            "primeExcess": 6906,
+            "perWrite": 20294,
+            "perBoundaryPerWrite": 845.5833333333334,
+            "cdpBracket": 176536,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6163411,
+              6163427,
+              6190107,
+              6190123,
+              6209939,
+              6209955,
+              6232171,
+              6232187,
+              6251895,
+              6251911,
+              6271643,
+              6271659,
+              6291391,
+              6291407,
+              6311871
+            ],
+            "tick0": 917,
+            "tick": 924,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 120264,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21964,
+            "endpoints": 120264,
+            "legs": [
+              19376,
+              20724,
+              19376,
+              21964,
+              19364,
+              19364
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19376,
+            "legWorstDeviation": 0.13356729975227086,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26164
+            ],
+            "primeExcess": 6788,
+            "perWrite": 20044,
+            "perBoundaryPerWrite": 835.1666666666666,
+            "cdpBracket": 174372,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6170799,
+              6170815,
+              6196979,
+              6196995,
+              6216371,
+              6216387,
+              6237111,
+              6237127,
+              6256503,
+              6256519,
+              6278483,
+              6278499,
+              6297863,
+              6297879,
+              6317243
+            ],
+            "tick0": 945,
+            "tick": 952,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 17,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6127007,
+              6127023,
+              6127039,
+              6127055,
+              6127071,
+              6127087,
+              6127103,
+              6127119,
+              6127135,
+              6127151,
+              6127167,
+              6127183,
+              6127199,
+              6127215,
+              6127231
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6135015,
+              6135031,
+              6143095,
+              6143111,
+              6151175,
+              6151191,
+              6159255,
+              6159271,
+              6167335,
+              6167351,
+              6175415,
+              6175431,
+              6183495,
+              6183511,
+              6191575
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6130215,
+              6130231,
+              6133495,
+              6133511,
+              6136775,
+              6136791,
+              6140055,
+              6140071,
+              6143335,
+              6143351,
+              6146615,
+              6146631,
+              6149895,
+              6149911,
+              6153175
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 123288,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22160,
+            "endpoints": 123288,
+            "legs": [
+              22160,
+              19736,
+              19748,
+              19736,
+              20468,
+              19712
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              1648,
+              16,
+              16
+            ],
+            "legMedian": 19742,
+            "legWorstDeviation": 0.12247999189545132,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26684
+            ],
+            "primeExcess": 6942,
+            "perWrite": 20548,
+            "perBoundaryPerWrite": 856.1666666666666,
+            "cdpBracket": 177936,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6194779,
+              6194795,
+              6221479,
+              6221495,
+              6243655,
+              6243671,
+              6263407,
+              6263423,
+              6283171,
+              6284819,
+              6304555,
+              6304571,
+              6325039,
+              6325055,
+              6344767
+            ],
+            "tick0": 973,
+            "tick": 980,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117048,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21652,
+            "endpoints": 117048,
+            "legs": [
+              19364,
+              19376,
+              19364,
+              19364,
+              21652,
+              13608
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              4240
+            ],
+            "legMedian": 19364,
+            "legWorstDeviation": -0.29725263375335675,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 13608 B against a cohort median of 19364 B (-5756 B, -29.7%), past the ±25% leg tolerance (±4841 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 13608 B against a cohort median of 19364 B (-5756 B, -29.7%), past the ±25% leg tolerance (±4841 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26164
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19508,
+            "perBoundaryPerWrite": 812.8333333333334,
+            "cdpBracket": 171156,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6199779,
+              6199795,
+              6225959,
+              6225975,
+              6245339,
+              6245355,
+              6264731,
+              6264747,
+              6284111,
+              6284127,
+              6303491,
+              6303507,
+              6325159,
+              6329399,
+              6343007
+            ],
+            "tick0": 1001,
+            "tick": 1008,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      }
+    ],
+    "allocFits": {
+      "perRound": {},
+      "mean": {}
+    },
+    "writeDriven": true,
+    "writeProvenance": {
+      "windows": 36,
+      "pairs": 36,
+      "unnamed": [],
+      "incomplete": [],
+      "ok": true
+    },
+    "controlVerdict": {
+      "ok": true,
+      "perDouble": 8.08088888888889,
+      "differential": 8.00148148148148
+    },
+    "fallsInMeasuredWindows": 10,
+    "refusedWindows": 13,
+    "refusalReasons": 19
+  },
+  "box": {
+    "bead": "rf2-24o2z",
+    "chromium": "chromium/147.0.7727.15",
+    "node": "v24.13.0",
+    "platform": "win32/x64/10.0.26200",
+    "load": {
+      "open": {
+        "at": "2026-08-20T20:27:02.700Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13473678943,
+        "cpuBusyMs": 3626670546,
+        "freeMemB": 16240730112,
+        "totalMemB": 68112736256,
+        "uptimeS": 708785.5
+      },
+      "close": {
+        "at": "2026-08-20T20:27:29.089Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13474208254,
+        "cpuBusyMs": 3626776339,
+        "freeMemB": 16247369728,
+        "totalMemB": 68112736256,
+        "uptimeS": 708811.89
+      },
+      "busyFraction": 0.16657586788935355
+    },
+    "session": {
+      "startedAt": "2026-08-20T20:26:27.996Z",
+      "sessionStartedAt": "2026-08-20T19:39:26.627Z",
+      "runsInSession": 6,
+      "sessionGapMs": 3600000,
+      "previousRun": {
+        "startedAt": "2026-08-20T20:25:27.340Z",
+        "endedAt": "2026-08-20T20:26:27.849Z",
+        "sinceStartMs": 60656,
+        "sinceEndMs": 147,
+        "sameSession": true
+      }
+    }
+  }
+}

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/reversed-3.json
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/reversed-3.json
@@ -1,0 +1,7541 @@
+{
+  "generatedAt": "2026-08-20T20:30:11.167Z",
+  "build": "hicasso-bench",
+  "initFn": "re-frame.bench.p0-app/-main",
+  "alloc": {
+    "benchmark": "P0:steady-state-allocation-slope",
+    "bead": "rf2-2rtt6.76",
+    "roots": 4,
+    "perRoot": {
+      "list": 300,
+      "grid": 6
+    },
+    "publishedPerRoot": {
+      "list": 300,
+      "grid": 300
+    },
+    "arm": {
+      "cells": 6,
+      "roots": 4,
+      "boundaries": 24,
+      "writes": 6,
+      "refusals": [],
+      "admissible": true
+    },
+    "boundaries": 24,
+    "writes": 6,
+    "primeWrites": 1,
+    "windowWrites": 7,
+    "bySite": false,
+    "sites": 2,
+    "siteNames": [
+      "dispatch",
+      "drain"
+    ],
+    "warmups": 3,
+    "rounds": 18,
+    "preciseMemory": true,
+    "controlDoubles": {
+      "d1": 1000,
+      "d2": 400
+    },
+    "controlSlack": 0.75,
+    "writeSelector": "all",
+    "writeLegs": [
+      "all"
+    ],
+    "writePaired": false,
+    "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+    "plan": {
+      "name": "floor",
+      "arms": true,
+      "rungs": false,
+      "fits": false
+    },
+    "segOrder": "fixed-reversed",
+    "passOrder": "parity",
+    "passSeed": "1787257775833",
+    "passSchedule": {
+      "flips": [
+        true,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false
+      ],
+      "attempts": 1,
+      "parityTied": false
+    },
+    "controlSlot": "first",
+    "instrument": "in-page performance.memory.usedJSHeapSize sampled at every leg boundary, rising steps accumulated separately from falling ones; --enable-precise-memory-info. A falling step is a collection this counter SAW; a leg that deviates from its cohort median by more than the leg tolerance is a work unit that is not one; and under the by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the other two can see. TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg has no interior reading and so no site step to be negative, and the intra-leg gate returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with these (see `bySite`), so a witness comparing byte for byte against a figure published at stride 2 can never be screened by all three",
+    "fallThresholdB": 600000,
+    "legTolerance": 0.25,
+    "verification": {
+      "unverified": 0,
+      "detail": []
+    },
+    "workCount": false,
+    "workVerification": {
+      "counted": false
+    },
+    "perRound": [
+      {
+        "round": 0,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 524,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              524
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 116.66666666666667,
+            "cdpBracket": 46232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3840262,
+              3840278,
+              3840294,
+              3840310,
+              3840326,
+              3840342,
+              3840358,
+              3840374,
+              3840390,
+              3840406,
+              3840422,
+              3840438,
+              3840454,
+              3840978,
+              3840994
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48576,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8144,
+            "endpoints": 48576,
+            "legs": [
+              8144,
+              8080,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.00992063492063492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8096,
+            "cdpBracket": 87388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3853886,
+              3853902,
+              3861966,
+              3861982,
+              3870126,
+              3870142,
+              3878222,
+              3878238,
+              3886302,
+              3886318,
+              3894382,
+              3894398,
+              3902462,
+              3902478,
+              3910542
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 52328,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3849986,
+              3850002,
+              3853266,
+              3853282,
+              3856546,
+              3856562,
+              3859826,
+              3859842,
+              3863106,
+              3863122,
+              3866386,
+              3866402,
+              3869666,
+              3869682,
+              3872946
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 133660,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 28292,
+            "endpoints": 133660,
+            "legs": [
+              20848,
+              20132,
+              28292,
+              20648,
+              21392,
+              22252
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21120,
+            "legWorstDeviation": 0.33958333333333335,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 28292 B against a cohort median of 21120 B (+7172 B, 34.0%), past the ±25% leg tolerance (±5280 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 28292 B against a cohort median of 21120 B (+7172 B, 34.0%), past the ±25% leg tolerance (±5280 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28708
+            ],
+            "primeExcess": 7588,
+            "perWrite": 22276.666666666668,
+            "perBoundaryPerWrite": 928.1944444444445,
+            "cdpBracket": 196592,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              4792471,
+              4792487,
+              4821195,
+              4821211,
+              4842059,
+              4842075,
+              4862207,
+              4862223,
+              4890515,
+              4890531,
+              4911179,
+              4911195,
+              4932587,
+              4932603,
+              4954855
+            ],
+            "tick0": 21,
+            "tick": 28,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 679620,
+            "fall": 268144,
+            "falls": 1,
+            "maxStep": 313912,
+            "endpoints": 411476,
+            "legs": [
+              313912,
+              -268144,
+              19536,
+              21932,
+              304740,
+              19404
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20734,
+            "legWorstDeviation": 14.139963345230058,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 313912 B against a cohort median of 20734 B (+293178 B, 1414.0%), past the ±25% leg tolerance (±5183.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -268144 B against a cohort median of 20734 B (-288878 B, -1393.3%), past the ±25% leg tolerance (±5183.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 5 of 6 read 304740 B against a cohort median of 20734 B (+284006 B, 1369.8%), past the ±25% leg tolerance (±5183.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 313912 B against a cohort median of 20734 B (+293178 B, 1414.0%), past the ±25% leg tolerance (±5183.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -268144 B against a cohort median of 20734 B (-288878 B, -1393.3%), past the ±25% leg tolerance (±5183.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 5 of 6 read 304740 B against a cohort median of 20734 B (+284006 B, 1369.8%), past the ±25% leg tolerance (±5183.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26276
+            ],
+            "primeExcess": 5542,
+            "perWrite": 113270,
+            "perBoundaryPerWrite": 4719.583333333333,
+            "cdpBracket": 194140,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5066651,
+              5066667,
+              5092943,
+              5092959,
+              5406871,
+              5406887,
+              5138743,
+              5138759,
+              5158295,
+              5158311,
+              5180243,
+              5180259,
+              5484999,
+              5485015,
+              5504419
+            ],
+            "tick0": 49,
+            "tick": 56,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 1,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5053787,
+              5053803,
+              5053819,
+              5053835,
+              5053851,
+              5053867,
+              5053883,
+              5053899,
+              5053915,
+              5053931,
+              5053947,
+              5053963,
+              5053979,
+              5053995,
+              5054011
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 87716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5061795,
+              5061811,
+              5069875,
+              5069891,
+              5077955,
+              5077971,
+              5086035,
+              5086051,
+              5094115,
+              5094131,
+              5102195,
+              5102211,
+              5110275,
+              5110291,
+              5118355
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5059239,
+              5059255,
+              5062519,
+              5062535,
+              5065799,
+              5065815,
+              5069079,
+              5069095,
+              5072359,
+              5072375,
+              5075639,
+              5075655,
+              5078919,
+              5078935,
+              5082199
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 125244,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22316,
+            "endpoints": 125244,
+            "legs": [
+              21004,
+              19772,
+              20588,
+              22316,
+              19772,
+              21696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20796,
+            "legWorstDeviation": 0.0730909790344297,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30964
+            ],
+            "primeExcess": 10168,
+            "perWrite": 20874,
+            "perBoundaryPerWrite": 869.75,
+            "cdpBracket": 187760,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5188911,
+              5188927,
+              5219891,
+              5219907,
+              5240911,
+              5240927,
+              5260699,
+              5260715,
+              5281303,
+              5281319,
+              5303635,
+              5303651,
+              5323423,
+              5323439,
+              5345135
+            ],
+            "tick0": 77,
+            "tick": 84,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 122360,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 26128,
+            "endpoints": 122360,
+            "legs": [
+              19256,
+              19256,
+              19256,
+              26128,
+              19184,
+              19184
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": 0.3568757789779809,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 26128 B against a cohort median of 19256 B (+6872 B, 35.7%), past the ±25% leg tolerance (±4814 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 26128 B against a cohort median of 19256 B (+6872 B, 35.7%), past the ±25% leg tolerance (±4814 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 20393.333333333332,
+            "perBoundaryPerWrite": 849.7222222222222,
+            "cdpBracket": 176816,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5291863,
+              5291879,
+              5317919,
+              5317935,
+              5337191,
+              5337207,
+              5356463,
+              5356479,
+              5375735,
+              5375751,
+              5401879,
+              5401895,
+              5421079,
+              5421095,
+              5440279
+            ],
+            "tick0": 105,
+            "tick": 112,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 2,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5255315,
+              5255331,
+              5255347,
+              5255363,
+              5255379,
+              5255395,
+              5255411,
+              5255427,
+              5255443,
+              5255459,
+              5255475,
+              5255491,
+              5255507,
+              5255523,
+              5255539
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85088,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5263339,
+              5263355,
+              5271419,
+              5271435,
+              5279499,
+              5279515,
+              5287579,
+              5287595,
+              5295659,
+              5295675,
+              5303739,
+              5303755,
+              5311819,
+              5311835,
+              5319899
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5258539,
+              5258555,
+              5261819,
+              5261835,
+              5265099,
+              5265115,
+              5268379,
+              5268395,
+              5271659,
+              5271675,
+              5274939,
+              5274955,
+              5278219,
+              5278235,
+              5281499
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118272,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19696,
+            "endpoints": 118272,
+            "legs": [
+              19696,
+              19696,
+              19696,
+              19696,
+              19696,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26532
+            ],
+            "primeExcess": 6836,
+            "perWrite": 19712,
+            "perBoundaryPerWrite": 821.3333333333334,
+            "cdpBracket": 175884,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5359299,
+              5359315,
+              5385847,
+              5385863,
+              5405559,
+              5405575,
+              5425271,
+              5425287,
+              5444983,
+              5444999,
+              5464695,
+              5464711,
+              5484407,
+              5484423,
+              5504119
+            ],
+            "tick0": 133,
+            "tick": 140,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 376912,
+            "fall": 256956,
+            "falls": 1,
+            "maxStep": 279448,
+            "endpoints": 119956,
+            "legs": [
+              19244,
+              19768,
+              279448,
+              20004,
+              19184,
+              19184
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              -256956,
+              16,
+              16
+            ],
+            "legMedian": 19506,
+            "legWorstDeviation": 13.326258587101405,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 279448 B against a cohort median of 19506 B (+259942 B, 1332.6%), past the ±25% leg tolerance (±4876.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 279448 B against a cohort median of 19506 B (+259942 B, 1332.6%), past the ±25% leg tolerance (±4876.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6534,
+            "perWrite": 62818.666666666664,
+            "perBoundaryPerWrite": 2617.4444444444443,
+            "cdpBracket": 173956,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5419151,
+              5419167,
+              5445207,
+              5445223,
+              5464467,
+              5464483,
+              5484251,
+              5484267,
+              5763715,
+              5506759,
+              5526763,
+              5526779,
+              5545963,
+              5545979,
+              5565163
+            ],
+            "tick0": 161,
+            "tick": 168,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 3,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 29120,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5380311,
+              5380327,
+              5380343,
+              5380359,
+              5380375,
+              5380391,
+              5380407,
+              5380423,
+              5380439,
+              5380455,
+              5380471,
+              5380487,
+              5380503,
+              5380519,
+              5380535
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5389247,
+              5389263,
+              5397327,
+              5397343,
+              5405407,
+              5405423,
+              5413487,
+              5413503,
+              5421567,
+              5421583,
+              5429647,
+              5429663,
+              5437727,
+              5437743,
+              5445807
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5384447,
+              5384463,
+              5387727,
+              5387743,
+              5391007,
+              5391023,
+              5394287,
+              5394303,
+              5397567,
+              5397583,
+              5400847,
+              5400863,
+              5404127,
+              5404143,
+              5407407
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118260,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19696,
+            "endpoints": 118260,
+            "legs": [
+              19696,
+              19696,
+              19696,
+              19696,
+              19684,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": -0.0006092607636068237,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6848,
+            "perWrite": 19710,
+            "perBoundaryPerWrite": 821.25,
+            "cdpBracket": 172784,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5445871,
+              5445887,
+              5472431,
+              5472447,
+              5492143,
+              5492159,
+              5511855,
+              5511871,
+              5531567,
+              5531583,
+              5551279,
+              5551295,
+              5570979,
+              5570995,
+              5590691
+            ],
+            "tick0": 189,
+            "tick": 196,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117792,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21716,
+            "endpoints": 117792,
+            "legs": [
+              19244,
+              21716,
+              19184,
+              19184,
+              19184,
+              19184
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19184,
+            "legWorstDeviation": 0.13198498748957466,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6856,
+            "perWrite": 19632,
+            "perBoundaryPerWrite": 818,
+            "cdpBracket": 171792,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5480455,
+              5480471,
+              5506511,
+              5506527,
+              5525771,
+              5525787,
+              5547503,
+              5547519,
+              5566703,
+              5566719,
+              5585903,
+              5585919,
+              5605103,
+              5605119,
+              5624303
+            ],
+            "tick0": 217,
+            "tick": 224,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 4,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5439547,
+              5439563,
+              5439579,
+              5439595,
+              5439611,
+              5439627,
+              5439643,
+              5439659,
+              5439675,
+              5439691,
+              5439707,
+              5439723,
+              5439739,
+              5439755,
+              5439771
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5447555,
+              5447571,
+              5455635,
+              5455651,
+              5463715,
+              5463731,
+              5471795,
+              5471811,
+              5479875,
+              5479891,
+              5487955,
+              5487971,
+              5496035,
+              5496051,
+              5504115
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5442755,
+              5442771,
+              5446035,
+              5446051,
+              5449315,
+              5449331,
+              5452595,
+              5452611,
+              5455875,
+              5455891,
+              5459155,
+              5459171,
+              5462435,
+              5462451,
+              5465715
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 130824,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 25848,
+            "endpoints": 130824,
+            "legs": [
+              25848,
+              22360,
+              19852,
+              19888,
+              21812,
+              19888
+            ],
+            "gaps": [
+              16,
+              1096,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20850,
+            "legWorstDeviation": 0.23971223021582733,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29376
+            ],
+            "primeExcess": 8526,
+            "perWrite": 21804,
+            "perBoundaryPerWrite": 908.5,
+            "cdpBracket": 188308,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5618963,
+              5618979,
+              5648355,
+              5648371,
+              5674219,
+              5675315,
+              5697675,
+              5697691,
+              5717543,
+              5717559,
+              5737447,
+              5737463,
+              5759275,
+              5759291,
+              5779179
+            ],
+            "tick0": 245,
+            "tick": 252,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 120248,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23004,
+            "endpoints": 120248,
+            "legs": [
+              19432,
+              19432,
+              19432,
+              19420,
+              23004,
+              19432
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19432,
+            "legWorstDeviation": 0.1838205022643063,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26232
+            ],
+            "primeExcess": 6800,
+            "perWrite": 20041.333333333332,
+            "perBoundaryPerWrite": 835.0555555555555,
+            "cdpBracket": 174440,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5699839,
+              5699855,
+              5726087,
+              5726103,
+              5745535,
+              5745551,
+              5764983,
+              5764999,
+              5784431,
+              5784447,
+              5803867,
+              5803883,
+              5826887,
+              5826903,
+              5846335
+            ],
+            "tick0": 273,
+            "tick": 280,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 5,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5660499,
+              5660515,
+              5660531,
+              5660547,
+              5660563,
+              5660579,
+              5660595,
+              5660611,
+              5660627,
+              5660643,
+              5660659,
+              5660675,
+              5660691,
+              5660707,
+              5660723
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5668507,
+              5668523,
+              5676587,
+              5676603,
+              5684667,
+              5684683,
+              5692747,
+              5692763,
+              5700827,
+              5700843,
+              5708907,
+              5708923,
+              5716987,
+              5717003,
+              5725067
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5663707,
+              5663723,
+              5666987,
+              5667003,
+              5670267,
+              5670283,
+              5673547,
+              5673563,
+              5676827,
+              5676843,
+              5680107,
+              5680123,
+              5683387,
+              5683403,
+              5686667
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 146780,
+            "fall": 26108,
+            "falls": 1,
+            "maxStep": 67208,
+            "endpoints": 120672,
+            "legs": [
+              19872,
+              19872,
+              67208,
+              -26108,
+              19860,
+              19872
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19872,
+            "legWorstDeviation": 2.382045088566828,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 67208 B against a cohort median of 19872 B (+47336 B, 238.2%), past the ±25% leg tolerance (±4968 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -26108 B against a cohort median of 19872 B (-45980 B, -231.4%), past the ±25% leg tolerance (±4968 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 67208 B against a cohort median of 19872 B (+47336 B, 238.2%), past the ±25% leg tolerance (±4968 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -26108 B against a cohort median of 19872 B (-45980 B, -231.4%), past the ±25% leg tolerance (±4968 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26736
+            ],
+            "primeExcess": 6864,
+            "perWrite": 24463.333333333332,
+            "perBoundaryPerWrite": 1019.3055555555555,
+            "cdpBracket": 176736,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5725507,
+              5725523,
+              5752259,
+              5752275,
+              5772147,
+              5772163,
+              5792035,
+              5792051,
+              5859259,
+              5859275,
+              5833167,
+              5833183,
+              5853043,
+              5853059,
+              5872931
+            ],
+            "tick0": 301,
+            "tick": 308,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116676,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19432,
+            "endpoints": 116676,
+            "legs": [
+              19432,
+              19432,
+              19432,
+              19432,
+              19420,
+              19432
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19432,
+            "legWorstDeviation": -0.0006175380815150268,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26232
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19446,
+            "perBoundaryPerWrite": 810.25,
+            "cdpBracket": 170868,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5740863,
+              5740879,
+              5767111,
+              5767127,
+              5786559,
+              5786575,
+              5806007,
+              5806023,
+              5825455,
+              5825471,
+              5844903,
+              5844919,
+              5864339,
+              5864355,
+              5883787
+            ],
+            "tick0": 329,
+            "tick": 336,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 6,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5702031,
+              5702047,
+              5702063,
+              5702079,
+              5702095,
+              5702111,
+              5702127,
+              5702143,
+              5702159,
+              5702175,
+              5702191,
+              5702207,
+              5702223,
+              5702239,
+              5702255
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5710039,
+              5710055,
+              5718119,
+              5718135,
+              5726199,
+              5726215,
+              5734279,
+              5734295,
+              5742359,
+              5742375,
+              5750439,
+              5750455,
+              5758519,
+              5758535,
+              5766599
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5705239,
+              5705255,
+              5708519,
+              5708535,
+              5711799,
+              5711815,
+              5715079,
+              5715095,
+              5718359,
+              5718375,
+              5721639,
+              5721655,
+              5724919,
+              5724935,
+              5728199
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 121544,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21040,
+            "endpoints": 121544,
+            "legs": [
+              19856,
+              20268,
+              19856,
+              21040,
+              20572,
+              19856
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20062,
+            "legWorstDeviation": 0.048748878476722164,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26720
+            ],
+            "primeExcess": 6658,
+            "perWrite": 20257.333333333332,
+            "perBoundaryPerWrite": 844.0555555555555,
+            "cdpBracket": 176372,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5771171,
+              5771187,
+              5797907,
+              5797923,
+              5817779,
+              5817795,
+              5838063,
+              5838079,
+              5857935,
+              5857951,
+              5878991,
+              5879007,
+              5899579,
+              5899595,
+              5919451
+            ],
+            "tick0": 357,
+            "tick": 364,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116592,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19416,
+            "endpoints": 116592,
+            "legs": [
+              19416,
+              19416,
+              19416,
+              19416,
+              19416,
+              19416
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19416,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26216
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19432,
+            "perBoundaryPerWrite": 809.6666666666666,
+            "cdpBracket": 170768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5783843,
+              5783859,
+              5810075,
+              5810091,
+              5829507,
+              5829523,
+              5848939,
+              5848955,
+              5868371,
+              5868387,
+              5887803,
+              5887819,
+              5907235,
+              5907251,
+              5926667
+            ],
+            "tick0": 385,
+            "tick": 392,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 7,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5742899,
+              5742915,
+              5742931,
+              5742947,
+              5742963,
+              5742979,
+              5742995,
+              5743011,
+              5743027,
+              5743043,
+              5743059,
+              5743075,
+              5743091,
+              5743107,
+              5743123
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5750907,
+              5750923,
+              5758987,
+              5759003,
+              5767067,
+              5767083,
+              5775147,
+              5775163,
+              5783227,
+              5783243,
+              5791307,
+              5791323,
+              5799387,
+              5799403,
+              5807467
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5746107,
+              5746123,
+              5749387,
+              5749403,
+              5752667,
+              5752683,
+              5755947,
+              5755963,
+              5759227,
+              5759243,
+              5762507,
+              5762523,
+              5765787,
+              5765803,
+              5769067
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 121500,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21464,
+            "endpoints": 121500,
+            "legs": [
+              19836,
+              19848,
+              19836,
+              20584,
+              21464,
+              19836
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19842,
+            "legWorstDeviation": 0.08174579175486342,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26712
+            ],
+            "primeExcess": 6870,
+            "perWrite": 20250,
+            "perBoundaryPerWrite": 843.75,
+            "cdpBracket": 183116,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5820495,
+              5820511,
+              5847223,
+              5847239,
+              5867075,
+              5867091,
+              5886939,
+              5886955,
+              5906791,
+              5906807,
+              5927391,
+              5927407,
+              5948871,
+              5948887,
+              5968723
+            ],
+            "tick0": 413,
+            "tick": 420,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116508,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19408,
+            "endpoints": 116508,
+            "legs": [
+              19408,
+              19408,
+              19396,
+              19408,
+              19396,
+              19396
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19402,
+            "legWorstDeviation": 0.0003092464694361406,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26208
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19418,
+            "perBoundaryPerWrite": 809.0833333333334,
+            "cdpBracket": 174600,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5837295,
+              5837311,
+              5863519,
+              5863535,
+              5882943,
+              5882959,
+              5902367,
+              5902383,
+              5921779,
+              5921795,
+              5941203,
+              5941219,
+              5960615,
+              5960631,
+              5980027
+            ],
+            "tick0": 441,
+            "tick": 448,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 8,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5800275,
+              5800291,
+              5800307,
+              5800323,
+              5800339,
+              5800355,
+              5800371,
+              5800387,
+              5800403,
+              5800419,
+              5800435,
+              5800451,
+              5800467,
+              5800483,
+              5800499
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5808283,
+              5808299,
+              5816363,
+              5816379,
+              5824443,
+              5824459,
+              5832523,
+              5832539,
+              5840603,
+              5840619,
+              5848683,
+              5848699,
+              5856763,
+              5856779,
+              5864843
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5803483,
+              5803499,
+              5806763,
+              5806779,
+              5810043,
+              5810059,
+              5813323,
+              5813339,
+              5816603,
+              5816619,
+              5819883,
+              5819899,
+              5823163,
+              5823179,
+              5826443
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 484544,
+            "fall": 356952,
+            "falls": 1,
+            "maxStep": 240728,
+            "endpoints": 127592,
+            "legs": [
+              20260,
+              240728,
+              19848,
+              183764,
+              -356952,
+              19848
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20054,
+            "legWorstDeviation": -18.799541238655628,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 240728 B against a cohort median of 20054 B (+220674 B, 1100.4%), past the ±25% leg tolerance (±5013.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read 183764 B against a cohort median of 20054 B (+163710 B, 816.3%), past the ±25% leg tolerance (±5013.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -356952 B against a cohort median of 20054 B (-377006 B, -1880.0%), past the ±25% leg tolerance (±5013.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 240728 B against a cohort median of 20054 B (+220674 B, 1100.4%), past the ±25% leg tolerance (±5013.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read 183764 B against a cohort median of 20054 B (+163710 B, 816.3%), past the ±25% leg tolerance (±5013.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -356952 B against a cohort median of 20054 B (-377006 B, -1880.0%), past the ±25% leg tolerance (±5013.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26700
+            ],
+            "primeExcess": 6646,
+            "perWrite": 80757.33333333333,
+            "perBoundaryPerWrite": 3364.8888888888887,
+            "cdpBracket": 182400,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5873219,
+              5873235,
+              5899935,
+              5899951,
+              5920211,
+              5920227,
+              6160955,
+              6160971,
+              6180819,
+              6180835,
+              6364599,
+              6364615,
+              6007663,
+              6007679,
+              6027527
+            ],
+            "tick0": 469,
+            "tick": 476,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116460,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19408,
+            "endpoints": 116460,
+            "legs": [
+              19372,
+              19396,
+              19396,
+              19396,
+              19408,
+              19396
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19396,
+            "legWorstDeviation": -0.0012373685295937306,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26208
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19410,
+            "perBoundaryPerWrite": 808.75,
+            "cdpBracket": 170628,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5898063,
+              5898079,
+              5924287,
+              5924303,
+              5943675,
+              5943691,
+              5963087,
+              5963103,
+              5982499,
+              5982515,
+              6001911,
+              6001927,
+              6021335,
+              6021351,
+              6040747
+            ],
+            "tick0": 497,
+            "tick": 504,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 9,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5857119,
+              5857135,
+              5857151,
+              5857167,
+              5857183,
+              5857199,
+              5857215,
+              5857231,
+              5857247,
+              5857263,
+              5857279,
+              5857295,
+              5857311,
+              5857327,
+              5857343
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5865127,
+              5865143,
+              5873207,
+              5873223,
+              5881287,
+              5881303,
+              5889367,
+              5889383,
+              5897447,
+              5897463,
+              5905527,
+              5905543,
+              5913607,
+              5913623,
+              5921687
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5860327,
+              5860343,
+              5863607,
+              5863623,
+              5866887,
+              5866903,
+              5870167,
+              5870183,
+              5873447,
+              5873463,
+              5876727,
+              5876743,
+              5880007,
+              5880023,
+              5883287
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 124040,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24768,
+            "endpoints": 124040,
+            "legs": [
+              19840,
+              19840,
+              19828,
+              24768,
+              19840,
+              19828
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19840,
+            "legWorstDeviation": 0.24838709677419354,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26704
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20673.333333333332,
+            "perBoundaryPerWrite": 861.3888888888888,
+            "cdpBracket": 178724,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5930199,
+              5930215,
+              5956919,
+              5956935,
+              5976775,
+              5976791,
+              5996631,
+              5996647,
+              6016475,
+              6016491,
+              6041259,
+              6041275,
+              6061115,
+              6061131,
+              6080959
+            ],
+            "tick0": 525,
+            "tick": 532,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116448,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19400,
+            "endpoints": 116448,
+            "legs": [
+              19400,
+              19388,
+              19388,
+              19400,
+              19388,
+              19388
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19388,
+            "legWorstDeviation": 0.0006189395502372602,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26188
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19408,
+            "perBoundaryPerWrite": 808.6666666666666,
+            "cdpBracket": 177176,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5940099,
+              5940115,
+              5966303,
+              5966319,
+              5985719,
+              5985735,
+              6005123,
+              6005139,
+              6024527,
+              6024543,
+              6043943,
+              6043959,
+              6063347,
+              6063363,
+              6082751
+            ],
+            "tick0": 553,
+            "tick": 560,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 10,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5905819,
+              5905835,
+              5905851,
+              5905867,
+              5905883,
+              5905899,
+              5905915,
+              5905931,
+              5905947,
+              5905963,
+              5905979,
+              5905995,
+              5906011,
+              5906027,
+              5906043
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5913827,
+              5913843,
+              5921907,
+              5921923,
+              5929987,
+              5930003,
+              5938067,
+              5938083,
+              5946147,
+              5946163,
+              5954227,
+              5954243,
+              5962307,
+              5962323,
+              5970387
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5909027,
+              5909043,
+              5912307,
+              5912323,
+              5915587,
+              5915603,
+              5918867,
+              5918883,
+              5922147,
+              5922163,
+              5925427,
+              5925443,
+              5928707,
+              5928723,
+              5931987
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119848,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20576,
+            "endpoints": 119848,
+            "legs": [
+              19828,
+              19828,
+              19840,
+              20576,
+              19840,
+              19840
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19840,
+            "legWorstDeviation": 0.037096774193548385,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26704
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19974.666666666668,
+            "perBoundaryPerWrite": 832.2777777777778,
+            "cdpBracket": 177172,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5971099,
+              5971115,
+              5997819,
+              5997835,
+              6017663,
+              6017679,
+              6037507,
+              6037523,
+              6057363,
+              6057379,
+              6077955,
+              6077971,
+              6097811,
+              6097827,
+              6117667
+            ],
+            "tick0": 581,
+            "tick": 588,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116352,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116352,
+            "legs": [
+              19372,
+              19372,
+              19384,
+              19372,
+              19372,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0006194507536650836,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19392,
+            "perBoundaryPerWrite": 808,
+            "cdpBracket": 171988,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5976583,
+              5976599,
+              6002783,
+              6002799,
+              6022171,
+              6022187,
+              6041559,
+              6041575,
+              6060959,
+              6060975,
+              6080347,
+              6080363,
+              6099735,
+              6099751,
+              6119135
+            ],
+            "tick0": 609,
+            "tick": 616,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 11,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5935627,
+              5935643,
+              5935659,
+              5935675,
+              5935691,
+              5935707,
+              5935723,
+              5935739,
+              5935755,
+              5935771,
+              5935787,
+              5935803,
+              5935819,
+              5935835,
+              5935851
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5943635,
+              5943651,
+              5951715,
+              5951731,
+              5959795,
+              5959811,
+              5967875,
+              5967891,
+              5975955,
+              5975971,
+              5984035,
+              5984051,
+              5992115,
+              5992131,
+              6000195
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5938835,
+              5938851,
+              5942115,
+              5942131,
+              5945395,
+              5945411,
+              5948675,
+              5948691,
+              5951955,
+              5951971,
+              5955235,
+              5955251,
+              5958515,
+              5958531,
+              5961795
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119776,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20568,
+            "endpoints": 119776,
+            "legs": [
+              19820,
+              19820,
+              19820,
+              19832,
+              20568,
+              19820
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19820,
+            "legWorstDeviation": 0.03773965691220989,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26696
+            ],
+            "primeExcess": 6876,
+            "perWrite": 19962.666666666668,
+            "perBoundaryPerWrite": 831.7777777777778,
+            "cdpBracket": 174452,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5989639,
+              5989655,
+              6016351,
+              6016367,
+              6036187,
+              6036203,
+              6056023,
+              6056039,
+              6075859,
+              6075875,
+              6095707,
+              6095723,
+              6116291,
+              6116307,
+              6136127
+            ],
+            "tick0": 637,
+            "tick": 644,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 121788,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24856,
+            "endpoints": 121788,
+            "legs": [
+              24856,
+              19372,
+              19372,
+              19372,
+              19348,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.28308899442494323,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 24856 B against a cohort median of 19372 B (+5484 B, 28.3%), past the ±25% leg tolerance (±4843 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 24856 B against a cohort median of 19372 B (+5484 B, 28.3%), past the ±25% leg tolerance (±4843 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 20298,
+            "perBoundaryPerWrite": 845.75,
+            "cdpBracket": 177144,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5998879,
+              5998895,
+              6025079,
+              6025095,
+              6049951,
+              6049967,
+              6069339,
+              6069355,
+              6088727,
+              6088743,
+              6108115,
+              6108131,
+              6127479,
+              6127495,
+              6146867
+            ],
+            "tick0": 665,
+            "tick": 672,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 12,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5963287,
+              5963303,
+              5963319,
+              5963335,
+              5963351,
+              5963367,
+              5963383,
+              5963399,
+              5963415,
+              5963431,
+              5963447,
+              5963463,
+              5963479,
+              5963495,
+              5963511
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5971295,
+              5971311,
+              5979375,
+              5979391,
+              5987455,
+              5987471,
+              5995535,
+              5995551,
+              6003615,
+              6003631,
+              6011695,
+              6011711,
+              6019775,
+              6019791,
+              6027855
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5966495,
+              5966511,
+              5969775,
+              5969791,
+              5973055,
+              5973071,
+              5976335,
+              5976351,
+              5979615,
+              5979631,
+              5982895,
+              5982911,
+              5986175,
+              5986191,
+              5989455
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119716,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20560,
+            "endpoints": 119716,
+            "legs": [
+              19788,
+              19812,
+              19824,
+              19824,
+              20560,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 0.037440710465233625,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6870,
+            "perWrite": 19952.666666666668,
+            "perBoundaryPerWrite": 831.3611111111112,
+            "cdpBracket": 174496,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6037951,
+              6037967,
+              6064655,
+              6064671,
+              6084459,
+              6084475,
+              6104287,
+              6104303,
+              6124127,
+              6124143,
+              6143967,
+              6143983,
+              6164543,
+              6164559,
+              6184371
+            ],
+            "tick0": 693,
+            "tick": 700,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116364,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116364,
+            "legs": [
+              19372,
+              19384,
+              19384,
+              19372,
+              19384,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": -0.0003096294767261843,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6794,
+            "perWrite": 19394,
+            "perBoundaryPerWrite": 808.0833333333334,
+            "cdpBracket": 170480,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6058079,
+              6058095,
+              6084267,
+              6084283,
+              6103655,
+              6103671,
+              6123055,
+              6123071,
+              6142455,
+              6142471,
+              6161843,
+              6161859,
+              6181243,
+              6181259,
+              6200631
+            ],
+            "tick0": 721,
+            "tick": 728,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 13,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 31952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6017135,
+              6017151,
+              6017167,
+              6017183,
+              6017199,
+              6017215,
+              6017231,
+              6017247,
+              6017263,
+              6017279,
+              6017295,
+              6017311,
+              6017327,
+              6017343,
+              6017359
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6029163,
+              6029179,
+              6037243,
+              6037259,
+              6045323,
+              6045339,
+              6053403,
+              6053419,
+              6061483,
+              6061499,
+              6069563,
+              6069579,
+              6077643,
+              6077659,
+              6085723
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6024363,
+              6024379,
+              6027643,
+              6027659,
+              6030923,
+              6030939,
+              6034203,
+              6034219,
+              6037483,
+              6037499,
+              6040763,
+              6040779,
+              6044043,
+              6044059,
+              6047323
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119740,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20572,
+            "endpoints": 119740,
+            "legs": [
+              19824,
+              19824,
+              19788,
+              19824,
+              20572,
+              19812
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.0377320419693301,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19956.666666666668,
+            "perBoundaryPerWrite": 831.5277777777778,
+            "cdpBracket": 174392,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6076307,
+              6076323,
+              6103011,
+              6103027,
+              6122851,
+              6122867,
+              6142691,
+              6142707,
+              6162495,
+              6162511,
+              6182335,
+              6182351,
+              6202923,
+              6202939,
+              6222751
+            ],
+            "tick0": 749,
+            "tick": 756,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116340,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116340,
+            "legs": [
+              19372,
+              19372,
+              19384,
+              19384,
+              19348,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": -0.0015481473836309217,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19390,
+            "perBoundaryPerWrite": 807.9166666666666,
+            "cdpBracket": 170468,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6089327,
+              6089343,
+              6115527,
+              6115543,
+              6134915,
+              6134931,
+              6154303,
+              6154319,
+              6173703,
+              6173719,
+              6193103,
+              6193119,
+              6212467,
+              6212483,
+              6231867
+            ],
+            "tick0": 777,
+            "tick": 784,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 14,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6048383,
+              6048399,
+              6048415,
+              6048431,
+              6048447,
+              6048463,
+              6048479,
+              6048495,
+              6048511,
+              6048527,
+              6048543,
+              6048559,
+              6048575,
+              6048591,
+              6048607
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6056391,
+              6056407,
+              6064471,
+              6064487,
+              6072551,
+              6072567,
+              6080631,
+              6080647,
+              6088711,
+              6088727,
+              6096791,
+              6096807,
+              6104871,
+              6104887,
+              6112951
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6051591,
+              6051607,
+              6054871,
+              6054887,
+              6058151,
+              6058167,
+              6061431,
+              6061447,
+              6064711,
+              6064727,
+              6067991,
+              6068007,
+              6071271,
+              6071287,
+              6074551
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119716,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20572,
+            "endpoints": 119716,
+            "legs": [
+              19788,
+              19824,
+              19812,
+              19812,
+              19812,
+              20572
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": 0.03836058954169191,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26676
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19952.666666666668,
+            "perBoundaryPerWrite": 831.3611111111112,
+            "cdpBracket": 177000,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6105087,
+              6105103,
+              6131779,
+              6131795,
+              6151583,
+              6151599,
+              6171423,
+              6171439,
+              6191251,
+              6191267,
+              6211079,
+              6211095,
+              6230907,
+              6230923,
+              6251495
+            ],
+            "tick0": 805,
+            "tick": 812,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116292,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116292,
+            "legs": [
+              19372,
+              19348,
+              19348,
+              19372,
+              19372,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": -0.0012389015073301672,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19382,
+            "perBoundaryPerWrite": 807.5833333333334,
+            "cdpBracket": 170420,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6109371,
+              6109387,
+              6135571,
+              6135587,
+              6154959,
+              6154975,
+              6174323,
+              6174339,
+              6193687,
+              6193703,
+              6213075,
+              6213091,
+              6232463,
+              6232479,
+              6251863
+            ],
+            "tick0": 833,
+            "tick": 840,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 15,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6068427,
+              6068443,
+              6068459,
+              6068475,
+              6068491,
+              6068507,
+              6068523,
+              6068539,
+              6068555,
+              6068571,
+              6068587,
+              6068603,
+              6068619,
+              6068635,
+              6068651
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6076435,
+              6076451,
+              6084515,
+              6084531,
+              6092595,
+              6092611,
+              6100675,
+              6100691,
+              6108755,
+              6108771,
+              6116835,
+              6116851,
+              6124915,
+              6124931,
+              6132995
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6071635,
+              6071651,
+              6074915,
+              6074931,
+              6078195,
+              6078211,
+              6081475,
+              6081491,
+              6084755,
+              6084771,
+              6088035,
+              6088051,
+              6091315,
+              6091331,
+              6094595
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120084,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20880,
+            "endpoints": 120084,
+            "legs": [
+              19824,
+              19812,
+              19824,
+              19824,
+              20880,
+              19824
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.053268765133171914,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20014,
+            "perBoundaryPerWrite": 833.9166666666666,
+            "cdpBracket": 175484,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6129347,
+              6129363,
+              6156051,
+              6156067,
+              6175891,
+              6175907,
+              6195719,
+              6195735,
+              6215559,
+              6215575,
+              6235399,
+              6235415,
+              6256295,
+              6256311,
+              6276135
+            ],
+            "tick0": 861,
+            "tick": 868,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116352,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116352,
+            "legs": [
+              19372,
+              19372,
+              19372,
+              19384,
+              19384,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0006194507536650836,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19392,
+            "perBoundaryPerWrite": 808,
+            "cdpBracket": 170480,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6150631,
+              6150647,
+              6176831,
+              6176847,
+              6196219,
+              6196235,
+              6215607,
+              6215623,
+              6234995,
+              6235011,
+              6254395,
+              6254411,
+              6273795,
+              6273811,
+              6293183
+            ],
+            "tick0": 889,
+            "tick": 896,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 16,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6104571,
+              6104587,
+              6104603,
+              6104619,
+              6104635,
+              6104651,
+              6104667,
+              6104683,
+              6104699,
+              6104715,
+              6104731,
+              6104747,
+              6104763,
+              6104779,
+              6104795
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6112579,
+              6112595,
+              6120659,
+              6120675,
+              6128739,
+              6128755,
+              6136819,
+              6136835,
+              6144899,
+              6144915,
+              6152979,
+              6152995,
+              6161059,
+              6161075,
+              6169139
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6107779,
+              6107795,
+              6111059,
+              6111075,
+              6114339,
+              6114355,
+              6117619,
+              6117635,
+              6120899,
+              6120915,
+              6124179,
+              6124195,
+              6127459,
+              6127475,
+              6130739
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119764,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20560,
+            "endpoints": 119764,
+            "legs": [
+              19812,
+              19824,
+              19824,
+              19824,
+              19824,
+              20560
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.03712671509281679,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 19960.666666666668,
+            "perBoundaryPerWrite": 831.6944444444445,
+            "cdpBracket": 176916,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6152747,
+              6152763,
+              6179451,
+              6179467,
+              6199279,
+              6199295,
+              6219119,
+              6219135,
+              6238959,
+              6238975,
+              6258799,
+              6258815,
+              6278639,
+              6278655,
+              6299215
+            ],
+            "tick0": 917,
+            "tick": 924,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 211860,
+            "fall": 90088,
+            "falls": 1,
+            "maxStep": 112088,
+            "endpoints": 121772,
+            "legs": [
+              19372,
+              20732,
+              19384,
+              -90088,
+              20832,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              112088,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": -5.6489833832180825,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read -90088 B against a cohort median of 19378 B (-109466 B, -564.9%), past the ±25% leg tolerance (±4844.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read -90088 B against a cohort median of 19378 B (-109466 B, -564.9%), past the ±25% leg tolerance (±4844.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6794,
+            "perWrite": 35310,
+            "perBoundaryPerWrite": 1471.25,
+            "cdpBracket": 175888,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6160135,
+              6160151,
+              6186323,
+              6186339,
+              6205711,
+              6205727,
+              6226459,
+              6226475,
+              6245859,
+              6357947,
+              6267859,
+              6267875,
+              6288707,
+              6288723,
+              6308095
+            ],
+            "tick0": 945,
+            "tick": 952,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 17,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6116343,
+              6116359,
+              6116375,
+              6116391,
+              6116407,
+              6116423,
+              6116439,
+              6116455,
+              6116471,
+              6116487,
+              6116503,
+              6116519,
+              6116535,
+              6116551,
+              6116567
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6124351,
+              6124367,
+              6132431,
+              6132447,
+              6140511,
+              6140527,
+              6148591,
+              6148607,
+              6156671,
+              6156687,
+              6164751,
+              6164767,
+              6172831,
+              6172847,
+              6180911
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6119551,
+              6119567,
+              6122831,
+              6122847,
+              6126111,
+              6126127,
+              6129391,
+              6129407,
+              6132671,
+              6132687,
+              6135951,
+              6135967,
+              6139231,
+              6139247,
+              6142511
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 230152,
+            "fall": 107072,
+            "falls": 1,
+            "maxStep": 127960,
+            "endpoints": 123080,
+            "legs": [
+              19816,
+              19816,
+              19816,
+              127960,
+              22908,
+              19756
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              -107072,
+              16
+            ],
+            "legMedian": 19816,
+            "legWorstDeviation": 5.457408155026242,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 127960 B against a cohort median of 19816 B (+108144 B, 545.7%), past the ±25% leg tolerance (±4954 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 127960 B against a cohort median of 19816 B (+108144 B, 545.7%), past the ±25% leg tolerance (±4954 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26692
+            ],
+            "primeExcess": 6876,
+            "perWrite": 38358.666666666664,
+            "perBoundaryPerWrite": 1598.2777777777776,
+            "cdpBracket": 177736,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6181855,
+              6181871,
+              6208563,
+              6208579,
+              6228395,
+              6228411,
+              6248227,
+              6248243,
+              6268059,
+              6268075,
+              6396035,
+              6288963,
+              6311871,
+              6311887,
+              6331643
+            ],
+            "tick0": 973,
+            "tick": 980,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116340,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116340,
+            "legs": [
+              19372,
+              19372,
+              19372,
+              19372,
+              19384,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0006194507536650836,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19390,
+            "perBoundaryPerWrite": 807.9166666666666,
+            "cdpBracket": 170468,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6186663,
+              6186679,
+              6212863,
+              6212879,
+              6232251,
+              6232267,
+              6251639,
+              6251655,
+              6271027,
+              6271043,
+              6290415,
+              6290431,
+              6309815,
+              6309831,
+              6329203
+            ],
+            "tick0": 1001,
+            "tick": 1008,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      }
+    ],
+    "allocFits": {
+      "perRound": {},
+      "mean": {}
+    },
+    "writeDriven": true,
+    "writeProvenance": {
+      "windows": 36,
+      "pairs": 36,
+      "unnamed": [],
+      "incomplete": [],
+      "ok": true
+    },
+    "controlVerdict": {
+      "ok": true,
+      "perDouble": 8.08088888888889,
+      "differential": 8.00148148148148
+    },
+    "fallsInMeasuredWindows": 6,
+    "refusedWindows": 9,
+    "refusalReasons": 14
+  },
+  "box": {
+    "bead": "rf2-24o2z",
+    "chromium": "chromium/147.0.7727.15",
+    "node": "v24.13.0",
+    "platform": "win32/x64/10.0.26200",
+    "load": {
+      "open": {
+        "at": "2026-08-20T20:30:11.333Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13476939443,
+        "cpuBusyMs": 3627970347,
+        "freeMemB": 15879884800,
+        "totalMemB": 68112736256,
+        "uptimeS": 708974.14
+      },
+      "close": {
+        "at": "2026-08-20T20:30:37.530Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13477450834,
+        "cpuBusyMs": 3628089890,
+        "freeMemB": 16141025280,
+        "totalMemB": 68112736256,
+        "uptimeS": 709000.328
+      },
+      "busyFraction": 0.18946989700982989
+    },
+    "session": {
+      "startedAt": "2026-08-20T20:29:35.832Z",
+      "sessionStartedAt": "2026-08-20T19:39:26.627Z",
+      "runsInSession": 9,
+      "sessionGapMs": 3600000,
+      "previousRun": {
+        "startedAt": "2026-08-20T20:28:32.649Z",
+        "endedAt": "2026-08-20T20:29:35.705Z",
+        "sinceStartMs": 63183,
+        "sinceEndMs": 127,
+        "sameSession": true
+      }
+    }
+  }
+}

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/reversed-4.json
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/reversed-4.json
@@ -1,0 +1,7551 @@
+{
+  "generatedAt": "2026-08-20T20:33:22.749Z",
+  "build": "hicasso-bench",
+  "initFn": "re-frame.bench.p0-app/-main",
+  "alloc": {
+    "benchmark": "P0:steady-state-allocation-slope",
+    "bead": "rf2-2rtt6.76",
+    "roots": 4,
+    "perRoot": {
+      "list": 300,
+      "grid": 6
+    },
+    "publishedPerRoot": {
+      "list": 300,
+      "grid": 300
+    },
+    "arm": {
+      "cells": 6,
+      "roots": 4,
+      "boundaries": 24,
+      "writes": 6,
+      "refusals": [],
+      "admissible": true
+    },
+    "boundaries": 24,
+    "writes": 6,
+    "primeWrites": 1,
+    "windowWrites": 7,
+    "bySite": false,
+    "sites": 2,
+    "siteNames": [
+      "dispatch",
+      "drain"
+    ],
+    "warmups": 3,
+    "rounds": 18,
+    "preciseMemory": true,
+    "controlDoubles": {
+      "d1": 1000,
+      "d2": 400
+    },
+    "controlSlack": 0.75,
+    "writeSelector": "all",
+    "writeLegs": [
+      "all"
+    ],
+    "writePaired": false,
+    "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+    "plan": {
+      "name": "floor",
+      "arms": true,
+      "rungs": false,
+      "fits": false
+    },
+    "segOrder": "fixed-reversed",
+    "passOrder": "parity",
+    "passSeed": "1787257962745",
+    "passSchedule": {
+      "flips": [
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false,
+        true
+      ],
+      "attempts": 1,
+      "parityTied": false
+    },
+    "controlSlot": "first",
+    "instrument": "in-page performance.memory.usedJSHeapSize sampled at every leg boundary, rising steps accumulated separately from falling ones; --enable-precise-memory-info. A falling step is a collection this counter SAW; a leg that deviates from its cohort median by more than the leg tolerance is a work unit that is not one; and under the by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the other two can see. TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg has no interior reading and so no site step to be negative, and the intra-leg gate returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with these (see `bySite`), so a witness comparing byte for byte against a figure published at stride 2 can never be screened by all three",
+    "fallThresholdB": 600000,
+    "legTolerance": 0.25,
+    "verification": {
+      "unverified": 0,
+      "detail": []
+    },
+    "workCount": false,
+    "workVerification": {
+      "counted": false
+    },
+    "perRound": [
+      {
+        "round": 0,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 524,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              524
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 116.66666666666667,
+            "cdpBracket": 46232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3840290,
+              3840306,
+              3840322,
+              3840338,
+              3840354,
+              3840370,
+              3840386,
+              3840402,
+              3840418,
+              3840434,
+              3840450,
+              3840466,
+              3840482,
+              3841006,
+              3841022
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48576,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8144,
+            "endpoints": 48576,
+            "legs": [
+              8144,
+              8080,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.00992063492063492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8096,
+            "cdpBracket": 87388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3853914,
+              3853930,
+              3861994,
+              3862010,
+              3870154,
+              3870170,
+              3878250,
+              3878266,
+              3886330,
+              3886346,
+              3894410,
+              3894426,
+              3902490,
+              3902506,
+              3910570
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 52328,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3850014,
+              3850030,
+              3853294,
+              3853310,
+              3856574,
+              3856590,
+              3859854,
+              3859870,
+              3863134,
+              3863150,
+              3866414,
+              3866430,
+              3869694,
+              3869710,
+              3872974
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 1108908,
+            "fall": 974808,
+            "falls": 3,
+            "maxStep": 526832,
+            "endpoints": 134100,
+            "legs": [
+              20848,
+              21084,
+              20132,
+              526832,
+              -235092,
+              -498192
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              -241524,
+              519948
+            ],
+            "legMedian": 20490,
+            "legWorstDeviation": -25.313909224011713,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 526832 B against a cohort median of 20490 B (+506342 B, 2471.2%), past the ±25% leg tolerance (±5122.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -235092 B against a cohort median of 20490 B (-255582 B, -1247.3%), past the ±25% leg tolerance (±5122.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 6 of 6 read -498192 B against a cohort median of 20490 B (-518682 B, -2531.4%), past the ±25% leg tolerance (±5122.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 526832 B against a cohort median of 20490 B (+506342 B, 2471.2%), past the ±25% leg tolerance (±5122.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -235092 B against a cohort median of 20490 B (-255582 B, -1247.3%), past the ±25% leg tolerance (±5122.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 6 of 6 read -498192 B against a cohort median of 20490 B (-518682 B, -2531.4%), past the ±25% leg tolerance (±5122.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28780
+            ],
+            "primeExcess": 8290,
+            "perWrite": 184818,
+            "perBoundaryPerWrite": 7700.75,
+            "cdpBracket": 191812,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              4797447,
+              4797463,
+              4826243,
+              4826259,
+              4847107,
+              4847123,
+              4868207,
+              4868223,
+              4888355,
+              4888371,
+              5415203,
+              5173679,
+              4938587,
+              5458535,
+              4960343
+            ],
+            "tick0": 21,
+            "tick": 28,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 548116,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 441440,
+            "endpoints": 548116,
+            "legs": [
+              24048,
+              21720,
+              22004,
+              19404,
+              19404,
+              441440
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21862,
+            "legWorstDeviation": 19.192114170707164,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 441440 B against a cohort median of 21862 B (+419578 B, 1919.2%), past the ±25% leg tolerance (±5465.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 441440 B against a cohort median of 21862 B (+419578 B, 1919.2%), past the ±25% leg tolerance (±5465.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26276
+            ],
+            "primeExcess": 4414,
+            "perWrite": 91352.66666666667,
+            "perBoundaryPerWrite": 3806.3611111111113,
+            "cdpBracket": 194080,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5066659,
+              5066675,
+              5092951,
+              5092967,
+              5117015,
+              5117031,
+              5138751,
+              5138767,
+              5160771,
+              5160787,
+              5180191,
+              5180207,
+              5199611,
+              5199627,
+              5641067
+            ],
+            "tick0": 49,
+            "tick": 56,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 1,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5053783,
+              5053799,
+              5053815,
+              5053831,
+              5053847,
+              5053863,
+              5053879,
+              5053895,
+              5053911,
+              5053927,
+              5053943,
+              5053959,
+              5053975,
+              5053991,
+              5054007
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 87716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5061791,
+              5061807,
+              5069871,
+              5069887,
+              5077951,
+              5077967,
+              5086031,
+              5086047,
+              5094111,
+              5094127,
+              5102191,
+              5102207,
+              5110271,
+              5110287,
+              5118351
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5059235,
+              5059251,
+              5062515,
+              5062531,
+              5065795,
+              5065811,
+              5069075,
+              5069091,
+              5072355,
+              5072371,
+              5075635,
+              5075651,
+              5078915,
+              5078931,
+              5082195
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 199908,
+            "fall": 74624,
+            "falls": 1,
+            "maxStep": 96956,
+            "endpoints": 125284,
+            "legs": [
+              21004,
+              19772,
+              20588,
+              96956,
+              19772,
+              21736
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              -74624,
+              16
+            ],
+            "legMedian": 20796,
+            "legWorstDeviation": 3.662242738988267,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read 96956 B against a cohort median of 20796 B (+76160 B, 366.2%), past the ±25% leg tolerance (±5199 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read 96956 B against a cohort median of 20796 B (+76160 B, 366.2%), past the ±25% leg tolerance (±5199 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              30964
+            ],
+            "primeExcess": 10168,
+            "perWrite": 33318,
+            "perBoundaryPerWrite": 1388.25,
+            "cdpBracket": 187800,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5188039,
+              5188055,
+              5219019,
+              5219035,
+              5240039,
+              5240055,
+              5259827,
+              5259843,
+              5280431,
+              5280447,
+              5377403,
+              5302779,
+              5322551,
+              5322567,
+              5344303
+            ],
+            "tick0": 77,
+            "tick": 84,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 196856,
+            "fall": 74732,
+            "falls": 1,
+            "maxStep": 119988,
+            "endpoints": 122124,
+            "legs": [
+              19256,
+              119988,
+              -74732,
+              19148,
+              19184,
+              19184
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19184,
+            "legWorstDeviation": 5.254587155963303,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 119988 B against a cohort median of 19184 B (+100804 B, 525.5%), past the ±25% leg tolerance (±4796 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -74732 B against a cohort median of 19184 B (-93916 B, -489.6%), past the ±25% leg tolerance (±4796 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 119988 B against a cohort median of 19184 B (+100804 B, 525.5%), past the ±25% leg tolerance (±4796 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -74732 B against a cohort median of 19184 B (-93916 B, -489.6%), past the ±25% leg tolerance (±4796 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6856,
+            "perWrite": 32809.333333333336,
+            "perBoundaryPerWrite": 1367.0555555555557,
+            "cdpBracket": 176580,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5291003,
+              5291019,
+              5317059,
+              5317075,
+              5336331,
+              5336347,
+              5456335,
+              5456351,
+              5381619,
+              5381635,
+              5400783,
+              5400799,
+              5419983,
+              5419999,
+              5439183
+            ],
+            "tick0": 105,
+            "tick": 112,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 2,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5254467,
+              5254483,
+              5254499,
+              5254515,
+              5254531,
+              5254547,
+              5254563,
+              5254579,
+              5254595,
+              5254611,
+              5254627,
+              5254643,
+              5254659,
+              5254675,
+              5254691
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85088,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5262491,
+              5262507,
+              5270571,
+              5270587,
+              5278651,
+              5278667,
+              5286731,
+              5286747,
+              5294811,
+              5294827,
+              5302891,
+              5302907,
+              5310971,
+              5310987,
+              5319051
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5257691,
+              5257707,
+              5260971,
+              5260987,
+              5264251,
+              5264267,
+              5267531,
+              5267547,
+              5270811,
+              5270827,
+              5274091,
+              5274107,
+              5277371,
+              5277387,
+              5280651
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119016,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20440,
+            "endpoints": 119016,
+            "legs": [
+              19696,
+              20440,
+              19696,
+              19696,
+              19696,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": 0.03777416734362307,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26532
+            ],
+            "primeExcess": 6836,
+            "perWrite": 19836,
+            "perBoundaryPerWrite": 826.5,
+            "cdpBracket": 176628,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5358143,
+              5358159,
+              5384691,
+              5384707,
+              5404403,
+              5404419,
+              5424859,
+              5424875,
+              5444571,
+              5444587,
+              5464283,
+              5464299,
+              5483995,
+              5484011,
+              5503707
+            ],
+            "tick0": 133,
+            "tick": 140,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 358396,
+            "fall": 240696,
+            "falls": 1,
+            "maxStep": 260480,
+            "endpoints": 117700,
+            "legs": [
+              260480,
+              19256,
+              20812,
+              19256,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              -240696,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": 12.527212297465725,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 260480 B against a cohort median of 19256 B (+241224 B, 1252.7%), past the ±25% leg tolerance (±4814 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 260480 B against a cohort median of 19256 B (+241224 B, 1252.7%), past the ±25% leg tolerance (±4814 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 59732.666666666664,
+            "perBoundaryPerWrite": 2488.861111111111,
+            "cdpBracket": 171700,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5419183,
+              5419199,
+              5445239,
+              5445255,
+              5705735,
+              5465039,
+              5484295,
+              5484311,
+              5505123,
+              5505139,
+              5524395,
+              5524411,
+              5543667,
+              5543683,
+              5562939
+            ],
+            "tick0": 161,
+            "tick": 168,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 3,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 29120,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5380319,
+              5380335,
+              5380351,
+              5380367,
+              5380383,
+              5380399,
+              5380415,
+              5380431,
+              5380447,
+              5380463,
+              5380479,
+              5380495,
+              5380511,
+              5380527,
+              5380543
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5389255,
+              5389271,
+              5397335,
+              5397351,
+              5405415,
+              5405431,
+              5413495,
+              5413511,
+              5421575,
+              5421591,
+              5429655,
+              5429671,
+              5437735,
+              5437751,
+              5445815
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5384455,
+              5384471,
+              5387735,
+              5387751,
+              5391015,
+              5391031,
+              5394295,
+              5394311,
+              5397575,
+              5397591,
+              5400855,
+              5400871,
+              5404135,
+              5404151,
+              5407415
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118224,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19696,
+            "endpoints": 118224,
+            "legs": [
+              19696,
+              19696,
+              19660,
+              19684,
+              19696,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": -0.0018277822908204712,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6848,
+            "perWrite": 19704,
+            "perBoundaryPerWrite": 821,
+            "cdpBracket": 172748,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5445879,
+              5445895,
+              5472439,
+              5472455,
+              5492151,
+              5492167,
+              5511863,
+              5511879,
+              5531539,
+              5531555,
+              5551239,
+              5551255,
+              5570951,
+              5570967,
+              5590663
+            ],
+            "tick0": 189,
+            "tick": 196,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 115620,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19256,
+            "endpoints": 115620,
+            "legs": [
+              19256,
+              19256,
+              19244,
+              19256,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": -0.0006231823847112588,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19270,
+            "perBoundaryPerWrite": 802.9166666666666,
+            "cdpBracket": 169620,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5480499,
+              5480515,
+              5506555,
+              5506571,
+              5525827,
+              5525843,
+              5545099,
+              5545115,
+              5564359,
+              5564375,
+              5583631,
+              5583647,
+              5602903,
+              5602919,
+              5622175
+            ],
+            "tick0": 217,
+            "tick": 224,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 4,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5439555,
+              5439571,
+              5439587,
+              5439603,
+              5439619,
+              5439635,
+              5439651,
+              5439667,
+              5439683,
+              5439699,
+              5439715,
+              5439731,
+              5439747,
+              5439763,
+              5439779
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5447563,
+              5447579,
+              5455643,
+              5455659,
+              5463723,
+              5463739,
+              5471803,
+              5471819,
+              5479883,
+              5479899,
+              5487963,
+              5487979,
+              5496043,
+              5496059,
+              5504123
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5442763,
+              5442779,
+              5446043,
+              5446059,
+              5449323,
+              5449339,
+              5452603,
+              5452619,
+              5455883,
+              5455899,
+              5459163,
+              5459179,
+              5462443,
+              5462459,
+              5465723
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 130860,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 25848,
+            "endpoints": 130860,
+            "legs": [
+              25848,
+              22360,
+              19888,
+              19888,
+              21812,
+              19888
+            ],
+            "gaps": [
+              16,
+              1096,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20850,
+            "legWorstDeviation": 0.23971223021582733,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29376
+            ],
+            "primeExcess": 8526,
+            "perWrite": 21810,
+            "perBoundaryPerWrite": 908.75,
+            "cdpBracket": 188344,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5618971,
+              5618987,
+              5648363,
+              5648379,
+              5674227,
+              5675323,
+              5697683,
+              5697699,
+              5717587,
+              5717603,
+              5737491,
+              5737507,
+              5759319,
+              5759335,
+              5779223
+            ],
+            "tick0": 245,
+            "tick": 252,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 120224,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23004,
+            "endpoints": 120224,
+            "legs": [
+              19432,
+              19396,
+              19432,
+              23004,
+              19432,
+              19432
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19432,
+            "legWorstDeviation": 0.1838205022643063,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26232
+            ],
+            "primeExcess": 6800,
+            "perWrite": 20037.333333333332,
+            "perBoundaryPerWrite": 834.8888888888888,
+            "cdpBracket": 174416,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5699847,
+              5699863,
+              5726095,
+              5726111,
+              5745543,
+              5745559,
+              5764955,
+              5764971,
+              5784403,
+              5784419,
+              5807423,
+              5807439,
+              5826871,
+              5826887,
+              5846319
+            ],
+            "tick0": 273,
+            "tick": 280,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 5,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5660507,
+              5660523,
+              5660539,
+              5660555,
+              5660571,
+              5660587,
+              5660603,
+              5660619,
+              5660635,
+              5660651,
+              5660667,
+              5660683,
+              5660699,
+              5660715,
+              5660731
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5668515,
+              5668531,
+              5676595,
+              5676611,
+              5684675,
+              5684691,
+              5692755,
+              5692771,
+              5700835,
+              5700851,
+              5708915,
+              5708931,
+              5716995,
+              5717011,
+              5725075
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5663715,
+              5663731,
+              5666995,
+              5667011,
+              5670275,
+              5670291,
+              5673555,
+              5673571,
+              5676835,
+              5676851,
+              5680115,
+              5680131,
+              5683395,
+              5683411,
+              5686675
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 124056,
+            "fall": 2036,
+            "falls": 1,
+            "maxStep": 22672,
+            "endpoints": 122020,
+            "legs": [
+              19872,
+              20468,
+              19872,
+              -2036,
+              19872,
+              21220
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              22672,
+              16,
+              16
+            ],
+            "legMedian": 19872,
+            "legWorstDeviation": -1.1024557165861513,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 4 of 6 read -2036 B against a cohort median of 19872 B (-21908 B, -110.2%), past the ±25% leg tolerance (±4968 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 4 of 6 read -2036 B against a cohort median of 19872 B (-21908 B, -110.2%), past the ±25% leg tolerance (±4968 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26736
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20676,
+            "perBoundaryPerWrite": 861.5,
+            "cdpBracket": 176736,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5725515,
+              5725531,
+              5752267,
+              5752283,
+              5772155,
+              5772171,
+              5792639,
+              5792655,
+              5812527,
+              5835199,
+              5833163,
+              5833179,
+              5853051,
+              5853067,
+              5874287
+            ],
+            "tick0": 301,
+            "tick": 308,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116688,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19432,
+            "endpoints": 116688,
+            "legs": [
+              19432,
+              19432,
+              19432,
+              19432,
+              19432,
+              19432
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19432,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26232
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19448,
+            "perBoundaryPerWrite": 810.3333333333334,
+            "cdpBracket": 170880,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5740859,
+              5740875,
+              5767107,
+              5767123,
+              5786555,
+              5786571,
+              5806003,
+              5806019,
+              5825451,
+              5825467,
+              5844899,
+              5844915,
+              5864347,
+              5864363,
+              5883795
+            ],
+            "tick0": 329,
+            "tick": 336,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 6,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5702039,
+              5702055,
+              5702071,
+              5702087,
+              5702103,
+              5702119,
+              5702135,
+              5702151,
+              5702167,
+              5702183,
+              5702199,
+              5702215,
+              5702231,
+              5702247,
+              5702263
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5710047,
+              5710063,
+              5718127,
+              5718143,
+              5726207,
+              5726223,
+              5734287,
+              5734303,
+              5742367,
+              5742383,
+              5750447,
+              5750463,
+              5758527,
+              5758543,
+              5766607
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5705247,
+              5705263,
+              5708527,
+              5708543,
+              5711807,
+              5711823,
+              5715087,
+              5715103,
+              5718367,
+              5718383,
+              5721647,
+              5721663,
+              5724927,
+              5724943,
+              5728207
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120816,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20604,
+            "endpoints": 120816,
+            "legs": [
+              19844,
+              20268,
+              19856,
+              20604,
+              19856,
+              19856
+            ],
+            "gaps": [
+              16,
+              16,
+              452,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19856,
+            "legWorstDeviation": 0.03767123287671233,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26720
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20136,
+            "perBoundaryPerWrite": 839,
+            "cdpBracket": 175644,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5771179,
+              5771195,
+              5797915,
+              5797931,
+              5817775,
+              5817791,
+              5838059,
+              5838511,
+              5858367,
+              5858383,
+              5878987,
+              5879003,
+              5898859,
+              5898875,
+              5918731
+            ],
+            "tick0": 357,
+            "tick": 364,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116592,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19416,
+            "endpoints": 116592,
+            "legs": [
+              19416,
+              19416,
+              19416,
+              19416,
+              19416,
+              19416
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19416,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26204
+            ],
+            "primeExcess": 6788,
+            "perWrite": 19432,
+            "perBoundaryPerWrite": 809.6666666666666,
+            "cdpBracket": 170756,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5783851,
+              5783867,
+              5810071,
+              5810087,
+              5829503,
+              5829519,
+              5848935,
+              5848951,
+              5868367,
+              5868383,
+              5887799,
+              5887815,
+              5907231,
+              5907247,
+              5926663
+            ],
+            "tick0": 385,
+            "tick": 392,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 7,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5742907,
+              5742923,
+              5742939,
+              5742955,
+              5742971,
+              5742987,
+              5743003,
+              5743019,
+              5743035,
+              5743051,
+              5743067,
+              5743083,
+              5743099,
+              5743115,
+              5743131
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5750915,
+              5750931,
+              5758995,
+              5759011,
+              5767075,
+              5767091,
+              5775155,
+              5775171,
+              5783235,
+              5783251,
+              5791315,
+              5791331,
+              5799395,
+              5799411,
+              5807475
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5746115,
+              5746131,
+              5749395,
+              5749411,
+              5752675,
+              5752691,
+              5755955,
+              5755971,
+              5759235,
+              5759251,
+              5762515,
+              5762531,
+              5765795,
+              5765811,
+              5769075
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122420,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22208,
+            "endpoints": 122420,
+            "legs": [
+              19836,
+              19836,
+              20760,
+              19848,
+              22208,
+              19836
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19842,
+            "legWorstDeviation": 0.1192420118939623,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26700
+            ],
+            "primeExcess": 6858,
+            "perWrite": 20403.333333333332,
+            "perBoundaryPerWrite": 850.1388888888888,
+            "cdpBracket": 184024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5820443,
+              5820459,
+              5847159,
+              5847175,
+              5867011,
+              5867027,
+              5886863,
+              5886879,
+              5907639,
+              5907655,
+              5927503,
+              5927519,
+              5949727,
+              5949743,
+              5969579
+            ],
+            "tick0": 413,
+            "tick": 420,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117276,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20164,
+            "endpoints": 117276,
+            "legs": [
+              19408,
+              19408,
+              19408,
+              19396,
+              19396,
+              20164
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19408,
+            "legWorstDeviation": 0.038953009068425394,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26208
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19546,
+            "perBoundaryPerWrite": 814.4166666666666,
+            "cdpBracket": 174600,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5837303,
+              5837319,
+              5863527,
+              5863543,
+              5882951,
+              5882967,
+              5902375,
+              5902391,
+              5921799,
+              5921815,
+              5941211,
+              5941227,
+              5960623,
+              5960639,
+              5980803
+            ],
+            "tick0": 441,
+            "tick": 448,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 8,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5800283,
+              5800299,
+              5800315,
+              5800331,
+              5800347,
+              5800363,
+              5800379,
+              5800395,
+              5800411,
+              5800427,
+              5800443,
+              5800459,
+              5800475,
+              5800491,
+              5800507
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5808291,
+              5808307,
+              5816371,
+              5816387,
+              5824451,
+              5824467,
+              5832531,
+              5832547,
+              5840611,
+              5840627,
+              5848691,
+              5848707,
+              5856771,
+              5856787,
+              5864851
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5803491,
+              5803507,
+              5806771,
+              5806787,
+              5810051,
+              5810067,
+              5813331,
+              5813347,
+              5816611,
+              5816627,
+              5819891,
+              5819907,
+              5823171,
+              5823187,
+              5826451
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 324936,
+            "fall": 197768,
+            "falls": 1,
+            "maxStep": 244724,
+            "endpoints": 127168,
+            "legs": [
+              19848,
+              244724,
+              -197768,
+              19848,
+              19836,
+              19836
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              764,
+              16
+            ],
+            "legMedian": 19842,
+            "legWorstDeviation": 11.333635722205424,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 244724 B against a cohort median of 19842 B (+224882 B, 1133.4%), past the ±25% leg tolerance (±4960.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -197768 B against a cohort median of 19842 B (-217610 B, -1096.7%), past the ±25% leg tolerance (±4960.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 244724 B against a cohort median of 19842 B (+224882 B, 1133.4%), past the ±25% leg tolerance (±4960.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 3 of 6 read -197768 B against a cohort median of 19842 B (-217610 B, -1096.7%), past the ±25% leg tolerance (±4960.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              27124
+            ],
+            "primeExcess": 7282,
+            "perWrite": 54156,
+            "perBoundaryPerWrite": 2256.5,
+            "cdpBracket": 182400,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5873215,
+              5873231,
+              5900355,
+              5900371,
+              5920219,
+              5920235,
+              6164959,
+              6164975,
+              5967207,
+              5967223,
+              5987071,
+              5987835,
+              6007671,
+              6007687,
+              6027523
+            ],
+            "tick0": 469,
+            "tick": 476,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116472,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19408,
+            "endpoints": 116472,
+            "legs": [
+              19396,
+              19408,
+              19408,
+              19396,
+              19396,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19396,
+            "legWorstDeviation": -0.0012373685295937306,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26208
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19412,
+            "perBoundaryPerWrite": 808.8333333333334,
+            "cdpBracket": 170640,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5913339,
+              5913355,
+              5939563,
+              5939579,
+              5958975,
+              5958991,
+              5978399,
+              5978415,
+              5997823,
+              5997839,
+              6017235,
+              6017251,
+              6036647,
+              6036663,
+              6056035
+            ],
+            "tick0": 497,
+            "tick": 504,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 9,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5872395,
+              5872411,
+              5872427,
+              5872443,
+              5872459,
+              5872475,
+              5872491,
+              5872507,
+              5872523,
+              5872539,
+              5872555,
+              5872571,
+              5872587,
+              5872603,
+              5872619
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5880403,
+              5880419,
+              5888483,
+              5888499,
+              5896563,
+              5896579,
+              5904643,
+              5904659,
+              5912723,
+              5912739,
+              5920803,
+              5920819,
+              5928883,
+              5928899,
+              5936963
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5875603,
+              5875619,
+              5878883,
+              5878899,
+              5882163,
+              5882179,
+              5885443,
+              5885459,
+              5888723,
+              5888739,
+              5892003,
+              5892019,
+              5895283,
+              5895299,
+              5898563
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 124040,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24008,
+            "endpoints": 124040,
+            "legs": [
+              19840,
+              19840,
+              19840,
+              20588,
+              24008,
+              19828
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19840,
+            "legWorstDeviation": 0.21008064516129032,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26692
+            ],
+            "primeExcess": 6852,
+            "perWrite": 20673.333333333332,
+            "perBoundaryPerWrite": 861.3888888888888,
+            "cdpBracket": 178712,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5945807,
+              5945823,
+              5972515,
+              5972531,
+              5992371,
+              5992387,
+              6012227,
+              6012243,
+              6032083,
+              6032099,
+              6052687,
+              6052703,
+              6076711,
+              6076727,
+              6096555
+            ],
+            "tick0": 525,
+            "tick": 532,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 123052,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 25968,
+            "endpoints": 123052,
+            "legs": [
+              19388,
+              19400,
+              19400,
+              19400,
+              25968,
+              19400
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19400,
+            "legWorstDeviation": 0.33855670103092783,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 5 of 6 read 25968 B against a cohort median of 19400 B (+6568 B, 33.9%), past the ±25% leg tolerance (±4850 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 5 of 6 read 25968 B against a cohort median of 19400 B (+6568 B, 33.9%), past the ±25% leg tolerance (±4850 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26188
+            ],
+            "primeExcess": 6788,
+            "perWrite": 20508.666666666668,
+            "perBoundaryPerWrite": 854.5277777777778,
+            "cdpBracket": 177200,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5955083,
+              5955099,
+              5981287,
+              5981303,
+              6000691,
+              6000707,
+              6020107,
+              6020123,
+              6039523,
+              6039539,
+              6058939,
+              6058955,
+              6084923,
+              6084939,
+              6104339
+            ],
+            "tick0": 553,
+            "tick": 560,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 10,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5920719,
+              5920735,
+              5920751,
+              5920767,
+              5920783,
+              5920799,
+              5920815,
+              5920831,
+              5920847,
+              5920863,
+              5920879,
+              5920895,
+              5920911,
+              5920927,
+              5920943
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5928727,
+              5928743,
+              5936807,
+              5936823,
+              5944887,
+              5944903,
+              5952967,
+              5952983,
+              5961047,
+              5961063,
+              5969127,
+              5969143,
+              5977207,
+              5977223,
+              5985287
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5923927,
+              5923943,
+              5927207,
+              5927223,
+              5930487,
+              5930503,
+              5933767,
+              5933783,
+              5937047,
+              5937063,
+              5940327,
+              5940343,
+              5943607,
+              5943623,
+              5946887
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119812,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19840,
+            "endpoints": 119812,
+            "legs": [
+              19828,
+              19804,
+              19828,
+              19840,
+              18340,
+              19828
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              2264,
+              16
+            ],
+            "legMedian": 19828,
+            "legWorstDeviation": -0.07504539035707081,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26704
+            ],
+            "primeExcess": 6876,
+            "perWrite": 19968.666666666668,
+            "perBoundaryPerWrite": 832.0277777777778,
+            "cdpBracket": 177136,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5985999,
+              5986015,
+              6012719,
+              6012735,
+              6032563,
+              6032579,
+              6052383,
+              6052399,
+              6072227,
+              6072243,
+              6092083,
+              6094347,
+              6112687,
+              6112703,
+              6132531
+            ],
+            "tick0": 581,
+            "tick": 588,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116340,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116340,
+            "legs": [
+              19372,
+              19348,
+              19384,
+              19384,
+              19372,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": -0.0015481473836309217,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19390,
+            "perBoundaryPerWrite": 807.9166666666666,
+            "cdpBracket": 172552,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5991423,
+              5991439,
+              6017623,
+              6017639,
+              6037011,
+              6037027,
+              6056375,
+              6056391,
+              6075775,
+              6075791,
+              6095175,
+              6095191,
+              6114563,
+              6114579,
+              6133963
+            ],
+            "tick0": 609,
+            "tick": 616,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 11,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5950671,
+              5950687,
+              5950703,
+              5950719,
+              5950735,
+              5950751,
+              5950767,
+              5950783,
+              5950799,
+              5950815,
+              5950831,
+              5950847,
+              5950863,
+              5950879,
+              5950895
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5958679,
+              5958695,
+              5966759,
+              5966775,
+              5974839,
+              5974855,
+              5982919,
+              5982935,
+              5990999,
+              5991015,
+              5999079,
+              5999095,
+              6007159,
+              6007175,
+              6015239
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5953879,
+              5953895,
+              5957159,
+              5957175,
+              5960439,
+              5960455,
+              5963719,
+              5963735,
+              5966999,
+              5967015,
+              5970279,
+              5970295,
+              5973559,
+              5973575,
+              5976839
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119716,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20560,
+            "endpoints": 119716,
+            "legs": [
+              19812,
+              19824,
+              19824,
+              20560,
+              19812,
+              19788
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 0.037440710465233625,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6870,
+            "perWrite": 19952.666666666668,
+            "perBoundaryPerWrite": 831.3611111111112,
+            "cdpBracket": 174384,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6007199,
+              6007215,
+              6033903,
+              6033919,
+              6053731,
+              6053747,
+              6073571,
+              6073587,
+              6093411,
+              6093427,
+              6113987,
+              6114003,
+              6133815,
+              6133831,
+              6153619
+            ],
+            "tick0": 637,
+            "tick": 644,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116340,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116340,
+            "legs": [
+              19384,
+              19372,
+              19372,
+              19372,
+              19372,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0006194507536650836,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              31668
+            ],
+            "primeExcess": 12296,
+            "perWrite": 19390,
+            "perBoundaryPerWrite": 807.9166666666666,
+            "cdpBracket": 177180,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6028263,
+              6028279,
+              6059947,
+              6059963,
+              6079347,
+              6079363,
+              6098735,
+              6098751,
+              6118123,
+              6118139,
+              6137511,
+              6137527,
+              6156899,
+              6156915,
+              6176287
+            ],
+            "tick0": 665,
+            "tick": 672,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 12,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5992671,
+              5992687,
+              5992703,
+              5992719,
+              5992735,
+              5992751,
+              5992767,
+              5992783,
+              5992799,
+              5992815,
+              5992831,
+              5992847,
+              5992863,
+              5992879,
+              5992895
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6000679,
+              6000695,
+              6008759,
+              6008775,
+              6016839,
+              6016855,
+              6024919,
+              6024935,
+              6032999,
+              6033015,
+              6041079,
+              6041095,
+              6049159,
+              6049175,
+              6057239
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5995879,
+              5995895,
+              5999159,
+              5999175,
+              6002439,
+              6002455,
+              6005719,
+              6005735,
+              6008999,
+              6009015,
+              6012279,
+              6012295,
+              6015559,
+              6015575,
+              6018839
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119752,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20572,
+            "endpoints": 119752,
+            "legs": [
+              19812,
+              19824,
+              19812,
+              20572,
+              19812,
+              19824
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 0.03804622060752851,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6870,
+            "perWrite": 19958.666666666668,
+            "perBoundaryPerWrite": 831.6111111111112,
+            "cdpBracket": 174532,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6066915,
+              6066931,
+              6093619,
+              6093635,
+              6113447,
+              6113463,
+              6133287,
+              6133303,
+              6153115,
+              6153131,
+              6173703,
+              6173719,
+              6193531,
+              6193547,
+              6213371
+            ],
+            "tick0": 693,
+            "tick": 700,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116364,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116364,
+            "legs": [
+              19372,
+              19372,
+              19372,
+              19384,
+              19384,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": -0.0003096294767261843,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6806,
+            "perWrite": 19394,
+            "perBoundaryPerWrite": 808.0833333333334,
+            "cdpBracket": 170492,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6087019,
+              6087035,
+              6113219,
+              6113235,
+              6132607,
+              6132623,
+              6151995,
+              6152011,
+              6171383,
+              6171399,
+              6190783,
+              6190799,
+              6210183,
+              6210199,
+              6229583
+            ],
+            "tick0": 721,
+            "tick": 728,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 13,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 31952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6046075,
+              6046091,
+              6046107,
+              6046123,
+              6046139,
+              6046155,
+              6046171,
+              6046187,
+              6046203,
+              6046219,
+              6046235,
+              6046251,
+              6046267,
+              6046283,
+              6046299
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6058103,
+              6058119,
+              6066183,
+              6066199,
+              6074263,
+              6074279,
+              6082343,
+              6082359,
+              6090423,
+              6090439,
+              6098503,
+              6098519,
+              6106583,
+              6106599,
+              6114663
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6053303,
+              6053319,
+              6056583,
+              6056599,
+              6059863,
+              6059879,
+              6063143,
+              6063159,
+              6066423,
+              6066439,
+              6069703,
+              6069719,
+              6072983,
+              6072999,
+              6076263
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 255016,
+            "fall": 135276,
+            "falls": 1,
+            "maxStep": 155852,
+            "endpoints": 119740,
+            "legs": [
+              19824,
+              19812,
+              19812,
+              19812,
+              19824,
+              -135276
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              155852
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": -7.827983040581466,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read -135276 B against a cohort median of 19812 B (-155088 B, -782.8%), past the ±25% leg tolerance (±4953 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read -135276 B against a cohort median of 19812 B (-155088 B, -782.8%), past the ±25% leg tolerance (±4953 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6876,
+            "perWrite": 42502.666666666664,
+            "perBoundaryPerWrite": 1770.9444444444443,
+            "cdpBracket": 174392,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6105247,
+              6105263,
+              6131951,
+              6131967,
+              6151791,
+              6151807,
+              6171619,
+              6171635,
+              6191447,
+              6191463,
+              6211275,
+              6211291,
+              6231115,
+              6386967,
+              6251691
+            ],
+            "tick0": 749,
+            "tick": 756,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116376,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116376,
+            "legs": [
+              19384,
+              19384,
+              19384,
+              19384,
+              19372,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19384,
+            "legWorstDeviation": -0.0006190672719768881,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19396,
+            "perBoundaryPerWrite": 808.1666666666666,
+            "cdpBracket": 170504,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6108079,
+              6108095,
+              6134279,
+              6134295,
+              6153679,
+              6153695,
+              6173079,
+              6173095,
+              6192479,
+              6192495,
+              6211879,
+              6211895,
+              6231267,
+              6231283,
+              6250655
+            ],
+            "tick0": 777,
+            "tick": 784,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 14,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6067135,
+              6067151,
+              6067167,
+              6067183,
+              6067199,
+              6067215,
+              6067231,
+              6067247,
+              6067263,
+              6067279,
+              6067295,
+              6067311,
+              6067327,
+              6067343,
+              6067359
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6075143,
+              6075159,
+              6083223,
+              6083239,
+              6091303,
+              6091319,
+              6099383,
+              6099399,
+              6107463,
+              6107479,
+              6115543,
+              6115559,
+              6123623,
+              6123639,
+              6131703
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6070343,
+              6070359,
+              6073623,
+              6073639,
+              6076903,
+              6076919,
+              6080183,
+              6080199,
+              6083463,
+              6083479,
+              6086743,
+              6086759,
+              6090023,
+              6090039,
+              6093303
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120456,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20568,
+            "endpoints": 120456,
+            "legs": [
+              19824,
+              19824,
+              19812,
+              20568,
+              19824,
+              20508
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.03753026634382567,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26676
+            ],
+            "primeExcess": 6852,
+            "perWrite": 20076,
+            "perBoundaryPerWrite": 836.5,
+            "cdpBracket": 180000,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6123839,
+              6123855,
+              6150531,
+              6150547,
+              6170371,
+              6170387,
+              6190211,
+              6190227,
+              6210039,
+              6210055,
+              6230623,
+              6230639,
+              6250463,
+              6250479,
+              6270987
+            ],
+            "tick0": 805,
+            "tick": 812,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116376,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116376,
+            "legs": [
+              19372,
+              19384,
+              19372,
+              19384,
+              19384,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19384,
+            "legWorstDeviation": -0.0006190672719768881,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6788,
+            "perWrite": 19396,
+            "perBoundaryPerWrite": 808.1666666666666,
+            "cdpBracket": 170492,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6128243,
+              6128259,
+              6154431,
+              6154447,
+              6173819,
+              6173835,
+              6193219,
+              6193235,
+              6212607,
+              6212623,
+              6232007,
+              6232023,
+              6251407,
+              6251423,
+              6270807
+            ],
+            "tick0": 833,
+            "tick": 840,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 15,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6087299,
+              6087315,
+              6087331,
+              6087347,
+              6087363,
+              6087379,
+              6087395,
+              6087411,
+              6087427,
+              6087443,
+              6087459,
+              6087475,
+              6087491,
+              6087507,
+              6087523
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6095307,
+              6095323,
+              6103387,
+              6103403,
+              6111467,
+              6111483,
+              6119547,
+              6119563,
+              6127627,
+              6127643,
+              6135707,
+              6135723,
+              6143787,
+              6143803,
+              6151867
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6090507,
+              6090523,
+              6093787,
+              6093803,
+              6097067,
+              6097083,
+              6100347,
+              6100363,
+              6103627,
+              6103643,
+              6106907,
+              6106923,
+              6110187,
+              6110203,
+              6113467
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 124944,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22824,
+            "endpoints": 124944,
+            "legs": [
+              19812,
+              19824,
+              19812,
+              22824,
+              22116,
+              19740
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              736
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 0.1516802906448683,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6870,
+            "perWrite": 20824,
+            "perBoundaryPerWrite": 867.6666666666666,
+            "cdpBracket": 179596,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6148663,
+              6148679,
+              6175367,
+              6175383,
+              6195195,
+              6195211,
+              6215035,
+              6215051,
+              6234863,
+              6234879,
+              6257703,
+              6257719,
+              6279835,
+              6280571,
+              6300311
+            ],
+            "tick0": 861,
+            "tick": 868,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117096,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20128,
+            "endpoints": 117096,
+            "legs": [
+              19372,
+              19372,
+              19384,
+              20128,
+              19372,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.03902539748090027,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19516,
+            "perBoundaryPerWrite": 813.1666666666666,
+            "cdpBracket": 171212,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6158731,
+              6158747,
+              6184919,
+              6184935,
+              6204307,
+              6204323,
+              6223695,
+              6223711,
+              6243095,
+              6243111,
+              6263239,
+              6263255,
+              6282627,
+              6282643,
+              6302015
+            ],
+            "tick0": 889,
+            "tick": 896,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 16,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6112671,
+              6112687,
+              6112703,
+              6112719,
+              6112735,
+              6112751,
+              6112767,
+              6112783,
+              6112799,
+              6112815,
+              6112831,
+              6112847,
+              6112863,
+              6112879,
+              6112895
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6120679,
+              6120695,
+              6128759,
+              6128775,
+              6136839,
+              6136855,
+              6144919,
+              6144935,
+              6152999,
+              6153015,
+              6161079,
+              6161095,
+              6169159,
+              6169175,
+              6177239
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6115879,
+              6115895,
+              6119159,
+              6119175,
+              6122439,
+              6122455,
+              6125719,
+              6125735,
+              6128999,
+              6129015,
+              6132279,
+              6132295,
+              6135559,
+              6135575,
+              6138839
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 131640,
+            "fall": 9756,
+            "falls": 1,
+            "maxStep": 31984,
+            "endpoints": 121884,
+            "legs": [
+              19812,
+              19824,
+              31984,
+              19740,
+              19740,
+              20460
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              -9756,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 0.6138863659299627,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 3 of 6 read 31984 B against a cohort median of 19818 B (+12166 B, 61.4%), past the ±25% leg tolerance (±4954.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 3 of 6 read 31984 B against a cohort median of 19818 B (+12166 B, 61.4%), past the ±25% leg tolerance (±4954.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6870,
+            "perWrite": 21940,
+            "perBoundaryPerWrite": 914.1666666666666,
+            "cdpBracket": 176664,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6160415,
+              6160431,
+              6187119,
+              6187135,
+              6206947,
+              6206963,
+              6226787,
+              6226803,
+              6258787,
+              6249031,
+              6268771,
+              6268787,
+              6288527,
+              6288543,
+              6309003
+            ],
+            "tick0": 917,
+            "tick": 924,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 126564,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 30740,
+            "endpoints": 126564,
+            "legs": [
+              19348,
+              30740,
+              19372,
+              11964,
+              19372,
+              25672
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.5868263473053892,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 30740 B against a cohort median of 19372 B (+11368 B, 58.7%), past the ±25% leg tolerance (±4843 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read 11964 B against a cohort median of 19372 B (-7408 B, -38.2%), past the ±25% leg tolerance (±4843 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 6 of 6 read 25672 B against a cohort median of 19372 B (+6300 B, 32.5%), past the ±25% leg tolerance (±4843 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 30740 B against a cohort median of 19372 B (+11368 B, 58.7%), past the ±25% leg tolerance (±4843 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read 11964 B against a cohort median of 19372 B (-7408 B, -38.2%), past the ±25% leg tolerance (±4843 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does",
+              "leg 6 of 6 read 25672 B against a cohort median of 19372 B (+6300 B, 32.5%), past the ±25% leg tolerance (±4843 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 21094,
+            "perBoundaryPerWrite": 878.9166666666666,
+            "cdpBracket": 180692,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6167803,
+              6167819,
+              6194003,
+              6194019,
+              6213367,
+              6213383,
+              6244123,
+              6244139,
+              6263511,
+              6263527,
+              6275491,
+              6275507,
+              6294879,
+              6294895,
+              6320567
+            ],
+            "tick0": 945,
+            "tick": 952,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 17,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6130511,
+              6130527,
+              6130543,
+              6130559,
+              6130575,
+              6130591,
+              6130607,
+              6130623,
+              6130639,
+              6130655,
+              6130671,
+              6130687,
+              6130703,
+              6130719,
+              6130735
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6138519,
+              6138535,
+              6146599,
+              6146615,
+              6154679,
+              6154695,
+              6162759,
+              6162775,
+              6170839,
+              6170855,
+              6178919,
+              6178935,
+              6186999,
+              6187015,
+              6195079
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6133719,
+              6133735,
+              6136999,
+              6137015,
+              6140279,
+              6140295,
+              6143559,
+              6143575,
+              6146839,
+              6146855,
+              6150119,
+              6150135,
+              6153399,
+              6153415,
+              6156679
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122852,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22152,
+            "endpoints": 122852,
+            "legs": [
+              19828,
+              22152,
+              19744,
+              20812,
+              19744,
+              19756
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              736
+            ],
+            "legMedian": 19792,
+            "legWorstDeviation": 0.11924009700889249,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26692
+            ],
+            "primeExcess": 6900,
+            "perWrite": 20475.333333333332,
+            "perBoundaryPerWrite": 853.1388888888888,
+            "cdpBracket": 177508,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6189755,
+              6189771,
+              6216463,
+              6216479,
+              6236307,
+              6236323,
+              6258475,
+              6258491,
+              6278235,
+              6278251,
+              6299063,
+              6299079,
+              6318823,
+              6319559,
+              6339315
+            ],
+            "tick0": 973,
+            "tick": 980,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116376,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116376,
+            "legs": [
+              19384,
+              19384,
+              19384,
+              19372,
+              19384,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19384,
+            "legWorstDeviation": -0.0006190672719768881,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19396,
+            "perBoundaryPerWrite": 808.1666666666666,
+            "cdpBracket": 170504,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6194563,
+              6194579,
+              6220763,
+              6220779,
+              6240163,
+              6240179,
+              6259563,
+              6259579,
+              6278963,
+              6278979,
+              6298351,
+              6298367,
+              6317751,
+              6317767,
+              6337139
+            ],
+            "tick0": 1001,
+            "tick": 1008,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      }
+    ],
+    "allocFits": {
+      "perRound": {},
+      "mean": {}
+    },
+    "writeDriven": true,
+    "writeProvenance": {
+      "windows": 36,
+      "pairs": 36,
+      "unnamed": [],
+      "incomplete": [],
+      "ok": true
+    },
+    "controlVerdict": {
+      "ok": true,
+      "perDouble": 8.08088888888889,
+      "differential": 8.00148148148148
+    },
+    "fallsInMeasuredWindows": 10,
+    "refusedWindows": 11,
+    "refusalReasons": 17
+  },
+  "box": {
+    "bead": "rf2-24o2z",
+    "chromium": "chromium/147.0.7727.15",
+    "node": "v24.13.0",
+    "platform": "win32/x64/10.0.26200",
+    "load": {
+      "open": {
+        "at": "2026-08-20T20:33:22.838Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13480075958,
+        "cpuBusyMs": 3629461608,
+        "freeMemB": 16062451712,
+        "totalMemB": 68112736256,
+        "uptimeS": 709165.64
+      },
+      "close": {
+        "at": "2026-08-20T20:33:49.137Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13480556333,
+        "cpuBusyMs": 3629614578,
+        "freeMemB": 15957704704,
+        "totalMemB": 68112736256,
+        "uptimeS": 709191.937
+      },
+      "busyFraction": 0.2415271297633991
+    },
+    "session": {
+      "startedAt": "2026-08-20T20:32:42.744Z",
+      "sessionStartedAt": "2026-08-20T19:39:26.627Z",
+      "runsInSession": 12,
+      "sessionGapMs": 3600000,
+      "previousRun": {
+        "startedAt": "2026-08-20T20:31:37.772Z",
+        "endedAt": "2026-08-20T20:32:42.037Z",
+        "sinceStartMs": 64972,
+        "sinceEndMs": 707,
+        "sameSession": true
+      }
+    }
+  }
+}

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/reversed-5.json
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/revarm-csca8/reversed-5.json
@@ -1,0 +1,7541 @@
+{
+  "generatedAt": "2026-08-20T20:36:45.688Z",
+  "build": "hicasso-bench",
+  "initFn": "re-frame.bench.p0-app/-main",
+  "alloc": {
+    "benchmark": "P0:steady-state-allocation-slope",
+    "bead": "rf2-2rtt6.76",
+    "roots": 4,
+    "perRoot": {
+      "list": 300,
+      "grid": 6
+    },
+    "publishedPerRoot": {
+      "list": 300,
+      "grid": 300
+    },
+    "arm": {
+      "cells": 6,
+      "roots": 4,
+      "boundaries": 24,
+      "writes": 6,
+      "refusals": [],
+      "admissible": true
+    },
+    "boundaries": 24,
+    "writes": 6,
+    "primeWrites": 1,
+    "windowWrites": 7,
+    "bySite": false,
+    "sites": 2,
+    "siteNames": [
+      "dispatch",
+      "drain"
+    ],
+    "warmups": 3,
+    "rounds": 18,
+    "preciseMemory": true,
+    "controlDoubles": {
+      "d1": 1000,
+      "d2": 400
+    },
+    "controlSlack": 0.75,
+    "writeSelector": "all",
+    "writeLegs": [
+      "all"
+    ],
+    "writePaired": false,
+    "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+    "plan": {
+      "name": "floor",
+      "arms": true,
+      "rungs": false,
+      "fits": false
+    },
+    "segOrder": "fixed-reversed",
+    "passOrder": "parity",
+    "passSeed": "1787258168844",
+    "passSchedule": {
+      "flips": [
+        true,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false
+      ],
+      "attempts": 1,
+      "parityTied": false
+    },
+    "controlSlot": "first",
+    "instrument": "in-page performance.memory.usedJSHeapSize sampled at every leg boundary, rising steps accumulated separately from falling ones; --enable-precise-memory-info. A falling step is a collection this counter SAW; a leg that deviates from its cohort median by more than the leg tolerance is a work unit that is not one; and under the by-site stride a NEGATIVE SITE STEP is a collection inside one leg that neither of the other two can see. TWO OF THE THREE RAN ON THIS ROW (rf2-fir5n): it was taken at a stride of 2, where a leg has no interior reading and so no site step to be negative, and the intra-leg gate returned an empty list BY CONSTRUCTION rather than by a switch. `certified` here means certified by the falling-step gate and by the leg tolerance and NO MORE. Arming the third needs the stride-3 reading, whose leg magnitudes are not comparable byte for byte with these (see `bySite`), so a witness comparing byte for byte against a figure published at stride 2 can never be screened by all three",
+    "fallThresholdB": 600000,
+    "legTolerance": 0.25,
+    "verification": {
+      "unverified": 0,
+      "detail": []
+    },
+    "workCount": false,
+    "workVerification": {
+      "counted": false
+    },
+    "perRound": [
+      {
+        "round": 0,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 700,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 524,
+            "endpoints": 700,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              524
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 116.66666666666667,
+            "cdpBracket": 46232,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3840262,
+              3840278,
+              3840294,
+              3840310,
+              3840326,
+              3840342,
+              3840358,
+              3840374,
+              3840390,
+              3840406,
+              3840422,
+              3840438,
+              3840454,
+              3840978,
+              3840994
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48576,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8144,
+            "endpoints": 48576,
+            "legs": [
+              8144,
+              8080,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0.00992063492063492,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8096,
+            "cdpBracket": 87388,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3853886,
+              3853902,
+              3861966,
+              3861982,
+              3870126,
+              3870142,
+              3878222,
+              3878238,
+              3886302,
+              3886318,
+              3894382,
+              3894398,
+              3902462,
+              3902478,
+              3910542
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 52328,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              3849986,
+              3850002,
+              3853266,
+              3853282,
+              3856546,
+              3856562,
+              3859826,
+              3859842,
+              3863106,
+              3863122,
+              3866386,
+              3866402,
+              3869666,
+              3869682,
+              3872946
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 394108,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 281092,
+            "endpoints": 394108,
+            "legs": [
+              20848,
+              26432,
+              20252,
+              20636,
+              23012,
+              281092
+            ],
+            "gaps": [
+              16,
+              16,
+              1756,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 21930,
+            "legWorstDeviation": 11.817692658458732,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 281092 B against a cohort median of 21930 B (+259162 B, 1181.8%), past the ±25% leg tolerance (±5482.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 281092 B against a cohort median of 21930 B (+259162 B, 1181.8%), past the ±25% leg tolerance (±5482.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              28720
+            ],
+            "primeExcess": 6790,
+            "perWrite": 65684.66666666667,
+            "perBoundaryPerWrite": 2736.8611111111113,
+            "cdpBracket": 196604,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              4792459,
+              4792475,
+              4821195,
+              4821211,
+              4842059,
+              4842075,
+              4868507,
+              4870263,
+              4890515,
+              4890531,
+              4911167,
+              4911183,
+              4934195,
+              4934211,
+              5215303
+            ],
+            "tick0": 21,
+            "tick": 28,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 320212,
+            "fall": 87344,
+            "falls": 1,
+            "maxStep": 129388,
+            "endpoints": 232868,
+            "legs": [
+              129388,
+              23116,
+              19536,
+              21876,
+              -87344,
+              19404
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              106812
+            ],
+            "legMedian": 20706,
+            "legWorstDeviation": 5.248816768086545,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 129388 B against a cohort median of 20706 B (+108682 B, 524.9%), past the ±25% leg tolerance (±5176.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -87344 B against a cohort median of 20706 B (-108050 B, -521.8%), past the ±25% leg tolerance (±5176.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 129388 B against a cohort median of 20706 B (+108682 B, 524.9%), past the ±25% leg tolerance (±5176.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 5 of 6 read -87344 B against a cohort median of 20706 B (-108050 B, -521.8%), past the ±25% leg tolerance (±5176.5 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26276
+            ],
+            "primeExcess": 5570,
+            "perWrite": 53368.666666666664,
+            "perBoundaryPerWrite": 2223.6944444444443,
+            "cdpBracket": 194072,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5066663,
+              5066679,
+              5092955,
+              5092971,
+              5222359,
+              5222375,
+              5245491,
+              5245507,
+              5265043,
+              5265059,
+              5286935,
+              5286951,
+              5199607,
+              5306419,
+              5325823
+            ],
+            "tick0": 49,
+            "tick": 56,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 1,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5053787,
+              5053803,
+              5053819,
+              5053835,
+              5053851,
+              5053867,
+              5053883,
+              5053899,
+              5053915,
+              5053931,
+              5053947,
+              5053963,
+              5053979,
+              5053995,
+              5054011
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 87716,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5061795,
+              5061811,
+              5069875,
+              5069891,
+              5077955,
+              5077971,
+              5086035,
+              5086051,
+              5094115,
+              5094131,
+              5102195,
+              5102211,
+              5110275,
+              5110291,
+              5118355
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5059239,
+              5059255,
+              5062519,
+              5062535,
+              5065799,
+              5065815,
+              5069079,
+              5069095,
+              5072359,
+              5072375,
+              5075639,
+              5075655,
+              5078919,
+              5078935,
+              5082199
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 273540,
+            "fall": 145876,
+            "falls": 1,
+            "maxStep": 191008,
+            "endpoints": 127664,
+            "legs": [
+              191008,
+              -145876,
+              19772,
+              23132,
+              19772,
+              19760
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19772,
+            "legWorstDeviation": 8.660530042484321,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 191008 B against a cohort median of 19772 B (+171236 B, 866.1%), past the ±25% leg tolerance (±4943 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -145876 B against a cohort median of 19772 B (-165648 B, -837.8%), past the ±25% leg tolerance (±4943 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 191008 B against a cohort median of 19772 B (+171236 B, 866.1%), past the ±25% leg tolerance (±4943 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 2 of 6 read -145876 B against a cohort median of 19772 B (-165648 B, -837.8%), past the ±25% leg tolerance (±4943 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26692
+            ],
+            "primeExcess": 6920,
+            "perWrite": 45590,
+            "perBoundaryPerWrite": 1899.5833333333333,
+            "cdpBracket": 187872,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5188911,
+              5188927,
+              5215619,
+              5215635,
+              5406643,
+              5406659,
+              5260783,
+              5260799,
+              5280571,
+              5280587,
+              5303719,
+              5303735,
+              5323507,
+              5323523,
+              5343283
+            ],
+            "tick0": 77,
+            "tick": 84,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 122148,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21656,
+            "endpoints": 122148,
+            "legs": [
+              21656,
+              19184,
+              19172,
+              19184,
+              19184,
+              19184
+            ],
+            "gaps": [
+              16,
+              16,
+              4504,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19184,
+            "legWorstDeviation": 0.12885738115095913,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6856,
+            "perWrite": 20358,
+            "perBoundaryPerWrite": 848.25,
+            "cdpBracket": 176604,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5291875,
+              5291891,
+              5317931,
+              5317947,
+              5339603,
+              5339619,
+              5358803,
+              5363307,
+              5382479,
+              5382495,
+              5401679,
+              5401695,
+              5420879,
+              5420895,
+              5440079
+            ],
+            "tick0": 105,
+            "tick": 112,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 2,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5255339,
+              5255355,
+              5255371,
+              5255387,
+              5255403,
+              5255419,
+              5255435,
+              5255451,
+              5255467,
+              5255483,
+              5255499,
+              5255515,
+              5255531,
+              5255547,
+              5255563
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 85088,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5263363,
+              5263379,
+              5271443,
+              5271459,
+              5279523,
+              5279539,
+              5287603,
+              5287619,
+              5295683,
+              5295699,
+              5303763,
+              5303779,
+              5311843,
+              5311859,
+              5319923
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5258563,
+              5258579,
+              5261843,
+              5261859,
+              5265123,
+              5265139,
+              5268403,
+              5268419,
+              5271683,
+              5271699,
+              5274963,
+              5274979,
+              5278243,
+              5278259,
+              5281523
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 119004,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20440,
+            "endpoints": 119004,
+            "legs": [
+              19696,
+              19696,
+              20440,
+              19696,
+              19696,
+              19684
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": 0.03777416734362307,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26544
+            ],
+            "primeExcess": 6848,
+            "perWrite": 19834,
+            "perBoundaryPerWrite": 826.4166666666666,
+            "cdpBracket": 174112,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5359015,
+              5359031,
+              5385575,
+              5385591,
+              5405287,
+              5405303,
+              5424999,
+              5425015,
+              5445455,
+              5445471,
+              5465167,
+              5465183,
+              5484879,
+              5484895,
+              5504579
+            ],
+            "tick0": 133,
+            "tick": 140,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 119800,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22168,
+            "endpoints": 119800,
+            "legs": [
+              19256,
+              22168,
+              20004,
+              19932,
+              19172,
+              19172
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19594,
+            "legWorstDeviation": 0.13136674492191489,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6446,
+            "perWrite": 19966.666666666668,
+            "perBoundaryPerWrite": 831.9444444444445,
+            "cdpBracket": 173800,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5419151,
+              5419167,
+              5445207,
+              5445223,
+              5464479,
+              5464495,
+              5486663,
+              5486679,
+              5506683,
+              5506699,
+              5526631,
+              5526647,
+              5545819,
+              5545835,
+              5565007
+            ],
+            "tick0": 161,
+            "tick": 168,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 3,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 29120,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5380311,
+              5380327,
+              5380343,
+              5380359,
+              5380375,
+              5380391,
+              5380407,
+              5380423,
+              5380439,
+              5380455,
+              5380471,
+              5380487,
+              5380503,
+              5380519,
+              5380535
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5389247,
+              5389263,
+              5397327,
+              5397343,
+              5405407,
+              5405423,
+              5413487,
+              5413503,
+              5421567,
+              5421583,
+              5429647,
+              5429663,
+              5437727,
+              5437743,
+              5445807
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5384447,
+              5384463,
+              5387727,
+              5387743,
+              5391007,
+              5391023,
+              5394287,
+              5394303,
+              5397567,
+              5397583,
+              5400847,
+              5400863,
+              5404127,
+              5404143,
+              5407407
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118272,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19696,
+            "endpoints": 118272,
+            "legs": [
+              19696,
+              19696,
+              19696,
+              19696,
+              19696,
+              19696
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19696,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26532
+            ],
+            "primeExcess": 6836,
+            "perWrite": 19712,
+            "perBoundaryPerWrite": 821.3333333333334,
+            "cdpBracket": 172784,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5445871,
+              5445887,
+              5472419,
+              5472435,
+              5492131,
+              5492147,
+              5511843,
+              5511859,
+              5531555,
+              5531571,
+              5551267,
+              5551283,
+              5570979,
+              5570995,
+              5590691
+            ],
+            "tick0": 189,
+            "tick": 196,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 115632,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19256,
+            "endpoints": 115632,
+            "legs": [
+              19256,
+              19256,
+              19256,
+              19256,
+              19256,
+              19256
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19256,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26040
+            ],
+            "primeExcess": 6784,
+            "perWrite": 19272,
+            "perBoundaryPerWrite": 803,
+            "cdpBracket": 169632,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5480491,
+              5480507,
+              5506547,
+              5506563,
+              5525819,
+              5525835,
+              5545091,
+              5545107,
+              5564363,
+              5564379,
+              5583635,
+              5583651,
+              5602907,
+              5602923,
+              5622179
+            ],
+            "tick0": 217,
+            "tick": 224,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 4,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5439535,
+              5439551,
+              5439567,
+              5439583,
+              5439599,
+              5439615,
+              5439631,
+              5439647,
+              5439663,
+              5439679,
+              5439695,
+              5439711,
+              5439727,
+              5439743,
+              5439759
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5447543,
+              5447559,
+              5455623,
+              5455639,
+              5463703,
+              5463719,
+              5471783,
+              5471799,
+              5479863,
+              5479879,
+              5487943,
+              5487959,
+              5496023,
+              5496039,
+              5504103
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5442743,
+              5442759,
+              5446023,
+              5446039,
+              5449303,
+              5449319,
+              5452583,
+              5452599,
+              5455863,
+              5455879,
+              5459143,
+              5459159,
+              5462423,
+              5462439,
+              5465703
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 429180,
+            "fall": 298332,
+            "falls": 1,
+            "maxStep": 325276,
+            "endpoints": 130848,
+            "legs": [
+              325276,
+              22348,
+              19888,
+              19888,
+              19888,
+              21812
+            ],
+            "gaps": [
+              16,
+              -298332,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20850,
+            "legWorstDeviation": 14.600767386091126,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 325276 B against a cohort median of 20850 B (+304426 B, 1460.1%), past the ±25% leg tolerance (±5212.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 325276 B against a cohort median of 20850 B (+304426 B, 1460.1%), past the ±25% leg tolerance (±5212.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              29376
+            ],
+            "primeExcess": 8526,
+            "perWrite": 71530,
+            "perBoundaryPerWrite": 2980.4166666666665,
+            "cdpBracket": 189080,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5618951,
+              5618967,
+              5648343,
+              5648359,
+              5973635,
+              5675303,
+              5697651,
+              5697667,
+              5717555,
+              5717571,
+              5737459,
+              5737475,
+              5757363,
+              5757379,
+              5779191
+            ],
+            "tick0": 245,
+            "tick": 252,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 120968,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23004,
+            "endpoints": 120968,
+            "legs": [
+              19432,
+              20176,
+              23004,
+              19432,
+              19396,
+              19432
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19432,
+            "legWorstDeviation": 0.1838205022643063,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26232
+            ],
+            "primeExcess": 6800,
+            "perWrite": 20161.333333333332,
+            "perBoundaryPerWrite": 840.0555555555555,
+            "cdpBracket": 175160,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5699839,
+              5699855,
+              5726087,
+              5726103,
+              5745535,
+              5745551,
+              5765727,
+              5765743,
+              5788747,
+              5788763,
+              5808195,
+              5808211,
+              5827607,
+              5827623,
+              5847055
+            ],
+            "tick0": 273,
+            "tick": 280,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 5,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5660499,
+              5660515,
+              5660531,
+              5660547,
+              5660563,
+              5660579,
+              5660595,
+              5660611,
+              5660627,
+              5660643,
+              5660659,
+              5660675,
+              5660691,
+              5660707,
+              5660723
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5668507,
+              5668523,
+              5676587,
+              5676603,
+              5684667,
+              5684683,
+              5692747,
+              5692763,
+              5700827,
+              5700843,
+              5708907,
+              5708923,
+              5716987,
+              5717003,
+              5725067
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5663707,
+              5663723,
+              5666987,
+              5667003,
+              5670267,
+              5670283,
+              5673547,
+              5673563,
+              5676827,
+              5676843,
+              5680107,
+              5680123,
+              5683387,
+              5683403,
+              5686667
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122032,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21968,
+            "endpoints": 122032,
+            "legs": [
+              19872,
+              19872,
+              20480,
+              19872,
+              19872,
+              21968
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19872,
+            "legWorstDeviation": 0.10547504025764895,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26724
+            ],
+            "primeExcess": 6852,
+            "perWrite": 20338.666666666668,
+            "perBoundaryPerWrite": 847.4444444444445,
+            "cdpBracket": 176736,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5725507,
+              5725523,
+              5752247,
+              5752263,
+              5772135,
+              5772151,
+              5792023,
+              5792039,
+              5812519,
+              5812535,
+              5832407,
+              5832423,
+              5852295,
+              5852311,
+              5874279
+            ],
+            "tick0": 301,
+            "tick": 308,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116616,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19432,
+            "endpoints": 116616,
+            "legs": [
+              19432,
+              19432,
+              19432,
+              19396,
+              19396,
+              19432
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19432,
+            "legWorstDeviation": -0.0018526142445450802,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26232
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19436,
+            "perBoundaryPerWrite": 809.8333333333334,
+            "cdpBracket": 170808,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5740851,
+              5740867,
+              5767099,
+              5767115,
+              5786547,
+              5786563,
+              5805995,
+              5806011,
+              5825443,
+              5825459,
+              5844855,
+              5844871,
+              5864267,
+              5864283,
+              5883715
+            ],
+            "tick0": 329,
+            "tick": 336,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 6,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5702019,
+              5702035,
+              5702051,
+              5702067,
+              5702083,
+              5702099,
+              5702115,
+              5702131,
+              5702147,
+              5702163,
+              5702179,
+              5702195,
+              5702211,
+              5702227,
+              5702243
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5710027,
+              5710043,
+              5718107,
+              5718123,
+              5726187,
+              5726203,
+              5734267,
+              5734283,
+              5742347,
+              5742363,
+              5750427,
+              5750443,
+              5758507,
+              5758523,
+              5766587
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5705227,
+              5705243,
+              5708507,
+              5708523,
+              5711787,
+              5711803,
+              5715067,
+              5715083,
+              5718347,
+              5718363,
+              5721627,
+              5721643,
+              5724907,
+              5724923,
+              5728187
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120828,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20604,
+            "endpoints": 120828,
+            "legs": [
+              19856,
+              20268,
+              20292,
+              19856,
+              20604,
+              19856
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20062,
+            "legWorstDeviation": 0.02701624962615891,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26708
+            ],
+            "primeExcess": 6646,
+            "perWrite": 20138,
+            "perBoundaryPerWrite": 839.0833333333334,
+            "cdpBracket": 175644,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5771159,
+              5771175,
+              5797883,
+              5797899,
+              5817755,
+              5817771,
+              5838039,
+              5838055,
+              5858347,
+              5858363,
+              5878219,
+              5878235,
+              5898839,
+              5898855,
+              5918711
+            ],
+            "tick0": 357,
+            "tick": 364,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116592,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19416,
+            "endpoints": 116592,
+            "legs": [
+              19416,
+              19416,
+              19416,
+              19416,
+              19416,
+              19416
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19416,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26216
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19432,
+            "perBoundaryPerWrite": 809.6666666666666,
+            "cdpBracket": 170768,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5783843,
+              5783859,
+              5810075,
+              5810091,
+              5829507,
+              5829523,
+              5848939,
+              5848955,
+              5868371,
+              5868387,
+              5887803,
+              5887819,
+              5907235,
+              5907251,
+              5926667
+            ],
+            "tick0": 385,
+            "tick": 392,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 7,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5742899,
+              5742915,
+              5742931,
+              5742947,
+              5742963,
+              5742979,
+              5742995,
+              5743011,
+              5743027,
+              5743043,
+              5743059,
+              5743075,
+              5743091,
+              5743107,
+              5743123
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5750907,
+              5750923,
+              5758987,
+              5759003,
+              5767067,
+              5767083,
+              5775147,
+              5775163,
+              5783227,
+              5783243,
+              5791307,
+              5791323,
+              5799387,
+              5799403,
+              5807467
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5746107,
+              5746123,
+              5749387,
+              5749403,
+              5752667,
+              5752683,
+              5755947,
+              5755963,
+              5759227,
+              5759243,
+              5762507,
+              5762523,
+              5765787,
+              5765803,
+              5769067
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122408,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22828,
+            "endpoints": 122408,
+            "legs": [
+              19836,
+              19848,
+              19836,
+              19836,
+              22828,
+              12156
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              7988
+            ],
+            "legMedian": 19836,
+            "legWorstDeviation": -0.3871748336358137,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 12156 B against a cohort median of 19836 B (-7680 B, -38.7%), past the ±25% leg tolerance (±4959 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 12156 B against a cohort median of 19836 B (-7680 B, -38.7%), past the ±25% leg tolerance (±4959 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26712
+            ],
+            "primeExcess": 6876,
+            "perWrite": 20401.333333333332,
+            "perBoundaryPerWrite": 850.0555555555555,
+            "cdpBracket": 184024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5820435,
+              5820451,
+              5847163,
+              5847179,
+              5867015,
+              5867031,
+              5886879,
+              5886895,
+              5906731,
+              5906747,
+              5926583,
+              5926599,
+              5949427,
+              5957415,
+              5969571
+            ],
+            "tick0": 413,
+            "tick": 420,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116484,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19408,
+            "endpoints": 116484,
+            "legs": [
+              19408,
+              19396,
+              19396,
+              19396,
+              19396,
+              19396
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19396,
+            "legWorstDeviation": 0.0006186842647968653,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26208
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19414,
+            "perBoundaryPerWrite": 808.9166666666666,
+            "cdpBracket": 174520,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5837295,
+              5837311,
+              5863519,
+              5863535,
+              5882943,
+              5882959,
+              5902355,
+              5902371,
+              5921767,
+              5921783,
+              5941179,
+              5941195,
+              5960591,
+              5960607,
+              5980003
+            ],
+            "tick0": 441,
+            "tick": 448,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 8,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5800275,
+              5800291,
+              5800307,
+              5800323,
+              5800339,
+              5800355,
+              5800371,
+              5800387,
+              5800403,
+              5800419,
+              5800435,
+              5800451,
+              5800467,
+              5800483,
+              5800499
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5808283,
+              5808299,
+              5816363,
+              5816379,
+              5824443,
+              5824459,
+              5832523,
+              5832539,
+              5840603,
+              5840619,
+              5848683,
+              5848699,
+              5856763,
+              5856779,
+              5864843
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5803483,
+              5803499,
+              5806763,
+              5806779,
+              5810043,
+              5810059,
+              5813323,
+              5813339,
+              5816603,
+              5816619,
+              5819883,
+              5819899,
+              5823163,
+              5823179,
+              5826443
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 484708,
+            "fall": 356424,
+            "falls": 1,
+            "maxStep": 402896,
+            "endpoints": 128284,
+            "legs": [
+              20260,
+              402896,
+              21052,
+              -356424,
+              19848,
+              20556
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20408,
+            "legWorstDeviation": 18.742061936495492,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 2 of 6 read 402896 B against a cohort median of 20408 B (+382488 B, 1874.2%), past the ±25% leg tolerance (±5102 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -356424 B against a cohort median of 20408 B (-376832 B, -1846.5%), past the ±25% leg tolerance (±5102 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 2 of 6 read 402896 B against a cohort median of 20408 B (+382488 B, 1874.2%), past the ±25% leg tolerance (±5102 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative",
+              "leg 4 of 6 read -356424 B against a cohort median of 20408 B (-376832 B, -1846.5%), past the ±25% leg tolerance (±5102 B): a leg BELOW its cohort is a leg something removed bytes from, and nothing in the work unit removes bytes — the collector does"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26712
+            ],
+            "primeExcess": 6304,
+            "perWrite": 80784.66666666667,
+            "perBoundaryPerWrite": 3366.027777777778,
+            "cdpBracket": 183104,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5873219,
+              5873235,
+              5899947,
+              5899963,
+              5920223,
+              5920239,
+              6323135,
+              6323151,
+              6344203,
+              6344219,
+              5987795,
+              5987811,
+              6007659,
+              6007675,
+              6028231
+            ],
+            "tick0": 469,
+            "tick": 476,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116460,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19408,
+            "endpoints": 116460,
+            "legs": [
+              19396,
+              19408,
+              19396,
+              19372,
+              19396,
+              19396
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19396,
+            "legWorstDeviation": -0.0012373685295937306,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26208
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19410,
+            "perBoundaryPerWrite": 808.75,
+            "cdpBracket": 170628,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5898351,
+              5898367,
+              5924575,
+              5924591,
+              5943987,
+              5944003,
+              5963411,
+              5963427,
+              5982823,
+              5982839,
+              6002211,
+              6002227,
+              6021623,
+              6021639,
+              6041035
+            ],
+            "tick0": 497,
+            "tick": 504,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 9,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5857407,
+              5857423,
+              5857439,
+              5857455,
+              5857471,
+              5857487,
+              5857503,
+              5857519,
+              5857535,
+              5857551,
+              5857567,
+              5857583,
+              5857599,
+              5857615,
+              5857631
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5865415,
+              5865431,
+              5873495,
+              5873511,
+              5881575,
+              5881591,
+              5889655,
+              5889671,
+              5897735,
+              5897751,
+              5905815,
+              5905831,
+              5913895,
+              5913911,
+              5921975
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5860615,
+              5860631,
+              5863895,
+              5863911,
+              5867175,
+              5867191,
+              5870455,
+              5870471,
+              5873735,
+              5873751,
+              5877015,
+              5877031,
+              5880295,
+              5880311,
+              5883575
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 123968,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24756,
+            "endpoints": 123968,
+            "legs": [
+              19828,
+              19828,
+              19828,
+              19828,
+              19804,
+              24756
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19828,
+            "legWorstDeviation": 0.24853742182771837,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26704
+            ],
+            "primeExcess": 6876,
+            "perWrite": 20661.333333333332,
+            "perBoundaryPerWrite": 860.8888888888888,
+            "cdpBracket": 178652,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5930199,
+              5930215,
+              5956919,
+              5956935,
+              5976763,
+              5976779,
+              5996607,
+              5996623,
+              6016451,
+              6016467,
+              6036295,
+              6036311,
+              6056115,
+              6056131,
+              6080887
+            ],
+            "tick0": 525,
+            "tick": 532,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116400,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19400,
+            "endpoints": 116400,
+            "legs": [
+              19388,
+              19400,
+              19400,
+              19364,
+              19364,
+              19388
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19388,
+            "legWorstDeviation": -0.0012378791004745203,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26200
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19400,
+            "perBoundaryPerWrite": 808.3333333333334,
+            "cdpBracket": 177140,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5940099,
+              5940115,
+              5966315,
+              5966331,
+              5985719,
+              5985735,
+              6005135,
+              6005151,
+              6024551,
+              6024567,
+              6043931,
+              6043947,
+              6063311,
+              6063327,
+              6082715
+            ],
+            "tick0": 553,
+            "tick": 560,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 10,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5905819,
+              5905835,
+              5905851,
+              5905867,
+              5905883,
+              5905899,
+              5905915,
+              5905931,
+              5905947,
+              5905963,
+              5905979,
+              5905995,
+              5906011,
+              5906027,
+              5906043
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5913827,
+              5913843,
+              5921907,
+              5921923,
+              5929987,
+              5930003,
+              5938067,
+              5938083,
+              5946147,
+              5946163,
+              5954227,
+              5954243,
+              5962307,
+              5962323,
+              5970387
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5909027,
+              5909043,
+              5912307,
+              5912323,
+              5915587,
+              5915603,
+              5918867,
+              5918883,
+              5922147,
+              5922163,
+              5925427,
+              5925443,
+              5928707,
+              5928723,
+              5931987
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120552,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20572,
+            "endpoints": 120552,
+            "legs": [
+              20572,
+              19840,
+              19828,
+              19828,
+              19840,
+              20548
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19840,
+            "legWorstDeviation": 0.03689516129032258,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26704
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20092,
+            "perBoundaryPerWrite": 837.1666666666666,
+            "cdpBracket": 178156,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5971087,
+              5971103,
+              5997807,
+              5997823,
+              6018395,
+              6018411,
+              6038251,
+              6038267,
+              6058095,
+              6058111,
+              6077939,
+              6077955,
+              6097795,
+              6097811,
+              6118359
+            ],
+            "tick0": 581,
+            "tick": 588,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116364,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116364,
+            "legs": [
+              19372,
+              19384,
+              19372,
+              19384,
+              19384,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": -0.0003096294767261843,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6794,
+            "perWrite": 19394,
+            "perBoundaryPerWrite": 808.0833333333334,
+            "cdpBracket": 171988,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5976583,
+              5976599,
+              6002771,
+              6002787,
+              6022159,
+              6022175,
+              6041559,
+              6041575,
+              6060947,
+              6060963,
+              6080347,
+              6080363,
+              6099747,
+              6099763,
+              6119135
+            ],
+            "tick0": 609,
+            "tick": 616,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 11,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28304,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5935639,
+              5935655,
+              5935671,
+              5935687,
+              5935703,
+              5935719,
+              5935735,
+              5935751,
+              5935767,
+              5935783,
+              5935799,
+              5935815,
+              5935831,
+              5935847,
+              5935863
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84624,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5943647,
+              5943663,
+              5951727,
+              5951743,
+              5959807,
+              5959823,
+              5967887,
+              5967903,
+              5975967,
+              5975983,
+              5984047,
+              5984063,
+              5992127,
+              5992143,
+              6000207
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51024,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5938847,
+              5938863,
+              5942127,
+              5942143,
+              5945407,
+              5945423,
+              5948687,
+              5948703,
+              5951967,
+              5951983,
+              5955247,
+              5955263,
+              5958527,
+              5958543,
+              5961807
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 120468,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20556,
+            "endpoints": 120468,
+            "legs": [
+              19812,
+              19812,
+              19824,
+              20556,
+              19824,
+              20544
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.036924939467312345,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20078,
+            "perBoundaryPerWrite": 836.5833333333334,
+            "cdpBracket": 175136,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5989831,
+              5989847,
+              6016535,
+              6016551,
+              6036363,
+              6036379,
+              6056191,
+              6056207,
+              6076031,
+              6076047,
+              6096603,
+              6096619,
+              6116443,
+              6116459,
+              6137003
+            ],
+            "tick0": 637,
+            "tick": 644,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 121596,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 24616,
+            "endpoints": 121596,
+            "legs": [
+              24616,
+              19384,
+              19372,
+              19384,
+              19372,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.2703065331819589,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 24616 B against a cohort median of 19378 B (+5238 B, 27.0%), past the ±25% leg tolerance (±4844.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 24616 B against a cohort median of 19378 B (+5238 B, 27.0%), past the ±25% leg tolerance (±4844.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6806,
+            "perWrite": 20266,
+            "perBoundaryPerWrite": 844.4166666666666,
+            "cdpBracket": 176952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5997523,
+              5997539,
+              6023723,
+              6023739,
+              6048355,
+              6048371,
+              6067755,
+              6067771,
+              6087143,
+              6087159,
+              6106543,
+              6106559,
+              6125931,
+              6125947,
+              6145319
+            ],
+            "tick0": 665,
+            "tick": 672,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 12,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5961847,
+              5961863,
+              5961879,
+              5961895,
+              5961911,
+              5961927,
+              5961943,
+              5961959,
+              5961975,
+              5961991,
+              5962007,
+              5962023,
+              5962039,
+              5962055,
+              5962071
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5969855,
+              5969871,
+              5977935,
+              5977951,
+              5986015,
+              5986031,
+              5994095,
+              5994111,
+              6002175,
+              6002191,
+              6010255,
+              6010271,
+              6018335,
+              6018351,
+              6026415
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              5965055,
+              5965071,
+              5968335,
+              5968351,
+              5971615,
+              5971631,
+              5974895,
+              5974911,
+              5978175,
+              5978191,
+              5981455,
+              5981471,
+              5984735,
+              5984751,
+              5988015
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 118968,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19824,
+            "endpoints": 118968,
+            "legs": [
+              19824,
+              19812,
+              19812,
+              19824,
+              19812,
+              19788
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": -0.0012113870381586917,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6876,
+            "perWrite": 19828,
+            "perBoundaryPerWrite": 826.1666666666666,
+            "cdpBracket": 174496,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6036319,
+              6036335,
+              6063023,
+              6063039,
+              6082863,
+              6082879,
+              6102691,
+              6102707,
+              6122519,
+              6122535,
+              6142359,
+              6142375,
+              6162187,
+              6162203,
+              6181991
+            ],
+            "tick0": 693,
+            "tick": 700,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116352,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116352,
+            "legs": [
+              19372,
+              19384,
+              19372,
+              19384,
+              19372,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0006194507536650836,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19392,
+            "perBoundaryPerWrite": 808,
+            "cdpBracket": 170480,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6056507,
+              6056523,
+              6082707,
+              6082723,
+              6102095,
+              6102111,
+              6121495,
+              6121511,
+              6140883,
+              6140899,
+              6160283,
+              6160299,
+              6179671,
+              6179687,
+              6199059
+            ],
+            "tick0": 721,
+            "tick": 728,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 13,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 31952,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6015563,
+              6015579,
+              6015595,
+              6015611,
+              6015627,
+              6015643,
+              6015659,
+              6015675,
+              6015691,
+              6015707,
+              6015723,
+              6015739,
+              6015755,
+              6015771,
+              6015787
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6027591,
+              6027607,
+              6035671,
+              6035687,
+              6043751,
+              6043767,
+              6051831,
+              6051847,
+              6059911,
+              6059927,
+              6067991,
+              6068007,
+              6076071,
+              6076087,
+              6084151
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6022791,
+              6022807,
+              6026071,
+              6026087,
+              6029351,
+              6029367,
+              6032631,
+              6032647,
+              6035911,
+              6035927,
+              6039191,
+              6039207,
+              6042471,
+              6042487,
+              6045751
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 573020,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 473840,
+            "endpoints": 573020,
+            "legs": [
+              19812,
+              19824,
+              19812,
+              19812,
+              19824,
+              473840
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19818,
+            "legWorstDeviation": 22.909577152083966,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 473840 B against a cohort median of 19818 B (+454022 B, 2291.0%), past the ±25% leg tolerance (±4954.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 473840 B against a cohort median of 19818 B (+454022 B, 2291.0%), past the ±25% leg tolerance (±4954.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26676
+            ],
+            "primeExcess": 6858,
+            "perWrite": 95503.33333333333,
+            "perBoundaryPerWrite": 3979.305555555555,
+            "cdpBracket": 176764,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6074735,
+              6074751,
+              6101427,
+              6101443,
+              6121255,
+              6121271,
+              6141095,
+              6141111,
+              6160923,
+              6160939,
+              6180751,
+              6180767,
+              6200591,
+              6200607,
+              6674447
+            ],
+            "tick0": 749,
+            "tick": 756,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117060,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20128,
+            "endpoints": 117060,
+            "legs": [
+              19372,
+              19372,
+              19348,
+              19372,
+              19372,
+              20128
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.03902539748090027,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19510,
+            "perBoundaryPerWrite": 812.9166666666666,
+            "cdpBracket": 171188,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6077567,
+              6077583,
+              6103767,
+              6103783,
+              6123155,
+              6123171,
+              6142543,
+              6142559,
+              6161907,
+              6161923,
+              6181295,
+              6181311,
+              6200683,
+              6200699,
+              6220827
+            ],
+            "tick0": 777,
+            "tick": 784,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 14,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6036623,
+              6036639,
+              6036655,
+              6036671,
+              6036687,
+              6036703,
+              6036719,
+              6036735,
+              6036751,
+              6036767,
+              6036783,
+              6036799,
+              6036815,
+              6036831,
+              6036847
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6044631,
+              6044647,
+              6052711,
+              6052727,
+              6060791,
+              6060807,
+              6068871,
+              6068887,
+              6076951,
+              6076967,
+              6085031,
+              6085047,
+              6093111,
+              6093127,
+              6101191
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6039831,
+              6039847,
+              6043111,
+              6043127,
+              6046391,
+              6046407,
+              6049671,
+              6049687,
+              6052951,
+              6052967,
+              6056231,
+              6056247,
+              6059511,
+              6059527,
+              6062791
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 124628,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 25472,
+            "endpoints": 124628,
+            "legs": [
+              19812,
+              19812,
+              19812,
+              19812,
+              19812,
+              25472
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19812,
+            "legWorstDeviation": 0.2856854431657581,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 6 of 6 read 25472 B against a cohort median of 19812 B (+5660 B, 28.6%), past the ±25% leg tolerance (±4953 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 6 of 6 read 25472 B against a cohort median of 19812 B (+5660 B, 28.6%), past the ±25% leg tolerance (±4953 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6876,
+            "perWrite": 20771.333333333332,
+            "perBoundaryPerWrite": 865.4722222222222,
+            "cdpBracket": 179408,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6093327,
+              6093343,
+              6120031,
+              6120047,
+              6139859,
+              6139875,
+              6159687,
+              6159703,
+              6179515,
+              6179531,
+              6199343,
+              6199359,
+              6219171,
+              6219187,
+              6244659
+            ],
+            "tick0": 805,
+            "tick": 812,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116352,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116352,
+            "legs": [
+              19384,
+              19384,
+              19372,
+              19372,
+              19372,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.0006194507536650836,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19392,
+            "perBoundaryPerWrite": 808,
+            "cdpBracket": 170480,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6108963,
+              6108979,
+              6135163,
+              6135179,
+              6154563,
+              6154579,
+              6173963,
+              6173979,
+              6193351,
+              6193367,
+              6212739,
+              6212755,
+              6232127,
+              6232143,
+              6251515
+            ],
+            "tick0": 833,
+            "tick": 840,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 15,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6070343,
+              6070359,
+              6070375,
+              6070391,
+              6070407,
+              6070423,
+              6070439,
+              6070455,
+              6070471,
+              6070487,
+              6070503,
+              6070519,
+              6070535,
+              6070551,
+              6070567
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6078351,
+              6078367,
+              6086431,
+              6086447,
+              6094511,
+              6094527,
+              6102591,
+              6102607,
+              6110671,
+              6110687,
+              6118751,
+              6118767,
+              6126831,
+              6126847,
+              6134911
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6073551,
+              6073567,
+              6076831,
+              6076847,
+              6080111,
+              6080127,
+              6083391,
+              6083407,
+              6086671,
+              6086687,
+              6089951,
+              6089967,
+              6093231,
+              6093247,
+              6096511
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 122964,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 23916,
+            "endpoints": 122964,
+            "legs": [
+              19824,
+              19824,
+              19824,
+              23916,
+              19740,
+              19740
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19824,
+            "legWorstDeviation": 0.20641646489104115,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26688
+            ],
+            "primeExcess": 6864,
+            "perWrite": 20494,
+            "perBoundaryPerWrite": 853.9166666666666,
+            "cdpBracket": 177616,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6131275,
+              6131291,
+              6157979,
+              6157995,
+              6177819,
+              6177835,
+              6197659,
+              6197675,
+              6217499,
+              6217515,
+              6241431,
+              6241447,
+              6261187,
+              6261203,
+              6280943
+            ],
+            "tick0": 861,
+            "tick": 868,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 116316,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 19384,
+            "endpoints": 116316,
+            "legs": [
+              19372,
+              19384,
+              19372,
+              19348,
+              19372,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": -0.0012389015073301672,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6812,
+            "perWrite": 19386,
+            "perBoundaryPerWrite": 807.75,
+            "cdpBracket": 170444,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6155443,
+              6155459,
+              6181643,
+              6181659,
+              6201031,
+              6201047,
+              6220431,
+              6220447,
+              6239819,
+              6239835,
+              6259183,
+              6259199,
+              6278571,
+              6278587,
+              6297959
+            ],
+            "tick0": 889,
+            "tick": 896,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 16,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6109383,
+              6109399,
+              6109415,
+              6109431,
+              6109447,
+              6109463,
+              6109479,
+              6109495,
+              6109511,
+              6109527,
+              6109543,
+              6109559,
+              6109575,
+              6109591,
+              6109607
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6117391,
+              6117407,
+              6125471,
+              6125487,
+              6133551,
+              6133567,
+              6141631,
+              6141647,
+              6149711,
+              6149727,
+              6157791,
+              6157807,
+              6165871,
+              6165887,
+              6173951
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6112591,
+              6112607,
+              6115871,
+              6115887,
+              6119151,
+              6119167,
+              6122431,
+              6122447,
+              6125711,
+              6125727,
+              6128991,
+              6129007,
+              6132271,
+              6132287,
+              6135551
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 121752,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 22212,
+            "endpoints": 121752,
+            "legs": [
+              22212,
+              19740,
+              19740,
+              19740,
+              19752,
+              20472
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19746,
+            "legWorstDeviation": 0.12488605287146765,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26676
+            ],
+            "primeExcess": 6930,
+            "perWrite": 20292,
+            "perBoundaryPerWrite": 845.5,
+            "cdpBracket": 176520,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6157127,
+              6157143,
+              6183819,
+              6183835,
+              6206047,
+              6206063,
+              6225803,
+              6225819,
+              6245559,
+              6245575,
+              6265315,
+              6265331,
+              6285083,
+              6285099,
+              6305571
+            ],
+            "tick0": 917,
+            "tick": 924,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 120300,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 21972,
+            "endpoints": 120300,
+            "legs": [
+              20732,
+              19372,
+              19372,
+              21972,
+              19372,
+              19384
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19378,
+            "legWorstDeviation": 0.13386314377128702,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26184
+            ],
+            "primeExcess": 6806,
+            "perWrite": 20050,
+            "perBoundaryPerWrite": 835.4166666666666,
+            "cdpBracket": 174428,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6165947,
+              6165963,
+              6192147,
+              6192163,
+              6212895,
+              6212911,
+              6232283,
+              6232299,
+              6251671,
+              6251687,
+              6273659,
+              6273675,
+              6293047,
+              6293063,
+              6312447
+            ],
+            "tick0": 945,
+            "tick": 952,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      },
+      {
+        "round": 17,
+        "controls": {
+          "idle": {
+            "kind": "idle",
+            "d": 0,
+            "rise": 192,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 16,
+            "endpoints": 192,
+            "legs": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 16,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              16
+            ],
+            "primeExcess": 0,
+            "perIter": 32,
+            "cdpBracket": 28288,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6122355,
+              6122371,
+              6122387,
+              6122403,
+              6122419,
+              6122435,
+              6122451,
+              6122467,
+              6122483,
+              6122499,
+              6122515,
+              6122531,
+              6122547,
+              6122563,
+              6122579
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl1": {
+            "kind": "control",
+            "d": 1000,
+            "rise": 48480,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 8064,
+            "endpoints": 48480,
+            "legs": [
+              8064,
+              8064,
+              8064,
+              8064,
+              8064,
+              8064
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 8064,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              8064
+            ],
+            "primeExcess": 0,
+            "perIter": 8080,
+            "cdpBracket": 84608,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6130363,
+              6130379,
+              6138443,
+              6138459,
+              6146523,
+              6146539,
+              6154603,
+              6154619,
+              6162683,
+              6162699,
+              6170763,
+              6170779,
+              6178843,
+              6178859,
+              6186923
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "ctl2": {
+            "kind": "control",
+            "d": 400,
+            "rise": 19680,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 3264,
+            "endpoints": 19680,
+            "legs": [
+              3264,
+              3264,
+              3264,
+              3264,
+              3264,
+              3264
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 3264,
+            "legWorstDeviation": 0,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              3264
+            ],
+            "primeExcess": 0,
+            "perIter": 3280,
+            "cdpBracket": 51008,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6125563,
+              6125579,
+              6128843,
+              6128859,
+              6132123,
+              6132139,
+              6135403,
+              6135419,
+              6138683,
+              6138699,
+              6141963,
+              6141979,
+              6145243,
+              6145259,
+              6148523
+            ],
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "arms": {
+          "uix-subs|grid/floor": {
+            "segment": "uix-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "uix-subs|grid/floor",
+            "rise": 245820,
+            "fall": 122976,
+            "falls": 1,
+            "maxStep": 145220,
+            "endpoints": 122844,
+            "legs": [
+              145220,
+              19756,
+              19756,
+              20800,
+              20464,
+              19744
+            ],
+            "gaps": [
+              16,
+              -122976,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 20110,
+            "legWorstDeviation": 6.22128294380905,
+            "legTolerance": 0.25,
+            "refusals": [
+              "leg 1 of 6 read 145220 B against a cohort median of 20110 B (+125110 B, 622.1%), past the ±25% leg tolerance (±5027.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "certified": false,
+            "legRefusals": [
+              "leg 1 of 6 read 145220 B against a cohort median of 20110 B (+125110 B, 622.1%), past the ±25% leg tolerance (±5027.5 B): a leg ABOVE its cohort means the ONE WORK UNIT premise this witness rests on has failed in this window, so refusing is correct rather than merely conservative"
+            ],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26680
+            ],
+            "primeExcess": 6570,
+            "perWrite": 40970,
+            "perBoundaryPerWrite": 1707.0833333333333,
+            "cdpBracket": 177488,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6187815,
+              6187831,
+              6214511,
+              6214527,
+              6359747,
+              6236771,
+              6256527,
+              6256543,
+              6276299,
+              6276315,
+              6297115,
+              6297131,
+              6317595,
+              6317611,
+              6337355
+            ],
+            "tick0": 973,
+            "tick": 980,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          },
+          "reagent-subs|grid/floor": {
+            "segment": "reagent-subs",
+            "arm": "grid/floor",
+            "rung": "floor",
+            "reads": 0,
+            "boundaries": 24,
+            "text": "0",
+            "writeSelector": "all",
+            "write": ":p0/write-all — the grid is rebuilt at the fixture's fixed `cells-n` whatever is mounted — V1's F_old control, flat in B by construction",
+            "pairKey": "reagent-subs|grid/floor",
+            "rise": 117084,
+            "fall": 0,
+            "falls": 0,
+            "maxStep": 20116,
+            "endpoints": 117084,
+            "legs": [
+              19372,
+              19384,
+              19372,
+              20116,
+              19372,
+              19372
+            ],
+            "gaps": [
+              16,
+              16,
+              16,
+              16,
+              16,
+              16
+            ],
+            "legMedian": 19372,
+            "legWorstDeviation": 0.038405946727235185,
+            "legTolerance": 0.25,
+            "refusals": [],
+            "certified": true,
+            "legRefusals": [],
+            "intraLegRefusals": [],
+            "primeLegs": [
+              26172
+            ],
+            "primeExcess": 6800,
+            "perWrite": 19514,
+            "perBoundaryPerWrite": 813.0833333333334,
+            "cdpBracket": 171200,
+            "sites": 2,
+            "siteLegs": [],
+            "siteWitness": null,
+            "samples": [
+              6192623,
+              6192639,
+              6218811,
+              6218827,
+              6238199,
+              6238215,
+              6257599,
+              6257615,
+              6276987,
+              6277003,
+              6297119,
+              6297135,
+              6316507,
+              6316523,
+              6335895
+            ],
+            "tick0": 1001,
+            "tick": 1008,
+            "work0": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "work": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            },
+            "workDelta": {
+              "events": 0,
+              "subs": 0,
+              "renders": 0
+            }
+          }
+        },
+        "writeLegs": [
+          "all"
+        ],
+        "segments": [
+          "uix-subs",
+          "reagent-subs"
+        ],
+        "controlIndex": 0,
+        "windowOrder": [
+          "control/idle",
+          "control/d1",
+          "control/d2",
+          "uix-subs|grid/floor",
+          "reagent-subs|grid/floor"
+        ]
+      }
+    ],
+    "allocFits": {
+      "perRound": {},
+      "mean": {}
+    },
+    "writeDriven": true,
+    "writeProvenance": {
+      "windows": 36,
+      "pairs": 36,
+      "unnamed": [],
+      "incomplete": [],
+      "ok": true
+    },
+    "controlVerdict": {
+      "ok": true,
+      "perDouble": 8.08088888888889,
+      "differential": 8.00148148148148
+    },
+    "fallsInMeasuredWindows": 5,
+    "refusedWindows": 10,
+    "refusalReasons": 13
+  },
+  "box": {
+    "bead": "rf2-24o2z",
+    "chromium": "chromium/147.0.7727.15",
+    "node": "v24.13.0",
+    "platform": "win32/x64/10.0.26200",
+    "load": {
+      "open": {
+        "at": "2026-08-20T20:36:45.764Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13483225881,
+        "cpuBusyMs": 3631217575,
+        "freeMemB": 15591960576,
+        "totalMemB": 68112736256,
+        "uptimeS": 709368.562
+      },
+      "close": {
+        "at": "2026-08-20T20:37:12.139Z",
+        "loadavg": [
+          0,
+          0,
+          0
+        ],
+        "loadavgSupported": false,
+        "cpus": 24,
+        "cpuIdleMs": 13483741268,
+        "cpuBusyMs": 3631337548,
+        "freeMemB": 15804379136,
+        "totalMemB": 68112736256,
+        "uptimeS": 709394.937
+      },
+      "busyFraction": 0.18882680684966002
+    },
+    "session": {
+      "startedAt": "2026-08-20T20:36:08.843Z",
+      "sessionStartedAt": "2026-08-20T19:39:26.627Z",
+      "runsInSession": 15,
+      "sessionGapMs": 3600000,
+      "previousRun": {
+        "startedAt": "2026-08-20T20:35:03.038Z",
+        "endedAt": "2026-08-20T20:36:05.465Z",
+        "sinceStartMs": 65805,
+        "sinceEndMs": 3378,
+        "sameSession": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
`rf2-csca8` — the first dataset ever recorded through the `fixed-reversed` arm, plus the record it produces. **The bead STAYS OPEN**, and the reason is a finding rather than a shortfall.

## What was measured

Fifteen runs, one session, one revision, one box, **interleaved one at a time**: five `fixed-reversed`, five `fixed`, five `parity`. Configuration identical to `segorder-rs8q6`'s six — `P0_ALLOC_PLAN=floor`, `P0_ALLOC_WRITE=all`, `P0_ROOTS=4`, `P0_ALLOC_CELLS=6`, `P0_ALLOC_ROUNDS=18` (B = 24).

**Pre-registered before the runner was invoked once**, in commit `fb93d522cb` (the page) and `3f85e96ef7` (the reader's comparisons and level read) — the run count, the interleave, the statistic, the worst-leg reading, the band, the admissibility rule, the level read and the stopping rule were all fixed in advance, and the `Result` section was committed deliberately empty.

**All fifteen were taken. None was dropped, extended or re-rolled. All fifteen control-certified.** 540 arm windows, 430 collection-free. Every run exited **1** on the falls gate (4 – 16 collections) and the leg-tolerance gate (9 – 24 windows) — this row's normal verdict, and by construction outside a statistic defined over `falls === 0`.

## What it found

**THE SLOT HYPOTHESIS IS REFUTED.** With `reagent-subs` in the second-driven slot the cluster does not go with it: **1 of 82** windows, against the same session's **8 of 63** at `fixed | uix-subs | pos1` (p = 0.0105) — and 1 of 82 against 10 of 63 on the masking-free companion (p = 0.0011).

**THE SUBSTRATE HYPOTHESIS IS NOT SETTLED, and the reason is a defect in the pre-registered statistic rather than a shortage of runs.** That statistic counts a window only when the in-band leg is the window's **worst**, and `fixed-reversed | uix-subs | pos0` has a median |worst leg| of **1,488 B** — above the band top — with 35 of its 68 windows worse than 1,224 B. The competing term is already recorded: **position 0 is where the ~748 B rider lives**, and `the-rider-follows-the-position-not-the-substrate.md` established it is position-locked. A masking-free companion — **written after the window and labelled POST-HOC everywhere it appears** — puts that cell at **7.4% in four of five runs**, between `fixed`'s 20.8% and `parity`'s 1.3%.

So on the pre-registered statistic the branch taken is NEITHER; on the companion the cluster does follow `uix` at about a third the rate. **Neither reading is discarded and neither is allowed to stand alone.**

**The methodological finding, and it was knowable in advance.** The reversed arm exists to move `uix` to position 0; position 0 is where the rider inflates the worst leg; the statistic is a per-window maximum, so the two terms compete for it. It is recorded rather than repaired, because repairing it means pre-registering a masking-free statistic and taking the window **again** — choosing the statistic after seeing which one gives the wanted answer is what pre-registration exists to prevent.

**THE MATCHED MODE BASELINE NOW EXISTS.** The bead recorded MODE as *associated, not established at a matched baseline* on a run-level contrast of 3 of 3 against 1 of 3 (p = 0.4). This window adds a second matched session at **4 of 5 against 0 of 5 (p = 0.0476)**; the two together are **7 of 8 `fixed` runs against 1 of 8 `parity` runs, p = 0.0101**. **But MODE narrows**: `fixed-reversed` is exactly as non-alternating as `fixed` and does not carry the term, so what separates from `parity` is the **forward** fixed order specifically, not "a plan that does not alternate".

## The floor read, published before any comparative

Three levels appear; the **three high-mode runs are ONE PER ARM**, so level is not confounded with the property under test. **No unexplained excursion** — `reversed-1` settled on the **identical** `reagent-subs` level to `segorder-rs8q6/fixed-1` and agrees to **6 B** on `uix-subs`, across two sessions, two dates and two segment-order modes. Null arm: 4,818 control legs, **0** in band.

## What was NOT done

- **`p0_run.cjs` was not touched.** The rig was frozen for the window and stayed frozen; the arm was used exactly as PR #8596 shipped it.
- **τ untouched in either direction.** `rf2-e9wr`'s refusal stands, `rf2-rs8q6`'s fence against widening is restated. No gate, threshold, band or budget moved.
- **No cluster-robust or mixed-effects estimate is offered**, and none should be at five clusters per arm. Every window-level p is published beside its run-level counterpart.
- **`implementation/package.json` untouched** (PR #8601's line), and **no row added to `docs/design/hicasso/studio/README.md`** — a suggested row is below instead.

## Suggested README row, for whoever owns the index

The index row for the existing `rf2-csca8` page (line ~135) is **stale against PR #8598**: it still reads `POSITION REFUTED` / `MODE CONFIRMED` over **118 runs / 3,140 windows**, which that PR corrected to unresolved/associated over 116 / 3,090. Worth repairing in the same pass. Suggested new row:

`| [P0 — the reversed fixed arm: a pre-registered fifteen-run window](the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md) | P0 | `rf2-csca8`, the WINDOW the bead was owed — the first dataset ever recorded through `P0_ALLOC_SEG_ORDER=fixed-reversed`. **Fifteen runs, one session, pre-registered before the runner ran once**; five per arm, interleaved, all fifteen taken and all fifteen control-certified. **The SLOT reading is REFUTED** — `reagent-subs` in the second-driven slot reads 1 of 82 against the same session's 8 of 63 (`p` = 0.0105). **The SUBSTRATE reading is NOT SETTLED, and the pre-registered statistic is why**: it is a per-window MAXIMUM and position 0 is where the ~748 B rider lives, so the reversed `uix` cell is masked (median |worst leg| 1,488 B, 35 of 68 windows above the band). A POST-HOC masking-free companion puts it at 7.4% in 4 of 5 runs, between `fixed`'s 20.8% and `parity`'s 1.3%. **The matched MODE baseline now exists** — 7 of 8 `fixed` runs against 1 of 8 `parity` runs across two matched sessions, `p` = 0.0101 — **but MODE narrows to the FORWARD fixed order**, since `fixed-reversed` is equally non-alternating and carries nothing. **τ untouched.** |`

## Quality gates

Every code below was captured by the running shell itself (`echo $?` on the same command line as the redirect), never read from a harness report. All re-run on the **final rebased base** (`origin/main` at `4824e70f0f`).

| gate | captured exit | result |
|---|---|---|
| `node hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs --self-test` | **0** | 64/64 passed (54 before; +10 for the reversed arm) |
| `node hicasso/test/re_frame/bench/hicasso/alloc_position_confound.cjs --self-test` | **0** | 33/33 — the neighbouring reader is unaffected |
| `python scripts/check_doc_slugs.py` | **0** | link targets and anchors under `docs/` |
| `python scripts/check_provenance_pins.py` | **0** | 144 pages, 773 pins, **0 findings** |
| `python scripts/check_readme_links.py --ci` | **0** | |
| `node .../p0_run.cjs --only alloc` × 15 | **1** × 15 | the falls and leg-tolerance gates, this row's normal verdict — see above |

**The reader self-test also runs in CI**, via `test:script-helpers`.

**Tree verification — three planted faults, each restored against an identical blob hash.**

1. **`check_doc_slugs.py`**: a broken link target planted in the new page returned **exit 1** naming `the-reversed-fixed-arm-...md:40`; restored to the identical blob hash `b26355457c7ee0f26515a720cb89fa6185fa0ff3` and green again.
2. **`check_provenance_pins.py`**: an unresolvable SHA planted at line 21 returned **exit 1** naming that page and line; restored to the identical blob hash `5a29a65cb02de519f8137ef5bb433695699a5f91` and green again.
3. **The reader's own fixtures, twice.** Making `fixed-reversed` windows group as `fixed` reds `window: each fixed-reversed cell is 1 run of 5, one window` at 63/64; re-pointing the CARRIER comparison at the `fixed` cell reds `window: the CARRIER contrast inside fixed-reversed is 1/68 vs 1/82, p = 1` at 63/64. Both restored to the identical blob hash `880a0623973dfb7eb32068b3542741f7735f5a14`. **The first attempt at plant (1) crashed the suite instead of failing it** — the pin dereferenced an absent row — so four reversed-arm pins were hardened to fail closed before the plant was repeated. That hardening is in the diff and its reason is in the comment above it.

**Not nominated, deliberately.** `mkdocs build --strict` does not cover this page: `mkdocs.yml`'s `exclude_docs` lists `design/hicasso/`.

**Fast-PR spine**: `python scripts/check_fast_pr_gap.py --list` reports **94** required checks the spine does not decide (captured exit 0). **The spine was not run**; the five targeted gates above were run directly, each in the foreground with its own captured code.

**By hand, because nothing validates it.** Table column counts on both changed pages were checked mechanically — **7 tables on the new page, 9 on the edited page, 0 mismatched rows** — and the checker was given a positive control (a deliberately short row, which it caught) before its zero was believed. Prose, rendering and nav were read by eye.
