### PR TITLE
docs(hicasso): narrow two 131-corpus absolutes to the invariant they meant (rf2-3yvef)

### DIFF
--- a/docs/design/hicasso/studio/the-cluster-follows-the-mode-and-the-third-arm-is-still-missing.md
+++ b/docs/design/hicasso/studio/the-cluster-follows-the-mode-and-the-third-arm-is-still-missing.md
@@ -181,15 +181,21 @@ across**:
   source — as a blockquote, or as a paragraph that says so in its closing
   sentence.
 - **the 131-run admissible corpus** — the two together, **3,688 collection-free,
-  3,520 positional**, against 116 / 3,258 / 3,090 here. **Nothing on this page is
-  read on it at all.**
+  3,520 positional**, against 116 / 3,258 / 3,090 here. That census is published
+  by the record named above and quoted here like every other figure of its. **No
+  effect, `p` or verdict on this page is DERIVED on it.** The census just given
+  and the reader's self-test pin under [Reproduction](#reproduction) are figures
+  ABOUT the 131 and are the only two; apart from them, nothing on this page is
+  read on it at all.
 
 So a figure this page derives is a figure about the 116; a figure quoted inside a
 superseding block is a figure about the fifteen, or — where the block says so —
 about the two matched sessions pooled at RUN level: this page's three `fixed`
 runs with the window's five, and its three `parity` with the window's five, 8
-against 8, and no part of the rest of either corpus. And no figure anywhere on
-this page is a figure about the 131.
+against 8, and no part of the rest of either corpus. And no effect, `p` or
+verdict anywhere on this page is derived on the 131 — the census of it above and
+the reader's self-test pin under [Reproduction](#reproduction) are figures ABOUT
+that corpus rather than readings taken on it, and they are the only two.
 
 **Two `plan=floor` runs are in the directory and out of this corpus**, and the
 reader names both rather than dropping them:


### PR DESCRIPTION
Reopened for the second time by a merged-PR audit. The audit's finding **HOLDS at the tip** and is actioned in full; nothing is refused.

Verified at `origin/main` (648 lines), then re-verified after rebase. #8623's central three-population repair is left intact — the 116-vs-15 scoping and the reproduction warning are coherent and untouched.

## The defect

Two page-wide absolutes over-reached, and the page's own surrounding figures disprove them. Both are **wrapped across source lines**, which is why a one-line grep for either sentence returns zero.

- L183-185, the 131-run bullet: publishes **3,688 collection-free, 3,520 positional** and then said *"Nothing on this page is read on it at all."* Those two counts are themselves a population census **of** the 131.
- L191-192, the summary that follows: strengthened it to *"no figure anywhere on this page is a figure about the 131."*
- L610-611, Reproduction: quotes the reader's self-test pin, `corpus: 131 admissible floor runs, of 133`. Verified against source — `alloc_cluster_carrier.cjs:808` carries that literal exactly.

## The repair

Both sentences now carry the intended invariant: **no effect, `p` or verdict on this page is DERIVED on the 131-run pooled corpus**, with the population census and the reader's self-test pin named as the two deliberate exceptions and the residual absolute kept for everything else.

The verb is the page's own. L171 already says a figure this page **DERIVES** is read on the 116, *"with one deliberate exception that names itself where it stands"* — the same move, the same vocabulary. No new scheme was invented and the three-population structure is unchanged.

One attribution added: `131 runs / 3,688 collection-free / 3,520 positional` is published by the window's own record (that page's L247-248, identical to the digit), so it is quoted like every other figure of that record's and now says so — which is what the bullet immediately above it already requires of the window's figures. Exempting it from the absolute without attributing it would have left exactly the loose end a next audit picks up.

**No measurement, no recomputation. No figure, verdict, band, table or `p` moved.** Diff is +10/-4 on one file.

## What a third audit would find, and what I checked

Enumerated every category of figure on the page and placed each against the qualifier. Exactly two touch the 131, and they are the two exempted:

| category | corpus | inside the qualifier? |
|---|---|---|
| effects, rates, `p`, verdicts this page derives (summary table, census tables, band tables, ordinal table, null arm) | 116 | yes — none is on the 131 |
| figures QUOTED from the fifteen-run window (4/5 vs 0/5, 1 of 68, 1 of 82, 8 of 63, 1,488 B, 20%/80%) | fifteen | yes — none is on the 131 |
| the pooled run-level reading (7 of 8 vs 1 of 8, `p` = 0.0101) | 3+5 vs 3+5 at run level, named as its own case | yes — explicitly not the whole of either corpus |
| population census (116 / 3,258 / 3,090; 118 / 3,308 / 3,140; 4,152; **131 / 3,688 / 3,520**) | the 131 triple IS about the 131 | **EXEMPT — first exception** |
| reader-control counts (387 / 182 / 205 / 101+11; 359 / 169 / 190 / 92+10; **`corpus: 131 admissible floor runs, of 133`**) | the pin IS about the 131/133 sweep | **EXEMPT — second exception** |
| exclusion counts (2 refused runs, 50 windows, 168 windows) | 116 construction | yes |
| non-run numbers already carved out at L644-648 (rig config, identifiers, sizing table) | no corpus | n/a |
| band bounds and leg excesses (1,050-1,224, 1,000-1,300, -4,324, +1,056, ~748) | bead definitions / 116 / earlier record | yes |
| Fisher fixture pins (0.4857, 2/252, 1) | reader fixtures | n/a |

