### PR TITLE
docs(hicasso): republish the commit-half decomposition, every arm at one commit (rf2-07rnj)

### DIFF
--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -70,9 +70,43 @@ main as `12e50c5b36`**, which recovers the measured read path in full
 Arm-order guard: clean on every arm, both phases. Positive control inside the
 interleave, adjudicated before anything is read.
 
-**The commit half** (per 141-key boundary commit through the runtime's own
-`commit-boundary!` seam; four identically-seeded frames per window; released
-and settled between samples behind a residue equality gate that never fired):
+**The commit half — REPUBLISHED, every arm taken at ONE commit** (`rf2-07rnj`'s
+re-take, 2026-08-21, base commit `3de77d3c23`; ms per 141-key boundary commit
+through the runtime's own `commit-boundary!` seam). **The window shape is stated
+because the shares are not invariant to it**: 32 identically-seeded frames per
+window, 8 × (2 + 8) = 64 kept samples per arm, eleven arms, grid 0.0015625
+ms/commit; three runs, `exit 0` each, released and settled between samples
+behind a residue equality gate that never fired. **Every term carries its own
+resolution verdict against its OWN run's null spread**, on a rule fixed before
+run 1 — the window note below sets both out.
+
+| term | run 1 | run 2 | run 3 | share of `c-local` | verdict |
+|---|---|---|---|---|---|
+| whole commit (`commit`, shipping seam) | 0.9391 | 0.9781 | 0.7859 | — | absolute; copy fidelity `c-local`/`commit` = 0.9501 / 0.9393 / 0.9841 |
+| `c-local` (the ablation baseline — every share below divides by it) | 0.8922 | 0.9187 | 0.7734 | — | absolute |
+| — **reaction build + cache insert** (`c-local − c-nosub`) | **0.6016** | **0.6156** | **0.5141** | **67.4% / 67.0% / 66.5%** | **RESOLVED** on every run |
+| — cell-map insert (`c-local − c-nomap`) | 0.0672 | 0.0656 | 0.0797 | 7.5% / 7.1% / 10.3% | RESOLVED on every run |
+| — watch wiring (`c-local − c-nowatch`) | 0.0594 | 0.0547 | 0.0500 | — | **UNRESOLVED** — clears its null in runs 1–2, ties it exactly in run 3 |
+| — activation capture (`c-local − c-noactivate`) | 0.0188 | 0.0187 | 0.0328 | — | **UNRESOLVED** on all three runs |
+| — reader membership (`c-local − c-noreaders`) | 0.0156 | 0.0062 | 0.0500 | — | **UNRESOLVED** on all three runs |
+| `b-build` (141 × subscribe + deref, no in-window dispose) | 0.6891 | 0.7047 | 0.5797 | — | context: build + compute alone |
+
+**Three of the five terms are unresolved, and NO BOUND IS PUBLISHED FOR ANY OF
+THEM.** Their readings are quoted above and nothing further is claimed: a null
+says what this instrument cannot SEE, never how large the invisible thing is.
+Reading any of those three rows as an upper bound would be the withdrawn
+`< 0.006 ms/commit` error one layer back, and that withdrawal stands.
+
+**What the re-take does settle is the thing this table was stale about.** Every
+share above divides by a `c-local` measured in the SAME run as its numerator, so
+the share column is no longer arithmetic across two instruments. The `c-noindex`
+arm and the `index write` row are gone — `rf2-dabt3` deleted the structure they
+priced — and `c-noreaders` stands in their place, unresolved and published as
+such.
+
+**The 2026-08-02 reading the table above replaces**, kept in place because the
+window notes below cite its cells by value (four identically-seeded frames per
+window — a quarter of the shape above, which is part of why its shares differ):
 
 | term | delta ms/commit | share of `c-local` |
 |---|---|---|
@@ -549,6 +583,134 @@ and settled between samples behind a residue equality gate that never fired):
 > **`rf2-07rnj` stays blocked.** It is blocked on the offset's cause being
 > established, and this window did not establish it.
 
+> **THE WHOLE RE-TAKE RAN AND PUBLISHES — TWO TERMS RESOLVE, THREE DO NOT**
+> (`rf2-07rnj`, 2026-08-21, base commit `3de77d3c23`; instrument **blob** hash
+> `c220a8c23c44ca6e19f9cab90528d932f271a784`, identical before the window and
+> after it, `:advanced`, Playwright HeadlessChrome). This is the re-take §1's
+> table now carries. Three runs, `exit 0` on each, **both arm-order guards
+> reportable on every run** (38 `[ok]` verdicts and no refusal on each), the
+> phase-A positive control passing on every run, the phase-B residue gate never
+> firing. The eleven-arm series `rf2-lo7uy` opened, so absolutes are not
+> arm-by-arm comparable with the nine- and eight-arm windows above.
+>
+> **What was fixed BEFORE run 1, and committed before run 1 so the ordering is
+> checkable rather than asserted.** The run count (three — the window does not
+> extend because an answer looks unsettled), the window shape (32 frames, 8 ×
+> (2 + 8) = 64 kept samples per arm, grid 0.0015625 ms/commit — the instrument's
+> own shape, no gate, tolerance or knob touched), and the adjudication rule
+> below. The pre-registration is the first commit of this window's branch and
+> the dataset `README.md` carries it in full.
+>
+> **THE RULE.** Each run carries its own three nulls, each of which is `c-local`
+> again through the same constructor, so each null delta has a true cost of
+> **exactly zero by construction**. That run's **null spread** is the interval
+> its three nulls span. A term **resolves in a run** iff its delta is strictly
+> greater than the maximum of that run's three nulls; a term is **RESOLVED** iff
+> it resolves in all three. Anything else is **UNRESOLVED AT THIS INSTRUMENT'S
+> RESOLUTION**, published with its readings quoted, **no bound, and no share**.
+> No null is subtracted from any term and no term is corrected by one.
+>
+> | null (`c-local −` the arm) | slot | run 1 | run 2 | run 3 |
+> |---|---|---|---|---|
+> | `c-null`, displaced in mean and shape | 2 | +0.0297 | +0.0141 | +0.0500 |
+> | `c-null-twin`, `c-local`'s footprint exactly | 9 | +0.0031 | +0.0281 | +0.0297 |
+> | `c-null-curve`, same mean, other shape | 10 | +0.0109 | +0.0172 | +0.0359 |
+> | **the run's null spread** | — | **[+0.0031, +0.0297]** | **[+0.0140, +0.0281]** | **[+0.0296, +0.0500]** |
+>
+> **The absolutes, all eleven arms** (p50 [min–max], ms per 141-key commit):
+>
+> | arm | run 1 | run 2 | run 3 |
+> |---|---|---|---|
+> | `commit` (shipping seam) | 0.9391 [0.6156–1.3469] | 0.9781 [0.6281–1.3781] | 0.7859 [0.6500–1.3031] |
+> | `c-local` (the copy) | 0.8922 [0.5969–1.2438] | 0.9187 [0.6875–1.3656] | 0.7734 [0.5906–0.9656] |
+> | `c-null` | 0.8625 [0.5938–1.2406] | 0.9047 [0.6031–1.3094] | 0.7234 [0.5813–0.9250] |
+> | `c-noactivate` | 0.8734 [0.6156–1.3406] | 0.9000 [0.6250–1.3813] | 0.7406 [0.5656–0.9781] |
+> | `c-nowatch` | 0.8328 [0.5688–1.2844] | 0.8641 [0.5844–1.1375] | 0.7234 [0.5688–0.9812] |
+> | `c-nosub` | 0.2906 [0.2031–0.4344] | 0.3031 [0.2094–0.4469] | 0.2594 [0.2031–0.3469] |
+> | `c-noreaders` | 0.8766 [0.6531–1.2656] | 0.9125 [0.5938–1.2875] | 0.7234 [0.5687–0.9906] |
+> | `c-nomap` | 0.8250 [0.5938–1.2125] | 0.8531 [0.5844–1.1750] | 0.6937 [0.5188–0.9063] |
+> | `b-build` | 0.6891 [0.5063–1.0125] | 0.7047 [0.4844–0.9437] | 0.5797 [0.4406–0.7437] |
+> | `c-null-twin` | 0.8891 [0.6062–1.2875] | 0.8906 [0.6250–1.2375] | 0.7438 [0.5719–0.9031] |
+> | `c-null-curve` | 0.8812 [0.5969–1.3031] | 0.9016 [0.6375–1.2813] | 0.7375 [0.5938–1.0500] |
+> | copy fidelity `c-local`/`commit` | 0.9501 | 0.9393 | 0.9841 |
+>
+> **THE SHARE COLUMN IS THE ROBUST STATISTIC HERE AND THE ABSOLUTES ARE THE
+> FRAGILE ONE**, which is worth saying plainly because it is the opposite of how
+> the two are usually read. `c-local` moved 0.7734–0.9187 across three runs of
+> one binary in one session — 19% — while the reaction build's share of it moved
+> 66.5–67.4%, a spread of nine tenths of one percentage point. A share divides
+> two arms measured microseconds apart in the same interleave, so whatever makes
+> the box faster or slower between runs largely divides out; an absolute carries
+> it whole. That is the case for republishing this decomposition as shares of a
+> same-run denominator, and it is also why no absolute here should be lifted out
+> of this table and quoted as a property of the tree.
+>
+> **THE TWO RESOLVED TERMS.** The reaction build + cache insert clears its run's
+> null by a factor of 10–20 on every run and is the dominant term of the commit
+> half at **66.5–67.4% of `c-local`**. The cell-map insert clears on every run at
+> **7.1–10.3%**. Those are the only two figures this window publishes.
+>
+> **THE THREE UNRESOLVED TERMS, AND NO BOUND ON ANY OF THEM.** Reader membership
+> reads `+0.0156 / +0.0062 / +0.0500` against null maxima of `0.0297 / 0.0281 /
+> 0.0500` — inside the spread on every run, and in run 3 exactly ON it. The
+> activation capture reads `+0.0188 / +0.0187 / +0.0328` against the same maxima
+> and is likewise inside on every run. **Watch wiring is the near miss and is
+> reported as a miss**: it clears in runs 1 and 2 (`+0.0594` and `+0.0547`) and
+> in run 3 reads `+0.0500` against a null maximum of `+0.0500` — an exact tie, at
+> a shape where `c-nowatch`, `c-noreaders` and `c-null` all returned the identical
+> p50 of `0.7234`. A rule fixed before the data is a rule you do not move once the
+> data is in, and moving "strictly greater" to "greater or equal" for one cell is
+> exactly the move the pre-registration exists to prevent. So it is published as
+> unresolved with its three readings quoted and nothing else claimed.
+>
+> **THIS SUPERSEDES THE EARLIER WINDOWS' READING OF WHICH TERMS RESOLVE, AND THE
+> DIFFERENCE IS THE TEST, NOT THE TREE.** The predecessors credited four of five
+> terms on **sign stability across runs**; three nulls at three slots is a
+> stricter and more honest test, and under it the activation capture and the watch
+> wiring join reader membership. Nothing about the terms themselves is claimed to
+> have changed — what changed is that they are now adjudicated against a measured
+> zero taken in the same run rather than against their own repeatability. It also
+> means `c-noactivate`'s standing is now settled from the other side: `rf2-tcffa`
+> established that it is not a noise floor and must not arbitrate a window's
+> width, and this window adds that it is not a resolved term either. It is an arm
+> whose delta this instrument cannot separate from zero.
+>
+> **What is NOT concluded.** No bound on any unresolved term, in either
+> direction. Not that any unresolved term is small — a term inside the null
+> spread has its size left open by that fact, which is the whole content of the
+> rule. Not that the window is too narrow: whether 128–256 frames would bring any
+> of the three clear is a prediction, and a rung added between runs makes the
+> series two instruments, so it was deliberately not attempted. Not any
+> restatement of §1's render half, of §4's render-half rows, or of the `rf2-lo7uy`
+> findings above; nothing was subtracted from anything.
+>
+> **The box.** Processor Queue Length (`\System\Processor Queue Length`) and
+> `% Processor Utility` were sampled together, five samples at 1 s, on a 24-core
+> host, immediately before the window and between every pair of runs. Queue:
+> `0,0,0,0,0` at 10:31:46 (utility ≤ 23.6%); `0,0,0,0,2` then `0,0,0,0,0` at
+> 10:35:11 and 10:35:32 (≤ 42.7% then ≤ 33.9%); `0,0,0,0,0` at 10:37:53
+> (≤ 26.9%); `0,0,3,0,1` then `0,0,0,0,0` at 10:41:09 and 10:41:29 (all +10:00).
+> **The two non-zero brackets are reported rather than dismissed**: each was taken
+> seconds after a run's own browser and node teardown, and each settled to all
+> zeroes on an immediate re-read, but nothing proves the first reading of the pair
+> was teardown rather than something else. The last bracket's utility of 59.7–66%
+> is this session's own tooling, which was active by then. **Nothing was sampled
+> inside a run**, so the quietness claim is a bracketing claim and nothing
+> stronger. One open PR on an unrelated surface and no other heavyweight worker in
+> flight, derived at start-up and re-derived before the edit.
+>
+> Raw driver output for all three runs is committed beside the instrument at
+> `implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj-retake/`
+> (`run1.txt`, `run2.txt`, `run3.txt`), verbatim except for the one
+> `shadow-cljs - config:` banner line per file, whose absolute path is replaced by
+> `<worktree>` and marked inline as redacted — the portability gate refuses a
+> tracked personal home path. No figure, guard verdict or exit line was touched;
+> each file differs from the driver's own output by exactly that one line. The
+> per-round p50s and per-round deltas are in the transcripts under
+> `:read-profile-commit-per-round` and `-per-round-deltas`, so this window is
+> re-adjudicable without being re-taken. That directory's `README.md` carries the
+> pre-registration.
+
 Micro table, over the page's own roster (ns/op): `subscribe-once` 5,284;
 `compute-sub` 1,170; the raw handler invoke 227; `registrar/lookup` 67;
 `frame-state-value` 266; the `call-with-frame-resolution` wrap 206; the
@@ -576,21 +738,25 @@ sub-cache peek 18; the sub-key mint 53.
    page whose subs are all single-source. The landed shape is therefore
    peek → run-scoped **value map** → fresh seeded per-read memo.
 4. **The commit half is the durable wiring and stays.** Its dominant term is
