### PR TITLE
docs(hicasso): relabel the re-take's pre-registration, narrow the share claim, fix two null minima (rf2-07rnj)

### DIFF
--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -593,13 +593,23 @@ window — a quarter of the shape above, which is part of why its shares differ)
 > firing. The eleven-arm series `rf2-lo7uy` opened, so absolutes are not
 > arm-by-arm comparable with the nine- and eight-arm windows above.
 >
-> **What was fixed BEFORE run 1, and committed before run 1 so the ordering is
-> checkable rather than asserted.** The run count (three — the window does not
-> extend because an answer looks unsettled), the window shape (32 frames, 8 ×
-> (2 + 8) = 64 kept samples per arm, grid 0.0015625 ms/commit — the instrument's
-> own shape, no gate, tolerance or knob touched), and the adjudication rule
-> below. The pre-registration is the first commit of this window's branch and
-> the dataset `README.md` carries it in full.
+> **What the programmer DECLARES was fixed before run 1**, and what the history
+> can and cannot show of it. The run count (three — the window does not extend
+> because an answer looks unsettled), the window shape (32 frames, 8 × (2 + 8) =
+> 64 kept samples per arm, grid 0.0015625 ms/commit — the instrument's own shape,
+> no gate, tolerance or knob touched), and the adjudication rule below. The
+> pre-registration is the first commit of this window's branch — `f34af10`, the
+> data commit's parent, carrying the registration and nothing else — and the
+> dataset `README.md` carries it in full. **What that ancestry establishes is
+> that the rule's CONTENT precedes the data in the commit graph. The ordering
+> against the runs themselves is declared, not checked.** Nothing durable puts
+> the commit object before run 1: its committer field reads 10:52:20, after the
+> last of the runs it registers — the box brackets below close at 10:41:29 — and
+> the branch reached the remote later still. The one artefact
+> pointing earlier is the author field, and that field does not fix when this
+> commit was made. So read the rule below as pre-registered on the programmer's
+> word — and read the numbers as readings, which they are either way, because
+> every delta, share and verdict here is re-derivable from the transcripts.
 >
 > **THE RULE.** Each run carries its own three nulls, each of which is `c-local`
 > again through the same constructor, so each null delta has a true cost of
@@ -615,7 +625,7 @@ window — a quarter of the shape above, which is part of why its shares differ)
 > | `c-null`, displaced in mean and shape | 2 | +0.0297 | +0.0141 | +0.0500 |
 > | `c-null-twin`, `c-local`'s footprint exactly | 9 | +0.0031 | +0.0281 | +0.0297 |
 > | `c-null-curve`, same mean, other shape | 10 | +0.0109 | +0.0172 | +0.0359 |
-> | **the run's null spread** | — | **[+0.0031, +0.0297]** | **[+0.0140, +0.0281]** | **[+0.0296, +0.0500]** |
+> | **the run's null spread** | — | **[+0.0031, +0.0297]** | **[+0.0141, +0.0281]** | **[+0.0297, +0.0500]** |
 >
 > **The absolutes, all eleven arms** (p50 [min–max], ms per 141-key commit):
 >
@@ -634,16 +644,27 @@ window — a quarter of the shape above, which is part of why its shares differ)
 > | `c-null-curve` | 0.8812 [0.5969–1.3031] | 0.9016 [0.6375–1.2813] | 0.7375 [0.5938–1.0500] |
 > | copy fidelity `c-local`/`commit` | 0.9501 | 0.9393 | 0.9841 |
 >
-> **THE SHARE COLUMN IS THE ROBUST STATISTIC HERE AND THE ABSOLUTES ARE THE
-> FRAGILE ONE**, which is worth saying plainly because it is the opposite of how
-> the two are usually read. `c-local` moved 0.7734–0.9187 across three runs of
-> one binary in one session — 19% — while the reaction build's share of it moved
-> 66.5–67.4%, a spread of nine tenths of one percentage point. A share divides
-> two arms measured microseconds apart in the same interleave, so whatever makes
-> the box faster or slower between runs largely divides out; an absolute carries
-> it whole. That is the case for republishing this decomposition as shares of a
-> same-run denominator, and it is also why no absolute here should be lifted out
-> of this table and quoted as a property of the tree.
+> **WHAT A SAME-RUN DENOMINATOR BUYS, AND WHAT IT DOES NOT.** `c-local` moved
+> 0.7734–0.9187 across three runs of one binary in one session — 19% — and every
+> absolute in the table above carries that movement whole. A share divides two
+> arms measured microseconds apart in the same interleave, so whatever makes the
+> box faster or slower between runs largely divides out of the ratio. That is the
+> case for republishing this decomposition as shares of a same-run denominator,
+> and it is why no absolute here should be lifted out of this table and quoted as
+> a property of the tree.
+>
+> **None of that makes the share column AS A COLUMN the steadier statistic.** On
+> the reaction build it plainly is: that share moved 66.5–67.4%
+> across the three runs, a spread of nine tenths of one percentage point, against
+> a denominator that moved 19% — and that row is worth reading share-first for
+> exactly that reason. The cell-map insert goes the other way. Its share moved
+> 7.1–10.3% — a spread of about 45% of its own lowest reading — while the
+> absolute it divides moved 0.0656–0.0797, a spread of about 21%: on that row the
+> share is the MORE variable of the two, not the less. What divides out of a ratio is the movement the two
+> arms share, and for a term of seven hundredths of a millisecond that leaves the
+> numerator's own scatter untouched and now measured against a moving
+> denominator. So read each row's share beside its own absolute rather than
+> trusting the column.
 >
 > **THE TWO RESOLVED TERMS.** The reaction build + cache insert clears its run's
 > null by a factor of 10–20 on every run and is the dominant term of the commit

