### PR TITLE
docs(hicasso): repoint live reproduce commands out of the deleted Freehand tree (rf2-wbdr7)

### DIFF
--- a/docs/design/hicasso/product/async-routing-recipes.md
+++ b/docs/design/hicasso/product/async-routing-recipes.md
@@ -127,7 +127,7 @@ Every one of those has its second direction. The clobber row's twin asserts that
 
 ## What did not hold at source
 
-1. **There is no "census article-editor witness" for late arrival.** The bead's deliverable line says the settle-merge recipe should *elevate the census article-editor witness*. The file that carries that name — `implementation/freehand/test/re_frame/bench/hicasso/front/census_article_editor_cljs_test.cljs` — is about the `:&` merge spelling on a census-real screen, and asserts nothing about late replies or touched fields. Its only use of the word *clobber* is attribute-merge clobber, which is a different thing with the same name.
+1. **There is no "census article-editor witness" for late arrival.** The bead's deliverable line says the settle-merge recipe should *elevate the census article-editor witness*. The file that carries that name — `implementation/hicasso/test/re_frame/bench/hicasso/front/census_article_editor_cljs_test.cljs` — is about the `:&` merge spelling on a census-real screen, and asserts nothing about late replies or touched fields. Its only use of the word *clobber* is attribute-merge clobber, which is a different thing with the same name.
 
     The actual R-C1 law lives in two places, neither of them a witness that could be elevated: `spec/conformance/freehand/fixtures/fh-ctrl-013.edn` with `implementation/freehand/test/re_frame/freehand/form_cljs_test.cljc`, which is the *freehand* substrate's leafwise seed rather than a consumer recipe; and `docs/design/freehand/studio/fitness-harness.md`, which records at its own §C.2 that the same-slug typing clobber is **still live** in the corpus and *"a harness case no green suite currently covers."*
 

--- a/docs/design/hicasso/studio/a-control-that-differences-the-constant-away.md
+++ b/docs/design/hicasso/studio/a-control-that-differences-the-constant-away.md
@@ -375,20 +375,20 @@ Reproduce the published run:
 
 ```bash
 HCLOCK_ONLY=bulk300,bulk100,narrow HCLOCK_SAMPLES=20 \
-  node implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+  node implementation/hicasso/test/re_frame/bench/hicasso/clock_run.cjs
 ```
 
 Reproduce the falsification, which exits 1 naming the control:
 
 ```bash
 HCLOCK_ONLY=bulk300 HCLOCK_SAMPLES=20 HCLOCK_CTL3_SABOTAGE=140 \
-  node implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+  node implementation/hicasso/test/re_frame/bench/hicasso/clock_run.cjs
 ```
 
 Reproduce the adjudicators' fixtures, with no browser and in under a second:
 
 ```bash
-node implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs --self-test
+node implementation/hicasso/test/re_frame/bench/hicasso/clock_run.cjs --self-test
 ```
 
 Every figure on this page is recomputable from the dataset the run writes when

--- a/docs/design/hicasso/studio/bulk-broad-re-taken.md
+++ b/docs/design/hicasso/studio/bulk-broad-re-taken.md
@@ -385,9 +385,9 @@ figure from this page should be restated without one:
 cd implementation && npm ci
 for i in $(seq 1 8); do
   HCLOCK_ONLY=M1,bulk300 HCLOCK_SAMPLES=20 HCLOCK_JSON=out/run$i.json \
-    node freehand/test/re_frame/bench/hicasso/clock_run.cjs
+    node hicasso/test/re_frame/bench/hicasso/clock_run.cjs
 done
-node freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs out/run*.json
+node hicasso/test/re_frame/bench/hicasso/clock_readjudicate.cjs out/run*.json
 ```
 
 The single-run form this page's ensemble was taken with, retained because it is

--- a/docs/design/hicasso/studio/coldmount-double-build-priced.md
+++ b/docs/design/hicasso/studio/coldmount-double-build-priced.md
@@ -57,8 +57,8 @@ Reproduce (each row is one page and one driver invocation; the plain command
 runs all five over the same gates):
 
 ```bash