-   the reaction build + cache insert (47.8%) — the once-per-unique-key
-   construction the design amortises over the mount, unavoidable without an
-   escrow the state machine forbids. The index write is 8.7% (~0.5 µs/key)
-   and the cell-map insert 4.3%; batching either buys tens of microseconds
-   on a 141-key mount and was declined as complexity the profile does not
-   license. **The index write half of that reading is HISTORICAL, and does
-   not describe this tree:** `rf2-dabt3` (`383ba2d645`) retired the
-   sub-index it prices — `front/sub_index.cljs` is deleted — so 8.7% prices
-   a structure the runtime no longer has, and there is no index write left
-   to batch. What that commit put in its place is not resolved by any window
-   this page publishes, so nothing is offered in the figure's stead and no
-   share in this list has been re-taken. The cell-map insert clause is
-   untouched by the retirement and stands. (The commit-half table at the top
-   of this section carries the same mark on its `index write` row, and the
-   window notes under it set the retirement out in full.)
+   the reaction build + cache insert, **66.5–67.4% of `c-local`** on
+   `rf2-07rnj`'s re-take — the once-per-unique-key construction the design
+   amortises over the mount, unavoidable without an escrow the state machine
+   forbids. The cell-map insert is **7.1–10.3%**; batching it buys tens of
+   microseconds on a 141-key mount and was declined as complexity the profile
+   does not license. (The 47.8% and 4.3% this list carried until the re-take
+   were the 2026-08-02 readings, taken at a quarter of the window shape and
+   against a `c-local` that has since lost the index write, lost the keyword
+   mint and gained the activation.) **The index write is gone from the list
+   entirely, and that half of the old reading was HISTORICAL rather than
+   merely stale:** `rf2-dabt3` (`383ba2d645`) retired the sub-index it priced
+   — `front/sub_index.cljs` is deleted — so 8.7% priced a structure the
+   runtime no longer has and there is no index write left to batch. What that
+   commit put in its place, reader membership, **the re-take could not
+   resolve: it sits inside the null spread on all three runs, and no figure
+   and no bound is offered for it** — nor for the watch wiring or the
+   activation capture, which the same rule leaves unresolved. (The
+   republished table at the top of this section carries every term with its
+   own verdict, and the window note under it carries the rule.)
 
 ## 2. The cheapening — the cold read becomes the port's probe
 
@@ -743,6 +909,15 @@ no longer the arm 0.7625 priced. The evidence is under §1's table and is not
 repeated here. 0.7625 and its 51.9 / 5.6 / 3.7% shares therefore stand exactly
 as they are, and the `index write` share among them names a structure
 `rf2-dabt3` has since deleted.
+
+**And they are now superseded as a description of this tree.** `rf2-07rnj`'s
+re-take ran on 2026-08-21 and republished the commit-half decomposition with
+every arm taken at ONE commit (§1): the reaction build is 66.5–67.4% of
+`c-local` and the cell-map insert 7.1–10.3%, while the watch wiring — 3.7%
+here — is one of three terms that re-take could not separate from its own
+measured null, and for which it publishes no figure and no bound. So 0.7625 and
+its 51.9 / 5.6 / 3.7% stand as the historical reading they are, taken at a
+window a quarter the width; the figures to carry forward are §1's.
 
 ## 5. The parity gap the re-take tripped over — found, bisected, repaired
 

--- a/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
+++ b/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
@@ -287,9 +287,12 @@ the shipping commit half no longer performs an `index/mount!` plus a
 whole-set `record-reads!` but pushes one reader slot per key. **That is a
 fusion, not a removal** — work leaves and different work arrives — so unlike
 the mint it licenses no direction at all, and the cost of what replaced the
-index write is not resolved by the widened-window re-take recorded in
-[the cold-read mount term](the-cold-read-mount-term.md), which declines to
-publish that term at all. **0.827 and 0.7625
+index write is still not resolved. The whole re-take recorded in
+[the cold-read mount term](the-cold-read-mount-term.md) republished that page's
+commit-half decomposition on 2026-08-21 with every arm taken at one commit, and
+reader membership — the reader slot that replaced the index write — is one of
+three terms it could not separate from its own measured null. It publishes no
+figure and no bound for any of them. **0.827 and 0.7625
 therefore price a commit half whose structure this tree no longer has.** The
 like-for-like comparison between the two stands, because both predate the
 retirement; neither is a figure for today's seam, no direction is claimed
@@ -408,7 +411,10 @@ asymmetry.**
    clause prices describes a structure the tree no longer has. The cell-map
    insert survives the retirement, and the item's conclusion is unaffected
    in either direction: what left was a batching candidate that had already
-   been declined. Nothing here has been re-measured (`rf2-07rnj`).
+   been declined. Nothing on THIS page has been re-measured: `rf2-07rnj`'s
+   re-take republished the sibling page's commit-half decomposition on
+   2026-08-21, not these rows, and it resolved neither reader membership nor
+   the watch wiring nor the activation capture.
 3. **30% is the interpreter against a compiler**, and the fence forbids the
    remedy. UIx's `$` is compile-time; ours is a runtime walk over a hiccup
    tree we must also *build* (0.291 ms of it). Closing that gap means

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj-retake/README.md
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj-retake/README.md
@@ -46,6 +46,34 @@ the window publishes the refusal and its evidence rather than a number.
 **The rig does not change mid-window.** A defect found mid-window stops the
 window; no figure is published across a rig change.
 
