### PR TITLE
docs(hicasso): native-ssr test no longer says there is no server entry (rf2-981ka)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/native_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/native_ssr_dom_cljs_test.cljs
@@ -63,10 +63,18 @@
     `re-frame.hicasso.roots-frames-hydration-dom-cljs-test`. What is
     native-specific is that two roots under OPPOSITE policies do not
     interfere, and that is the row below.
-  - **A Hicasso server entry.** There is none, and none is needed: the
-    consumer calls `react-dom/server` and the policy is honoured by
-    rendering. The harness here is `renderToString` called by hand, which
-    is the only server path in the package.
+  - **The product server door.** When this file was written there was
+    none, and the bullet said so. `re-frame.hicasso.server/render` has
+    shipped since, and it IS the package's server path:
+    `impl.roots/open-adoption-window!` names it as one of the two
+    minters of the adoption window, once per request, so the fork is
+    decided once for both sides of the wire. Its own rows are in
+    `re-frame.hicasso.server-render-ssr-dom-cljs-test`. What has not
+    changed is that the door is not a NATIVE-tier claim: what these
+    rows read is the `:server` declaration's effect on the bytes,
+    which is React's own under either caller, so the harness here
+    stays a hand-rolled `renderToString` rather than putting a request
+    envelope and a payload between the claim and the measurement.
 
   ## The mutation witnesses, one per assertion class
 
