### PR TITLE
docs(hicasso): the two non-runnable annotations over-claimed the historical loss (rf2-wbdr7)

### DIFF
--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -95,10 +95,11 @@ workstation with other agents running concurrently. Every arm is an
 figure.
 
 **Taken with — and it no longer runs.** The Freehand substrate was retired
-(`rf2-0yp7w`) and `implementation/freehand/` deleted, so the driver below is on
-no commit reachable from `main` and there is no tip equivalent to re-point it
-to. It is recorded as the instrument that produced §§1–5, not offered as a
-command:
+(`rf2-0yp7w`) and `implementation/freehand/` deleted, so the driver below is
+absent at tip and there is no live equivalent to re-point it to. The history
+survives: the path is still reachable from `main`, and the driver is intact at
+`ef3131f4a2`, the commit before the deletion. It is recorded as the instrument
+that produced §§1–5, not offered as a command:
 
 ```
 node implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs

--- a/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
+++ b/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
@@ -66,10 +66,11 @@
 > [the converged witness set](p0-converged-witness-set.md).
 
 **Taken with — and it no longer runs.** The Freehand substrate was retired
-(`rf2-0yp7w`) and `implementation/freehand/` deleted, so the driver below is on
-no commit reachable from `main` and there is no tip equivalent to re-point it
-to. It is recorded as the instrument that produced the figures, not offered as
-a command:
+(`rf2-0yp7w`) and `implementation/freehand/` deleted, so the driver below is
+absent at tip and there is no live equivalent to re-point it to. The history
+survives: the path is still reachable from `main`, and the driver is intact at
+`ef3131f4a2`, the commit before the deletion. It is recorded as the instrument
+that produced the figures, not offered as a command:
 
 ```bash
 cd implementation


### PR DESCRIPTION
Closes the audit-#8622 comment on `rf2-wbdr7`, which PR #8624 left undischarged.

## The defect

PR #8622 marked two Freehand-substrate drivers non-runnable and wrote, on both pages:

> the driver below is on **no commit reachable from `main`** and there is no tip equivalent to re-point it to

The *absent at tip* half is right. The reachability half is false, and it is the stronger claim — it tells a reader the instrument was erased from `main`'s history, when the history is intact and the driver is one commit away.

## Verified at `origin/main` before editing

Every figure below was re-derived here, each with a control, rather than carried over from the audit.

| Claim | Measured | Control |
|---|---|---|
| `ef3131f4a2` is an ancestor of `origin/main` | `merge-base --is-ancestor` exit **0** | a live worker-branch tip through the same call: exit **1** |
| `ef3131f4a2` is the parent of the deletion commit | `c951808b47^` = `ef3131f4a2…` — string compare **YES** | — |
| both drivers exist at that commit | `ls-tree` returns both blobs (`660cd084e0…`, `0b7752ca51…`) | a bogus sibling path returns empty; the tree itself carries **5,284** files |
| path history on `origin/main` | `reads_ladder_run.cjs` **9**, `spine_ablation_run.cjs` **10** | a bogus path returns **0** |
| no tip equivalent | both basenames: **0** tracked files at tip; `implementation/freehand/` **0** | `clock_run.cjs` through the identical call: **4** |

So `9/10` reproduces exactly, and *"absent at tip"* / *"no live equivalent"* stand. Only the history claim was wrong.

**A false zero worth recording.** A multi-line `grep -Pzo` for the wrapped phrase returned **0** on files that plainly contain it — these pages are CRLF, so the pattern's `\n` never matched. The line-level fixed-string grep found both. A zero from a wrong pattern is indistinguishable from a clean sweep, so every empty result above carries a positive control.

## The change

Both annotations now read:

> …so the driver below is **absent at tip** and there is **no live equivalent** to re-point it to. The history survives: the path is still reachable from `main`, and the driver is intact at `ef3131f4a2`, the commit before the deletion.

Citing the commit is a judgement call and it is made deliberately: this corpus pins provenance everywhere, so naming where a reader can still find the instrument is idiomatic rather than gold-plating — and it is one clause, not a history reconstruction. The kept paths, blob tables and every pinned record on both pages are untouched.

**Not touched, and why.** `studio/the-candidates-clock.md:1442` carries a superficially similar sentence, but it is a **blob**-level claim (`f5bb751d…` is on no reachable commit) that *affirms* the path history in the same breath — *"thirty commits touch `clock_run.cjs` there and not one carries it"*. That is exactly the distinction this PR is restoring, already made correctly, in a pinned record row. `bulk-broad-re-taken` is likewise untouched: the audit of #8624 notes its *"The driver has moved since the blob above…"* sentence was mis-attributed to the `uix-spine` annotation, and it is a pinned record that is correct as it stands.

