### PR TITLE
docs(method): tighten the three non-README mayor-method files

### DIFF
--- a/docs/the-mayor-method/bootstrap.md
+++ b/docs/the-mayor-method/bootstrap.md
@@ -5,9 +5,8 @@ terse on purpose; it assumes you have read [`README.md`](README.md).
 
 Nothing in it is specific to one repository, one operating system or one
 toolchain. The concrete values it needs — your tracker's commands, your gate
-command, your hot-zone file list, your worktree parent directory — are facts
-about *your* project, and they belong in your project's agent-instructions file
-where every agent already reads them.
+command, your hot-zone file list, your worktree parent directory — belong in
+your project's agent-instructions file, where every agent already reads them.
 
 ```text
 You are the mayor for this repository.
@@ -88,11 +87,9 @@ Acknowledge "I am the Mayor now".
 
 ## The hard-won list
 
-These are the parts that bite. Each cost real hours, and none is obvious up front.
-
-The [loops](loops.md) page carries the ones that belong to a particular loop — the
-merge criterion, reaping, routing a finding, tracker mechanics. What follows is
-everything else.
+These are the parts that bite, and none is obvious up front. The [loops](loops.md)
+page carries the ones belonging to a particular loop — the merge criterion, reaping,
+routing a finding, tracker mechanics; what follows is everything else.
 
 ### Local-green is not CI
 
@@ -103,13 +100,13 @@ drift-check. Merge on a CI rollup that is complete as well as clean.
 A failing *touched-surface* gate is never an override. Dispatch a fix worker to the
 same branch that runs the **actual** failing gate.
 
-The brief must be able to say **which** required checks the local gate omits — and
-say it by citing one path, not by re-listing them, because the required set moves.
-Make the project *derive* that list rather than document it. Two shapes make a
-hand-written list wrong within a week: a second or third required status context the
-local runner has no lane in at all, and a required check that is a **step inside a
-job the runner does run**, which no skipped-tier enumeration can see and which
-reports under that job's name however little it resembles what the step does.
+The brief must say **which** required checks the local gate omits, by citing one path
+rather than re-listing them, because the required set moves — so make the project
+*derive* that list rather than document it. Two shapes make a hand-written list wrong
+within a week: a required status context the local runner has no lane in at all, and a
+required check that is a **step inside a job the runner does run**, which no
+skipped-tier enumeration can see and which reports under that job's name however little
+it resembles what the step does.
 
 ### The exit code is the verdict; the summary is decoration
 
@@ -130,15 +127,14 @@ The same blindness has three more shapes:
   a mutating step, **verify the tree rather than the message.**
 
 **But "capture the runner's own exit code" settles WHOSE number to read, not that the
-number means pass** — and the two sound alike enough that a brief writes the second
+number means pass**, and the two sound alike enough that a brief writes the second
 meaning the first. For an instrument whose job is to REFUSE, a non-zero exit is the
-NORMAL case: one measurement runner documents a non-zero expected exit, all twenty runs
-of a window exited the same way, nineteen were admissible, and the twentieth failed its
-positive CONTROL and read low while exiting exactly like the good ones. Admissibility
-lived in the artefact the run produced, not in its status. So a brief for such a gate
-names the record's own admissibility criteria and states what the expected exit code IS,
-so the worker can tell a routine refusal from a crash — and never says "the exit code is
-the verdict" for a runner that refuses by design.
+NORMAL case, and admissibility lives in the artefact the run produced rather than in its
+status: one window's twenty runs all exited identically, nineteen admissible and the
+twentieth failing its positive CONTROL. So a brief for such a gate names the record's own
+admissibility criteria and states what the expected exit code IS, so the worker can tell a
+routine refusal from a crash — and never says "the exit code is the verdict" for a runner
+that refuses by design.
 
 ### Concurrent workers share the machine's temp directory
 
@@ -210,16 +206,12 @@ dispatching. **A verified "nothing to do" is a good outcome; an assumed one is n
 
 ### The mayor's briefs are the main source of error
 
-This is the finding most worth knowing at the start.
-
-Across one sustained session, workers corrected the mayor's stated premises about
-twenty times. Not on style — on facts the mayor asserted and had not checked: counts
-that had drifted between filing and dispatch; a file asserted to carry a claim it did
-not carry; a defect described as fail-open that measured as fail-slow; a defect
-described as silent whose error was raised loudly at source and discarded one layer
-up; a remedy that was unsatisfiable for the same reason as the bug it fixed.
-
-Workers caught every one and nothing reached the trunk. But each cost a full worker
+This is the finding most worth knowing at the start. Across one sustained session,
+workers corrected the mayor's stated premises about twenty times — not on style, but on
+facts the mayor asserted and had not checked: counts drifted between filing and
+dispatch, a file asserted to carry a claim it did not, a defect called fail-open that
+measured as fail-slow, a remedy unsatisfiable for the same reason as the bug it fixed.
+Workers caught every one and nothing reached the trunk, but each cost a full worker
 cycle, and together they cost more than any worker-side failure in the same period.
 
 So "guard the mayor's context, dispatch bounded work" is necessary and not sufficient.
@@ -255,42 +247,35 @@ sentence, a worker handed a task that should not exist will invent one that does
 **The work**, with a control that proves it.
 
 The best refusal seen here came with measurement rather than argument. An item claimed a
-CI timeout was too tight. The worker sampled 183 runs of that step — median 13 seconds
-against a 300-second cap — then found the actual cause was a mirror serving 21 MB at
-52 kB/s while the same job had fetched 11 MB at 7.8 MB/s seconds earlier. It closed the
-item and left a comment in the workflow so nobody re-derives it. A refusal on principle
-can be argued with; that one cannot.
+CI timeout was too tight; the worker sampled 183 runs of that step — median 13 seconds
+against a 300-second cap — found the real cause was a slow mirror, closed the item, and
+left a comment in the workflow so nobody re-derives it. A refusal on principle can be
+argued with; that one cannot.
 
 ### Defect classes worth naming
 
-These recurred often enough that naming them helps you spot the next one.
-
 **The control that cannot catch its own case.** A scanner missed every forbidden import
-after the first. Its permanent test planted the forbidden import as the first and only
-entry, so the test exercised exactly the path that worked. The gate had been green about
-a class it did not cover, and the proof of coverage was the blind spot.
-
-Apply the generalisation deliberately: **ask of every control whether it is constructed so
-that it avoids the case it exists to catch.** The worker who found the above asked that
-question of every other control in the same file and found two more, one of which had no
-control at all.
+after the first; its permanent test planted one as the first and only entry, so the test
+exercised exactly the path that worked. The proof of coverage was the blind spot. **Ask of
+every control whether it is constructed so that it avoids the case it exists to catch** —
+the worker who found that one asked it of every other control in the same file and found
+two more, one of which had no control at all.
 
 **The hollow gate.** A test that proves something by observing the absence of a symptom,
-where the same absence occurs for unrelated reasons. There is a mechanical test for it:
-**delete the signal but keep the fault.** If the test stays green, it was proving nothing.
-One worker did exactly this and showed that three symptoms its item was built on — no
-requests, idle status, no output — all stayed green when only the error report was removed.
+where the same absence occurs for unrelated reasons. The mechanical test: **delete the
+signal but keep the fault.** If the test stays green, it was proving nothing — one worker
+did exactly that and showed three symptoms its item was built on all stayed green when only
+the error report was removed.
 
-**Replace a hollow control; do not patch it.** Every one found here was replaced, because
-patching one produces a second thing that looks like a control and is not — and the next
-reader trusts it harder for having a history of being fixed.
+**Replace a hollow control; do not patch it.** Patching produces a second thing that looks
+like a control and is not, and the next reader trusts it harder for having a history of
+being fixed.
 
 **Measured honestly, then interpreted too generously.** A worker predicted a focus cycle of
-four elements, measured five, and recorded what it measured. That was right. It then
-described the extra element as acceptable — but the extra element was the document body, and
-the feature is a focus trap. Measuring correctly and concluding wrongly is a distinct failure
-from measuring wrongly, and it is harder to see, because the evidence in the report is
-accurate.
+four elements, measured five, recorded what it measured — right so far — then called the
+extra element acceptable, when it was the document body and the feature is a focus trap.
+Measuring correctly and concluding wrongly is harder to see than measuring wrongly, because
+the evidence in the report is accurate.
 
 **The artefact a consumer copies still teaches the broken form.** Code fixed; the example,
 recipe or guide not. Seen three times. When reviewing a fix, ask what a reader copies, and
@@ -311,19 +296,17 @@ mistaken for one that was wrong.
 
 ### Two tensions the method does not resolve
 
-Naming them is more useful than pretending they are solved.
-
 **Keeping workers busy starves work that needs the machine quiet.** Timing measurements, or
-anything contended, cannot run while several workers compile. No amount of prioritisation fixes
-it, because the fleet is the constraint. What worked: notice when the only remaining work is
-the exclusive kind, then deliberately drain and take it. Make that a decision you announce, not
+anything contended, cannot run while several workers compile, and no amount of prioritisation
+fixes it because the fleet is the constraint. What worked: notice when the only remaining work
+is the exclusive kind, then deliberately drain and take it — **a decision you announce**, not
 something that happens by default.
 
-**"Reap only on the worker's own report" leaves residue.** The rule is correct — every proxy for
+**"Reap only on the worker's own report" leaves residue.** The rule is correct: every proxy for
 "this worker is finished" has killed a live run. But an agent that vanishes will never report,
-and its worktree becomes unreapable. There is a second cost too: a worker can need its tree
-*after* it reports, because its change hits a conflict and needs a rebase. Nothing is lost when
-that happens, because the commits were pushed, but the worker has to rebuild its tree first.
+and its worktree becomes unreapable. A second cost too: a worker can need its tree *after* it
+reports, because its change hits a conflict and needs a rebase — nothing is lost, since the
+commits were pushed, but it has to rebuild the tree first.
 
 Keep the rule. Let the residue accumulate, and clear it on explicit operator authority rather
 than inventing another proxy.
@@ -333,18 +316,16 @@ than inventing another proxy.
 The mayor surfaces decisions; the operator decides; the mayor records the decision on the item
 so future workers inherit it.
 
-One mayor got the split wrong in one direction: it was holding nine items "for the operator" when
-three were genuinely operator calls. The rest were decisions the project's stated stance already
-answered, and it was being deferential rather than useful. When you present a list of held items,
-sort them first — and it is fair for the operator to ask which of them actually need them.
-
-Two refinements that worked:
+One mayor held nine items "for the operator" when three were genuinely operator calls; the rest
+were already answered by the project's stated stance, and it was being deferential rather than
+useful. **Sort a list of held items before you present it**, and expect the operator to ask which
+of them actually need them.
 
 **Separate "needs a decision" from "needs work under a decision."** Many items are mostly the
 second. Ship the part that is true under every option, and leave the item open with the choice
-stated. Progress without pre-empting the operator.
+stated: progress without pre-empting the operator.
 
 **Record what a held decision is costing.** One held item caused a worker to read a correct,
 catalogued error as silence, which caused a mis-filed item, which cost another worker a cycle to
-refute. That chain belongs on the item. It is the difference between "still waiting" and "here is
-what waiting cost."
+refute. That chain belongs on the item — it is the difference between "still waiting" and "here
+is what waiting cost."

--- a/docs/the-mayor-method/bootstrap.md
+++ b/docs/the-mayor-method/bootstrap.md
@@ -75,10 +75,11 @@ and paste that block verbatim into every dispatch preamble. Skip the interview i
 the operator's opening message already names the stance; restate it as a one-line
 confirmation instead.
 
-SET UP THE LOOPS. The five loops are in `loops.md`. Codify each as a command file
-in this repository so each is one invocation and one source of truth, rather than
-re-pasted prose. When a method rule changes, re-read the matching command file — a
-link checker catches renamed files, not semantic drift.
+SET UP THE LOOPS. The five loops are in `loops.md`. If you codify each as a command
+file so it is one invocation, keep that file a THIN pointer into `loops.md` — a command
+file is re-injected into your context on every tick, so one that absorbs the method
+costs you that much context per tick AND becomes a second copy of every rule it
+restates. Two copies disagree within days, and the loop follows the file that runs.
 
 Acknowledge "I am the Mayor now".
 ```
@@ -87,63 +88,27 @@ Acknowledge "I am the Mayor now".
 
 ## The hard-won list
 
-These are the parts that bite, and none is obvious up front. The [loops](loops.md)
-page carries the ones belonging to a particular loop — the merge criterion, reaping,
-routing a finding, tracker mechanics; what follows is everything else.
-
-### Local-green is not CI
-
-A worker's "all gates pass locally" usually means "the subset I ran", and the red CI
-gate is one its local run skipped — an integration or live test, a linter, a
-drift-check. Merge on a CI rollup that is complete as well as clean.
-
-A failing *touched-surface* gate is never an override. Dispatch a fix worker to the
-same branch that runs the **actual** failing gate.
-
-The brief must say **which** required checks the local gate omits, by citing one path
-rather than re-listing them, because the required set moves — so make the project
-*derive* that list rather than document it. Two shapes make a hand-written list wrong
-within a week: a required status context the local runner has no lane in at all, and a
-required check that is a **step inside a job the runner does run**, which no
-skipped-tier enumeration can see and which reports under that job's name however little
-it resembles what the step does.
+These are the parts that bite, and none is obvious up front. Anything belonging to a
+particular loop lives in [loops.md](loops.md) and anything belonging to a brief lives in
+[dispatch-prompt-template.md](dispatch-prompt-template.md); what follows is everything else.
+The block above may restate a rule from either, because it has to stand alone as a prompt —
+this list may not.
 
 ### The exit code is the verdict; the summary is decoration
 
-Piping a gate into a filter returns the *pipe's* status, not the runner's, so a
-worker reads "0 failures" and reports green on a failed run. Require capture to a
-file, an explicit echo of the exit code, and that number in the report.
+The mechanics of capturing it belong to a brief and are in
+[dispatch-prompt-template.md](dispatch-prompt-template.md). What belongs here is the
+limit of the rule.
 
-The same blindness has three more shapes:
-
-* **A command's own failure and a later reassuring line land in one buffer.** A
-  failed fetch followed by "Already up to date" looks like a quiet no-op. Check the
-  exit of the step that fetched, not the summary of the step after it.
-* **The harness reports an exit code of its own, and it can be a trailing filter's.**
-  A run whose real status was 1 surfaced as 0 because a filter sat on the end of the
-  command line. Run each gate alone, with nothing appended.
-* **A command can succeed and still not do the thing.** A fast-forward pull printed
-  `Updating <old>..<new>` twice in one session while the head did not move. So after
-  a mutating step, **verify the tree rather than the message.**
-
-**But "capture the runner's own exit code" settles WHOSE number to read, not that the
-number means pass**, and the two sound alike enough that a brief writes the second
-meaning the first. For an instrument whose job is to REFUSE, a non-zero exit is the
-NORMAL case, and admissibility lives in the artefact the run produced rather than in its
-status: one window's twenty runs all exited identically, nineteen admissible and the
-twentieth failing its positive CONTROL. So a brief for such a gate names the record's own
+**"Capture the runner's own exit code" settles WHOSE number to read, not that the number
+means pass**, and the two sound alike enough that a brief writes the second meaning the
+first. For an instrument whose job is to REFUSE, a non-zero exit is the NORMAL case, and
+admissibility lives in the artefact the run produced rather than in its status: one
+window's twenty runs all exited identically, nineteen admissible and the twentieth
+failing its positive CONTROL. So a brief for such a gate names the record's own
 admissibility criteria and states what the expected exit code IS, so the worker can tell a
 routine refusal from a crash — and never says "the exit code is the verdict" for a runner
 that refuses by design.
-
-### Concurrent workers share the machine's temp directory
-
-Two workers writing the same log path overwrite each other, and the loser reads a
-green belonging to someone else's run — plausible numbers, wrong code. This defeats
-the rule above, because the captured exit code is also theirs.
-
-Use worktree-local paths, name every artefact for the worktree **and** the attempt,
-and have workers confirm a log is their own before believing it.
 
 ### A test pinning current broken behaviour, and the fix for it, are mutually invalidating
 
@@ -163,11 +128,10 @@ contradicts a live symptom.
 
 ### Never let a worker stash
 
-Stashes are repository-global. They surface in sibling worktrees and cross-contaminate
-them. Put a no-stash line in every dispatch; workers commit to their branch instead.
-
-Workers violate this rule repeatedly even when told, so pair the ban with the
-alternative — commit first, then rebase — and say why.
+Stashes are repository-global: they surface in sibling worktrees and contaminate them.
+Workers violate this rule repeatedly even when told, so **pair the ban with the
+alternative** — commit first, then rebase — and say why. A prohibition with no named
+substitute is the one workers route around.
 
 ### The worktree guard can be fooled
 
@@ -188,9 +152,7 @@ the item with the fix written out, and dispatch it.
 Workers die mid-run for reasons unrelated to their work. Put "commit and push as you
 go, not at the end" in every brief, with the reason.
 
-The mayor may push a worker's existing commits, which is pure durability. Never build
-a commit from someone else's uncommitted work — only that worker knows whether it
-forms a coherent change.
+The mayor may push a worker's existing commits, which is pure durability.
 
 ### A reviewer's "P1" can be out of scope
 
@@ -282,10 +244,7 @@ recipe or guide not. Seen three times. When reviewing a fix, ask what a reader c
 whether that changed.
 
 **The unsatisfiable instruction.** A rule that cannot be obeyed on some path — "every gate
-prints X" when a third of them do not. Workers facing one do not stop; they improvise, and
-the improvisation varies. **When a rule says *every*, check the quantifier.**
-
-Correcting one of these often surfaces something useful. Scoping "every gate derives its root
+prints X" when a third of them do not. Correcting one often surfaces something useful. Scoping "every gate derives its root
 from the script path" to the gates that actually do revealed that the others resolve against
 the working directory, which changes what a worker must do.
 
@@ -302,14 +261,10 @@ fixes it because the fleet is the constraint. What worked: notice when the only 
 is the exclusive kind, then deliberately drain and take it — **a decision you announce**, not
 something that happens by default.
 
