### PR TITLE
docs(bench): rig commentary states the admissible corpus, and p=0.2253 stops being a refutation (rf2-ylmat, rf2-6kxub)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/implementation/core/test/re_frame/bench/p0_ladder_structural.test.cjs
@@ -2427,9 +2427,13 @@ test('THE SEGMENT ORDER — `parity` is the default and `fixed` breaks the confo
 // perfectly confounded: with the plan as shipped, `uix-subs` is position 1 in
 // every `fixed` window there has ever been, so the 8-of-38 cluster is equally
 // consistent with "uix under `fixed`" and with "the SECOND-driven arm under
-// `fixed`". PR #8593 refuted POSITION on 3,140 windows and found SUBSTRATE
-// associated but not necessary, which leaves the MODE — and no committed run
-// puts uix at position 0 while HOLDING THE MODE CONSTANT.
+// `fixed`". On the ADMISSIBLE corpus that analysis read — 116 runs, 3,090
+// positional windows, two control-refused runs excluded — PR #8593 left
+// POSITION UNRESOLVED rather than refuted (`p` = 0.2253 is a failure to
+// reject, not a demonstration of equality) and found SUBSTRATE associated but
+// not necessary, so none of the three candidates was eliminated and the MODE
+// still could not be read against itself from one orientation — no committed
+// run put uix at position 0 while HOLDING THE MODE CONSTANT.
 //
 // `fixed-reversed` is that arrangement and nothing else, so the pin drives the
 // sequence and reads the three properties that make it the discriminator: it

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -198,9 +198,20 @@ const ONLY = (() => {
 // ---------------------------------------------------------------------------
 //
 // rf2-6kxub measured the floor arm's high-mode RATE tracking ELAPSED TIME
-// WITHIN A SESSION — 0/6 at 8.2 min, 1/8 at 14.9, 2/20 at 19.7, 37/69 at 88.3,
+// WITHIN A SESSION — 0/6 at 8.2 min, 1/7 at 14.9, 2/19 at 19.7, 37/69 at 88.3,
 // with a within-session gradient at one-tail p = 0.0198 on a boundary-free
-// Mann-Whitney. That locates the rate on elapsed-time-within-session and NAMES
+// Mann-Whitney.
+//
+// THOSE ARE THE ADMISSIBLE DENOMINATORS, and the refusal basis is named here
+// so the rationale does not teach a failed positive control as a low reading.
+// `alloc_mode_rate_session.cjs` refuses any record whose
+// `alloc.controlVerdict.ok` is not exactly true, which drops
+// `alloc-9jrhi/bisect-5` and `alloc-77gz8/run12`. A REFUSED CONTROL IS NO
+// READING AT ALL, never a low one: it leaves the denominator and never the
+// numerator, which is why the two short sessions move 1/8 -> 1/7 and
+// 2/20 -> 2/19 while 0/6 and 37/69 do not move at all.
+//
+// That locates the rate on elapsed-time-within-session and NAMES
 // NO MECHANISM: thermal state, V8 tier accumulation and heap fragmentation
 // over a long session all survive it equally, and across sessions the duration
 // is confounded with the date and the clock time.

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1936,16 +1936,22 @@ const ALLOC_PLAN_SHAPE = ALLOC_PLAN_SHAPES[ALLOC_PLAN];
 // been. The 1,050-1,224 B cluster that bead names sits at 8 of 38 such
 // windows, and 8 of 38 is equally consistent with "uix under `fixed`" and
 // with "the SECOND-driven arm under `fixed`". No committed run separates
-// them: the analysis on PR #8593 re-derived POSITION as refuted (parity uix
-// 8/747 at position 0 against 3/724 at position 1, Fisher two-sided
-// p = 0.2254) and SUBSTRATE as associated but NOT necessary (reagent carries
-// the term twice in 1,588), which leaves the MODE as the only surviving arm
-// — and the mode cannot be read against itself from one orientation.
+// them. On the ADMISSIBLE corpus PR #8593's analysis read — 116 runs, 3,090
+// positional windows, two control-refused runs excluded — POSITION came out
+// UNRESOLVED (parity uix 8/733 at position 0 against 3/712 at position 1,
+// Fisher two-sided p = 0.2253) and SUBSTRATE ASSOCIATED BUT NOT NECESSARY
+// (reagent carries the term twice in 1,564). p = 0.2253 IS A FAILURE TO
+// REJECT AND NOT A REFUTATION: on eleven in-band windows nothing there bounds
+// a position effect at any useful width, so POSITION was left standing rather
+// than knocked out, and NONE of the three candidates was eliminated. What
+// that analysis could not supply was a CONTRAST — uix at position 0 with the
+// mode held still — and the mode cannot be read against itself from one
+// orientation.
 //
 // `fixed-reversed` drives the plan REVERSED every round, so it puts the
 // second substrate at position 0 while HOLDING THE MODE CONSTANT. That is
 // the one arrangement the corpus lacks. Parity already supplies uix at
-// position 0 for 747 windows, but it supplies it UNDER PARITY, which is the
+// position 0 for 733 windows, but it supplies it UNDER PARITY, which is the
 // term the contrast is trying to hold still.
 //
 // WHAT EACH OUTCOME SETTLES, pre-registered here rather than chosen after the


### PR DESCRIPTION
Two beads, one surface, comments only. PR #8598 excluded two control-refused datasets from the floor corpus. The studio pages and index rows were corrected; read-only commentary inside the rig and its structural test still published the pre-correction figures as current fact.

**No threshold, band, budget status, τ or rig behaviour moves.** Every changed line begins with `//` — verified mechanically, see below. The pre-registered outcome bullets above `ALLOC_SEG_ORDERS` are untouched, because a landed studio page quotes them verbatim.

## What landed

**rf2-ylmat — three figure sites, one of which carried an independent inference defect.**

| File | Was | Now |
|---|---|---|
| `p0_ladder_structural.test.cjs` | "refuted POSITION on 3,140 windows" | UNRESOLVED on the admissible **3,090** |
| `p0_run.cjs` | `8/747` vs `3/724`, `p = 0.2254` | `8/733` vs `3/712`, `p = 0.2253` |
| `p0_run.cjs` | "reagent carries the term twice in **1,588**" | **1,564** |
| `p0_run.cjs` | "parity supplies uix at position 0 for **747** windows" | **733** |

That last row is a **fourth site the brief did not name**; a fixed-string census over both files found it and now returns empty.

**The inference was wrong independently of the denominators.** `p = 0.2253` is a FAILURE TO REJECT, so "which leaves the MODE as the only surviving arm" inverted what the statistic says — POSITION was left standing rather than knocked out, and none of the three candidates was eliminated. Correcting only the numbers would have left the worse half in place. The comment now states the true rationale for the reversed-fixed arm: what that analysis could not supply was a **contrast**, not a surviving arm.

**rf2-6kxub — the elapsed-time rate sequence.** `0/6, 1/8, 2/20, 37/69` → `0/6, 1/7, 2/19, 37/69`, and the refusal basis is now named so the rationale cannot teach a failed positive control as a low observation. A refused control is **no reading at all**, never a low one, which is why it leaves the denominator and never the numerator — and why the sequence could not have been patched by arithmetic on the numbers as written.

## Provenance — figures were re-derived, never transcribed

This bead family exists because a figure was transcribed from a source that had since moved, so nothing here comes from a bead, a brief or a page.

- The rate sequence is the **printed output** of `alloc_mode_rate_session.cjs`, run in this worktree.
- The carrier figures are `alloc_cluster_carrier.cjs` plus the landed record it backs; the reader pins `p ≈ 0.2253` in its own self-test.

**Each corrected figure is now ANCHORED to the corpus it was read on** ("116 runs, 3,090 positional windows"). That is deliberate: the corpus has *already grown again* — see the finding below — so an unanchored figure would go stale a third time.

## Finding, reported and NOT actioned — out of this bead's fence

`alloc_cluster_carrier.cjs --corpus` now reads **131 runs / 3,520 positional**, because `revarm-csca8`'s fifteen-run window landed. Two present-tense claims in this commentary are consequently stale, and **both are older than these beads and neither is a pre-#8598 figure**:

- `p0_run.cjs` — "That is the one arrangement the corpus lacks." The corpus now holds five `fixed-reversed` runs (68 windows at uix/pos0).
- The same block's lead-in in both files reads as though the arm is still unanswered.

I have **not** rewritten these. They sit in a **pre-registration** block whose bullets a landed studio page quotes verbatim, rewriting pre-registration prose after the outcome is known is the wrong move, and `rf2-csca8` owns that narrative. Flagging for the mayor to file rather than acting unilaterally. Where my own rewritten sentence would otherwise have asserted something false, I put it in the past tense instead.

## Quality gates

All exit codes below are captured in the running shell with `echo "EXIT=$?"` on the same command line as the redirect, never taken from the harness and never read through a pipe.

| Gate | Command | Captured exit |
|---|---|---|
| Registered test owning both files | `node core/test/re_frame/bench/p0_ladder_structural.test.cjs` | **0** — 100 passed |
| Full CI gate, **re-run on the final rebased base** | `npm run test:script-helpers` | **0** |
| Source-of-truth reader (rf2-6kxub) | `alloc_mode_rate_session.cjs --self-test` | **0** — 42/42 |
| Source-of-truth reader (rf2-ylmat) | `alloc_cluster_carrier.cjs --self-test` | **0** — 64/64 |

`test:script-helpers` is the job that runs `p0_ladder_structural.test.cjs` in CI; it also runs both readers' self-tests. It was re-run **after** the final rebase, so the green is about the tree being merged.

### Tree verification — planted fault, and it covers BOTH files

A comment-only change affords no plant the runtime sees, so faults were planted where the gate actually evaluates. `p0_ladder_structural.test.cjs` reads `p0_run.cjs` **as source text** and asserts patterns against it, which gives a discriminating plant for the rig file too:

- **`p0_ladder_structural.test.cjs`** — an expected value in the reversed-fixed-arm test.
- **`p0_run.cjs`** — the preflight string a `has(/unknown P0_ALLOC_SEG_ORDER/)` assertion targets.

The gate went **RED, captured exit 1**, naming both by name: `p0_run.cjs: expected /unknown P0_ALLOC_SEG_ORDER/ — and the preflight refuses a mistyped order BY NAME`, and `- 'PLANTED-FAULT-RIGPROSE'`.

**The discrimination is the red itself** — the faults existed only in this worktree, so a run that had wandered into a sibling's would have come back green.

Scope was checked against a control run: **`2/100 failed`** against a baseline of **`100 passed`**, so the plants failed exactly two tests and aborted no others.

Both plants applied with a **verified match count of 1** each (checked *before* the gate ran — the files are CRLF, where an end-of-line-anchored pattern silently matches nothing), and both were restored to the **identical blob hashes** `26341ae4a7872faa53320b49822538f708d618c9` and `ebb08f9f10171d8b67cecee98cb7e85c0a5b9e42`, compared with version control's own content hash rather than a diff.

### Not run, and why

- **Browser, benchmark and measurement lanes** — nothing here changes what the rig computes, and no window was taken. `p0_run.cjs` is a frozen rig; only comments inside it moved.
- **`mkdocs build --strict`, `check_doc_slugs.py`, `check_readme_links.py`** — no file under `docs/` is touched, and `docs_dir` is `docs`, so `implementation/**` was never a candidate for the docs gates.
- **The fast-PR spine** — not run. Per `scripts/check_fast_pr_gap.py --list` the spine leaves 94 required checks undecided, so it would not have been the authority here in any case; the targeted gates above were run directly instead.

### Verified by hand

- **Comments-only**, mechanically: every added and removed line in `git diff -U0` matches `^[+-]\s*//`, with no exceptions.
- **Census of pre-correction figures** across both files now returns empty, run with fixed-string matching and a positive control that returns 3 hits — a zero from a wrong pattern reads exactly like a clean tree.
- **Merge-base (three-dot) diff read for reverts**: every removed line is one of my own sites; no sibling's work is undone.