+## WHAT THE WINDOW RETURNED
+
+All three runs certified: `exit 0` each, both arm-order guards reportable on
+every run (38 `[ok]` verdicts and no refusal per run), the phase-A positive
+control passing on every run, the phase-B residue gate never firing. The
+instrument **blob** hash was `c220a8c23c44ca6e19f9cab90528d932f271a784` before
+the window and after it.
+
+Each run's null spread, and the maximum the terms are adjudicated against:
+
+| null (`c-local −` the arm) | slot | run 1 | run 2 | run 3 |
+|---|---|---|---|---|
+| `c-null` | 2 | +0.0297 | +0.0141 | +0.0500 |
+| `c-null-twin` | 9 | +0.0031 | +0.0281 | +0.0297 |
+| `c-null-curve` | 10 | +0.0109 | +0.0172 | +0.0359 |
+| **maximum** | — | **+0.0297** | **+0.0281** | **+0.0500** |
+
+| term (`c-local −` the arm) | run 1 | run 2 | run 3 | verdict |
+|---|---|---|---|---|
+| reaction build + cache insert | +0.6016 | +0.6156 | +0.5141 | **RESOLVED** — 67.4% / 67.0% / 66.5% of `c-local` |
+| cell-map insert | +0.0672 | +0.0656 | +0.0797 | **RESOLVED** — 7.5% / 7.1% / 10.3% of `c-local` |
+| watch wiring | +0.0594 | +0.0547 | +0.0500 | UNRESOLVED — clears in runs 1–2, exact tie with the null maximum in run 3 |
+| activation capture | +0.0188 | +0.0187 | +0.0328 | UNRESOLVED on all three runs |
+| reader membership | +0.0156 | +0.0062 | +0.0500 | UNRESOLVED on all three runs |
+
+**No bound is published for any unresolved term**, in either direction. A term
+inside the null spread has its size left open by that fact.
+
 ## Reproduction
 
 ```bash

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj-retake/README.md
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj-retake/README.md
@@ -1,0 +1,63 @@
+# `read_profile` phase-A/B transcripts — `rf2-07rnj`'s whole re-take
+
+Raw driver output from `rf2-07rnj`'s re-take of the commit-half
+decomposition, one file per run, in run order. The window is written up in
+`docs/design/hicasso/studio/the-cold-read-mount-term.md`; these are the
+transcripts that page's republished table is read off.
+
+## THE PRE-REGISTRATION — written and committed BEFORE run 1 started
+
+Everything in this section was fixed before the first run and held for every
+arm of every run. It is committed as its own commit so the ordering is
+checkable in the history rather than asserted here.
+
+| | |
+|---|---|
+| **Base commit** | `3de77d3c23` |
+| **Instrument blob** | `c220a8c23c44ca6e19f9cab90528d932f271a784` (`read_profile_app.cljs`) |
+| **Run count** | **3, fixed before run 1.** The window does not extend because an answer looks unsettled. |
+| **Window shape** | 32 frames/window, 8 × (2 + 8) = 64 kept samples per arm, 11 arms, grid 0.0015625 ms/commit — the instrument's shape exactly as it stands. No gate, tolerance or knob is touched. |
+| **Series** | The eleven-arm series `rf2-lo7uy` opened. Absolutes are not arm-by-arm comparable with the nine- or eight-arm windows before it. |
+
+**The adjudication rule, fixed before run 1.** Each run carries its own three
+nulls — `c-null` (slot 2), `c-null-twin` (slot 9), `c-null-curve` (slot 10) —
+each of which is `c-local` again through the same constructor, so each null
+delta has a true cost of **exactly zero by construction**. That run's **null
+spread** is the closed interval spanned by its three null deltas.
+
+- A term **RESOLVES IN A RUN** iff its delta is strictly greater than the
+  maximum of that run's three null deltas.
+- A term is **RESOLVED** iff it resolves in all three runs. It publishes as a
+  figure: its three readings and its share of that run's `c-local`.
+- A term that does not resolve in all three runs publishes as **UNRESOLVED AT
+  THIS INSTRUMENT'S RESOLUTION**, with its readings quoted and **NO BOUND OF
+  ANY KIND**, and **no share**. A null says what the instrument cannot see,
+  never how large the invisible thing is (`rf2-lo7uy`'s close record; the
+  withdrawn `< 0.006 ms/commit` is the error this forbids).
+- No null is subtracted from any term, and no term is corrected by one.
+- **Shares are quoted with the window shape beside them**, because they are not
+  invariant to it: the reaction build reads 56% of `c-local` at 4 frames and
+  67–68% at 32.
+
+**Refusal is a result.** If the arm-order guards are not reportable, the
+phase-A positive control fails, or the phase-B residue gate fires on any run,
+the window publishes the refusal and its evidence rather than a number.
+
+**The rig does not change mid-window.** A defect found mid-window stops the
+window; no figure is published across a rig change.
+
+## Reproduction
+
+```bash
+HICASSO_INIT_FN=re-frame.bench.hicasso.read-profile-app/-main \
+HICASSO_OUT_DIR=out/hicasso-readprof \
+  node implementation/hicasso/test/re_frame/bench/hicasso/run.cjs
+```
+
+## The one redaction, stated so nobody reads these as doctored
+
+Each file is the driver's output verbatim except for exactly one line, the
+`shadow-cljs - config:` banner, whose absolute path is replaced by
+`<worktree>` and marked inline as redacted — the portability gate refuses a
+tracked personal home path and is right to. Nothing else is touched: no
+figure, no guard verdict, no exit line.

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj-retake/run1.txt
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj-retake/run1.txt
@@ -1,0 +1,260 @@
+[hicasso] building :advanced bundle — re-frame.bench.hicasso.read-profile-app/-main -> out/hicasso-readprof
+shadow-cljs - updating dependencies
+shadow-cljs - dependencies updated
+[:hicasso-bench] Compiling ...
+[:hicasso-bench] Build completed. (187 files, 132 compiled, 0 warnings, 33.42s)
+shadow-cljs - config: <worktree>\implementation\shadow-cljs.edn   ;; ABSOLUTE PATH REDACTED — see README.md
+;; order-guard ok   the recorded 2.01x is REFUSED  — ratio 2.0125
+;; order-guard ok   the same study's uncontaminated slope passes  — forward 2830.7 / reversed 2842.8
+;; order-guard ok   a single-order result is refused as UNCHECKED  — only 1 stratum — the question was never asked
+;; order-guard ok   overlapping ranges are indistinguishable even 20% apart in median  — medians 1.2000x apart but the ranges OVERLAP — indistinguishable
+;; order-guard ok   the measured warm-up step is caught by PHASE, which no reversal would show  — phase: FIRST-THIRD reads 1.2633x LAST-THIRD, ranges disjoint
+;; order-guard ok   an arm that reads exactly zero in both strata is indistinguishable, not infinite  — within 10%
+;; order-guard ok   cyclic rotation gives every arm exactly ONE within-round predecessor  — rotation over 6 rounds: distinct predecessors per arm 1,1,1,1 (only the round seam ever differs, and that is one sample in R)
+;; order-guard ok   the reflecting schedule gives every arm TWO, in balance  — reflected: 2,2,2,2 predecessors per arm, largest modal share 50%
+;; order-guard ok   at k=2 an ALWAYS-reflecting schedule runs one order for ever and is UNCHECKED  — always-reflect over 6 rounds of 2 arms: 1 distinct order(s), predecessors per arm 2,1 — rotating a pair by one IS reversing it, so the two cancel
+;; order-guard ok   at k=2 slot-order alternates, and every arm gets TWO predecessors in balance  — slot-order: 2 distinct orders, predecessors per arm 3,2, largest modal share 50%
+;; order-guard ok   samples whose :position went NON-FINITE refuse instead of narrowing the question  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it
+;; order-guard ok   a present-but-NIL :position is the same loss, and recording NONE is still excused  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it — and a run offering no position at all is excused, not refused
+;; harvest OK — 1202 elements, 141 reads (141 distinct), from the real page's own entry
+;; ==== ARM-ORDER GUARD — read-profile phase A (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   ctl2  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              warm                     n=30  p50      11.0500  [9.7000–16.6000]
+;;              ship                     n=30  p50      11.5000  [9.8000–17.2000]
+;;     [ok  ] by phase        medians 1.1587x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=20  p50      10.4000  [9.7000–12.3000]
+;;              LAST-THIRD               n=20  p50      12.0500  [10.8000–17.2000]
+;;   floor  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       0.3000  [0.1000–0.5000]
+;;              warm                     n=30  p50       0.3000  [0.2000–0.5000]
+;;     [ok  ] by phase        medians 1.5000x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=20  p50       0.2000  [0.1000–0.5000]
+;;              LAST-THIRD               n=20  p50       0.3000  [0.2000–0.5000]
+;;   local  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              no-shell                 n=30  p50       5.8000  [5.1000–8.6000]
+;;              ship                     n=30  p50       5.8500  [4.7000–9.2000]
+;;     [ok  ] by phase        medians 1.1698x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=20  p50       5.3000  [4.7000–6.6000]
+;;              LAST-THIRD               n=20  p50       6.2000  [5.7000–9.2000]
+;;   no-shell  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              local                    n=36  p50       5.5000  [4.6000–8.1000]
+;;              probe                    n=24  p50       5.5500  [4.5000–8.5000]
+;;     [ok  ] by phase        medians 1.1667x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=20  p50       5.1000  [4.5000–5.8000]
+;;              LAST-THIRD               n=20  p50       5.9500  [5.1000–8.5000]
+;;   probe  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       2.6000  [2.1000–4.3000]
+;;              no-shell                 n=30  p50       2.7500  [2.2000–3.8000]
+;;     [ok  ] by phase        medians 1.1200x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=20  p50       2.5000  [2.1000–3.2000]
+;;              LAST-THIRD               n=20  p50       2.8000  [2.5000–4.3000]
+;;   probe-fresh  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              floor                    n=18  p50       1.2000  [1.1000–1.6000]
+;;              probe                    n=42  p50       1.3000  [1.1000–1.9000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       1.2000  [1.1000–1.6000]
+;;              LAST-THIRD               n=20  p50       1.3000  [1.2000–1.9000]
+;;   ship  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              local                    n=24  p50       2.9000  [2.5000–4.1000]
+;;              ctl2                     n=36  p50       3.0000  [2.5000–4.8000]
+;;     [ok  ] by phase        medians 1.1636x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=20  p50       2.7500  [2.5000–4.8000]
+;;              LAST-THIRD               n=20  p50       3.2000  [2.8000–4.1000]
+;;   warm  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              floor                    n=36  p50       0.5000  [0.4000–1.3000]
+;;              ctl2                     n=24  p50       0.5000  [0.4000–0.8000]
+;;     [ok  ] by phase        medians 1.2000x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=20  p50       0.5000  [0.4000–0.6000]
+;;              LAST-THIRD               n=20  p50       0.6000  [0.5000–0.8000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-census
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; HICASSO read-profile-arms
+{:ship {:n 60, :min 0.3125, :max 0.6, :p50 0.375, :p95 0.5125000029802322, :p99 0.5778749975562094}, :local {:n 60, :min 0.5875, :max 1.15, :p50 0.725, :p95 1.0024999998509883, :p99 1.105750004202127}, :no-shell {:n 60, :min 0.5625, :max 1.0625, :p50 0.6875, :p95 0.852500008046627, :p99 1.0329999929666518}, :probe {:n 60, :min 0.2625, :max 0.5375, :p50 0.3375, :p95 0.4375, :p99 0.5006250028312205}, :probe-fresh {:n 60, :min 0.1375, :max 0.2375, :p50 0.1625, :p95 0.22499999403953552, :p99 0.23750000312924385}, :floor {:n 60, :min 0.0125, :max 0.0625, :p50 0.0375, :p95 0.04999999701976776, :p99 0.0625}, :warm {:n 60, :min 0.05, :max 0.1625, :p50 0.0625, :p95 0.10000000894069672, :p99 0.14037499755620944}, :ctl2 {:n 60, :min 1.2125, :max 2.15, :p50 1.4312, :p95 1.629375000298023, :p99 2.105749998092651}}
+;; ==== READ PROFILE, PHASE A (ms per 141-read pass; diagnostic in-page clock) ====
+;;   reads/pass 141  passes/sample 8  design 6x(4+10)
+;;   ship: p50 0.3750 [0.3125 - 0.6000] ms/pass  (2.66 us/read)
+;;   local: p50 0.7250 [0.5875 - 1.1500] ms/pass  (5.14 us/read)
+;;   no-shell: p50 0.6875 [0.5625 - 1.0625] ms/pass  (4.88 us/read)
+;;   probe: p50 0.3375 [0.2625 - 0.5375] ms/pass  (2.39 us/read)
+;;   probe-fresh: p50 0.1625 [0.1375 - 0.2375] ms/pass  (1.15 us/read)
+;;   floor: p50 0.0375 [0.0125 - 0.0625] ms/pass  (0.27 us/read)
+;;   warm: p50 0.0625 [0.0500 - 0.1625] ms/pass  (0.44 us/read)
+;;   ctl2: p50 1.4312 [1.2125 - 2.1500] ms/pass  (10.15 us/read)
+;; ==== PHASE A DELTAS (floors; stubs stated in the ns docstring) ====
+;;   copy fidelity: local/ship = 1.9333  (local is the FROZEN subscribe-once path)
+;;   the-hicasso-shell (local - no-shell): delta 0.0375 ms/pass (0.27 us/read, 5.2% of the baseline)
+;;   churn-vs-probe (local - probe, the candidate's saving): delta 0.3875 ms/pass (2.75 us/read, 53.4% of the baseline)
+;;   memo-economy (probe-fresh - probe): delta -0.1750 ms/pass (-1.24 us/read, -107.7% of the baseline)
+;;   probe-overhead (probe - floor): delta 0.3000 ms/pass (2.13 us/read, 88.9% of the baseline)
+;;   warm steady-state: 0.0625 ms/pass (0.44 us/read)
+;;   control: predicted 1.375x, measured 1.431x [1.213–2.150] — the range meets the prediction within ±25%
+;; ==== ARM-ORDER GUARD — read-profile phase B (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   b-build  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null-twin              n=24  p50      21.5000  [16.4000–28.9000]
+;;              c-nomap                  n=40  p50      22.3500  [16.2000–32.4000]
+;;     [ok  ] by phase        medians 1.1268x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50      20.5000  [16.2000–29.2000]
+;;              FIRST-THIRD              n=21  p50      23.1000  [17.1000–32.4000]
+;;   c-local  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              commit                   n=32  p50      28.5000  [19.1000–39.8000]
+;;              c-null                   n=32  p50      28.6500  [20.1000–37.0000]
+;;     [ok  ] by phase        medians 1.1728x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50      27.2000  [19.1000–31.2000]
+;;              FIRST-THIRD              n=21  p50      31.9000  [24.9000–39.8000]
+;;   c-noactivate  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null                   n=32  p50      27.9500  [19.7000–42.9000]
+;;              c-nowatch                n=32  p50      28.0000  [20.0000–36.4000]
+;;     [ok  ] by phase        medians 1.1336x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50      26.2000  [20.2000–31.2000]
+;;              FIRST-THIRD              n=21  p50      29.7000  [22.6000–42.9000]
+;;   c-nomap  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              b-build                  n=32  p50      24.9500  [19.0000–37.1000]
+;;              c-noreaders              n=32  p50      27.2500  [20.0000–38.8000]
+;;     [ok  ] by phase        medians 1.1477x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50      23.7000  [19.0000–30.3000]
+;;              FIRST-THIRD              n=21  p50      27.2000  [20.2000–38.8000]
+;;   c-noreaders  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=40  p50      27.0000  [20.9000–40.5000]
+;;              c-nomap                  n=24  p50      29.1000  [21.8000–32.4000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      26.4000  [21.6000–32.3000]
+;;              FIRST-THIRD              n=21  p50      28.6000  [23.2000–40.5000]
+;;   c-nosub  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noreaders              n=32  p50       9.2500  [6.5000–12.4000]
+;;              c-nowatch                n=32  p50       9.3000  [6.8000–13.9000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50       9.0000  [6.8000–10.2000]
+;;              FIRST-THIRD              n=21  p50       9.9000  [7.6000–13.9000]
+;;   c-nowatch  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=24  p50      26.3500  [18.2000–34.3000]
+;;              c-noactivate             n=40  p50      27.2000  [20.1000–41.1000]
+;;     [ok  ] by phase        medians 1.1076x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50      25.1000  [18.2000–29.9000]
+;;              FIRST-THIRD              n=21  p50      27.8000  [20.5000–39.6000]
+;;   c-null  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noactivate             n=24  p50      26.8500  [19.0000–39.7000]
+;;              c-local                  n=32  p50      27.6000  [19.8000–35.0000]
+;;              c-null-twin              n= 7  p50      28.9000  [20.1000–32.2000]
+;;              <none>                   n= 1  p50      37.9000  [37.9000–37.9000]
+;;     [ok  ] by phase        medians 1.1970x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50      26.4000  [19.8000–32.1000]
+;;              FIRST-THIRD              n=21  p50      31.6000  [20.3000–37.9000]
+;;   c-null-curve  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              commit                   n=32  p50      27.8000  [20.0000–34.9000]
+;;              c-null-twin              n=32  p50      29.0000  [19.1000–41.7000]
+;;     [ok  ] by phase        medians 1.1268x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50      27.6000  [20.0000–32.3000]
+;;              FIRST-THIRD              n=21  p50      31.1000  [23.5000–41.7000]
+;;   c-null-twin  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null-curve             n=32  p50      27.2000  [19.4000–41.2000]
+;;              b-build                  n=32  p50      29.3500  [21.8000–39.6000]
+;;     [ok  ] by phase        medians 1.1756x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50      26.2000  [19.4000–32.0000]
+;;              FIRST-THIRD              n=21  p50      30.8000  [23.5000–41.2000]
+;;   commit  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-local                  n=32  p50      29.7000  [19.7000–43.1000]
+;;              c-null-curve             n=32  p50      30.9500  [21.6000–42.7000]
+;;     [ok  ] by phase        medians 1.1985x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=21  p50      27.2000  [20.7000–34.0000]
+;;              FIRST-THIRD              n=21  p50      32.6000  [24.6000–42.7000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-commit
+{:c-null-twin {:n 64, :min 0.6062, :max 1.2875, :p50 0.8891, :p95 1.1120312474668026, :p99 1.255999999642372}, :c-local {:n 64, :min 0.5969, :max 1.2438, :p50 0.8922, :p95 1.105312499590218, :p99 1.1886250008270143}, :c-noreaders {:n 64, :min 0.6531, :max 1.2656, :p50 0.8766, :p95 1.0310937505215405, :p99 1.1376562499999996}, :c-noactivate {:n 64, :min 0.6156, :max 1.3406, :p50 0.8734, :p95 1.0762500001117585, :p99 1.2126562506332987}, :c-null {:n 64, :min 0.5938, :max 1.2406, :p50 0.8625, :p95 1.1096875006332994, :p99 1.2051875024288892}, :c-nowatch {:n 64, :min 0.5688, :max 1.2844, :p50 0.8328, :p95 1.0700000017881393, :p99 1.2548437507450578}, :commit {:n 64, :min 0.6156, :max 1.3469, :p50 0.9391, :p95 1.1959374982863664, :p99 1.3389999974891542}, :c-nomap {:n 64, :min 0.5938, :max 1.2125, :p50 0.825, :p95 1.0745312497019768, :p99 1.1790312499180435}, :b-build {:n 64, :min 0.5063, :max 1.0125, :p50 0.6891, :p95 0.9057812498882413, :p99 0.9494999983161685}, :c-null-curve {:n 64, :min 0.5969, :max 1.3031, :p50 0.8812, :p95 1.080312501080334, :p99 1.1849999977648253}, :c-nosub {:n 64, :min 0.2031, :max 0.4344, :p50 0.2906, :p95 0.37453124988824127, :p99 0.4205937506631016}}
+;; HICASSO read-profile-commit-per-round
+{:c-null-twin [1.0109 0.925 1.0156 0.8422 0.9141 0.7484 0.8078 0.8375], :c-local [1.0531 0.9375 1.0281 0.8516 0.9094 0.8859 0.7359 0.8703], :c-noreaders [1.0094 0.8328 0.8703 0.8687 0.9078 0.7578 0.8141 0.8781], :c-noactivate [1.0531 0.8797 1.025 0.7609 0.8578 0.7766 0.7641 0.8625], :c-null [1.0891 0.9578 0.9922 0.8469 0.8906 0.8328 0.7734 0.8313], :c-nowatch [0.8734 0.85 0.9453 0.8484 0.8125 0.7563 0.6312 0.8156], :commit [1.0313 0.9656 1.1844 0.9281 0.9734 0.9187 0.7453 0.8578], :c-nomap [0.9109 0.8109 0.9125 0.825 0.8656 0.7297 0.7688 0.7328], :b-build [0.7672 0.7 0.7094 0.6813 0.7109 0.6375 0.5687 0.6547], :c-null-curve [0.9516 0.9156 1.0344 0.8359 0.9063 0.8406 0.8328 0.8562], :c-nosub [0.3141 0.2813 0.3266 0.2875 0.2891 0.275 0.2766 0.2828]}
+;; HICASSO read-profile-commit-per-round-deltas
+{:c-null [-0.036 -0.0203 0.0359 0.0047 0.0188 0.0531 -0.0375 0.039], :c-noactivate [0 0.0578 0.0031 0.0907 0.0516 0.1093 -0.0282 0.0078], :c-nowatch [0.1797 0.0875 0.0828 0.0032 0.0969 0.1296 0.1047 0.0547], :c-nosub [0.739 0.6562 0.7015 0.5641 0.6203 0.6109 0.4593 0.5875], :c-noreaders [0.0437 0.1047 0.1578 -0.0171 0.0016 0.1281 -0.0782 -0.0078], :c-nomap [0.1422 0.1266 0.1156 0.0266 0.0438 0.1562 -0.0329 0.1375], :c-null-twin [0.0422 0.0125 0.0125 0.0094 -0.0047 0.1375 -0.0719 0.0328], :c-null-curve [0.1015 0.0219 -0.0063 0.0157 0.0031 0.0453 -0.0969 0.0141]}
+;; HICASSO read-profile-slot-plan
+[{:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :commit, :slot 0} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-local, :slot 1} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :c-null, :slot 2} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-noactivate, :slot 3} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-nowatch, :slot 4} {:positions [1 1 3 3 8 8 10 10], :mean-position 5.5, :id :c-nosub, :slot 5} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-noreaders, :slot 6} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-nomap, :slot 7} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :b-build, :slot 8} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-null-twin, :slot 9} {:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :c-null-curve, :slot 10}]
+;; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====
+;;   design 8x(2+8)  window = 32 frames/commit each  kept = 64 samples/arm (EVEN — p50 is the mean of two middle clock readings)  grid = 0.001563 ms/commit
+;;   slot plan (each arm's kept-sample sweep positions — the schedule is indexed by SAMPLE, so this footprint repeats identically every round; rf2-lo7uy):
+;;     slot 0 commit: [2 3 4 5 6 7 8 9]  mean 5.500
+;;     slot 1 c-local: [1 3 4 5 6 7 8 10]  mean 5.500
+;;     slot 2 c-null: [0 0 2 4 5 6 7 9]  mean 4.125
+;;     slot 3 c-noactivate: [1 1 3 5 6 8 10 10]  mean 5.500
+;;     slot 4 c-nowatch: [0 0 2 2 4 7 9 9]  mean 4.125
+;;     slot 5 c-nosub: [1 1 3 3 8 8 10 10]  mean 5.500
+;;     slot 6 c-noreaders: [0 0 2 2 4 7 9 9]  mean 4.125
+;;     slot 7 c-nomap: [1 1 3 5 6 8 10 10]  mean 5.500
+;;     slot 8 b-build: [0 0 2 4 5 6 7 9]  mean 4.125
+;;     slot 9 c-null-twin: [1 3 4 5 6 7 8 10]  mean 5.500
+;;     slot 10 c-null-curve: [2 3 4 5 6 7 8 9]  mean 5.500
+;;   commit: p50 0.9391 [0.6156 - 1.3469] ms/pass  (6.66 us/read)
+;;   c-local: p50 0.8922 [0.5969 - 1.2438] ms/pass  (6.33 us/read)
+;;   c-null: p50 0.8625 [0.5938 - 1.2406] ms/pass  (6.12 us/read)
+;;   c-noactivate: p50 0.8734 [0.6156 - 1.3406] ms/pass  (6.19 us/read)
+;;   c-nowatch: p50 0.8328 [0.5688 - 1.2844] ms/pass  (5.91 us/read)
+;;   c-nosub: p50 0.2906 [0.2031 - 0.4344] ms/pass  (2.06 us/read)
+;;   c-noreaders: p50 0.8766 [0.6531 - 1.2656] ms/pass  (6.22 us/read)
+;;   c-nomap: p50 0.8250 [0.5938 - 1.2125] ms/pass  (5.85 us/read)
+;;   b-build: p50 0.6891 [0.5063 - 1.0125] ms/pass  (4.89 us/read)
+;;   c-null-twin: p50 0.8891 [0.6062 - 1.2875] ms/pass  (6.31 us/read)
+;;   c-null-curve: p50 0.8812 [0.5969 - 1.3031] ms/pass  (6.25 us/read)
+;; ==== PHASE B DELTAS (c-local minus ablation; floors) ====
+;;   copy fidelity: c-local/commit = 0.9501
+;;   NULL CONTROL (c-local - c-null): delta 0.0297 ms/pass (0.21 us/read, 3.3% of the baseline)
+;;     ^ true cost EXACTLY ZERO by construction — both arms are C-FULL. What it reads is this instrument's own error at this shape, and it is what the terms below are adjudicated against (rf2-3l6hf). It bounds no term's cost: a delta inside this spread is a term the window cannot SEE, which leaves its size open in both directions
+;;     ^ slot 1 against slot 2, on footprints that differ in BOTH mean position and shape. The two nulls below hold that zero and move the SLOT, which is what makes the offset's cause readable rather than only its size (rf2-lo7uy)
+;;   NULL CONTROL, position TWIN (c-local - c-null-twin): delta 0.0031 ms/pass (0.02 us/read, 0.4% of the baseline)
+;;     ^ same zero, and this arm's kept-sample position footprint IS c-local's, so ANY cost that is a function of sweep position cancels term by term. A reading here is error sweep position cannot explain; a reading of zero here beside a non-zero c-null puts the offset ON position
+;;   NULL CONTROL, equal MEAN position (c-local - c-null-curve): delta 0.0109 ms/pass (0.08 us/read, 1.2% of the baseline)
+;;     ^ same zero, c-local's MEAN position on a DIFFERENT footprint: a linear within-sweep drift cancels here, a curved one does not. Read the three nulls together — alike means the offset is not positional; c-null alone means it is; c-null and this one means it is and is not linear
+;;   activation-capture (c-local - c-noactivate): delta 0.0188 ms/pass (0.13 us/read, 2.1% of the baseline)
+;;     ^ a REAL term here, NOT a floor and not an arbiter: nothing activates on this UIx host, but the hook key is never published and so never cached, and this prices that lookup (rf2-tcffa, rf2-19usn). The capture itself is real only under the ratom family (rf2-lzpfj)
+;;   watch-wiring (c-local - c-nowatch): delta 0.0594 ms/pass (0.42 us/read, 6.7% of the baseline)
+;;   reaction-build+cache-insert (c-local - c-nosub): delta 0.6016 ms/pass (4.27 us/read, 67.4% of the baseline)
+;;   reader-membership (c-local - c-noreaders): delta 0.0156 ms/pass (0.11 us/read, 1.8% of the baseline)
+;;   cell-map-insert (c-local - c-nomap): delta 0.0672 ms/pass (0.48 us/read, 7.5% of the baseline)
+;;   b-build (build+compute, no in-window dispose): 0.6891 ms/pass (4.89 us/read)
+;; HICASSO read-profile-micro
+{:subscribe-once 7446.8085, :compute-sub 1489.3617, :handler-invoke 361.7021, :registrar-lookup 124.1135, :frame-state-value 464.539, :resolution-wrap 372.3404, :cache-peek-miss 39.0071, :sub-key-mint 21.2766}
+;; ==== MICRO (ns/op over the page's own roster) ====
+;;   subscribe-once: 7446.8 ns
+;;   compute-sub: 1489.4 ns
+;;   handler-invoke: 361.7 ns
+;;   registrar-lookup: 124.1 ns
+;;   frame-state-value: 464.5 ns
+;;   resolution-wrap: 372.3 ns
+;;   cache-peek-miss: 39.0 ns
+;;   sub-key-mint: 21.3 ns
+;; HICASSO DONE
+;; ==== HICASSO RUNTIME ====
+;; chromium 147.0.7727.15 (playwright), :advanced, goog.DEBUG false
+;; ==== HICASSO read-profile-census ====
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; ==== HICASSO read-profile-arms ====
+{:ship {:n 60, :min 0.3125, :max 0.6, :p50 0.375, :p95 0.5125000029802322, :p99 0.5778749975562094}, :local {:n 60, :min 0.5875, :max 1.15, :p50 0.725, :p95 1.0024999998509883, :p99 1.105750004202127}, :no-shell {:n 60, :min 0.5625, :max 1.0625, :p50 0.6875, :p95 0.852500008046627, :p99 1.0329999929666518}, :probe {:n 60, :min 0.2625, :max 0.5375, :p50 0.3375, :p95 0.4375, :p99 0.5006250028312205}, :probe-fresh {:n 60, :min 0.1375, :max 0.2375, :p50 0.1625, :p95 0.22499999403953552, :p99 0.23750000312924385}, :floor {:n 60, :min 0.0125, :max 0.0625, :p50 0.0375, :p95 0.04999999701976776, :p99 0.0625}, :warm {:n 60, :min 0.05, :max 0.1625, :p50 0.0625, :p95 0.10000000894069672, :p99 0.14037499755620944}, :ctl2 {:n 60, :min 1.2125, :max 2.15, :p50 1.4312, :p95 1.629375000298023, :p99 2.105749998092651}}
+;; ==== HICASSO read-profile-commit ====
+{:c-null-twin {:n 64, :min 0.6062, :max 1.2875, :p50 0.8891, :p95 1.1120312474668026, :p99 1.255999999642372}, :c-local {:n 64, :min 0.5969, :max 1.2438, :p50 0.8922, :p95 1.105312499590218, :p99 1.1886250008270143}, :c-noreaders {:n 64, :min 0.6531, :max 1.2656, :p50 0.8766, :p95 1.0310937505215405, :p99 1.1376562499999996}, :c-noactivate {:n 64, :min 0.6156, :max 1.3406, :p50 0.8734, :p95 1.0762500001117585, :p99 1.2126562506332987}, :c-null {:n 64, :min 0.5938, :max 1.2406, :p50 0.8625, :p95 1.1096875006332994, :p99 1.2051875024288892}, :c-nowatch {:n 64, :min 0.5688, :max 1.2844, :p50 0.8328, :p95 1.0700000017881393, :p99 1.2548437507450578}, :commit {:n 64, :min 0.6156, :max 1.3469, :p50 0.9391, :p95 1.1959374982863664, :p99 1.3389999974891542}, :c-nomap {:n 64, :min 0.5938, :max 1.2125, :p50 0.825, :p95 1.0745312497019768, :p99 1.1790312499180435}, :b-build {:n 64, :min 0.5063, :max 1.0125, :p50 0.6891, :p95 0.9057812498882413, :p99 0.9494999983161685}, :c-null-curve {:n 64, :min 0.5969, :max 1.3031, :p50 0.8812, :p95 1.080312501080334, :p99 1.1849999977648253}, :c-nosub {:n 64, :min 0.2031, :max 0.4344, :p50 0.2906, :p95 0.37453124988824127, :p99 0.4205937506631016}}
+;; ==== HICASSO read-profile-commit-per-round ====
+{:c-null-twin [1.0109 0.925 1.0156 0.8422 0.9141 0.7484 0.8078 0.8375], :c-local [1.0531 0.9375 1.0281 0.8516 0.9094 0.8859 0.7359 0.8703], :c-noreaders [1.0094 0.8328 0.8703 0.8687 0.9078 0.7578 0.8141 0.8781], :c-noactivate [1.0531 0.8797 1.025 0.7609 0.8578 0.7766 0.7641 0.8625], :c-null [1.0891 0.9578 0.9922 0.8469 0.8906 0.8328 0.7734 0.8313], :c-nowatch [0.8734 0.85 0.9453 0.8484 0.8125 0.7563 0.6312 0.8156], :commit [1.0313 0.9656 1.1844 0.9281 0.9734 0.9187 0.7453 0.8578], :c-nomap [0.9109 0.8109 0.9125 0.825 0.8656 0.7297 0.7688 0.7328], :b-build [0.7672 0.7 0.7094 0.6813 0.7109 0.6375 0.5687 0.6547], :c-null-curve [0.9516 0.9156 1.0344 0.8359 0.9063 0.8406 0.8328 0.8562], :c-nosub [0.3141 0.2813 0.3266 0.2875 0.2891 0.275 0.2766 0.2828]}
+;; ==== HICASSO read-profile-commit-per-round-deltas ====
+{:c-null [-0.036 -0.0203 0.0359 0.0047 0.0188 0.0531 -0.0375 0.039], :c-noactivate [0 0.0578 0.0031 0.0907 0.0516 0.1093 -0.0282 0.0078], :c-nowatch [0.1797 0.0875 0.0828 0.0032 0.0969 0.1296 0.1047 0.0547], :c-nosub [0.739 0.6562 0.7015 0.5641 0.6203 0.6109 0.4593 0.5875], :c-noreaders [0.0437 0.1047 0.1578 -0.0171 0.0016 0.1281 -0.0782 -0.0078], :c-nomap [0.1422 0.1266 0.1156 0.0266 0.0438 0.1562 -0.0329 0.1375], :c-null-twin [0.0422 0.0125 0.0125 0.0094 -0.0047 0.1375 -0.0719 0.0328], :c-null-curve [0.1015 0.0219 -0.0063 0.0157 0.0031 0.0453 -0.0969 0.0141]}
+;; ==== HICASSO read-profile-slot-plan ====
+[{:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :commit, :slot 0} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-local, :slot 1} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :c-null, :slot 2} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-noactivate, :slot 3} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-nowatch, :slot 4} {:positions [1 1 3 3 8 8 10 10], :mean-position 5.5, :id :c-nosub, :slot 5} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-noreaders, :slot 6} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-nomap, :slot 7} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :b-build, :slot 8} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-null-twin, :slot 9} {:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :c-null-curve, :slot 10}]
+;; ==== HICASSO read-profile-micro ====
+{:subscribe-once 7446.8085, :compute-sub 1489.3617, :handler-invoke 361.7021, :registrar-lookup 124.1135, :frame-state-value 464.539, :resolution-wrap 372.3404, :cache-peek-miss 39.0071, :sub-key-mint 21.2766}
+[hicasso] ok

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj-retake/run2.txt
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj-retake/run2.txt
@@ -1,0 +1,259 @@
+[hicasso] cleared .shadow-cljs/builds/hicasso-bench — one build id, N arms (rf2-2rtt6.20)
+[hicasso] building :advanced bundle — re-frame.bench.hicasso.read-profile-app/-main -> out/hicasso-readprof
+[:hicasso-bench] Compiling ...
+[:hicasso-bench] Build completed. (187 files, 132 compiled, 0 warnings, 38.59s)
+shadow-cljs - config: <worktree>\implementation\shadow-cljs.edn   ;; ABSOLUTE PATH REDACTED — see README.md
+;; order-guard ok   the recorded 2.01x is REFUSED  — ratio 2.0125
+;; order-guard ok   the same study's uncontaminated slope passes  — forward 2830.7 / reversed 2842.8
+;; order-guard ok   a single-order result is refused as UNCHECKED  — only 1 stratum — the question was never asked
+;; order-guard ok   overlapping ranges are indistinguishable even 20% apart in median  — medians 1.2000x apart but the ranges OVERLAP — indistinguishable
+;; order-guard ok   the measured warm-up step is caught by PHASE, which no reversal would show  — phase: FIRST-THIRD reads 1.2633x LAST-THIRD, ranges disjoint
+;; order-guard ok   an arm that reads exactly zero in both strata is indistinguishable, not infinite  — within 10%
+;; order-guard ok   cyclic rotation gives every arm exactly ONE within-round predecessor  — rotation over 6 rounds: distinct predecessors per arm 1,1,1,1 (only the round seam ever differs, and that is one sample in R)
+;; order-guard ok   the reflecting schedule gives every arm TWO, in balance  — reflected: 2,2,2,2 predecessors per arm, largest modal share 50%
+;; order-guard ok   at k=2 an ALWAYS-reflecting schedule runs one order for ever and is UNCHECKED  — always-reflect over 6 rounds of 2 arms: 1 distinct order(s), predecessors per arm 2,1 — rotating a pair by one IS reversing it, so the two cancel
+;; order-guard ok   at k=2 slot-order alternates, and every arm gets TWO predecessors in balance  — slot-order: 2 distinct orders, predecessors per arm 3,2, largest modal share 50%
+;; order-guard ok   samples whose :position went NON-FINITE refuse instead of narrowing the question  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it
+;; order-guard ok   a present-but-NIL :position is the same loss, and recording NONE is still excused  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it — and a run offering no position at all is excused, not refused
+;; harvest OK — 1202 elements, 141 reads (141 distinct), from the real page's own entry
+;; ==== ARM-ORDER GUARD — read-profile phase A (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   ctl2  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ship                     n=30  p50      11.4000  [10.0000–15.0000]
+;;              warm                     n=30  p50      11.5000  [10.0000–15.5000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50      11.4500  [10.0000–15.5000]
+;;              FIRST-THIRD              n=20  p50      12.4500  [10.8000–14.4000]
+;;   floor  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       0.3000  [0.2000–0.6000]
+;;              warm                     n=30  p50       0.3000  [0.2000–0.9000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.3000  [0.2000–0.5000]
+;;              LAST-THIRD               n=20  p50       0.3000  [0.2000–0.9000]
+;;   local  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ship                     n=30  p50       6.1000  [5.0000–10.5000]
+;;              no-shell                 n=30  p50       6.1000  [5.1000–9.1000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       6.1500  [5.3000–10.5000]
+;;              FIRST-THIRD              n=20  p50       6.7500  [5.7000–7.8000]
+;;   no-shell  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=24  p50       5.6000  [4.7000–8.0000]
+;;              local                    n=36  p50       5.9500  [4.9000–7.7000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       5.7500  [4.9000–7.7000]
+;;              FIRST-THIRD              n=20  p50       6.2500  [5.7000–8.0000]
+;;   probe  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       2.5000  [2.2000–3.7000]
+;;              no-shell                 n=30  p50       2.6000  [2.2000–3.9000]
+;;     [ok  ] by phase        medians 1.2245x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       2.4500  [2.2000–3.2000]
+;;              FIRST-THIRD              n=20  p50       3.0000  [2.4000–3.9000]
+;;   probe-fresh  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe                    n=42  p50       1.2500  [1.1000–1.9000]
+;;              floor                    n=18  p50       1.3000  [1.1000–1.9000]
+;;     [ok  ] by phase        medians 1.1538x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       1.3000  [1.1000–1.6000]
+;;              FIRST-THIRD              n=20  p50       1.5000  [1.2000–1.9000]
+;;   ship  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ctl2                     n=36  p50       3.0500  [2.5000–4.3000]
+;;              local                    n=24  p50       3.1000  [2.6000–4.1000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       3.2000  [2.6000–4.0000]
+;;              FIRST-THIRD              n=20  p50       3.3500  [2.8000–4.1000]
+;;   warm  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              floor                    n=36  p50       0.5500  [0.4000–1.3000]
+;;              ctl2                     n=24  p50       0.6000  [0.4000–1.2000]
+;;     [ok  ] by phase        medians 1.2000x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       0.5000  [0.4000–1.3000]
+;;              FIRST-THIRD              n=20  p50       0.6000  [0.5000–0.7000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-census
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; HICASSO read-profile-arms
+{:ship {:n 60, :min 0.3125, :max 0.5375, :p50 0.3875, :p95 0.5006249994039536, :p99 0.5227499993145465}, :local {:n 60, :min 0.625, :max 1.3125, :p50 0.7625, :p95 1.0068749994039532, :p99 1.297749996483326}, :no-shell {:n 60, :min 0.5875, :max 1, :p50 0.725, :p95 0.9506250023841858, :p99 0.9778749947249888}, :probe {:n 60, :min 0.275, :max 0.4875, :p50 0.325, :p95 0.43875000029802314, :p99 0.4801249952614307}, :probe-fresh {:n 60, :min 0.1375, :max 0.2375, :p50 0.1625, :p95 0.22499999403953552, :p99 0.23749999701976776}, :floor {:n 60, :min 0.025, :max 0.1125, :p50 0.0375, :p95 0.05062501132488247, :p99 0.09037500053644168}, :warm {:n 60, :min 0.05, :max 0.1625, :p50 0.075, :p95 0.10062500834465023, :p99 0.15512500718235966}, :ctl2 {:n 60, :min 1.25, :max 1.9375, :p50 1.4312, :p95 1.8762499995529651, :p99 1.915375003516674}}
+;; ==== READ PROFILE, PHASE A (ms per 141-read pass; diagnostic in-page clock) ====
+;;   reads/pass 141  passes/sample 8  design 6x(4+10)
+;;   ship: p50 0.3875 [0.3125 - 0.5375] ms/pass  (2.75 us/read)
+;;   local: p50 0.7625 [0.6250 - 1.3125] ms/pass  (5.41 us/read)
+;;   no-shell: p50 0.7250 [0.5875 - 1.0000] ms/pass  (5.14 us/read)
+;;   probe: p50 0.3250 [0.2750 - 0.4875] ms/pass  (2.30 us/read)
+;;   probe-fresh: p50 0.1625 [0.1375 - 0.2375] ms/pass  (1.15 us/read)
+;;   floor: p50 0.0375 [0.0250 - 0.1125] ms/pass  (0.27 us/read)
+;;   warm: p50 0.0750 [0.0500 - 0.1625] ms/pass  (0.53 us/read)
+;;   ctl2: p50 1.4312 [1.2500 - 1.9375] ms/pass  (10.15 us/read)
+;; ==== PHASE A DELTAS (floors; stubs stated in the ns docstring) ====
+;;   copy fidelity: local/ship = 1.9677  (local is the FROZEN subscribe-once path)
+;;   the-hicasso-shell (local - no-shell): delta 0.0375 ms/pass (0.27 us/read, 4.9% of the baseline)
+;;   churn-vs-probe (local - probe, the candidate's saving): delta 0.4375 ms/pass (3.10 us/read, 57.4% of the baseline)
+;;   memo-economy (probe-fresh - probe): delta -0.1625 ms/pass (-1.15 us/read, -100.0% of the baseline)
+;;   probe-overhead (probe - floor): delta 0.2875 ms/pass (2.04 us/read, 88.5% of the baseline)
+;;   warm steady-state: 0.0750 ms/pass (0.53 us/read)
+;;   control: predicted 1.450x, measured 1.431x [1.250–1.938] — the range meets the prediction within ±25%
+;; ==== ARM-ORDER GUARD — read-profile phase B (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   b-build  (64 samples)
+;;     [ok  ] by predecessor  medians 1.1035x apart but the ranges OVERLAP — indistinguishable
+;;              c-null-twin              n=24  p50      21.2500  [17.0000–30.2000]
+;;              c-nomap                  n=40  p50      23.4500  [15.5000–29.4000]
+;;     [ok  ] by phase        medians 1.1442x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      20.8000  [15.5000–26.3000]
+;;              LAST-THIRD               n=21  p50      23.8000  [17.4000–30.2000]
+;;   c-local  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null                   n=32  p50      28.7500  [23.1000–43.7000]
+;;              commit                   n=32  p50      29.6500  [22.0000–40.2000]
+;;     [ok  ] by phase        medians 1.1655x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      27.8000  [22.0000–37.5000]
+;;              LAST-THIRD               n=21  p50      32.4000  [23.0000–43.7000]
+;;   c-noactivate  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nowatch                n=32  p50      28.5000  [20.0000–44.2000]
+;;              c-null                   n=32  p50      29.1000  [20.8000–35.7000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      29.2000  [21.1000–35.2000]
+;;              LAST-THIRD               n=21  p50      32.0000  [23.2000–44.2000]
+;;   c-nomap  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noreaders              n=32  p50      25.8000  [18.8000–37.6000]
+;;              b-build                  n=32  p50      27.6000  [18.7000–37.0000]
+;;     [ok  ] by phase        medians 1.1407x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      26.3000  [18.8000–30.9000]
+;;              LAST-THIRD               n=21  p50      30.0000  [21.5000–37.6000]
+;;   c-noreaders  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=40  p50      28.9500  [19.0000–41.2000]
+;;              c-nomap                  n=24  p50      30.1500  [23.0000–38.7000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      29.6000  [19.0000–36.6000]
+;;              LAST-THIRD               n=21  p50      30.7000  [22.5000–41.2000]
+;;   c-nosub  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nowatch                n=32  p50       9.5500  [6.8000–13.2000]
+;;              c-noreaders              n=32  p50      10.1000  [6.7000–14.3000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      10.1000  [6.7000–13.4000]
+;;              LAST-THIRD               n=21  p50      10.1000  [7.7000–13.3000]
+;;   c-nowatch  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nosub                  n=24  p50      27.3000  [20.1000–34.9000]
+;;              c-noactivate             n=40  p50      27.7500  [18.7000–36.4000]
+;;     [ok  ] by phase        medians 1.1179x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      26.3000  [18.7000–35.4000]
+;;              LAST-THIRD               n=21  p50      29.4000  [22.8000–35.8000]
+;;   c-null  (64 samples)
+;;     [ok  ] by predecessor  medians 1.1431x apart but the ranges OVERLAP — indistinguishable
+;;              c-null-twin              n= 7  p50      25.5000  [19.3000–33.3000]
+;;              c-local                  n=32  p50      29.1000  [21.3000–40.5000]
+;;              c-noactivate             n=24  p50      29.1500  [21.6000–41.9000]
+;;              <none>                   n= 1  p50      29.6000  [29.6000–29.6000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      27.9000  [21.3000–33.4000]
+;;              LAST-THIRD               n=21  p50      30.4000  [21.8000–41.9000]
+;;   c-null-curve  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              commit                   n=32  p50      28.4000  [20.4000–41.0000]
+;;              c-null-twin              n=32  p50      29.2000  [22.7000–40.2000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      28.8000  [20.4000–33.9000]
+;;              LAST-THIRD               n=21  p50      30.2000  [22.9000–41.0000]
+;;   c-null-twin  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null-curve             n=32  p50      28.1000  [20.0000–38.8000]
+;;              b-build                  n=32  p50      30.2000  [22.4000–39.6000]
+;;     [ok  ] by phase        medians 1.1159x apart but the ranges OVERLAP — indistinguishable
+;;              FIRST-THIRD              n=21  p50      27.6000  [20.0000–35.9000]
+;;              LAST-THIRD               n=21  p50      30.8000  [24.1000–38.8000]
+;;   commit  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-local                  n=32  p50      30.7500  [24.0000–44.1000]
+;;              c-null-curve             n=32  p50      32.1500  [20.1000–42.5000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      30.8000  [25.0000–38.9000]
+;;              LAST-THIRD               n=21  p50      33.3000  [24.0000–44.1000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-commit
+{:c-null-twin {:n 64, :min 0.625, :max 1.2375, :p50 0.8906, :p95 1.1351562492549419, :p99 1.2217499993368983}, :c-local {:n 64, :min 0.6875, :max 1.3656, :p50 0.9187, :p95 1.193125001899898, :p99 1.306562499143183}, :c-noreaders {:n 64, :min 0.5938, :max 1.2875, :p50 0.9125, :p95 1.1570312501862645, :p99 1.2382812477648257}, :c-noactivate {:n 64, :min 0.625, :max 1.3813, :p50 0.9, :p95 1.0995312513783575, :p99 1.2296562505513424}, :c-null {:n 64, :min 0.6031, :max 1.3094, :p50 0.9047, :p95 1.1332812493667004, :p99 1.2818124997243283}, :c-nowatch {:n 64, :min 0.5844, :max 1.1375, :p50 0.8641, :p95 1.0864062525331972, :p99 1.1256874987855554}, :commit {:n 64, :min 0.6281, :max 1.3781, :p50 0.9781, :p95 1.2856250010430812, :p99 1.3466250002756714}, :c-nomap {:n 64, :min 0.5844, :max 1.175, :p50 0.8531, :p95 1.1203124985098833, :p99 1.1730312502756715}, :b-build {:n 64, :min 0.4844, :max 0.9437, :p50 0.7047, :p95 0.9084374973550439, :p99 0.927999998703599}, :c-null-curve {:n 64, :min 0.6375, :max 1.2813, :p50 0.9016, :p95 1.1812499985098839, :p99 1.2733749981224536}, :c-nosub {:n 64, :min 0.2094, :max 0.4469, :p50 0.3031, :p95 0.4120312513783574, :p99 0.4291562489792704}}
+;; HICASSO read-profile-commit-per-round
+{:c-null-twin [0.8641 0.8313 0.9391 0.8516 0.8562 1.0734 0.925 0.9594], :c-local [0.8578 0.8875 0.9297 0.8656 0.8406 1.0453 0.9859 0.9672], :c-noreaders [0.9703 0.7797 0.9141 0.8406 0.7813 1.0547 1.0328 0.9359], :c-noactivate [0.9141 0.7594 0.9281 0.8453 0.8016 1.0109 1.0141 0.9969], :c-null [0.9141 0.8859 0.7922 0.8438 0.8656 1.0313 0.9688 0.9438], :c-nowatch [0.7781 0.8438 0.8797 0.7984 0.7609 1.0281 0.9344 0.8906], :commit [0.9875 0.9031 1.0078 0.9125 0.9047 1.1297 1.1375 1.0406], :c-nomap [0.8609 0.7563 0.8422 0.7687 0.7562 1.0234 0.9359 0.9391], :b-build [0.6469 0.5953 0.7141 0.6531 0.6547 0.7531 0.7359 0.7562], :c-null-curve [0.9531 0.85 0.9406 0.8797 0.8609 1.0438 0.9484 0.9328], :c-nosub [0.3156 0.2937 0.3047 0.2781 0.2875 0.375 0.3219 0.3094]}
+;; HICASSO read-profile-commit-per-round-deltas
+{:c-null [-0.0563 0.0016 0.1375 0.0218 -0.025 0.014 0.0171 0.0234], :c-noactivate [-0.0563 0.1281 0.0016 0.0203 0.039 0.0344 -0.0282 -0.0297], :c-nowatch [0.0797 0.0437 0.05 0.0672 0.0797 0.0172 0.0515 0.0766], :c-nosub [0.5422 0.5938 0.625 0.5875 0.5531 0.6703 0.664 0.6578], :c-noreaders [-0.1125 0.1078 0.0156 0.025 0.0593 -0.0094 -0.0469 0.0313], :c-nomap [-0.0031 0.1312 0.0875 0.0969 0.0844 0.0219 0.05 0.0281], :c-null-twin [-0.0063 0.0562 -0.0094 0.014 -0.0156 -0.0281 0.0609 0.0078], :c-null-curve [-0.0953 0.0375 -0.0109 -0.0141 -0.0203 0.0015 0.0375 0.0344]}
+;; HICASSO read-profile-slot-plan
+[{:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :commit, :slot 0} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-local, :slot 1} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :c-null, :slot 2} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-noactivate, :slot 3} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-nowatch, :slot 4} {:positions [1 1 3 3 8 8 10 10], :mean-position 5.5, :id :c-nosub, :slot 5} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-noreaders, :slot 6} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-nomap, :slot 7} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :b-build, :slot 8} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-null-twin, :slot 9} {:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :c-null-curve, :slot 10}]
+;; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====
+;;   design 8x(2+8)  window = 32 frames/commit each  kept = 64 samples/arm (EVEN — p50 is the mean of two middle clock readings)  grid = 0.001563 ms/commit
+;;   slot plan (each arm's kept-sample sweep positions — the schedule is indexed by SAMPLE, so this footprint repeats identically every round; rf2-lo7uy):
+;;     slot 0 commit: [2 3 4 5 6 7 8 9]  mean 5.500
+;;     slot 1 c-local: [1 3 4 5 6 7 8 10]  mean 5.500
+;;     slot 2 c-null: [0 0 2 4 5 6 7 9]  mean 4.125
+;;     slot 3 c-noactivate: [1 1 3 5 6 8 10 10]  mean 5.500
+;;     slot 4 c-nowatch: [0 0 2 2 4 7 9 9]  mean 4.125
+;;     slot 5 c-nosub: [1 1 3 3 8 8 10 10]  mean 5.500
+;;     slot 6 c-noreaders: [0 0 2 2 4 7 9 9]  mean 4.125
+;;     slot 7 c-nomap: [1 1 3 5 6 8 10 10]  mean 5.500
+;;     slot 8 b-build: [0 0 2 4 5 6 7 9]  mean 4.125
+;;     slot 9 c-null-twin: [1 3 4 5 6 7 8 10]  mean 5.500
+;;     slot 10 c-null-curve: [2 3 4 5 6 7 8 9]  mean 5.500
+;;   commit: p50 0.9781 [0.6281 - 1.3781] ms/pass  (6.94 us/read)
+;;   c-local: p50 0.9187 [0.6875 - 1.3656] ms/pass  (6.52 us/read)
+;;   c-null: p50 0.9047 [0.6031 - 1.3094] ms/pass  (6.42 us/read)
+;;   c-noactivate: p50 0.9000 [0.6250 - 1.3813] ms/pass  (6.38 us/read)
+;;   c-nowatch: p50 0.8641 [0.5844 - 1.1375] ms/pass  (6.13 us/read)
+;;   c-nosub: p50 0.3031 [0.2094 - 0.4469] ms/pass  (2.15 us/read)
+;;   c-noreaders: p50 0.9125 [0.5938 - 1.2875] ms/pass  (6.47 us/read)
+;;   c-nomap: p50 0.8531 [0.5844 - 1.1750] ms/pass  (6.05 us/read)
+;;   b-build: p50 0.7047 [0.4844 - 0.9437] ms/pass  (5.00 us/read)
+;;   c-null-twin: p50 0.8906 [0.6250 - 1.2375] ms/pass  (6.32 us/read)
+;;   c-null-curve: p50 0.9016 [0.6375 - 1.2813] ms/pass  (6.39 us/read)
+;; ==== PHASE B DELTAS (c-local minus ablation; floors) ====
+;;   copy fidelity: c-local/commit = 0.9393
+;;   NULL CONTROL (c-local - c-null): delta 0.0141 ms/pass (0.10 us/read, 1.5% of the baseline)
+;;     ^ true cost EXACTLY ZERO by construction — both arms are C-FULL. What it reads is this instrument's own error at this shape, and it is what the terms below are adjudicated against (rf2-3l6hf). It bounds no term's cost: a delta inside this spread is a term the window cannot SEE, which leaves its size open in both directions
+;;     ^ slot 1 against slot 2, on footprints that differ in BOTH mean position and shape. The two nulls below hold that zero and move the SLOT, which is what makes the offset's cause readable rather than only its size (rf2-lo7uy)
+;;   NULL CONTROL, position TWIN (c-local - c-null-twin): delta 0.0281 ms/pass (0.20 us/read, 3.1% of the baseline)
+;;     ^ same zero, and this arm's kept-sample position footprint IS c-local's, so ANY cost that is a function of sweep position cancels term by term. A reading here is error sweep position cannot explain; a reading of zero here beside a non-zero c-null puts the offset ON position
+;;   NULL CONTROL, equal MEAN position (c-local - c-null-curve): delta 0.0172 ms/pass (0.12 us/read, 1.9% of the baseline)
+;;     ^ same zero, c-local's MEAN position on a DIFFERENT footprint: a linear within-sweep drift cancels here, a curved one does not. Read the three nulls together — alike means the offset is not positional; c-null alone means it is; c-null and this one means it is and is not linear
+;;   activation-capture (c-local - c-noactivate): delta 0.0187 ms/pass (0.13 us/read, 2.0% of the baseline)
+;;     ^ a REAL term here, NOT a floor and not an arbiter: nothing activates on this UIx host, but the hook key is never published and so never cached, and this prices that lookup (rf2-tcffa, rf2-19usn). The capture itself is real only under the ratom family (rf2-lzpfj)
+;;   watch-wiring (c-local - c-nowatch): delta 0.0547 ms/pass (0.39 us/read, 6.0% of the baseline)
+;;   reaction-build+cache-insert (c-local - c-nosub): delta 0.6156 ms/pass (4.37 us/read, 67.0% of the baseline)
+;;   reader-membership (c-local - c-noreaders): delta 0.0062 ms/pass (0.04 us/read, 0.7% of the baseline)
+;;   cell-map-insert (c-local - c-nomap): delta 0.0656 ms/pass (0.47 us/read, 7.1% of the baseline)
+;;   b-build (build+compute, no in-window dispose): 0.7047 ms/pass (5.00 us/read)
+;; HICASSO read-profile-micro
+{:subscribe-once 7375.8865, :compute-sub 1382.9787, :handler-invoke 351.0638, :registrar-lookup 102.8369, :frame-state-value 421.9858, :resolution-wrap 351.0638, :cache-peek-miss 46.0993, :sub-key-mint 24.8227}
+;; ==== MICRO (ns/op over the page's own roster) ====
+;;   subscribe-once: 7375.9 ns
+;;   compute-sub: 1383.0 ns
+;;   handler-invoke: 351.1 ns
+;;   registrar-lookup: 102.8 ns
+;;   frame-state-value: 422.0 ns
+;;   resolution-wrap: 351.1 ns
+;;   cache-peek-miss: 46.1 ns
+;;   sub-key-mint: 24.8 ns
+;; HICASSO DONE
+;; ==== HICASSO RUNTIME ====
+;; chromium 147.0.7727.15 (playwright), :advanced, goog.DEBUG false
+;; ==== HICASSO read-profile-census ====
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; ==== HICASSO read-profile-arms ====
+{:ship {:n 60, :min 0.3125, :max 0.5375, :p50 0.3875, :p95 0.5006249994039536, :p99 0.5227499993145465}, :local {:n 60, :min 0.625, :max 1.3125, :p50 0.7625, :p95 1.0068749994039532, :p99 1.297749996483326}, :no-shell {:n 60, :min 0.5875, :max 1, :p50 0.725, :p95 0.9506250023841858, :p99 0.9778749947249888}, :probe {:n 60, :min 0.275, :max 0.4875, :p50 0.325, :p95 0.43875000029802314, :p99 0.4801249952614307}, :probe-fresh {:n 60, :min 0.1375, :max 0.2375, :p50 0.1625, :p95 0.22499999403953552, :p99 0.23749999701976776}, :floor {:n 60, :min 0.025, :max 0.1125, :p50 0.0375, :p95 0.05062501132488247, :p99 0.09037500053644168}, :warm {:n 60, :min 0.05, :max 0.1625, :p50 0.075, :p95 0.10062500834465023, :p99 0.15512500718235966}, :ctl2 {:n 60, :min 1.25, :max 1.9375, :p50 1.4312, :p95 1.8762499995529651, :p99 1.915375003516674}}
+;; ==== HICASSO read-profile-commit ====
+{:c-null-twin {:n 64, :min 0.625, :max 1.2375, :p50 0.8906, :p95 1.1351562492549419, :p99 1.2217499993368983}, :c-local {:n 64, :min 0.6875, :max 1.3656, :p50 0.9187, :p95 1.193125001899898, :p99 1.306562499143183}, :c-noreaders {:n 64, :min 0.5938, :max 1.2875, :p50 0.9125, :p95 1.1570312501862645, :p99 1.2382812477648257}, :c-noactivate {:n 64, :min 0.625, :max 1.3813, :p50 0.9, :p95 1.0995312513783575, :p99 1.2296562505513424}, :c-null {:n 64, :min 0.6031, :max 1.3094, :p50 0.9047, :p95 1.1332812493667004, :p99 1.2818124997243283}, :c-nowatch {:n 64, :min 0.5844, :max 1.1375, :p50 0.8641, :p95 1.0864062525331972, :p99 1.1256874987855554}, :commit {:n 64, :min 0.6281, :max 1.3781, :p50 0.9781, :p95 1.2856250010430812, :p99 1.3466250002756714}, :c-nomap {:n 64, :min 0.5844, :max 1.175, :p50 0.8531, :p95 1.1203124985098833, :p99 1.1730312502756715}, :b-build {:n 64, :min 0.4844, :max 0.9437, :p50 0.7047, :p95 0.9084374973550439, :p99 0.927999998703599}, :c-null-curve {:n 64, :min 0.6375, :max 1.2813, :p50 0.9016, :p95 1.1812499985098839, :p99 1.2733749981224536}, :c-nosub {:n 64, :min 0.2094, :max 0.4469, :p50 0.3031, :p95 0.4120312513783574, :p99 0.4291562489792704}}
+;; ==== HICASSO read-profile-commit-per-round ====
+{:c-null-twin [0.8641 0.8313 0.9391 0.8516 0.8562 1.0734 0.925 0.9594], :c-local [0.8578 0.8875 0.9297 0.8656 0.8406 1.0453 0.9859 0.9672], :c-noreaders [0.9703 0.7797 0.9141 0.8406 0.7813 1.0547 1.0328 0.9359], :c-noactivate [0.9141 0.7594 0.9281 0.8453 0.8016 1.0109 1.0141 0.9969], :c-null [0.9141 0.8859 0.7922 0.8438 0.8656 1.0313 0.9688 0.9438], :c-nowatch [0.7781 0.8438 0.8797 0.7984 0.7609 1.0281 0.9344 0.8906], :commit [0.9875 0.9031 1.0078 0.9125 0.9047 1.1297 1.1375 1.0406], :c-nomap [0.8609 0.7563 0.8422 0.7687 0.7562 1.0234 0.9359 0.9391], :b-build [0.6469 0.5953 0.7141 0.6531 0.6547 0.7531 0.7359 0.7562], :c-null-curve [0.9531 0.85 0.9406 0.8797 0.8609 1.0438 0.9484 0.9328], :c-nosub [0.3156 0.2937 0.3047 0.2781 0.2875 0.375 0.3219 0.3094]}
+;; ==== HICASSO read-profile-commit-per-round-deltas ====
+{:c-null [-0.0563 0.0016 0.1375 0.0218 -0.025 0.014 0.0171 0.0234], :c-noactivate [-0.0563 0.1281 0.0016 0.0203 0.039 0.0344 -0.0282 -0.0297], :c-nowatch [0.0797 0.0437 0.05 0.0672 0.0797 0.0172 0.0515 0.0766], :c-nosub [0.5422 0.5938 0.625 0.5875 0.5531 0.6703 0.664 0.6578], :c-noreaders [-0.1125 0.1078 0.0156 0.025 0.0593 -0.0094 -0.0469 0.0313], :c-nomap [-0.0031 0.1312 0.0875 0.0969 0.0844 0.0219 0.05 0.0281], :c-null-twin [-0.0063 0.0562 -0.0094 0.014 -0.0156 -0.0281 0.0609 0.0078], :c-null-curve [-0.0953 0.0375 -0.0109 -0.0141 -0.0203 0.0015 0.0375 0.0344]}
+;; ==== HICASSO read-profile-slot-plan ====
+[{:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :commit, :slot 0} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-local, :slot 1} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :c-null, :slot 2} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-noactivate, :slot 3} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-nowatch, :slot 4} {:positions [1 1 3 3 8 8 10 10], :mean-position 5.5, :id :c-nosub, :slot 5} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-noreaders, :slot 6} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-nomap, :slot 7} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :b-build, :slot 8} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-null-twin, :slot 9} {:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :c-null-curve, :slot 10}]
+;; ==== HICASSO read-profile-micro ====
+{:subscribe-once 7375.8865, :compute-sub 1382.9787, :handler-invoke 351.0638, :registrar-lookup 102.8369, :frame-state-value 421.9858, :resolution-wrap 351.0638, :cache-peek-miss 46.0993, :sub-key-mint 24.8227}
+[hicasso] ok

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj-retake/run3.txt
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj-retake/run3.txt
@@ -1,0 +1,259 @@
+[hicasso] cleared .shadow-cljs/builds/hicasso-bench — one build id, N arms (rf2-2rtt6.20)
+[hicasso] building :advanced bundle — re-frame.bench.hicasso.read-profile-app/-main -> out/hicasso-readprof
+[:hicasso-bench] Compiling ...
+[:hicasso-bench] Build completed. (187 files, 132 compiled, 0 warnings, 38.27s)
+shadow-cljs - config: <worktree>\implementation\shadow-cljs.edn   ;; ABSOLUTE PATH REDACTED — see README.md
+;; order-guard ok   the recorded 2.01x is REFUSED  — ratio 2.0125
+;; order-guard ok   the same study's uncontaminated slope passes  — forward 2830.7 / reversed 2842.8
+;; order-guard ok   a single-order result is refused as UNCHECKED  — only 1 stratum — the question was never asked
+;; order-guard ok   overlapping ranges are indistinguishable even 20% apart in median  — medians 1.2000x apart but the ranges OVERLAP — indistinguishable
+;; order-guard ok   the measured warm-up step is caught by PHASE, which no reversal would show  — phase: FIRST-THIRD reads 1.2633x LAST-THIRD, ranges disjoint
+;; order-guard ok   an arm that reads exactly zero in both strata is indistinguishable, not infinite  — within 10%
+;; order-guard ok   cyclic rotation gives every arm exactly ONE within-round predecessor  — rotation over 6 rounds: distinct predecessors per arm 1,1,1,1 (only the round seam ever differs, and that is one sample in R)
+;; order-guard ok   the reflecting schedule gives every arm TWO, in balance  — reflected: 2,2,2,2 predecessors per arm, largest modal share 50%
+;; order-guard ok   at k=2 an ALWAYS-reflecting schedule runs one order for ever and is UNCHECKED  — always-reflect over 6 rounds of 2 arms: 1 distinct order(s), predecessors per arm 2,1 — rotating a pair by one IS reversing it, so the two cancel
+;; order-guard ok   at k=2 slot-order alternates, and every arm gets TWO predecessors in balance  — slot-order: 2 distinct orders, predecessors per arm 3,2, largest modal share 50%
+;; order-guard ok   samples whose :position went NON-FINITE refuse instead of narrowing the question  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it
+;; order-guard ok   a present-but-NIL :position is the same loss, and recording NONE is still excused  — 18 of 24 samples have NO USABLE :position (nil, absent or non-finite) in a run that records them — the harness lost them, so this contrast is over the rest and the sample count above is not it — and a run offering no position at all is excused, not refused
+;; harvest OK — 1202 elements, 141 reads (141 distinct), from the real page's own entry
+;; ==== ARM-ORDER GUARD — read-profile phase A (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   ctl2  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              warm                     n=30  p50       9.1000  [8.3000–11.2000]
+;;              ship                     n=30  p50       9.3500  [8.3000–11.5000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       8.7000  [8.3000–10.1000]
+;;              FIRST-THIRD              n=20  p50       9.5000  [8.9000–11.5000]
+;;   floor  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              probe-fresh              n=30  p50       0.2000  [0.1000–0.5000]
+;;              warm                     n=30  p50       0.2000  [0.1000–0.4000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.2000  [0.1000–0.5000]
+;;              LAST-THIRD               n=20  p50       0.2000  [0.1000–0.4000]
+;;   local  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              no-shell                 n=30  p50       4.6000  [4.3000–5.8000]
+;;              ship                     n=30  p50       4.9000  [4.4000–6.7000]
+;;     [ok  ] by phase        medians 1.1333x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       4.5000  [4.3000–5.0000]
+;;              FIRST-THIRD              n=20  p50       5.1000  [4.5000–6.7000]
+;;   no-shell  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              local                    n=36  p50       4.4000  [4.1000–5.3000]
+;;              probe                    n=24  p50       4.6500  [4.2000–5.5000]
+;;     [ok  ] by phase        medians 1.1163x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       4.3000  [4.1000–5.5000]
+;;              FIRST-THIRD              n=20  p50       4.8000  [4.3000–5.4000]
+;;   probe  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              no-shell                 n=30  p50       2.1000  [1.9000–3.2000]
+;;              probe-fresh              n=30  p50       2.1000  [1.8000–2.7000]
+;;     [ok  ] by phase        medians 1.1750x apart but the ranges OVERLAP — indistinguishable
+;;              LAST-THIRD               n=20  p50       2.0000  [1.8000–2.6000]
+;;              FIRST-THIRD              n=20  p50       2.3500  [2.0000–3.2000]
+;;   probe-fresh  (60 samples)
+;;     [ok  ] by predecessor  medians 1.1000x apart but the ranges OVERLAP — indistinguishable
+;;              floor                    n=18  p50       1.0000  [0.9000–1.6000]
+;;              probe                    n=42  p50       1.1000  [0.9000–2.0000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       1.1000  [1.0000–1.6000]
+;;              LAST-THIRD               n=20  p50       1.1000  [0.9000–1.5000]
+;;   ship  (60 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              ctl2                     n=36  p50       2.4000  [2.1000–3.9000]
+;;              local                    n=24  p50       2.4000  [2.2000–3.2000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=20  p50       2.3000  [2.1000–2.8000]
+;;              FIRST-THIRD              n=20  p50       2.5000  [2.3000–3.0000]
+;;   warm  (60 samples)
+;;     [ok  ] by predecessor  medians 1.2500x apart but the ranges OVERLAP — indistinguishable
+;;              floor                    n=36  p50       0.4000  [0.3000–0.8000]
+;;              ctl2                     n=24  p50       0.5000  [0.4000–0.6000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=20  p50       0.5000  [0.4000–0.5000]
+;;              LAST-THIRD               n=20  p50       0.5000  [0.4000–0.8000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-census
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; HICASSO read-profile-arms
+{:ship {:n 60, :min 0.2625, :max 0.4875, :p50 0.3, :p95 0.375, :p99 0.43587500229477855}, :local {:n 60, :min 0.5375, :max 0.8375, :p50 0.6, :p95 0.7381249971687793, :p99 0.8153750006854533}, :no-shell {:n 60, :min 0.5125, :max 0.6875, :p50 0.5625, :p95 0.6624999947845935, :p99 0.680124998241663}, :probe {:n 60, :min 0.225, :max 0.4, :p50 0.2625, :p95 0.35125000849366184, :p99 0.3926250042021274}, :probe-fresh {:n 60, :min 0.1125, :max 0.25, :p50 0.1375, :p95 0.18812500014901157, :p99 0.22050000175833684}, :floor {:n 60, :min 0.0125, :max 0.0625, :p50 0.025, :p95 0.04999999701976776, :p99 0.055124998241662934}, :warm {:n 60, :min 0.0375, :max 0.1, :p50 0.0625, :p95 0.0749999888241291, :p99 0.08524999931454649}, :ctl2 {:n 60, :min 1.0375, :max 1.4375, :p50 1.1625, :p95 1.350624994188547, :p99 1.415375003516674}}
+;; ==== READ PROFILE, PHASE A (ms per 141-read pass; diagnostic in-page clock) ====
+;;   reads/pass 141  passes/sample 8  design 6x(4+10)
+;;   ship: p50 0.3000 [0.2625 - 0.4875] ms/pass  (2.13 us/read)
+;;   local: p50 0.6000 [0.5375 - 0.8375] ms/pass  (4.26 us/read)
+;;   no-shell: p50 0.5625 [0.5125 - 0.6875] ms/pass  (3.99 us/read)
+;;   probe: p50 0.2625 [0.2250 - 0.4000] ms/pass  (1.86 us/read)
+;;   probe-fresh: p50 0.1375 [0.1125 - 0.2500] ms/pass  (0.98 us/read)
+;;   floor: p50 0.0250 [0.0125 - 0.0625] ms/pass  (0.18 us/read)
+;;   warm: p50 0.0625 [0.0375 - 0.1000] ms/pass  (0.44 us/read)
+;;   ctl2: p50 1.1625 [1.0375 - 1.4375] ms/pass  (8.24 us/read)
+;; ==== PHASE A DELTAS (floors; stubs stated in the ns docstring) ====
+;;   copy fidelity: local/ship = 2.0000  (local is the FROZEN subscribe-once path)
+;;   the-hicasso-shell (local - no-shell): delta 0.0375 ms/pass (0.27 us/read, 6.2% of the baseline)
+;;   churn-vs-probe (local - probe, the candidate's saving): delta 0.3375 ms/pass (2.39 us/read, 56.2% of the baseline)
+;;   memo-economy (probe-fresh - probe): delta -0.1250 ms/pass (-0.89 us/read, -90.9% of the baseline)
+;;   probe-overhead (probe - floor): delta 0.2375 ms/pass (1.68 us/read, 90.5% of the baseline)
+;;   warm steady-state: 0.0625 ms/pass (0.44 us/read)
+;;   control: predicted 1.125x, measured 1.162x [1.037–1.438] — the range meets the prediction within ±25%
+;; ==== ARM-ORDER GUARD — read-profile phase B (in-page ms, diagnostic) ====
+;;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was measured; tolerance 10%, overlapping ranges are indistinguishable
+;;   b-build  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nomap                  n=40  p50      18.5000  [14.1000–23.8000]
+;;              c-null-twin              n=24  p50      18.7000  [14.5000–23.1000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      17.9000  [14.3000–23.8000]
+;;              LAST-THIRD               n=21  p50      19.4000  [15.4000–23.1000]
+;;   c-local  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null                   n=32  p50      23.9000  [19.1000–28.9000]
+;;              commit                   n=32  p50      24.9500  [18.9000–30.9000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      23.6000  [20.1000–28.7000]
+;;              FIRST-THIRD              n=21  p50      24.7000  [18.9000–30.9000]
+;;   c-noactivate  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null                   n=32  p50      23.2500  [18.1000–31.3000]
+;;              c-nowatch                n=32  p50      24.8000  [20.1000–29.5000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      23.1000  [18.1000–31.3000]
+;;              LAST-THIRD               n=21  p50      23.1000  [20.5000–29.5000]
+;;   c-nomap  (64 samples)
+;;     [ok  ] by predecessor  medians 1.1479x apart but the ranges OVERLAP — indistinguishable
+;;              c-noreaders              n=32  p50      19.9500  [16.6000–28.8000]
+;;              b-build                  n=32  p50      22.9000  [18.4000–29.0000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      20.5000  [18.2000–28.8000]
+;;              LAST-THIRD               n=21  p50      21.8000  [18.5000–29.0000]
+;;   c-noreaders  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-nomap                  n=24  p50      22.4000  [19.6000–31.7000]
+;;              c-nosub                  n=40  p50      23.5500  [18.2000–29.3000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      22.6000  [20.3000–29.3000]
+;;              LAST-THIRD               n=21  p50      23.4000  [19.8000–28.9000]
+;;   c-nosub  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noreaders              n=32  p50       7.9500  [6.6000–11.1000]
+;;              c-nowatch                n=32  p50       8.4000  [6.5000–10.5000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50       8.1000  [6.6000–10.5000]
+;;              LAST-THIRD               n=21  p50       8.3000  [6.7000–10.4000]
+;;   c-nowatch  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-noactivate             n=40  p50      22.8500  [18.3000–29.6000]
+;;              c-nosub                  n=24  p50      23.3500  [18.2000–31.4000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      22.7000  [18.8000–31.4000]
+;;              FIRST-THIRD              n=21  p50      23.2000  [18.2000–29.6000]
+;;   c-null  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null-twin              n= 7  p50      22.5000  [18.6000–23.8000]
+;;              c-local                  n=32  p50      22.9000  [18.6000–29.6000]
+;;              c-noactivate             n=24  p50      24.6000  [19.7000–28.3000]
+;;              <none>                   n= 1  p50      29.4000  [29.4000–29.4000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      22.6000  [19.1000–29.6000]
+;;              LAST-THIRD               n=21  p50      23.2000  [20.1000–28.3000]
+;;   c-null-curve  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null-twin              n=32  p50      23.0000  [19.9000–30.2000]
+;;              commit                   n=32  p50      24.4000  [19.0000–33.6000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      22.7000  [19.0000–30.2000]
+;;              LAST-THIRD               n=21  p50      24.7000  [20.2000–33.6000]
+;;   c-null-twin  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null-curve             n=32  p50      23.0500  [18.3000–28.9000]
+;;              b-build                  n=32  p50      25.0500  [21.1000–28.0000]
+;;     [ok  ] by phase        within 10%
+;;              LAST-THIRD               n=21  p50      23.5000  [19.8000–28.4000]
+;;              FIRST-THIRD              n=21  p50      23.7000  [18.3000–28.9000]
+;;   commit  (64 samples)
+;;     [ok  ] by predecessor  within 10%
+;;              c-null-curve             n=32  p50      25.1500  [20.8000–41.7000]
+;;              c-local                  n=32  p50      25.2000  [21.0000–30.9000]
+;;     [ok  ] by phase        within 10%
+;;              FIRST-THIRD              n=21  p50      24.9000  [21.2000–41.7000]
+;;              LAST-THIRD               n=21  p50      25.4000  [21.8000–30.9000]
+;;   VERDICT: reportable — no arm reads differently for its position in the plan
+;; HICASSO read-profile-commit
+{:c-null-twin {:n 64, :min 0.5719, :max 0.9031, :p50 0.7438, :p95 0.8718749992549419, :p99 0.8932812516018748}, :c-local {:n 64, :min 0.5906, :max 0.9656, :p50 0.7734, :p95 0.8940625013783573, :p99 0.9262499992549418}, :c-noreaders {:n 64, :min 0.5687, :max 0.9906, :p50 0.7234, :p95 0.8656250014901161, :p99 0.9433749996125697}, :c-noactivate {:n 64, :min 0.5656, :max 0.9781, :p50 0.7406, :p95 0.9132812485098838, :p99 0.972218749448657}, :c-null {:n 64, :min 0.5813, :max 0.925, :p50 0.7234, :p95 0.8829687487334013, :p99 0.9210624998062849}, :c-nowatch {:n 64, :min 0.5688, :max 0.9812, :p50 0.7234, :p95 0.8564062478020785, :p99 0.9635312497243285}, :commit {:n 64, :min 0.65, :max 1.3031, :p50 0.7859, :p95 0.9596875015646218, :p99 1.1121562505513423}, :c-nomap {:n 64, :min 0.5188, :max 0.9063, :p50 0.6937, :p95 0.8684375001117585, :p99 0.90625}, :b-build {:n 64, :min 0.4406, :max 0.7437, :p50 0.5797, :p95 0.70437499769032, :p99 0.7299687475711106}, :c-null-curve {:n 64, :min 0.5938, :max 1.05, :p50 0.7375, :p95 0.9101562509313225, :p99 0.9830624974891541}, :c-nosub {:n 64, :min 0.2031, :max 0.3469, :p50 0.2594, :p95 0.3240624990314245, :p99 0.3350625002756714}}
+;; HICASSO read-profile-commit-per-round
+{:c-null-twin [0.7875 0.7391 0.6609 0.7844 0.8031 0.8141 0.7156 0.725], :c-local [0.7578 0.7766 0.6391 0.8281 0.7828 0.7547 0.7562 0.7297], :c-noreaders [0.6937 0.7719 0.6969 0.7719 0.7172 0.7797 0.6859 0.7469], :c-noactivate [0.8344 0.7094 0.7062 0.8078 0.6734 0.7078 0.7188 0.7937], :c-null [0.7578 0.6875 0.6266 0.7953 0.7453 0.7297 0.7313 0.7125], :c-nowatch [0.7266 0.7344 0.6672 0.7328 0.7234 0.7766 0.6937 0.7125], :commit [0.7813 0.7859 0.7484 0.8406 0.7891 0.7891 0.7516 0.8047], :c-nomap [0.6859 0.7313 0.6156 0.7531 0.7125 0.7172 0.6812 0.6422], :b-build [0.5563 0.5469 0.5141 0.6062 0.5719 0.6172 0.5797 0.5906], :c-null-curve [0.7156 0.7937 0.6609 0.8047 0.6922 0.8125 0.7594 0.7297], :c-nosub [0.2531 0.2609 0.2375 0.2594 0.2672 0.2797 0.2188 0.2625]}
+;; HICASSO read-profile-commit-per-round-deltas
+{:c-null [0 0.0891 0.0125 0.0328 0.0375 0.025 0.0249 0.0172], :c-noactivate [-0.0766 0.0672 -0.0671 0.0203 0.1094 0.0469 0.0374 -0.064], :c-nowatch [0.0312 0.0422 -0.0281 0.0953 0.0594 -0.0219 0.0625 0.0172], :c-nosub [0.5047 0.5157 0.4016 0.5687 0.5156 0.475 0.5374 0.4672], :c-noreaders [0.0641 0.0047 -0.0578 0.0562 0.0656 -0.025 0.0703 -0.0172], :c-nomap [0.0719 0.0453 0.0235 0.075 0.0703 0.0375 0.075 0.0875], :c-null-twin [-0.0297 0.0375 -0.0218 0.0437 -0.0203 -0.0594 0.0406 0.0047], :c-null-curve [0.0422 -0.0171 -0.0218 0.0234 0.0906 -0.0578 -0.0032 0]}
+;; HICASSO read-profile-slot-plan
+[{:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :commit, :slot 0} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-local, :slot 1} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :c-null, :slot 2} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-noactivate, :slot 3} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-nowatch, :slot 4} {:positions [1 1 3 3 8 8 10 10], :mean-position 5.5, :id :c-nosub, :slot 5} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-noreaders, :slot 6} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-nomap, :slot 7} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :b-build, :slot 8} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-null-twin, :slot 9} {:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :c-null-curve, :slot 10}]
+;; ==== READ PROFILE, PHASE B — THE COMMIT HALF (ms per 141-key boundary commit) ====
+;;   design 8x(2+8)  window = 32 frames/commit each  kept = 64 samples/arm (EVEN — p50 is the mean of two middle clock readings)  grid = 0.001563 ms/commit
+;;   slot plan (each arm's kept-sample sweep positions — the schedule is indexed by SAMPLE, so this footprint repeats identically every round; rf2-lo7uy):
+;;     slot 0 commit: [2 3 4 5 6 7 8 9]  mean 5.500
+;;     slot 1 c-local: [1 3 4 5 6 7 8 10]  mean 5.500
+;;     slot 2 c-null: [0 0 2 4 5 6 7 9]  mean 4.125
+;;     slot 3 c-noactivate: [1 1 3 5 6 8 10 10]  mean 5.500
+;;     slot 4 c-nowatch: [0 0 2 2 4 7 9 9]  mean 4.125
+;;     slot 5 c-nosub: [1 1 3 3 8 8 10 10]  mean 5.500
+;;     slot 6 c-noreaders: [0 0 2 2 4 7 9 9]  mean 4.125
+;;     slot 7 c-nomap: [1 1 3 5 6 8 10 10]  mean 5.500
+;;     slot 8 b-build: [0 0 2 4 5 6 7 9]  mean 4.125
+;;     slot 9 c-null-twin: [1 3 4 5 6 7 8 10]  mean 5.500
+;;     slot 10 c-null-curve: [2 3 4 5 6 7 8 9]  mean 5.500
+;;   commit: p50 0.7859 [0.6500 - 1.3031] ms/pass  (5.57 us/read)
+;;   c-local: p50 0.7734 [0.5906 - 0.9656] ms/pass  (5.49 us/read)
+;;   c-null: p50 0.7234 [0.5813 - 0.9250] ms/pass  (5.13 us/read)
+;;   c-noactivate: p50 0.7406 [0.5656 - 0.9781] ms/pass  (5.25 us/read)
+;;   c-nowatch: p50 0.7234 [0.5688 - 0.9812] ms/pass  (5.13 us/read)
+;;   c-nosub: p50 0.2594 [0.2031 - 0.3469] ms/pass  (1.84 us/read)
+;;   c-noreaders: p50 0.7234 [0.5687 - 0.9906] ms/pass  (5.13 us/read)
+;;   c-nomap: p50 0.6937 [0.5188 - 0.9063] ms/pass  (4.92 us/read)
+;;   b-build: p50 0.5797 [0.4406 - 0.7437] ms/pass  (4.11 us/read)
+;;   c-null-twin: p50 0.7438 [0.5719 - 0.9031] ms/pass  (5.27 us/read)
+;;   c-null-curve: p50 0.7375 [0.5938 - 1.0500] ms/pass  (5.23 us/read)
+;; ==== PHASE B DELTAS (c-local minus ablation; floors) ====
+;;   copy fidelity: c-local/commit = 0.9841
+;;   NULL CONTROL (c-local - c-null): delta 0.0500 ms/pass (0.35 us/read, 6.5% of the baseline)
+;;     ^ true cost EXACTLY ZERO by construction — both arms are C-FULL. What it reads is this instrument's own error at this shape, and it is what the terms below are adjudicated against (rf2-3l6hf). It bounds no term's cost: a delta inside this spread is a term the window cannot SEE, which leaves its size open in both directions
+;;     ^ slot 1 against slot 2, on footprints that differ in BOTH mean position and shape. The two nulls below hold that zero and move the SLOT, which is what makes the offset's cause readable rather than only its size (rf2-lo7uy)
+;;   NULL CONTROL, position TWIN (c-local - c-null-twin): delta 0.0297 ms/pass (0.21 us/read, 3.8% of the baseline)
+;;     ^ same zero, and this arm's kept-sample position footprint IS c-local's, so ANY cost that is a function of sweep position cancels term by term. A reading here is error sweep position cannot explain; a reading of zero here beside a non-zero c-null puts the offset ON position
+;;   NULL CONTROL, equal MEAN position (c-local - c-null-curve): delta 0.0359 ms/pass (0.25 us/read, 4.6% of the baseline)
+;;     ^ same zero, c-local's MEAN position on a DIFFERENT footprint: a linear within-sweep drift cancels here, a curved one does not. Read the three nulls together — alike means the offset is not positional; c-null alone means it is; c-null and this one means it is and is not linear
+;;   activation-capture (c-local - c-noactivate): delta 0.0328 ms/pass (0.23 us/read, 4.2% of the baseline)
+;;     ^ a REAL term here, NOT a floor and not an arbiter: nothing activates on this UIx host, but the hook key is never published and so never cached, and this prices that lookup (rf2-tcffa, rf2-19usn). The capture itself is real only under the ratom family (rf2-lzpfj)
+;;   watch-wiring (c-local - c-nowatch): delta 0.0500 ms/pass (0.35 us/read, 6.5% of the baseline)
+;;   reaction-build+cache-insert (c-local - c-nosub): delta 0.5141 ms/pass (3.65 us/read, 66.5% of the baseline)
+;;   reader-membership (c-local - c-noreaders): delta 0.0500 ms/pass (0.35 us/read, 6.5% of the baseline)
+;;   cell-map-insert (c-local - c-nomap): delta 0.0797 ms/pass (0.57 us/read, 10.3% of the baseline)
+;;   b-build (build+compute, no in-window dispose): 0.5797 ms/pass (4.11 us/read)
+;; HICASSO read-profile-micro
+{:subscribe-once 6737.5887, :compute-sub 1028.3688, :handler-invoke 255.3191, :registrar-lookup 70.922, :frame-state-value 269.5035, :resolution-wrap 241.1348, :cache-peek-miss 24.8227, :sub-key-mint 21.2766}
+;; ==== MICRO (ns/op over the page's own roster) ====
+;;   subscribe-once: 6737.6 ns
+;;   compute-sub: 1028.4 ns
+;;   handler-invoke: 255.3 ns
+;;   registrar-lookup: 70.9 ns
+;;   frame-state-value: 269.5 ns
+;;   resolution-wrap: 241.1 ns
+;;   cache-peek-miss: 24.8 ns
+;;   sub-key-mint: 21.3 ns
+;; HICASSO DONE
+;; ==== HICASSO RUNTIME ====
+;; chromium 147.0.7727.15 (playwright), :advanced, goog.DEBUG false
+;; ==== HICASSO read-profile-census ====
+{:reads 141, :distinct 141, :by-sub-id {:conduit/your-feed? 1, :conduit/slugs 1, :conduit/tags 1, :conduit/article 69, :conduit/favorite-pending? 69}, :input-kinds {:db 141}}
+;; ==== HICASSO read-profile-arms ====
+{:ship {:n 60, :min 0.2625, :max 0.4875, :p50 0.3, :p95 0.375, :p99 0.43587500229477855}, :local {:n 60, :min 0.5375, :max 0.8375, :p50 0.6, :p95 0.7381249971687793, :p99 0.8153750006854533}, :no-shell {:n 60, :min 0.5125, :max 0.6875, :p50 0.5625, :p95 0.6624999947845935, :p99 0.680124998241663}, :probe {:n 60, :min 0.225, :max 0.4, :p50 0.2625, :p95 0.35125000849366184, :p99 0.3926250042021274}, :probe-fresh {:n 60, :min 0.1125, :max 0.25, :p50 0.1375, :p95 0.18812500014901157, :p99 0.22050000175833684}, :floor {:n 60, :min 0.0125, :max 0.0625, :p50 0.025, :p95 0.04999999701976776, :p99 0.055124998241662934}, :warm {:n 60, :min 0.0375, :max 0.1, :p50 0.0625, :p95 0.0749999888241291, :p99 0.08524999931454649}, :ctl2 {:n 60, :min 1.0375, :max 1.4375, :p50 1.1625, :p95 1.350624994188547, :p99 1.415375003516674}}
+;; ==== HICASSO read-profile-commit ====
+{:c-null-twin {:n 64, :min 0.5719, :max 0.9031, :p50 0.7438, :p95 0.8718749992549419, :p99 0.8932812516018748}, :c-local {:n 64, :min 0.5906, :max 0.9656, :p50 0.7734, :p95 0.8940625013783573, :p99 0.9262499992549418}, :c-noreaders {:n 64, :min 0.5687, :max 0.9906, :p50 0.7234, :p95 0.8656250014901161, :p99 0.9433749996125697}, :c-noactivate {:n 64, :min 0.5656, :max 0.9781, :p50 0.7406, :p95 0.9132812485098838, :p99 0.972218749448657}, :c-null {:n 64, :min 0.5813, :max 0.925, :p50 0.7234, :p95 0.8829687487334013, :p99 0.9210624998062849}, :c-nowatch {:n 64, :min 0.5688, :max 0.9812, :p50 0.7234, :p95 0.8564062478020785, :p99 0.9635312497243285}, :commit {:n 64, :min 0.65, :max 1.3031, :p50 0.7859, :p95 0.9596875015646218, :p99 1.1121562505513423}, :c-nomap {:n 64, :min 0.5188, :max 0.9063, :p50 0.6937, :p95 0.8684375001117585, :p99 0.90625}, :b-build {:n 64, :min 0.4406, :max 0.7437, :p50 0.5797, :p95 0.70437499769032, :p99 0.7299687475711106}, :c-null-curve {:n 64, :min 0.5938, :max 1.05, :p50 0.7375, :p95 0.9101562509313225, :p99 0.9830624974891541}, :c-nosub {:n 64, :min 0.2031, :max 0.3469, :p50 0.2594, :p95 0.3240624990314245, :p99 0.3350625002756714}}
+;; ==== HICASSO read-profile-commit-per-round ====
+{:c-null-twin [0.7875 0.7391 0.6609 0.7844 0.8031 0.8141 0.7156 0.725], :c-local [0.7578 0.7766 0.6391 0.8281 0.7828 0.7547 0.7562 0.7297], :c-noreaders [0.6937 0.7719 0.6969 0.7719 0.7172 0.7797 0.6859 0.7469], :c-noactivate [0.8344 0.7094 0.7062 0.8078 0.6734 0.7078 0.7188 0.7937], :c-null [0.7578 0.6875 0.6266 0.7953 0.7453 0.7297 0.7313 0.7125], :c-nowatch [0.7266 0.7344 0.6672 0.7328 0.7234 0.7766 0.6937 0.7125], :commit [0.7813 0.7859 0.7484 0.8406 0.7891 0.7891 0.7516 0.8047], :c-nomap [0.6859 0.7313 0.6156 0.7531 0.7125 0.7172 0.6812 0.6422], :b-build [0.5563 0.5469 0.5141 0.6062 0.5719 0.6172 0.5797 0.5906], :c-null-curve [0.7156 0.7937 0.6609 0.8047 0.6922 0.8125 0.7594 0.7297], :c-nosub [0.2531 0.2609 0.2375 0.2594 0.2672 0.2797 0.2188 0.2625]}
+;; ==== HICASSO read-profile-commit-per-round-deltas ====
+{:c-null [0 0.0891 0.0125 0.0328 0.0375 0.025 0.0249 0.0172], :c-noactivate [-0.0766 0.0672 -0.0671 0.0203 0.1094 0.0469 0.0374 -0.064], :c-nowatch [0.0312 0.0422 -0.0281 0.0953 0.0594 -0.0219 0.0625 0.0172], :c-nosub [0.5047 0.5157 0.4016 0.5687 0.5156 0.475 0.5374 0.4672], :c-noreaders [0.0641 0.0047 -0.0578 0.0562 0.0656 -0.025 0.0703 -0.0172], :c-nomap [0.0719 0.0453 0.0235 0.075 0.0703 0.0375 0.075 0.0875], :c-null-twin [-0.0297 0.0375 -0.0218 0.0437 -0.0203 -0.0594 0.0406 0.0047], :c-null-curve [0.0422 -0.0171 -0.0218 0.0234 0.0906 -0.0578 -0.0032 0]}
+;; ==== HICASSO read-profile-slot-plan ====
+[{:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :commit, :slot 0} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-local, :slot 1} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :c-null, :slot 2} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-noactivate, :slot 3} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-nowatch, :slot 4} {:positions [1 1 3 3 8 8 10 10], :mean-position 5.5, :id :c-nosub, :slot 5} {:positions [0 0 2 2 4 7 9 9], :mean-position 4.125, :id :c-noreaders, :slot 6} {:positions [1 1 3 5 6 8 10 10], :mean-position 5.5, :id :c-nomap, :slot 7} {:positions [0 0 2 4 5 6 7 9], :mean-position 4.125, :id :b-build, :slot 8} {:positions [1 3 4 5 6 7 8 10], :mean-position 5.5, :id :c-null-twin, :slot 9} {:positions [2 3 4 5 6 7 8 9], :mean-position 5.5, :id :c-null-curve, :slot 10}]
+;; ==== HICASSO read-profile-micro ====
+{:subscribe-once 6737.5887, :compute-sub 1028.3688, :handler-invoke 255.3191, :registrar-lookup 70.922, :frame-state-value 269.5035, :resolution-wrap 241.1348, :cache-peek-miss 24.8227, :sub-key-mint 21.2766}
+[hicasso] ok


### PR DESCRIPTION
Closes rf2-07rnj.

`rf2-07rnj`'s whole re-take of the commit-half decomposition. Every arm taken at
ONE commit, three runs, and the table republished with absolutes, deltas and
shares together. The `c-noindex` row retires and `c-noreaders` takes its place.

## The pre-registration, committed before run 1

The first commit on this branch is the pre-registration and it carries no
measurement. Fixed before the first run and held for every arm of every run:

- **Run count 3.** The window does not extend because an answer looks unsettled.
- **Window shape**: 32 frames/window, 8 × (2 + 8) = 64 kept samples per arm,
  eleven arms, grid 0.0015625 ms/commit — the instrument's own shape. No gate,
  tolerance or knob was touched, and the instrument **blob** hash was
  `c220a8c23c44ca6e19f9cab90528d932f271a784` before the window and after it.
- **The adjudication rule.** Each run's *null spread* is the interval its three
  nulls span (each null is `c-local` again, so each has a true cost of exactly
  zero by construction). A term resolves in a run iff its delta is strictly
  greater than that run's null maximum; it is RESOLVED iff it resolves in all
  three. Anything else publishes as UNRESOLVED with its readings quoted, **no
  bound and no share**.
- **Refusal is a result**, and the rig does not change mid-window.

## The result

All three runs certified: `exit 0` each, both arm-order guards reportable (38
`[ok]` verdicts, no refusal, per run), phase-A positive control passing on every
run, phase-B residue gate never firing.

| term (`c-local −` the arm) | run 1 | run 2 | run 3 | verdict |
|---|---|---|---|---|
| reaction build + cache insert | +0.6016 | +0.6156 | +0.5141 | **RESOLVED** — 67.4% / 67.0% / 66.5% of `c-local` |
| cell-map insert | +0.0672 | +0.0656 | +0.0797 | **RESOLVED** — 7.5% / 7.1% / 10.3% |
| watch wiring | +0.0594 | +0.0547 | +0.0500 | UNRESOLVED — clears in runs 1–2, exact tie in run 3 |
| activation capture | +0.0188 | +0.0187 | +0.0328 | UNRESOLVED on all three |
| reader membership | +0.0156 | +0.0062 | +0.0500 | UNRESOLVED on all three |

Null maxima: `+0.0297 / +0.0281 / +0.0500`.

**No bound is published for any unresolved term**, in either direction. A null
says what the instrument cannot see, never how large the invisible thing is.

Three points the page states rather than smooths over:

1. **The share column is the robust statistic and the absolutes are the fragile
   one.** `c-local` moved 19% across three runs of one binary in one session
   (0.7734–0.9187) while the reaction build's share of it moved 0.9 percentage
   points. That is the case for republishing as same-run shares, and the reason
   no absolute here should be lifted out and quoted as a property of the tree.
2. **Watch wiring is a near miss reported as a miss.** In run 3 it reads
   `+0.0500` against a null maximum of `+0.0500` — an exact tie, at a shape
   where `c-nowatch`, `c-noreaders` and `c-null` all returned the identical p50
   `0.7234`. Moving "strictly greater" to "greater or equal" for one cell after
   the data is in is precisely what the pre-registration exists to prevent.
3. **This supersedes the earlier windows' reading of which terms resolve, and
   the difference is the test rather than the tree.** The predecessors credited
   four of five terms on *sign stability across runs*; three nulls at three
   slots is a stricter test, and under it the activation capture and the watch
   wiring join reader membership.

## What this discharges

- The whole re-take: every arm at one commit, absolutes/deltas/shares
  republished together. §1's table is now the re-take's; the 2026-08-02 reading
  is kept immediately beneath it, labelled, because the window notes below cite
  its cells by value.
- The `0.8625` denominator obligation — every share now divides by a `c-local`
  measured in the same run as its numerator.
- The `c-noindex` row retires; `c-noreaders` takes its place, unresolved.
- §1's "Reading it" 4 carries the republished shares instead of 47.8% / 4.3%.
- §4's `51.9 / 5.6 / 3.7%` are marked superseded as a description of this tree.
- The sibling page's §6(b) and §9.2 are repointed at the re-take.

## Quality gates

Nominated by path. I did **not** run the fast-PR spine; I ran the targeted gates
directly, and `scripts/check_fast_pr_gap.py --list` reports 94 required checks
the spine does not run in any case — a fact about the spine, not a census of
what ran here.

| gate | exit | how the tree was verified |
|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | planted-fault, twice |
| `scripts/check_provenance_pins.py --changed-since origin/main` | **0** | planted-fault; **2 pages inspected**, 47 pins, 0 findings |
| `scripts/check_readme_links.py --ci` | **0** | the surface for the new dataset `README.md` under `implementation/` |

Every exit code above was captured by `echo $?` on the same command line in the
same shell as the runner, never read from a harness report.

**Neither python gate prints a root banner, so each was proved to read this
worktree by a planted fault**, restored and verified by `git hash-object --path`
against the committed object:

- `check_doc_slugs.py`, plant A — a broken link target inserted on a line I
  authored in `the-cold-read-mount-term.md`: **exit 1**, naming
  `no-such-page-rf2-07rnj.md` at that exact line. Restored to the identical
  **blob** hash `6c8d482ff6f5ec6124b7958cfed20de996143e15`.
- `check_doc_slugs.py`, plant B — the link target on a line I edited in
  `the-in-page-mount-term-decomposed.md`: **exit 1**, naming the plant.
  Restored to the identical **blob** hash
  `0a680b53a3f24c5f5bd38f9fc4f4c8a82224dad3`.
- `check_provenance_pins.py`, plant C — the base-commit pin in my own window
  note replaced by an unresolvable token: **exit 1**, `0fedcba98765
  [UNRESOLVABLE]` at that line. Restored to the identical **blob** hash
  `6c8d482ff6f5ec6124b7958cfed20de996143e15`.

**`mkdocs build --strict` is correctly NOT nominated**: `mkdocs.yml`'s
`exclude_docs` keeps `design/hicasso/` out of the site.

**No CLJS suite is nominated and none was run**, because no CLJS source changed:
the instrument's blob hash is identical at my base, at run time and at the
rebased base. The diff is documentation, a dataset directory and three
transcripts.

**Verified by hand, since nothing validates prose, tables, rendering or nav.**
Table column counts across every table in both edited pages and the dataset
README: `the-cold-read-mount-term.md` **17 tables / 133 rows / 0 mismatched**
(14 tables before — the three added are the republished decomposition, the null
table and the eleven-arm absolutes table); `the-in-page-mount-term-decomposed.md`
**10 tables / 91 rows / 0 mismatched** (no table row added or removed);
the dataset `README.md` **3 tables / 20 rows / 0 mismatched**. All anchors and
link targets in the edited regions checked by hand as well as by the gate.

**Gates re-run on the final base after the rebase.** PR #8619 merged during the
window; it touched `docs/design/hicasso/studio/README.md` and
`alloc_cluster_carrier.cjs`, neither of which this branch touches. The
merge-base (three-dot) diff was read before pushing: 22 deletions, every one of
them text this PR rewrites in place, and nothing that reverts a sibling's work.

## The box

Processor Queue Length and `% Processor Utility` sampled together, five samples
at 1 s, on a 24-core host, before the window and between every pair of runs.
Queue read all zeroes on four of six brackets. The two non-zero brackets
(`0,0,0,0,2` and `0,0,3,0,1`) were each taken seconds after a run's own teardown
and each settled to all zeroes on an immediate re-read; both are reported rather
than dismissed, because nothing proves the first reading of either pair was
teardown. **Nothing was sampled inside a run**, so the quietness claim is a
bracketing claim and nothing stronger.

## One thing deliberately not done

`docs/design/hicasso/studio/README.md` indexes 54 pages and has never carried a
row for `the-cold-read-mount-term.md`. That gap predates this bead and adding a
row to a 54-row shared index is not this window's job, so it is flagged rather
than taken.