-**"Reap only on the worker's own report" leaves residue.** The rule is correct: every proxy for
-"this worker is finished" has killed a live run. But an agent that vanishes will never report,
-and its worktree becomes unreapable. A second cost too: a worker can need its tree *after* it
-reports, because its change hits a conflict and needs a rebase — nothing is lost, since the
-commits were pushed, but it has to rebuild the tree first.
-
-Keep the rule. Let the residue accumulate, and clear it on explicit operator authority rather
-than inventing another proxy.
+**The reaping rule is correct and it leaks.** An agent that vanishes never reports, so its
+worktree can never be reaped, and the residue grows without bound. No proxy fixes this — that
+is the point of the rule — so the residue is a standing cost the operator clears on request,
+not a defect to engineer away.
 
 ### Deciding what is actually the operator's
 

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -428,11 +428,10 @@ byte-identical diff; once a merge landed mid-gate, and the remainder took a whol
 review cycle to carry. Neither merge was wrong on the criterion — both were green on every clause.
 
 **Use the host's own draft flag rather than a rule to remember.** Merge commands refuse a draft, so the
-interlock is enforced where it cannot be forgotten, which is the property the no-stash rule and a
-mayor-side commit guard both have and the reason they hold. The rejected alternative was to have the
-mayor check worker liveness before every merge: it works, but it must be remembered on every merge
-forever, and it re-introduces exactly the worktree-activity sweep the merge loop deliberately does not
-do.
+interlock is enforced where it cannot be forgotten — the property the no-stash rule and a mayor-side
+commit guard both have, and the reason they hold. The rejected alternative, having the mayor check
+worker liveness before every merge, works but must be remembered on every merge forever, and it
+re-introduces exactly the worktree-activity sweep the merge loop deliberately does not do.
 
 ---
 

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -624,228 +624,144 @@ A skipped gate needs a one-line reason in the change body. A silent skip fails r
 
 ## Quality gates — how a gate is run
 
-Paste this section verbatim too, on the same footing as the boundary block. The gate menu settles *which*
-gate runs; only this settles *how*. **The paste begins at the next paragraph and runs to the end of the
-section** — starting at the first imperative instead drops the paragraphs that scope the block.
+The gate menu settles *which* gate runs; this settles *how*. Scope it to the gate the brief
+names: the wedge paragraph assumes a gate heavy enough that two cannot coexist, and the
+planted-fault paragraphs assume a gate in which a safe, bounded, discriminating fault can be
+planted at a line the worker is already editing. A cheap link validator is *plantable* without
+being *heavyweight* — two different questions. Everything else applies to any dispatch that runs
+anything at all.
 
-**This section is scoped, and the axis is the NOMINATED GATE'S CAPABILITIES — not prose versus code.** Read each
-part against the gate the brief actually names. The wedge-recovery paragraph assumes a *heavyweight* gate, one
-heavy enough that two cannot coexist on the machine; a cheap checker never wedges, and for it that paragraph
-describes nothing. The planted-fault half of the tree-verification rule, the scoped-plant paragraph and the
-restore-hashing cautions assume something far more common: a gate in which a safe, bounded, DISCRIMINATING fault
-can be planted at a line the worker is already editing, proving that the nominated gate reaches the edited
-surface. **Wherever such a plant exists those parts apply and are pasted** — emphatically including the cheap
-validators that run over a documentation edit, which red on a single broken link target and go green again on
-restore. **A cheap prose gate is a *plantable* gate; what it is not is a *heavyweight* one**, and those are two
-different questions.
+**Split a compound gate before you reach for detaching.** A script chaining two phases often
+splits into two runs that each fit inside the harness ceiling, which keeps every verdict in the
+foreground and removes the strand risk rather than managing it. Read what the script runs before
+concluding it cannot be foregrounded.
 
-**That axis is a correction, and the evidence for it came from the dispatch that carried the old one.** An
-earlier version scoped by the shape of the deliverable, calling a documentation correction ungateable, while the
-worker carrying it had already planted a broken link target, watched the validator red on exactly that
-worktree-only fault, restored, and hashed the restore against the committed object. Read literally, that rule
-would have stripped the planted-fault and restore-hash clauses from precisely the brief where they did the work.
+**Where it genuinely does not split, detaching is correct — ending the turn is the defect.**
+Detach, then poll both the log and the exit-code file in a bounded loop *within the same turn*.
+Poll both: the log shows progress, the exit file carries the verdict and appears only once the run
+is over. A worker that ends its turn waiting for a completion notification strands — the
+notification does not always arrive, and a turn that has ended has nothing left to wake. Every
+such worker was recovered intact the moment somebody asked it for a status. Word this as the
+sanctioned path, not as a concession; a worker who thinks it has erred reads for how to atone and
+straight past the instruction that would save it.
 
-**The rest is unconditional for any dispatch that runs anything at all**, and is pasted verbatim whatever the
-deliverable: the detach-and-poll sanction, the never-pipe rule, the capture-your-own-exit-code rule, and the
-artefact-naming rule. A one-line documentation edit still runs a link validator, and all four bite on it.
+**A gate heavy enough that two cannot coexist WEDGES rather than fails** — no progress, no exit
+file, no error, from a run that was healthy a minute ago. This is contention for the MACHINE, so
+per-attempt naming does nothing for it and every same-file rule around it misses it. To recover,
+correlate your own build artefact's modification time against the candidate runs' start times and
+**kill only the one you can show is yours**; a peer's run recovers by itself once memory frees.
 
-**Say what a brief whose gate affords no plant does instead, or that gets improvised too** — the improvisation
-was measured on the *enforcing* side, where five dispatches in one session carried five different lengths of
-this one block, nobody having decided to drop anything. Three cases, and they are not the same. Where NO
-automated gate covers the surface, the wording is settled under *Quality gates — which gate* above. Where a gate
-DOES cover the surface but affords no safe discriminating plant, that gate still runs and the unconditional four
-still bite; what lapses is only the planted-fault route to proving which tree was read, and which route is left
-turns on the gate's *other* capability. If it prints its root, the brief nominates the root-banner route and the
-worker says which one it used. If it prints nothing either, neither route is on offer — silent AND unplantable is
-a real pairing rather than a corner, since many gates print nothing — and the brief says exactly that: no
-discriminating tree-verification route here, or the concrete bounded mechanism the gate does afford in place of
-one. Nominating a route the gate cannot supply is the failure recorded further down, where an earlier rule
-claimed every gate printed a banner and the workers who met it improvised. Point at the settled wording rather
-than restating it, and **scope the block rather than shortening it** — dropping the sanction along with the
-parts that do not apply is the same failure by a shorter road.
+**Read the clock before killing anything on elapsed time.** Ask the system for the time rather
+than inferring it from how much has happened. This fails in both directions — one worker killed a
+healthy run believing seventeen minutes had passed when it had been two, and the loop watching
+from outside reads a worker that has just rebased as stalled.
 
-**But first, check whether the gate is COMPOUND — a script that chains two phases often splits into two runs
-that each fit.** This is strictly better than detaching, because it keeps every verdict in the foreground and
-removes the strand risk rather than managing it. A worker here split a build-and-run script that measured past
-the ceiling and both halves finished well inside it; the same day two workers detached the whole thing instead,
-both died at the cap, and one left a build cache so damaged that the next attempt failed with twenty-two
-cascading errors naming files it had never touched. **Read what the script actually runs before deciding it
-cannot be foregrounded.**
+**Invoke a backgrounded gate by its ABSOLUTE path**, for two independent reasons. A script that
+derives its repository root from its own invocation path gets a relative one back; and an
+interpreter handed a relative script path resolves it against the working directory first, so a
+wrong directory hands it a *sibling worktree's copy*, which then pins faithfully to the sibling's
+root. One run did exactly that inside another live worker's checkout and reported the resulting
+verdict as its own. A complete, internally consistent run about somebody else's work is far harder
+to catch than a broken one.
 
-**Where it genuinely does not split, detaching is CORRECT; ending the turn afterwards is the defect.** Where a
-harness hard-kills a foreground command well below what the full gate needs, "foreground, to completion" is not
-on offer however the brief is worded. Foreground a gate that fits inside the ceiling; **detach one that does
-not, then poll both its log and its exit-code file in a bounded loop, within the same turn.** Poll both, because
-they answer different questions: the log shows progress, while the exit file carries the verdict and appears
-only once the run is actually over.
+**Verify which tree the gate actually read**, by whichever of two routes it affords:
 
-What strands a worker is ending the turn instead, waiting for a completion notification — it does not always
-arrive, and a turn that has ended has nothing left to wake. The worker then reports "standing by" through idle
-tick after idle tick while its branch sits unmoved: four such incidents in a single day, then three more inside
-one hour, every one recovered intact the moment somebody asked it for a status.
+* Where it prints its root, check that line names your worktree. That check, not any naming rule,
+  is what has caught the observed cross-worktree collisions.
+* Where it prints nothing — and many will not — the proof is **the red from a planted fault**.
+  Plant at a line you are already editing and check the failure names what you planted. Do not
+  expect the reported path to name your worktree; a repository-relative path cannot tell two
+  checkouts apart. **The discrimination is the red itself**: the fault exists only in your tree,
+  so a run that had wandered into a sibling's would have come back green.
 
-**Do not word this grudgingly.** Two of that last three *apologised for detaching*, which is exactly why the
-polling instruction had not landed: a worker who believes it has already erred reads for how to atone rather
-than for what to do next, and reads straight past the instruction that would have saved it.
-
-**A gate heavy enough that two cannot coexist WEDGES rather than fails.** Two workers in one wave ran the same
-heavyweight suite concurrently, each holding several gigabytes, and both hung — neither returned, and neither
-reported a failure. Nothing else here catches that: every rule around it protects two workers writing the same
-*file*, and both of these had correct, distinct names throughout. This is contention for the MACHINE, and
-per-attempt naming does nothing for it. Recognise it rather than diagnosing it as a bug in your own change — no
-progress in the log, no exit file, from a run that was healthy a minute ago. To recover, correlate your own
-build artefact's modification time against the start times of the candidate runs, and **kill only the one you
-can show is yours**: a peer's run recovers by itself once memory frees, and killing it costs somebody else a
-full gate.
-
-**Read the clock before you kill anything on elapsed time.** That same worker briefly killed a healthy run
-because it believed seventeen minutes had passed when about two had. Ask the system for the time; do not infer
-it from how much has happened. Elapsed-time and count-based inference about a running process fail the same
-way, and this one runs in both directions — the loop watching from outside hits it too, reading a worker that
-has just rebased as stalled.
-
-**Invoke a backgrounded gate by its ABSOLUTE path.** This holds by two different mechanisms. A script that
-derives its repository root from its own invocation path gets a relative one when the invocation is relative.
-And an interpreter handed a relative script path resolves *that* against the working directory first, so a wrong
-directory hands it a sibling worktree's copy of the script, which then pins faithfully to the sibling's root.
-Either way, a `cd` followed by a relative invocation does not reliably keep that `cd` once backgrounded. One run
-did exactly that inside *another live worker's* checkout: it took that tree as its gate root, its diff root and
-its classifier input, then reported the resulting verdict as its own. **A complete, internally consistent run
-about somebody else's work is far harder to catch than a broken one.**
-
-**Verify which tree a gate actually read, by whichever of two routes it affords.**
-
-* Where a gate prints its root, check that line names your worktree. That check, not any naming rule, is what
-  has actually caught the observed cross-worktree collisions.
-* Where a gate prints nothing — and many will not — the proof is **the red from a planted fault.** Plant it at
-  a line you are already editing, run the gate red, and check the failure names what you planted. Do not expect
-  the reported path to name your worktree; a repository-relative path cannot tell two checkouts apart. **The
-  discrimination is the red itself**: the fault exists only in your tree, so a run that had wandered into a
-  sibling's would have come back green.
+Where a gate affords neither route, say so in the brief — silent and unplantable is a real pairing
+rather than a corner — and name whatever bounded mechanism it does afford instead. Nominating a
+route the gate cannot supply makes workers improvise, and the improvisation varies.
 
 **A green sabotage run is a reason to stop, not to proceed.**
 
-This half is written down because an earlier version of this rule claimed *every* gate printed a root banner,
-which is an instruction a worker on a silent gate cannot satisfy. Two hit it in one day, and one arrived at the
-negative control unprompted — because a worker facing an unsatisfiable rule improvises rather than stops.
+**Never pipe a gate through a filter.** A pipeline's exit status is its *last* command's, so a red
+runner reads green. Redirect to a log, echo the runner's own exit code, and quote that number —
+with the redirect and the echo on **one command line, in one shell**. A separate invocation starts
+a fresh shell whose status is whatever that shell last did, typically the directory change:
+silent, and it yields a plausible zero.
 
-**Never pipe a gate through a filter.** A pipeline's exit status is its *last* command's, so a red runner reads
-green and the change claims a pass it never got. Redirect to a log file, echo the runner's own exit code
-explicitly, and quote that number — with the redirect and the echo on **one command line, in one shell**. A
-separate invocation starts a *fresh* shell whose status is not the gate's but whatever that shell last did,
-typically the directory change: silent, and it yields a plausible zero.
+**Quote the number you captured, never one the harness reports about the same run.** That is a
+different measurement and it disagrees routinely — dozens of times across one fleet, including a
+compile failure, a genuine two-assertion failure and a browser run standing over three real ones.
+**Every disagreement surfaced as exit 0.** More than half were deliberately sabotaged runs, where
+believing the reported zero would have read as "the control does not bite" and inverted the
+conclusion.
 
-**The number you quote is the one you captured** — never one the harness reports about the same run. That is a
-different measurement and it disagrees routinely rather than rarely: at least forty-four times in three days
-across twenty-nine workers, among them a compile failure from an unbalanced parenthesis, a genuine
-two-assertion failure, and a browser run standing over three real ones. **Every one surfaced as exit 0**, and
-every one was caught because the worker quoted the number it had captured. **More than half were *deliberately
-sabotaged* runs**, where believing the reported zero would have read as "the control does not bite" and
-inverted the conclusion. Recount that census when you cite it rather than carrying it forward by adding the
-instances you have just seen, which is how it came to be understated by two thirds.
+**An ABSENT exit-code file is NO VERDICT, not a pass.** It reads as success because the log ends
+with the gate's own output and nothing contradicts it. Any death between the last line and the
+exit does it. **A gate you cannot quote a captured number for has not run** — re-run it, and say
+whether you re-ran the whole gate or one step.
 
-**An ABSENT exit-code file is NO VERDICT — not a pass.** The rules above are about a number that is present and
-wrong; this is about one that was never written, and it reads as success because the log ends with the gate's own
-output and nothing contradicts it. Any death between the last line and the exit does it: a runtime cap killing the
-shell in the final step, an OOM kill, a dropped connection. **A gate you cannot quote a captured number for has not
-run.** Re-run it, and say whether you re-ran the whole gate or one step.
+**A search that returns ZERO is not a check that passed.** A wrong pattern answers "no matches" in
+the same voice as "nothing is wrong"; the recurring instance is a backslash-bearing literal quoted
+so the shell strips them. Match fixed strings as fixed strings, and when a search underwrites a
+claim, run it once against something it should find.
 
-**A search that returns ZERO is not a check that passed.** A wrong *pattern* answers "no matches" in the same voice
-as "nothing is wrong" — the recurring instance is a backslash-bearing literal, quoted so the shell strips them,
-matching none of the files that plainly contained it. Match fixed strings as fixed strings (`grep -F`). When a search
-underwrites a claim, run it once against something it should find.
+**Name every gate artefact for your worktree AND for the attempt**, log and exit file both, in a
+directory version control ignores. A name missing either half fails the gate **open**, and the two
+halves close different holes. The scratch path is keyed to the session, so peers share one
+directory: two workers in one wave wrote the same exit-code filename, and one read a zero a peer
+had left while its own gate was still running. **The worktree suffix cannot close the second
+mechanism, because there both writers are you** — a runtime cap kills the *shell*, what it spawned
+survives holding the same open descriptors, and it writes at its offset while the restart writes
+from zero, so the artefact is spliced rather than clobbered. Measured twice: an `exit 0` sitting
+beside 18 real failures, and an orphan reporting two failures from a run already killed. Expect
+this route more often than the peer collision, since detaching is the sanctioned path and
+kill-and-restart is routine. **And clean the artefacts up: one leftover is enough to make a
+worktree unreapable.**
 
-**Put every gate artefact where version control ignores it, and name each one for your worktree AND for the
-attempt** — the log and the exit-code file both. Neither half is tidiness; a name missing either fails the gate
-**open**.
+**Verify a restore by hashing the bytes, never by reading a diff.** A rewrite that flips line
+endings reads clean having changed every line — and **a patch that never applied reads clean too**,
+because "unchanged" and "not attempted" are the same diff. That second one is the dangerous half:
+a plant that silently no-ops makes the sabotage run come back green, so the worker reports a guard
+that fired when nothing was ever broken. Hash before the plant, compare after the restore. Five
+cautions:
 
-The scratch path is keyed to the session, not the worktree, so every worker in a wave shares one directory. Two
-of six workers in a single wave wrote the same exit-code filename there; one then read a zero a peer's run had
-already left while its own gate was still running, and found its log interleaved by two writers at independent
-offsets, one line beginning mid-word.
+* **Where line endings are translated, use version control's own content hash against the
+  committed object**, not a byte digest of the working file — a checkout during a rebase rewrites
+  the working file after you hashed it, and a false "restore failed" sends the worker off to doubt
+  the sabotage result, which was the deliverable.
+* **Call it a *blob* hash in the words immediately before the token.** A content hash is
+  indistinguishable from a commit id, and a provenance checker classifying each hex token by the
+  nearest description on its left will file it as a citation of a commit that exists nowhere.
+* **Anchor a patch to a single line.** A multi-line anchor can match nothing, with no error and no
+  edit.
+* **An anchor at the end of a line matches nothing where line endings are translated** — a
+  carriage return sits between the text and the line ending. This defeats a single-line anchor as
+  readily as a multi-line one, so the caution above does not cover it. **Read the match count
+  before you run the gate**: zero is unambiguous and free, where the hash convicts a no-op plant
+  only after a whole run has been spent.
+* **A hash proves the SOURCE changed, not that the runtime ever saw it.** One plant applied
+  genuinely — the hashes differed — but the file was not in the build's module graph, so the
+  watcher served the pre-plant compile and the witness came back green. A green sabotage run is
+  evidence only once both halves hold: the hash for the source, and positive evidence the runtime
+  observed the plant.
 
