### PR TITLE
fix(hicasso): the retired self-test spelling must refuse, not fall through (rf2-xk4is)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -3848,7 +3848,14 @@ function fixtureRoundsTask(over) {
 
   t('the driver exposes its decision and does not drive itself on require', () => {
     assert.ok(MAIN.length > 0, 'the driver must expose its run as `main`');
-    assert.match(SRC, /module\.exports = \{ summarise, verdict, verdictSelfTest \};/);
+    // Named seat by seat rather than as one literal line, the shape
+    // `clock_run.cjs`'s pin above already uses. The literal form asserted the
+    // export list's PUNCTUATION as strictly as its contents, so adding a seat
+    // failed it for a reason that had nothing to do with the decision it
+    // guards (rf2-xk4is added `FLAGS` / `unknownFlags`).
+    for (const name of ['summarise', 'verdict', 'verdictSelfTest']) {
+      assert.match(SRC, new RegExp(`module\\.exports = \\{[^}]*\\b${name}\\b`), `\`${name}\` must be exported`);
+    }
     assert.match(SRC, /if \(require\.main === module\) \{\s*main\(\);/);
   });
 
@@ -3899,6 +3906,107 @@ function fixtureRoundsTask(over) {
     assert.match(ok, /survived its DOM read-back/);
     assert.match(ok, /no yield correction was refused/);
   });
+}
+
+// --- THE SELF-TEST FLAG, AND THE ONE THAT IS RETIRED (rf2-xk4is) ------------
+//
+// #8616 standardised both drivers on `--self-test` and shipped no alias — this
+// is pre-alpha, and an alias for a spelling nothing depends on is a
+// compatibility shim. Its merged-PR audit found the retirement unsafe anyway.
+// Neither driver validated its arguments, so the old hyphenless spelling was
+// not retired at all: it was SILENTLY IGNORED and fell through into the
+// default path, which for these two is an `:advanced` release build and a
+// headless Chromium. Measured at that merge commit: `clock_run.cjs` reached
+// the shadow-cljs release spawn and `hd8_run.cjs` reached its provenance
+// block one line above `build()`. A typo cost an hour and produced a run
+// nobody had asked for.
+//
+// AND THE SECOND FINDING WAS ABOUT THIS FILE. It renamed four labels and
+// inspected the BODY of `if (SELFTEST_ONLY)` while asserting nothing about how
+// `SELFTEST_ONLY` is DERIVED, so a mutation of either driver back to the old
+// token — or to any other — left every assertion here green. The rename was
+// pinned nowhere: `test:script-helpers` invokes only `ladder_band.cjs
+// --self-test` directly, which is why that third driver is not repeated here.
+//
+// This is the missing pin, and it is deliberately four claims per driver and
+// no more: the argv definition itself, the closed flag vocabulary, that the
+// vocabulary REFUSES a token outside it, and that the refusal is wired ahead
+// of everything the driver would otherwise spend. The last is the one that
+// matters — a rule the entry point never consults is not a rule — and it is
+// the same lesson this file's header draws about the exit decision.
+{
+  const RETIRED = /--selftest/;
+  const DRIVERS = [
+    {
+      name: 'clock_run.cjs',
+      mod: require('./clock_run.cjs'),
+      flags: ['--no-build', '--self-test'],
+      tag: '[clock]',
+      // From the head of `main` down to the self-test branch: everything the
+      // driver does before it can stop, which is where the refusal has to sit.
+      head: ['async function main() {', '  if (SELFTEST_ONLY) {'],
+    },
+    {
+      name: 'hd8_run.cjs',
+      mod: require('./hd8_run.cjs'),
+      flags: ['--self-test'],
+      tag: '[hd8]',
+      head: ['async function main() {', '  if (SELFTEST_ONLY) {'],
+    },
+  ];
+
+  for (const d of DRIVERS) {
+    const SRC = fs.readFileSync(path.join(__dirname, d.name), 'utf8');
+    const t = (what, fn) => test(`${d.name}: ${what}`, fn);
+
+    t('the self-test flag is spelt `--self-test` where argv is read', () => {
+      // The DEFINITION, not the block it gates. This is the assertion whose
+      // absence let the rename go unpinned.
+      assert.match(SRC, /const SELFTEST_ONLY = process\.argv\.includes\('--self-test'\);/);
+      assert.deepStrictEqual(d.mod.FLAGS, d.flags);
+    });
+
+    t('the retired spelling appears nowhere in the driver, comments included', () => {
+      // Comments included on purpose. A retirement that still names the dead
+      // token in a comment or a usage line is an invitation to type it, and
+      // the drivers say what happened without spelling it.
+      const hits = SRC.split('\n')
+        .map((line, i) => [i + 1, line])
+        .filter(([, line]) => RETIRED.test(line))
+        .map(([n, line]) => `${n}: ${line.trim()}`);
+      assert.deepStrictEqual(
+        hits,
+        [],
+        `${d.name} names the retired self-test spelling. It has no alias by decision (rf2-xk4is); ` +
+          `the flag is \`--self-test\` and nothing in the driver should say otherwise.`
+      );
+    });
+
+    t('an argument outside the vocabulary is refused, the retired spelling included', () => {
+      assert.deepStrictEqual(d.mod.unknownFlags(d.flags), [], 'every declared flag must be accepted');
+      assert.deepStrictEqual(d.mod.unknownFlags(['--selftest']), ['--selftest']);
+      assert.deepStrictEqual(d.mod.unknownFlags(['--self-test', '--nope']), ['--nope']);
+      // No positional argument either: these drivers take their knobs from the
+      // environment, so a bare token is as much a typo as a bad flag.
+      assert.deepStrictEqual(d.mod.unknownFlags(['self-test']), ['self-test']);
+    });
+
+    t('the refusal is wired ahead of every self-test, build and browser', () => {
+      const head = SRC.slice(SRC.indexOf(d.head[0]), SRC.indexOf(d.head[1]));
+      assert.ok(head.length > 0, `could not locate the head of main() in ${d.name}`);
+      assert.match(head, /const unknown = unknownFlags\(process\.argv\.slice\(2\)\);/);
+      assert.match(head, /if \(unknown\.length > 0\) \{/);
+      assert.match(head, /process\.exit\(2\);/);
+      assert.ok(
+        head.indexOf('unknownFlags(') < head.indexOf('SelfTest()') || !head.includes('SelfTest()'),
+        'the argument check must come before the adjudicators run, not after'
+      );
+      assert.ok(
+        !/build\(\)|chromium/.test(head),
+        'nothing may be built or launched above the argument check — that is the whole point of it'
+      );
+    });
+  }
 }
 
 // --- THE ADJECTIVE, which is what both instrument errors hid behind ---------

--- a/implementation/hicasso/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/clock_run.cjs
@@ -217,6 +217,34 @@ const CTL3_SABOTAGE = Number(process.env.HCLOCK_CTL3_SABOTAGE || 0) || null;
 // prose, and this is how a reader runs them in a second.
 const SELFTEST_ONLY = process.argv.includes('--self-test');
 
+// AND THE FLAG VOCABULARY IS CLOSED — these two, and no positional argument at
+// all, because every other knob this driver has is an `HCLOCK_*` environment
+// variable. So an argument that is not on this list is not a knob the driver
+// has: it is a typo, and a typo can only be answered two ways — refuse it, or
+// spend an hour of somebody's afternoon on a run they did not ask for. It used
+// to be answered the second way. `--self-test` was spelt without its hyphen
+// until rf2-xk4is, and #8616's merged-PR audit found the retirement unsafe for
+// exactly this reason: nothing here validated its arguments, so the old token
+// was SILENTLY IGNORED and fell straight through into the `:advanced` release
+// build and the headless Chromium below.
+//
+// There is deliberately no alias. This is pre-alpha and an alias for a spelling
+// nothing depends on is a compatibility shim. But retiring a spelling and
+// swallowing it are different acts, and only the general rule performs the
+// first: a list of dead tokens would be the shim wearing a refusal's clothes,
+// and would still swallow the next typo.
+//
+// Nor is this an argument parser. The vocabulary IS the list, the check is the
+// list, and there is no help text to generate and no near-miss to guess at —
+// guessing would be the nag this repo rejects. What it buys is the difference
+// between refusing in twenty milliseconds and refusing in twenty minutes.
+const FLAGS = ['--no-build', '--self-test'];
+
+// Exported rather than inlined, for this file's own lesson: a rule a test can
+// only quote is not a checked rule (`clock_exit_path.test.cjs`, on the exit
+// decision this driver used to get wrong).
+const unknownFlags = (argv) => argv.filter((a) => !FLAGS.includes(a));
+
 const ALL_ROWS = ['M1', 'bulk300', 'bulk100', 'narrow', 'keystroke'];
 const ONLY = (process.env.HCLOCK_ONLY || '').trim();
 const ROWS = ONLY ? ALL_ROWS.filter((r) => ONLY.split(',').includes(r)) : ALL_ROWS;
@@ -3086,6 +3114,19 @@ function datasetFor(outcomes, meta) {
 // ---------------------------------------------------------------------------
 
 async function main() {
+  // THE ARGUMENTS FIRST, before a single adjudicator runs. A refusal that
+  // arrives after the build has already cost what the refusal was for
+  // (rf2-xk4is).
+  const unknown = unknownFlags(process.argv.slice(2));
+  if (unknown.length > 0) {
+    console.error(`[clock] unknown argument${unknown.length > 1 ? 's' : ''}: ${unknown.join(' ')}`);
+    console.error(
+      `[clock] this driver takes ${FLAGS.join(' ')} and nothing else; ` +
+        `every other knob is an HCLOCK_* environment variable. Nothing was built.`
+    );
+    process.exit(2);
+  }
+
   // THE ADJUDICATORS' SELF-TESTS, and they run before anything is built or
   // launched. `ctl3SelfTest` is the one that matters for this driver's new
   // control: its cases are the REFUSALS — superlinear work, an arm that does
@@ -3461,6 +3502,9 @@ async function main() {
 }
 
 module.exports = {
+  // The CLI surface, exported so its pin can drive it (rf2-xk4is).
+  FLAGS,
+  unknownFlags,
   reportability,
   rowAdjudication,
   rowRegime,

--- a/implementation/hicasso/test/re_frame/bench/hicasso/hd8_run.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/hd8_run.cjs
@@ -196,6 +196,28 @@ const SENTINEL_TIMEOUT_MS = 20 * 60 * 1000;
 // rather than on the far side of an hour (the shape `clock_run.cjs` uses).
 const SELFTEST_ONLY = process.argv.includes('--self-test');
 
+// ...AND IT IS THE ONLY ONE. This driver's flag vocabulary is closed at one
+// entry and it takes no positional argument at all — every other knob is an
+// `HD8_*` environment variable, and the run's provenance block prints which of
+// them were set. So an argument off this list is not a knob: it is a typo, and
+// the sweep it falls into is an `:advanced` release build plus three headless
+// Chromium runs whose own page budget is twenty minutes.
+//
+// It fell into exactly that until rf2-xk4is. `--self-test` was spelt without
+// its hyphen until #8616 renamed it, and that PR's merged-PR audit found the
+// retirement unsafe here: nothing validated arguments, so the retired token
+// was SILENTLY IGNORED and the driver went on to build and measure.
+//
+// No alias — pre-alpha, and an alias for a spelling nothing depends on is a
+// compatibility shim. The rule is the general one rather than a list of dead
+// tokens, because a list would swallow the next typo just as quietly, and
+// because a driver whose whole vocabulary is one flag has nothing to parse.
+const FLAGS = ['--self-test'];
+
+// Exported so the pin can drive the rule rather than quote it — this driver's
+// exit block is in `clock_exit_path.test.cjs` for the same reason.
+const unknownFlags = (argv) => argv.filter((a) => !FLAGS.includes(a));
+
 // ---------------------------------------------------------------------------
 // Build + serve
 // ---------------------------------------------------------------------------
@@ -945,6 +967,19 @@ function verdictSelfTest() {
 // ---------------------------------------------------------------------------
 
 async function main() {
+  // THE ARGUMENTS BEFORE THE GUARD, and the guard is already first for the
+  // reason that applies here twice over: discovering the mistake on the far
+  // side of an hour is not discovering it (rf2-xk4is).
+  const unknown = unknownFlags(process.argv.slice(2));
+  if (unknown.length > 0) {
+    console.error(`[hd8] unknown argument${unknown.length > 1 ? 's' : ''}: ${unknown.join(' ')}`);
+    console.error(
+      `[hd8] this driver takes ${FLAGS.join(' ')} and nothing else; ` +
+        `every other knob is an HD8_* environment variable. Nothing was built.`
+    );
+    process.exit(2);
+  }
+
   // The guard's own self-test FIRST. A guard nobody has watched catch its
   // recorded faults is not a guard, and running it after the measurement
   // would mean discovering a broken instrument on the far side of an hour.
@@ -1120,7 +1155,9 @@ async function main() {
   );
 }
 
-module.exports = { summarise, verdict, verdictSelfTest };
+// `FLAGS` / `unknownFlags` are the CLI surface, exported so its pin can drive
+// it (rf2-xk4is).
+module.exports = { FLAGS, unknownFlags, summarise, verdict, verdictSelfTest };
 
 if (require.main === module) {
   main();

--- a/implementation/hicasso/test/re_frame/bench/hicasso/ladder_band.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/ladder_band.cjs
@@ -429,6 +429,22 @@ function main() {
       }
       console.log('\nladder_band self-test ok');
       return;
+    } else if (argv[i].startsWith('--')) {
+      // This one already refused the retired spelling, but only by ACCIDENT:
+      // it took the token for a dataset filename and died on the `readRun`
+      // below with an ENOENT stack trace. An accident is not a retirement —
+      // it says nothing to whoever typed it, and it would stop refusing
+      // altogether the day somebody left a file lying about under that name
+      // (rf2-xk4is, from #8616's merged-PR audit).
+      //
+      // Unlike its two neighbours this driver DOES take positionals, so the
+      // closed vocabulary is scoped to the flag namespace: anything shaped
+      // like a flag must be one of ours, anything else is a dataset.
+      console.error(`ladder_band.cjs: unknown flag ${argv[i]}`);
+      console.error(
+        'usage: ladder_band.cjs [--emit out.json] <dataset.json ...>   |   --from compact.json   |   --self-test'
+      );
+      process.exit(2);
     } else files.push(argv[i]);
   }
 


### PR DESCRIPTION
Reopened by #8616's merged-PR audit. #8616 standardised the three native
benchmark drivers on `--self-test` and shipped no alias; the audit found that
this made the old spelling *unspoken*, not *retired*.

## What was wrong

Measured at merge commit `8d4672db2b`, under a preload that turns every
`child_process` door into a hard stop, so the heavyweight path could be
observed without being paid for:

| before | `--self-test` | `--selftest` |
| --- | --- | --- |
| `clock_run.cjs` | exit 0 | **reached the shadow-cljs `:advanced` release spawn** |
| `hd8_run.cjs` | exit 0 | **reached `git rev-parse HEAD` in the provenance block, one line above `build()`** |
| `ladder_band.cjs` | exit 0 | exit 1 — but by an ENOENT stack trace, having taken the token for a dataset filename |

Neither of the first two validated arguments at all, so the retired spelling
was silently ignored and fell into the default path: a release build and a
headless Chromium whose own page budget is twenty minutes. The third refused,
but incidentally — it says nothing to whoever typed it, and it would stop
refusing the day a file turned up under that name.

## What changed

**The alias stays absent.** Pre-alpha, and an alias for a spelling nothing
depends on is a compatibility shim.

What is new is that the two build-and-browser drivers declare their flag
vocabulary and refuse anything outside it, at the head of `main` before a
single adjudicator runs. The vocabulary is closed *by construction* rather than
by choice: both take every other knob from an `HCLOCK_*` / `HD8_*` environment
variable and no positional argument at all, so the check is the CLI's own
surface written down — two entries and one, no parser, no generated help, no
near-miss guess. `ladder_band.cjs` does take positionals, so its rule is scoped
to the flag namespace: anything flag-shaped must be one of ours.

The general rule rather than a list of dead tokens, deliberately. A list would
be the shim wearing a refusal's clothes, and would still swallow the next typo
— `--self_test`, `--selfTest`, a stray `--no-buld`.

| after | `--self-test` | `--selftest` |
| --- | --- | --- |
| `clock_run.cjs` | exit 0 | **exit 2** — `unknown argument: --selftest` … `Nothing was built.` |
| `hd8_run.cjs` | exit 0 | **exit 2** — same shape, `HD8_*` named |
| `ladder_band.cjs` | exit 0 | **exit 2** — `unknown flag --selftest`, plus the usage line |

## The pin, which is the half the audit said was missing

`clock_exit_path.test.cjs` renamed four labels and inspected the *body* of
`if (SELFTEST_ONLY)` while asserting nothing about how `SELFTEST_ONLY` is
*derived*, so a mutation of either driver back to the old token left every
assertion green. The new block is four claims per driver and no more:

1. the argv definition is spelt `--self-test` — the assertion whose absence let
   the rename go unpinned;
2. the retired spelling appears nowhere in the driver, comments included (a
   retirement that still names the dead token in a usage line is an invitation
   to type it, so the drivers say what happened without spelling it);
3. a token outside the vocabulary is refused, that one included, and so is a
   bare positional;
4. the refusal is wired **above** every self-test, `build()` and `chromium` in
   the head of `main` — the claim that makes it fail *fast* rather than merely
   fail.

`ladder_band.cjs` is not repeated there because `test:script-helpers` already
invokes it directly, and the sabotage run below shows that invocation catching
the same mutation.

No package registration is added: `clock_exit_path.test.cjs` is already in
`test:script-helpers`, so `implementation/package.json` is untouched.

One incidental repair: hd8's export pin moved from one literal `module.exports
= { … };` line to the seat-by-seat match `clock_run.cjs`'s pin already used.
The literal form asserted the export list's *punctuation* as strictly as its
contents, so adding a seat failed it for a reason unrelated to the decision it
guards.

## Quality gates

Verified by hand, and stated because nothing automated covers it: the four
markdown tables above are 3 columns wide in every row including the separators;
no markdown was touched by this change, so no doc gate applies.

| gate | run | captured exit |
| --- | --- | --- |
| `npm run test:script-helpers` (nominated) | pre-rebase, clean | **0** |
| `npm run test:script-helpers` | **sabotage** — `ladder_band.cjs`'s flag mutated to the retired spelling | **2**, at `ladder_band.cjs: unknown flag --self-test` |
| `npm run test:script-helpers` | post-rebase, final base, clean | **0** — `clock_exit_path.test.cjs: 383 passed` |
| `node …/clock_exit_path.test.cjs` | **sabotage** — `clock_run.cjs`'s argv spelling reverted | **1**, `2/383 failed`, naming both new tests |
| `node …/clock_exit_path.test.cjs` | clean | **0**, `383 passed` |
| `python scripts/check_retired_spellings.py` | clean | **0** |

Every number above is the one the invoking shell captured with `>log 2>&1;
echo "EXIT=$?"` on a single line — never a harness report about the same run,
and never through a pipe.

**Which tree each gate read.** `test:script-helpers` prints no root banner, so
the discriminating route is the planted fault: the sabotage rows are faults
that existed only in this branch's checkout, and a run that had wandered into a
sibling would have come back green. Both plants were anchored to a single line,
the match count was read as `1` before each run, and both restores were
verified by the identical **blob** hash before the plant and after it —
`0077ff331a3dcf3e98ec5e29f054d1f2ffad518d` for `clock_run.cjs` and
`a47f8e62f30d2106709a981fa1b36b1bf41d7c4c` for `ladder_band.cjs` — not by
reading a diff.

**Negative-control method.** The *before* rows could not be taken by simply
running the drivers, since the thing being fixed is a typo entering the
build-and-browser path and taking it would have started exactly that. They were
taken under a `node --require` preload that replaces every `child_process` door
with a hard stop printing what was about to be spawned. A run exiting there
reached the heavyweight spawn; a run exiting 0 or 2 stopped before it. Both
*before* rows exited at the stop; both *after* rows exit 2 with no build
attempted.

**Not run, deliberately:** the fast-PR spine, shadow-cljs, any browser or
Playwright suite, and every JVM gate — an allocation window was live on the box
and two heavyweight runs wedge rather than fail. `scripts/check_fast_pr_gap.py
--list` reports **94** required checks the spine does not run; that is a fact
about the spine, not a census of this PR, and the spine was not run here at
all. The targeted gates run directly are the six rows above.

Closes rf2-xk4is.