-node implementation/freehand/test/re_frame/bench/hicasso/coldmount_run.cjs
-COLDMOUNT_ONLY=M1L1 node implementation/freehand/test/re_frame/bench/hicasso/coldmount_run.cjs
+node implementation/hicasso/test/re_frame/bench/hicasso/coldmount_run.cjs
+COLDMOUNT_ONLY=M1L1 node implementation/hicasso/test/re_frame/bench/hicasso/coldmount_run.cjs
 ```
 
 The five published rows were taken one row per invocation — fresh build (the
@@ -389,7 +389,7 @@ The double build is untouched by .13, so the fractions on this page stand. Their
 > ms and per-token arming; only ≥256 ms or no reaper at all flips it). The
 > evidence for the win remains the swap-the-primitive probe — which
 > `rf2-2rtt6.80` has since committed as a runnable on-demand diagnostic,
-> `node implementation/freehand/test/re_frame/bench/hicasso/adoption_witness_run.cjs`,
+> `node implementation/hicasso/test/re_frame/bench/hicasso/adoption_witness_run.cjs`,
 > measuring its page's render-to-passive-flush gap before it will read an
 > adoption integer and printing REFUSED with that gap when it cannot bound it.
 > **None of that revives the `shipped` rows below.**

--- a/docs/design/hicasso/studio/cross-checked-against-an-outside-instrument.md
+++ b/docs/design/hicasso/studio/cross-checked-against-an-outside-instrument.md
@@ -547,7 +547,7 @@ strengthens the case for.
 | Benchmark revision | `krausest/js-framework-benchmark` at commit **`247fafa22c1f2caeb4cad179aa64cf444398cbc7`** (*"incremental run"*, 2026-07-28), read back from the surviving clone rather than recalled. It was reached as a shallow clone of `master` taken 2026-08-01, and `master` alone is not a pin — the branch has moved since. The clone is kept at `%LOCALAPPDATA%\Temp\jsfb-rguy1\repo`, **outside this repository, never committed**. That SHA belongs to the benchmark's repository, not to this one, so it resolves there and nowhere else — canonically at [github.com/krausest/js-framework-benchmark/commit/247fafa22c1f2caeb4cad179aa64cf444398cbc7](https://github.com/krausest/js-framework-benchmark/commit/247fafa22c1f2caeb4cad179aa64cf444398cbc7) |
 | Build | `:hicasso-bench`, `:advanced`, `goog.DEBUG false`, via `--config-merge` only — no build id added, `implementation/shadow-cljs.edn` untouched |
 | Bundles | `rf2-reagent` `300a273bd20d44fcc9a6ef6718a2366faf73d691b2a2122c43003d4fc0ce8ac6` · `rf2-hicasso` `1cc9fef3bca6a6a85602361f807ff95d8338ffefba0dcad9ed04dc8ff343814f` · `rf2-uix` `4594e3f11222a16e7ef47f3fb7c6827854ff3cd9e3fa4ea07682482adea1abc1`. One set of three, shared by both runs below — the re-take measured the published bundles rather than a rebuild, which is what isolates the parity question from five days of implementation drift |
-| Retained datasets | `implementation/freehand/test/re_frame/bench/hicasso/data/jsfb-rguy1/` — both runs, **byte-exact as the instrument wrote them**, so a fresh clone can read this page's parity object, gate counts and per-round figures out of the tree instead of taking them on trust. `ours3.json`, the 2026-08-02 run, 6,124 bytes, SHA-256 `eacd43ed782ac7a80d3b47bb4f92a4e1dfa46f8d0f68eee6f757442cbe84f136`; `ours4.json`, the 2026-08-07 re-take, 35,553 bytes, SHA-256 `3e31fae2e408a2745b70bde6aa96cd242f9f9d17f8abf17af8e6e795577c5093`. Both carry `provenance.bundles: {}` — `jsfb_ours_run.cjs` declared the field and never filled it, so neither run binds itself to the three digests above; `provenance.json` beside them does it instead, and from `rf2-rguy1` (2026-08-08) the instrument does it itself. The benchmark clone and the run logs are **not** vendored |
+| Retained datasets | `implementation/hicasso/test/re_frame/bench/hicasso/data/jsfb-rguy1/` — both runs, **byte-exact as the instrument wrote them**, so a fresh clone can read this page's parity object, gate counts and per-round figures out of the tree instead of taking them on trust. `ours3.json`, the 2026-08-02 run, 6,124 bytes, SHA-256 `eacd43ed782ac7a80d3b47bb4f92a4e1dfa46f8d0f68eee6f757442cbe84f136`; `ours4.json`, the 2026-08-07 re-take, 35,553 bytes, SHA-256 `3e31fae2e408a2745b70bde6aa96cd242f9f9d17f8abf17af8e6e795577c5093`. Both carry `provenance.bundles: {}` — `jsfb_ours_run.cjs` declared the field and never filled it, so neither run binds itself to the three digests above; `provenance.json` beside them does it instead, and from `rf2-rguy1` (2026-08-08) the instrument does it itself. The benchmark clone and the run logs are **not** vendored |
 | Their run | started 2026-08-01 23:55:03 AUSEST, ended 00:00:55, **exit 0**, driver's own PlausibilityCheck `successful run` |
 | Our run | started 2026-08-02 00:01:09 AUSEST, ended 00:06:59, **exit 1**. Unverified writes and page errors cleared; the positive control failed ([§5](#5-the-control-failed-and-here-is-what-that-does-and-does-not-touch)) and **so did the DOM parity gate** — `parity.identical: false`. The earlier claim that parity cleared here is **withdrawn** (`rf2-rguy1`, 2026-08-07): this run predates the attribute-sorting gate, so the gate it is quoted as passing did not yet exist ([§1.3](#13-the-one-deliberate-deviation-and-why-it-strengthens-the-comparison)) |
 | Our DOM-parity re-take | started 2026-08-07 18:33:08 AUSEST, ended 18:39:47, **exit 1** — scoped to the positive control alone. **DOM parity IDENTICAL**, `firstDiff: null`, canonical and raw lengths `216,066` on all three arms; 0 unverified of 1,000 writes; 0 page errors. Landed harness at `851961adc6`, whose `jsfb_ours_run.cjs` differs from the pinned blob below only in `rf2-emvod`'s raw-`TaskDuration` reporting and `JSFB_ONLY` — the canonicalisation and the exit gate are byte-identical, so this is the same instrument on the parity question. Run against the three bundles above, digests re-verified before the run. **This re-take establishes the DOM gate only**; the ratios on this page are unchanged and remain those of the 2026-08-02 run |
@@ -580,7 +580,7 @@ cd /tmp/jsfb && npm --prefix server install && npm --prefix webdriver-ts ci \
 (cd server && npm start &)                      # serves :8080
 
 cd <re-frame2>/implementation && npm ci
-node freehand/test/re_frame/bench/hicasso/jsfb_build.cjs --dest /tmp/jsfb
+node hicasso/test/re_frame/bench/hicasso/jsfb_build.cjs --dest /tmp/jsfb
 
 cd /tmp/jsfb/webdriver-ts                        # THEIRS
 node dist/benchmarkRunner.js \
@@ -589,9 +589,9 @@ node dist/benchmarkRunner.js \
 
 cd <re-frame2>/implementation                    # OURS — 5 rounds, as published
 JSFB_ROUNDS=5 JSFB_OURS_JSON=/tmp/ours.json \
-  node freehand/test/re_frame/bench/hicasso/jsfb_ours_run.cjs
+  node hicasso/test/re_frame/bench/hicasso/jsfb_ours_run.cjs
 
-node freehand/test/re_frame/bench/hicasso/jsfb_compare.cjs \
+node hicasso/test/re_frame/bench/hicasso/jsfb_compare.cjs \
   --theirs /tmp/jsfb/webdriver-ts/results --ours /tmp/ours.json
 ```
 

