### PR TITLE
docs(hicasso): the hand-rolled renderToString is not the only server path (rf2-981ka)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
@@ -177,11 +177,13 @@
 ;; this arm. These doors are what let a caller say the word.
 ;;
 ;; **The PREFIX's server half is React's too, and it needs no door
-;; here.** A consumer server-renders through `react-dom/server` itself —
-;; `renderToString(element, #js {"identifierPrefix" "a-"})` — which per
-;; the census is the only server path this package has.
-;; So the two sides already meet in React's own vocabulary and what
-;; matters is that the caller hands BOTH of them the same string.
+;; here.** It is spelled on whichever server caller bakes the bytes:
+;; `re-frame.hicasso.server/render` carries `:identifier-prefix`, a
+;; pass-through of exactly this shape, and a hand-rolled
+;; `renderToString(element, #js {"identifierPrefix" "a-"})` names
+;; React's option directly. Either way the two sides meet in React's
+;; own vocabulary and what matters is that the caller hands BOTH of
+;; them the same string.
 ;; Agreement is the contract; presence on one side proves nothing.
 ;;
 ;; **That settles the prefix and not the pair**, and the difference is

--- a/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
@@ -250,9 +250,10 @@
   it does not work here TODAY, for a reason already measured rather than
   suspected. A hydrating root carries the adoption closer as a SIBLING of
   the app subtree (`impl.mount/tree`), React derives a `useId` from tree
-  POSITION as well as from the prefix, and this package's only server
-  path emits no counterpart to that fork — so a `useId` minted in the app
-  subtree hydrates into a value the server never wrote. That is
+  POSITION as well as from the prefix, and a hand-rolled
+  `renderToString` — bytes no product door baked — emits no counterpart
+  to that fork, so a `useId` minted in the app subtree hydrates into a
+  value the server never wrote. That is
   dispositions.md HS-11's second obstruction, green in
   `identifier-prefix-ssr-dom-cljs-test`, and it would have traded a
   drifting mismatch for a fixed one on the same attribute. It would also

--- a/implementation/hicasso/src/re_frame/hicasso/native.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/native.cljc
@@ -1079,8 +1079,9 @@
   response and appears once the client has adopted the page, which is
   what makes an island reaching for `window` safe to write without
   saying anything. One mechanism serves both arms ([[component]]), and
-  neither needs a server entry of Hicasso's own: the consumer calls
-  `react-dom/server` and the policy is honoured by rendering.
+  the policy is honoured by rendering under either caller — through
+  [[re-frame.hicasso.server/render]], the package's server door, or
+  through `react-dom/server` called by hand.
 
   Like `defview` this is not a compiler: it reads no body, expands to a
   `def`, and captures the name and the source coordinate

--- a/implementation/hicasso/test/re_frame/hicasso/client_only_arms_ssr_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/client_only_arms_ssr_cljs_test.cljs
@@ -150,8 +150,11 @@
 
 (defn- server-html
   "The page as a REAL server render, through `react-dom/server`'s own
-  `renderToString` — the only server path this package has, and exactly
-  the call a consumer makes."
+  `renderToString`, called by hand — the smallest thing that produces
+  server bytes, so what these rows read is the arm's own server
+  behaviour and nothing else. The package's own server door is
+  `re-frame.hicasso.server/render`; this harness sits beside it, not
+  instead of it."
   [hiccup]
   (react-dom-server/renderToString
     (mount/provider frame-id (codec/root-element frame-id hiccup))))

--- a/implementation/hicasso/test/re_frame/hicasso/core_view_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/core_view_ssr_dom_cljs_test.cljs
@@ -7,9 +7,12 @@
   *Client-only* in the operative column, and they read that for one
   reason: nothing else server-renders a `h/defview`. This file is that
   witness. It runs the surfaces through `react-dom/server`'s own
-  `renderToString` — the only server path this package has, and exactly
-  the call a consumer makes — and then hydrates those same bytes through
-  the product door.
+  `renderToString`, called by hand — the smallest thing that produces
+  server bytes, so what these rows read is the surface's own server
+  behaviour and nothing else — and then hydrates those same bytes
+  through the product door. The package's own server door is
+  `re-frame.hicasso.server/render`; this harness sits beside it, not
+  instead of it.
 
   ## What a row here has to show, and why the list is not negotiable
 
@@ -24,9 +27,9 @@
   ## The one thing these rows deliberately do NOT claim
 
   A hydrating root's tree is `Fragment[closer, adoption-provider[…]]`
