### PR TITLE
fix(bench): the null-floor verdict derives its span occupancy instead of asserting zero (rf2-2iaph)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/alloc_null_floor.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/alloc_null_floor.cjs
@@ -333,6 +333,42 @@ function step(l) {
   return null;
 }
 
+// THE SHAPE OF THE CORPUS AGAINST THE BAR — DERIVED ONCE, PRINTED TWICE.
+// Section A and THE VERDICT four hundred lines of output below it both state
+// the span's occupancy, the bar's position relative to the span, and how far
+// the bar's partition is from the two-population one. They used to state them
+// SEPARATELY: A read the cells, the verdict carried literals written when the
+// corpus was 242 cells and the span really did hold none. When phase 4 put a
+// cell in the span, A said `1 cells` and the verdict went on saying
+// `zero of ${all.length}` — the wrong count wearing the right corpus size — so
+// one run of one program contradicted itself in two places (rf2-2iaph). Both
+// now read this object, and can no longer disagree without disagreeing with
+// the cells.
+function shape(all) {
+  const pooled = ladder(all);
+  return {
+    n: all.length,
+    // STRICTLY BELOW THE SPAN, which is not `ladder`'s mode-1 population: that
+    // one is everything under the mode-2 floor and so includes the span's own
+    // cell. Section A's three counts must partition the corpus, so this is the
+    // narrow one.
+    mode1n: all.filter((c) => c.abs <= MODE1_CEIL_B).length,
+    spanN: all.filter((c) => c.abs > MODE1_CEIL_B && c.abs < MODE2_FLOOR_B).length,
+    mode2n: pooled.mode2n,
+    overBar: pooled.overBar,
+    spanWidth: MODE2_FLOOR_B - MODE1_CEIL_B,
+    // SIGNED, so that no sentence below has to carry the direction as a word:
+    // positive is above the span's upper edge, negative is inside the span.
+    barOffset: PUBLISHED.barB - MODE2_FLOOR_B,
+    // The cells the two partitions disagree about, counted DIRECTLY rather than
+    // by differencing the two totals — which gives the self-test a second and
+    // independent derivation of the same number to hold this one against.
+    splitDiff: all.filter((c) => (c.abs > PUBLISHED.barB) !== (c.abs >= MODE2_FLOOR_B)).length,
+    splitDiffAt: [...new Set(all.filter((c) => (c.abs > PUBLISHED.barB) !== (c.abs >= MODE2_FLOOR_B))
+      .map((c) => c.abs))].sort((a, b) => a - b),
+  };
+}
+
 // --- the corpus, assembled ---------------------------------------------------
 
 // `{ window, design, run, rel, session, cells }` per committed run, in the
