### PR TITLE
docs(studio): record the settled rf2-egdaq split on the #8531 measurement record (rf2-egdaq)

### DIFF
--- a/docs/design/hicasso/studio/does-arming-the-census-move-the-high-level.md
+++ b/docs/design/hicasso/studio/does-arming-the-census-move-the-high-level.md
@@ -228,13 +228,52 @@ runs TAKEN, and thirty-five were taken on each arm.
 
 **One disclosure that is not a criterion.** `lane/control-verdict` adjudicates on
 **overlap** — whether the measured range contains a value within slack of the prediction
-— not on the point estimate, and `rf2-egdaq` is the open ruling on whether it tightens.
+— not on the point estimate. `rf2-egdaq`, the ruling on whether it tightens, has since
+been SETTLED, and neither half of it reaches this row's criterion; see below.
 Six of the sixty-nine runs pass with a mean `perDouble` above 9 against the predicted 8
 (the loosest is 11.06); the other sixty-three sit at 8.08–8.11. Four of the six loose runs
 read high and two read low, against 33 of 63 high among the tight ones, and the loose runs
 fall in both arms. **`controlVerdict.ok` was the pre-declared criterion and it is the one
 applied**; the point estimates are published here so a reader adjudicating under a future
 stricter rule can re-score this window without re-running it.
