### PR TITLE
docs(method): four repairs from running the loops

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -695,6 +695,13 @@ the same voice as "nothing is wrong"; the recurring instance is a backslash-bear
 so the shell strips them. Match fixed strings as fixed strings, and when a search underwrites a
 claim, run it once against something it should find.
 
+**This is not a fact about searching, and reading it as one is how it gets past you.** ANY
+instrument that can answer "nothing here" gives the same answer when misused, and a misused one
+raises no error — so its all-clear is complete, well-formed and plausible. Measured: a
+surface-classifier handed revisions where it expects file paths reported every surface as
+unaffected, which is exactly what a genuinely unaffected change looks like. Exercise any such
+instrument once against an input it should flag, whatever kind of instrument it is.
+
 **Name every gate artefact for your worktree AND for the attempt**, log and exit file both, in a
 directory version control ignores. A name missing either half fails the gate **open**, and the two
 halves close different holes. The scratch path is keyed to the session, so peers share one

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -92,6 +92,13 @@ new job landed is computed against the superseded matrix and legitimately reads
 band-minus-one, which the count alone cannot distinguish from a change genuinely one
 job short. Update the branch and re-check before judging this clause.
 
+**A third cause is commoner than both, and its remedy is neither: the set is still BEING BUILT.**
+A change opened moments ago legitimately reads a small fraction of the band while its runs are
+created, and the count climbs to full over the following minutes. Updating the branch there
+repairs nothing and restarts the wait. Clause 4 already separates the cases, so read it first when
+the count is short: below band **with** live runs at the head is a set still building, and the
+answer is to wait; below band with **none** is the case this clause is actually about.
+
 **And one reading above the band is correct.** A change that adds a required job
 sees that job in its own rollup, so it legitimately reads band-plus-one before the
 standing band has moved — the arming proving itself rather than a miscount, and the
@@ -397,7 +404,11 @@ Filter out before shaping anything:
 * items gated on another's merge;
 * items whose surface a live worker holds;
 * items colliding in a hot-zone file;
-* items whose resource is exclusive and currently contended.
+* items whose resource is exclusive and currently contended — but this exclusion has a release
+  condition, and it is the only one on the list that the loop itself must eventually lift. Where
+  the exclusive items are all that REMAINS, the filter has stopped protecting the fleet and is
+  simply refusing the backlog. Say so, stop refilling, let the fleet drain, and take that work
+  deliberately. A filter with no release condition becomes a permanent fence.
 
 **A ready list overstates readiness by a lot.** In practice roughly a fifth of "ready"
 items were genuinely dispatchable; the rest were fenced by something the tracker cannot
@@ -916,6 +927,16 @@ for either answer.
 rollback to an earlier snapshot, a re-import over the top — and nothing in the loop surfaces it, so the
 session's "closed" count quietly overstates. Verifying at the moment you close is not enough. Each cycle,
 re-check everything closed this session and re-close what genuinely reverted, with evidence.
+
+**But a status change made by a LIVE worker is that worker speaking, not corruption.** The rule
+above trains you to read an unexpected status as a bad write, and it supplies no competing
+reading, so the wrong one arrives with nothing to check it. A worker that un-claims an item is
+often saying something precise — commonly that only part of it was shippable and the rest is the
+operator's, which holding the item would bury. Its report is the authority on what it meant, and
+the report is usually minutes behind the status. **Where a worker is alive on the item, read the
+report before you act on the clock**: tracker history timestamps cluster tightly enough that a
+one-second gap is no evidence of a machine write, and reversing a worker's deliberate signal
+destroys the message.
 
 **But read the item's notes before re-closing anything.** If your process audits merged changes, expect
 closed items to reappear: twelve did in one session, and every one was a legitimate audit reopening the


### PR DESCRIPTION
Four repairs to the method, each traced to something that actually went wrong (or nearly did) while running the five loops. Written from experience rather than from re-reading the documents.

`README.md` is untouched — it is for humans and is not a destination for operational material.

## The four

**1. A status change made by a live worker is a signal, not corruption.** `loops.md`, attached to the existing revert rule.

I read a worker's deliberate un-claim as a machine re-import, wrote that wrong inference onto the item as a note, and re-claimed it — reversing a considered decision. The worker had un-claimed because only half the item was shippable and the rest was the operator's; holding it would have buried that.

The root cause is that the document supplied the wrong reading and no competing one. The existing "a tracker write can silently revert" rule trains you to read an unexpected status as a bad write. Nothing described a worker changing status *to communicate*. The rule made the error more likely, not less — so the repair sits where the priming happens rather than in a section of its own.

**2. A short rollup is usually a set still being built.** `loops.md`, clause 1.