So the qualifier does not **under-reach**: everything the old absolute covered is still covered, minus exactly two named exceptions. And it does not **over-reach**: it exempts only figures that genuinely are about the 131, and both say so where they stand.

**Two further 131 statements examined and deliberately LEFT.** Both already carry the narrow verb, so neither over-reaches and neither needed touching:

- L74-75, opening blockquote: *"nothing on this page is re-derived against the 131-run corpus that window produced."* The verb is **re-derived against**. The census is quoted, not re-derived; the self-test pin is a quote of the reader's output. True as written, and the weakest of the three, so it cannot contradict the narrowed pair.
- L570-580: *"nothing here is RE-DERIVED against it"* (subject is the fifteen-run arm, not the 131) and *"Every number this page DERIVES is still the 116-run corpus it was computed on."* Both hold, because the 131 census is QUOTED rather than derived — which is precisely what this PR now makes explicit on the page. Confirmed from the sibling record rather than assumed.

**Studio index row NOT touched and NOT made wrong.** `docs/design/hicasso/studio/README.md` L135 scopes this page's analysis to "116 runs / 3,090 positional windows", attributes the window figures to the sibling record, and quotes no 131 figure anywhere. This change moves no figure and no verdict, so the row remains exactly correct. Left alone as instructed — a follow-up index row is owed on it by another bead.

## Quality gates

Machine courtesy observed: an allocation window is live on the box, the surface is markdown, so **no** `test-fast-pr.sh`, shadow-cljs, browser, npm or JVM gate was run. **The fast-PR spine was NOT run at all.** `scripts/check_fast_pr_gap.py --list` reports **94** required checks the spine does not run — that is a fact about the spine, not a census of what I ran.

Exit codes below are captured in-shell (redirect and `echo "EXIT=$?"` on one command line), never piped through a filter and never taken from a harness report. Artefacts named per worktree and per attempt.

| gate | exit | detail |
|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | 754 markdown files across 11 roots (`docs` 412); "no broken links" |
| `scripts/check_provenance_pins.py --changed-since origin/main` | **0** | **1 page inspected**, 0 cited pins, 0 findings |

Both re-run green on the **final rebased base** after the trunk moved under me (`61cb6369` to `55b77447`; only beads checkpoints landed, no `studio/` path touched).

The provenance gate reports **1 page inspected**, not 0 — the `--changed-since` blind spot a sibling worker hit (exit 0 having inspected nothing, because the file was untracked) does not apply here.

**How each gate was proven to read THIS worktree.** Neither prints its root, so both were proven by a planted fault, each at a line this change actually edits. The fault existed only in this worktree, so a run that had wandered into a sibling checkout would have returned green:

- `check_doc_slugs.py` — broke the anchor on an added line (`#reproduction` to `#reproduction-planted-fault-quantnarrow`). Match count read **before** running: 2, non-zero, so no silent no-op. Gate went **exit 1**, naming `BROKEN ANCHOR: ...:187 -> #reproduction-planted-fault-quantnarrow`.
- `check_provenance_pins.py` — planted an unresolvable commit pin on an added line. Gate went **exit 1**: `...:185 0123456789abcdef0123456789abcdef01234567 [UNRESOLVABLE]`, correctly classified by nearest commit word. This also confirms the gate reaches this page rather than merely counting it.

Both restores verified by the identical **blob** hash `356858c9062e5df0f1167cdcb5d947d5da246b09` against the committed object, not by reading a diff.

## Hand-verified, because no gate checks it

Nothing validates this markdown's prose, tables, rendering or nav, so:

- **Anchors.** 4 distinct intra-page anchors, 9 occurrences: `#the-corpus` (3), `#what-the-p-values-are-not` (3), `#reproduction` (2 — both added here), `#and-a-control-on-the-reader-itself` (1). Every one resolves to a heading present in the file; all 20 heading slugs are unique, so no `_N`/`-N` suffix ambiguity. `## Reproduction` exists at L590.
- **Tables.** 9 tables, **none added, removed or modified**. Column counts identical before and after: 4 cols (summary, 5 rows; corpus, 9 rows), 3 cols (ordinal, 6 rows; POSITION bands, 4; SUBSTRATE bands, 4; MODE baselines, 5), 2 cols (refused runs, 4 rows), 8 cols (census, 8 rows), 5 cols (run-level census, 8 rows). Every row in every table matches its own header and delimiter width. The single `cols=1` pipe-leading line is `|worst leg|` absolute-value notation mid-paragraph, not a table — pre-existing and untouched.
- **`mkdocs build --strict` deliberately NOT nominated**: `exclude_docs` keeps `docs/design/**` out of the site, so it would have inspected nothing here.
- **Merge-base diff read for reverts** in the three-dot form against the merge base (not the tip): one file, +10/-4, only the two intended sentences. This page was rewritten twice in the last hour and nothing of either rewrite is undone.