--- a/docs/design/hicasso/studio/raw-escape-spec.md
+++ b/docs/design/hicasso/studio/raw-escape-spec.md
@@ -548,7 +548,7 @@ The *mechanism* exists as `codec/as-element`; the *taught name* does not. **This
 called that mechanism "public" until 2026-08-06, where A, B, C and `decisions.md` all call
 it INTERNAL — and the operative fact is neither word.** `as-element` is a non-private
 `defn`, so a fixture that requires `re-frame.bench.hicasso.front.codec` can call it; but
-that namespace lives in the bench tree under `implementation/freehand/test/`,
+that namespace lives in the bench tree under `implementation/hicasso/test/`,
 `arm1/lang.clj` does not export it, and the guide's `h` is `re-frame.hicasso` — a package
 that does not exist yet. Reachable from a test, reachable from nothing an author writes:
 that is the sense in which the sibling records are right, and the sense a reader of this

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -94,7 +94,11 @@ workstation with other agents running concurrently. Every arm is an
 (`:freehand-release`). **Browser numbers**; nothing here is a JVM or Node
 figure.
 
-Reproduce:
+**Taken with — and it no longer runs.** The Freehand substrate was retired
+(`rf2-0yp7w`) and `implementation/freehand/` deleted, so the driver below is on
+no commit reachable from `main` and there is no tip equivalent to re-point it
+to. It is recorded as the instrument that produced §§1–5, not offered as a
+command:
 
 ```
 node implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs

--- a/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
+++ b/docs/design/hicasso/studio/rows-re-adjudicated-on-the-corrected-clock.md
@@ -465,8 +465,9 @@ ensemble was taken at, so it is filed rather than done here.
 > corpus, printed by the canonical tool and quoted from nowhere else:
 >
 > ```bash
