### PR TITLE
docs(hicasso): repoint the studio index's two bench commands out of the deleted Freehand tree (rf2-wbdr7)

### DIFF
--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -66,11 +66,11 @@ npm run bench:hicasso
 HICASSO_INIT_FN=re-frame.bench.hicasso.<arm>-app/-main \
 HICASSO_OUT_DIR=out/hicasso-<arm> \
 HICASSO_PORT=8132 \
-  node freehand/test/re_frame/bench/hicasso/run.cjs
+  node hicasso/test/re_frame/bench/hicasso/run.cjs
 
 # an arm that needs more than one page load brings its own thin driver on
 # the same build id — e.g. the converged clock table, one row per page
-node freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
+node hicasso/test/re_frame/bench/hicasso/p0_converge_run.cjs
 ```
 
 Exit codes: `0` measured and clean, `1` the run failed, **`2` the arm-order


### PR DESCRIPTION
Closes the last two live pointers into the deleted Freehand tree, completing `rf2-wbdr7` alongside the now-merged #8622.

`implementation/freehand/` was removed by PR #8322. The studio index's "one build id, one driver" block still invoked two drivers through it, at lines 69 and 73:

```
  node freehand/test/re_frame/bench/hicasso/run.cjs
node freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
```

Both repointed to `hicasso/test/...`, keeping the block's `cd implementation`-relative spelling rather than imposing an absolute one.

## Classification

Both lines are **live instructions**, not records: the block opens with `cd implementation`, the prose calls the first "the default entry" and the second "an arm that needs more than one page load brings its own thin driver", and the paragraph immediately under the fence states exit codes in the present tense. Neither could reproduce anything.

## Census of this file — the count is 2, and that is the whole of it

Swept for **both** spellings plus every other `Freehand` mention:

| Spelling | Occurrences | Disposition |
|---|---|---|
| `node freehand/...` (cd-relative) | 2 | **repointed** — lines 69, 73 |
| `node implementation/freehand/...` | 0 | none present |
| `docs/design/freehand/studio/` (lines 12–13) | 1 | **left** — a docs tree, not the deleted code tree; 10 tracked files, present |
| `hd8-freehand-codec-donor-arm.md` (line 140) | 1 | **left** — table row; target present; prose is an explicit "frozen historical record" |

The zero on row 2 is controlled, not assumed: the same pattern returns **162 occurrences across 44 files** elsewhere under `docs/design/hicasso/`, and this file is absent from that list. The file's entire command corpus is 3 lines (63, 69, 73); line 63 is `npm run bench:hicasso` and names no path.

There were exactly 2, and there are now 0 live unrepaired pointers here.

## Quality gates

Every exit code below was captured in the same shell as the runner and echoed explicitly — never read from a harness report, never taken through a pipe.

| Run | Gate | Exit |
|---|---|---|
| baseline | `check_doc_slugs.py` | **0** |
| plant A (prose) | `check_doc_slugs.py` | **1** — red, as designed |
| plant B (md link in fence) | `check_doc_slugs.py` | **1** — red, unexpectedly |
| plant C (bogus shell path in fence) | `check_doc_slugs.py` | **0** |
| plant C | `check_provenance_pins.py --changed-since` | **0** |
| final, post-rebase | `check_doc_slugs.py` | **0** |
| final, post-rebase | `check_provenance_pins.py --changed-since` | **0** |

All gates re-run on the **final base** after rebasing past #8622 and #8621; the pre-rebase greens are not the ones quoted.

### Which tree the gate read

Planted-fault route. A broken link target planted in **prose** at line 12 turned `check_doc_slugs.py` red naming exactly what was planted:

```
BROKEN TARGET: docs\design\hicasso\studio\README.md:12 -> ../zzz-idxpoint-planted-fault-a.md
```

That fault existed in this worktree only, so a run that had wandered into a sibling checkout would have come back green. `check_provenance_pins.py` additionally reports `1 page inspected` — this file, seen because it changed.

Each restore was verified against the committed object by the identical **blob** hash `68093b4cc5ed8a8558bf0ce80e6b8c8b320f97da`, never by reading a diff.

### A correction: this tree's gate does *not* simply strip fences

The repository's own guidance says the doc gates strip fenced blocks before reading. **Under `docs/design/hicasso/` that is not the whole story**, and plant B measured it: a markdown link planted inside the fence at line 69 turned the gate **red**, under a distinct rule (`rf2-mmyc`, "markdown link inside a code fence"). These trees' fences are pasteable deliverables and are held to more.

So the operative claim needed a sharper control. Plant C put the **actual fault class of this change** — a shell path pointing at `zzz/idxpoint/no/such/directory/anywhere/planted_fault_c.cjs` — inside the same fence, and **both gates returned 0**. Neither gate inspects a shell command target, in a fence or out of one.

**Both edited lines sit inside the fence, and the gates therefore inspect nothing this PR changes.** The greens above bound the file, not the change.

### The covering check: existence sweep

Paths extracted from the file's own `node` invocations and resolved against `implementation/` (the block's working directory):

- `implementation/hicasso/test/re_frame/bench/hicasso/run.cjs` — **PRESENT**
- `implementation/hicasso/test/re_frame/bench/hicasso/p0_converge_run.cjs` — **PRESENT**

**2 of 2 present.** Negative control — the two paths this change replaced, through the identical code path: both **ABSENT**. The sweep discriminates.

Drivers were **not executed**: an allocation window is live, and the existence sweep is the check.

### Hand verification (nothing validates this file's prose, tables or rendering)

- **Table column counts, verified by hand: 55 rows, all 3 columns, zero exceptions.** Header `| Page | Phase | What it settles |`, delimiter `|---|---|---|`, table spans lines 108–162.
- **No table row is touched** — `0` added-or-removed lines beginning with `|` in the merge-base diff. The edits are at 69 and 73, outside the table.
- Merge-base diff read in the **three-dot** form against the rebased base: 1 file, 2 insertions, 2 deletions, and it reverts nothing. This file is a shared ledger with a concurrent writer (`worker/foldcorpus-nkeba` holds a committed change to the table region at line ~100+), so that read was the point.

### Spine

**Not run** — deliberately, per the live allocation window; no shadow-cljs, browser, npm or JVM gate was started. `scripts/check_fast_pr_gap.py --list` reports **94** required checks the fast spine does not run; that is a fact about the spine, not a census of what ran here.

## Corpus state

With #8622 merged, `docs/design/hicasso/` retains 28 `freehand` command-shaped lines — 4 cd-relative, 24 absolute — which reconciles exactly with #8622's declared partition of 26 pinned provenance records plus 2 live-with-no-tip-equivalent. Both of the latter were spot-checked and are explicitly marked ("**Taken with — and it no longer runs**"; "**The driver has moved since the blob above, and this page is not re-pinned to where it went**"). **No live unrepaired pointer remains.**