-**The worktree suffix cannot close the second mechanism, because there both writers are the same worktree.** A
-process the harness could not kill goes on writing to an inherited descriptor after its replacement has started:
-the runtime cap kills the *shell*, and what that shell spawned survives holding the same open log and exit file.
-It writes at *its* offset while the restart writes from zero, so the artefact is not cleanly clobbered but spliced.
-Measured twice independently: one worker was left with `exit 0` sitting beside 18 real failures; another found an
-orphaned test process reporting two failures from a run that had already been killed. The worktree suffix was
-present and correct in both and made no difference to either.
+**Scope a plant to the suite under test.** Where the runner executes a whole lane in one block
+without catching exceptions, a plant that crashes any namespace stops every namespace after it and
+the log still looks plausible. Compare namespace and assertion counts against a control run.
 
-**Expect this route more often than the peer collision, not less**, because detaching a long gate is the sanctioned
-path, so kill-and-restart is routine rather than exceptional. A fresh number per attempt sends the orphan's write
-somewhere you will never quote. It is belt to the capture rule's braces rather than a replacement for it — the
-second worker above was saved by quoting its own shell's captured code instead of the log.
+**Re-run the gates on the final base after every rebase.** A pre-rebase green is evidence about a
+tree that no longer exists, and nothing warns you: the rebase reports success and the old log still
+says exit 0. One worker rebased four times past eleven landings, and re-running changed the
+artefact rather than reconfirming it — fixes for three of its own findings had merged in the
+interval, so the record it was about to publish carried a count false of the trunk.
 
-**One leftover artefact is enough to make a worktree unreapable.** Nine accumulated exactly that way before anyone
-worked out why they would not remove. The cheapest fix is to not create the residue.
-
-**Verify a restore by hashing the bytes, never by reading a diff.** A brief that proves a guard is *exact* rather
-than merely present tells the worker to plant a fault, run the gate, then restore — and a diff misreads that restore
-two ways. A rewrite that flips line endings reads clean having changed every line; and **a patch that never applied
-reads clean too**, because "unchanged" and "not attempted" are the same diff. The second is the dangerous one: a
-plant that silently no-ops makes the sabotage run come back green, so the worker reports a guard that fired when
-nothing was ever broken — a false proof of a real guard, which is worse than no proof.
-
-Hash the file before the plant and compare after the restore. Five cautions:
-
-* **On a checkout whose line endings are translated, use version control's own content hash against the committed
-  object, not a plain byte digest of the working file.** A checkout during a rebase can rewrite the working file
-  after you hashed it, so a plain digest reports a *correct* restore as failed. A false "restore failed" is not
-  merely noise: the worker's next move is to doubt the whole sabotage result, and the sabotage result is the
-  deliverable.
-* **When you write that hash down, call it a *blob* hash in the words immediately before the token.** A content
-  hash is forty hex characters, indistinguishable from a commit id, and the prose carrying it is commit-flavoured
-  by construction — "identical before the plant and after it, against the committed object". A provenance checker
-  that classifies each hex token by the *nearest* description on its left reads "committed", files the token as a
-  citation of a commit that exists nowhere, and reds a gate over the one sentence in the record that describes its
-  own evidence. "The identical blob hash `<token>`" costs a word and settles it; the correct word further left
-  loses to whatever sits closer.
-* **Anchor a patch to a single line.** One worker's multi-line anchor matched nothing, with no error and no edit,
-  and only the hash caught it.
-* **A pattern anchored at the end of a line matches nothing where line endings are translated** — a carriage
-  return sits between the text and the line ending, so the anchor never reaches the text. This defeats a
-  single-line anchor exactly as readily as a multi-line one, so the caution above does not cover it. And the
-  detector here is cheaper and earlier than the hash: **read the match count before you run the gate.** Zero is
-  unambiguous and free, where the hash convicts a no-op plant only after a whole gate run has been spent, and
-  convicts it as a signal the worker still has to interpret.
-* **A hash proves the SOURCE changed, not that the runtime ever saw it.** One worker planted a one-line fault and
-  its live witness came back green. The hashes differed, so the plant had genuinely applied and the rule above
-  reported success — but the file was not in the host build's module graph, so the watcher never noticed the edit
-  and served the pre-plant compile. Restarting the build produced the red at once. So **a green sabotage run is
-  evidence only once both halves hold**: the hash for the source, and positive evidence the runtime observed the
-  plant. Read without that second half, the green says *my witness proves nothing*, and the worker's next move is
-  to tune the witness until it reds against a fault that was never being compiled — a conclusion about the wrong
-  artefact altogether. The hash deepens this trap rather than closing it, because it is genuine evidence for a
-  narrower claim than the worker needs.
-
-**Scope a plant to the suite under test.** If the runner executes the whole lane in one block without catching
-exceptions, a plant that crashes any namespace stops every namespace after it — and the log still looks plausible.
-One worker's unconditional plant aborted partway and the suite it was trying to prove never ran. Compare namespace
-and assertion counts against a control run.
-
-**Re-run the gates on the final base after every rebase.** A pre-rebase green is evidence about a tree that no longer
-exists, and under a saturated wave the trunk moves under a worker routinely. Nothing warns you: the rebase reports
-success, and the old log still says exit 0. One worker rebased four times past eleven landings, and re-running the
-gates on the final base *changed the artefact* rather than merely reconfirming it — fixes for three of its own five
-findings had merged in the interval, so the governance record it was about to publish carried a membership count
-**false of the trunk**. A false count in a record like that is not caught later; it is cited later.
-
-**Diff your branch against its MERGE BASE before you push, and read that diff for what you would REVERT.** Not for
-conflicts — version control reports those itself, and a clean rebase is exactly the case this rule is for. The
-question the diff answers is whether your push undoes something a sibling landed while you worked, which nothing will
-raise and no gate covers: a revert of a merged change is well-formed, it compiles, and it passes every check the tree
-has. In a shared document, a stale copy of one region reapplies as a silent deletion of everything that landed in it
-since. One worker's first push would have reverted a concurrent rewrite of a shared ledger; it caught that by reading
-the diff before reporting, and by nothing else.
-
-**The base is half that instruction, and the wrong base defeats it.** Compare against the point your branch left the
-trunk, never against the trunk's current tip. A tip comparison also carries everything the *trunk* gained while you
-worked, which is not what this step asks: it buries the one hunk that matters under siblings' unrelated work, and it
-degrades worst exactly when the trunk has moved most — which is when this read is most needed. One worker, following
-a tip-shaped wording, read several hundred kilobytes of content none of which was its own. In the dominant toolchain
-the merge-base comparison is the three-dot form, `<TRUNK>...HEAD`; plain `<TRUNK>` is the two-dot one that produced
-that noise.
+**Diff your branch against its MERGE BASE before you push, and read that diff for what you would
+REVERT.** Not for conflicts — version control reports those, and a clean rebase is exactly the case
+this rule is for. The question is whether your push undoes something a sibling landed while you
+worked, which no gate covers: a revert of a merged change is well-formed, compiles, and passes
+every check the tree has. In a shared document, a stale copy of one region reapplies as a silent
+deletion of everything that landed in it since. **The base is half the instruction** — compare
+against the point your branch left the trunk, never the trunk's current tip, which buries the one
+hunk that matters under siblings' unrelated work and degrades worst exactly when the trunk has
+moved most. In the dominant toolchain that is the three-dot form, `<TRUNK>...HEAD`.
 
 ---
 

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -23,7 +23,7 @@ a capable agent. Placeholders:
 > **And a summary is not a lighter version of a stance.** The lenses say what good
 > looks like; everything after them says when to STOP. A paraphrase keeps the
 > memorable half and drops the restraining one, and what survives does not read as
-> incomplete. It reads as a stance that wants MORE of everything, which is precisely
+> incomplete — it reads as a stance that wants MORE of everything, which is precisely
 > the failure the second half exists to prevent.
 
 ---
@@ -32,30 +32,14 @@ a capable agent. Placeholders:
 
 The order is what makes it accurate. Each step is a check the next depends on.
 
-1. **Read the tracker item, and order it by the tracker's own TIMESTAMPS.** The
-   description is *usually* the oldest text and corrections accrete below it, so a
-   top-down read gets superseded instructions. But the bottom is not reliably newest
-   either: audit notes append into the description block while dated comments render
-   after it, so the last lines on screen can be days staler than material higher up.
-   `bd show | tail` is not a read-the-newest method.
-
-   **Nor is grepping the prose for dates.** A date inside the text is content, not a
-   mutation time — an undated scope correction is invisible to it, an old description
-   can cite a later release date, and `bd update --description` can make the
-   "oldest" field the most recently edited one. Use `bd history <id>`, which lists real
-   mutation times newest-first, and `bd comments <id> --json` for comment `created_at`.
-
-   **The plain history listing tells you a newer mutation exists, not what it says** —
-   it prints commit, time, author and the item's title and status, and names no changed
-   field. To see the change itself, `bd history <id> --json` carries a full item
-   snapshot per commit. **Walk adjacent pairs newest-first until you reach the first
-   change to a text-bearing field** — description, notes, acceptance, design — because
-   the history carries duplicate checkpoint snapshots and status-only mutations, so
-   comparing the newest pair alone can truthfully report "nothing changed" while a
-   still-current instruction change sits a few pairs back. **And if the bead
-   has children, re-enumerate them before concluding a decision is absent** — a ruling
-   is sometimes recorded as a *new child bead*, where no amount of reading the parent
-   will find it.
+1. **Read the tracker item, and order it by the tracker's own TIMESTAMPS** — not by
+   position, and not by dates written in the prose. The full mechanics are spelled out
+   for the worker under *Common preamble* below: the description is usually the oldest
+   text but the bottom is not reliably the newest either, a date in the prose is content
+   rather than a mutation time, the plain history listing names no changed field, you
+   walk adjacent snapshot pairs newest-first to the first text-bearing change, and you
+   re-enumerate a bead's children before concluding a decision is absent. Every one of
+   those binds the mayor writing the brief exactly as it binds the worker reading it.
 2. **Check every factual claim you are about to write.** Does the symbol resolve?
    Does the file say what you think? Is the count still true? Is the ruling you cite
    *ruled*, or only recommended? A recommendation and a decision read identically in
@@ -90,48 +74,36 @@ same case, and gets the sentence too.
 The first is the highest-yield sentence in the preamble. Read-the-item-first caught
 five stale briefs in a single day: one whose fix had landed two days earlier under a
 sibling item; one that named the wrong audit finding; one told to execute a resolution
-that had already merged; one that a scope correction had redefined from an allocation
-leak to a baseline-contamination leak; and one carrying three wrong path, flag and
-script details. **Every one of those briefs was accurate when it was written.**
-
-The yield is in *the item governs the brief*, not in the direction of reading. This
-sentence used to credit "the bottom-up rule" for those catches; the catches were real
-and the attribution was wrong.
+that had already merged; one a scope correction had redefined; and one carrying three
+wrong path, flag and script details. **Every one of those briefs was accurate when it
+was written**, and the yield is in *the item governs the brief* rather than in the
+direction of reading.
 
 **The third is scoped by the nominated gate's capabilities — not by prose versus
 code.** Ask whether the gate covering the edited surface affords a safe, bounded,
 discriminating fault at a line the brief is already touching. Where it does, the
-sentence is satisfiable and goes in — and a documentation correction is emphatically
-included, because the cheap validators that run over a docs tree red on one broken link
-target or one bad heading anchor and go green again on restore. That is measured rather
-than supposed: doc-only briefs have planted exactly those faults *in this file*, taken
-a red naming the plant, and hash-verified the restore against the committed object.
-Where the covering gate affords no such plant, the sentence is the unsatisfiable
-quantifier the method-reread loop is told to hunt for, and an unsatisfiable rule does
-not stop the reader — it makes one up.
+sentence goes in — and a documentation correction is emphatically included, because the
+cheap validators that run over a docs tree red on one broken link target or one bad
+heading anchor and go green again on restore. That is measured rather than supposed:
+doc-only briefs have planted exactly those faults *in this file*, taken a red naming the
+plant, and hash-verified the restore against the committed object. Where the covering
+gate affords no such plant, the sentence is the unsatisfiable quantifier the
+method-reread loop is told to hunt for, and an unsatisfiable rule does not stop the
+reader — it makes one up.
 
 **That failure was measured on the *enforcing* side rather than a worker's.** On one
-dispatch tick four editing briefs went out, two of them prose-only, and both carried
-the first two sentences verbatim while neither carried the third. Nobody decided to
-drop it. Each brief improvised the same omission separately, which is the tell that the
-rule was doing no work. That observation is why this section exists and it still
-holds — but the reason those briefs improvised is that the rule was **unscoped**, not
-that prose has no controls. Scoping it on the shape of the deliverable would have
-licensed the same two omissions with a reason attached, and it is the same wrong axis
-this section carried until it was corrected one section down, under *Quality gates —
-how a gate is run*.
+dispatch tick four editing briefs went out, two of them prose-only, and all four carried
+the first two sentences verbatim while none carried the third. Nobody decided to drop it;
+each brief improvised the same omission separately, which is the tell that the rule was
+doing no work — because it was **unscoped**, not because prose has no controls. Scoping
+it on the shape of the deliverable licenses the same omissions with a reason attached.
 
 **Say what a brief whose gate affords no plant does instead, or that gets improvised
-too.** Both wordings are already settled below, and they are different wordings for
-different cases. Where no automated gate covers the surface at all, *Quality gates —
-which gate* has it: the brief says so, and the worker verifies by hand and reports what
-it checked and the counts in the change body. Where a gate does cover the surface but
-affords no safe discriminating plant, *Quality gates — how a gate is run* has it: that
-gate still runs and the unconditional rules still bite; what lapses is only the
-planted-fault route to proving which tree was read, and the brief nominates the route
-the gate does supply or says outright that it supplies none. Point at both rather than
-restating either. Naming the alternative is what keeps the scoping from reading as
-permission to prove nothing.
+too.** Both wordings are settled below and cover different cases: where no automated gate
+covers the surface at all, *Quality gates — which gate*; where a gate does cover it but
+affords no safe discriminating plant, *Quality gates — how a gate is run*. Point at both
+rather than restating either — naming the alternative is what keeps the scoping from
+reading as permission to prove nothing.
 
 ---
 
@@ -174,13 +146,12 @@ Better still, when the number will keep moving: brief the fix to name the **clas
 than the count. A rule written as a class does not re-drift.
 
 **An item's LIST OF SITES goes stale the same way, and it is worse than a count, because it
-drifts in MEMBERSHIP rather than in magnitude.** A count that has drifted is obviously
-suspect once re-run. A list looks equally authoritative whether or not its entries are still
-true, and it is wrong in two directions at once: an entry somebody else already fixed sends
-a worker to edit correct text — or to revert a repair — while a site the list never had is
-left live. Four items in one session named sites that were already amended, or asserted a
-verification that a different change had since falsified; one named "three of four" when the
-standing state was one.
+drifts in MEMBERSHIP rather than in magnitude.** A list looks equally authoritative whether
+or not its entries are still true, and it is wrong in two directions at once: an entry
+somebody else already fixed sends a worker to edit correct text — or to revert a repair —
+while a site the list never had is left live. Four items in one session named sites already
+amended, or asserted a verification a later change had falsified; one named "three of four"
+when the standing state was one.
 
 **So require the list be RE-DERIVED at the current tip, and require the DELTA to be
 reported.** The delta is a deliverable in its own right, not bookkeeping: it is the only
@@ -200,18 +171,16 @@ So attach the measurement to the lean in the same breath. *"I think A beats B, a
 the cost that decides it, not a preference."*
 
 The evidence is one dispatch where every part of the author's lean was wrong and the number
-found it. The brief said compiling a doc corpus would beat growing a static checker, and
-guessed that speed was the risk. The worker measured: the compile takes **24.73s for 441
-files**, so the speed argument died. It then rejected compiling anyway, on three grounds the
-brief had not imagined — **12 of 25 required namespaces are imaginary**, so the compile runs
-against stubs whose fidelity nobody owns; only **52 of 206 blocks** open a namespace form, so
-the other 154 need grouping by hand, which is the very per-block harness the brief had named
-as disqualifying; and the job would move to a slower CI class already rejected elsewhere. Final
-margin: **0.12s against 46s, about 380x, for the same catch**.
-
-The same brief's fallback was wrong in a checkable way too — it prescribed scoping a rule
-**per page**, which flags **21 sites on a corpus that is correct**, where the item's own shape,
-**per section**, measures **0**. The worker followed the item over the brief and was right to.
+found it. The brief said compiling a doc corpus would beat growing a static checker and guessed
+that speed was the risk; the worker measured the compile at **24.73s for 441 files**, killing
+that argument, then rejected compiling anyway on three grounds the brief had not imagined — half
+the required namespaces are imaginary, so the compile runs against stubs whose fidelity nobody
+owns; three-quarters of the blocks open no namespace form, so they need the very per-block
+harness the brief had called disqualifying; and the job would move to a slower CI class already
+rejected elsewhere. Final margin: **0.12s against 46s, about 380x, for the same catch**. That
+brief's fallback was wrong in a checkable way too — it prescribed scoping a rule **per page**,
+which flags 21 sites on a corpus that is correct, where the item's own shape, **per section**,
+measures 0. The worker followed the item over the brief and was right to.
 
 Two rules come out of that. **Ask for the cost whenever you state a lean** — it converts a
 confident wrong brief into a correct outcome, and costs the worker one measurement. And
@@ -256,10 +225,10 @@ as owning nothing: what it will touch is recorded on the item it was dispatched 
 in version control.
 
 **A fence is derived, never remembered — and the worker derives it again at start-up.**
-Step 3 above settles how you establish it; this is what the brief then asks of the worker,
-because a list assembled from memory of who you dispatched is stale inside the dispatch's
-own lifetime and on a busy fleet can be wrong before the brief is finished. So the fence
-travels as a claim the worker re-checks, like every other premise, and its own result wins.
+Step 3 above settles how you establish it; a list assembled from memory of who you dispatched
+is stale inside the dispatch's own lifetime and on a busy fleet can be wrong before the brief
+is finished, so the fence travels as a claim the worker re-checks, like every other premise,
+and its own result wins.
 **That re-check is the load-bearing half, because the two staleness directions cost
 differently.** Too BROAD costs one re-derivation — the worker is warned off something
 nobody holds. Too NARROW omits a worker dispatched after you last looked, and two workers