-  (`impl.mount/tree`) and the server path emits no counterpart
-  to that fork, so a tree containing a `useId` hydrates into an id
-  mismatch — HS-11's obstruction 2, measured in
+  (`impl.mount/tree`) and this file's hand-rolled server path emits no
+  counterpart to that fork, so a tree containing a `useId` hydrates into
+  an id mismatch — HS-11's obstruction 2, measured in
   `identifier-prefix-ssr-dom-cljs-test` and unrepaired. **No surface in
   this file mints a `useId`**, so every row below is unaffected and none
   of them repairs it either. That obstruction is HS-11/HS-14's and it

--- a/implementation/hicasso/test/re_frame/hicasso/facade_roster_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/facade_roster_ssr_dom_cljs_test.cljs
@@ -51,9 +51,10 @@
   ## What these rows deliberately do NOT claim
 
   A hydrating root carries the adoption closer as a SIBLING of the app
-  subtree and the package's server path emits no counterpart, so a tree
-  containing a `useId` hydrates into an id mismatch — HS-11's obstruction
-  2, measured in `identifier-prefix-ssr-dom-cljs-test` and unrepaired.
+  subtree and this file's hand-rolled server path emits no counterpart,
+  so a tree containing a `useId` hydrates into an id mismatch — HS-11's
+  obstruction 2, measured in `identifier-prefix-ssr-dom-cljs-test` and
+  unrepaired.
   **No surface in this file mints a `useId`**: `route-link` is a plain
   function that adds no hook, `use-subs` reads through the collector's
   existing pair, and `reg-state` mints registry entries rather than
