### PR TITLE
docs(hicasso): reconcile the cluster/third-arm page with its own superseding blockquote (rf2-3yvef)

### DIFF
--- a/docs/design/hicasso/studio/the-cluster-follows-the-mode-and-the-third-arm-is-still-missing.md
+++ b/docs/design/hicasso/studio/the-cluster-follows-the-mode-and-the-third-arm-is-still-missing.md
@@ -49,10 +49,23 @@ one.
 
 **The MODE is the only arm still standing, and it is an ASSOCIATION rather than
 a result. Position is unresolved, not refuted. Substrate is associated but not
-necessary. The discriminating arm the bead asks for is STILL OWED A WINDOW — and
-more plainly than the first version of this page implied, because the one
-property that survives is the one the committed corpus cannot separate and the
-one whose exposure is three runs.**
+necessary. The discriminating arm the bead asks for was OWED A WINDOW when this
+page was written — and more plainly than the first version of this page implied,
+because the one property that survives is the one the committed corpus cannot
+separate and the one whose exposure is three runs.**
+
+> **THAT WINDOW HAS SINCE BEEN TAKEN, so the last clause above records what was
+> outstanding when this page was written and is not its current position.**
+> [The reversed fixed arm: a pre-registered fifteen-run window](the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md)
+> recorded fifteen runs and moves two of the three verdicts in the table below:
+> the SLOT reading is refuted, MODE gains the matched baseline this page says it
+> lacks but narrows to the **forward** fixed order, and SUBSTRATE is still
+> unsettled — for a reason this page did not anticipate. The reconciliation on
+> this page is the blockquote closing
+> [what the p-values are not](#what-the-p-values-are-not); the figures behind it
+> belong to the window's own record and are quoted from there. **Every number
+> here is read on the 116-run corpus of [the corpus](#the-corpus) below, and none
+> is re-derived against the 131-run corpus that window produced.**
 
 | arm of the question | verdict | the counts it rests on | Fisher, two-sided |
 |---|---|---|---|
@@ -142,6 +155,13 @@ corpus for any purpose will meet it.
 run is `P0_ALLOC_PLAN=floor`, `P0_ALLOC_WRITE=all`, `P0_ROOTS=4`, B = 24, six
 writes, one instrument — checked rather than assumed, because a pooled census
 over unlike units would be meaningless and the byte band is absolute.
+
+**This is the corpus AS THIS PAGE READ IT, and every figure below is anchored to
+it.** [The reversed fixed arm](the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md)
+has since added fifteen runs, taking the admissible corpus to **131 runs, 3,688
+collection-free, 3,520 positional** against 116 / 3,258 / 3,090 here. **Nothing
+on this page is re-derived against them**, so a figure quoted from here is a
+figure about the 116, and the two censuses must not be read across.
 
 **Two `plan=floor` runs are in the directory and out of this corpus**, and the
 reader names both rather than dropping them:
@@ -309,7 +329,21 @@ and no arithmetic on the windows inside them can turn three runs into a
 controlled comparison. **A replication of the `fixed` arm at higher n against
 same-session `parity` is what would settle it**, and that is an allocation
 window rather than an analysis. That the mode arm is the only one still standing
-makes the reversed-`fixed` window more clearly necessary, not less.
+made the reversed-`fixed` window more clearly necessary, not less.
+
+**SINCE SETTLED, and narrowed by the settling.**
+[The reversed fixed arm](the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md)
+took exactly that replication — five `fixed` and five `parity` runs interleaved
+in one session — and reads **4 of 5 `fixed` runs against 0 of 5 `parity` runs,
+`p` = 0.0476** at run level. Taken with this page's 3 of 3 against 1 of 3 that is
+**7 of 8 against 1 of 8, `p` = 0.0101**, which is the first run-level separation
+the record has had that controls session, date and revision. **But the same
+window put five `fixed-reversed` runs beside them and they do not carry the
+term** — 1 of 68 windows at the primary band — and `fixed-reversed` is exactly as
+non-alternating as `fixed`. So what separates from `parity` is the **forward**
+fixed order specifically, not "a plan that does not alternate". Those counts are
+that window's corpus, not this one's. The paragraph above is left as written: its
+reasoning is what commissioned the window.
 
 The negative control on the same contrast: `reagent` at position 0, `fixed`
 against `parity`, reads **0 of 43 against 2 of 666, `p` = 1.0**. Reagent does not
@@ -369,20 +403,36 @@ show.
 > statistic below is a per-window MAXIMUM, and at position 0 the already-recorded
 > ~748 B rider competes with the cluster for it. So the reversed arm's `uix` cell
 > is masked, and the window that was supposed to settle the substrate could not.
+>
+> **The title is left standing rather than corrected.** It names this record, and
+> it is the name both the studio index and the new page link it by; a page
+> renamed to its own correction stops being findable as the thing that was
+> corrected. It is half wrong, and this is where it says so.
 
-## Why the discriminating arm is still owed a window
+## Why the discriminating arm was owed a window
 
 The bead names its discriminator: *a fixed run with the segment order REVERSED
 (uix leading), which `p0_run.cjs` does not currently offer.* **That remains the
 right instrument, the reason it is needed has changed rather than gone away —
-and since this page was first written the arm itself has LANDED.**
+and since this page was first written the arm itself has LANDED, and has since
+been RUN.**
 
 `P0_ALLOC_SEG_ORDER=fixed-reversed` is now one of three names in
 `ALLOC_SEG_ORDERS`, and it drives the plan reversed every round: the mode held
-constant, the second substrate at position 0. **So what is outstanding is no
-longer the rig change. It is the WINDOW** — a `fixed-reversed` run at adequate
-n, read against the `fixed` and `parity` arms already in the corpus. That is
-bench-slot-bound rather than quiet-box-bound, and it is why this bead stays open.
+constant, the second substrate at position 0. **So what was outstanding when this
+page was written was no longer the rig change but the WINDOW** — a
+`fixed-reversed` run at adequate n, read against the `fixed` and `parity` arms
+already in the corpus. That was bench-slot-bound rather than quiet-box-bound.
+
+> **THE WINDOW HAS SINCE BEEN TAKEN.**
+> [The reversed fixed arm](the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md)
+> ran five `fixed-reversed` runs at that n, interleaved with five `fixed` and
+> five `parity` in one session. **The bead does stay open, but not for the reason
+> this section gives.** What is owed now is a **masking-free statistic,
+> pre-registered as such, and the reversed arm taken again under it** — because
+> the statistic this window pre-registered is a per-window MAXIMUM and it is
+> masked in the one cell the whole discriminator rests on. The reasoning below is
+> left as written: it is what commissioned the window.
 
 The bead's stated reason was that no position arm existed. That reason is
 superseded — `parity` supplies uix at both positions, 1,445 windows of it, and
@@ -402,8 +452,23 @@ Inside `fixed` the confound is untouched:
 mode constant, and it is the only arrangement that does.** If the cluster follows
 uix to position 0, the carrier is the substrate under `fixed`; if it stays at
 position 1 with reagent now in it, the carrier is the slot. **No committed run
-answers that**, because none was taken in the reversed order — the arm exists in
-the rig now, but no dataset has been recorded through it.
+answered that** when this page was written, because none had been taken in the
+reversed order.
+
+**Five have been taken since, and the disjunction above did not resolve cleanly.**
+On the pre-registered statistic neither branch fires:
+`fixed-reversed | uix-subs | pos0` reads **1 of 68** and
+`fixed-reversed | reagent-subs | pos1` reads **1 of 82**, `p` = 1.0000 between
+them, against the same session's **8 of 63** at `fixed | uix-subs | pos1`.
+**The STAYS branch is refuted** — putting `reagent-subs` in the second-driven
+slot does not move the cluster there, 8 of 63 against 1 of 82, `p` = 0.0105.
+**The FOLLOWS branch is masked rather than
+tested**, because position 0 is where the already-recorded ~748 B rider lives and
+it competes for the per-window maximum the statistic reads: that cell's median
+|worst leg| is **1,488 B**, above the top of the band, and only **20%** of its
+in-band legs are the window's worst against `fixed`'s **80%**. Every figure in
+this paragraph is that window's own corpus, not this page's; the record is
+[the reversed fixed arm](the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md).
 
 ### What it cost, now that it has been made
 
@@ -422,7 +487,8 @@ The outcomes are pre-registered in the source rather than chosen after the run:
 the cluster FOLLOWS uix to position 0 and the carrier is the substrate under
 `fixed`; it STAYS at position 1 and the carrier is the second-driven slot,
 whichever substrate occupies it; BOTH or NEITHER and neither property is the
-carrier as stated.
+carrier as stated. **They have since been read, and the pre-registered statistic
+returned NEITHER**; what that does and does not settle is recorded above.
 
 ## What the earlier read got wrong, and one thing it did not
 
@@ -470,11 +536,15 @@ not absent.
   bound is available at a useful width on eleven in-band windows.
 - **Three `fixed` runs is three.** 81 windows, one box, one session, one
   revision. Every `fixed` figure on this page rests on them.
-- **The reversed-`fixed` arm now EXISTS in the rig and has never been RUN.**
-  `P0_ALLOC_SEG_ORDER=fixed-reversed` landed after this analysis was first
-  written, so the discriminator is available; no dataset has been recorded
-  through it, so nothing here is read against it. **The arm existing is not the
-  arm answering.**
+- **The reversed-`fixed` arm has SINCE BEEN RUN, and nothing here is read against
+  it.** `P0_ALLOC_SEG_ORDER=fixed-reversed` landed after this analysis was first
+  written, and
+  [a pre-registered fifteen-run window](the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md)
+  has since recorded five runs through it. Every number on this page is still the
+  116-run corpus it was computed on, so those runs bear on its verdicts without
+  being counted in any of its figures. **The arm answering is not this page
+  answering**: what that window settled, what it narrowed and what it could not
+  reach are its record to state, not this one's.
 - **The last-leg term at `parity` position 0 is described and not chased.** Its
   ordinal signature is published above because it decides the band question; its
   identity is nobody's yet.


### PR DESCRIPTION
Closes rf2-3yvef.

`docs/design/hicasso/studio/the-cluster-follows-the-mode-and-the-third-arm-is-still-missing.md`
contradicted itself in its own present tense. A blockquote in it says the window
has since been taken; other sites still asserted the opposite as the page's
current position.

One file changed. `docs/design/hicasso/studio/README.md` is **untouched** — its
row was corrected by #8617 and already carries the superseding facts, so nothing
here makes it wrong.

## The census I ran, and what it found

The bead named three sites and said to treat that as a floor. Running my own
census found **four** present-tense assertions, not three — the fourth is at the
old line 310, in the MODE section, and no earlier report had named it.

| site (pre-edit line) | what it asserted | disposition |
|---|---|---|
| 52 | "the discriminating arm ... is STILL OWED A WINDOW" | RESIDUE — reconciled |
| 310–312 | "what would settle it ... makes the reversed-`fixed` window more clearly necessary" | RESIDUE — reconciled (**found by my census, not previously reported**) |
| 373 | heading "Why the discriminating arm is still owed a window" | RESIDUE — heading retensed |
| 382–385 | "what is outstanding ... It is the WINDOW ... why this bead stays open" | RESIDUE — reconciled |
| 404–406 | "No committed run answers that ... no dataset has been recorded through it" | RESIDUE — reconciled |
| 473–477 | "now EXISTS in the rig and has never been RUN" | RESIDUE — reconciled |

Reconciled, not rewritten, in the register the existing blockquote already
models: each superseded reading is kept and marked as superseded rather than
deleted, and each is followed by what the window actually returned.

## Three refusals, source-located

**1. The page TITLE stays.** The blockquote already calls it half wrong. It also
names this record and is the string both the studio index and the new page link
it by, so a page renamed to its own correction stops being findable as the thing
that was corrected. I added that reasoning to the blockquote rather than acting
on the title.

**2. Line 87–88, "a large association worth the reversed-`fixed` arm", stays.**
It is a judgement about what the figure justified, made at the time and
vindicated by the window. It asserts nothing about run status.

**3. Line 344, "the right response to three clusters is more clusters ... which
is the reversed-`fixed` arm", stays.** A methodological statement, true then and
now, and the superseding blockquote begins seven lines below it.

Also left alone as genuine records: the seat note at 9–15 (this page took no
window — still true), the equivalence-bound statements at 256/259/470 (about
POSITION under `parity`, which the new window did not settle — its parity cells
read 0 of 41 and 0 of 32), and "Three `fixed` runs is three" at 472.

## Figures re-derived, not transcribed

Every figure quoted from the new window was read off
`the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md` at this tip, not
from the bead and not from #8611's body. The blockquote's three summary claims
all reproduce:

- **SLOT refuted** — `fixed-reversed` reagent at pos1 reads 1 of 82 against the
  same session's 8 of 63 at `fixed` uix pos1, `p` = 0.0105.
- **MODE gains a matched baseline, and narrows** — 4 of 5 against 0 of 5,
  `p` = 0.0476 at run level; pooled with this page's 3 of 3 against 1 of 3 that
  is 7 of 8 against 1 of 8, `p` = 0.0101. `fixed-reversed` is exactly as
  non-alternating as `fixed` and does not carry the term, so the separation is
  the FORWARD fixed order specifically.
- **SUBSTRATE unsettled** — the pre-registered statistic is a per-window MAXIMUM
  and the ~748 B position-locked rider competes for it; that cell's median worst
  leg is 1,488 B and only 20% of its in-band legs are the window's worst, against
  `fixed`'s 80%.

Each is attributed on the page to the window's own corpus, and a note under "The
corpus" now records that every number on this page is read on the 116-run corpus
and none is re-derived against the 131-run one (3,688 collection-free / 3,520
positional against 3,258 / 3,090).

## Quality gates

Prose-only change. Per dispatch, no heavy gate was run — an allocation window is
live on this box and two heavyweight runs wedge rather than fail. No
`test-fast-pr.sh`, no shadow-cljs, no browser/Playwright, no npm build, no JVM
gate. **The fast-PR spine was not run at all.** The cheap Python checkers below
are the gates that cover this surface, and they never wedge.

| gate | captured exit | how it was proved to read THIS worktree |
|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | planted fault (below) |
| `scripts/check_provenance_pins.py --changed-since origin/main` | **0** | prints "1 page inspected" — the mayor tree has no changed page, so a run rooted there reports 0; also planted fault (below) |
| `scripts/check_fast_pr_gap.py --list` | **0** | informational; figure below |

Exit codes are the ones captured with an explicit `echo $?` on the same command
line as the redirect, never a harness-reported number. Nothing was piped through
a filter. Gate artefacts are named per-worktree and per-attempt.

**Both gates proved by planted fault, restored and hash-verified.**

- `check_doc_slugs.py` is silent on green, so the plant is the discriminator. One
  in-page anchor was broken (`](#the-corpus)` to a non-existent slug) on a line
  written by this change; the match count was checked to be exactly 1 before
  running. The gate went **red, exit 1**, naming
  `...-third-arm-is-still-missing.md:67 -> #the-corpus-PLANTED-FAULT-CLUSTERARM`.
  That fault existed only in this worktree, so a run that had wandered elsewhere
  would have come back green.
- `check_provenance_pins.py` likewise: one unresolvable 40-hex token described as
  a commit. **Red, exit 1**, `1 unresolvable, 1 finding`, naming the planted line.
- Both restored and verified by **the identical blob hash
  `6b7eb00b8d90cb3e08a815b54d9c3a016690768b`** before each plant and after each
  restore — git's own content hash, not a plain byte digest, because this
  checkout translates line endings. Same blob hash again after the rebase.

**No edit lands inside a fenced code block**, so the fence-stripping blind spot
in both link gates does not bound these greens. Confirmed by the planted fault
reding at line 67, which is one of the lines this change added.

`scripts/check_readme_links.py --ci` is **not** nominated: `docs/design/hicasso/studio/`
sits under the docs-gate roots, so it is `check_doc_slugs.py`'s surface.
`mkdocs build --strict` is **not** nominated: `mkdocs.yml`'s `exclude_docs`
keeps `docs/design/**` out of the site.

### Hand-verified, because nothing gates it

Link targets and anchors are the whole of what those gates check. Prose, tables,
rendering and nav are unchecked, so these were verified by hand:

- **Tables: 9 in the file, all correct.** Every one uniform, contiguous, no stray
  or escaped-pipe defects. Rows and cells-per-row, in file order: 5 rows / 4
  cells, 6/3, 9/4, 4/2, 8/8, 8/5, 4/3, 4/3, 5/3. **No table was changed.**
- **Pipe-bearing prose outside any table: 7 lines**, all inline-code cell names
  or the literal "worst leg" bars, matching the convention already used on this
  page and its sibling. None is adjacent to a delimiter row, so none can be
  parsed as a table.
- **Headings: 20, all slugs unique** — no `_N` suffixing anywhere, so the renamed
  heading takes the clean slug `why-the-discriminating-arm-was-owed-a-window`.
- **In-page anchor links: 4, all resolve.** The old slug
  `why-the-discriminating-arm-is-still-owed-a-window` had **zero** inbound
  references repo-wide (fixed-string grep, before and after the rename), so
  retensing that heading broke nothing.
- **Relative file links: 9, all resolve** on disk.

### Fast-spine-versus-required-CI gap

`scripts/check_fast_pr_gap.py --list` derives **94** required checks the spine
does not run. That is a fact about the SPINE, not a census of what ran here — no
spine was run, only the three targeted gates in the table above.

### Base

Rebased onto `origin/main` after #8616 merged mid-run, and **both gates re-run on
the final base** (exit 0 each). The three-dot merge-base diff
(`origin/main...HEAD`) touches exactly one file, so this push reverts nothing a
sibling landed.