@@ -417,27 +386,26 @@ at all.
   not. The warrant is three for three: every measurement change merged on one day was audited, and every
   one had its published claim stated slightly stronger than its evidence — three different workers, all
   exemplary on the run itself. One called three values *run-medians* when the code stored the arithmetic
-  MEAN of five per-round ratios, and the effect-versus-null separation those values carried was the whole
-  stated basis for the conclusion. One said a spread "loosely brackets" a figure that sat *above* the
-  maximum of its own three measured ratios, so it bracketed nothing. What slipped every time is the prose
-  ONE LAYER ABOVE the number: a worker that has just spent an hour being rigorous writes its summary in
-  ordinary confident English, and ordinary confident English overclaims. Not one audit overturned a
-  measurement or a refusal — what they corrected is the sentence a future reader will quote, and readers
-  quote the sentence, not the log. That is how a measured result becomes a false premise in someone
-  else's brief three weeks later. Premises-are-claims catches that on the INPUT side; this is the same
-  defect on the OUTPUT side, and nothing was checking it.
+  MEAN of five per-round ratios, which was the whole stated basis for its conclusion; one said a spread
+  "loosely brackets" a figure sitting *above* the maximum of its own measured ratios, so it bracketed
+  nothing. What slips is the prose ONE LAYER ABOVE the number: a worker that has just spent an hour being
+  rigorous writes its summary in ordinary confident English, and ordinary confident English overclaims.
+  Not one audit overturned a measurement or a refusal — what they corrected is the sentence a future
+  reader will quote, which is how a measured result becomes a false premise in someone else's brief three
+  weeks later. Premises-are-claims catches that on the INPUT side; this is the same defect on the OUTPUT
+  side, and nothing was checking it.
 - **An impossible reading cannot bound the quantity.** It tells you the instrument's error reached at
-  least that far. It does not calibrate the error and it does not bound the thing you are measuring. If
-  you report a bound, name the NULL OR CONTROL ARM that produced it. A bound derived from the impossible
-  readings themselves is not a bound — report the term as UNRESOLVED instead. The arithmetic: let an
-  observed delta *y* be an unknown positive true cost *t* plus estimator error *e*. A reading of
-  *y* = −0.0062 proves only that the negative error excursion exceeded 0.0062 + *t*; it does not make
-  ±0.0062 a calibrated symmetric floor, and it cannot upper-bound *t*. A most-negative observation is a
-  statement about the ERROR TERM, not about the quantity. Comparing most-negative readings from
-  *different* positive-cost arms at two window widths likewise cannot establish a floor-scaling factor.
-  One window reported membership as "bounded: < 0.006 ms/commit" from its own most-negative reading; the
-  merged-change audit refuted it, and the next window's second run then read −0.0141 — more than twice
-  the claimed floor — refuting it again on independent arithmetic.
+  least that far; it neither calibrates the error nor bounds what you are measuring. If you report a
+  bound, name the NULL OR CONTROL ARM that produced it — a bound derived from the impossible readings
+  themselves is not a bound, so report the term as UNRESOLVED instead. The arithmetic: let an observed
+  delta *y* be an unknown positive true cost *t* plus estimator error *e*. A reading of *y* = −0.0062
+  proves only that the negative error excursion exceeded 0.0062 + *t*; it does not make ±0.0062 a
+  calibrated symmetric floor, and it cannot upper-bound *t*. A most-negative observation is a statement
+  about the ERROR TERM, not about the quantity, and comparing most-negative readings from *different*
+  positive-cost arms at two window widths likewise cannot establish a floor-scaling factor. One window
+  reported membership as "bounded: < 0.006 ms/commit" from its own most-negative reading; the
+  merged-change audit refuted it, and the next window's second run then read −0.0141, refuting it again
+  on independent arithmetic.
 
 Report what ran, what refused and on which control, the raw numbers, and — as its own heading — what was
 **not** concluded. A window that publishes nothing still reports everything.
@@ -472,17 +440,17 @@ do.
 
 Several blocks below travel **verbatim** into every dispatch. Get them there by
 **extracting mechanically, then pasting the result into the prompt.** Both halves are
-mandatory and they close different failures. The extraction is what makes paraphrase
+mandatory and they close different failures: the extraction is what makes paraphrase
 impossible — a matched range cannot reword, where a mayor retyping two hundred lines of
-gate mechanics can and does. The paste is what makes non-receipt impossible: a block that
-is in the prompt cannot be un-received.
+gate mechanics can and does — and the paste is what makes non-receipt impossible, because
+a block that is in the prompt cannot be un-received.
 
 **Sending the worker to the FILE is not a substitute.** A worker that skims it, or reads
 part of it, has not received the block at all, and nothing in the transcript distinguishes
 that from a worker who read every line — so the first evidence is a worker doing something
 the block forbids. Between a failure prevented by construction and one prevented by a
-reader's diligence, take construction. The context cost is the acknowledged price and it is
-the right thing to spend context on: a brief is the mayor's scarce output.
+reader's diligence, take construction; the context cost is the acknowledged price, and a
+brief is the mayor's scarce output.
 
 **Anchor the extraction to CONTENT, never to line numbers.** A line range against a living
 document is a measured constant that goes stale exactly where it has to be right, and an
@@ -614,12 +582,10 @@ transcripts.
 **A pass that concludes only in the ignored tree concludes where nobody can read it.** Every project keeps
 some scratch tree version control cannot see, and that invisibility is what makes the failure silent: an
 item can cite a design by a path no maintainer has. Two audits were lost exactly that way here, and a mayor
-re-ran an entire three-design programme in one day for want of looking there first. Widening what version
-control tracks is not the fix — working notes still stay local, and only the *conclusion* is promoted, into
-whichever tracked record already owns the surface, as a dated amendment where one exists and a new page only
-when the evidence stands on its own. Three workers in a single day found their design already written in
-that tree and promoted the surviving conclusion rather than re-deriving it, which is why the preamble tells
-the worker to look there first.
+re-ran an entire three-design programme in one day for want of looking there first — which is why the
+preamble tells the worker to look there first. Widening what version control tracks is not the fix: working
+notes stay local, and only the *conclusion* is promoted, into whichever tracked record already owns the
+surface, as a dated amendment where one exists and a new page only when the evidence stands on its own.
 
 ---
 
@@ -627,18 +593,15 @@ the worker to look there first.
 
 Every editing dispatch runs the project's pre-checkin gate before opening a change, and lists what ran in a
 change-body section headed **exactly** `## Quality gates` with pass and fail counts. **The readers are the
-mayor's merge sweep and the merged-PR audits — both of them agents, and no machinery whatever.** An earlier
-version of this line called the verbatim heading a contract for automated audits, and no such audit exists: a
-fixed-string search for `Quality gates` across the tracked tree returns this file, the two mayor command
-files, the tracker export, one design page, and two test docstrings that point a reader at a PR's own section
-— no script, no workflow, no audit tool. The search was controlled by matching that same fixed string inside
-`docs/the-mayor-method/`, so the zero is a real absence and not a wrong pattern. **Exactly** stays regardless,
-because it is what lets a reader jump to the section in a long change body rather than read the whole thing.
-What the false justification cost is measured: PR #8376 headed its section `## Gates — captured exit codes`
-and carried every fact the rule asks for, and the mayor hand-edited the missing word into it seven seconds
-before merging it on 2026-08-16. **A heading that does not conform is a note to the worker and nothing more.**
-It is never grounds to edit somebody else's change body, and never a merge blocker — the five clauses are the
-merge criterion, and this is not among them.
+mayor's merge sweep and the merged-change audits — both of them agents, and no machinery whatever.** An
+earlier version of this line called the verbatim heading a contract for automated audits; a controlled
+fixed-string search for it found no script, no workflow and no audit tool anywhere in the tracked tree.
+**Exactly** stays regardless, because it is what lets a reader jump to the section in a long change body
+rather than read the whole thing — but that is a convention for readers, not a contract, and what the false
+justification cost is measured: one change carrying every fact the rule asks for under a differently-worded
+heading was hand-edited to conform seconds before it merged. **A heading that does not conform is a note to
+the worker and nothing more.** It is never grounds to edit somebody else's change body, and never a merge
+blocker — the five clauses are the merge criterion, and this is not among them.
 
 - **Gate the transitive surface, not just the file you changed.** A public-surface change breaks its
   *consumers*, not itself. Gate every artefact reachable from the diff through import edges.
@@ -678,11 +641,10 @@ restore. **A cheap prose gate is a *plantable* gate; what it is not is a *heavyw
 different questions.
 
 **That axis is a correction, and the evidence for it came from the dispatch that carried the old one.** An
-earlier version scoped by the shape of the deliverable, calling a documentation correction ungateable and then
-acknowledging four lines later that the same edit runs a link validator — while the worker carrying it had
-already planted a broken link target, watched the validator red on exactly that worktree-only fault, restored,
-and hashed the restore against the committed object. Read literally, that rule would have stripped the
-planted-fault and restore-hash clauses from precisely the brief where they did the work.
+earlier version scoped by the shape of the deliverable, calling a documentation correction ungateable, while the
+worker carrying it had already planted a broken link target, watched the validator red on exactly that
+worktree-only fault, restored, and hashed the restore against the committed object. Read literally, that rule
+would have stripped the planted-fault and restore-hash clauses from precisely the brief where they did the work.
 
 **The rest is unconditional for any dispatch that runs anything at all**, and is pasted verbatim whatever the
 deliverable: the detach-and-poll sanction, the never-pipe rule, the capture-your-own-exit-code rule, and the
@@ -690,29 +652,26 @@ artefact-naming rule. A one-line documentation edit still runs a link validator,
 
 **Say what a brief whose gate affords no plant does instead, or that gets improvised too** — the improvisation
 was measured on the *enforcing* side, where five dispatches in one session carried five different lengths of
-this one block, nobody having decided to drop anything. Three cases, and they are not the same. Where NO automated
-gate covers the surface, the wording is already settled under *Quality gates — which gate* above: the brief says
-so, and the worker verifies it by hand and reports what it checked and the counts in the change body. Where a
-gate DOES cover the surface but affords no safe discriminating plant, that gate still runs and the unconditional
-four still bite; what lapses is only the planted-fault route to proving which tree was read, and which route is
-left turns on the gate's *other* capability. If it prints its root, the brief nominates the root-banner route and
-the worker says which one it used. If it prints nothing either, neither route is on offer — the two-route rule
-below is explicit that many gates print nothing, so silent AND unplantable is a real pairing rather than a corner
-— and the brief says exactly that: no discriminating tree-verification route here, or the concrete bounded
-mechanism the gate does afford in place of one. Nominating a route the gate cannot supply is the failure recorded
-further down, where an earlier rule claimed every gate printed a banner and the workers who met it
-improvised. Point at the settled wording rather than restating it, and **scope the block rather than
-shortening it** — dropping the sanction along with the parts that do not apply is the same failure by a
-shorter road.
+this one block, nobody having decided to drop anything. Three cases, and they are not the same. Where NO
+automated gate covers the surface, the wording is settled under *Quality gates — which gate* above. Where a gate
+DOES cover the surface but affords no safe discriminating plant, that gate still runs and the unconditional four
+still bite; what lapses is only the planted-fault route to proving which tree was read, and which route is left
+turns on the gate's *other* capability. If it prints its root, the brief nominates the root-banner route and the
+worker says which one it used. If it prints nothing either, neither route is on offer — silent AND unplantable is
+a real pairing rather than a corner, since many gates print nothing — and the brief says exactly that: no
+discriminating tree-verification route here, or the concrete bounded mechanism the gate does afford in place of
+one. Nominating a route the gate cannot supply is the failure recorded further down, where an earlier rule
+claimed every gate printed a banner and the workers who met it improvised. Point at the settled wording rather
+than restating it, and **scope the block rather than shortening it** — dropping the sanction along with the
+parts that do not apply is the same failure by a shorter road.
 
 **But first, check whether the gate is COMPOUND — a script that chains two phases often splits into two runs
 that each fit.** This is strictly better than detaching, because it keeps every verdict in the foreground and
-removes the strand risk rather than managing it. A worker here met a build-and-run script that measured past
-the ceiling and ran each half as its own foreground call: both finished well inside it, nothing was killed,
-and no cache was left corrupt by an orphan. The same day, two workers detached the whole thing instead; both
-died at the cap, and one left a build cache so damaged that the next attempt failed with twenty-two cascading
-errors naming files it had never touched. **Read what the script actually runs before deciding it cannot be
-foregrounded.**
+removes the strand risk rather than managing it. A worker here split a build-and-run script that measured past
+the ceiling and both halves finished well inside it; the same day two workers detached the whole thing instead,
+both died at the cap, and one left a build cache so damaged that the next attempt failed with twenty-two
+cascading errors naming files it had never touched. **Read what the script actually runs before deciding it
+cannot be foregrounded.**
 
 **Where it genuinely does not split, detaching is CORRECT; ending the turn afterwards is the defect.** Where a
 harness hard-kills a foreground command well below what the full gate needs, "foreground, to completion" is not
@@ -779,12 +738,11 @@ typically the directory change: silent, and it yields a plausible zero.
 
 **The number you quote is the one you captured** — never one the harness reports about the same run. That is a
 different measurement and it disagrees routinely rather than rarely: at least forty-four times in three days
-across twenty-nine workers, counted from the workers' own completion reports and the merged changes whose bodies
-preserve them. Among them a compile failure from an unbalanced parenthesis, a genuine two-assertion failure, and a
-browser run standing over three real ones. **Every one surfaced as exit 0**, and every one was caught because the
-worker quoted the number it had captured. **At least twenty-three of the forty-four — more than half — were
-*deliberately sabotaged* runs**, where believing the reported zero would have read as "the control does not bite"
-and inverted the conclusion. Recount that census when you cite it; do not carry it forward by adding the
+across twenty-nine workers, among them a compile failure from an unbalanced parenthesis, a genuine
+two-assertion failure, and a browser run standing over three real ones. **Every one surfaced as exit 0**, and
+every one was caught because the worker quoted the number it had captured. **More than half were *deliberately
+sabotaged* runs**, where believing the reported zero would have read as "the control does not bite" and
+inverted the conclusion. Recount that census when you cite it rather than carrying it forward by adding the
 instances you have just seen, which is how it came to be understated by two thirds.
 
 **An ABSENT exit-code file is NO VERDICT — not a pass.** The rules above are about a number that is present and

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -349,21 +349,17 @@ at all.
   passed that should not have. Widening a threshold to admit today's run retro-admits that failure
   too, and the series loses the one property that made it worth running.
 - **Do not improve the rig mid-window.** No new instrument, no extra rungs, no third estimator,
-  however obvious the improvement looks from inside the run. One worker declined to build a rung it
-  genuinely needed, mid-series, on the grounds that *"a rung added between runs makes the series two
-  instruments"* — the clearest statement of this rule anyone here has managed. File the improvement
-  and run it as its own window.
+  however obvious it looks from inside the run: a rung added between runs makes the series two
+  instruments. File the improvement and run it as its own window.
 - **Do not restate a published figure on thin evidence.** A worker holding four reportable runs, every
   one reading *below* both published figures, recorded them without publishing. That was right: four
   runs disagreeing with a number are a reason to look again, not a mandate to move it.
-- **Verify the machine with real counters, not the convenient one.** One system's headline CPU counter
-  read 93% while the true value was 11%. Cross-check with a second source, and prefer the counter that
-  says whether anything is actually *waiting for a core* — that is the only thing the window cares
-  about. **Read that counter on its own, and never inside a measured run.** Sampled alongside anything
-  heavy it measures the sampler: one reading of 59–77 was the dispatcher's own directory copy, and it
-  nearly disqualified a window that was in fact idle. Sampled *inside* a run it measures the benchmark,
-  which answers nothing — so bracket the run and say plainly that nothing is claimed about within-run
-  quietness beyond the bracketing.
+- **Verify the machine with real counters, not the convenient one.** One system's headline CPU
+  counter read 93% while the true value was 11%. Cross-check, and prefer the counter saying whether
+  anything is actually *waiting for a core*. **Read it on its own, never inside a measured run**:
+  sampled beside anything heavy it measures the sampler — one reading of 59–77 was the dispatcher's
+  own directory copy — and sampled inside a run it measures the benchmark. Bracket the run, and say
+  plainly that nothing is claimed about within-run quietness beyond the bracketing.
 - **Only a CLOCK estimand needs the quiet machine.** A census of monotone counters — allocations,
   recomputations, calls — reads the same on a loaded box, so it may run beside anything and must not
   consume a drain. Classify the estimand before you schedule it. Getting this wrong is expensive in
@@ -377,35 +373,26 @@ at all.
   that is worthless and then gets published and cited.
 - **One run at a time, never concurrent.** Concurrency is precisely the contention the window exists to
   exclude, so two runs the worker believes are independent still are not.
