### PR TITLE
bench(p0): stop printHeapControl asserting a rule the verdict already names (rf2-egdaq)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -4485,6 +4485,14 @@ function ladderStructuralFailures(row) {
 //
 // The verdict NAMES ITS OWN RULE (`verdict.rule`) rather than this printer
 // asserting one, for that same reason — the string comes from the answer.
+//
+// So the VERDICT line below names no adjudicator of its own. It used to
+// carry the literal `lane/control-verdict-strict` beside the dynamic
+// `rule`, which the merged-PR audit of #8574 caught: a caller moved back
+// to the overlap rule would have printed both names in one sentence, and
+// the hardcoded half is the one a reader believes. `:rule` is the lane's
+// own identifier for which of its two rules answered — `every-round` here,
+// `overlap` there — so it is the whole label this record needs.
 function printHeapControl(row) {
   const c = row.control.measured;
   console.log(
@@ -4493,7 +4501,7 @@ function printHeapControl(row) {
   );
   const v = row.control.verdict;
   console.log(
-    `;;   VERDICT (lane/control-verdict-strict, rule ${v.rule}, ` +
+    `;;   VERDICT (rule ${v.rule}, ` +
       `slack ±${(row.control.slack * 100).toFixed(0)}%): ${v.ok ? 'OK' : 'FAILED'}`
   );
   console.log(`;;     ${v.why}`);


### PR DESCRIPTION
Closes rf2-egdaq's last open thread — the cosmetic-but-real finding from the merged-PR audit of #8574.

## What was wrong

`printHeapControl`'s own comment states the design rule: *"The verdict NAMES ITS OWN RULE (`verdict.rule`) rather than this printer asserting one … the string comes from the answer."* The code did not honour it. The VERDICT line carried a hardcoded `lane/control-verdict-strict` immediately in front of the dynamic `rule ${v.rule}`:

```js
`;;   VERDICT (lane/control-verdict-strict, rule ${v.rule}, ` +
```

`v.rule` is `every-round` today because `p0_heap.cljs` calls `lane/control-verdict-strict`. If a caller ever drifted back to `lane/control-verdict`, the same line would print `lane/control-verdict-strict, rule overlap` — the printer contradicting the verdict it is printing, in one sentence, with the hardcoded half the one a reader believes. That is the exact ambiguity the block above it says a published record must not carry: *"A published record that names the wrong adjudicator is worse than one that names none."*

## The repair

Drop the literal. `:rule` is the lane's own identifier for which of its two rules answered, and `lane.cljs`'s contract says each answer carries it "so a published record cannot be read under the other one" — so it is the whole label this record needs. One line of code, plus a comment saying the omission is deliberate.

No adjudication behaviour changes: `p0_heap.cljs` still calls `lane/control-verdict-strict`, `p0_app.cljs` still calls the overlap rule, and no published figure moves. The audit said explicitly that **no source-grep pin is needed**, so none was added — a census gate asserting "this call site says `-strict`" is the nag-diagnostic class the project stance rejects.

Deliberately preserved, untouched: the operator-facing records question recorded on rf2-egdaq (are the ten published heap-control figures restated under the new rule, or does it apply from the next run — Mike's call), and the flag on `p0_run.cjs`'s allocation-window mean-control, which is a different rule and rf2-rs8q6 territory.

### One brief premise that did not hold

The dispatch brief said `printHeapControl` lives under `implementation/hicasso/test/re_frame/bench/hicasso/`. It does not — it is at `implementation/core/test/re_frame/bench/p0_run.cjs:4488`, and that is the only occurrence of the contradiction in the tree. The audit's substantive finding was accurate in every other respect and reproduced exactly as described.

## Quality gates

Local runner, exit codes captured with the redirect and the `echo` on one command line and quoted from that capture, not from any harness report.

| Gate | Command | Exit | Result |
|---|---|---|---|
| p0 driver load + structural pins (post-rebase) | `node core/test/re_frame/bench/p0_ladder_structural.test.cjs` | `0` | 100 passed, 0 failed |
| Control A — sabotage, syntax fault in the changed line | same | `1` | `SyntaxError` at `p0_run.cjs:4504`, the edited line |
| Control B — sabotage, defect reinstated verbatim | same | `0` | 100 passed — **the gate does not pin the printed string** |
| Hand-check of the printed output (see below) | node harness over the real function source | `0` | 3/3 cases correct |
| Surface classifier | `.github/scripts/report-changed-surfaces.sh implementation/core/test/re_frame/bench/p0_run.cjs` | `0` | see coverage note |

`p0_ladder_structural.test.cjs` is the one automated consumer of `p0_run.cjs` — it `require`s the module, so a fault in this file fails it. It is a step of `npm run test:script-helpers`, which runs in `test.yml` and in the fast-PR spine. I ran that single step rather than the whole compound: the other steps do not load `p0_run.cjs`, and this worktree has no `implementation/node_modules`.

**The controls are the deliverable, and Control B is the important one.** Control A shows the gate genuinely reads this worktree's copy of the file — the sabotage stack trace names `…\re-frame2-worktrees\verdictlbl\…\p0_run.cjs:4504`, my edited line. Control B reinstates the exact defect this PR removes and the gate stays **green at 100 passed** — so the property being fixed has **no automated coverage at all**. `printHeapControl` is not exported and nothing anywhere matches its output strings. Restores after both plants were verified by `git hash-object` against the committed blob `4d6033c9e5…` (blob hash, not a byte digest, because line endings are translated on this platform), and both plants were confirmed to have applied by match count before the run rather than after it.

Because no gate covers the output, I verified it **by hand**, driving the real extracted source of `printHeapControl` against three synthetic verdicts:

```
A. strict rule, OK      ;;   VERDICT (rule every-round, slack ±25%): OK
B. THE DRIFT CASE       ;;   VERDICT (rule overlap, slack ±25%): OK
C. a round outside      ;;   VERDICT (rule every-round, slack ±25%): FAILED
                        ;;     OUTSIDE round 3: 0 B, off by -75.00% of the prediction
```

Case B is the one the audit named: post-fix it reads cleanly as `rule overlap`, where pre-fix it would have read `lane/control-verdict-strict, rule overlap`. Cases A and C confirm the pass and fail paths, the per-round line and the `OUTSIDE` naming all still render.

### What this local run does NOT cover — the merge decision is CI's

Derived from the classifier rather than hand-listed. It flags this path `true` for: `implementation_jvm`, `cljs_node_test`, `adapter_diagnostic`, `cljs_browser`, `cljs_prod`, `bundle_isolation`, `tools_jvm`, `tools_jvm_machines_viz`, `tools_jvm_testbed_support`, `tools_cljs_machines_viz`, `template_expensive`, `mcp_conformance`, `mcp_live`, `playground`. **None of those ran locally.** The classifier is deliberately conservative for anything under `implementation/`; this diff is nine added comment lines and one changed template literal in a Node bench driver that no production or test build imports, so I expect all of them to be no-ops on the substance — but that is CI's to confirm, not mine.

Doc gates were correctly **not** run and are not skipped in a way that needs excusing: the diff touches no markdown, and `documentation` is not among the surfaces the classifier flags. No measurement window was taken — no P0 bench, no release build, no browser.