@@ -208,8 +209,11 @@
 
 (defn- server-html
   "The page as a REAL server render, through `react-dom/server`'s own
-  `renderToString` — the only server path this package has, and exactly
-  the call a consumer makes."
+  `renderToString`, called by hand — the smallest thing that produces
+  server bytes, so what these rows read is the surface's own server
+  behaviour and nothing else. The package's own server door is
+  `re-frame.hicasso.server/render`; this harness sits beside it, not
+  instead of it."
   ([hiccup] (server-html frame-id hiccup))
   ([kw hiccup]
    (react-dom-server/renderToString

--- a/implementation/hicasso/test/re_frame/hicasso/identifier_prefix_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/identifier_prefix_ssr_dom_cljs_test.cljs
@@ -21,8 +21,8 @@
       render has no counterpart for, and `useId` is derived from tree
       POSITION as well as from the prefix. So the two sides disagree on
       the id's tail while agreeing perfectly on its head (§2), and a page
-      whose bytes were baked by the only server path this package has
-      hydrates into a text mismatch.
+      whose bytes were baked by a hand-rolled `renderToString` rather
+      than by a product door hydrates into a text mismatch.
 
   §3 pins that cause to a single structural difference and §4 and §5 run
   the whole clause on the far side of it, so what is missing is named
@@ -90,8 +90,11 @@
   ## The harness
 
   The server bytes come from `react-dom/server`'s own `renderToString`, called
-  by hand with React's own `identifierPrefix` option — the only server path
-  this package has, and exactly the call a consumer makes. The client half is
+  by hand with React's own `identifierPrefix` option — the smallest thing that
+  produces server bytes under a named prefix. The package's own server door,
+  `re-frame.hicasso.server/render`, spells the same option as
+  `:identifier-prefix`; this harness sits beside it, not instead of it, so
+  what these rows read is the prefix and nothing else. The client half is
   the product door `impl.mount/hydrate-root!` and never `hydrateRoot`
   directly: what is under test is the door's pass-through, so a row reaching
   past it would witness React rather than this arm.
@@ -199,10 +202,11 @@
   "The bytes an SSR route delivers for `hiccup` under `frame-kw`, with
   React's own `identifierPrefix` — `nil` for a route that names none.
 
-  **The tree a consumer can spell today**: the frame provider over the
+  **The tree a consumer spells BY HAND**: the frame provider over the
   root element, handed to `react-dom/server`'s `renderToString`. That
-  hand-rolled call is the only server path this package has, so these are
-  the bytes an SSR route actually ships."
+  hand-rolled call bakes no adoption closer, so these are the bytes a
+  hand-rolled SSR route ships — `root-shaped-server-html!` below is the
+  other tree, and §3 pins the difference to that one fork."
   [frame-kw hiccup prefix]
   (react-dom-server/renderToString
     (mount/provider frame-kw (codec/root-element frame-kw hiccup))


### PR DESCRIPTION
Closes rf2-981ka (REOPENED by the merged-PR audit of #8645).

`re-frame.hicasso.server/render` shipped on 2026-08-14 (rf2-b6jkj, PR #8236). PR #8645 (`c284981624`) corrected the two carriers in `native_ssr_dom_cljs_test.cljs`; the audit of that PR found the same now-false present-tense architecture claim standing in five more files and reopened this bead to sweep them.

Commentary and docstrings only. **No assertion is touched and no behaviour changes.**

## The sweep, re-derived at tip

The audit named **seven carriers across five files**. All seven are still live — none had been fixed in the meantime, and none was a phantom. Re-deriving the sweep from the phrasings rather than from the list found **four more across two additional files**, so the corrected figure is **eleven carriers across seven files**.

| # | Site | On the audit's list? |
|---|---|---|
| 1 | `impl/mount.cljs:182` | yes |
| 2 | `identifier_prefix_ssr_dom_cljs_test.cljs:24` | yes |
| 3 | `identifier_prefix_ssr_dom_cljs_test.cljs:93-94` | yes |
| 4 | `identifier_prefix_ssr_dom_cljs_test.cljs:204` | yes |
| 5 | `core_view_ssr_dom_cljs_test.cljs:10` | yes |
| 6 | `client_only_arms_ssr_cljs_test.cljs:153` | yes |
| 7 | `facade_roster_ssr_dom_cljs_test.cljs:211` | yes |
| 8 | `impl/overlay.cljs:253` | **no — delta** |
| 9 | `native.cljc:1082` | **no — delta** |
| 10 | `core_view_ssr_dom_cljs_test.cljs:27` | **no — delta** |
| 11 | `facade_roster_ssr_dom_cljs_test.cljs:54` | **no — delta** |

The four the list did not have are the same claim wearing different words: `the package's server path`, `this package's only server path`, and — in `native.cljc` — the second half of the very sentence #8645 deleted from the test file (*"the consumer calls `react-dom/server` and the policy is honoured by rendering"*), still standing in production source.

## The discriminator, and what was left standing

> Does this line assert that the hand-rolled harness is the package's ONLY server path (or that no product server entry exists) — or does it merely describe the harness as deliberately minimal, without claiming exclusivity?

Only the first is false. Five lines matched the greps and were **deliberately left alone** because they are already correct:

- **`impl/mount.cljs:504-515`** — *"**A** server path emitting no counterpart to that fork…"*, indefinite article, and the very next paragraph names `re-frame.hicasso.server/render` as the matching server-render entry. This one sits in the same file as carrier #1, which is what made that carrier an internal contradiction rather than merely stale.
- **`impl/roots.cljs:58`** — names both doors and calls the hand-rolled render *"a render that neither door took"*. Exactly the distinction being swept for, already drawn.
- **`presence_ssr_seam_dom_cljs_test.cljs:18`** — returns a deliberately SPLIT verdict, *"closed through the package's server entry, open through a hand-rolled `renderToString`"*.
- **`facade_roster_ssr_dom_cljs_test.cljs:176`** — *"the only server-observable fact about the sugar"*. Same words, different claim.
- **`presence_ssr_seam_dom_cljs_test.cljs:99`** — *"whether or not any server path works at all"*. Same words, different claim.

## The repair shape

#8645's register, applied consistently: these are **deliberately minimal harnesses beside the product door**, not the package's only server path. `impl/mount.cljs`'s prefix comment additionally now names `:identifier-prefix` on the door as the other spelling of React's own `identifierPrefix`, which is what makes its *the two sides meet in React's own vocabulary* argument true again rather than true by accident.

## Carriers found OUTSIDE this PR's fence — for routing, not touched here

The same false claim also stands in `docs/design/hicasso/product/`: `checkpoint-3-native.md:203`, `correction-ledger.md:89`, and `dispositions.md:282`, `:283`, `:301`. The bead explicitly fences the ledger and the dispositions rows to rf2-s52w / the ledger keeper, and a live peer holds the first two. Left untouched and reported.

## Quality gates

Focused hicasso node lane, chosen because its `ns-regexp` `^re-frame\.hicasso\..+-cljs-test$` selects **all four touched test namespaces** and its graph compiles **all three touched source namespaces** (verified present in the built bundle). Every exit code below is the runner's own, captured with `echo $?` on the same command line, on the final rebased base.

| Gate | Command | Exit |
|---|---|---|
| Focused hicasso node compile | `node scripts/compile-node-test.cjs node-test-hicasso out/node-test-hicasso.js` | **0** (549 files, 0 warnings) |
| Focused hicasso node run | `node out/node-test-hicasso.js` | **0** — 1326 tests / 5407 assertions / 0 failures / 0 errors |
| Hicasso invariants | `npm run test:hicasso-invariants` | **0** (freeze, optional-module reachability, complaint catalogue, budget ledger, example-fence coverage, facade inventory, guide samples) |
| Retired spellings | `python scripts/check_retired_spellings.py` | **0** |
| Changed-surface classifier | `.github/scripts/report-changed-surfaces.sh <paths>` | **0** |

### Sabotage: one plant per edited region, all eleven

A commentary-only change still affords a plant: a docstring is a string literal, so one bare quote closes it early and the compile goes red. Each plant was applied to its own region, match count asserted **exactly 1** before planting, compiled, then restored and the restore **verified by `git hash-object` blob hash against the committed object** (not a byte digest — Windows translates line endings).

All eleven read **exit 1**, and each error names its own file and the planted line:

| Region | File | Plant | Exit |
|---|---|---|---|
| 01 | `impl/mount.cljs` | un-comment (see below) | 1 |
| 02 | `impl/overlay.cljs` | bare quote | 1 |
| 03 | `native.cljc` | bare quote | 1 |
| 04 | `client_only_arms_ssr_cljs_test.cljs` | bare quote | 1 |
| 05, 06 | `core_view_ssr_dom_cljs_test.cljs` | bare quote | 1, 1 |
| 07, 08 | `facade_roster_ssr_dom_cljs_test.cljs` | bare quote | 1, 1 |
| 09, 10, 11 | `identifier_prefix_ssr_dom_cljs_test.cljs` | bare quote | 1, 1, 1 |

**Region 01 needed a different plant, and the reason is worth stating**: `impl/mount.cljs`'s edited region is a `;;` line comment, not a docstring. A quote inside a `;;` comment is inert — the reader discards the line — so no compile gate can reach that text as text. The plant there strips one `;; ` prefix, making the edited prose live code; the compile reddens with *Use of undeclared Var `re-frame.hicasso.impl.mount/hand-rolled`* pointing at line 182. That proves the gate covers the file and the region's location, which is the most a comment admits.

The control run before and after the eleven plants returned **identical namespace and assertion counts** (1326 / 5407), so no plant left residue and none silently truncated the lane.

### Searches were controlled in both directions

A grep returning zero is not a check that passed. Each sweep pattern was exercised against `native_ssr_dom_cljs_test.cljs` at `c284981624^` — the pre-#8645 blob that is known to carry the claim — and each found it there (`only server path` → 2 hits, `server entry` → 1, `exactly the call a consumer makes` → 1) while returning empty at tip. The classifier was controlled the same way: handed `README.md` it reports every surface false, and handed a *revision* instead of paths it reports every surface false too — the silent-zero failure mode — so the run above was given paths.

### Gates deliberately NOT nominated

- **`scripts/check_doc_slugs.py`** — read its source rather than assumed: `DEFAULT_ROOTS = ("docs", "spec", "skills", "migration")` plus `tools/*/spec`, and it reads `.md` files only. `implementation/` is outside every root, so it exits 0 on anything here, on two counts.
- **`scripts/check_readme_links.py --ci`** — markdown beside source. This PR changes no markdown at all.
- **Browser lane (`test:browser`)** — the classifier reports `cljs_browser=true`, and it is not run locally: cold Chromium dominates worker wall-clock and CI owns it. The three touched `-dom-cljs-test` namespaces DID run here under the node lane, where their DOM rows self-skip and their `renderToString` rows do not.
- **`implementation_jvm`, `migration_hicasso_codemod`, `hicasso_controlled`, `hicasso_hmr`** — reported true by the classifier, not run locally, left to CI.

**Local-green is not CI.**

### Checked by hand, because nothing gates it

No gate validates cljdoc `[[...]]` wikilinks (grepped for one; there is none), and no gate reads prose. Verified manually: `[[re-frame.hicasso.server/render]]` resolves (`server.cljs` — `(ns re-frame.hicasso.server)` at `:1`, `(defn render` at `:330`), and `root-shaped-server-html!` resolves in its own file (`:215`). No markdown links were added or changed. Table column counts in this body checked by hand.