-- **Your published sentences are claims too, and they are audited.** For every summarising statement you
-  write, name the exact evidence that licenses it and check the arithmetic of any comparison in it. Do
-  not attribute an observed spread to a single cause unless your own data excludes the others — if your
-  queue samples include a non-zero inside a measurement phase, you may not call the dispersion the
-  instrument's alone. Name the estimator you actually computed, not the one the surrounding prose
-  habitually says. A hedged sentence that survives audit is worth more than a confident one that does
-  not. The warrant is three for three: every measurement change merged on one day was audited, and every
-  one had its published claim stated slightly stronger than its evidence — three different workers, all
-  exemplary on the run itself. One called three values *run-medians* when the code stored the arithmetic
-  MEAN of five per-round ratios, which was the whole stated basis for its conclusion; one said a spread
-  "loosely brackets" a figure sitting *above* the maximum of its own measured ratios, so it bracketed
-  nothing. What slips is the prose ONE LAYER ABOVE the number: a worker that has just spent an hour being
-  rigorous writes its summary in ordinary confident English, and ordinary confident English overclaims.
-  Not one audit overturned a measurement or a refusal — what they corrected is the sentence a future
-  reader will quote, which is how a measured result becomes a false premise in someone else's brief three
-  weeks later. Premises-are-claims catches that on the INPUT side; this is the same defect on the OUTPUT
-  side, and nothing was checking it.
-- **An impossible reading cannot bound the quantity.** It tells you the instrument's error reached at
-  least that far; it neither calibrates the error nor bounds what you are measuring. If you report a
-  bound, name the NULL OR CONTROL ARM that produced it — a bound derived from the impossible readings
-  themselves is not a bound, so report the term as UNRESOLVED instead. The arithmetic: let an observed
-  delta *y* be an unknown positive true cost *t* plus estimator error *e*. A reading of *y* = −0.0062
-  proves only that the negative error excursion exceeded 0.0062 + *t*; it does not make ±0.0062 a
-  calibrated symmetric floor, and it cannot upper-bound *t*. A most-negative observation is a statement
-  about the ERROR TERM, not about the quantity, and comparing most-negative readings from *different*
-  positive-cost arms at two window widths likewise cannot establish a floor-scaling factor. One window
-  reported membership as "bounded: < 0.006 ms/commit" from its own most-negative reading; the
-  merged-change audit refuted it, and the next window's second run then read −0.0141, refuting it again
-  on independent arithmetic.
+- **Your published sentences are claims too.** **What slips is the prose ONE LAYER ABOVE the number**:
+  a worker that has just spent an hour being rigorous writes its summary in ordinary confident English,
+  and ordinary confident English overclaims. Three measurement changes merged in one day, all exemplary
+  on the run itself, and all three overstated their published claim — one called three values
+  *run-medians* where the code stored the arithmetic MEAN of five per-round ratios, which was its whole
+  stated basis; one said a spread "loosely brackets" a figure sitting *above* the maximum of its own
+  ratios. No audit overturned a measurement or a refusal. What they corrected is the sentence a future
+  reader will quote, which is how a measured result becomes a false premise in someone else's brief.
+  So: name the evidence licensing each summarising statement, check the arithmetic of any comparison,
+  name the estimator you actually computed rather than the one the surrounding prose habitually says,
+  and do not attribute a spread to one cause unless your data excludes the others.
+- **An impossible reading cannot bound the quantity.** Let an observed delta *y* be an unknown
+  positive true cost *t* plus estimator error *e*. A reading of *y* = −0.0062 proves only that the
+  negative error excursion exceeded 0.0062 + *t*: it neither makes ±0.0062 a calibrated symmetric
+  floor nor upper-bounds *t*. **A most-negative observation is a statement about the ERROR TERM, not
+  about the quantity** — and comparing most-negative readings from *different* positive-cost arms at
+  two window widths cannot establish a floor-scaling factor either. If you report a bound, name the
+  NULL OR CONTROL ARM that produced it; otherwise report the term as UNRESOLVED. One window quoted
+  "bounded: < 0.006 ms/commit" from its own most-negative reading, was refuted by audit, and was
+  refuted again by the next window reading −0.0141.
 
 Report what ran, what refused and on which control, the raw numbers, and — as its own heading — what was
 **not** concluded. A window that publishes nothing still reports everything.

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -271,8 +271,7 @@ one-worker-per-item, and do not reflexively bundle everything.
 
 **One agent owns a surface; surfaces run in parallel.** That is how you avoid serial handling:
 same-surface items ride one agent, which never collides with itself, while genuinely separable
-surfaces dispatch as concurrent agents. Two workers never share a surface — they merge-conflict
-and can silently revert each other.
+surfaces dispatch as concurrent agents.
 
 **The serial exceptions**, where same-surface work is *meant* to be sequential: a deliberately
 serial epic, and a single tightly-coupled module whose core files many items touch. That surface
@@ -594,7 +593,11 @@ blocker — the five clauses are the merge criterion, and this is not among them
 - **Local-green is not CI.** "Green locally" usually means the subset the worker ran; the red gate is one it
   skipped. The merge decision is CI's, not the worker's hand-off. So the brief must say *which* required
   checks the local gate omits — and say it by citing **one path**, not by re-listing them, because the
-  required set moves. Make the project *derive* that list rather than document it.
+  required set moves. Make the project *derive* that list rather than document it. Two shapes
+  make a hand-written one wrong inside a week: a required status context the local runner has no
+  lane in at all, and a required check that is a **step inside a job the runner does run**, which
+  no skipped-tier enumeration can see and which reports under that job's name however little it
+  resembles what the step does.
 - **Never nominate a gate that does not cover the surface being edited.** Site builds, linters and test
   runners all carry exclusion lists, and a gate run over an excluded path exits green having verified
   nothing — the same fail-open defect worth hunting anywhere else, except it is now the brief telling the

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -54,12 +54,12 @@ once every clause is already met.
 
 **A change still published as a draft is not a merge candidate, and no number of
 clauses makes it one.** The five test the CHANGE — whether what is proposed is
-green — and none of them can see whether its author has finished with it. Workers
-are told to push as they go and publish as soon as commits exist, because pushed
-commits are the only durable worker state, so *green* and *done* are separate facts
-and this criterion only ever measured the first. Marking a change ready for review
-is the worker's last act, and hosts refuse to merge a draft, so the interlock costs
-this loop nothing to remember. See *Publishing the change* in
+green — and none of them can see whether its author has finished with it: workers
+push as they go because pushed commits are the only durable worker state, so *green*
+and *done* are separate facts and this criterion only ever measured the first.
+Marking a change ready for review is the worker's last act, and hosts refuse to merge
+a draft, so the interlock costs this loop nothing to remember. See
+*Publishing the change* in
 [`dispatch-prompt-template.md`](dispatch-prompt-template.md).
 
 Resolve the head first — the branch name **and** the head revision — because
@@ -71,34 +71,31 @@ clauses 4 and 5 are both keyed to it.
 4. **Every workflow run at the change's current head revision COMPLETED.**
 5. **The check set was computed against the workflow matrix on the trunk now.**
 
-Each of those is one line and each hides a way to be wrong. They are unpacked
-below.
+Each hides a way to be wrong, unpacked below.
 
 ### Clause 1 — zero failures is not green
 
-Zero-failures-zero-pending is also exactly what an **empty** rollup reports. That
-is what a change shows in the seconds before its workflow runs are created, and
-what everything shows while the CI provider is down. One change merged here on a
-rollup read as 0/0/0 eleven seconds before its runs existed; during a provider
-outage the same day, six changes at once reported mergeable with zero checks, and
-a criterion without this clause would have taken all six.
+Zero-failures-zero-pending is also exactly what an **empty** rollup reports — what
+a change shows in the seconds before its workflow runs are created, and what
+everything shows while the CI provider is down. One change merged here on a rollup
+read as 0/0/0 eleven seconds before its runs existed; during a provider outage the
+same day, six changes at once reported mergeable with zero checks.
 
 So require a **count**, and require it to be in the band this repository actually
 produces. A rollup carrying a fraction of the checks a full one carries is no
 greener than an empty one.
 
 **Measure the band; never trust a number written down.** It moves as the matrix
-grows. In one programme the figure here moved four times in three days. Measure it
-on changes merged *after* the last matrix change, because a change branched before
-a new job landed is computed against the superseded matrix and legitimately reads
-band-minus-one — which the count alone cannot distinguish from a change genuinely
-one job short. Update the branch and re-check before judging this clause.
+grows — in one programme the figure here moved four times in three days. Measure it
+on changes merged *after* the last matrix change, because a change branched before a
+new job landed is computed against the superseded matrix and legitimately reads
+band-minus-one, which the count alone cannot distinguish from a change genuinely one
+job short. Update the branch and re-check before judging this clause.
 
-**And one reading above the band is correct.** A change that adds a required
-job sees that job in its own rollup, so it legitimately reads band-plus-one
-before the standing band has moved — the arming proving itself rather than a
-miscount, and the one case where a total above the band is not a reason to
-look further.
+**And one reading above the band is correct.** A change that adds a required job
+sees that job in its own rollup, so it legitimately reads band-plus-one before the
+standing band has moved — the arming proving itself rather than a miscount, and the
+one case where a total above the band is not a reason to look further.
 
 ### Clause 2 — cancelled is not passed
 
@@ -120,29 +117,28 @@ change caused it.
 
 **If it did not, what you have is uncertainty, not a verdict.** The reflex — this change
 reds it, so this change broke it — dispatches a fix worker onto that change's branch and
-puts a workaround on a possibly innocent one. But the correction is not the opposite
-reflex. A job that never ran on the trunk is silent about *both* sides: it is no evidence
-the trunk is broken, and none that the change is clean. The red change may perfectly well
-have introduced the failure itself. Only running the gate settles it. Reproduce the actual
-failing check on a clean checkout of the change's base, or set up an equivalent controlled
-comparison. If it fails there, the defect is the trunk's and the fix belongs on a new branch
-off it; if it passes, the change owns the failure and the fix belongs on the change's own
-branch.
+puts a workaround on a possibly innocent one; but the correction is not the opposite
+reflex. A job that never ran on the trunk is silent about *both* sides: no evidence the
+trunk is broken, and none that the change is clean. Only running the gate settles it.
+Reproduce the actual failing check on a clean checkout of the change's base, or set up an
+equivalent controlled comparison. If it fails there, the defect is the trunk's and the fix
+belongs on a new branch off it; if it passes, the change owns the failure and the fix
+belongs on the change's own branch.
 
 **A right answer reached by the refuted inference is still a defect**, because the
 inference is what you carry to the next case. One mayor here called a red change innocent
-on the bare ground that its failing gate is skipped on trunk pushes, and dispatched no fix
-worker on that basis; it reproduced the gate nowhere. A sibling landed shortly after, the
-failure cleared, and the call now reads correct in the record. The outcome did not validate
-the reasoning — and nothing left in the record tells the two apart.
+on the bare ground that its failing gate is skipped on trunk pushes, reproducing the gate
+nowhere; a sibling landed shortly after, the failure cleared, and the call now reads correct
+in the record. The outcome did not validate the reasoning, and nothing left in the record
+tells the two apart.
 
 ### Clause 3 — require the terminal state, do not enumerate the bad ones
 
 Do not test this by listing the states that block. The vocabulary is longer than it
 looks — queued and in-progress are not the whole of it; hosts also return requested,
 waiting and pending — and a rule that enumerates the bad states fails open on the
-first state nobody wrote down. That is the same fail-open shape this whole section
-exists to close.
+first state nobody wrote down, the same fail-open shape this whole section exists to
+close.
 
 Invert it: require the terminal state. Anything else blocks and is re-checked next
 tick.
@@ -166,16 +162,15 @@ already bitten:
   re-trigger commit. A stale-revision run is not evidence about this head. **A guard
   that blocks forever is not safe, it is differently wrong.**
 
-**Two mechanical traps live in this clause, and they fail in opposite directions.**
-Both are worth stating because both are one character from correct:
+**Two mechanical traps live in this clause, both one character from correct, and they
+fail in opposite directions:**
 
 * **Case.** Your CLI may report check states in one case and run statuses in
   another. A comparison written against the wrong one counts every *finished* run as
   non-terminal, and every change reads blocked. This one fails **closed** — it never
-  ships a bad merge, and it never announces itself either. It presents as a CI queue
-  that will not drain, which is entirely believable. The tell is that every change
-  reads identically blocked; real CI does not stall a whole queue in lockstep.
-  Case-fold the comparison.
+  ships a bad merge, and it never announces itself either, presenting as a CI queue
+  that will not drain. The tell is that every change reads identically blocked; real
+  CI does not stall a whole queue in lockstep. Case-fold the comparison.
 * **Abbreviated revisions.** A run query filtered by an abbreviated revision may match
   nothing and return an empty list — which reads as "no live runs" and passes this
   clause **vacuously**. Pass the full revision.
@@ -185,14 +180,13 @@ Both are worth stating because both are one character from correct:
 This is the newest clause and the least visible, because every field you can read
 says green.
 
-Two changes merged four minutes apart here. The first added a required browser job
-and a new three-engine arm; the second was still checked against the base from
-before it, so the browser check it should have run came back *skipped* and the newly
-required one never appeared in its rollup at all. *"All required checks passed"* was
-a true statement about the old matrix and said nothing about the matrix already on
-the trunk. That tree happened to be green — an audit ran the suites by hand
-afterwards to establish it — but the guard had not known, which is the entire
-problem.
+Two changes merged four minutes apart here. The first added a required browser job;
+the second was still checked against the base from before it, so the browser check
+it should have run came back *skipped* and the newly required one never appeared in
+its rollup at all. *"All required checks passed"* was a true statement about the old
+matrix and said nothing about the matrix already on the trunk. That tree happened to
+be green — an audit established it by hand afterwards — but the guard had not known,
+which is the entire problem.
 
 Note the cost structure: this is the direct price of the merge-the-queue-first
 remedy below. **A burst is precisely when the base moves under a check set.**
@@ -211,14 +205,13 @@ identical, the count is unchanged, only a label moved. That is intact — but yo
 know by reading.
 
 Do this **before** merging. It is easy to merge and then reason that the drift was
-harmless. It usually is, and "usually" is what the other four clauses exist to
-refuse.
+harmless; it usually is, and "usually" is what the other four clauses exist to refuse.
 
 **And the set can move the other way, from the branch rather than the trunk.** Everything
-above is about keys ARRIVING underneath a change. A change that retires a surface REMOVES
+above is about keys ARRIVING underneath a change; a change that retires a surface REMOVES
 them, so its rollup legitimately reads below the band — and any programme that deletes a
-subsystem produces a run of such changes, so this stops being an edge case for the whole
-length of that work. **The count cannot tell a legitimate narrowing from a silent disarm.
+subsystem produces a run of such changes, so this is not an edge case for the whole length
+of that work. **The count cannot tell a legitimate narrowing from a silent disarm.
 Read which key left, and check it against what the change itself deleted.** A check whose
 entire subject went in the same change is retirement; a check that leaves while its subject
 still stands is the fail-open shape the programme exists to hunt, and it arrives wearing
@@ -231,14 +224,14 @@ failure output stays actionable, and that the quality-gates section is present.
 
 **Read the FILE LIST against the item, not just the count — and "scope did not sprawl" does
 not already cover it.** Sprawl is EXTRA work, and it announces itself because extra files read
-as new work. The opposite shape does not: a change that silently REVERTS merged work is green.
-It is well-formed, it compiles, and it passes every gate the tree has. One change here carried
-twenty-four files under a subject accurate about the one its author meant to touch, at 611
-insertions against 910 deletions, out of a worktree whose base had moved. **So a path the item
-does not explain is a finding whichever DIRECTION it runs**, and direction is the test rather
-than size: for a surprising file, ask whether something PRESENT on the branch is ABSENT from the
-trunk. On that change a source file had put back a symbol belonging to a retired subsystem, so
-the branch's content was OLDER than the trunk's.
+as new work. The opposite shape does not: a change that silently REVERTS merged work is green,
+well-formed, compiles, and passes every gate the tree has. One change here carried twenty-four
+files under a subject accurate about the one its author meant to touch, at 611 insertions
+against 910 deletions, out of a worktree whose base had moved; a source file had put back a
+symbol belonging to a retired subsystem, so the branch's content was OLDER than the trunk's.
+**So a path the item does not explain is a finding whichever DIRECTION it runs**, and direction
+is the test rather than size: for a surprising file, ask whether something PRESENT on the branch
+is ABSENT from the trunk.
 
 **Do not reach for a gate here.** A revert of merged work is mechanically indistinguishable from
 a change that is not one; the only discriminator is whether the reader EXPECTED those paths, so a
@@ -264,17 +257,16 @@ lives in a fork the server will not touch. **A surviving remote ref is never gro
 to reap a worktree early.**
 
 **"Base branch was modified" usually means stale — until something is moving the
-base.** The rejection reads like a lost race, so the reflex is to retry. Seven
-retries here proved otherwise: the branch was simply behind, and the remedy is to
+base.** The rejection reads like a lost race, so the reflex is to retry; seven
+retries here proved otherwise, the branch was simply behind, and the remedy is to
 update it and re-check.
 
 But any automation that writes to the trunk after a merge turns that reflex into a
 trap, because then the race is real. A post-merge hook that commits and pushes
 asynchronously means the base never holds still during a burst, and the next merge
-is refused for a reason no amount of updating fixes. **One change here was refused
-thirty times.** Both transports agreed, so it was not a client quirk, and updating
-the branch made it worse before better — CI restarts, and another hook commit lands
-inside that window.
+is refused for a reason no amount of updating fixes — **one change here was refused
+thirty times**, on both transports, and updating the branch made it worse before
+better, because CI restarts and another hook commit lands inside that window.
 
 The remedy is counterintuitive: **merge the whole queue FIRST, then give the
 straggler a genuinely empty window.** Raising its nominal priority does the opposite
@@ -316,9 +308,9 @@ fetches and the fast-forward in the same seconds.
 
 **An aborted fast-forward has two causes with different remedies, and the message says
 which** — and it says which only because the pair above no longer reads the shared file.
-Both reproduce unchanged under the fetch-and-merge pair, so the change costs nothing here.
-Naming remote and branch cures the silent no-op but neither abort, so read the text
-before reaching for a familiar fix:
+Both reproduce unchanged under that pair, so the change costs nothing here. Naming remote
+and branch cures the silent no-op but neither abort, so read the text before reaching for a
+familiar fix:
 
 * **"Local changes would be overwritten"** — uncommitted tracker state. Checkpoint it
   first, *then* clear, *then* retry. Clearing before checkpointing reverts whatever the
@@ -357,10 +349,9 @@ fleet size is the cause and the mayor says so rather than re-running indefinitel
 
 **And a check that never TERMINATES is a third case that neither remedy fits.** It has not
 failed, so nothing above is triggered; it has not passed, so clause 3 rejects the change for
-as long as it runs. Read literally, the criterion leaves the mayor no move at all and the
-honest thing to do is wait forever — which is exactly when the pressure to override arrives.
-**It is not a sixth clause.** Clause 3 already blocks the change, and correctly; what is
-missing is only what to DO about it.
+as long as it runs — which is exactly when the pressure to override arrives. **It is not a
+sixth clause**: clause 3 already blocks the change, and correctly, and what is missing is only
+what to DO about it.
 
 **Recognise it on the clock, against that job's OWN normal cost — measured, never
 remembered.** A remembered constant cannot detect a delta, and job costs move; the recent
