### PR TITLE
docs(method): name the EVENT a date refers to, and narrow the bound-warrant rule (rf2-r0hq5)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -388,8 +388,10 @@ at all.
   negative error excursion exceeded 0.0062 + *t*: it neither makes ±0.0062 a calibrated symmetric
   floor nor upper-bounds *t*. **A most-negative observation is a statement about the ERROR TERM, not
   about the quantity** — and comparing most-negative readings from *different* positive-cost arms at
-  two window widths cannot establish a floor-scaling factor either. If you report a bound, name the
-  NULL OR CONTROL ARM that produced it; otherwise report the term as UNRESOLVED. One window quoted
+  two window widths cannot establish a floor-scaling factor either. **Where a bound is inferred from
+  estimator error or noise-floor behaviour, name the NULL OR CONTROL ARM that produced it**; otherwise
+  report the term as UNRESOLVED. A bound resting on a direct analytic argument or an independently
+  calibrated error figure needs no arm at all — say which warrant you have. One window quoted
   "bounded: < 0.006 ms/commit" from its own most-negative reading, was refuted by audit, and was
   refuted again by the next window reading −0.0141.
 
@@ -710,8 +712,14 @@ worktree unreapable.**
 endings reads clean having changed every line — and **a patch that never applied reads clean too**,
 because "unchanged" and "not attempted" are the same diff. That second one is the dangerous half:
 a plant that silently no-ops makes the sabotage run come back green, so the worker reports a guard
-that fired when nothing was ever broken. Hash before the plant, compare after the restore. Five
-cautions:
+that fired when nothing was ever broken. Hash before the plant, compare after the restore.
+
+**Commit your own edits before you plant anything**, because the obvious restore — asking version
+control for the file back — returns it to the last COMMITTED state, not to your pre-plant working
+state. Plant from a dirty tree and that restore silently discards the very work the gate was being
+run against, and the run afterwards is green about a tree you did not mean to have. The hash check
+is what catches it, which is the case for doing the hash check rather than an argument against the
+restore. Six cautions:
 
 * **Where line endings are translated, use version control's own content hash against the
   committed object**, not a byte digest of the working file — a checkout during a rebase rewrites

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -719,7 +719,7 @@ control for the file back — returns it to the last COMMITTED state, not to you
 state. Plant from a dirty tree and that restore silently discards the very work the gate was being
 run against, and the run afterwards is green about a tree you did not mean to have. The hash check
 is what catches it, which is the case for doing the hash check rather than an argument against the
-restore. Six cautions:
+restore. Five cautions on the plant itself:
 
 * **Where line endings are translated, use version control's own content hash against the
   committed object**, not a byte digest of the working file — a checkout during a rebase rewrites

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -621,14 +621,19 @@ and both readings went wrong in a single day here, in opposite directions.
    edits. It belongs on the list because it reads strong and not one of its four parts observes the
    agent.
 
-   **The timestamps split by QUESTION, and the two questions take OPPOSITE answers.** A rebase replays
-   the *authored* time and rewrites only the *committed* one, so two honest readers can call one change
-   forty-three minutes old and seventy-five seconds old. Liveness wants the *committed* time, which
-   moves when the worker moves. But **DATING a change in prose — a design record, a governance note,
-   any claim about when work was done — wants the *authored* time**, because that is when the work was
-   written. Where the project merges by rebase the two differ on essentially every landed change, and
-   the error is invisible once made. A reader who has met only the liveness rule has been taught that
-   the authored time is the untrustworthy one, and will "correct" a right date into a wrong one.
+   **A change carries two clocks recording two different EVENTS, so name the event before you read a
+   clock.** The *authored* time records when the work was written; the *committed* time records when it
+   was last replayed onto the trunk. A rebase replays the first unchanged and rewrites the second, so
+   where a project merges by rebase they differ on essentially every landed change — two honest readers
+   called one change forty-three minutes old and seventy-five seconds old, and neither had misread.
+
+   Liveness asks *did this worker do something recently*, which is the replay event, so it reads the
+   committed time. A date in prose asks something else, and **which** something else is the whole
+   question: when the work was written is the authored time, when it reached the trunk is the committed
+   time, and a record that says only "dated" has not been specified. **Name the event in the sentence**
+   — "written on", "landed on" — and the clock follows from it. Do not write a rule that says prose
+   takes one clock: that trades a defect for its mirror, and the error is invisible once made, because
+   both are real timestamps on the same change and each is correct for its own event.
 
 2. **Is there a live task to message?** Message first — resuming beats redispatching, because the
    worker's context is still there. **The commonest strand by far is a worker that detached a long gate


### PR DESCRIPTION
Two corrections to `docs/the-mayor-method`, both from audit findings recorded on rf2-r0hq5.

## 1. Name the event, do not swap one universal clock for another

`loops.md` said that dating a change in prose wants the *authored* clock. The audit's finding is that this trades a defect for its mirror: it is still a universal rule about prose, when the real question is **which event the sentence is dating**.

A change carries two clocks recording two different events — when the work was written, and when it was last replayed onto the trunk. The passage now says to name the event in the sentence ("written on", "landed on") and let the clock follow, and says explicitly not to write a rule that gives prose one clock.

Liveness is unchanged: it asks about the replay event, so it reads the committed time.

## 2. Narrow the bound-warrant rule to the defect it repairs

Shape 6 said any reported bound must name the null or control arm that produced it. The audit found that broader than the defect: a bound resting on a direct analytic argument, or on an independently calibrated error figure, needs no arm at all. Now scoped to bounds **inferred from estimator error or noise-floor behaviour**, with the alternative warrants named.

## 3. One trap met while gating this very commit

Restoring a planted fault by asking version control for the file back returns it to the last **committed** state, not to the pre-plant working state. Planting from a dirty tree therefore discards the work the gate is being run against, and the run afterwards is green about a tree you did not mean to have. It happened here, and the hash check caught it — which is the case for the hash check, not an argument against the restore. Recorded as a paragraph above the existing cautions list.

## Quality gates

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_readme_links.py --ci` | **0** |
| `python -m mkdocs build --strict` | **0** |

**Non-vacuity proved from a committed state**, after the trap above: a broken target planted at `loops.md:63` took `check_doc_slugs.py` to exit 1 naming the plant, restored to blob `c4f782d7ed1e52c59dffb230e253100e06d52bab` — identical before and after — and green again at exit 0. Match count read before planting.

No heading added, renamed or removed in any file; `README.md` untouched. The list count under the new paragraph was checked and corrected — it has five entries, not six.