@@ -385,10 +421,24 @@ function groupBy(rows, key) {
 const f1 = (x) => (x === null || x === undefined ? 'n/a' : x.toFixed(1));
 const num = (x) => (x === null || x === undefined ? 'n/a' : String(x));
 
+// WHERE THE BAR SITS RELATIVE TO THE SPAN, IN WORDS RENDERED FROM THE OFFSET.
+// "half a byte above" is the wording the record settled on, and it is
+// ARITHMETIC rather than a figure of speech — 45 − 44.5 = 0.5 — so it is
+// rendered here rather than typed. The third rendering is the point: a bar that
+// fell inside the span would SAY SO, in this reader's own voice. The check this
+// replaced forbade the literal `LANDS INSIDE THAT GAP` in a program that had no
+// way to emit it, and so could only ever agree with itself.
+const barPosition = (d) => (d > 0
+  ? `sits ${d === 0.5 ? 'half a byte' : `${f1(d)} B`} above`
+  : d < 0 ? `lands ${f1(-d)} B inside`
+    : 'sits on the upper edge of');
+
 function report() {
   const rows = corpus();
   const all = cellsOf(rows);
   const pooled = ladder(all);
+  // Section A and THE VERDICT both print from this. See `shape`.
+  const sh = shape(all);
   const out = [];
   const L = (s) => out.push(s === undefined ? ';;' : `;; ${s}`.trimEnd());
 
@@ -415,16 +465,13 @@ function report() {
   L();
 
   L('A. THE SHAPE, WHICH GOVERNS EVERY LADDER BELOW: TWO POPULATIONS, NOT ONE TAIL.');
-  const gap = all.filter((c) => c.abs > MODE1_CEIL_B && c.abs < MODE2_FLOOR_B);
-  const m1 = all.filter((c) => c.abs <= MODE1_CEIL_B);
-  const m2 = all.filter((c) => c.abs >= MODE2_FLOOR_B);
-  L(`  mode 1, at or below ${MODE1_CEIL_B} B/boundary : ${m1.length} cells`);
-  L(`  the gap, (${MODE1_CEIL_B}, ${MODE2_FLOOR_B})              : ${gap.length} cells`);
-  L(`  mode 2, at or above ${MODE2_FLOOR_B} B/boundary : ${m2.length} cells`);
+  L(`  mode 1, at or below ${MODE1_CEIL_B} B/boundary : ${sh.mode1n} cells`);
+  L(`  the gap, (${MODE1_CEIL_B}, ${MODE2_FLOOR_B})              : ${sh.spanN} cells`);
+  L(`  mode 2, at or above ${MODE2_FLOOR_B} B/boundary : ${sh.mode2n} cells`);
   L(`  Both edges are observed, not chosen: ${MODE1_CEIL_B} is the largest cell below the gap and`);
   L(`  ${MODE2_FLOOR_B} the smallest above it, over all ${all.length}.`);
-  L(`  THE PUBLISHED BAR AT ${PUBLISHED.barB} SITS HALF A BYTE ABOVE THAT SPAN.`);
-  if (gap.length === 0) {
+  L(`  THE PUBLISHED BAR AT ${PUBLISHED.barB} ${barPosition(sh.barOffset).toUpperCase()} THAT SPAN.`);
+  if (sh.spanN === 0) {
     L(`  Any bar in (${MODE1_CEIL_B}, ${MODE2_FLOOR_B}] classifies all ${all.length} cells identically; the published one differs`);
   } else {
     // PHASE 4 PUT A CELL IN THE SPAN, so the "any bar in the span is the same
@@ -435,14 +482,14 @@ function report() {
     // narrowed rather than overturned — the span still holds a fraction of a
     // percent of the corpus — but "identically" was an absolute claim and it
     // has an exception, so the reader states the exception instead.
-    const pct = ((gap.length / all.length) * 100).toFixed(2);
-    L(`  THE SPAN IS NO LONGER EMPTY: ${gap.length} of ${all.length} cells (${pct}%) sit inside it, so bars within`);
+    const pct = ((sh.spanN / all.length) * 100).toFixed(2);
+    L(`  THE SPAN IS NO LONGER EMPTY: ${sh.spanN} of ${all.length} cells (${pct}%) sit inside it, so bars within`);
     L(`  (${MODE1_CEIL_B}, ${MODE2_FLOOR_B}] no longer all classify alike. The shape is narrowed, not overturned —`);
-    L(`  ${m1.length} cells below and ${m2.length} above against ${gap.length} between. The published one differs`);
+    L(`  ${sh.mode1n} cells below and ${sh.mode2n} above against ${sh.spanN} between. The published one differs`);
   }
-  L(`  from that partition on EXACTLY ONE cell of ${all.length}, the one at ${MODE2_FLOOR_B}, which it counts`);
-  L('  below the bar. So the bar\'s VALUE is robust however its derivation behaved — and so are');
-  L('  the two counts below, which differ by that one cell and by nothing else:');
+  L(`  from that partition on EXACTLY ${sh.splitDiff} of ${all.length} cells, at ${sh.splitDiffAt.join(', ')} B/boundary,`);
+  L(`  which it counts ${sh.barOffset > 0 ? 'below' : 'above'} the bar. So the bar's VALUE is robust however its derivation`);
+  L('  behaved — and so are the two counts below, which differ by those cells and by nothing else:');
   L(`    over the ${PUBLISHED.barB} B bar : ${pooled.overBar}/${all.length}      in mode 2 : ${pooled.mode2n}/${all.length}`);
   L('  Every cross-window comparison below is stated OVER THE BAR, the basis the published');
   L('  figures use. Mode-2 membership is used only for the shape and for mode 1\'s own ladder.');
@@ -540,8 +587,10 @@ function report() {
 
   L('THE VERDICT, in the three parts the bead asks for.');
   L(`  THE MEDIAN, ${PUBLISHED.median} — HOLDS. Mode 1's median is 1.5 in the first window and 1.5 in the last.`);
-  L(`  THE BAR, ${PUBLISHED.barB} — DOES NOT MOVE. It lands inside a ${MODE2_FLOOR_B - MODE1_CEIL_B} B/boundary span that holds`);
-  L(`    zero of ${all.length} cells, and it separates the two populations correctly.`);
+  L(`  THE BAR, ${PUBLISHED.barB} — DOES NOT MOVE. It ${barPosition(sh.barOffset)} a ${sh.spanWidth} B/boundary span`);
+  L(`    that holds ${sh.spanN} of ${sh.n} cells, which is what makes its VALUE robust however its`);
+  L('    derivation behaved. ROBUST IS NOT THE SAME AS EXACT, and A states the difference:');
+  L(`    its partition differs from the two-population one on ${sh.splitDiff} of ${sh.n} cells.`);
   L(`  THE p90, ${PUBLISHED.p90} — CANNOT BE REPAIRED BY RE-CUTTING IT, because a pooled percentile is not a`);
   L('    magnitude on a two-population mixture. It should be RETIRED and replaced by two figures');
   L(`    that are: mode 1's own dispersion (p90 ${pooled.mode1.p90} over the corpus) and the fraction over the`);
@@ -764,11 +813,93 @@ function selfTest() {
   ck('the report states the corpus total', /TOTAL 569 cells over 16 runs, 4 windows, 5 sessions\./.test(rep), true);
   ck('the report states the span occupancy, which is now one rather than zero',
     /the gap, \(21, 44\.5\)\s+: 1 cells/.test(rep), true);
-  ck('and says so in prose rather than still claiming any bar in the span is the same bar',
-    /THE SPAN IS NO LONGER EMPTY/.test(rep) && !/classifies all \d+ cells identically/.test(rep), true);
   ck('the report refuses to move the bar', /THE BAR, 45 — DOES NOT MOVE\./.test(rep), true);
-  ck('the report does not claim the bar lies inside the empty span',
-    /SITS HALF A BYTE ABOVE THAT SPAN/.test(rep) && !/LANDS INSIDE THAT GAP/.test(rep), true);
+
+  // ---------------------------------------------------------------------------
+  // SECTION A AND THE VERDICT, READ BACK AND COMPARED AS NUMBERS — rf2-2iaph.
+  //
+  // What stood here asserted the ABSENCE of the literal `LANDS INSIDE THAT GAP`
+  // from a program that had never had a way to emit that string, while the
+  // verdict said `lands inside a 23.5 B/boundary span that holds zero of
+  // ${all.length} cells` — a hardcoded count wearing the right corpus size,
+  // false since phase 4 put a cell in the span, and flatly contradicting
+  // section A four hundred lines above it. The suite was green through every
+  // run of that. It had to be: a phrase the program cannot print is not a
+  // control, and the check could only ever see the words.
+  //
+  // The demonstration is one line long. Leave the claim exactly as it was and
+  // change only its WORDING to contain the forbidden phrase, and the old check
+  // goes red — same fault, opposite verdict. It was measuring the sentence.
+  //
+  // So nothing below tests for a phrase. Each check EXTRACTS A NUMBER from the
+  // rendered report — once from section A, once from the verdict — and holds
+  // both against a third derived here from the cells. Three consequences, and
+  // they are why this cannot go hollow the way its predecessor did:
+  //
+  //   * a hardcoded figure in either section disagrees with the cells and reds,
+  //     whatever words surround it;
+  //   * `above` and `inside` are ONE check with opposite signs rather than two
+  //     literals, so the report cannot claim a position the arithmetic denies;
+  //   * a wording change that stops a number being found yields `NO MATCH` and
+  //     FAILS. A pattern that matches nothing is the failure mode this whole
+  //     bead is about, so it must never be the quiet answer.
+  const sh = shape(all);
+  const grab = (re, f) => { const m = re.exec(rep); return m === null ? 'NO MATCH' : f(m); };
+  // AND EACH PATTERN MUST FIND ITS LINE EXACTLY ONCE. `exec` stops at the first
+  // match, so without this a pattern loose enough to hit both sections would
+  // compare one section's number with itself and pass. That is the trap a
+  // permanent test walks straight past when it only ever plants one thing to
+  // find, and it is worth more here than anywhere: the checks below exist
+  // precisely to make two sections disagree out loud.
+  const hits = (re) => (rep.match(new RegExp(re.source, 'g')) || []).length;
+
+  const A_SPAN = /the gap, \([\d.]+, [\d.]+\)\s+: (\d+) cells/;
+  const A_POS = /THE PUBLISHED BAR AT ([\d.]+) (?:SITS|LANDS) (HALF A BYTE|[\d.]+ B) (ABOVE|INSIDE) THAT SPAN\./;
+  const A_DIFF = /from that partition on EXACTLY (\d+) of (\d+) cells, at ([\d., ]+) B\/boundary/;
+  const V_POS = /DOES NOT MOVE\. It (?:sits|lands) (half a byte|[\d.]+ B) (above|inside) a ([\d.]+) B\/boundary span/;
+  const V_SPAN = /that holds (\d+) of (\d+) cells, which is what makes its VALUE robust/;
+  const V_DIFF = /its partition differs from the two-population one on (\d+) of (\d+) cells\./;
+
+  ck('each figure the two sections are compared on is located exactly once',
+    [A_SPAN, A_POS, A_DIFF, V_POS, V_SPAN, V_DIFF].map(hits), [1, 1, 1, 1, 1, 1]);
+
+  // THE SPAN'S OCCUPANCY, three ways: what A prints, what the verdict prints,
+  // and what the cells say. This is the bead's own contradiction, as a check.
+  ck('the span occupancy agrees between section A, the verdict and the cells',
+    [grab(A_SPAN, (m) => Number(m[1])), grab(V_SPAN, (m) => Number(m[1])), grab(V_SPAN, (m) => Number(m[2]))],
+    [sh.spanN, sh.spanN, sh.n]);
+
+  // THE BAR'S POSITION, read back as a SIGNED OFFSET rather than as a direction
+  // word. `sits on the upper edge of` is deliberately unmatched by both
+  // patterns: a corpus that put the bar exactly on the mode-2 floor reds here
+  // and gets looked at, rather than sliding through on a third wording.
+  const offset = (mag, dir) => (mag.toLowerCase() === 'half a byte' ? 0.5 : Number(mag.split(' ')[0])) *
+    (dir.toLowerCase() === 'above' ? 1 : -1);
+  ck('section A states the bar and its offset from the span, and both are derived',
+    grab(A_POS, (m) => [Number(m[1]), offset(m[2], m[3])]), [PUBLISHED.barB, sh.barOffset]);
+  ck('the verdict states the same offset, and the span\'s width with it',
+    grab(V_POS, (m) => [offset(m[1], m[2]), Number(m[3])]), [sh.barOffset, sh.spanWidth]);
+
+  // HOW FAR THE BAR'S PARTITION IS FROM THE TWO-POPULATION ONE — the verdict's
+  // third clause, which said `separates the two populations correctly` while A
+  // said it differs on one cell. Both sections now print the count, and A
+  // prints the cells it is.
+  ck('the partition difference agrees between section A, the verdict and the cells',
+    [grab(A_DIFF, (m) => [Number(m[1]), Number(m[2]), m[3]]), grab(V_DIFF, (m) => [Number(m[1]), Number(m[2])])],
+    [[sh.splitDiff, sh.n, sh.splitDiffAt.join(', ')], [sh.splitDiff, sh.n]]);
+  // ...and that count is derived a SECOND way here, by differencing the two
+  // totals rather than by counting the cells the partitions disagree about, so
+  // the number the report is held to is not the report's own arithmetic.
+  ck('and differencing the two totals gives the same count',
+    pooled.mode2n - pooled.overBar, sh.splitDiff);
+
+  // THE BRANCH IS THE ONE THE OCCUPANCY CALLS FOR. Both of these sentences are
+  // emittable — unlike the literal the old guard forbade — and exactly one of
+  // them belongs in any given run.
+  ck('the empty-span sentence is printed exactly when the span is empty',
+    [/classifies all \d+ cells identically/.test(rep), /THE SPAN IS NO LONGER EMPTY/.test(rep)],
+    [sh.spanN === 0, sh.spanN > 0]);
+  // ---------------------------------------------------------------------------
   ck('the report names the basis of its cross-window comparisons',
     /Every cross-window comparison below is stated OVER THE BAR/.test(rep), true);
   ck('the report leaves the p90 to a ruling', /THAT IS A RULING, NOT THIS READER'S CALL/.test(rep), true);
@@ -818,6 +949,6 @@ if (require.main === module) {
 
 module.exports = {
   PUBLISHED, MODE1_CEIL_B, MODE2_FLOOR_B, WINDOWS, LADDER,
-  allRecords, discover, nullCells, median, quantile, ladder, step, corpus, cellsOf,
+  allRecords, discover, nullCells, median, quantile, ladder, step, shape, corpus, cellsOf,
   report, tables, selfTest,
 };


### PR DESCRIPTION
`alloc_null_floor.cjs` printed, in section A, `the gap, (21, 44.5) : 1 cells` — and then four hundred lines of output later, in THE VERDICT:

> `THE BAR, 45 — DOES NOT MOVE. It lands inside a 23.5 B/boundary span that holds zero of 569 cells, and it separates the two populations correctly.`

Section A **derived** its count. The verdict carried literals written when the corpus was 242 cells and the span really did hold none, with `all.length` interpolated beside them so the wrong count wore the right corpus size. `a9ec2c662d`'s phase-4 fold-in is what turned it from fragile into false.

**All three clauses were wrong against the same run's own arithmetic**, not just the one the bead's title names:

| the verdict said | section A said, in the same run |
|---|---|
| the bar `lands inside` the span | `THE PUBLISHED BAR AT 45 SITS HALF A BYTE ABOVE THAT SPAN.` |
| the span holds `zero of 569` cells | `the gap, (21, 44.5) : 1 cells` |
| it `separates the two populations correctly` | `the published one differs from that partition on EXACTLY ONE cell of 569` |

## The gate was hollow, and here is the measurement that says so

The self-test asserted `/SITS HALF A BYTE ABOVE THAT SPAN/.test(rep) && !/LANDS INSIDE THAT GAP/.test(rep)`. **The forbidden literal appeared nowhere in the program but inside that regex** — `grep -c 'LANDS INSIDE THAT GAP'` over the file reads **1**, the check itself. The program had no way to emit the string it was forbidden to emit, so the negative arm could only ever agree with itself.

**Delete the signal, keep the fault.** Two runs of the identical false claim, differing only in wording:

| run | the claim | the words | captured exit |
|---|---|---|---|
| at `origin/main`, untouched | the bar lands inside the span, which holds zero of 569 | `It lands inside a 23.5 B/boundary span` | **0** — *55 checks* |
| one wording change, same claim | the bar lands inside the span, which holds zero of 569 | `It LANDS INSIDE THAT GAP, a 23.5 B/boundary span` | **1** — `the report does not claim the bar lies inside the empty span: got false, want true` |

Same fault, opposite verdicts. The check was measuring the sentence. The plant target matched **exactly 1** line before planting, and the restore was verified by **blob** hash — `git hash-object --path` reading `1b3109763326…` against `git rev-parse HEAD:<path>` `1b3109763326…`, with `git status --porcelain` empty.

## Replaced, not patched

Adding `LANDS INSIDE A ... SPAN` to the forbidden list would have produced a third thing that looks like a control, and the next reader would trust it harder for having a history of being fixed.

**The report now derives the claim once.** `shape()` computes the span occupancy, the bar's **signed** offset from the span and the partition difference from the cells; section A and the verdict both print from that object, so they cannot disagree without disagreeing with the cells. The direction word is rendered from the sign of the offset — so this reader **can** now say `lands inside` in its own voice, and does so only when that is true. The forbidden phrase became an emittable one, which is the difference between a control and a coincidence.

**The self-test no longer tests for a phrase.** Six patterns extract *numbers* from the rendered report — once from section A, once from the verdict — and hold both against a third derivation from the cells. The partition difference is derived a **second** way, by differencing the two totals rather than by counting the cells the partitions disagree about, so the number the report is held to is not the report's own arithmetic.

### Why the replacement cannot avoid its own case

The named failure mode is a control built so that it exercises the path that works. Two ways this one could have gone that way, both closed and both measured:

* **A pattern that finds nothing must FAIL, never pass quietly.** `grab` returns the string `NO MATCH` on a null `exec`, which mismatches the expected number. That is the whole bead's failure mode, so it is the one answer the gate must never treat as clean.
* **`exec` stops at the first match**, so a pattern loose enough to hit both sections would compare one section's number *with itself* and pass. Every pattern is therefore required to locate its line **exactly once**.

**Five plants, on the committed work, each removing a different way the fault could return.** Control run green before and after; every restore blob-verified against `HEAD`; every match count exactly 1 before planting.

| plant | property removed | captured exit | the check that caught it |
|---|---|---|---|
| `S1a` | the verdict hardcodes a well-formed but wrong occupancy (`0`) | **1** | `the span occupancy agrees…: got [1,0,569], want [1,1,569]` |
| `S1b` | the verdict carries the original word `zero` | **1** | `located exactly once: got […,0,…]` **and** `got [1,"NO MATCH","NO MATCH"]` |
| `S2` | the verdict claims the bar LANDS INSIDE the span | **1** | `the verdict states the same offset…: got [-0.5,23.5], want [0.5,23.5]` |
| `S3` | the verdict prints a different derived number for the partition difference | **1** | `the partition difference agrees…: got [[1,569,"44.5"],[102,569]]` |
| `S4` | a compared line appears twice, so `exec` could read one section against itself | **1** | `located exactly once: got [2,1,1,1,1,1]` |

`S1b` is the load-bearing one: it restores the **exact** literal this bead is about, and the replacement reds on it twice over — once because the pattern stops matching, once because the uniqueness count drops to zero. A silent zero is not available to it.

## The published wording changes, deliberately — please read this clause

**It does.** The verdict now reads:

> `THE BAR, 45 — DOES NOT MOVE. It sits half a byte above a 23.5 B/boundary span`
> `  that holds 1 of 569 cells, which is what makes its VALUE robust however its`
> `  derivation behaved. ROBUST IS NOT THE SAME AS EXACT, and A states the difference:`
> `  its partition differs from the two-population one on 1 of 569 cells.`

`zero of 569` → `1 of 569`; `lands inside` → `sits half a byte above`; `separates the two populations correctly` → `ROBUST IS NOT THE SAME AS EXACT … differs … on 1 of 569 cells`. This is **#8649's settled language**, which landed on the doc side of the same audit at `dddc0c991f` while this was in flight: *"It sits half a byte above a 23.5 B/boundary span … which is what makes its value robust however its derivation behaved. **Robust is not the same as exact** … the bar's partition differs from the population partition on one cell."* Section A's `EXACTLY ONE cell of 569` is derived for the same reason and states the same thing.

The doc page keeps `zero of 242` because its 242-cell derivation is deliberately preserved under an amendment banner. This reader prints the **live** corpus, so it says 1 of 569. The two are consistent, not identical.

## No figure moves, and no pin is rewritten

* **`--tables` is byte-identical** across the change, base versus tip, both captured exit 0. That matters because the record page states that every table on it is `--tables`' output pasted unedited, so the page needs no edit.
* **An empty diff is what a broken comparison also produces, so it was canaried.** Changing `barB` from 45 to 44 in the base copy — match count exactly 1 — produces a **24-line** diff. The comparison is a reading, not a silence.
* **The report differs in exactly two hunks**, both quoted above. Every number in it — 569, 44.5, 23.5, 45, 21, every ladder rung, every over-bar count — is unchanged. The only new numeral is the `1` that replaces `zero` and `ONE`.
* **No provenance pin cites this file.** `git grep` for its base blob `1b3109763326…` across `docs/`, `spec/` and `implementation/` returns nothing — and that zero was exercised: the same grep for `703f5074e148…`, a hash genuinely pinned in `a-control-that-differences-the-constant-away.md:341`, finds it. So the "THE RIG FILE MOVED UNDER THIS BRANCH AFTER THE LAST RUN" precedent has nothing to attach to here. No pinned hash, table or run datum is touched.

## The same question, asked of every other control in this file

Filed rather than fixed, per the brief — reported here so the merge reader can see the shape of what is left.

**The controls that are sound.** Discovery is checked against the pinned corpus in both directions *and* carries an explicit positive control on the exclusions, whose comment already names the "an empty result reads as a clean corpus rather than as a broken reader" trap. The common-support control carries an explicit bite check (`it does move phase 3's figure`). The table checks carry a positive control on row count. The gap and ladder-rung checks are derived over every window.

**One live cluster, all of it the same defect class, all of it made false by the same event** — `a9ec2c662d`'s fold-in from 242 cells / 3 windows / 3 sessions to 569 / 4 / 5. Filed as **rf2-oflj7**:

1. `WINDOW AND SESSION ARE THE SAME PARTITION HERE … each window is exactly one session` — the line **three above it** prints `4 windows, 5 sessions`, and the corpus table shows phase 4 carrying two session ids. No control.
2. Section C's heading, `PER WINDOW — which is also per session`. Same. No control.
3. Section F: `which all eight runs have` — there are sixteen, which the report prints itself. No control.
4. Section D: `its p90 rises from 3 to 9`, in a sentence framed first-window-to-last. The last window's mode-1 p90 is **4.5**; 9 is phase 3's. No control.
5. The verdict's `NOT DECIDABLE HERE. Three windows are three sessions` — and the self-test does not merely miss this, it **pins** it with a presence check, while the file's own header amendment says the question is now partly answered.
6. The verdict's `WHAT IS MISSING: two sessions on ONE design` — that measurement has been taken, as #8649 says in as many words.
7. **A claim with no control at all**: section G asserts unconditionally that `37.8` is *"below both"* of two **derived** numbers (currently 60 and 90). True today; nothing would notice if a future window took either below it.

Not fixed here because 5 and 6 change what the reader **concludes** about the bead's third question — a ruling, not a worker's call — and 1–4 need a per-session derivation the report does not currently have. `shape()` and the read-the-numbers-back block are the pattern to extend.

Also **rf2-j0szk**: the three studio doc pages rf2-2iaph's description recorded under "what else still carries the superseded pass-order reading" are `docs/design/hicasso/**`, outside this fence. Re-homed so closing rf2-2iaph does not orphan them a second time — the #8639 audit already orphaned them once by assigning them to `rf2-fk6pj`, which then closed. All three re-verified at source; one line number in the original text is off by one and is corrected on the new bead. `README.md:134` is confirmed **still live** after #8649 merged (that PR repaired the pass-order row at `:133`; this is the design-control row).

## Quality gates

All exit codes below are the runner's own, captured to a `.exit` file and read back from it; every artefact is named for the worktree and attempt. **Every gate was re-run after the rebase onto `origin/main` `7e2e46f451`**, and the figures below are the post-rebase run.

| gate | command | captured exit |
|---|---|---|
| null-floor self-test | `node hicasso/test/re_frame/bench/hicasso/alloc_null_floor.cjs --self-test` | **0** — *60 checks (was 55); 569 cells, 16 runs, 4 windows, 5 sessions; the gap holds 1* |
| null-floor census | `node hicasso/test/re_frame/bench/hicasso/alloc_null_floor.cjs` | **0** |
| null-floor tables | `node hicasso/test/re_frame/bench/hicasso/alloc_null_floor.cjs --tables` | **0** |
| tables, base vs tip | `diff` of the two `--tables` captures | **0** — *byte-identical, canaried at 24 lines* |
| **the registered gate**, whole chain | `npm run test:script-helpers` | **0** — *all 28 entries; 427 lines* |
| sabotage suite, 5 plants | control + 5 plants + control | **0** — *control green either side, all five plants exit 1, all restores blob-verified* |

**The sabotage driver was itself corrected before it was believed.** Its first two runs died on `FileNotFoundError` reading a log that was never written: `subprocess(shell=True)` on Windows is `cmd.exe`, where the bash redirect `> log 2>&1; echo $?` is not a command. Had it been written to swallow that, the plants would have reported nothing and read as done. It now invokes `node` directly and takes the process's own `returncode`.

**The surface classifier was run on PATHS and exercised in three directions**, because a classifier that reports every surface unaffected looks exactly like a clean all-clear:

| input | surfaces reported affected |
|---|---|
| `implementation/hicasso/.../alloc_null_floor.cjs` (this change) | **5** — `cljs_node_test`, `cljs_browser`, `migration_hicasso_codemod`, `hicasso_controlled`, `hicasso_hmr` |
| `implementation/deps.edn` (an input it should flag differently) | **6** |
| `origin/main...HEAD` — **the misuse**, a revision where it wants paths | **0** — the silent false all-clear, reproduced |

So the reading for this change is a reading. **What the local run does not cover**, derived from that first row rather than hand-listed: `cljs_node_test`, `cljs_browser`, `hicasso_controlled`, `hicasso_hmr` and `migration_hicasso_codemod` are CI's. The classifier is path-prefix conservative — anything under `implementation/hicasso/**` flags them — and none of them can reach a standalone `.cjs` reader that **nothing in the repository `require`s**; `git grep alloc_null_floor -- implementation/` returns only `package.json`, registering it as a gate entry, and that entry is the whole chain run green above. Local-green is not CI.

**Skipped, with reasons.** `mkdocs build --strict` is not a gate here and was not run: `mkdocs.yml` sets `docs_dir: docs`, so `implementation/**` was never a candidate for the site and will never appear in `exclude_docs` — the second door, not the excluded-trees one. Neither link gate was run: both are markdown-only, and this change touches one `.cjs` file — no `README.md`, no repo-root markdown, no markdown beside source, nothing under the docs gate's roots. `check_provenance_pins.py` validates changed pages under `docs/design/hicasso/`; this PR changes none. No CLJS, JVM, browser or bundle suite was run — this reader launches no browser, builds no bundle and is required by nothing.

Nothing validates this file's prose or its rendered report text, so both were read by hand and diffed line by line against the base.
