### PR TITLE
docs(hicasso): scope the 116-run anchor and name the three corpus populations (rf2-3yvef)

### DIFF
--- a/docs/design/hicasso/studio/the-cluster-follows-the-mode-and-the-third-arm-is-still-missing.md
+++ b/docs/design/hicasso/studio/the-cluster-follows-the-mode-and-the-third-arm-is-still-missing.md
@@ -7,9 +7,14 @@ filed rather than chased: the uix SUBSTRATE, the POSITION in the round, or the
 segment-order MODE.
 
 **No allocation window was taken for this page, and no rig file was edited.**
-Every figure is re-derived from datasets already committed under
-`implementation/hicasso/test/re_frame/bench/hicasso/data/`. The extraction it
-rests on is `alloc_position_confound.cjs` at the identical blob
+Every figure this page DERIVES is re-derived from datasets already committed
+under `implementation/hicasso/test/re_frame/bench/hicasso/data/`. Figures QUOTED
+from
+[the reversed fixed arm](the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md)
+are that record's rather than this one's, and every paragraph carrying one says
+so where it stands; see [the corpus](#the-corpus) for the three populations in
+play. The extraction this page's own figures rest on is
+`alloc_position_confound.cjs` at the identical blob
 `cd1a80711ca1846cc6e4c5cfece0bbc6ad673164` — unchanged by this correction, which
 touched only the admissibility filter and the claims, never the window
 extraction.
@@ -64,8 +69,10 @@ separate and the one whose exposure is three runs.**
 > this page is the blockquote closing
 > [what the p-values are not](#what-the-p-values-are-not); the figures behind it
 > belong to the window's own record and are quoted from there. **Every number
-> here is read on the 116-run corpus of [the corpus](#the-corpus) below, and none
-> is re-derived against the 131-run corpus that window produced.**
+> this page DERIVES is read on the 116-run corpus of
+> [the corpus](#the-corpus) below; the window's figures appear here only inside
+> blocks that name it as their source; and nothing on this page is re-derived
+> against the 131-run corpus that window produced.**
 
 | arm of the question | verdict | the counts it rests on | Fisher, two-sided |
 |---|---|---|---|
@@ -156,12 +163,33 @@ run is `P0_ALLOC_PLAN=floor`, `P0_ALLOC_WRITE=all`, `P0_ROOTS=4`, B = 24, six
 writes, one instrument — checked rather than assumed, because a pooled census
 over unlike units would be meaningless and the byte band is absolute.
 
-**This is the corpus AS THIS PAGE READ IT, and every figure below is anchored to
-it.** [The reversed fixed arm](the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md)
-has since added fifteen runs, taking the admissible corpus to **131 runs, 3,688
-collection-free, 3,520 positional** against 116 / 3,258 / 3,090 here. **Nothing
-on this page is re-derived against them**, so a figure quoted from here is a
-figure about the 116, and the two censuses must not be read across.
+**This is the corpus AS THIS PAGE READ IT.** Since it was read, a second corpus
+exists, so **three populations are now in play and they must not be read
+across**:
+
+- **the 116-run admissible corpus** — the table above, this page's own. Every
+  figure this page DERIVES is read on it, with one deliberate exception that
+  names itself where it stands: the reader control at
+  [a control on the reader itself](#and-a-control-on-the-reader-itself) is
+  computed BEFORE admissibility, on the fourteen runs an earlier record
+  published.
+- **the fifteen-run matched window** — five `fixed-reversed`, five `fixed`, five
+  `parity`, interleaved in one session, recorded by
+  [the reversed fixed arm](the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md).
+  Its figures are QUOTED here, never re-derived, and they appear only inside
+  passages that mark themselves as superseding and name that record as their
+  source — as a blockquote, or as a paragraph that says so in its closing
+  sentence.
+- **the 131-run admissible corpus** — the two together, **3,688 collection-free,
+  3,520 positional**, against 116 / 3,258 / 3,090 here. **Nothing on this page is
+  read on it at all.**
+
+So a figure this page derives is a figure about the 116; a figure quoted inside a
+superseding block is a figure about the fifteen, or — where the block says so —
+about the two matched sessions pooled at RUN level: this page's three `fixed`
+runs with the window's five, and its three `parity` with the window's five, 8
+against 8, and no part of the rest of either corpus. And no figure anywhere on
+this page is a figure about the 131.
 
 **Two `plan=floor` runs are in the directory and out of this corpus**, and the
 reader names both rather than dropping them:
@@ -366,7 +394,9 @@ The run-level table in the census above is published for exactly this reason.
 Read against it:
 
 - **The `fixed` arm's 38 windows are 3 runs**, one of which supplies half the
-  in-band windows. Every `fixed` figure on this page inherits that.
+  in-band windows. Every `fixed` figure this page DERIVES inherits that; the
+  window's own `fixed` arm, quoted in the superseding blocks, is five runs in a
+  second session and does not.
 - **The `parity` cells are barely clustered at the primary band** — at most one
   in-band window per run — so the caveat bites hardest on the `fixed` arm, which
   is the arm the strongest claim rested on. That asymmetry is unfortunate and it
@@ -535,14 +565,17 @@ not absent.
   estimate near a 2.6x odds ratio is a failure to reject, and no equivalence
   bound is available at a useful width on eleven in-band windows.
 - **Three `fixed` runs is three.** 81 windows, one box, one session, one
-  revision. Every `fixed` figure on this page rests on them.
-- **The reversed-`fixed` arm has SINCE BEEN RUN, and nothing here is read against
-  it.** `P0_ALLOC_SEG_ORDER=fixed-reversed` landed after this analysis was first
-  written, and
+  revision. Every `fixed` figure this page DERIVES rests on them — the window's
+  five are a second session's, quoted and not counted in with these.
+- **The reversed-`fixed` arm has SINCE BEEN RUN, and nothing here is RE-DERIVED
+  against it.** `P0_ALLOC_SEG_ORDER=fixed-reversed` landed after this analysis was
+  first written, and
   [a pre-registered fifteen-run window](the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md)
-  has since recorded five runs through it. Every number on this page is still the
-  116-run corpus it was computed on, so those runs bear on its verdicts without
-  being counted in any of its figures. **The arm answering is not this page
+  has since recorded five runs through it. Every number this page DERIVES is still
+  the 116-run corpus it was computed on — that window's own figures appear here
+  only inside the superseding blocks that quote them, and are marked there — so
+  those runs bear on its verdicts without being counted in any figure this page
+  computed. **The arm answering is not this page
   answering**: what that window settled, what it narrowed and what it could not
   reach are its record to state, not this one's.
 - **The last-leg term at `parity` position 0 is described and not chased.** Its
@@ -556,8 +589,8 @@ not absent.
 
 ## Reproduction
 
-Every measured figure on this page — every window and leg count, byte value,
-rate, ordinal and `p` — is re-derived from the committed records by:
+Every measured figure this page DERIVES — every window and leg count, byte value,
+rate, ordinal and `p` — was re-derived from the committed records by:
 
 ```bash
 node implementation/hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs --corpus
@@ -570,6 +603,18 @@ comes from, by:
 node implementation/hicasso/test/re_frame/bench/hicasso/alloc_cluster_carrier.cjs \
   implementation/hicasso/test/re_frame/bench/hicasso/data/segorder-rs8q6/*.json
 ```
+
+**The first of those two sweeps has since WIDENED, and re-running it today does
+not print this page's census.** The fifteen-run window's runs are committed under
+`data/revarm-csca8/`, so `--corpus` now admits them and reads the **131**-run
+corpus — the reader's own self-test pins `corpus: 131 admissible floor runs, of
+133`, and its header records both censuses in sequence. This page's figures are
+the 116-run reading that same command gave before that window landed. To read
+them again the file list has to be given explicitly — `--corpus` scans the whole
+data directory, while any other argument is taken as a file to load, which is how
+the second command above scopes itself — and the files wanted are those of the
+seven directories in [the corpus](#the-corpus), `revarm-csca8` excluded. The second sweep is
+unaffected: it is already path-scoped to `segorder-rs8q6`.
 
 That reader imports its window extraction from `alloc_position_confound.cjs`
 rather than restating it, so the two records cannot drift about what a window is,


### PR DESCRIPTION
Reopened by the merged-PR audit on `rf2-3yvef` (comment 2026-08-20T23:03:39Z). The
present-tense reconciliation that landed in #8618 is sound and is **not** touched here:
the stale claims stay retensed, the old heading stays gone, the window figures stay, and
the substrate question stays open.

What #8618 also introduced were figures quoted from the fifteen-run window sitting
*underneath* page-wide assertions that every number on the page is read on the 116-run
corpus. Those assertions were false of the very figures the same change added. This PR
scopes them. **No measurement, no recomputation, no verdict moved, no figure changed.**

## Assertion-to-population mapping

The three populations are now named in one place (`## The corpus`): the **116-run**
admissible corpus, the **fifteen-run** matched window, and the **131-run** corpus the
window produced. Every corpus assertion and the population it governs:

| line | assertion (after this change) | population | true of exactly that set? |
|---|---|---|---|
| 10 | "Every figure this page DERIVES is re-derived from datasets already committed" | 116 | yes — quoted figures carved out in the next sentence |
| 72 | "Every number this page DERIVES is read on the 116-run corpus" | 116 | yes |
| 74 | "the window's figures appear here only inside blocks that name it as their source" | 15 | yes — all 8 quoting sites verified below |
| 171 | "Every figure this page DERIVES is read on it", with the reader-control exception named | 116 | yes — exception is the pre-admissibility control |
| 179 | "Its figures are QUOTED here, never re-derived" | 15 | yes |
| 184 | "Nothing on this page is read on it at all" | 131 | yes |
| 187 | closing summary: derives to 116, quoted to 15, pooled run-level to 8-vs-8, none to 131 | all three | yes |
| 397 | "Every `fixed` figure this page DERIVES inherits that" (3 runs) | 116 | yes — window's `fixed` arm is 5 runs, now excluded explicitly |
| 568 | "Every `fixed` figure this page DERIVES rests on them" | 116 | yes |
| 574 | "Every number this page DERIVES is still the 116-run corpus" | 116 | yes |
| 592 | "Every measured figure this page DERIVES ... was re-derived by" | 116 | yes |

Two assertions were over-broad in the same way but were **not** named by the audit; they
are fixed here because they fail the same test (lines 395 and 566 above). The window's
`fixed` arm is five runs in a second session, so "every `fixed` figure on this page rests
on three runs" became false once those figures arrived.

**Figures quoted from the window, and the passage marking each** (8 sites, all verified to
name the sibling record): the answer-first blockquote; the corpus bullet; the "SINCE
SETTLED" paragraph (4/5 vs 0/5, `p` = 0.0476; 7/8 vs 1/8, `p` = 0.0101; 1/68); the "THE
WINDOW HAS SINCE BEEN TAKEN" blockquote (1/82, 8/63, 7/8 vs 1/8); the second such
blockquote; the "Five have been taken since" paragraph (1/68, 1/82, `p` = 1.0000, 8/63,
`p` = 0.0105, 1,488 B, 20%/80%); the "not concluded" bullet; the new Reproduction note.

The **7/8 vs 1/8** combined reading belongs to neither population alone — it pools this
page's three matched runs with the window's five — so the summary sentence names it as its
own case rather than filing it under the fifteen.

## Two things found while verifying, beyond the audit's list

1. **The `--corpus` sweep has widened, so the Reproduction section was stale.** The
   window's datasets are committed under `data/revarm-csca8/`, and `corpus()` in
   `alloc_cluster_carrier.cjs` walks the whole data directory, so `--corpus` now reads
   **131** runs — the reader's own self-test pins `corpus: 131 admissible floor runs, of
   133`. Re-running the documented command no longer prints this page's census. Recorded in
   the Reproduction section. No recipe is asserted that I did not verify from source:
   `argv.includes('--corpus') ? corpus() : argv` means non-flag args are a **file** list,
   not directories, so the wording says "files".
2. **"Every `p` on this page is Fisher's exact test, two-sided" still holds** for the
   quoted values. The sibling record uses the same reader, whose `fisherExactTwoSided()`
   produces them. Checked rather than assumed; no edit needed.

## Index ledger

`docs/design/hicasso/studio/README.md` is **not touched**. Its row for this page already
scopes the 116 to this page's own analysis and separately attributes the window figures to
the sibling record, and this change moves no figure and no verdict — so the row is not
made wrong. No row change is needed.

## Quality gates

Each gate was redirected to its own per-worktree, per-attempt log with the runner's exit
code captured on the same command line, and the number quoted below is that captured one,
not any harness-reported status.

| gate | captured exit | how I proved it read MY worktree |
|---|---|---|
| `scripts/check_doc_slugs.py` (final base) | **0** | planted fault: broke `](#and-a-control-on-the-reader-itself)` to `#zzz-planted-fault-not-a-real-anchor`; gate returned **exit 1** naming `...missing.md:173 -> #zzz-planted-fault-not-a-real-anchor`. The fault existed only here, so a run in a sibling checkout would have come back green. |
| `scripts/check_provenance_pins.py --changed-since origin/main` (final base) | **0** | planted fault: a hex token worded `landed on main as`; gate returned **exit 1** naming `...missing.md:19 ... [UNRESOLVABLE]`. It also prints its scope: `1 page inspected`. |

Both restores were verified by hashing against the committed object rather than by reading
a diff: the identical **blob** hash `13ee08d9880e96432477a22d261137ca96a0871f` before each
plant and after each restore.

Green provenance output: `1 page inspected, 0 cited pins — 0 landed, 0 stranded, 0
unresolvable, 0 foreign; 0 accompanied in scope; 0 findings.` The `0 cited pins` is
load-bearing: it confirms the page's existing blob hash is still classified as a **digest**
and was not repainted into a pin by the edit beside it.

Gates were re-run on the **final rebased base**: `origin/main` moved from `4aca654ed1` to
`2de41e2252` mid-work, so the branch was rebased and both gates re-run green afterwards.

**`mkdocs build --strict` is NOT nominated** — `exclude_docs` keeps `docs/design/**` out of
the site, so it would inspect nothing changed here.

**I did not run the fast-PR spine** (an allocation window is live on this box; this surface
is markdown and the cheap validators cover it). `scripts/check_fast_pr_gap.py --list`
reports **94** required checks the spine does not run — a fact about the spine, not a
census of what I ran.

## Hand verification (nothing gates prose, tables, rendering or nav)

- **Tables: 9 on the page, all column-consistent.** Header/separator/data column counts,
  counting escaped `\|` as cell text: L77-81 = 4 cols (3 data rows); L124-129 = 3 cols (4);
  L151-159 = 4 cols (7); L197-200 = 2 cols (2); L219-226 = 8 cols (6); L235-242 = 5 cols
  (6); L287-290 = 3 cols (2); L316-319 = 3 cols (2); L338-342 = 3 cols (3). **This change
  adds and modifies no table** — the diff contains no added or removed line beginning with
  `|`. A tenth `|`-leading line, `|worst leg|` at L498, is mid-paragraph prose with no
  delimiter row, is pre-existing, and renders as text.
- **Anchors: every link target in the diff resolved by hand and by gate.** `#the-corpus` to
  `## The corpus`; `#and-a-control-on-the-reader-itself` to `### And a control on the
  reader itself`; `#what-the-p-values-are-not` to `## What the p-values are not`; the
  relative link to `the-reversed-fixed-arm-a-pre-registered-fifteen-run-window.md` resolves
  to an existing 309-line file. The planted-fault run confirms the anchor gate actually
  adjudicates these rather than passing them silently.
- **Merge-base diff read for reverts** (three-dot, `origin/main...HEAD`): one file, and the
  trunk never touched it. PR #8622 swept 14 sibling studio pages while this work was in
  flight and correctly left this page alone, per its fence. Nothing of a sibling's is
  reverted.

Closes rf2-3yvef.