@@ -376,8 +384,12 @@
 
 (defn- server-html
   "The page as a REAL server render. `react-dom/server`'s own
-  `renderToString`, called by hand — the only server path this package
-  has, and exactly the call a consumer makes."
+  `renderToString`, called by hand: no adoption window, no payload, no
+  request envelope — the smallest thing that produces server bytes, so
+  what these rows read is the `:server` declaration's effect and
+  nothing else. The package's own server door is
+  `re-frame.hicasso.server/render`; this harness sits beside it, not
+  instead of it."
   ([hiccup] (server-html frame-id hiccup))
   ([kw hiccup]
    (react-dom-server/renderToString


### PR DESCRIPTION
## What and why

`implementation/hicasso/test/re_frame/hicasso/native_ssr_dom_cljs_test.cljs` carried a `## What is deliberately NOT here` bullet asserting two things that are both false at trunk tip:

> **A Hicasso server entry.** There is none, and none is needed: the consumer calls `react-dom/server` and the policy is honoured by rendering. The harness here is `renderToString` called by hand, which is the only server path in the package.

`re-frame.hicasso.server/render` shipped on 2026-08-14 in `30317bfe0e` (rf2-b6jkj, PR #8236) — 452 lines, `render` at line 330 — and `implementation/hicasso/src/re_frame/hicasso/impl/roots.cljs` names it as one of the *two minters* of the adoption window, "once per REQUEST, closed in that door's `finally`", recording that because both doors call `impl.mount/tree` "the fork is decided once for both sides of the wire". So it is not merely present: it is **the** package's server path, and this file's hand-rolled `renderToString` is the harness beside it.

This mattered beyond its size. An audit read the bullet, believed it, and built a "root cause: there is no Hicasso server entry" finding on rf2-s52w on top of it.

## The resolution: amended in place, not dropped

Kept as a *deliberately not here* bullet, narrowed to what is actually absent, and shaped like the `identifierPrefix` bullet directly above it — which the file already amended in place when its own condition changed, rather than deleting.

What remains deliberately absent is the **product server door's rows**, not the door. This file's subject is the `:server` declaration's effect on the bytes, which is React's own under either caller; the door's own rows live in `re-frame.hicasso.server-render-ssr-dom-cljs-test`. Going through the door here would put a request envelope and a payload between the claim and the measurement, so the harness stays minimal — and the bullet now says that, instead of claiming no door exists.

A second carrier of the same false sentence lives in the same file: `server-html`'s docstring said its `renderToString` was "the only server path this package has, and exactly the call a consumer makes". Corrected with it; same claim, same file.

Out of scope by the filing auditor's own reasoning, which binds this PR too: the sentence also propagated into `docs/design/hicasso/product/correction-ledger.md` and `checkpoint-3-native.md`. Those are the ledger keeper's surface and a dated record — a witness may not amend the row it witnesses. Flagged, not touched.

No assertion changed. Commentary only.

## Quality gates

Focused lane: `:node-test-hicasso` (`^re-frame\.hicasso\..+-cljs-test$`), which selects this namespace. Each run was redirected to its own log with the runner's own exit code captured on the same command line; the numbers below are those captured numbers.

| Run | Command | Captured exit |
|---|---|---|
| Control 1 — plant in ns docstring | `node scripts/compile-node-test.cjs node-test-hicasso out/node-test-hicasso.js && node out/node-test-hicasso.js` | **1** (expected red) |
| Control 2 — plant in `server-html` docstring | same | **1** (expected red) |
| Green — final rebased base | same | **0** |
| Green — this namespace alone | `node out/node-test-hicasso.js --test=re-frame.hicasso.native-ssr-dom-cljs-test` | **0** |

Green run: `Build completed. (549 files, 114 compiled, 0 warnings, 21.47s)`, then `Ran 1326 tests containing 5407 assertions. 0 failures, 0 errors.` This namespace alone: `Ran 18 tests containing 47 assertions. 0 failures, 0 errors.` — 18 rows being the file's 18 `deftest` forms.

**The controls.** A comment-only change still affords a discriminating plant, because a docstring is a string literal: a bare `"` planted in it changes how the file READS. One plant per edited region, each anchored to a single line with the match count read first (1 in both cases):

* Plant 1, in the amended ns-docstring bullet, failed the build naming this file at the planted line — proving the file is in the build's module graph and that the compiler reads that region.
* Plant 2, in the amended `server-html` docstring some 310 lines further down, failed the build naming this file again — proving the second edited region is gated too, which plant 1 could not show, because it aborts the read before reaching it.

Both restored with `git checkout HEAD -- <file>`, and each restore verified by **git blob hash** `4c18db2e52985c2c735ba1738080094800df41eb` matching the committed object (a blob hash, not a commit sha — and taken against the committed object rather than the working bytes, because line endings are translated on this platform). The edits were committed before either plant, so the restore could not discard them.

Worth recording: the harness reported "exit code 0" for BOTH red control runs, while the captured runner exit was `1`. Two more instances of that known disagreement, both surfacing as a false green.

**Link gates: none reaches this text, verified at source rather than assumed.** `scripts/check_doc_slugs.py`'s `DEFAULT_ROOTS` is `("docs", "spec", "skills", "migration")` plus `tools/*/spec` — `implementation/` is absent, so it exits 0 on anything here. `scripts/check_readme_links.py --ci` covers `README.md` beside source, repo-root markdown, and (since rf2-i4nb2) non-README tracked markdown beside source; a `.cljs` docstring is none of the three. Moot in any case: the added text contains no markdown link and no `[[...]]` cross-reference — checked with a grep exercised against a line that does contain one, so the zero is a measurement rather than an empty search.

**Skipped, with reasons.** No JVM suite ran: the changed file is `.cljs`, and `implementation/hicasso`'s JVM lane does not compile it. No browser lane ran: it is a cold Chromium plus full shadow-cljs sweep, and the compile that would catch the only defect this diff can introduce is shared with the node lane that did run.

**What CI covers that this local run does not**, derived from `.github/scripts/report-changed-surfaces.sh` on the changed path rather than hand-listed. It arms six surfaces: `implementation_jvm`, `cljs_node_test`, `cljs_browser`, `migration_hicasso_codemod`, `hicasso_controlled`, `hicasso_hmr`.

Of those the local run covers `cljs_node_test` only, and through the focused `node-test-hicasso` sibling rather than the required `node-test` build itself. The notable uncovered one is **`cljs_browser`**: this namespace ends in `-dom-cljs-test`, so its DOM rows run there and were not executed locally — the node lane runs the `renderToString` rows and skips the DOM ones, exactly as the file's own docstring says. The always-on repo-wide static checks are likewise CI's.

Closes rf2-981ka.