@@ -368,8 +359,8 @@ successful runs of the same job are the baseline, and reading them costs one que
 here: a job whose last successes took 1.4 to 1.7 minutes was forty-nine minutes in and still
 going. **A timeout kill usually reports as CANCELLED rather than as a failure**, which clause
 2 handles correctly — cancelled is not passed — while saying nothing about *why*. Elapsed
-time against the job's declared cap is what tells them apart: landing ON the cap is a timeout
-kill, finishing well inside it is a superseding push or a hand cancel, and both numbers are
+time against the job's declared cap tells them apart: landing ON the cap is a timeout kill,
+finishing well inside it is a superseding push or a hand cancel, and both numbers are
 readable. Expect rollup jobs to go red seconds afterwards; those fail BECAUSE of the
 cancellation and are consequences rather than findings, so counting them as independent
 failures overstates the problem and points at the wrong remedy.
@@ -399,28 +390,23 @@ notifications, and do not trust a filter that returned empty — an empty filter
 dry backlog. One mayor under-saturated at one to three workers while a hundred items
 were ready, because a homegrown filter kept answering empty.
 
-**Read the newest note first, and order the item by the tracker's own timestamps.** The
-description is *usually* the oldest text and corrections accrete below it, so a top-down read
-gets superseded instructions — but the bottom is not reliably the newest either, because audit
-notes append into the description block while dated comments render after it. `bd show | tail`
-is not a read-the-newest method, and neither is grepping the prose for dates: a date in the
-text is content rather than a mutation time, so an undated correction is invisible to it and an
-edited description can be the newest field on the item. `bd history <id>` lists real mutation
-times newest-first; `bd comments <id> --json` carries comment `created_at`. That listing tells you
-a newer mutation exists but names no changed field — for the change itself, `bd history <id> --json`
-carries a full snapshot per commit — walk adjacent pairs newest-first until the first change to a
-text-bearing field, because the history holds duplicate checkpoint snapshots and status-only
-mutations and the newest pair alone can truthfully say nothing changed. And when a bead has
-children, re-enumerate them — a ruling is sometimes recorded as a new child bead rather than as
-a note. **But a child is one of two carriers, and naming one reads as exhaustive**: a ruling that
-discharges a slice is more often the CLOSE REASON of a bead already CLOSED and linked as a
-*dependency*, which is normative text rather than an archival note. So read the item's dependency
-list and not only its children, and read each linked item's status and close reason before you
-brief from the item's own words — and note that enumerating by id prefix is not enumerating,
-because a generated id does not share the parent's prefix, so a prefix filter returns the children
-while silently omitting the bead that governs. That is how a dispatch on 2026-08-18 went out to
-delete a tree that a closed dependency had ruled KEEP, its ruling having sat on the item's own
-dependency list the whole time.
+**Read the newest note first, and order the item by the tracker's own timestamps** — not by
+position, and not by dates written in the prose. The mechanics are set out for the worker under
+*Common preamble* in [`dispatch-prompt-template.md`](dispatch-prompt-template.md), and they bind
+the mayor reading the item exactly as they bind the worker: `bd show | tail` is not a
+read-the-newest method, `bd history <id>` lists real mutation times newest-first,
+`bd history <id> --json` carries the snapshot that says *what* changed, and you walk adjacent
+pairs newest-first to the first change to a text-bearing field.
+
+**A child bead is one of two carriers, and naming one reads as exhaustive.** Re-enumerate an
+item's children — a ruling is sometimes recorded as a new child rather than as a note — but a
+ruling that discharges a slice is more often the CLOSE REASON of a bead already CLOSED and linked
+as a *dependency*, which is normative text rather than an archival note. So read the dependency
+list as well as the children, and read each linked item's status and close reason before you brief
+from the item's own words. **Enumerating by id prefix is not enumerating**: a generated id does not
+share the parent's prefix, so a prefix filter returns the children while silently omitting the bead
+that governs. That is how one dispatch went out to delete a tree that a closed dependency had ruled
+KEEP, its ruling having sat on the item's own dependency list the whole time.
 
 Filter out before shaping anything:
 
@@ -444,17 +430,19 @@ duplicate.
 still resolves while the count is zero or triple. Re-run the item's own census at the
 current trunk tip.
 
+Measured drifts in one session: 8 → 9, "four hits" → 23 lines, "roughly 6–10" → 23,
+"4 of 21 cached" → 13 of 21. Two items once went out in one wave against work merged
+fifteen hours earlier; both workers returned a correct "already fixed", so the waste was
+two dispatches rather than a wrong result.
+
 **Exclude any generated export from a tree-wide census.** Where the tracker keeps a
 whole-database export inside the working tree, it carries every title, description and comment
 and therefore matches almost any identifier a census greps for. Both halves of the cost are
 real and the second is the dangerous one: one such grep returned a hundred kilobytes of tracker
-rows before a single real hit, which in a context-bounded worker is a material loss for
-nothing; and nothing in the output announces that a tracker row is not a source file, so an
-inflated census reads exactly like a correct one and sends its worker looking for sites that do
-not exist. Exclude it in the brief as much as in your own check. Measured drifts in one session: 8 → 9, "four hits" → 23 lines,
-"roughly 6–10" → 23, "4 of 21 cached" → 13 of 21. Two items once went out in one wave
-against work merged fifteen hours earlier; both workers returned a correct "already
-fixed", so the waste was two dispatches rather than a wrong result.
+rows before a single real hit, a material loss in a context-bounded worker; and nothing in the
+output announces that a tracker row is not a source file, so an inflated census reads exactly
+like a correct one and sends its worker looking for sites that do not exist. Exclude it in the
+brief as much as in your own check.
 
 **The sibling that discharges an item is usually the one whose fence sent the work
 elsewhere.** A tree fenced off from item A is exactly the tree item B is free to take.
@@ -505,22 +493,19 @@ that is already open. Six routed findings landed that way in one evening, none
 conflicting, several fixed minutes after they were found.
 
 **But routing does not create an owner, and that is the half people drop.** The message
-lives in one agent's transcript. If that agent dies, times out, or reasonably declines the
-extra item — declining is often correct — the finding evaporates, and the audit that found
-it has already run. An audit caught exactly this: a mayor had identified a stale deferral
-but *"routed it only to a transient worker, leaving no durable owner"*, the sole record
-being a close reason on a **different** item — a record on the wrong object, because nobody
-reads a closed item looking for open work.
+lives in one agent's transcript, so if that agent dies, times out, or reasonably declines the
+extra item — declining is often correct — the finding evaporates, and the audit that found it
+has already run. An audit caught exactly this: a mayor had *"routed it only to a transient
+worker, leaving no durable owner"*, the sole record being a close reason on a **different**
+item — a record on the wrong object, because nobody reads a closed item looking for open work.
+So put **one note on the owning item** saying what was routed, to whom, and what happens if it
+does not land.
 
-So put **one note on the owning item** saying what was routed, to whom, and what happens if
-it does not land.
-
-**Sometimes routing is the wrong move altogether.** A worker dispatched under a
-deliberately bounded fence has that fence widened mid-flight by a second finding, which is
-how a bounded repair becomes an unbounded one. Then leave that owner queued or sequenced
-instead, and note the overlap on the in-flight item — saying explicitly that the item is
-owned elsewhere and is **not** part of the in-flight repair, so nobody reading that item's
-newest notes adopts it.
+**Sometimes routing is the wrong move altogether.** It widens a deliberately bounded fence
+mid-flight, which is how a bounded repair becomes an unbounded one. Then leave that owner
+queued or sequenced instead, and note the overlap on the in-flight item — saying explicitly
+that the item is owned elsewhere and is **not** part of the in-flight repair, so nobody
+reading that item's newest notes adopts it.
 
 Route-and-note, or queue-and-note. An owner plus one note is common to both and is the whole
 safeguard. It does not want to grow past that: no routing registry, no tracking field, no
@@ -535,12 +520,12 @@ needs the operator, and do not manufacture work.
 
 ## 3. Backlog reread
 
-**Dispatch reads the ready list; this loop reads everything else.** A ready list is a
-projection. It answers *what could go out right now*, and by construction it omits held
-items, blocked items and items a live worker already holds. Those are the ones that fail
-quietly: a dispatchable item that goes wrong is caught on the next tick, because the tick
-is looking straight at it, while a held item that should have been released is caught by
-nobody, because nothing in the short loop reads it again.
+**Dispatch reads the ready list; this loop reads everything else.** A ready list answers
+*what could go out right now*, so by construction it omits held items, blocked items and
+items a live worker already holds — and those are the ones that fail quietly. A dispatchable
+item that goes wrong is caught on the next tick, because the tick is looking straight at it;
+a held item that should have been released is caught by nobody, because nothing in the short
+loop reads it again.
 
 So on a medium cadence, read **all** open items from the raw list — not a saved filter, not
 the ready view, not what you remember filing. On each one order the material by the tracker's
@@ -596,14 +581,13 @@ says when to STOP. A paraphrase keeps the memorable half and drops the restraini
 what survives does not read as incomplete — it reads as a stance that wants MORE of
 everything, which is precisely the failure the second half exists to prevent.
 
-Which clauses turn out to be load-bearing is worth knowing in advance, because they are the
-ones a summary sheds first. In one project: *"trust the programmer"* is what rejects a
-nagging diagnostic; *"close minutiae rather than actioning it"* is what lets an item die with
-its reasoning recorded instead of consuming a worker; *"a finding is a CLAIM"* is what stops
-an audit's output being mistaken for a queue. And the licence to refuse is load-bearing: in
-one session three of six dispatches came back as reasoned refusals, and each was worth more
-than the work would have been, because a migration performed on a false premise costs far
-more than a tracker item.
+Which clauses turn out to be load-bearing is worth knowing in advance, because a summary
+sheds those first. In one project: *"trust the programmer"* rejects a nagging diagnostic;
+*"close minutiae rather than actioning it"* lets an item die with its reasoning recorded
+instead of consuming a worker; *"a finding is a CLAIM"* stops an audit's output being
+mistaken for a queue. The licence to refuse is load-bearing too — in one session three of
+six dispatches came back as reasoned refusals, each worth more than the work would have
+been, because a migration performed on a false premise costs far more than a tracker item.
 
 Also reassert any **voice** the operator has asked for. Voice drift returns within about ten
 turns, which is exactly why it belongs in a recurring loop rather than in one session's
@@ -638,52 +622,48 @@ is a real signal, just never the complete one.
 outside, and both readings went wrong in a single day here, in opposite directions.
 
 1. **Has the *tip revision* on that item's branch changed since the last tick?** Record the
-   revision id, not a count of changes — **an *ahead* count, the changes your branch carries
-   beyond the trunk, survives a rebase unchanged**, and rebasing onto a moved trunk is what a
+   revision id, not a count of changes. **An *ahead* count — the changes your branch carries
+   beyond the trunk — survives a rebase unchanged**, and rebasing onto a moved trunk is what a
    briefed worker does constantly, so a count fails on the common case rather than an edge one.
-   Say which count, because only that one is invariant: counting *everything reachable* from
-   the branch does move under a rebase, having counted what the trunk gained as well. So the
-   misleading count is the ahead count — which is also the one you naturally read. The
-   timestamps split the same way: a rebase replays the *authored* time and rewrites only the
-   *committed* one, so two honest readers can call one change forty-three minutes old and
-   seventy-five seconds old and neither be misreading.
-   Reading the count and the authored time together, a healthy worker here was called unchanged
-   for two consecutive ticks — it had rebased two minutes before the second read and had
-   committed all of its assigned work. A changed id says alive everywhere a count does, plus
-   that case; an unchanged id still says *nothing* on its own, which is what saved that worker,
-   because the next step is to ask rather than to reap. **Read the tip from whichever ref the
-   worker's commit updates DIRECTLY, and prefer a read that performs no refresh at all** — a
-   refresh is what exposes the shared fetch-head trap under *After each merge*, which is on this
-   read path too and is silent here. Where workers share one repository metadata directory, the
-   shared local ref moves the moment a worker commits, while the *published* ref moves only when
-   that worker chooses to push. So the published one lags, and it lags in the direction that
-   reads as death: the read most likely to condemn a healthy worker is the one that asks the
-   wrong ref.
-   **And an unchanged tip says something only once it is corroborated with worktree activity.** A
+   Say *which* count, because only the ahead count is invariant: counting everything reachable
+   from the branch does move under a rebase, having counted what the trunk gained as well — so
+   the misleading one is also the one you naturally read. A changed id says alive everywhere a
+   count does, plus that case; an unchanged id still says *nothing* on its own, which is why the
+   next step is to ask rather than to reap. A healthy worker here was called unchanged for two
+   consecutive ticks, having rebased two minutes before the second read with all of its assigned
+   work committed.
+   **Read the tip from whichever ref the worker's commit updates DIRECTLY, and prefer a read that
+   performs no refresh at all** — a refresh is what exposes the shared fetch-head trap under
+   *After each merge*, which is on this read path too and is silent here. Where workers share one
+   repository metadata directory, the shared local ref moves the moment a worker commits while the
+   *published* ref moves only when that worker chooses to push: the published one lags, and it
+   lags in the direction that reads as death.
+   **An unchanged tip says something only once it is corroborated with worktree activity.** A
    worker inside a long gate commits nothing by design, so a still tip is the *expected* reading
    for the commonest healthy state rather than a warning — which is why the corroboration, and
-   not the tip, is what carries the verdict. **That corroboration is a WRITE clock, so a worker
-   that is only READING touches nothing** — twice in one day a worker grepping its own gate log
-   was called stranded on twenty-three minutes of no writes.
-   **And the most convincing false signature is on none of the discredited lists: a change fully
+   not the tip, carries the verdict. **That corroboration is a WRITE clock, so a worker that is
+   only READING touches nothing** — twice in one day a worker grepping its own gate log was
+   called stranded on twenty-three minutes of no writes.
+   **The most convincing false signature is on none of the discredited lists: a change fully
    green at the band, a clean worktree, a tip commit some minutes old, and the change still a
    DRAFT.** It reads as a worker that finished and forgot to publish — a real state, and the one
    the message step exists to catch — but a worker presenting exactly so was on attempt three of
-   its local gate. **A green rollup is evidence about the PUSHED tree, not about the worker**: CI
-   ran on what was already pushed, and a clean tree is what you see *between* edits rather than
-   only after the last one. It belongs on the list precisely because it reads strong, and because
-   not one of its four parts observes the agent.
-   **That timestamp split is by QUESTION, and the OTHER question takes the OPPOSITE answer.**
-   Everything above asks *is this worker alive?*, and liveness wants the *committed* time: the
-   rebase rewrites it, so it moves when the worker moves. But **DATING a change in prose — in a
-   design record, a governance note, any claim about when work was done — wants the *authored*
-   time**, because that is when the work was written, while the committed time records only when
-   the trunk happened to replay it. Where the project merges by rebase the two differ on
-   essentially every landed change, so this is the common case rather than a corner of it, and the
-   error is invisible once made: both are real timestamps on the same change, and each is correct
-   for its own question. A reader who has met only the liveness rule has been taught that the
-   authored time is the untrustworthy one, and will "correct" a right date into a wrong one — which
-   happened here, costing a live worker a wrong flag and the loop a retraction to the operator.
+   its local gate. **A green rollup is evidence about the PUSHED tree, not about the worker**, and
+   a clean tree is what you see *between* edits rather than only after the last one. It belongs on
+   the list precisely because it reads strong, and because not one of its four parts observes the
+   agent.
+   **The timestamps split by QUESTION, and the two questions take OPPOSITE answers.** A rebase
+   replays the *authored* time and rewrites only the *committed* one, so two honest readers can
+   call one change forty-three minutes old and seventy-five seconds old and neither be misreading.
+   Liveness wants the *committed* time, which moves when the worker moves. But **DATING a change
+   in prose — a design record, a governance note, any claim about when work was done — wants the
+   *authored* time**, because that is when the work was written, while the committed time records
+   only when the trunk happened to replay it. Where the project merges by rebase the two differ on
+   essentially every landed change, and the error is invisible once made: both are real timestamps
+   on the same change, each correct for its own question. A reader who has met only the liveness
+   rule has been taught that the authored time is the untrustworthy one, and will "correct" a right
+   date into a wrong one — which happened here, costing a live worker a wrong flag and the loop a
+   retraction to the operator.
 2. **Is there a live task to message?** Try messaging first — resuming beats redispatching,
    because the worker's context is still there. **The commonest strand by far is a worker that
    detached a long gate and then ended its turn**, waiting for a completion event that nothing
@@ -762,11 +742,11 @@ it "reported" does not change what it is.
 
 **Clearing the mayor's context destroys its ability to QUOTE a report, so record which worktree
 belongs to which agent at DISPATCH time** — one line per dispatch, in a mayor-local file the
-project does not track. The reap test is unchanged and nothing here weakens it; this only supplies
-a documented route to obtain the sentence once the context that held it is gone. Measured here:
-after one clear, fourteen worktrees existed and exactly three had a quotable report — all three
-dispatched after it — while nine of the remaining eleven held work that was fully upstream with
-their items closed. The rule failed safe and nothing was lost; the cost is monotone accumulation.
+project does not track. The reap test is unchanged; this only supplies a documented route to the
+sentence once the context that held it is gone. Measured here: after one clear, fourteen worktrees
+existed and exactly three had a quotable report, all three dispatched after it, while nine of the
+remaining eleven held work fully upstream with their items closed. The rule failed safe and nothing
+was lost; the cost is monotone accumulation.
 
 **Dispatch time, not report time.** A report-time record has to survive the window between the
 report arriving and the clear; dispatch always precedes the report, so the line is on disk before
@@ -775,19 +755,18 @@ a clear can matter.
 **What the id buys is the TRANSCRIPT, not a live conversation.** Messaging does not reach across a
 clear — every one of eight agents whose ids had been recorded exactly as prescribed answered *"no
 transcript found"*, while an agent dispatched by the current session resumed on the identical call.
-Their transcripts were nonetheless intact on disk, and seven of the eight opened their last message
+Their transcripts were intact on disk nonetheless, and seven of the eight opened their last message
 with precisely the sentence the reap test demands. **Reading it is a READ, not an inference** — the