-> node freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs \
->   freehand/test/re_frame/bench/hicasso/data/clock-emvod/run*.json
+> cd implementation
+> node hicasso/test/re_frame/bench/hicasso/clock_readjudicate.cjs \
+>   hicasso/test/re_frame/bench/hicasso/data/clock-emvod/run*.json
 > # exit 0 — ROW M1, PAIR hicasso / uix-subs:
 > #   point 1.1718x  95% CI [1.1263 – 1.2190]  over 8 reportable run(s)
 > #   VERDICT K1 MISSED, DECISIVELY — the whole interval is above the 1.1x mount gate
@@ -912,8 +913,8 @@ git rev-parse <candidate>:$P   # must print 84aa25d93b65ee55f3d28d339d57720e3a50
 
 ```bash
 cd implementation && npm ci
-node freehand/test/re_frame/bench/hicasso/clock_run.cjs           # one run, all five rows
-node freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs out/run*.json
+node hicasso/test/re_frame/bench/hicasso/clock_run.cjs           # one run, all five rows
+node hicasso/test/re_frame/bench/hicasso/clock_readjudicate.cjs out/run*.json
 ```
 
 ### 7.1 What this page cannot regenerate
@@ -969,9 +970,9 @@ readjudicator can adjudicate on all thirteen axes without re-running the box.
 
 ```bash
 cd implementation
-node freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs \
-  freehand/test/re_frame/bench/hicasso/data/clock-0qj9w/run1.json \
-  freehand/test/re_frame/bench/hicasso/data/clock-0qj9w/run2.json
+node hicasso/test/re_frame/bench/hicasso/clock_readjudicate.cjs \
+  hicasso/test/re_frame/bench/hicasso/data/clock-0qj9w/run1.json \
+  hicasso/test/re_frame/bench/hicasso/data/clock-0qj9w/run2.json
 # exit 3 — neither file carries a `canonical` verdict, both are printed in
 #          full, and no reportable subset is drawn from either
 ```