+
+### The rule since settled: a split, and what it does not reach (rf2-egdaq)
+
+`rf2-egdaq` was open when this window was published and is **no longer open**. The answer
+is a **SPLIT** — one rule per instrument, not one rule for both arms — landed in PR #8574
+and completed by the operator's records ruling of 2026-08-21.
+
+- **The HEAP arm went STRICT.** `re-frame.bench.p0-heap`'s positive control is adjudicated
+  by `lane/control-verdict-strict`: EVERY ROUND inside the ±25% band. On a byte counter
+  overlap is not a weaker gate but an absent one — the failure this control exists to
+  catch is a collector that has stopped seeing transient garbage, and its shape is a round
+  reading ~0 B, which under overlap PASSES, because `min` 0 sits under the roof while
+  `max` ~4,700,000 sits over the floor and a good round vouches for a dead one.
+- **The CLOCK arm REFUSED strict, and that refusal STANDS.** `re-frame.bench.p0-app`'s
+  control is a clock RATIO, and the 2026-07-31 quantum ruling keeps **overlap** where the
+  legs sit within a few of Chrome's 100 µs `performance.now()` quanta and a low round is
+  the clock's resolution rather than a defect. Eighty controls re-adjudicated from the
+  committed record read **80 of 80** under overlap and **64 of 80** under strict, every
+  miss LOW and every one on the two rows whose legs are one to three quanta wide, while
+  the 20-plus-quantum rows pass strict 40 of 40 —
+  [the breakdown](p0-converged-witness-set.md#the-strict-reading-over-eighty-controls-rf2-egdaq).
+  Nothing here reopens it, and the split is the point.
+
+**The ten published heap-control figures are RE-ADJUDICATED under strict, and all ten
+pass.** That is the operator's 2026-08-21 call, taken so that the published evidence and
+the current rule agree with no two-rules asterisk. **No window was re-run**: a published
+`[min–max]` whose two ends both sit inside the band bounds every round inside it, so the
+committed records settle it as they stand. The widest excursion either way across that
+series is **4,690,838 B against a prediction of 4,700,000 B — 0.195% low, against a band
+of ±25%** and better than two orders of magnitude inside it. Nothing flips.
+
+**None of that moves a figure on this page, and the reason is stated rather than left to
+be inferred.** This is the `--only alloc` row, and its `controlVerdict.ok` is neither lane
+rule: it is that row's own test in `p0_run.cjs`, an absolute-error check on the **mean**
+`perDouble` and on the differential slope, at **±75%**. The split above adjudicates the
+heap and clock rows and does not reach this one, whose control is `rf2-rs8q6` territory.
+So the six loose runs disclosed just above stand on exactly the terms they were published
+under, and so do all sixty-nine admissible readings.
 
 ## What this window does not settle
 


### PR DESCRIPTION
Bead `rf2-egdaq`, half (b). **Executes the operator ruling of 2026-08-21 (OPTION A)** and nothing else: one doc page, +40/−1, no measurement re-run and no benchmark invoked.

## Which record, and how it was established

The ruling names "the #8531 measurement record". **`#8531` appears nowhere in the tracked tree** — `git grep -nF '#8531' -- . ':!.beads'` exits 1 with zero hits, and the control `git grep -nF '#8574'` returns 1 hit on `implementation/core/test/re_frame/bench/p0_run.cjs:4491`, so that zero is a reading rather than a broken pattern.

A bare `8531` search returns two studio hits, and **both are false positives**: `reads-per-boundary-heap-ladder.md:2135` matches inside the blob `9f3d42be7b3aa529e8fc6ef8531262ceb4d65f1a`, and `the-cold-read-mount-term.md:641` matches inside the decimal `0.8531`. Neither page mentions the PR.

The record was identified from PR #8531 itself. Its title is `bench(p0): arming the census does not move the high level — the confound is refuted (rf2-c4hhk)`; its body names **`docs/design/hicasso/studio/does-arming-the-census-move-the-high-level.md`** as "Record:"; and its file list contains exactly one new studio page (+316/−0) plus a one-line index row and seventy datasets. The page is still 316 lines, unchanged since it landed.

## The three amendments

**(1) It no longer calls `rf2-egdaq` open.** The one place it did was the admissibility disclosure, and only that clause changed:

> — not on the point estimate. `rf2-egdaq`, the ruling on whether it tightens, has since been SETTLED, and neither half of it reaches this row's criterion; see below.

**(2) It states the landed split adjudication**, in a new `###` section under Admissibility: the heap arm on `lane/control-verdict-strict` (every round inside the ±25% band, because on a byte counter overlap is an absent gate rather than a weaker one — a round reading ~0 B passes it), and the clock arm **refusing** strict under the 2026-07-31 quantum ruling, with the eighty-control breakdown (80/80 overlap, 64/80 strict, every miss LOW and on the one-to-three-quantum rows, 40/40 on the 20-plus-quantum rows) cross-linked to `p0-converged-witness-set.md`. "Nothing here reopens it, and the split is the point."

**(3) It records the re-adjudication.** "**The ten published heap-control figures are RE-ADJUDICATED under strict, and all ten pass.** … **No window was re-run**: a published `[min–max]` whose two ends both sit inside the band bounds every round inside it … The widest excursion either way across that series is **4,690,838 B against a prediction of 4,700,000 B — 0.195% low, against a band of ±25%** and better than two orders of magnitude inside it. Nothing flips."

## One thing the ruling did not anticipate, and why the section says it

This page's own control **is neither lane rule**, and without saying so the true statement in (3) would be read as covering this window's sixty-nine controls — six of which have a mean `perDouble` above 9 and one at 11.06, outside a ±25% band. Verified in the code and in the data, at the page's base revision `7fbfa8bc96` and on the trunk alike: `--only alloc` computes `row.controlVerdict` in `summariseAlloc` as `Math.abs(x - 8) / 8 <= row.controlSlack` on the **mean** `perDouble` and on the differential slope, with `ALLOC_CONTROL_SLACK` defaulting to **0.75**; and every `alloc-c4hhk` dataset carries `controlVerdict = {ok, perDouble, differential}` — no `rule`, no `band`, no `perRound`, i.e. not a `lane/control-verdict` answer at all. The new section says this plainly and leaves that control where the bead already put it, in `rf2-rs8q6` territory.

## Untouched, and the evidence

The three-dot diff is one hunk of one line plus one insertion, so everything else on the page is byte-identical by construction:

- **The arming result** — `## The answer, first`, "ARMING DOES NOT MOVE THE LEVEL", the nine unarmed runs at 21,632 / 22,072, `armed-13`, the byte-identical ramp — outside the diff.
- **The retained raw-data disclosure** — `armed-25` "committed rather than deleted … not replaced with a seventy-first run", and "Each retains every window's raw sample stream, so the estimator can be re-derived without a browser" — outside the diff.
- **The clock arm's refusal** — restated as standing, and no code or clock-arm record is touched. `git diff --name-only origin/main...HEAD` lists one path.

Also untouched by design: the studio index row for this page does not mention `rf2-egdaq`, so no `studio/README.md` edit was needed (that file is held elsewhere). The accepted `printHeapControl` coverage gap is neither restated nor pinned.

## Residue filed, not actioned

`rf2-wmya0` (P2) — three pages outside this fence still frame `rf2-egdaq` as open: `p0-converged-witness-set.md` (:775, :783, :1382, :2173), `p0-reagent-on-subs-baseline.md` (:220, :237, :378), `decisions.md` (:1615). Plus `p0_run.cjs`'s "NO PUBLISHED ROW IS RE-ADJUDICATED BY THIS", whose substance still holds but whose framing is now the opposite of the disposition. All verified at source.

## Quality gates

Exit codes are the ones **I captured** — each runner redirected to a log with its own `$?` echoed to a `.exit` file on one command line in one shell. No figure here comes from the harness. All four re-run on the final base after the rebase onto `origin/main` (which had moved only by a beads checkpoint).

| Gate | Command | Captured exit |
|---|---|---|
| Doc slugs | `python scripts/check_doc_slugs.py` | **0** |
| Provenance pins | `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | **0** — 1 page, 4 cited pins, 4 landed, 0 stranded, 0 unresolvable, 0 findings. No pinned blob rewritten; the rig-blob table is outside the diff |
| README links | `python scripts/check_readme_links.py --ci` | **0** (out of surface for this path; run anyway, cheap) |
| Table column re-count | ad-hoc counter, this page | **0** — 7 tables, 0 ragged |

**`mkdocs build --strict` is NOT nominated and does not apply.** Read at source: `mkdocs.yml`'s `exclude_docs` block carries `design/hicasso/`, so the build cannot see this page.

**Not run, with reason:** no CLJS/JVM suite — the diff is one markdown file under an mkdocs-excluded tree and touches no code, no test and no build input. The fast-PR spine was not run; its documentation tier is classifier-gated, so CI is cited for the link gates rather than a local spine pass.

### The gates proved to reach this file

Both plants sat on the one link line the diff adds, mid-line rather than at end-of-line, with the match count read as exactly **1** before each. My own edit was committed first, so the restore could not silently discard the work under test.

| Plant | Gate | Sabotage exit | Restored |
|---|---|---|---|
| Anchor `#no-such-anchor-planted-by-heapadj` | `check_doc_slugs.py` | **1** — `BROKEN ANCHOR: … does-arming-the-census-move-the-high-level.md:259` | blob `31de2975ff…` == committed blob |
| Target `p0-converged-witness-set-planted-by-heapadj.md` | `check_doc_slugs.py` | **1** — `BROKEN TARGET: … :259` | blob `31de2975ff…` == committed blob |

Both restores verified by `git hash-object` against the **committed blob object**, not by a byte digest of the working file; `grep -cF 'planted-by-heapadj'` reads **0** residue and the tree is clean.

### The table counter is a reading, not a silence

The counter honours `\|` escapes and pipes inside inline code. Exercised against a deliberately ragged fixture before being trusted: it exits **1** and names the short row (`widths=[(3,3),(4,3),(5,3),(6,2),(7,3)]`), while reading a `| \`a \| b\` | pipes \`x|y\` inside code |` row as **2** columns and not 3 or 4. On this page it exits **0**: seven tables at 2, 2, 4, 7, 5, 12 and 2 columns, none ragged — the same seven PR #8531 counted by hand. **This diff adds no table and alters no row.**

Nothing validates this page's prose or rendering, so the wording above was read line by line.