-agent's own words, the same sentence you would have quoted from your own context — so it satisfies
-the test as written and adds no further proxy. The eighth carried only an interim progress note, and
-its worktree correctly stayed.
+agent's own words — so it satisfies the test as written and adds no further proxy. The eighth
+carried only an interim progress note, and its worktree correctly stayed.
 
-Two cautions came out of establishing that. **An id is a way to FIND the report, never an answer in
-itself**: within the dispatching session, message first, because that distinguishes *alive* from
-*finished* and a transcript cannot. And **beware a per-agent scratch sink that merely shares the
-id** — one such file was empty for seven of those eight agents while their real transcripts sat
-complete elsewhere, was *also* empty for a current-session agent that finished normally, and for the
-eighth held a hardlink to the real transcript, so the wrong file returned exactly one plausible
-non-empty result and made the wrong conclusion self-consistent.
+Two cautions came out of that. **An id is a way to FIND the report, never an answer in itself**:
+within the dispatching session, message first, because that distinguishes *alive* from *finished*
+and a transcript cannot. And **beware a per-agent scratch sink that merely shares the id** — one
+such file was empty for seven of those eight agents while their real transcripts sat complete
+elsewhere, was *also* empty for a current-session agent that finished normally, and for the eighth
+held a hardlink to the real transcript, so the wrong file returned exactly one plausible non-empty
+result and made the wrong conclusion self-consistent.
 
 **Whether to hold the report TEXT somewhere of your own is the operator's call.** A transcript path
 the platform documents as an implementation detail is not a contract, and local-history retention
@@ -857,20 +836,20 @@ happened to be printed.
 
 **"Verifiably merged" needs a test, and where the project merges by REBASE the two obvious ones are
 both wrong — in opposite directions.** A rebase replays every commit under a new identity, so a
-merged branch never becomes an ancestor of the trunk and never stops reading as *ahead* of it.
-Ancestry therefore reports fully merged work as unmerged, and the ahead count says the same thing
-for the same reason. That is the identical rebase invariance *The stranded sweep* explains above,
-asked on a different question — containment rather than liveness — which is why that paragraph is
-the cross-reference here rather than something to restate.
+merged branch never becomes an ancestor of the trunk and never stops reading as *ahead* of it:
+ancestry reports fully merged work as unmerged, and the ahead count says the same thing for the same
+reason. That is the rebase invariance *The stranded sweep* explains above, asked on containment
+rather than on liveness, which is why that paragraph is the cross-reference here rather than
+something to restate.
 
 **The test is patch-equivalence**, which asks what each commit *does* rather than which object it
 is: an equivalent patch already upstream means the work is contained, and anything with no upstream
 equivalent is genuinely new. In the dominant toolchain that is `cherry`, which marks the two answers
-`-` and `+`. It protects in both directions at once, and that is what earns it over either half of a
+`-` and `+`. It protects in both directions at once, which is what earns it over either half of a
 rule that only ever fails safe one way. Measured here across 63 worktrees: 60 branches read one to
-three commits ahead of the trunk and 58 of those were fully merged, while one carried three commits
-that were genuinely new. Deleting on ancestry would have kept all 58 forever; deleting on the ahead
-count alone would have destroyed those three. One command separated them.
+three commits ahead of the trunk, 58 of those fully merged and one carrying three genuinely new
+commits. Deleting on ancestry would have kept all 58 forever; deleting on the ahead count alone
+would have destroyed those three.
 
 **Key destructive operations on identity, never on a name.** Branch names repeat across sessions and
 prefix-match each other. A search for `head:feature-x` also returns the change for `feature-x2`, and
@@ -947,18 +926,18 @@ verdict off a filter is the same failure in a different suit, and it reaches eve
 just gates. Two instances in one session, both from trimming output to keep a log short. Four closes were sent
 with long reasons and their output trimmed to the last line — which, when the reason is long, *is* the reason
 text, so a refused close and an accepted one looked identical; all four evaporated and were found cycles later
-reading open with no reason recorded. Nine worktree removals were then called with the wrong argument shape and
-their output counted for a string that the script prints on the way out whether it acts or refuses; every one
-had exited non-zero saying "nothing was touched", and all nine were still there. A maintenance script that
-refuses safely is doing its job; the failure is the caller who does not look.
+reading open with no reason recorded. Nine worktree removals were then counted for a string the script prints on
+the way out whether it acts or refuses; every one had exited non-zero saying "nothing was touched", and all nine
+were still there. A maintenance script that refuses safely is doing its job; the failure is the caller who does
+not look.
 
 **But the exit status and the mutation are two different questions, and only the first is cheap.** A non-zero
 status is proof the command refused, so **always read it** — that alone would have caught both incidents above.
-A *zero* status proves only that the command reported success. It does not prove state changed: an idempotent
-call legitimately succeeds having done nothing, and a durable operation can acknowledge locally before the
-remote or the postcondition you actually care about is true. **So when the outcome you need is a state change or
-a durable one — or when a successful no-op is possible — re-read the exact target as well.** Never take the
-printed output for either answer.
+A *zero* status proves only that the command reported success, not that state changed: an idempotent call
+legitimately succeeds having done nothing, and a durable operation can acknowledge locally before the remote or
+the postcondition you actually care about is true. **So when the outcome you need is a state change or a durable
+one — or when a successful no-op is possible — re-read the exact target as well.** Never take the printed output
+for either answer.
 
 **A tracker write can silently revert.** Items verified closed can read open again cycles later — a
 rollback to an earlier snapshot, a re-import over the top — and nothing in the loop surfaces it, so the

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -450,10 +450,6 @@ vocabulary for the two rather than inventing a second.
 Pick the shape by kind first, then priority, then size. The shapes are in
 [`dispatch-prompt-template.md`](dispatch-prompt-template.md).
 
-**One agent owns a surface; surfaces run in parallel.** Same-surface items ride one
-agent, which never collides with itself. Two workers never share a surface — they
-merge-conflict and can silently revert each other.
-
 **The unit is the block, not the file.** Two items dispatched into the same *paragraph*
 of one document conflicted, the second change could not merge, and by the time its worker
 was resumed the hygiene loop had reaped its worktree. Two costs from one scheduling error.
@@ -559,12 +555,8 @@ backlog from the ready view is the exact failure this loop exists to go behind.
 block verbatim into every dispatch preamble.** This loop is that file's natural home,
 because it is also the loop that re-reads it.
 
-**Never summarise a stance.** The lenses say what good looks like; everything after them
-says when to STOP. A paraphrase keeps the memorable half and drops the restraining one, and
-what survives does not read as incomplete — it reads as a stance that wants MORE of
-everything, which is precisely the failure the second half exists to prevent.
-
-Which clauses turn out to be load-bearing is worth knowing in advance, because a summary
+**Never summarise a stance** — [`dispatch-prompt-template.md`](dispatch-prompt-template.md)
+carries why a paraphrase fails. Which clauses turn out to be load-bearing is worth knowing in advance, because a summary
 sheds those first. In one project: *"trust the programmer"* rejects a nagging diagnostic;
 *"close minutiae rather than actioning it"* lets an item die with its reasoning recorded
 instead of consuming a worker; *"a finding is a CLAIM"* stops an audit's output being

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -604,89 +604,78 @@ and name the dispatch. Otherwise one line is enough.
 
 Look for items marked in-progress. If no live worker holds one, it may be stranded.
 
-**But start from the worktrees, because that set is routinely empty while workers are
-running.** Unless your dispatches explicitly claim their items, a worker holds items that
-still read *open*, and this loop's nominal input is empty by construction rather than by
-health. Measured here: the in-progress list returned nothing while a worker was provably
-alive — files being written seconds earlier, a gate process burning CPU — and the three items
-it held all read open. A *"nothing in progress, sweep clean"* report is then not evidence of
-anything, and a streak of them is a streak of reads of an empty set.
+**But start from the worktrees, because that set is routinely empty while workers are running.**
+Unless your dispatches explicitly claim their items, a worker holds items that still read *open*, so
+this loop's nominal input is empty by construction rather than by health. Measured here: the
+in-progress list returned nothing while a worker was provably alive — files written seconds earlier,
+a gate process burning CPU — and the three items it held all read open. A *"nothing in progress,
+sweep clean"* report is then not evidence of anything, and a streak of them is a streak of reads of
+an empty set.
 
-The failure is worse than a missed strand. A dead worker's items sit open, look dispatchable,
-and the next dispatch tick sends a **second worker to the same branch** — the collision this
-method spends a section forbidding. So enumerate the worktrees first, sweep each for recent
-file activity, and map trees to items; where an item *is* marked in-progress, read it too. It
-is a real signal, just never the complete one.
+**The failure is worse than a missed strand**: a dead worker's items sit open, look dispatchable, and
+the next dispatch tick sends a **second worker to the same branch**. So enumerate the worktrees
+first, sweep each for recent file activity, and map trees to items. Where an item *is* marked
+in-progress, read it too — a real signal, never the complete one.
 
-**Discriminate before acting** — a long-running worker and a stranded one look identical from
-outside, and both readings went wrong in a single day here, in opposite directions.
+**Discriminate before acting.** A long-running worker and a stranded one look identical from outside,
+and both readings went wrong in a single day here, in opposite directions.
 
-1. **Has the *tip revision* on that item's branch changed since the last tick?** Record the
-   revision id, not a count of changes. **An *ahead* count — the changes your branch carries
-   beyond the trunk — survives a rebase unchanged**, and rebasing onto a moved trunk is what a
-   briefed worker does constantly, so a count fails on the common case rather than an edge one.
-   Say *which* count, because only the ahead count is invariant: counting everything reachable
-   from the branch does move under a rebase, having counted what the trunk gained as well — so
-   the misleading one is also the one you naturally read. A changed id says alive everywhere a
-   count does, plus that case; an unchanged id still says *nothing* on its own, which is why the
-   next step is to ask rather than to reap. A healthy worker here was called unchanged for two
-   consecutive ticks, having rebased two minutes before the second read with all of its assigned
-   work committed.
+1. **Has the *tip revision* on that item's branch changed since the last tick?** Record the revision
+   id, never a count of changes: **an *ahead* count survives a rebase unchanged**, and rebasing onto a
+   moved trunk is what a briefed worker does constantly, so a count fails on the common case. A
+   healthy worker here was called unchanged across two ticks, having rebased two minutes before the
+   second read with all its work committed.
+
    **Read the tip from whichever ref the worker's commit updates DIRECTLY, and prefer a read that
-   performs no refresh at all** — a refresh is what exposes the shared fetch-head trap under
-   *After each merge*, which is on this read path too and is silent here. Where workers share one
-   repository metadata directory, the shared local ref moves the moment a worker commits while the
-   *published* ref moves only when that worker chooses to push: the published one lags, and it
-   lags in the direction that reads as death.
-   **An unchanged tip says something only once it is corroborated with worktree activity.** A
-   worker inside a long gate commits nothing by design, so a still tip is the *expected* reading
-   for the commonest healthy state rather than a warning — which is why the corroboration, and
-   not the tip, carries the verdict. **That corroboration is a WRITE clock, so a worker that is
-   only READING touches nothing** — twice in one day a worker grepping its own gate log was
-   called stranded on twenty-three minutes of no writes.
-   **The most convincing false signature is on none of the discredited lists: a change fully
-   green at the band, a clean worktree, a tip commit some minutes old, and the change still a
-   DRAFT.** It reads as a worker that finished and forgot to publish — a real state, and the one
-   the message step exists to catch — but a worker presenting exactly so was on attempt three of
-   its local gate. **A green rollup is evidence about the PUSHED tree, not about the worker**, and
-   a clean tree is what you see *between* edits rather than only after the last one. It belongs on
-   the list precisely because it reads strong, and because not one of its four parts observes the
-   agent.
-   **The timestamps split by QUESTION, and the two questions take OPPOSITE answers.** A rebase
-   replays the *authored* time and rewrites only the *committed* one, so two honest readers can
-   call one change forty-three minutes old and seventy-five seconds old and neither be misreading.
-   Liveness wants the *committed* time, which moves when the worker moves. But **DATING a change
-   in prose — a design record, a governance note, any claim about when work was done — wants the
-   *authored* time**, because that is when the work was written, while the committed time records
-   only when the trunk happened to replay it. Where the project merges by rebase the two differ on
-   essentially every landed change, and the error is invisible once made: both are real timestamps
-   on the same change, each correct for its own question. A reader who has met only the liveness
-   rule has been taught that the authored time is the untrustworthy one, and will "correct" a right
-   date into a wrong one — which happened here, costing a live worker a wrong flag and the loop a
-   retraction to the operator.
-2. **Is there a live task to message?** Try messaging first — resuming beats redispatching,
-   because the worker's context is still there. **The commonest strand by far is a worker that
-   detached a long gate and then ended its turn**, waiting for a completion event that nothing
-   sends. Seven such incidents happened in one day; every one recovered intact the moment
-   somebody asked for a status.
-3. **Only when there is no live task and no movement in the tip:** push any existing commits on the
-   branch — pure durability — then set the item back to open with a note saying what was found
-   and what was salvaged, and redispatch.
-   **Read WHY the worker stopped before you act on that last word.** When the stop reason names an
-   exhausted allowance — a spend cap, a rate limit, a usage quota with a stated reset — redispatch
-   is not a remedy, because *a remedy that draws on the resource whose exhaustion caused the
-   failure is not a remedy*: every attempt fails identically until the reset, and every attempt
-   spends. The salvage half still applies in full. Leave the item open with the reason and the
-   reset time recorded, and stop dispatching rather than retrying. **Merging is unaffected**, and
-   that is the half that still pays — integrating a finished change draws on none of that
-   allowance, and a change whose author has already stopped can still be the one unblocking
-   everything queued behind it. So the order is salvage, then merge whatever is green, then stop.
-   A reason naming a limit and a reset is categorically different from a crash, a timeout, or
-   step 2's detached-gate strand: **the reason text, not the symptom, chooses the remedy**, and
-   all three symptoms look identical from outside.
+   performs no refresh** — a refresh exposes the shared fetch-head trap under *After each merge*,
+   which is on this path too and is silent here. Where workers share one repository metadata
+   directory, the local ref moves the moment a worker commits while the *published* ref moves only
+   when that worker pushes: the published one lags, in the direction that reads as death.
 
-**Never build a commit from someone else's uncommitted work.** Only that worker knows whether
-it forms a coherent change.
+   **An unchanged tip says nothing on its own** — a worker inside a long gate commits nothing by
+   design, so a still tip is the *expected* reading for the commonest healthy state. Corroborate with
+   worktree activity, and note that **the corroboration is a WRITE clock, so a worker that is only
+   READING touches nothing**: twice in one day a worker grepping its own gate log was called stranded
+   on twenty-three minutes of no writes.
+
+   **The most convincing false signature is on none of the discredited lists: a change fully green at
+   the band, a clean worktree, a tip commit some minutes old, and the change still a DRAFT.** It reads
+   as a worker that finished and forgot to publish — a real state, and the one step 2 exists to catch
+   — but a worker presenting exactly so was on attempt three of its local gate. **A green rollup is
+   evidence about the PUSHED tree, not about the worker**, and a clean tree is what you see *between*
+   edits. It belongs on the list because it reads strong and not one of its four parts observes the
+   agent.
+
+   **The timestamps split by QUESTION, and the two questions take OPPOSITE answers.** A rebase replays
+   the *authored* time and rewrites only the *committed* one, so two honest readers can call one change
+   forty-three minutes old and seventy-five seconds old. Liveness wants the *committed* time, which
+   moves when the worker moves. But **DATING a change in prose — a design record, a governance note,
+   any claim about when work was done — wants the *authored* time**, because that is when the work was
+   written. Where the project merges by rebase the two differ on essentially every landed change, and
+   the error is invisible once made. A reader who has met only the liveness rule has been taught that
+   the authored time is the untrustworthy one, and will "correct" a right date into a wrong one.
+
+2. **Is there a live task to message?** Message first — resuming beats redispatching, because the
+   worker's context is still there. **The commonest strand by far is a worker that detached a long gate
+   and then ended its turn**, waiting for a completion event nothing sends. Seven such incidents in one
+   day; every one recovered intact the moment somebody asked for a status.
+
+3. **Only with no live task AND no tip movement:** push any existing commits — pure durability — then
+   set the item back to open with a note on what was found and salvaged, and redispatch.
+
+   **Read WHY the worker stopped before acting on that last word.** Where the stop reason names an
+   exhausted allowance with a stated reset, redispatch is not a remedy: *a remedy that draws on the
+   resource whose exhaustion caused the failure is not a remedy*, so every attempt fails identically
+   until the reset and every attempt spends. Salvage still applies in full — record the reason and the
+   reset time, and stop dispatching rather than retrying. **Merging is unaffected**, and that is the
+   half that still pays: integrating a finished change draws on none of that allowance, and a change
+   whose author has already stopped can still be the one unblocking everything queued behind it. So
+   the order is salvage, merge whatever is green, then stop. **The reason text, not the symptom,
+   chooses the remedy** — a quota death, a crash, a timeout and step 2's detached-gate strand look
+   identical from outside.
+
+**Never build a commit from someone else's uncommitted work.** Only that worker knows whether it forms
+a coherent change.
 
 ---
 
@@ -741,43 +730,35 @@ report you received. *"I think it is done"* is the inference this rule exists to
 it "reported" does not change what it is.
 
 **Clearing the mayor's context destroys its ability to QUOTE a report, so record which worktree
-belongs to which agent at DISPATCH time** — one line per dispatch, in a mayor-local file the
-project does not track. The reap test is unchanged; this only supplies a documented route to the
-sentence once the context that held it is gone. Measured here: after one clear, fourteen worktrees
-existed and exactly three had a quotable report, all three dispatched after it, while nine of the
-remaining eleven held work fully upstream with their items closed. The rule failed safe and nothing
-was lost; the cost is monotone accumulation.
-
-**Dispatch time, not report time.** A report-time record has to survive the window between the
-report arriving and the clear; dispatch always precedes the report, so the line is on disk before
-a clear can matter.
+belongs to which agent at DISPATCH time** — one line per dispatch, in a mayor-local file the project
+does not track. The reap test is unchanged; this only supplies a route to the sentence once the
+context that held it is gone. After one clear, fourteen worktrees existed and exactly three had a
+quotable report, all three dispatched after it. The rule failed safe; the cost is monotone
+accumulation. **Dispatch time, not report time** — dispatch always precedes the report, so the line
+is on disk before a clear can matter.
 
 **What the id buys is the TRANSCRIPT, not a live conversation.** Messaging does not reach across a