@@ -982,7 +983,7 @@ in both directions:
 
 ```bash
 cd implementation
-node freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+node hicasso/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
 ```
 
 The cross-check probe in [§2.1](#21-what-the-correction-therefore-does-not-reach)
@@ -1097,8 +1098,8 @@ ensembles, and the seven runs this page was written on are untouched.
 
 ```bash
 cd implementation
-node freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs \
-  freehand/test/re_frame/bench/hicasso/data/clock-emvod/run*.json
+node hicasso/test/re_frame/bench/hicasso/clock_readjudicate.cjs \
+  hicasso/test/re_frame/bench/hicasso/data/clock-emvod/run*.json
 # exit 0 — all eight datasets are eligible published evidence, every run is
 #          printed with its own magnitude and its own refusals beside it, and
 #          the reportable subset is drawn only where the gates left one

--- a/docs/design/hicasso/studio/slim-non-reactive-arm-diagnosis.md
+++ b/docs/design/hicasso/studio/slim-non-reactive-arm-diagnosis.md
@@ -56,11 +56,11 @@ Two corrections to the bead's statement of the symptom fall out of this:
 
 ```bash
 cd C:/path/to/re-frame2
-node implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
+node implementation/hicasso/test/re_frame/bench/hicasso/z3vlz_run.cjs
 
 # one rung at a time
 Z3VLZ_ONLY=slim-only Z3VLZ_PORT=8171 \
-  node implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
+  node implementation/hicasso/test/re_frame/bench/hicasso/z3vlz_run.cjs
 ```
 
 Exit codes: `0` every declared bundle matched and every page ran; `1` a build

--- a/docs/design/hicasso/studio/ssr-spike-witness.md
+++ b/docs/design/hicasso/studio/ssr-spike-witness.md
@@ -441,7 +441,7 @@ ceiling is nowhere near this regime, which is why the published verdict above is
 unaffected.
 
 Repro:
-`ADOPTWIT_CEILING_MS=0.3 node implementation/freehand/test/re_frame/bench/hicasso/adoption_witness_run.cjs`
+`ADOPTWIT_CEILING_MS=0.3 node implementation/hicasso/test/re_frame/bench/hicasso/adoption_witness_run.cjs`
 — and expect either outcome.
 
 ## X4 — the screen is alive

--- a/docs/design/hicasso/studio/the-band-re-calibrated.md
+++ b/docs/design/hicasso/studio/the-band-re-calibrated.md
@@ -546,16 +546,16 @@ the load half of the design is identical and not merely equivalent.
 ```bash
 cd implementation
 # build once
-HCLOCK_ONLY=bulk300 node freehand/test/re_frame/bench/hicasso/clock_run.cjs
+HCLOCK_ONLY=bulk300 node hicasso/test/re_frame/bench/hicasso/clock_run.cjs
 
 # then one rung, three replicates — and issue NO other command while it runs
 for r in 1 2 3; do
-  node freehand/test/re_frame/bench/hicasso/seam_ladder.cjs \
+  node hicasso/test/re_frame/bench/hicasso/seam_ladder.cjs \
     --load 12 --label "L12-r$r" --json "out/ladder-ymi6j/L12-r$r.json"
 done
 
 # recompute every figure on this page from the datasets
-node freehand/test/re_frame/bench/hicasso/ladder_band.cjs out/ladder-ymi6j/L*.json
+node hicasso/test/re_frame/bench/hicasso/ladder_band.cjs out/ladder-ymi6j/L*.json
 ```
 
 ### 9.1 The dataset survives this time, and that was the point

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -1472,14 +1472,14 @@ both clocks, [the band re-calibrated](the-band-re-calibrated.md). Neither
 failure mode can recur: `ladder_band.cjs` recomputes every figure from the
 driver's own datasets using `seam.cjs`'s exported adjudicators, and the compact
 per-block dataset it emits is **committed** at
-`implementation/freehand/test/re_frame/bench/hicasso/data/ladder-ymi6j.json`.
+`implementation/hicasso/test/re_frame/bench/hicasso/data/ladder-ymi6j.json`.
 That is the one command this section's own audit asked for, and it runs from a
 clean clone against a file the clone already has:
 
 ```bash
 cd implementation
-node freehand/test/re_frame/bench/hicasso/ladder_band.cjs \
-  --from freehand/test/re_frame/bench/hicasso/data/ladder-ymi6j.json
+node hicasso/test/re_frame/bench/hicasso/ladder_band.cjs \
+  --from hicasso/test/re_frame/bench/hicasso/data/ladder-ymi6j.json
 ```
 
 It regenerates every published aggregate of the re-taken ladder — every band,

--- a/docs/design/hicasso/studio/the-clock-behind-the-published-rows.md
+++ b/docs/design/hicasso/studio/the-clock-behind-the-published-rows.md
@@ -711,8 +711,8 @@ questions from one ensemble.
 
 ```bash
 cd implementation
-HCLOCK_JSON=out/window/run1.json node freehand/test/re_frame/bench/hicasso/clock_run.cjs
-node freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs out/window/run*.json
+HCLOCK_JSON=out/window/run1.json node hicasso/test/re_frame/bench/hicasso/clock_run.cjs
+node hicasso/test/re_frame/bench/hicasso/clock_readjudicate.cjs out/window/run*.json
 ```
 
 The driver's exit code is a whole-run verdict and is **not** a row's licence:

--- a/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
+++ b/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
@@ -111,7 +111,7 @@ measurement failure — see §5.
 |---|---|
 | **Producing commit** | `b8e6da66814e380cafe08a9ebdf58d74f3730828` on `worker/inpage-409ab`, based on `origin/main` `667c744dc8`. Working tree clean at every run (`out/` and `logs/` are ignored), so the stamped blobs are the commit's. **Authored, and rebase-merged, so this SHA is on no branch and will not resolve in a fresh clone**; it landed on main as **`4866dfa90c`** (same patch — identical `git patch-id --stable`), with the blob it contributed unchanged. The landed SHA is the one to check out; it sits on a later base, so it carries the change rather than the whole measured tree |
 | **Reproduction** | `HICASSO_INIT_FN=re-frame.bench.hicasso.inpage-ladder-app/-main HICASSO_OUT_DIR=out/hicasso-inpage-ladder HICASSO_PORT=8152 node implementation/freehand/test/re_frame/bench/hicasso/run.cjs` |
-| **Re-deriving every figure below** | `node implementation/freehand/test/re_frame/bench/hicasso/inpage_ladder_aggregate.cjs` — fail-closed, see §7 |
+| **Re-deriving every figure below** | `node implementation/hicasso/test/re_frame/bench/hicasso/inpage_ladder_aggregate.cjs` — fail-closed, see §7 |
 | **Build** | `:hicasso-bench` (`--config-merge` entry swap; `implementation/shadow-cljs.edn` untouched) — `:advanced`, `goog.DEBUG false`, cache cleared per `rf2-2rtt6.20`. 199 files, 144 compiled, **0 warnings** |
 | **Runtime** | `HeadlessChrome/147.0.7727.15` (Windows NT 10.0 x64), node `v24.13.0`, hardware-concurrency 24, device-memory 32 |
 | **Design** | 6 rounds × (4 warmup + 10 samples) per arm — 60 samples per arm per run, four runs |
@@ -329,7 +329,7 @@ command that rebuilds every published aggregate from them. This page ships
 both.
 
 ```bash
-node implementation/freehand/test/re_frame/bench/hicasso/inpage_ladder_aggregate.cjs
+node implementation/hicasso/test/re_frame/bench/hicasso/inpage_ladder_aggregate.cjs
 ```
 
 It reads the four runs' **raw per-sample rounds** and recomputes, per arm,

--- a/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
+++ b/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
@@ -65,7 +65,11 @@
 > consequences of `.25` are on
 > [the converged witness set](p0-converged-witness-set.md).
 
-Reproduce:
+**Taken with — and it no longer runs.** The Freehand substrate was retired
+(`rf2-0yp7w`) and `implementation/freehand/` deleted, so the driver below is on
+no commit reachable from `main` and there is no tip equivalent to re-point it
+to. It is recorded as the instrument that produced the figures, not offered as
+a command:
 
 ```bash
 cd implementation
@@ -75,8 +79,8 @@ ABL_ROUNDS=4 ABL_SNAP_ROUNDS=2 \
 
 Instrument: `implementation/freehand/test/re_frame/freehand/bench/spine_ablation.cljs`
 (page), `…/spine_ablation_app.cljs` (`:advanced` entry),
-`…/spine_ablation_run.cjs` (driver). It rides `freehand-release` through
-`--config-merge` and adds no build id.
+`…/spine_ablation_run.cjs` (driver). It rode `freehand-release` through
+`--config-merge` and added no build id.
 
 ---
 


### PR DESCRIPTION
Closes the live half of `rf2-wbdr7`. PR #8616 corrected a reproduce instruction's FLAG to `--self-test` and left its executable path pointing into `implementation/freehand/`, which PR #8322 deleted. Updating the flag and not the path is the tell: a live instruction was read as prose.

## The partition

The corpus is not one thing, and a mechanical sweep would have been destructive. **58** command-shaped lines under `docs/design/hicasso` name the deleted tree. They split three ways, and the discriminating question for prose is tense and mood — an imperative a reader is meant to obey is live; a past-tense report of a run already taken, or a path identifying the object measured at a pinned revision, is a record.

| | lines | disposition |
|---|---|---|
| Live imperatives, tip equivalent exists | 28 driver invocations + 5 path arguments | repointed |
| Live imperatives, **no** tip equivalent | 2 | marked non-runnable |
| Pinned provenance records | 26 | **untouched** |
| Live, but file held by another worker | 2 | left, named below |

Plus **3** present-tense pointers outside the command set that falsely asserted a *current* location — the bead's criterion-2 exception. Total **36** path occurrences rewritten across **18** distinct paths in **15** files.

### Repointed (live)

`implementation/freehand/test/re_frame/bench/hicasso/` becomes `implementation/hicasso/test/re_frame/bench/hicasso/`, and the `cd implementation`-relative form `freehand/test/…` becomes `hicasso/test/…`. Anchored by line number with an asserted before-text, so a missed anchor aborts rather than silently no-ops.

Pages: `a-control-that-differences-the-constant-away` (the bead's own, all three `Reproduce…` blocks), `bulk-broad-re-taken`, `coldmount-double-build-priced`, `cross-checked-against-an-outside-instrument`, `rows-re-adjudicated-on-the-corrected-clock`, `slim-non-reactive-arm-diagnosis`, `ssr-spike-witness`, `the-band-re-calibrated`, `the-candidates-clock`, `the-clock-behind-the-published-rows`, `the-in-page-mount-term-decomposed`.

One block on `rows-re-adjudicated` had a bare relative path with no stated cwd — repointing alone would have left it broken, so it gains the `cd implementation` every other block on that page already carries.

### Marked non-runnable, not repointed

`reads-per-boundary-heap-ladder` and `uix-spine-per-read-decomposition` say **Reproduce:** over drivers on the retired Freehand *substrate* (`reads_ladder_run.cjs`, `spine_ablation_run.cjs`, built by `:freehand-release`). Verified: those basenames exist at **no** path at tip, so there is nothing to repoint to. Their `Reproduce:` label is replaced by an explicit statement that the driver is on no commit reachable from `main`, and the path is kept because it identifies what ran.

### Present-tense pointers repaired

* `cross-checked…:550` promised "a fresh clone can read this page's parity object … out of the tree" at a dead dataset directory. The datasets exist under `hicasso/`.
* `raw-escape-spec:551` — "that namespace **lives** in the bench tree under `implementation/freehand/test/`".
* `product/async-routing-recipes:130` — "The file that carries that name — X — **is** about…", where X exists under `hicasso/`.

### Deliberately untouched — 26 lines

Every `| **Reproduction** |` row that sits in a record table beside a **Producing / Authoring / Measured commit** pin, reporting exit codes already observed ("exit 0 on all ten"). At those revisions the Freehand path was correct; rewriting it would make the command false of the tree it names. `p0-converged-witness-set` (8), `our-walk-against-reagents` (4), `census-real-clock-rows` (2), `hd8-composed-donor-arm` (2, one reading "**at the producing commit above**"), and one each on `hd8-freehand-codec-donor-arm`, `ssr-spike-witness`, `the-cold-read-mount-term`, `the-route-link-render-term-priced`, `the-interpreter-walk-profiled-and-cheapened`, `the-page-chrome-row…` ("the measured tree survives nowhere"), `the-in-page-mount-term-decomposed` (its Provenance row; the sibling *Re-deriving* row **was** repointed, because that one recomputes from committed datasets at tip), `the-candidates-clock` (2).

Two more that look repointable and are not:

* `rows-re-adjudicated:899` sets `P=implementation/freehand/…/clock_run.cjs` and feeds it to **`git rev-parse <candidate>:$P`**. The path *is* the pinned object; repointing breaks the check.
* `bulk-broad-re-taken:399` retains a single-run form under its own sentence: "**The driver has moved since the blob above, and this page is not re-pinned to where it went.**" The page already declares its own record status.

All blob/provenance tables naming Freehand paths are left as they stand — one page says why better than I can: "The table names the blobs that **ran** rather than the blobs that **ship**, because those are different questions and only the first is provenance."

### Out of scope, deliberately

`docs/design/freehand/studio/**` (5 command lines) is itself the Freehand record and its drivers exist nowhere; the bead scopes criterion 1 to `docs/design/hicasso`. Left alone.

## Not done — fenced file

`docs/design/hicasso/studio/README.md:69` and `:73` are **unambiguously live** operator instructions (`cd implementation`, "the default entry", "any other arm, same build id, same driver", a present-tense "Exit codes:" paragraph) pointing at `freehand/test/re_frame/bench/hicasso/{run,p0_converge_run}.cjs`. Both drivers exist at tip under `hicasso/`. The file is the shared studio index ledger with concurrent writers, so it is **not touched here**. `rf2-wbdr7` stays **OPEN** for those two lines.

Also surfaced, not actioned — these need a ruling rather than a path rewrite, and are noted on the bead:

* `docs/design/hicasso/production-server-arm.md:163,182` cite `implementation/freehand/src/…` and `implementation/ui/test/…` in a "Piece | Where | State" table whose State column reads "shipped" / "shipped and running". Both trees are retired, nothing to repoint to, and `implementation/ui/` is outside this bead.
* `docs/design/hicasso/product/async-routing-recipes.md:132` — "The actual R-C1 law **lives** in two places", naming `spec/conformance/freehand/fixtures/fh-ctrl-013.edn` (0 tracked files under `spec/conformance/freehand/`; `fh-ctrl-013` matches nothing repo-wide) and a Freehand-substrate test. Where R-C1 lives now is a content question, not a path one.

## Quality gates

Captured with the redirect and the `echo $?` on **one command line, in one shell**; the numbers below are the ones I captured, not any the harness reported. Artefacts named per worktree and per attempt.

| gate | captured exit | when |
|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | pre-rebase, and re-run on the final base |
| `scripts/check_provenance_pins.py --changed-since origin/main` | **0** | pre-rebase, and re-run on the final base |
| `scripts/check_readme_links.py --ci` | **0** | pre-rebase, and re-run on the final base |

Re-run after the rebase, because #8618 and #8615 landed while this was in flight and a pre-rebase green is evidence about a tree that no longer exists. Both of those pages were checked at the new base: they carry **0** Freehand command lines, so the fence left nothing behind.

**Which tree each gate read.** `check_provenance_pins.py` prints `15 pages inspected, 155 cited pins — 117 landed, 36 stranded, 1 unresolvable, 1 foreign; 37 accompanied in scope; 0 findings` — 15 is exactly this branch's changed-page count, so it read this diff. `check_doc_slugs.py` prints nothing at all, so it took the planted-fault route: a broken link target added **inside the fenced block at the line repointed on `a-control-that-differences-the-constant-away.md`** (`docs/design/hicasso/` is one of the two trees where a doc link inside a fence *is* reported). It went **red, exit 1**, naming `…:392 -> ./no-such-page-xyzzy-repoint.md` — a fault present in no other checkout, so a run that had wandered into a sibling would have come back green. Restored and verified by the identical **blob** hash `6399eccbbcff24bf3d006b225b6f60ea8a3ab59f` against the committed object, not by reading a diff; the plant's match count was checked as exactly 1 before the gate ran, since these files are CRLF and an end-anchored pattern would have matched nothing.

**What the gates did not inspect.** Both strip fenced code blocks before reading links, and under `docs/design/hicasso/` the inversion only makes *markdown links* inside fences reportable. Every path this PR rewrites is a **shell command argument**, and roughly three quarters of them sit inside fences. **No gate here inspected a single path I changed.** The greens above are real but they are about the rest of the page.

**The check that actually covers this change is not a gate.** Each of the 18 distinct rewritten paths was tested for existence at this tip: **18 of 18 exist, 0 missing**, with a negative control (`nope_control.cjs`) correctly reported missing so the checker is known to discriminate. A command repointed to a second wrong path is worse than an obviously broken one.

**Six offline commands exercised at the repointed paths**, before and again after the rebase, every documented exit code reproduced — no browser, no build, no measurement:

| command (cwd `implementation/`) | page says | captured |
|---|---|---|
| `clock_run.cjs --self-test` | "no browser and in under a second" | **0** |
| `clock_exit_path.test.cjs` | refusal fixtures | **0** |
| `clock_readjudicate.cjs data/clock-0qj9w/run{1,2}.json` | "exit 3" | **3** |
| `clock_readjudicate.cjs data/clock-emvod/run*.json` | "exit 0" | **0** |
| `ladder_band.cjs --from data/ladder-ymi6j.json` | regenerates the aggregates | **0** |
| `inpage_ladder_aggregate.cjs` | "fail-closed" | **0** |

**By hand, because nothing validates this markdown's prose, tables or rendering.** Exactly **2** table rows were touched, both 3 pipes before and after (2-column rows in a `| | |` / `|---|---|` table). Total pipe count is byte-identical across all 15 changed files, so no table structure moved anywhere. **0** headings touched and **0** markdown links added or removed, so no anchor could have been invalidated.

**Spine:** not run. An allocation window was live on the box (`worker/revorder-csca8`), and this surface is markdown, so only the cheap python checkers were run — none of which can wedge. `scripts/check_fast_pr_gap.py --list` reports **94** required checks the fast-PR spine does not run; that is a fact about the spine, not a census of what ran here. `mkdocs build --strict` is **not** nominated: `exclude_docs` keeps `docs/design/**` out of the site.