## Quality gates

Both are cheap validators, run in the foreground, each redirected to a log with its exit code echoed on the same command line and quoted from that capture — not from any harness report.

| Gate | Exit | What it reported |
|---|---|---|
| `check_provenance_pins.py --changed-since origin/main` | **0** | **2 pages inspected**, 96 cited pins — 74 landed, 21 stranded, 1 unresolvable, 0 foreign; 22 accompanied in scope; **0 findings** |
| `check_doc_slugs.py` | **0** | silent (0-byte log) |

**2 pages inspected** is the number that matters: it is exactly the changed set, so `--changed-since` was not looking past this work.

**Each gate was proven to read THIS worktree by a planted fault**, since neither prints a root banner:

- **`check_doc_slugs.py`** — a broken link target planted in **prose** on an edited line turned it **red (exit 1)**, naming `reads-per-boundary-heap-ladder.md:102 -> ./no-such-page-histfix-control.md`. That is a line this PR changes.
- **`check_provenance_pins.py`** — swapping the new pin for an unresolvable token turned it **red (exit 1)** at `reads-per-boundary-heap-ladder.md:101`, and the counts moved `74 landed / 1 unresolvable` → `73 landed / 2 unresolvable`. That delta is a positive control in its own right: it shows the gate **extracted the new citation and classified it as a landed pin**, which is the property the accompaniment rule turns on.

Both restores were verified by **blob hash against the committed object**, not by reading a diff — the identical blob hash `4dd2f60c34719ca508acdb64bc78262deccbaffd` before the plant and after the restore, twice. Each plant refused unless it matched exactly once, so a silent no-op could not have passed for a successful sabotage.

**The cited commit's covering check is not a gate**, so it is reported directly: `ef3131f4a2` resolves, is an ancestor of `origin/main`, and contains both named driver paths — with the negative controls in the table above.

## Hand verification — nothing here validates prose

| | ladder | uix-spine |
|---|---|---|
| headings before → after | 100 → **100** | 15 → **15** |
| table rows (`^\|`) before → after | 411 → **411** | 50 → **50** |
| markdown links before → after | 47 → **47** | 8 → **8** |
| table rows touched by the diff | **0** | **0** |
| lines | 3,313 → 3,314 | 565 → 566 |

**No table changed**, no heading changed, no link added or removed — the edit adds no markdown link at all, which is why the slug gate is silent on it and why the planted one was needed to prove the gate bites. Anchors were checked by hand on the same basis: no heading text moves, so no in-repo anchor can be invalidated.

**Post-edit census**, controlled: `no commit reachable from \`main\`` now returns **0** hits under `docs/`; the identical grep against `origin/main`'s copies of these two files returns **1** each, so the sweep works and both instances are repaired.

**Merge-base diff read three-dot** (`origin/main...HEAD`, base `24ef305`): 2 files, 10 insertions / 8 deletions, confined to the two sentences. **It reverts nothing** — no sibling change is in that region.

**Rebased once, and every gate above was re-run on the final base.** The trunk moved 5 commits under this work (including `78b88918a1`, `rf2-aon8c`'s capability-row fix). None of them touches either file, the rebase was clean, and the two blobs came through byte-identical (`4dd2f60c34`, `18380dbcbd`). Both gates re-run green on `24ef305`, `check_provenance_pins` again reporting **2 pages inspected / 0 findings**; the citation re-verified there too — ancestor exit **0** against a negative control's exit **1**, path history still **9** and **10** against a bogus path's **0**; gap still **94**. The figures in this body describe the base this PR will merge onto, not the one it was written on.

**Spine NOT run**, deliberately: an allocation window is live on this box and the surface is markdown. `check_fast_pr_gap.py --list` = **94** required checks the fast spine does not decide — a fact about the spine, not a census of what ran here.

## Fence

Re-derived rather than taken on trust. **No open PR touches either file** (3 open PRs; positive control — 2 of them do touch other `docs/design/hicasso/` paths). Of 26 worker branches, the only committed hit besides mine is `worker/repoint-wbdr7`, which is a **false holder**: its content is already upstream via rebase-merge, so the two-dot diff against `origin/main` on these files is **0** lines where mine is **40**. `studio/README.md` was not touched.