Three changes read 19, 23 and 24 checks against a band of 88, then all three reached 88/88 and merged green fifteen minutes later. Clause 1 named two causes of a short count — a superseded matrix, and a change genuinely one job short — and the remedy it gives for the first is *update the branch and re-check*. Applied to a freshly opened change that is simply still building, that repairs nothing and restarts the wait.

Clause 4's live-run query already separates the cases exactly; it was just read fourth. Considered reordering the clauses instead, and rejected it: the numbering is cited from outside the document and reordering would break those citations for a benefit one sentence achieves.

**3. The exclusive-resource filter needs a release condition.** `loops.md`, the dispatch filter list.

The filter excludes items whose resource is exclusive and contended — correctly, every tick. The rule that says to eventually stop refilling, drain, and take that work lived in a different document's essay on unresolved tensions, with nothing in the loop body pointing at it. So the loop's standing instruction was to fence that work forever, and the counterweight was somewhere the loop never looks.

Observed directly: by the third tick every remaining item was operator-held, gated on an unmerged change, or in a lane needing a quiet machine — five of them on that one resource. I noticed despite the loop, not because of it. A filter with no release condition is a permanent fence.

**4. The zero-result rule is about instruments, not searches.** `dispatch-prompt-template.md`.

A worker invoked a surface classifier with revisions where it expects file paths. It reported every surface unaffected — well-formed, complete, and indistinguishable from a genuinely unaffected change. The existing rule ("a search that returns ZERO is not a check that passed") is right and its illustration is a quoting error, so nothing in it tells a reader it reaches a classifier or a linter given a bad path. Widened in place rather than added to, so the rule count stays flat.

## What I deliberately did NOT do

**No deletions.** The brief licenses cutting rules and I looked for dead weight, but two hours is not enough exercise of a document this dense to tell inert from quietly load-bearing. Several rules I would have called verbose turned out to be the ones that caught things this session — reading the file list against the item made a 340,000-line change reviewable, and the captured-exit-code rule caught two more harness disagreements today. The cost is asymmetric: a redundant rule wastes context, a deleted load-bearing one costs a worker cycle every time it would have fired.

**Four candidates rejected as already covered**, because "the rule exists and did not reach the reader" is a different repair from "the rule is missing":

| Observed | Why it is not a finding |
|---|---|
| Two of my briefs carried a wrong path and a missed obligation | The premises-are-claims sentence caught both, as designed. The mechanism worked. |
| An audit's findings document existed only inside its worktree at reap time | Covered twice — the removal guard refuses trees holding notes, and the preamble already requires the verdict self-contained on the item. |
| Merge ticks fired repeatedly with nothing green | Not a defect. "Loops fire on time, not on state" already says so. Self-evident material the brief excludes. |
| The harness reported exit 0 for two sabotage runs that captured exit 1 | The rule exists, gives this exact reasoning, and a worker followed it and was right. Confirmatory. |

**Two held for want of evidence**: tracker commands slow enough to change loop behaviour (one observation, undecidable), and a worker's tracker command writing into the mayor checkout (contained, and possibly one tool's path-resolution quirk rather than a general hazard).

Everything stays generic — no tracker commands, no repo paths, no shell syntax, no OS specifics, no real change numbers.

## Quality gates

| Command | Captured exit |
|---|---|
| `check_doc_slugs.py` (final tree) | **0** |
| `mkdocs build --strict` (final tree) | **0** |
| `check_doc_slugs.py` with a planted fault | **1** |
| `check_doc_slugs.py` after restore | **0** |

Exit codes captured in-shell with the redirect and echo on one command line, never piped and never read from a harness report.

**Control.** With the real edit committed first, a broken anchor was planted on a single line I had already edited; the match count read exactly 1 before the run. The gate went red naming `loops.md:100 -> #clause-99-planted-methodretro` — a string that exists only in this worktree, which is what proves the gate read this tree rather than a sibling. Restore verified by git **blob** hash: `65561b6a1f92b7189478534c27117f82fe8eebc8`, identical to the committed object, with plant residue count 0.

**Not nominated:** `check_readme_links.py --ci`. Its surface is repo-root markdown and READMEs beside source; `docs/**` belongs to `check_doc_slugs.py`. Running it would have returned a green that inspected nothing changed here.

**Checked by hand**, since no gate covers it: no heading was added or altered, so the two anchors cited from outside this tree (`loops.md#1-merge` and `loops.md#after-each-merge`) still resolve — verified present. No tables were touched, so no column counts to re-check. Neither edit sits inside a fenced code block, so both gates genuinely inspected the changed lines.

**Revert check.** `git diff origin/main...HEAD` is exactly the two files, +29/−1. The trunk has not moved since the merge base and touches none of these paths, so nothing is being undone.