--- a/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj-retake/README.md
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/data/readprofile-07rnj-retake/README.md
@@ -5,11 +5,16 @@ decomposition, one file per run, in run order. The window is written up in
 `docs/design/hicasso/studio/the-cold-read-mount-term.md`; these are the
 transcripts that page's republished table is read off.
 
-## THE PRE-REGISTRATION — written and committed BEFORE run 1 started
+## THE PRE-REGISTRATION — DECLARED as fixed before run 1 started
 
-Everything in this section was fixed before the first run and held for every
-arm of every run. It is committed as its own commit so the ordering is
-checkable in the history rather than asserted here.
+Everything in this section is declared to have been fixed before the first run
+and held for every arm of every run. It is committed as its own commit,
+`f34af10`, the data commit's parent — so the history establishes that this
+content precedes the data, and that is all it establishes. It does not show the
+commit object itself existing before run 1: that commit's committer field reads
+after the last run, and the branch reached the remote later still. **The
+ordering against the runs is the programmer's declaration, not a check.** The
+readings below are re-derivable from the transcripts either way.
 
 | | |
 |---|---|


### PR DESCRIPTION
Three documentary repairs the merged-PR audit of #8631 reopened `rf2-07rnj` for. **No window was re-run, no measurement re-derived, and the transcripts are untouched** — the audit says explicitly not to spend the box on these.

## 1. The pre-registration claim overreached — RELABELLED

The audit offered two outcomes: supply a genuinely pre-run durable anchor, or relabel the claim as the programmer's declared ordering. **I took the relabel, because no pre-run anchor exists.**

- `f34af10` is the data commit's parent and carries the registration alone, so the history proves **content ancestry** and nothing more.
- Its **committer** field reads `2026-08-21T10:52:20+10:00` — after the last box bracket, which closes at 10:41:29.
- The branch's first appearance on the remote is the PR that carried it, created `2026-08-21T00:54:55Z` = 10:54:55 +10:00, later still.
- The only artefact pointing earlier is the author field at 10:31:39.

So there is nothing durable to cite. The page now says what the ancestry establishes, says the ordering against the runs is declared rather than checked, and adds that the readings are worth the same either way because every delta, share and verdict is re-derivable from the transcripts.

**Two files, not one.** The audit names two phrases — "pre-registered and committed before run 1" and "ordering checkable in history". The first is the page's; the second is verbatim the dataset `README.md`'s ("checkable in the history rather than asserted here"), and the page points readers at that README as carrying the pre-registration in full. Relabelling one and leaving the other asserting the un-provable ordering would have left the two contradicting each other, so both are repaired, identically in substance.

**No general rule about which clock dates a commit is stated** — that question is `rf2-r0hq5`'s and is fenced. The page says only that this commit's author field does not fix when this commit was made.

## 2. "THE SHARE COLUMN IS THE ROBUST STATISTIC HERE" — NARROWED

The claim was column-wide and the data does not support it column-wide.

| | run 1 | run 2 | run 3 | spread |
|---|---|---|---|---|
| reaction build, share | 67.4% | 67.0% | 66.5% | 0.9 pp |
| cell-map insert, share | 7.5% | 7.1% | 10.3% | ~45% of its lowest reading |
| cell-map insert, absolute | 0.0672 | 0.0656 | 0.0797 | ~21% of its lowest reading |

On the cell-map row the **share is the more variable of the two, not the less** — dividing out the box removes the movement the two arms share, and for a term of seven hundredths of a millisecond that leaves the numerator's own scatter untouched and now measured against a moving denominator.

Replaced with the two statements that are true: the **same-run-denominator benefit**, which is real and does apply to the column (it is why no absolute here should be lifted out and quoted as a property of the tree), and the **reaction-row tightness** as an observation about that row. Readers are told to read each row's share beside its own absolute.

Nothing downstream depended on the broad claim — §1's own table caption states only the same-run-denominator point, and the "Reading it" and §4 passages cite the resolved figures, not the robustness claim.

## 3. Two null-spread minima — FIXED against the transcripts

Checked against the landed transcripts rather than the brief:

| run | transcript line | three nulls | published min | correct min |
|---|---|---|---|---|
| 2 | `run2.txt:217` | 0.0141 / 0.0281 / 0.0172 | +0.0140 | **+0.0141** |
| 3 | `run3.txt:220` | 0.0500 / 0.0297 / 0.0359 | +0.0296 | **+0.0297** |

Run 1's `[+0.0031, +0.0297]` was already correct. Both figures already appear correctly in the per-null rows directly above the spread row, so this is a transcription slip in the summary row alone. **Neither affects a verdict** — adjudication is against each run's null *maximum*, and both maxima are unchanged.

## Verified by hand

Neither gate checks table column counts or rendering, so:

- The one table I touched (the null table in the re-take window note) has a 5-column header, a 5-column separator and four 5-cell rows, all matching. Only cell values changed; no cell was added or removed.
- The dataset `README.md` change is prose above its tables; no table row was touched there.
- Blockquote markers are unbroken through both rewritten paragraphs — the whole window note is a `>` block and every new line carries the marker.
- No new links or headings were introduced in either file, so no anchor could break.

## Gates

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_provenance_pins.py` | 0 |
| `python scripts/check_readme_links.py --ci` | 0 |

The third is not in the brief but is the gate that actually covers `README.md` beside source, which this PR edits. `mkdocs build --strict` is deliberately **not** nominated: `docs/design/` sits in `mkdocs.yml`'s `exclude_docs`, so it would return a green that inspected nothing here.
