### PR TITLE
fix(hicasso): ladder_band must read all of argv before it runs a mode (rf2-xk4is)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -3925,8 +3925,10 @@ function fixtureRoundsTask(over) {
 // inspected the BODY of `if (SELFTEST_ONLY)` while asserting nothing about how
 // `SELFTEST_ONLY` is DERIVED, so a mutation of either driver back to the old
 // token — or to any other — left every assertion here green. The rename was
-// pinned nowhere: `test:script-helpers` invokes only `ladder_band.cjs
-// --self-test` directly, which is why that third driver is not repeated here.
+// pinned nowhere: `test:script-helpers` invoked only `ladder_band.cjs
+// --self-test` directly, which is the PASSING case and says nothing about a
+// refusal. The third driver has its own block below now, for a reason the
+// next section gives.
 //
 // This is the missing pin, and it is deliberately four claims per driver and
 // no more: the argv definition itself, the closed flag vocabulary, that the
@@ -4007,6 +4009,121 @@ function fixtureRoundsTask(over) {
       );
     });
   }
+}
+
+// --- AND THE THIRD DRIVER, WHERE THE VOCABULARY ONLY HELD ON A PREFIX ------
+//
+// #8621 closed the vocabulary for the two drivers above and left this one
+// looking closed. Its merged-PR audit found it was not: `ladder_band.cjs` ran
+// the self-test and returned from INSIDE its argv loop, so it never read a
+// token that came after `--self-test`. Reproduced at that merge commit —
+//
+//     --self-test --selftest            exit 0
+//     --self-test --definitely-unknown  exit 0
+//     --selftest --self-test            exit 2
+//
+// — which is a spelling refused in one order and swallowed in the other, and
+// so not retired at all. THE ORDER PAIR IS THE TEST. A witness in the second
+// position alone passes against the broken parser, which is precisely how the
+// gap survived a landing: `test:script-helpers` invokes `ladder_band.cjs
+// --self-test` and nothing else, and that is the case that worked.
+//
+// The repair made PARSING and ACTING different things rather than adding a
+// validating pass — a second pass is where the care would have been needed,
+// because `--emit` and `--from` consume the token after them and a pass that
+// did not know it would read `--emit --from.json` as a flag. `parseArgv` is
+// pure and total, reads the vector once, and returns a plan only after
+// reaching the end of it; `main` is the only thing that acts.
+//
+// This driver takes DATASET FILENAMES where its two neighbours take none, so
+// its rule is scoped to the flag namespace and not to all of argv — the line
+// #8621 drew, kept. Hence no `unknownFlags` here: the vocabulary and the
+// arity of each flag in it are one question for this driver, and `parseArgv`
+// is where both are answered.
+{
+  const LB = path.join(__dirname, 'ladder_band.cjs');
+  const lb = require('./ladder_band.cjs');
+  const LBSRC = fs.readFileSync(LB, 'utf8');
+  const t = (what, fn) => test(`ladder_band.cjs: ${what}`, fn);
+
+  /** The driver as an operator meets it: a real process, a real exit code. */
+  const run = (...argv) => cp.spawnSync(process.execPath, [LB, ...argv], { encoding: 'utf8' });
+
+  t('the flag vocabulary is closed, and the retired spelling is not in it', () => {
+    assert.deepStrictEqual(lb.FLAGS, ['--self-test', '--emit', '--from']);
+    assert.ok(!lb.FLAGS.includes('--selftest'), 'no alias by decision (rf2-xk4is)');
+    // The usage line is the vocabulary an operator is shown, so it may not
+    // name a token the parser refuses.
+    assert.ok(!/--selftest/.test(lb.USAGE));
+  });
+
+  t('the retired spelling appears nowhere in the driver, comments included', () => {
+    // The two blocks above hold their drivers to this; the exception here is
+    // the header that RECORDS the retirement, which has to name the token to
+    // say what happened to it. Everywhere else it is an invitation to type it.
+    const hits = LBSRC.split('\n')
+      .map((line, i) => [i + 1, line])
+      .filter(([, line]) => /--selftest/.test(line) && !/^\s*\/\//.test(line))
+      .map(([n, line]) => `${n}: ${line.trim()}`);
+    assert.deepStrictEqual(hits, [], 'the retired spelling may survive only in prose that retires it');
+  });
+
+  t('an unknown flag is refused BEFORE `--self-test`', () => {
+    assert.deepStrictEqual(lb.parseArgv(['--selftest', '--self-test']), { error: 'unknown flag --selftest' });
+    assert.deepStrictEqual(lb.parseArgv(['--definitely-unknown', '--self-test']), {
+      error: 'unknown flag --definitely-unknown',
+    });
+  });
+
+  t('an unknown flag is refused AFTER `--self-test` — the position that used to exit 0', () => {
+    // THE ONE THAT MATTERS. Delete it and the pair above still passes against
+    // a parser that stops reading at the self-test flag.
+    assert.deepStrictEqual(lb.parseArgv(['--self-test', '--selftest']), { error: 'unknown flag --selftest' });
+    assert.deepStrictEqual(lb.parseArgv(['--self-test', '--definitely-unknown']), {
+      error: 'unknown flag --definitely-unknown',
+    });
+    // And after a VALUED flag too, which is the other way a parser stops
+    // reading early.
+    assert.deepStrictEqual(lb.parseArgv(['--from', 'x.json', '--selftest']), { error: 'unknown flag --selftest' });
+  });
+
+  t('the refusal is the process exit, in both positions and not just the plan', () => {
+    // A pure rule the entry point never consults is not a rule. These are the
+    // audit's own probes, run as probes.
+    assert.strictEqual(run('--self-test', '--selftest').status, 2, 'retired spelling AFTER the self-test flag');
+    assert.strictEqual(run('--self-test', '--definitely-unknown').status, 2, 'unknown flag AFTER the self-test flag');
+    assert.strictEqual(run('--selftest', '--self-test').status, 2, 'retired spelling BEFORE it');
+    const ok = run('--self-test');
+    assert.strictEqual(ok.status, 0, 'and the flag itself still works');
+    assert.match(ok.stdout, /ladder_band self-test ok/);
+  });
+
+  t('a valued flag consumes its value, so a filename is never read as a flag', () => {
+    // The trap a naive validate-then-act split falls into: `--from.json` here
+    // is a VALUE. Refusing it would break the driver in the name of closing
+    // the vocabulary.
+    assert.deepStrictEqual(lb.parseArgv(['--emit', '--from.json', 'a.json']), {
+      plan: { selfTest: false, emit: '--from.json', from: null, files: ['a.json'] },
+    });
+    assert.deepStrictEqual(lb.parseArgv(['--emit']), { error: '--emit needs a filename' });
+    assert.deepStrictEqual(lb.parseArgv(['--from']), { error: '--from needs a filename' });
+  });
+
+  t('nothing is executed above the parse, and the parse reads all of argv', () => {
+    const head = LBSRC.slice(LBSRC.indexOf('function main() {'), LBSRC.indexOf('  if (plan.selfTest) {'));
+    assert.ok(head.length > 0, 'could not locate the head of main() in ladder_band.cjs');
+    assert.match(head, /const \{ plan, error \} = parseArgv\(process\.argv\.slice\(2\)\);/);
+    assert.match(head, /process\.exit\(2\);/);
+    // The defect itself, stated: no mode may run from inside the parser.
+    const parser = LBSRC.slice(LBSRC.indexOf('function parseArgv(argv) {'), LBSRC.indexOf('function main() {'));
+    assert.ok(parser.length > 0, 'could not locate parseArgv in ladder_band.cjs');
+    assert.ok(
+      !/selfTest\(\)|readRun\(|process\.exit/.test(parser),
+      'parseArgv must parse and nothing else — running a mode inside it is what left the tail of argv unread'
+    );
+    // Requiring the driver must not RUN it, or this whole block would.
+    assert.match(LBSRC, /if \(require\.main === module\) main\(\);/);
+  });
 }
 
 // --- THE ADJECTIVE, which is what both instrument errors hid behind ---------

--- a/implementation/hicasso/test/re_frame/bench/hicasso/ladder_band.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/ladder_band.cjs
@@ -411,42 +411,96 @@ function selfTest() {
 }
 
 // ---------------------------------------------------------------------------
+//
+// THE ARGUMENT VECTOR, READ WHOLE BEFORE ANY MODE RUNS (rf2-xk4is).
+//
+// This driver already refused an unknown flag, and it refused the retired
+// `--selftest` spelling among them — but only when the token happened to come
+// FIRST. The old parser ran the self-test and returned from inside the loop
+// the moment it saw `--self-test`, so every token after that one was never
+// looked at: `--self-test --selftest` exited 0 and so did `--self-test
+// --definitely-unknown`, while the same pair typed the other way round exited
+// 2. A vocabulary enforced on a prefix of the vector is not a closed
+// vocabulary, and a spelling refused in one order and swallowed in the other
+// is not retired (#8621's merged-PR audit, which reproduced all three).
+//
+// The repair is not a second validation pass — that is where the care would
+// be needed, because `--emit` and `--from` each consume the token AFTER them
+// and a pass that does not know it would read `--emit --from.json` as a flag.
+// It is simply that PARSING and ACTING are now different things. The parser
+// below is pure: it reads left to right exactly once, consuming each valued
+// flag's value as a value, and it returns either the whole plan or the first
+// reason there cannot be one. Nothing runs until it has reached the end of
+// the vector, so there is no prefix for a token to hide behind.
+//
+// Unlike its two neighbours this driver DOES take positionals, so the closed
+// vocabulary is scoped to the flag namespace: anything shaped like a flag
+// must be one of ours, anything else is a dataset. And there is deliberately
+// no alias for the retired spelling — this is pre-alpha, and an alias for a
+// spelling nothing depends on is a compatibility shim.
+
+const USAGE =
+  'usage: ladder_band.cjs [--emit out.json] <dataset.json ...>   |   --from compact.json   |   --self-test';
+
+/** The flags that take a filename, and the plan field each one fills. */
+const VALUED = { '--emit': 'emit', '--from': 'from' };
+
+/**
+ * The whole vocabulary. Derived rather than restated, so there is no second
+ * list to drift from the parser that enforces it.
+ */
+const FLAGS = ['--self-test', ...Object.keys(VALUED)];
+
+/**
+ * Pure, total, and exported — a rule a test can only quote is not a checked
+ * rule, which is the lesson `clock_exit_path.test.cjs` draws about this
+ * fleet's exit decisions and applies here to its argument vectors.
+ *
+ * Returns `{ plan }` or `{ error }`, never both and never a partial plan.
+ */
+function parseArgv(argv) {
+  const plan = { selfTest: false, emit: null, from: null, files: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i];
+    if (!tok.startsWith('--')) {
+      plan.files.push(tok);
+    } else if (tok === '--self-test') {
+      // Recorded, not run. Running it here is what let the tokens after it go
+      // unread.
+      plan.selfTest = true;
+    } else if (tok in VALUED) {
+      // A valued flag's VALUE is a value whatever it looks like, so it is
+      // consumed here and never offered to the flag check above.
+      const value = argv[++i];
+      if (value === undefined) return { error: `${tok} needs a filename` };
+      plan[VALUED[tok]] = value;
+    } else {
+      return { error: `unknown flag ${tok}` };
+    }
+  }
+  return { plan };
+}
 
 function main() {
-  const argv = process.argv.slice(2);
-  let emit = null;
-  let from = null;
-  const files = [];
-  for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === '--emit') emit = argv[++i];
-    else if (argv[i] === '--from') from = argv[++i];
-    else if (argv[i] === '--self-test') {
-      const st = selfTest();
-      for (const c of st.checks) console.log(`${c.ok ? 'ok  ' : 'FAIL'}  ${c.name}${c.detail ? '  — ' + c.detail : ''}`);
-      if (!st.ok) {
-        console.error('\nladder_band self-test FAILED');
-        process.exit(1);
-      }
-      console.log('\nladder_band self-test ok');
-      return;
-    } else if (argv[i].startsWith('--')) {
-      // This one already refused the retired spelling, but only by ACCIDENT:
-      // it took the token for a dataset filename and died on the `readRun`
-      // below with an ENOENT stack trace. An accident is not a retirement —
-      // it says nothing to whoever typed it, and it would stop refusing
-      // altogether the day somebody left a file lying about under that name
-      // (rf2-xk4is, from #8616's merged-PR audit).
-      //
-      // Unlike its two neighbours this driver DOES take positionals, so the
-      // closed vocabulary is scoped to the flag namespace: anything shaped
-      // like a flag must be one of ours, anything else is a dataset.
-      console.error(`ladder_band.cjs: unknown flag ${argv[i]}`);
-      console.error(
-        'usage: ladder_band.cjs [--emit out.json] <dataset.json ...>   |   --from compact.json   |   --self-test'
-      );
-      process.exit(2);
-    } else files.push(argv[i]);
+  const { plan, error } = parseArgv(process.argv.slice(2));
+  if (error) {
+    console.error(`ladder_band.cjs: ${error}`);
+    console.error(USAGE);
+    process.exit(2);
   }
+
+  if (plan.selfTest) {
+    const st = selfTest();
+    for (const c of st.checks) console.log(`${c.ok ? 'ok  ' : 'FAIL'}  ${c.name}${c.detail ? '  — ' + c.detail : ''}`);
+    if (!st.ok) {
+      console.error('\nladder_band self-test FAILED');
+      process.exit(1);
+    }
+    console.log('\nladder_band self-test ok');
+    return;
+  }
+
+  const { emit, from, files } = plan;
 
   let runs;
   if (from) {
@@ -454,9 +508,7 @@ function main() {
     runs = j.runs.map(inflate);
   } else {
     if (files.length === 0) {
-      console.error(
-        'usage: ladder_band.cjs [--emit out.json] <dataset.json ...>   |   --from compact.json   |   --self-test'
-      );
+      console.error(USAGE);
       process.exit(2);
     }
     runs = files.map(readRun);
@@ -637,4 +689,11 @@ function main() {
   }
 }
 
-main();
+// `parseArgv` is the CLI surface, exported so its pin can drive the rule
+// rather than quote it; the entry point is guarded so that requiring this
+// file to reach it does not also RUN it. That pairing is the point — a
+// module that read `process.argv` at module scope is exactly why the
+// preceding rule in this fleet went untested until it broke.
+module.exports = { FLAGS, USAGE, parseArgv };
+
+if (require.main === module) main();


### PR DESCRIPTION
`ladder_band.cjs` enforced its flag vocabulary on a **prefix** of argv, not on
all of it. The parser ran the self-test and returned from *inside* the argv
loop, so a token after `--self-test` was never read. #8621's merged-PR audit
reproduced the order dependence; so did I, at `origin/main` before touching
anything.

A spelling refused in one order and swallowed in the other is not retired, and
a vocabulary enforced on a prefix is not closed.

## The repair

**Parsing and acting are now different things** — not a second validating pass.
A second pass is where the care would have been needed: `--emit` and `--from`
each consume the token *after* them, so a pass that did not know it would read
`--emit --from.json` as a flag and break the driver in the name of closing the
vocabulary.

`parseArgv` is pure and total. It reads the vector once, left to right,
consuming each valued flag's value **as a value**, and returns either the whole
plan or the first reason there cannot be one — never both, never a partial
plan. `main` is the only thing that acts, and it cannot act until the parser has
reached the end of argv. There is no prefix left for a token to hide behind.

The driver takes dataset filenames where its two neighbours take none, so its
rule stays scoped to the **flag namespace** — the line #8621 drew, kept. No
alias for the retired spelling: pre-alpha, and an alias for a spelling nothing
depends on is a compatibility shim. No did-you-mean, no list of dead tokens, no
generated help.

`parseArgv` is exported and the entry point is guarded with
`require.main === module`, so a test can *drive* the rule rather than quote it —
this file's own fleet learned that lesson the hard way, and `clock_exit_path.test.cjs`'s
header says so.

## The witnesses — the order pair IS the test

Seven, in `clock_exit_path.test.cjs`, which `test:script-helpers` already runs
(no new package registration; `implementation/package.json` untouched). An
unknown or retired flag is refused **BEFORE** `--self-test` and **AFTER** it,
and the second is the one that matters: a witness in the "before" position alone
passes against the broken parser, which is exactly how the gap survived a
landing — `test:script-helpers` invoked `ladder_band.cjs --self-test`, the case
that worked.

Also pinned: the closed vocabulary and that the retired spelling is not in it;
that the retired token survives only in prose that retires it; that the refusal
is a real **process exit** in all four argv shapes the audit probed by hand;
that a valued flag consumes its value so a filename is never read as a flag, and
that a valued flag with no value says so; and that nothing executes above the
parse — `parseArgv` may not call `selfTest()`, `readRun` or `process.exit`,
because running a mode inside the parser is the defect itself.

## Quality gates

**Gate: `npm run test:script-helpers` from `implementation/`.** Foreground, one
shell, redirected to a log with the runner's own exit code echoed on the same
command line. Every number below is the one I captured, not one reported about
the run.

| run | tree | captured exit | `clock_exit_path.test.cjs` |
|---|---|---|---|
| baseline, before any edit | branch base | **0** | 383 passed |
| sabotage | fault planted | **1** | **2/390 failed** |
| after restore | final source | **0** | 390 passed |
| after rebase onto the moved trunk | final base | **0** | 390 passed |

**How I proved the gate read MY worktree.** The gate prints no root banner, so
the proof is the red from a planted fault. I reintroduced the exact defect —
made `parseArgv` return its plan early on `--self-test`, a single-line change at
a line I was already editing, match count verified as 1 before running anything
— and the gate came back **exit 1** naming:

```
FAIL  ladder_band.cjs: an unknown flag is refused AFTER `--self-test` — the position that used to exit 0
FAIL  ladder_band.cjs: the refusal is the process exit, in both positions and not just the plan
clock_exit_path.test.cjs: 2/390 failed
```

The fault existed only in this checkout, so a run that had wandered into a
sibling's would have come back green. **And the sabotage discriminates in the
direction the audit cared about**: the BEFORE-position witness stayed green
under it. That is the audit's finding restated as a measurement — a before-only
witness passes against a broken parser.

Restore verified by hashing the bytes against the committed object, not by
reading a diff: the identical blob hash `88cac1b450210258a00a75f90ccd2aeb5b1968ec`
before the plant and after the restore.

**The four negative controls, BEFORE and AFTER.** Real process exits, captured
per invocation:

| argv | before | after |
|---|---|---|
| `--self-test --selftest` | 0 — retired spelling accepted | **2** |
| `--self-test --definitely-unknown` | 0 — unknown flag accepted | **2** |
| `--selftest --self-test` | 2 — refused, only because it came first | **2** |
| `--self-test` | 0 | **0** |

Four more, checking the redesign did not overreach: `--emit --from.json --self-test`
exits 0 (the value is a value, not a flag), `--emit` alone and `--from` alone now
exit 2 saying which flag needs a filename rather than printing a misleading
usage, and `--from x.json --nope` exits 2 — an unknown flag after a *valued*
flag, the other way a parser stops reading early.

**Both neighbours re-probed, and both are order-independent**, which is what
made this driver the odd one out: `clock_run.cjs` and `hd8_run.cjs` each exit 2
on `--self-test --selftest` and on `--self-test --definitely-unknown`.

**Spine: NOT run.** An allocation window was live on the box, and two
heavyweight runs on one box wedge rather than fail. No `scripts/test-fast-pr.sh`,
no shadow-cljs, no browser, no npm build, no JVM gate. `test:script-helpers` is a
chain of sub-second node self-tests. Targeted gates run directly:
`npm run test:script-helpers` (four times, above) and
`python scripts/check_retired_spellings.py` (captured exit **0**, no output).
There is no JS lint gate on this path — no eslint or prettier config under
`implementation/`.

**Fast-spine gap:** `scripts/check_fast_pr_gap.py --list` reports **94** required
checks the spine does not run. That is a fact about the spine, not a census of
what I ran; I did not run the spine at all.

**No markdown touched**, so no doc gate is nominated. (`mkdocs build --strict`
would not cover `docs/design/**` in any case.)

## What a third audit would find

This bead has been reopened twice, so before closing it I went looking for the
third gap rather than waiting for it.

- **In scope and checked clean.** The two neighbours validate all of argv
  (re-probed above). No caller `require`s `ladder_band.cjs` — the export and the
  `require.main` guard are new surface, used only by the pin. The retired token
  survives in `implementation/` only inside `clock_exit_path.test.cjs`, which
  must name it to refuse it, and in `ladder_band.cjs`'s own header prose, which
  must name it to record what happened; the "comments included" witness here is
  deliberately narrower than the two-driver one above for exactly that reason,
  and it still refuses the token on any line that is not wholly a comment.
- **Out of scope, and I judge it not worth a bead.** Five sibling drivers in the
  same directory — `alloc_position_confound.cjs`, `alloc_cluster_carrier.cjs`,
  `alloc_mode_rate_session.cjs`, `alloc_pass_position.cjs`,
  `alloc_window_ceiling.cjs` — have no closed vocabulary at all, and
  `alloc_pass_position.cjs` honours `--self-test` only at `args[0]`. But this
  bead names three drivers, none of these ever used the retired spelling, and
  the whole justification for the fail-fast rule was refusing in twenty
  milliseconds rather than twenty minutes — these are offline analysis scripts
  over dataset files with no build and no Chromium behind them. Extending the
  rule there would be the argument-validation framework #8621 declined to build.
  Recorded rather than actioned.

Fixes rf2-xk4is.
