### PR TITLE
docs(hicasso): the 2026-08-20 recertification page ended with its closing paragraph twice (rf2-hic-090)

### DIFF
--- a/docs/design/hicasso/product/post-rename-recertification-2026-08-20.md
+++ b/docs/design/hicasso/product/post-rename-recertification-2026-08-20.md
@@ -444,11 +444,5 @@ That does not weaken §4's refusal; it is the refusal's own evidence, arriving w
 
 This is a claim about a window that closed when the sentence was written, not a standing property. What
 generalises is the anchor: **every figure on this page is stated of `2f96ecc98c`**, and a reader who needs
-to know whether it still describes the trunk can re-run the commands above rather than take this
-paragraph's word for it.
-
-This is a claim about a window that closed when the sentence was written, not a standing property. What
-generalises is the anchor: **every figure on this page is stated of `2f96ecc98c`**, and a reader who needs
 to know whether it still describes the trunk can re-run the two commands above rather than take this
 paragraph's word for it.
-


### PR DESCRIPTION
The merged-PR audit of #8560 recorded two publication defects in the 2026-08-20
post-rename recertification results record. Both are repaired here. Nothing else
on the page changes, and **nothing about the recertification itself is judged or
closed** — `rf2-hic-090` stays open for its real remaining question, which is
Mike's ruling on naming-ledger row 18 / `rf2-t32wg`.

## What was wrong, verified at source

**1. §8 ended with the same four-sentence window/anchor paragraph twice.** The
audit cited lines 445-453. Located by text rather than by that range, the actual
shape was: copy A at **445-448**, a blank separator at 449, copy B at **450-453**,
and the EOF blank at 454. So the audit's range spanned both copies correctly and
the numbers had not drifted.

**2. `git diff --check` reported a new blank line at EOF.** Reproduced verbatim
against the pre-fix tree:

```
docs/design/hicasso/product/post-rename-recertification-2026-08-20.md:454: new blank line at EOF.
```

## Which copy was kept, and why

**Copy B — "the two commands above" — is the one kept.** §8 shows exactly two
commands, and they were counted rather than assumed:

| Line | Command |
|---|---|
| 432 | `git diff --name-only 2f96ecc98c..origin/main` |
| 436 | `git diff --name-only 2f96ecc98c..origin/main -- implementation` (filtered) |

Nothing else in §8 is a command; the other backticked spans are a PR number and
a section link. Two commands, so "the two commands above" is accurate and the
bare "the commands above" of copy A is the vaguer of the pair rather than the
correct one. The 2026-08-18 page agrees independently: its own §8 also shows two
commands and closes with the identical sentence reading "the two commands above".
No re-wording was needed — one of the two copies was already right.

Net diff: **6 deletions, 0 insertions**. `git diff origin/main...HEAD` was read
for silent reverts; it touches only the paragraph and the trailing blank.

## Quality gates

| Gate | Command | Captured exit |
|---|---|---|
| Markdown link targets + heading anchors | `python scripts/check_doc_slugs.py --repo-root <worktree> --verbose` | **0** (`no broken links.`) |
| Provenance pins on changed pages | `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** (1 page inspected, 11 cited pins — 11 landed, 0 stranded, 0 unresolvable, 0 foreign, 0 findings) |
| Whitespace / EOF | `git diff --check origin/main...HEAD` | **0** (empty output) |
| Whitespace, whole file as a fresh addition | `git diff --check <empty-tree> HEAD -- <page>` | **0** — the 454-line defect is gone |
| **Control: same command against the pre-fix tree** | `git diff --check <empty-tree> origin/main -- <page>` | **2** — reports `:454: new blank line at EOF.` |

Every number above is the runner's own exit code, captured with the redirect and
the `echo $?` on one command line. All gates were re-run on the final base after
the rebase.

**Sabotage control.** The link gate was proved to bite this page rather than pass
it vacuously. With the repair already committed, the anchor on line 442 —
`[§4.2](#42-and-family-5-still-reports-…)` — was broken by a single-line,
single-match patch (match count checked as `1` before running anything). The gate
went **red, captured exit 1**, naming the plant:

```
BROKEN ANCHOR: docs\design\hicasso\product\post-rename-recertification-2026-08-20.md:442
  -> #42-and-family-5-PLANTED-BROKEN-ANCHOR-no-verdict-here-for-a-different-and-much-narrower-reason
```

Restored with `git checkout HEAD -- <page>`, and the restore verified by blob
hash rather than by eye: the working file's `git hash-object` reads
`c84ad4b155755b245e72dadb7e9af97d96a7c68e`, identical to the committed blob hash
for the same path, and `git status` is clean.

## Gates deliberately not run, with reasons

- **`mkdocs build --strict` is not the gate for this page.** `mkdocs.yml`'s
  `exclude_docs` block was read at source and lists `design/hicasso/`, so the
  build cannot see this tree at all; nominating it would have returned a green
  that inspected nothing.
- **The fenced-block blind spot does not apply here.** Both link gates strip
  fences before reading a link, but this page contains **zero** fenced code
  blocks (`grep -c '^```' → 0`), so everything changed is prose the gates can see.

## Verified by hand, because nothing gates it

- **The surviving paragraph reads correctly in place.** §8 now runs 441-448: the
  Family-5 exception paragraph, a blank line, then the single window/anchor
  paragraph closing the page. No dangling connective was left behind by the
  deletion, and the file now ends with one newline after `paragraph's word for it.`
- **No table column count broke.** All **12** tables on the page were re-counted
  with escaped `\|` inside inline code honoured: every one is internally
  consistent, **0 ragged**. The edit is nowhere near a table — the nearest ends
  at line 398 — so this is a confirmation rather than a repair.
- **Exactly one copy of the paragraph remains.** The fixed-string search
  underwriting that claim was itself controlled: run across
  `docs/design/hicasso/product/*.md` it returns **two files** (this page and the
  2026-08-18 one), so it finds what it should; run against this page alone it
  returns **1**.

Closes nothing. Refs rf2-hic-090.
