### PR TITLE
docs(method): name the recorded event, and bound the two clocks (rf2-r0hq5)

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -622,18 +622,30 @@ and both readings went wrong in a single day here, in opposite directions.
    agent.
 
    **A change carries two clocks recording two different EVENTS, so name the event before you read a
-   clock.** The *authored* time records when the work was written; the *committed* time records when it
-   was last replayed onto the trunk. A rebase replays the first unchanged and rewrites the second, so
-   where a project merges by rebase they differ on essentially every landed change — two honest readers
-   called one change forty-three minutes old and seventy-five seconds old, and neither had misread.
+   clock.** The *authored* time is the author timestamp recorded on the change; the *committed* time is
+   the committer timestamp on the object as it currently stands, and it moves every time that object is
+   rewritten. A rebase rewrites the second and replays the first unchanged, so where a project merges by
+   rebase they differ on essentially every landed change — two honest readers called one change
+   forty-three minutes old and seventy-five seconds old, and neither had misread.
 
-   Liveness asks *did this worker do something recently*, which is the replay event, so it reads the
+   Liveness asks *did this worker do something recently*, which is the rewrite event, so it reads the
    committed time. A date in prose asks something else, and **which** something else is the whole
-   question: when the work was written is the authored time, when it reached the trunk is the committed
-   time, and a record that says only "dated" has not been specified. **Name the event in the sentence**
-   — "written on", "landed on" — and the clock follows from it. Do not write a rule that says prose
-   takes one clock: that trades a defect for its mirror, and the error is invisible once made, because
-   both are real timestamps on the same change and each is correct for its own event.
+   question — a record that says only "dated" has not been specified. **Name the event in the sentence**
+   — "authored on", "last rewritten on" — and where that event is one the change itself records, the
+   clock follows from it. Do not write a rule that says prose takes one clock: that trades a defect for
+   its mirror, and the error is invisible once made, because both are real timestamps on the same change
+   and each is correct for its own event.
+
+   **Where the event is not one the change records, no clock on the change answers.** Rebase is not the
+   only rewrite: amending, or squashing a fixup, moves the committed time while carrying the original
+   author timestamp forward, and an author date can be set explicitly to any value — so the authored
+   time is no proof of when content was written, and a queued or deferred integration leaves the
+   committed time recording a rewrite rather than an arrival. Ancestry is sound where the fields are
+   not, and it settles ORDER only. **A date tying a change to an EXTERNAL event — a run, a measurement,
+   an outage — therefore needs an anchor that event itself recorded, or a chronology you declare and
+   stand behind.** One change here called its first commit a pre-run registration: authored nine seconds
+   before the first sample, committed twenty minutes after the last, and neither number establishes the
+   claim.
 
 2. **Is there a live task to message?** Message first — resuming beats redispatching, because the
    worker's context is still there. **The commonest strand by far is a worker that detached a long gate


### PR DESCRIPTION
Closes rf2-r0hq5.

The `#8641` merged-PR audit reopened this owner with two obligations still uncovered by the passage that landed in `#8630`/`#8641`. Both are repaired here, in **one** place — the same list item that already answers the liveness question — so the two readings sit side by side and cannot drift apart.

## What was wrong

The rule stated two universal equivalences the audit rejected:

- *"The authored time records when the work was written"* — but an amend or a squashed fixup moves the committer field while carrying the original author timestamp forward, and an author date can be set explicitly to any value. So the authored field is not proof of when content was written.
- *"The committed time records when it was last replayed onto the trunk"*, with "when it reached the trunk" mapped to it — but a queued or deferred integration leaves that field recording a rewrite rather than an arrival.

The boundary also generalised from **rebase alone**, and the rule said nothing about the case the downstream audit of `#8631` recorded: a date tying a change to an event **outside** the change.

## What changed

`docs/the-mayor-method/loops.md`, +22 / -10 in one passage:

- Both fields are now stated as what they are — timestamps *recorded on the change* — rather than as semantic equivalences.
- "Name the event" survives as the rule, now qualified: the clock follows from the event **where that event is one the change itself records**.
- A new short paragraph covers the case where it is not. It names amend, fixup and explicit author dates as rewrites beside rebase; it says ancestry settles content ORDER and nothing more; and it requires an anchor the external event itself recorded, or a declared chronology, for a date tying a change to a run, a measurement or an outage. The measured instance is carried generically — a first commit called a pre-run registration, authored nine seconds before the first sample and committed twenty minutes after the last.

Existing liveness passages, and the *Hygiene* cross-reference to this paragraph, are untouched. No headings changed, so `loops.md#1-merge` and `loops.md#after-each-merge` still resolve.

## Scope

The third obligation on the bead — "three copies of the disputed rule", two of them in the mayor command files — is **discharged by deletion**: all seven of those files were retired in `88c338f454`, and the directory is gone from the index (verified; a control confirms the pathspec is right). There is no third copy to reconcile, so this is a one-file change.

No Hicasso-page work is included; that downstream wording is owned by rf2-07rnj.

The method tree stays generic: a pattern census over the added lines reads 0 for bead ids, PR numbers, `git` invocations, tracker commands, OS mechanics, repository names and source paths. The zeros are real — the same patterns fire 6, 2 and 20 times against `CLAUDE.md`.

## Quality gates

Each number below was captured with the redirect and the `echo $?` on one command line, in one shell, and is quoted from the captured exit file — never from a harness report about the same run.

| Gate | Captured exit | Notes |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | Covers `docs/`; final rebased base |
| `python -m mkdocs build --strict` | **0** | `the-mayor-method/` is not in `mkdocs.yml`'s `exclude_docs`, verified before relying on it; final rebased base |
| `python scripts/check_readme_links.py --ci` | **0** | Run because `CLAUDE.md` cites two `loops.md` anchors |

**Planted-fault control.** A broken anchor link was planted at a single line inside the edited paragraph, after committing the real edit so the restore could not discard it. Match count read 1 before the plant, so the anchor was unambiguous. `check_doc_slugs.py` then returned captured exit **1**, naming the plant by file, line and target — evidence the gate read this branch's worktree and not a sibling's. Restored with a checkout and verified by **git blob hash**: the restored working file and the committed object are the same blob, `8b7b546cc42f051af20f7784e5415aa06e423b93`. Residue count for the plant string afterwards: 0.

`mkdocs build --strict` was confirmed against this worktree by a different route — the rendered output contained the new sentence.

## Bounds on those greens, stated because they are real

- **Neither link gate looks inside a fenced code block**; both share one extractor that strips fences before reading links. Not load-bearing here: the change adds 0 code fences and no edit sits inside one.
- **Nothing validates prose, tables or rendering.** Checked by hand: the change introduces **0** markdown links, **0** headings, **0** table rows and **0** code fences, so there are no new anchors to resolve and no column counts to check. The two anchors other files cite into this page were confirmed present and unmodified.
- Longest added line is 104 characters, within the file's existing convention (file maximum 120; 66 lines already exceed 100).

## Revert check

`git diff origin/main...HEAD` is confined to the one passage. Nothing landed on the trunk under `docs/the-mayor-method/` between the branch point and the final rebase — the only intervening commits were tracker checkpoints — so this push undoes no sibling's work.