-clear — every one of eight agents whose ids had been recorded exactly as prescribed answered *"no
-transcript found"*, while an agent dispatched by the current session resumed on the identical call.
-Their transcripts were intact on disk nonetheless, and seven of the eight opened their last message
-with precisely the sentence the reap test demands. **Reading it is a READ, not an inference** — the
-agent's own words — so it satisfies the test as written and adds no further proxy. The eighth
-carried only an interim progress note, and its worktree correctly stayed.
+clear: eight agents whose ids had been recorded exactly as prescribed all answered *"no transcript
+found"*, while an agent dispatched by the current session resumed on the identical call. Their
+transcripts were intact on disk nonetheless, and seven of the eight opened their last message with
+precisely the sentence the reap test demands. **Reading it is a READ, not an inference**, so it
+satisfies the test as written and adds no further proxy.
 
-Two cautions came out of that. **An id is a way to FIND the report, never an answer in itself**:
-within the dispatching session, message first, because that distinguishes *alive* from *finished*
-and a transcript cannot. And **beware a per-agent scratch sink that merely shares the id** — one
-such file was empty for seven of those eight agents while their real transcripts sat complete
-elsewhere, was *also* empty for a current-session agent that finished normally, and for the eighth
-held a hardlink to the real transcript, so the wrong file returned exactly one plausible non-empty
-result and made the wrong conclusion self-consistent.
+**An id is a way to FIND the report, never an answer in itself**: within the dispatching session,
+message first, because that distinguishes *alive* from *finished* and a transcript cannot. And
+**beware a per-agent scratch sink that merely shares the id** — one was empty for seven of those
+eight while their real transcripts sat complete elsewhere, *also* empty for a current-session agent
+that finished normally, and for the eighth held a hardlink to the real transcript, so the wrong
+file returned one plausible non-empty result and made the wrong conclusion self-consistent.
 
-**Whether to hold the report TEXT somewhere of your own is the operator's call.** A transcript path
-the platform documents as an implementation detail is not a contract, and local-history retention
-sweeps typically DELETE rather than truncate.
+A transcript path the platform documents as an implementation detail is not a contract, and
+local-history retention sweeps typically DELETE rather than truncate — so whether to hold the report
+text somewhere of your own is the operator's call.
 
-**Reaping on the report is correct and still costs something.** A worker can need its tree *after*
-it reports, because its change hits a conflict and needs a rebase. Pushed commits make that
-survivable — the worker recreates the tree on the existing branch and continues. Whether to hold a
-worktree while its change is open is a real trade, and "leave the rule alone and accept the rebuild"
-is a defensible answer. **Do not add a second condition to a rule whose strength is that it has
-one.**
+**Reaping on the report is correct and still costs something**: a worker can need its tree *after*
+it reports, because its change hits a conflict. Pushed commits make that survivable — it recreates
+the tree on the existing branch and continues. **Do not add a second condition to a rule whose
+strength is that it has one.**
 
 ### Removing
 

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -222,58 +222,44 @@ the same number. The two readings differ by one question, and the answer is in t
 Check also that the diff matches its tracker item, that scope did not sprawl, that
 failure output stays actionable, and that the quality-gates section is present.
 
-**Read the FILE LIST against the item, not just the count — and "scope did not sprawl" does
-not already cover it.** Sprawl is EXTRA work, and it announces itself because extra files read
-as new work. The opposite shape does not: a change that silently REVERTS merged work is green,
-well-formed, compiles, and passes every gate the tree has. One change here carried twenty-four
-files under a subject accurate about the one its author meant to touch, at 611 insertions
-against 910 deletions, out of a worktree whose base had moved; a source file had put back a
-symbol belonging to a retired subsystem, so the branch's content was OLDER than the trunk's.
-**So a path the item does not explain is a finding whichever DIRECTION it runs**, and direction
-is the test rather than size: for a surprising file, ask whether something PRESENT on the branch
-is ABSENT from the trunk.
+**Read the FILE LIST against the item, not just the count — "scope did not sprawl" does not
+cover it.** Sprawl is EXTRA work and announces itself, because extra files read as new work. The
+opposite shape does not: a change that silently REVERTS merged work is green, well-formed,
+compiles, and passes every gate the tree has. One here carried twenty-four files at 611 insertions
+against 910 deletions, out of a worktree whose base had moved, putting back a symbol belonging to
+a retired subsystem — the branch's content was OLDER than the trunk's. **So a path the item does
+not explain is a finding whichever DIRECTION it runs**, and direction is the test rather than
+size: for a surprising file, ask whether something PRESENT on the branch is ABSENT from the trunk.
 
-**Do not reach for a gate here.** A revert of merged work is mechanically indistinguishable from
-a change that is not one; the only discriminator is whether the reader EXPECTED those paths, so a
-gate would be a control that cannot catch its own case. The worker-side half of this — diff
-against the merge base before pushing and read it for what you would revert — is already on every
-brief; this is the mayor-side half, for the case that half exists to catch and by definition did
-not: the worker that never ran it.
+**Do not reach for a gate here.** A revert is mechanically indistinguishable from a change that is
+not one; the only discriminator is whether the reader EXPECTED those paths, so a gate would be a
+control that cannot catch its own case. The worker-side half — diff against the merge base before
+pushing — is on every brief; this is the mayor-side half, for the worker that never ran it.
 
 Merge every green change **regardless of author**, including the operator's own.
 
-**Prefer server-side head-branch deletion over a client-side delete flag.** A branch
-still checked out in a worktree cannot be deleted locally, and clients typically
-abandon the *remote* deletion along with the local one — so the flag orphans a remote
-branch on every merge whose worker has not yet reported. Three for three in the
-session that measured it, against roughly twenty manual cleanups that were skipped
-more often than they were run. Turn on the repository setting instead: the server
-deletes the head branch as the merge lands and does not care what a worktree is
-holding. Zero orphans by construction, and nothing to remember afterwards.
-
-A manual remote delete then survives only as the rare fallback for a ref that
-outlives a verified merge — head-ref protection, or a cross-repo change whose head
-lives in a fork the server will not touch. **A surviving remote ref is never grounds
-to reap a worktree early.**
+**Prefer server-side head-branch deletion over a client-side delete flag.** A branch still
+checked out in a worktree cannot be deleted locally, and clients typically abandon the *remote*
+deletion along with the local one — so the flag orphans a remote branch on every merge whose
+worker has not yet reported. The repository setting has none of that: the server deletes the head
+branch as the merge lands and does not care what a worktree holds. Zero orphans by construction.
+A manual remote delete then survives only for a ref that outlives a verified merge — head-ref
+protection, or a head living in a fork the server will not touch. **A surviving remote ref is
+never grounds to reap a worktree early.**
 
 **"Base branch was modified" usually means stale — until something is moving the
 base.** The rejection reads like a lost race, so the reflex is to retry; seven
 retries here proved otherwise, the branch was simply behind, and the remedy is to
 update it and re-check.
 
-But any automation that writes to the trunk after a merge turns that reflex into a
-trap, because then the race is real. A post-merge hook that commits and pushes
-asynchronously means the base never holds still during a burst, and the next merge
-is refused for a reason no amount of updating fixes — **one change here was refused
-thirty times**, on both transports, and updating the branch made it worse before
-better, because CI restarts and another hook commit lands inside that window.
-
-The remedy is counterintuitive: **merge the whole queue FIRST, then give the
-straggler a genuinely empty window.** Raising its nominal priority does the opposite
-of what it looks like, because priority without an empty window is just more attempts
-against a moving base. And if a change refuses more than about three times while
-blocking nothing, **shelve it** and take it opportunistically. Persistence on an item
-that is blocking nothing is its own gold-plating.
+But any automation that writes to the trunk after a merge makes the race real. A post-merge hook
+that commits asynchronously means the base never holds still during a burst, and the next merge is
+refused for a reason no amount of updating fixes — **one change here was refused thirty times**,
+and updating the branch made it worse before better, because CI restarts and another hook commit
+lands inside that window. The remedy is counterintuitive: **merge the whole queue FIRST, then give
+the straggler a genuinely empty window.** Raising its priority is just more attempts against a
+moving base. If a change refuses more than about three times while blocking nothing, **shelve it**
+— persistence on an item blocking nothing is its own gold-plating.
 
 ### After each merge
 
@@ -292,19 +278,17 @@ four times in one session and was never real.
 Read the *fetch's* own exit code for the same reason. A failed fetch and a subsequent
 "Already up to date" print into the same buffer, and the reassuring line is the lie.
 
-**Do not collapse that pair back into a pull.** A pull picks its merge target out of a
-scratch file that any concurrent git process in the same checkout can rewrite — most
-exposed being the shared checkout every agent reaches into to add a worktree — and a
-captured target does not fail honestly. Measured here: in one arrangement it silently
-fast-forwarded the trunk **onto a feature branch**; in another it aborted wearing the
-divergence message below, on a clean tree zero commits ahead, where that message's remedy
-is inert. **A failure that borrows another cause's message cannot be discriminated by
-message text**, so the repair is to retire the command that reads the shared file, not to
-add a third case to the list. A remote-tracking ref cannot be captured that way: it is
-written atomically, and every concurrent fetcher sets it to the same trunk head or a newer
-one, both of which still fast-forward. Expect the exposure to **grow with fleet size** —
-dispatching immediately after merging is what puts the concurrent fetches and the
-fast-forward in the same seconds.
+**Do not collapse that pair back into a pull.** A pull picks its merge target out of a scratch
+file any concurrent git process in the same checkout can rewrite — most exposed being the shared
+checkout every agent reaches into to add a worktree — and a captured target does not fail
+honestly. Measured here: in one arrangement it silently fast-forwarded the trunk **onto a feature
+branch**; in another it aborted wearing the divergence message below, on a clean tree zero commits
+ahead, where that remedy is inert. **A failure that borrows another cause's message cannot be
+discriminated by message text**, so the repair is to retire the command that reads the shared
+file, not to add a third case. A remote-tracking ref cannot be captured that way: it is written
+atomically, and every concurrent fetcher sets it to the trunk head or newer, both of which still
+fast-forward. The exposure **grows with fleet size** — dispatching immediately after merging puts
+the concurrent fetches and the fast-forward in the same seconds.
 
 **An aborted fast-forward has two causes with different remedies, and the message says
 which** — and it says which only because the pair above no longer reads the shared file.
@@ -341,11 +325,10 @@ not — dispatch a fix worker onto the **existing** branch that runs the **actua
 gate, not a proxy that already passed.
 
 **A failure BEFORE any repository code ran is the second case, and the failing step names
-itself** — an action download rate-limited, a runner setup step dying. The diff cannot have
-caused it, so no second observation is needed: re-run the failed jobs and hold the re-run to the
-same clauses. **But re-running is not a cure.** One job died in setup on the same rate limit
-twice, eight minutes apart, so when SEVERAL changes fail that way rather than one job twice,
-fleet size is the cause and the mayor says so rather than re-running indefinitely.
+itself** — an action download rate-limited, a runner setup step dying. The diff cannot have caused
+it, so no second observation is needed: re-run the failed jobs and hold the re-run to the same
+clauses. **But re-running is not a cure** — when SEVERAL changes fail that way rather than one job
+twice, fleet size is the cause and the mayor says so.
 
 **And a check that never TERMINATES is a third case that neither remedy fits.** It has not
 failed, so nothing above is triggered; it has not passed, so clause 3 rejects the change for

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -293,18 +293,18 @@ Read the *fetch's* own exit code for the same reason. A failed fetch and a subse
 "Already up to date" print into the same buffer, and the reassuring line is the lie.
 
 **Do not collapse that pair back into a pull.** A pull picks its merge target out of a
-scratch file that any concurrent git process in the same checkout can rewrite, and the
-checkout most exposed is the shared one every agent reaches into to add a worktree or read
-the trunk. A captured target does not fail honestly. Measured here: in one arrangement it
-silently fast-forwarded the trunk **onto a feature branch**; in another it aborted wearing
-the divergence message below, on a tree that was clean and zero commits ahead, where that
-message's remedy is inert. **A failure that borrows another cause's message cannot be
-discriminated by message text**, so the repair is to retire the command that reads the
-shared file, not to add a third case to the list. A remote-tracking ref cannot be captured
-that way: it is written atomically, and every concurrent fetcher sets it to the same trunk
-head or a newer one, both of which still fast-forward. Expect the exposure to **grow with
-fleet size** — dispatching immediately after merging is exactly what puts the concurrent
-fetches and the fast-forward in the same seconds.
+scratch file that any concurrent git process in the same checkout can rewrite — most
+exposed being the shared checkout every agent reaches into to add a worktree — and a
+captured target does not fail honestly. Measured here: in one arrangement it silently
+fast-forwarded the trunk **onto a feature branch**; in another it aborted wearing the
+divergence message below, on a clean tree zero commits ahead, where that message's remedy
+is inert. **A failure that borrows another cause's message cannot be discriminated by
+message text**, so the repair is to retire the command that reads the shared file, not to
+add a third case to the list. A remote-tracking ref cannot be captured that way: it is
+written atomically, and every concurrent fetcher sets it to the same trunk head or a newer
+one, both of which still fast-forward. Expect the exposure to **grow with fleet size** —
+dispatching immediately after merging is what puts the concurrent fetches and the
+fast-forward in the same seconds.
 
 **An aborted fast-forward has two causes with different remedies, and the message says
 which** — and it says which only because the pair above no longer reads the shared file.


### PR DESCRIPTION
Tightens the three non-README pages of `docs/the-mayor-method` against a sharper test than
"make it shorter": **does the tree hold only key information, techniques and gotchas, with no
duplication and nothing a competent mayor would work out unaided?**

`README.md` is untouched. It is the human-facing introduction, and it is not a destination —
nothing cut from the other three was moved into it.

## Result

| file | before | after | |
|---|---:|---:|---:|
| `bootstrap.md` | 19,283 | 15,833 | −17.9% |
| `dispatch-prompt-template.md` | 66,488 | 53,090 | −20.2% |
| `loops.md` | 62,966 | 58,617 | −6.9% |
| **total** | **148,737** | **127,540** | **−14.2%** |

Byte counts are of the committed (LF) blobs on both sides, so the comparison is like for like.

## What was cut, and why each cut is not a rule

**Meta-commentary about the document's own drafting history.** The gate-mechanics section was
the worst of it: 19,689 bytes carrying 17 real traps wrapped in paragraphs about how to scope
the paste, why an earlier version's axis was wrong, and the observation that five dispatches
had carried five different lengths of the block. A mayor needs the traps. It does not need the
provenance of the paragraph stating them. That section is now 10,384 bytes and every one of the
17 traps survives.

**Narration where the rule was already clear.** Four Shape 6 measurement bullets, the reaping
section, the stranded sweep, and the merge-loop sections each stated their rule, then restated
it, then narrated the incident that produced it at full length. The incident stays wherever it
is what makes the rule stick — the wedge with no exit file, the run that pinned to a sibling
worktree, the harness exit code disagreeing with the captured one — and goes where the rule
carries itself.

**Genuine cross-file duplication.** `bootstrap.md` opened its list by claiming it carried what
does *not* belong to a loop. That was false. A shingle scan across the three files measured it,
and each overlap is resolved by moving the rule to the file that owns it rather than by
softening the claim:

- `### Local-green is not CI` and `### Concurrent workers share the machine's temp directory`
  are **removed outright** — both halves of each were carried in full elsewhere. The single
  increment neither destination had, the two shapes that make a hand-written required-check list
  wrong inside a week, moves into the dispatch page's gate menu.
- The surface-ownership rule, the stance-paraphrase argument and the reaping rule each drop to
  one owner and a pointer.
- The dispatch page stated the surface-ownership rule **twice, forty lines apart**.

Shared 9-word runs, before → after: bootstrap↔loops **47 → 13**, dispatch↔loops **90 → 30**,
bootstrap↔dispatch **52 → 38**. What remains is chiefly the pasteable bootstrap prompt, which
has to stand alone as a prompt and may legitimately restate. The list below it now says so
rather than claiming a purity it does not have.

## One correction written from first-hand experience

`bootstrap.md` told a new mayor to codify each loop as a command file, "one invocation and one
source of truth, rather than re-pasted prose". Followed literally, that is what produced the
problem this change exists to fix: command files that absorbed the method, grew past 35KB each,
and were re-injected into the mayor's context on every tick. The advice now says to keep such a
file a **thin pointer**, and says why — a command file is re-injected every tick, so one that
absorbs the method costs that context per tick *and* becomes a second copy of every rule it
restates.

## Constraints held

- **No heading added or renamed.** Two were removed, both in `bootstrap.md`, both for sections
  removed as duplicates. Nothing anywhere cites a `bootstrap.md` anchor — the only anchors cited
  outside this tree are `loops.md#1-merge` and `loops.md#after-each-merge`, and both are
  byte-identical to base.
- `README.md` byte-identical to base.
- Both operator-specific slots — the project-stance slot and the voice slot — left in place and
  still empty.
- No repository name, tracker id, change number, path outside this tree, or operator name. The
  one pull-request number that had leaked into `dispatch-prompt-template.md` is gone.

## Quality gates

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_readme_links.py --ci` | **0** |
| `python -m mkdocs build --strict` | **0** |

`docs/the-mayor-method/` sits inside `docs_dir` and is not in `mkdocs.yml`'s `exclude_docs`, so
the strict build does cover it.

**Non-vacuity proved, not assumed.** A broken link target planted at `loops.md:63` took
`check_doc_slugs.py` to **exit 1**, naming the plant:

```
BROKEN TARGET: docs\the-mayor-method\loops.md:63 -> no-such-file-xyz.md
```

Restored and verified by content hash rather than by eye — blob `c8ab8595f0cccdd9a162a1091c92adfc6d6a08d4`
identical before the plant and after the restore — then green again at exit 0.

The first plant attempt **failed to match and the gate stayed green**, which is the
"a search that returns zero is not a check that passed" trap from this very document catching
its own author. The match count was read before the second attempt.
