### PR TITLE
test(bench): rank the pass term over the design's own assignments, not 48^8 (rf2-t4vu1)

### DIFF
--- a/docs/design/hicasso/studio/the-band-on-the-aggregate-and-the-second-session.md
+++ b/docs/design/hicasso/studio/the-band-on-the-aggregate-and-the-second-session.md
@@ -4,6 +4,45 @@
 sessions**, read against a band **declared before run 1** and computed on the
 same object as the figure it adjudicates.
 
+> **THE BAND'S REFERENCE IS RE-ADJUDICATED, AND OUTCOME 1 STANDS — 2026-08-21
+> (`rf2-t4vu1`).** The band below drew each of the eight runs' pass labels
+> **independently** from that run's own 48 admissible schedules, a support of
+> 48⁸. **That is not an assignment this design could have drawn.**
+> `alloc_pass_design.cjs`'s rule draws **two** free schedules and forces the
+> other two as their exact complements, and the pre-registration then repeats
+> the quadruple verbatim in session B — so the eight-run assignment ranges over
+> **48 × 46 = 2,208** configurations. Both restrictions are load-bearing: the
+> complement pairing is what cancels every per-index nuisance out of the pooled
+> contrast, and the cross-session repeat is what makes the session the only
+> thing separating the two halves. A reference that breaks either ranks the
+> observation against assignments the window could not have produced.
+>
+> **2,208 is small enough to enumerate, so the reference is now exact and
+> nothing is sampled.** Every figure below is left exactly as it was published
+> and nothing measured here is withdrawn; the corrections are marked in place at
+> three sites, and the corrected reading is:
+>
+> | | published below | re-adjudicated |
+> |---|---|---|
+> | mid-rung (signal) *p* | 0.00005 = 1/20001 | **0.002717 = 6 of 2,208** |
+> | mid-rung reference p97.5 | +0.176% | **+0.252%** |
+> | R = 0 null (control) *p* | 0.0934 | **0.121377 = 268 of 2,208** |
+> | smallest attainable *p* | 1/20001 | **2/2,208 = 0.000906** |
+> | phase 3 re-read under this band | 0.0013 | **0.006341 = 14 of 2,208** |
+>
+> **Not one measured term moves** — +0.31% mid-rung, 2.25 B/boundary null, all
+> eight per-run figures, both session terms — because only the reference
+> changed. **The outcome does not move either:** the signal clears α = 0.05 and
+> the null-arm control does not fire, so this window still reads OUTCOME 1 on
+> the pre-registration's own terms. What moves is how far the observation sits
+> out in the corpus's own spread, and the honest figure is less extreme than the
+> published one.
+>
+> **The floor is 2/2,208 and not 1/2,208,** which is a property of the design
+> rather than a convention: complementing both free schedules at once maps the
+> support onto itself and negates the statistic exactly, so the reference is
+> symmetric about zero and every two-sided count is even.
+
 This window owes three things and takes no rig change. `implementation/core/test/re_frame/bench/p0_run.cjs`
 is byte-identical to `origin/main` throughout — the bead's own words are *"WHAT
 THE NEXT WINDOW OWES. No rig change; `p0_run.cjs` needs nothing."*
@@ -148,10 +187,25 @@ construction rather than by assumption, and any parity structure or linear drift
 in the block values enters every re-labelling symmetrically.
 
 Each run's own reference is **exact** — all 48 re-labellings, so a per-run
-p-value is a rank among 48 and involves no sampling. Only the combination across
-runs is sampled, because the product is 48⁸: **20,000 draws from the committed
-seed `legorder-band-1`**, α = 0.05 two-sided, the observation counted, so the
-smallest attainable p is 1/20001.
+p-value is a rank among 48 and involves no sampling. ~~Only the combination
+across runs is sampled, because the product is 48⁸: **20,000 draws from the
+committed seed `legorder-band-1`**, α = 0.05 two-sided, the observation counted,
+so the smallest attainable p is 1/20001.~~
+
+> **CORRECTED 2026-08-21 (`rf2-t4vu1`).** The struck sentence is the defect the
+> banner names, and it is the reading rather than the arithmetic: the
+> combination across runs is not a free product, because the design does not
+> draw eight schedules. It draws **two** and forces the rest, so the assignment
+> ranges over **48 × 46 = 2,208** configurations — enumerable, so nothing is
+> sampled at all. α = 0.05 two-sided, and the smallest attainable *p* is
+> **2/2,208**. The declared 20,000 draws and the seed `legorder-band-1` are kept
+> in the pre-registration and reported unused rather than removed: a
+> pre-registration is not amended once its runs are taken, and the sampled
+> branch is what a design too large to enumerate would still need.
+>
+> **The per-run ranks above are unaffected and are now labelled MARGINAL** —
+> each is what one run's own schedule could have been holding its siblings
+> nowhere, which is a different statement from the joint rank the outcome reads.
 
 **What it does not control, named rather than assumed away:** residual functions
 of the round index that the two balanced columns do not span — `r mod 4` among
@@ -217,15 +271,33 @@ certainly not 96.
 
 | | term | two-sided *p* | reference p97.5 |
 |---|---|---|---|
-| **MID-RUNG (signal)** | **+0.31%** | **0.00005** = 1/20001 | +0.176% |
-| R = 0 NULL (control) | 2.25 B/boundary | 0.0934 | 3.03 B/boundary |
+| **MID-RUNG (signal)** | **+0.31%** | ~~**0.00005** = 1/20001~~ | ~~+0.176%~~ |
+| R = 0 NULL (control) | 2.25 B/boundary | ~~0.0934~~ | ~~3.03 B/boundary~~ |
 
-**Not one of the 20,000 re-labellings reached the observed term**, so *p* sits
+~~**Not one of the 20,000 re-labellings reached the observed term**, so *p* sits
 at the floor the pre-registration named — the smallest value the declared draw
 count can return. The observed term is 1.8× the reference's own 97.5th
-percentile. And the null arm, whose true term is zero by construction, **did not
-fire**: *p* = 0.0934, clear of α with room, so the band is not one that reports
-a term on anything handed to it.
+percentile.~~ And the null arm, whose true term is zero by construction, **did
+not fire**, clear of α with room, so the band is not one that reports a term on
+anything handed to it.
+
+> **RE-ADJUDICATED 2026-08-21 (`rf2-t4vu1`).** Both *p* columns and both
+> reference percentiles above were computed over 48⁸ independent per-run draws
+> rather than over the 2,208 assignments this design could have produced. **The
+> two terms do not move and neither does the outcome.** Over the design's own
+> support, enumerated exhaustively:
+>
+> | | term | two-sided *p* | reference p97.5 |
+> |---|---|---|---|
+> | **MID-RUNG (signal)** | **+0.31%** | **0.002717** = 6 of 2,208 | **+0.252%** |
+> | R = 0 NULL (control) | 2.25 B/boundary | **0.121377** = 268 of 2,208 | **3.15 B/boundary** |
+>
+> **Six of the 2,208 assignments read at least as extreme as the observation**,
+> so *p* is a rank and not a floor — the floor here is 2/2,208 and the
+> observation does not sit on it. The observed term is **1.25×** the reference's
+> own 97.5th percentile rather than 1.8×. The null arm still does not fire, at
+> *p* = 0.121377 against the published 0.0934. **OUTCOME 1 stands** on the
+> pre-registration's own terms: signal *p* ≤ 0.05, control *p* > 0.05.
 
 **All eight runs read positive**, and the parity term straddles zero:
 
@@ -269,7 +341,15 @@ else changed:
 | | term | two-sided *p* | verdict |
 |---|---|---|---|
 | phase 3 under **its own** band | +0.45% pooled | — | **REFUSED**, outcome 3 |
-| phase 3 under **this** band | +0.44% mean | **0.0013** | **clears α = 0.05** |
+| phase 3 under **this** band | +0.44% mean | ~~**0.0013**~~ **0.006341** | **clears α = 0.05** |
+
+> **RE-ADJUDICATED 2026-08-21 (`rf2-t4vu1`).** Phase 3 declared the same
+> [A, B, ~A, ~B] quadruple in one session, so its assignment support is the same
+> 2,208 and its re-read moves the same way: **14 of 2,208**, *p* = 0.006341
+> against the published 0.0013. Its term is unchanged at +0.44% mean and its
+> null-arm control is still clear, at *p* = 0.699275. **The conclusion of this
+> section is untouched** — phase 3's data cleared this band and its own band was
+> the thing that refused it.
 
 **Phase 3's own diagnosis of its band is confirmed.** It recorded that the band
 compared an aggregate against a per-observation noise scale and was therefore
@@ -447,6 +527,33 @@ until it is shown to bite, so it was: a one-character change to the reference
 percentile in the same eight-run reading moved the null arm's reference p95 from
 2.82 to 2.89 B/boundary, and the identical diff reported it.
 
+**AND IT MOVED A THIRD TIME, AND THAT MOVE DOES CHANGE FIGURES — 2026-08-21
+(`rf2-t4vu1`).** The two moves above were argued to be inert and shown to be;
+this one is not, and pretending otherwise would be the more comfortable half of
+the same habit. The band's reference support is repaired from 48⁸ independent
+per-run draws to the design's own 2,208 assignments, which carries
+`alloc_pass_position.cjs` from the blob `2f4f204780` to the blob
+`3a2e14b1a1c1ec44d7c4ce53bce659ef26dbfadf` and `alloc_pass_design.cjs` from the
+blob `eb44f78dc6` to the blob `678f580689d6915978721b7cfd101e456b36e01a`.
+
+**The measured pin at the head of this section is kept and the pre-registration
+is again not amended.** Every *term* on this page is still the one measured on
+the blob `787ffde48a` and reproduces unchanged on all three: the repair touches
+only what the observed term is ranked AGAINST. The three *p*-values and two
+reference percentiles it does move are re-adjudicated in place at the banner and
+at both section-D sites rather than overwritten, and the reasoning for each is
+beside it.
+
+**Two things were repaired that the corpus never reached, and they are named
+rather than folded in.** `alloc_pass_design.cjs` now pins that its own selection
+rule's output is a point of the band's support — the two files being two
+statements of one design is exactly what `rf2-t4vu1` found them not to be. And
+the band now REFUSES an arm carrying no block instead of returning *p* = 1 for
+it: the earlier reference compared every draw against `Math.abs(null)`, so a
+corpus with no R = 0 arm at all cleared the null-arm control vacuously and
+outcome 1 would have been read with no negative control under it. This corpus
+carries 327 null-arm cells and takes neither clause.
+
 ## Two defects found and deliberately NOT repaired
 
 An estimator must not change between a pre-registration and the runs it is read
@@ -466,9 +573,12 @@ on, so both are recorded here and owned by the bead rather than fixed in place.
   belongs in the boundary rather than in a paragraph.
 
 Both are now closed under `rf2-flxxa`, along with the session-partition defect
-the audit of PR #8634 found later. The reader that carries the repairs is the
-blob `2f4f204780`, named in the provenance note above; the figures on this page
-remain the ones measured on the blob `787ffde48a`, and reproduce on both.
+the audit of PR #8634 found later — the blob `2f4f204780` — and the band's
+assignment support under `rf2-t4vu1`, the blob
+`3a2e14b1a1c1ec44d7c4ce53bce659ef26dbfadf`, both named in the provenance note
+above. The **terms** on this page remain the ones measured on the blob
+`787ffde48a` and reproduce on all three; the *p*-values the last of those moves
+are re-adjudicated in place and marked where they are quoted.
 
 ## Reproduction
 

--- a/implementation/hicasso/test/re_frame/bench/hicasso/alloc_pass_design.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/alloc_pass_design.cjs
@@ -77,6 +77,10 @@ const {
   decompose,
   separation,
   admissibleRun: readerAdmissibleRun,
+  assignmentRoles,
+  assignmentSupport,
+  admissibleSchedules,
+  supportSize,
 } = require('./alloc_pass_position.cjs');
 
 // The window this file was written for. Both are re-derivable from the record
@@ -382,6 +386,29 @@ function designControl() {
       assert.strictEqual(got.dot, 0, `${p.seed}: ${f.name} — parity·pass over the blocks`);
     }
   }
+
+  // AND THE RULE'S OUTPUT IS A POINT OF THE BAND'S OWN SUPPORT, which is where
+  // `rf2-t4vu1` found the two disagreeing. This file draws TWO free schedules
+  // and forces the other two as their exact complements; the band in
+  // `alloc_pass_position.cjs` was re-drawing each run's schedule independently
+  // from the 48, a support of 48⁸ that admits quadruples this rule cannot
+  // produce. The rule is what MAKES the support what it is, so the two
+  // statements of one design are pinned against each other here rather than
+  // only over there.
+  const { roles, generatorKeys } = assignmentRoles(picks.map((p) => ({ flips: p.flips })));
+  assert.strictEqual(generatorKeys.length, 2, 'the rule draws exactly TWO free schedules');
+  assert.deepStrictEqual(
+    roles.map((r) => `${r.generator}${r.complement ? '~' : ''}`),
+    ['0', '1', '0~', '1~'],
+    'and the other two are their exact complements, in that order'
+  );
+  const admissibleSet = admissibleSchedules(ROUNDS);
+  assert.strictEqual(admissibleSet.length, 48, 'the reader and this file agree on the admissible set');
+  const support = assignmentSupport(generatorKeys.length, admissibleSet);
+  assert.strictEqual(support.length, supportSize(2, 48), 'the support is 48 × 46');
+  assert.strictEqual(support.length, 2208, 'which is 2,208 ordered assignments');
+  const keyed = new Set(support.map((t) => t.map((i) => admissibleSet[i].map((f) => (f ? '1' : '0')).join('')).join('|')));
+  assert.ok(keyed.has(generatorKeys.join('|')), 'and the rule\'s own draw is one of them');
 
   // THE NEGATIVE CONTROL. Phase 2's run-2 schedule over six rounds:
   // `page, page, all, page, all, all`, symmetric difference 4 from parity —

--- a/implementation/hicasso/test/re_frame/bench/hicasso/alloc_pass_position.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/alloc_pass_position.cjs
@@ -129,9 +129,16 @@
 // admissible only if it is balanced, `q·parity = 0` and `q·linear = 0` — the
 // criteria `alloc_pass_design.cjs` selected the real schedules under. At
 // twelve rounds there are 48 such schedules and the set is CLOSED UNDER
-// COMPLEMENT, so every reference distribution here is exactly symmetric about
-// zero by construction rather than by assumption, and any parity structure or
-// linear drift in the block values enters every re-labelling symmetrically.
+// COMPLEMENT, so any parity structure or linear drift in the block values
+// enters every re-labelling symmetrically.
+//
+// AND THE RESTRICTION IS ON THE WHOLE ASSIGNMENT, NOT ON EACH RUN SEPARATELY,
+// which is the repair `rf2-t4vu1` filed. Phase 4 drew TWO schedules and the
+// design forced the other two as their complements, then repeated the quadruple
+// verbatim in the second session — so the eight-run assignment ranges over
+// 48 × 46 = 2,208 configurations and not over 48⁸. See `assignmentRoles` for
+// why each restriction is load-bearing and `termReference` for what follows
+// from the support being closed under global complement.
 //
 // WHAT IT DOES NOT CONTROL, named rather than assumed away: residual functions
 // of the round index that the two balanced columns do not span — `r mod 4`
@@ -651,6 +658,127 @@ function relabel(bs, flips) {
 
 const passTerm = (bs) => decompose(bs, (b) => b.first === 'page').half;
 
+// The index of each schedule's complement inside the same enumeration. The
+// admissible set is closed under complement and no balanced schedule is its own
+// complement, so this is a fixed-point-free involution on `0..n−1`.
+function complementIndex(schedules) {
+  const at = new Map(schedules.map((f, i) => [flipKey(f), i]));
+  return schedules.map((f) => at.get(flipKey(f.map((x) => !x))));
+}
+
+// --- THE DESIGN'S OWN ASSIGNMENT SUPPORT -------------------------------------
+//
+// A RUN'S SCHEDULE IS NOT DRAWN INDEPENDENTLY OF ITS SIBLINGS, and an earlier
+// revision of this reference behaved as though it were: it drew each of the
+// eight runs from that run's own 48 admissible schedules, a support of 48⁸.
+// Phase 4 never drew eight schedules. `alloc_pass_design.cjs`'s rule draws
+// TWO — the first admissible seed, then the first subsequent one drawing
+// neither that schedule nor its complement — and the design then FORCES the
+// other two as their exact complements, after which the pre-registration
+// REPEATS the quadruple verbatim in session B. The whole eight-run labelling is
+// a function of two free schedules, and 48⁸ admits assignments this design
+// could not have produced: quadruples that are not complementary pairs, and
+// second sessions that do not repeat the first.
+//
+// Both restrictions are load-bearing rather than incidental. THE COMPLEMENT
+// PAIRING is what cancels every per-index nuisance out of the pooled pass
+// contrast — the whole reason the design carries it — so a reference that
+// breaks it ranks the observation against assignments in which a nuisance is
+// free that in the observation was cancelled. THE CROSS-SESSION REPEAT is what
+// makes the session the only thing differing between the two halves, which is
+// the contrast this window took a second session to obtain.
+//
+// `assignmentRoles` READS THAT STRUCTURE OFF THE DECLARATION rather than
+// assuming it: for each declared run, which free schedule it takes and whether
+// it takes that schedule complemented. A declaration of eight unrelated
+// schedules yields eight generators, and the old independent support falls out
+// as that special case rather than being the general one.
+function assignmentRoles(declaredRuns) {
+  const generatorKeys = [];
+  const roles = declaredRuns.map((d) => {
+    const key = flipKey(d.flips);
+    const anti = flipKey(d.flips.map((x) => !x));
+    const own = generatorKeys.indexOf(key);
+    if (own >= 0) return { generator: own, complement: false };
+    const inverted = generatorKeys.indexOf(anti);
+    if (inverted >= 0) return { generator: inverted, complement: true };
+    generatorKeys.push(key);
+    return { generator: generatorKeys.length - 1, complement: false };
+  });
+  return { roles, generatorKeys };
+}
+
+// The design a reference is taken over, read off the committed declaration.
+const bandDesign = (declared) => ({
+  ...assignmentRoles(declared.runs),
+  rounds: declared.window.rounds,
+});
+
+// `S · (S−2) · … · (S−2(k−1))` — see `assignmentSupport`.
+function supportSize(generators, n) {
+  let size = 1;
+  for (let j = 0; j < generators; j++) size *= n - 2 * j;
+  return size;
+}
+
+// Every ordered tuple of admissible schedules the design could have drawn its
+// free schedules as: distinct, and no two complementary. Each choice removes
+// the schedule taken AND its complement, because a design that drew one
+// schedule twice — or a schedule beside its own complement — is not the design
+// that was declared, and its quadruple would not be four distinct runs.
+//
+// ORDERED, because the runs are not interchangeable: run 1 and run 2 carry
+// different blocks, so handing them the two free schedules the other way round
+// is a different assignment. At phase 4's `k = 2` over `S = 48` that is
+// 48 × 46 = 2,208 — small enough to enumerate, so the reference is EXACT.
+function assignmentSupport(generators, schedules) {
+  const comp = complementIndex(schedules);
+  const out = [];
+  const walk = (tuple) => {
+    if (tuple.length === generators) {
+      out.push(tuple.slice());
+      return;
+    }
+    const taken = new Set();
+    for (const t of tuple) {
+      taken.add(t);
+      taken.add(comp[t]);
+    }
+    for (let i = 0; i < schedules.length; i++) {
+      if (taken.has(i)) continue;
+      tuple.push(i);
+      walk(tuple);
+      tuple.pop();
+    }
+  };
+  walk([]);
+  return out;
+}
+
+// One assignment drawn uniformly from that same support, for a design whose
+// support is too large to enumerate. Each generator is drawn from the schedules
+// not already taken and not the complement of one — the support's own
+// definition — so the draw is uniform over it.
+function drawAssignment(next, generators, schedules, comp) {
+  const tuple = [];
+  const taken = new Set();
+  while (tuple.length < generators) {
+    const pool = [];
+    for (let i = 0; i < schedules.length; i++) if (!taken.has(i)) pool.push(i);
+    const i = pool[Math.floor(next() * pool.length)];
+    tuple.push(i);
+    taken.add(i);
+    taken.add(comp[i]);
+  }
+  return tuple;
+}
+
+// Where the support fits under this it is enumerated and the reference is
+// exact; above it, the declared `draws` and `seed` sample from the SAME
+// support. Phase 4's 2,208 is two orders below. A design drawing four free
+// schedules would be 48 × 46 × 44 × 42 = 4,080,384 and would not be.
+const EXACT_SUPPORT_LIMIT = 250000;
+
 // The term this window reads: the MEAN of the per-run pass terms. Each run is a
 // complete balanced design on its own, so a run-level offset — and phase 2
 // measured one of 20% on a floor — cancels exactly out of every per-run
@@ -681,44 +809,101 @@ function rng(seed) {
 
 // THE REFERENCE DISTRIBUTION, and the two-sided rank of the observation in it.
 //
-// Each run's own reference set is EXACT — all 48 admissible re-labellings, so
-// the per-run p-value is a rank among 48 and involves no sampling at all. Only
-// the COMBINATION across runs is sampled, because the product is 48^8 and that
-// is not enumerable. The sample is a fixed count from a committed seed.
+// The statistic is re-read over every assignment THE DESIGN COULD HAVE DRAWN,
+// which is NOT every combination of per-run schedules — see `assignmentRoles`
+// for what that distinction cost. At phase 4's two free schedules over 48
+// admissible ones the support holds 48 × 46 = 2,208 assignments, so the
+// reference is EXACT: `p` is a rank among all of them, nothing is sampled, and
+// the declared `draws` and `seed` do the sampling they were declared for only
+// where the support is too large to enumerate.
 //
-// The p-value counts the observation itself, which is the standard
-// conservative convention: with `draws` re-labellings the smallest attainable
-// two-sided p is `1/(draws+1)`.
-function termReference(runs, { draws, seed }) {
-  const sets = runs.map((r) => {
-    const flips = admissibleSchedules(r.rounds);
-    return { blocks: r.blocks, flips, terms: flips.map((f) => passTerm(relabel(r.blocks, f))) };
-  });
-  const observed = meanRunTerm(runs);
-  const next = rng(seed);
-  const sample = [];
-  for (let d = 0; d < draws; d++) {
+// IT IS EXACTLY SYMMETRIC ABOUT ZERO, by construction rather than by
+// assumption. The support is closed under complementing every free schedule at
+// once, that map complements every run's labelling, and a complemented
+// labelling negates that run's term exactly — so each assignment's statistic is
+// paired with its own negation. Two consequences a page reading this has to
+// carry: a two-sided count is always EVEN, and the smallest attainable p is
+// `2/|support|` rather than `1/|support|`.
+//
+// The sampled branch keeps the conservative convention it always had — the
+// observation is counted, so the smallest attainable p there is `1/(draws+1)`.
+//
+// AND A REFERENCE THAT DOES NOT CONTAIN THE OBSERVATION IS NOT A REFERENCE FOR
+// IT. An executed assignment whose free schedules are not themselves admissible
+// is refused rather than ranked, and so is one the record does not reproduce.
+function termReference(runs, { draws, seed, design }) {
+  const schedules = admissibleSchedules(design.rounds);
+  const comp = complementIndex(schedules);
+  const at = new Map(schedules.map((f, i) => [flipKey(f), i]));
+  const observedTuple = design.generatorKeys.map((k) => at.get(k));
+  if (observedTuple.some((i) => i === undefined)) {
+    return { refused: 'the executed assignment draws a schedule the design does not admit' };
+  }
+
+  // Each run's term under EVERY admissible re-labelling, computed once and read
+  // by index from here on: the support is enumerated over schedule INDICES, so
+  // no assignment re-derives a median.
+  const terms = runs.map((r) => schedules.map((f) => passTerm(relabel(r.blocks, f))));
+  const statistic = (tuple) => {
     let s = 0;
     let n = 0;
-    for (const set of sets) {
-      const t = set.terms[Math.floor(next() * set.terms.length)];
+    for (let i = 0; i < design.roles.length; i++) {
+      const g = tuple[design.roles[i].generator];
+      const t = terms[i][design.roles[i].complement ? comp[g] : g];
       if (t !== null) { s += t; n++; }
     }
-    sample.push(n ? s / n : 0);
+    return n ? s / n : 0;
+  };
+
+  const observed = meanRunTerm(runs);
+  // AN ARM THAT CARRIES NO BLOCK HAS NO TERM, AND THAT IS A REFUSAL RATHER THAN
+  // A PASS. The earlier revision let `observed` be `null`, compared every draw
+  // against `Math.abs(null) = 0`, and returned p = 1 — so a corpus carrying no
+  // R = 0 arm at all cleared the null-arm control vacuously and outcome 1 was
+  // read with no negative control under it. Same class as the `--admit` that
+  // exited 0 on an empty corpus.
+  if (observed === null) {
+    return { refused: 'the arm carries no block at all, so there is no term to rank' };
   }
+  // AND THE OBSERVATION MUST BE A POINT OF ITS OWN REFERENCE. Re-labelling the
+  // blocks under the schedules the declaration says were drawn has to reproduce
+  // the measured term exactly; where it does not, the record and the
+  // declaration disagree about what ran and no rank off either is meaningful.
+  if (statistic(observedTuple) !== observed) {
+    return { refused: 'the declared assignment does not reproduce the measured term' };
+  }
+
+  const generators = design.generatorKeys.length;
+  const support = supportSize(generators, schedules.length);
+  const exact = support > 0 && support <= EXACT_SUPPORT_LIMIT;
+  let sample;
+  if (exact) {
+    sample = assignmentSupport(generators, schedules).map(statistic);
+  } else {
+    const next = rng(seed);
+    sample = [];
+    for (let d = 0; d < draws; d++) sample.push(statistic(drawAssignment(next, generators, schedules, comp)));
+  }
+
   const atLeast = sample.filter((t) => Math.abs(t) >= Math.abs(observed)).length;
   const sorted = sample.map(Math.abs).sort((a, b) => a - b);
   return {
     observed,
-    draws,
-    seed,
-    // Per run, the exact rank among that run's own 48 re-labellings.
-    perRun: sets.map((set, i) => {
-      const t = passTerm(runs[i].blocks);
-      const ge = set.terms.filter((x) => Math.abs(x) >= Math.abs(t)).length;
-      return { label: runs[i].label, term: t, of: set.terms.length, p: ge / set.terms.length };
+    exact,
+    support,
+    generators,
+    draws: exact ? sample.length : draws,
+    seed: exact ? null : seed,
+    // Per run, the exact rank among that run's own 48 re-labellings. A MARGINAL
+    // statement and now labelled as one: it is what a single run's schedule
+    // could have been holding its siblings nowhere, and the joint support above
+    // is what the window is adjudicated on.
+    perRun: runs.map((r, i) => {
+      const t = passTerm(r.blocks);
+      const ge = terms[i].filter((x) => Math.abs(x) >= Math.abs(t)).length;
+      return { label: r.label, term: t, of: terms[i].length, p: ge / terms[i].length };
     }),
-    p: (atLeast + 1) / (draws + 1),
+    p: exact ? atLeast / sample.length : (atLeast + 1) / (draws + 1),
     p95: sorted[Math.floor(sorted.length * 0.95)],
     p975: sorted[Math.floor(sorted.length * 0.975)],
   };
@@ -868,26 +1053,50 @@ function report(rows, declared = null) {
 
   if (declared && declared.band) {
     const { draws, seed, alpha } = declared.band;
+    const design = bandDesign(declared);
     const runsOf = (rungs, stat) =>
       rows.map(({ label, row }) => ({ label, rounds: row.rounds, blocks: blocks(row, label, rungs, stat) }));
-    const signal = termReference(runsOf(MID_RUNGS, 'ratio'), { draws, seed });
-    const control = termReference(runsOf(NULL_RUNGS, 'delta'), { draws, seed });
+    const signal = termReference(runsOf(MID_RUNGS, 'ratio'), { draws, seed, design });
+    const control = termReference(runsOf(NULL_RUNGS, 'delta'), { draws, seed, design });
+
+    if (signal.refused || control.refused) {
+      out.push(';;');
+      out.push(';; THE BAND IS REFUSED AND NO p IS PRINTED. A rank is only a rank against a');
+      out.push(';; reference the observation is a member of.');
+      for (const r of [signal.refused, control.refused]) if (r) out.push(`;;   ${r}`);
+      return { lines: out, refused: true };
+    }
 
     out.push(';;');
-    out.push(';; THE BAND — a restricted randomisation of the PASS LABELS over the schedules');
-    out.push(`;; the design would equally have admitted (${admissibleSchedules(declared.window.rounds).length} at ${declared.window.rounds} rounds, closed under`);
-    out.push(`;; complement). Block VALUES are untouched. ${draws} draws from the committed seed`);
-    out.push(`;; ${JSON.stringify(seed)}; alpha ${alpha}. Nothing here is a byte threshold.`);
+    out.push(';; THE BAND — a restricted randomisation of the PASS LABELS over the assignments');
+    out.push(';; THE DESIGN ITSELF could have drawn, which is not every combination of per-run');
+    out.push(`;; schedules. ${signal.generators} free schedule(s) out of the ${admissibleSchedules(design.rounds).length} admissible at ${design.rounds} rounds (closed`);
+    out.push(`;; under complement); the rest of the ${design.roles.length} runs are FORCED by the declaration's`);
+    out.push(`;; complement pairing and its session repeat. ${signal.support} assignments in all, and the`);
+    out.push(';; block VALUES are untouched.');
+    if (signal.exact) {
+      out.push(`;;   EXACT — every one of the ${signal.support} is enumerated, so nothing is sampled and the`);
+      out.push(`;;   declared ${draws} draws from ${JSON.stringify(seed)} are not used. The support is closed under`);
+      out.push(';;   global complement, so the reference is exactly symmetric about zero, every');
+      out.push(`;;   two-sided count is even, and the smallest attainable p is 2/${signal.support}.`);
+    } else {
+      out.push(`;;   SAMPLED — the support is too large to enumerate, so ${draws} draws from the committed`);
+      out.push(`;;   seed ${JSON.stringify(seed)}. The observation is counted, so the smallest attainable p is`);
+      out.push(`;;   1/${draws + 1}.`);
+    }
+    out.push(`;;   alpha ${alpha}. Nothing here is a byte threshold.`);
     out.push(';;   arm | term | two-sided p | reference p95 | reference p97.5');
     for (const [name, ref, unit] of [['MID-RUNG (signal)', signal, '%'], ['R=0 NULL (control)', control, 'B/boundary']]) {
       const shown = unit === '%' ? pct(ref.observed) : `${ref.observed === null ? 'n/a' : ref.observed.toFixed(2)} B/bnd`;
       const p95 = unit === '%' ? pct(ref.p95) : `${ref.p95.toFixed(2)} B/bnd`;
       const p975 = unit === '%' ? pct(ref.p975) : `${ref.p975.toFixed(2)} B/bnd`;
-      out.push(`;;   ${name} | ${shown} | ${ref.p.toFixed(4)} | ${p95} | ${p975}`);
+      out.push(`;;   ${name} | ${shown} | ${ref.p.toFixed(6)} | ${p95} | ${p975}`);
     }
     out.push(';;');
-    out.push(';;   PER RUN, exact — the rank of the run\'s own term among all its re-labellings.');
-    out.push(';;     run | mid-rung term | exact p (of 48) | null term | exact p');
+    out.push(';;   PER RUN, MARGINAL — the rank of the run\'s own term among all its own');
+    out.push(';;   re-labellings, holding its siblings nowhere. The verdict above is the JOINT');
+    out.push(';;   rank over the design\'s assignments, and it is the one the outcome reads.');
+    out.push(`;;     run | mid-rung term | marginal p (of ${signal.perRun[0] ? signal.perRun[0].of : 0}) | null term | marginal p`);
     signal.perRun.forEach((s, i) => {
       const c = control.perRun[i];
       out.push(
@@ -901,14 +1110,14 @@ function report(rows, declared = null) {
     out.push(';;');
     if (!ctlOk) {
       out.push(`;;   OUTCOME 3 — NO VERDICT. The R = 0 null arm, whose true term is ZERO by`);
-      out.push(`;;   construction, itself returns p = ${control.p.toFixed(4)} <= ${alpha} through the identical`);
+      out.push(`;;   construction, itself returns p = ${control.p.toFixed(6)} <= ${alpha} through the identical`);
       out.push(';;   pipeline. A band that fires on a known-zero population cannot adjudicate the');
       out.push(';;   mid rungs, and the pre-registration makes that a refusal rather than a footnote.');
     } else if (sigOk) {
       out.push(`;;   OUTCOME 1 — THE PASS TERM IS ESTABLISHED as a within-window term at alpha ${alpha}:`);
-      out.push(`;;   p = ${signal.p.toFixed(4)}, with the null-arm control clear at p = ${control.p.toFixed(4)}.`);
+      out.push(`;;   p = ${signal.p.toFixed(6)}, with the null-arm control clear at p = ${control.p.toFixed(6)}.`);
     } else {
-      out.push(`;;   OUTCOME 2 — THE PASS TERM IS NOT ESTABLISHED. p = ${signal.p.toFixed(4)} > ${alpha}; the term`);
+      out.push(`;;   OUTCOME 2 — THE PASS TERM IS NOT ESTABLISHED. p = ${signal.p.toFixed(6)} > ${alpha}; the term`);
       out.push(';;   sits inside the spread the same design returns on re-labelled data.');
     }
 
@@ -1135,6 +1344,15 @@ function selfTest() {
         for (const rung of MID_RUNGS) {
           a[`${segment}|${arm}#${rung}@all`] = { certified: true, legMedian: 5000 };
           a[`${segment}|${arm}#${rung}@page`] = { certified: true, legMedian: 5000 + pageDelta };
+        }
+        // AND AN R = 0 ARM, reading the floor exactly under both legs so its
+        // true term is zero the way the real null arm's is. It is here because
+        // the band now REFUSES an arm carrying no block rather than returning
+        // p = 1 for it: a fixture with no null arm would exercise the refusal
+        // instead of the two-session verdict it is built for.
+        for (const rung of NULL_RUNGS) {
+          a[`${segment}|${arm}#${rung}@all`] = { certified: true, legMedian: 1000 };
+          a[`${segment}|${arm}#${rung}@page`] = { certified: true, legMedian: 1000 };
         }
         a[`${segment}|${FLOOR_ARM}@all`] = { certified: true, legMedian: 1000 };
         a[`${segment}|${FLOOR_ARM}@page`] = { certified: true, legMedian: 1000 };
@@ -1476,6 +1694,43 @@ function selfTest() {
   // effect makes every block value ±`effect` and the median of six of them is
   // degenerate, which is a property of the FIXTURE and not of any real corpus.
   const declaredRuns = JSON.parse(fs.readFileSync(declPath, 'utf8')).runs;
+
+  // --- THE JOINT ASSIGNMENT SUPPORT, WHICH IS THE DESIGN'S AND NOT EACH RUN'S -
+  //
+  // `rf2-t4vu1`'s repair, pinned on the SUPPORT rather than only on each run's
+  // 48 marginal schedules — which is exactly what the earlier pins reached and
+  // is why an eight-fold independent draw sat under them unnoticed.
+  const design = bandDesign(JSON.parse(fs.readFileSync(declPath, 'utf8')));
+  assert.strictEqual(design.generatorKeys.length, 2, 'phase 4 draws exactly TWO free schedules');
+  assert.deepStrictEqual(
+    design.roles.map((r) => `${r.generator}${r.complement ? '~' : ''}`),
+    ['0', '1', '0~', '1~', '0', '1', '0~', '1~'],
+    'and the declared eight runs are [A, B, ~A, ~B] repeated verbatim in session B'
+  );
+
+  // THE SIZE IS ARITHMETIC AND IS DERIVABLE WITHOUT RUNNING ANYTHING: 48 ways to
+  // draw A; B must be admissible, not A and not ~A, and the set is closed under
+  // complement with no schedule its own complement, so exactly two are removed
+  // and 46 remain. 48 × 46 = 2,208, ORDERED because run 1 and run 2 carry
+  // different blocks.
+  const support = assignmentSupport(2, sched12);
+  assert.strictEqual(supportSize(2, 48), 2208, 'the closed form is 48 × 46');
+  assert.strictEqual(support.length, 2208, 'and the enumeration returns exactly that many');
+  assert.strictEqual(new Set(support.map((t) => t.join(','))).size, 2208, 'with no repeats');
+
+  // AND IT REFUSES IN BOTH DIRECTIONS, which is what makes the count evidence
+  // rather than a number that happened to come out right. Dropping the
+  // exclusion would give 48 × 48 = 2,304 — 96 more — so the two degenerate
+  // shapes are named and each is checked for absence.
+  {
+    const compIdx = complementIndex(sched12);
+    const inSupport = new Set(support.map((t) => t.join(',')));
+    assert.ok(inSupport.has(`0,${1 === compIdx[0] ? 2 : 1}`), 'a distinct non-complementary pair IS in the support');
+    assert.ok(!inSupport.has('0,0'), 'a design that drew one schedule twice is not this design');
+    assert.ok(!inSupport.has(`0,${compIdx[0]}`), 'nor is one that drew a schedule beside its own complement');
+    assert.strictEqual(2304 - support.length, 96, 'and the exclusion removes exactly the 96 such pairs');
+  }
+
   const synth = (flips, label, { pass = 0, parity = 0 }) =>
     flips.map((f, r) => ({
       run: label, round: r, first: f ? 'all' : 'page', n: 1,
@@ -1484,7 +1739,9 @@ function selfTest() {
     }));
   const corpus = (model) =>
     declaredRuns.map((d, i) => ({ label: String(i + 1), rounds: 12, blocks: synth(d.flips, String(i + 1), model) }));
-  const band = (model) => termReference(corpus(model), { draws: 20000, seed: 'self-test' });
+  const band = (model) => termReference(corpus(model), { draws: 20000, seed: 'self-test', design });
+  assert.strictEqual(band({}).exact, true, 'the reference over this design is enumerated, not sampled');
+  assert.strictEqual(band({}).support, 2208, 'over all 2,208 assignments');
 
   // A PURE PASS EFFECT AT THE SIZE THIS WINDOW IS LOOKING FOR — 0.6%, the
   // median of the four terms published across phases 2 and 3 — must clear the
@@ -1526,18 +1783,90 @@ function selfTest() {
     assert.ok(r.p >= 1 / 48 - 1e-12, `and cannot beat 1/48, got ${r.p}`);
   }
 
-  // THE REFERENCE IS A FUNCTION OF THE SEED AND NOTHING ELSE.
-  const twice = () => JSON.stringify(termReference(corpus({ pass: 0.004 }), { draws: 500, seed: 'k' }));
-  assert.strictEqual(twice(), twice(), 'the same seed returns the same reference');
-  assert.notStrictEqual(
-    JSON.stringify(termReference(corpus({ pass: 0.004 }), { draws: 500, seed: 'k' }).p95),
-    JSON.stringify(termReference(corpus({ pass: 0.004 }), { draws: 500, seed: 'other' }).p95),
-    'and a different seed returns a different one, so the seed is doing work'
+  // THE REFERENCE IS EXACT, SO THE DECLARED SEED IS INERT — and that is the
+  // property to pin now, where before it was the opposite one. An exhaustive
+  // enumeration of 2,208 assignments is a function of the corpus and the design
+  // alone; a reader that still varied with the seed would be sampling
+  // something. The declaration's `draws` and `seed` are kept and reported
+  // unused rather than deleted: they are what the sampled branch needs, and a
+  // pre-registration is not amended after its runs.
+  const ref = (s, d) => termReference(corpus({ pass: 0.004 }), { draws: d, seed: s, design });
+  assert.strictEqual(JSON.stringify(ref('k', 500)), JSON.stringify(ref('k', 500)), 'the reference is deterministic');
+  assert.strictEqual(
+    JSON.stringify(ref('k', 500)),
+    JSON.stringify(ref('other', 7)),
+    'and neither the seed nor the draw count moves it, because nothing is sampled'
   );
+
+  // --- THE JOINT SUPPORT IS WHAT IS BEING RANKED, AND HERE IS THE PROOF -------
+  //
+  // EIGHT COPIES OF ONE RUN READ EXACTLY ZERO AT EVERY ONE OF THE 2,208
+  // ASSIGNMENTS, and that is arithmetic rather than a measurement. Complementing
+  // a labelling negates that run's term, and the design hands each free schedule
+  // to two runs as itself and to two more complemented; with identical runs the
+  // four terms cancel in pairs and the mean is exactly 0 whatever A and B are.
+  //
+  // IT IS THE CONTROL THAT DISCRIMINATES THE TWO SUPPORTS. Under eight
+  // independent per-run draws the same corpus has a real spread — the pairing is
+  // what collapses it — so a reference that had gone back to drawing each run
+  // separately would fail here and nowhere else in this block.
+  {
+    const compIdx = complementIndex(sched12);
+    const one = corpus({ pass: 0.006 })[0].blocks;
+    const t = sched12.map((f) => passTerm(relabel(one, f)));
+    let worst = 0;
+    for (const tuple of support) {
+      let s = 0;
+      for (const role of design.roles) {
+        const g = tuple[role.generator];
+        s += t[role.complement ? compIdx[g] : g];
+      }
+      worst = Math.max(worst, Math.abs(s / design.roles.length));
+    }
+    assert.ok(worst < 1e-15,
+      `eight identical runs read exactly 0 at every one of the ${support.length} assignments, got ${worst}`);
+    // AND THE DEGENERACY IS THE PAIRING'S, NOT FLAT DATA'S. The same run's own
+    // 48 marginal terms have a real spread — an assignment handing every run
+    // one schedule, which is what an eight-fold independent draw permits and
+    // this design does not, reads that schedule's own term.
+    assert.ok(Math.max(...t.map(Math.abs)) > 1e-6,
+      'the run itself carries a real term, so the cancellation is the design and not the data');
+  }
+
+  // THE SUPPORT IS CLOSED UNDER GLOBAL COMPLEMENT, so the reference is exactly
+  // symmetric about zero and a two-sided count is always EVEN. That is why the
+  // smallest attainable p is 2/2208 and not 1/2208 — a floor a page quoting this
+  // band has to quote correctly, and one no amount of sampling would have shown.
+  {
+    const compIdx = complementIndex(sched12);
+    for (const [a, b] of support.slice(0, 64)) {
+      assert.ok(
+        support.some(([x, y]) => x === compIdx[a] && y === compIdx[b]),
+        'every assignment (A, B) is in the support beside (~A, ~B)'
+      );
+    }
+    const counted = (r) => Math.round(r.p * r.support);
+    for (const r of [band({ pass: 0.006 }), band({}), band({ parity: 1 }), band({ pass: 0.006, parity: 1 })]) {
+      assert.strictEqual(counted(r) % 2, 0, `a two-sided count over a symmetric support is even, got ${counted(r)}`);
+    }
+  }
+
+  // AND A REFERENCE THE OBSERVATION IS NOT A MEMBER OF IS REFUSED, NOT RANKED.
+  {
+    const bogus = { ...design, generatorKeys: [flipKey(Array.from({ length: 12 }, () => false)), design.generatorKeys[1]] };
+    const got = termReference(corpus({ pass: 0.006 }), { draws: 500, seed: 'k', design: bogus });
+    assert.ok(/does not admit/.test(got.refused || ''), `an inadmissible free schedule is refused, got: ${JSON.stringify(got.refused)}`);
+    const crossed = { ...design, generatorKeys: [design.generatorKeys[1], design.generatorKeys[0]] };
+    const swap = termReference(corpus({ pass: 0.006 }), { draws: 500, seed: 'k', design: crossed });
+    assert.ok(/does not reproduce/.test(swap.refused || ''),
+      `an assignment the record does not reproduce is refused, got: ${JSON.stringify(swap.refused)}`);
+  }
 
   console.log(`[alloc-pass-position] self-test OK — 12 published blocks, both decompositions, `
     + `the parity tie, the null arm's 38 cells, the floor-free estimator's 3 of 6, `
-    + `${sched12.length} admissible schedules, the band's three synthetic controls, the `
+    + `${sched12.length} admissible schedules, the design's own ${support.length}-assignment support in both `
+    + `directions, the identical-run degeneracy that only the paired support produces, `
+    + `the band's four synthetic controls, the `
     + `fail-closed boundary in both directions, the realised labelling on both a fixture and `
     + `phase 4's own run 1, the declared session partition collapsed and mispartitioned, and `
     + `both branches of the session verdict all reproduce`);
@@ -1593,6 +1922,12 @@ module.exports = {
   relabel,
   passTerm,
   meanRunTerm,
+  complementIndex,
+  assignmentRoles,
+  assignmentSupport,
+  supportSize,
+  bandDesign,
+  EXACT_SUPPORT_LIMIT,
   rng,
   termReference,
   median,


### PR DESCRIPTION
Closes rf2-t4vu1.

## What was wrong

Phase 4's aggregate band drew each of the eight runs' pass labels **independently**
from that run's own 48 admissible schedules — a support of 48⁸. The design never
drew eight schedules. `alloc_pass_design.cjs`'s rule draws **two** free schedules
and forces the other two as their exact complements, and the pre-registration
then repeats the quadruple verbatim in session B. So the eight-run assignment
ranges over **48 × 46 = 2,208** configurations, not 48⁸.

Both restrictions are load-bearing rather than incidental. The complement pairing
is what cancels every per-index nuisance out of the pooled pass contrast — the
whole reason the design carries it — so a reference that breaks it ranks the
observation against assignments in which a nuisance is free that in the
observation was cancelled. The cross-session repeat is what makes the session the
only thing separating the two halves, which is the contrast the window took a
second session to obtain.

## The repair

`assignmentRoles` reads the structure off the **declaration** rather than
assuming it: for each declared run, which free schedule it takes and whether it
takes it complemented. A declaration of eight unrelated schedules yields eight
generators, so the old independent support falls out as that special case rather
than being the general one.

2,208 is enumerable, so the reference is now **exact** and nothing is sampled.
The declared `draws` and `seed` are kept in the pre-registration and reported
unused — a pre-registration is not amended after its runs, and the sampled branch
is what a design too large to enumerate would still need.

Two fail-closed clauses come with it, both named on the page:

- **An arm carrying no block is REFUSED** rather than compared against
  `Math.abs(null)` and returning p = 1. A corpus with no R = 0 arm at all cleared
  the null-arm control vacuously and outcome 1 would have been read with no
  negative control under it — the same class as the `--admit` that exited 0 on an
  empty corpus.
- **An executed assignment the record does not reproduce**, or whose free
  schedules are not admissible, is refused rather than ranked.

## The re-adjudication

Published figures are left standing and the corrections are marked in place at
three sites under dated banners, per the studio convention. **No measured term
moves** — only what the term is ranked against does.

| | published | re-adjudicated |
|---|---|---|
| mid-rung (signal) *p* | 0.00005 = 1/20001 | **0.002717 = 6 of 2,208** |
| mid-rung reference p97.5 | +0.176% | **+0.252%** |
| R = 0 null (control) *p* | 0.0934 | **0.121377 = 268 of 2,208** |
| smallest attainable *p* | 1/20001 | **2/2,208 = 0.000906** |
| phase 3 re-read under this band | 0.0013 | **0.006341 = 14 of 2,208** |

**OUTCOME 1 is unchanged**: signal *p* ≤ 0.05, null-arm control *p* > 0.05. The
observed term is 1.25× the reference's own p97.5 rather than 1.8×. The floor is
2/2,208 and not 1/2,208 because complementing both free schedules at once maps
the support onto itself and negates the statistic exactly, so the reference is
symmetric about zero and every two-sided count is even.

The provenance pins are **not** rewritten. The measured pin stays at the blob
`787ffde48a`; the new instrument blobs are named beside it, and the note says
plainly that this move — unlike the two before it — does change figures.

## What the test now pins, that it did not

The self-test reached each run's 48 **marginal** schedules and nothing else,
which is why an eight-fold independent draw sat under it unnoticed. It now pins
the **joint support** in both directions:

- the 48 × 46 count against its closed form, and the 96 pairs the exclusion
  removes, with both degenerate shapes checked for absence by name;
- the declared role pattern `[A, B, ~A, ~B]` repeated verbatim in session B;
- the global-complement closure that makes every two-sided count even;
- **eight identical runs reading exactly 0 at all 2,208 assignments** — a
  degeneracy only the paired support produces, and the control that discriminates
  the two supports;
- both refusal clauses;
- that the reference is invariant under seed and draw count, because nothing is
  sampled (this replaces the old pin that the seed *does* move it).

`alloc_pass_design.cjs`'s control now pins that its own selection rule's draw is a
point of that support — the two files being two statements of one design is
exactly what this bead found them not to be.

## Gates, with captured exit codes

Each number below is the runner's own `$?`, captured with the redirect and the
echo on one command line.

| gate | captured exit |
|---|---|
| `node hicasso/test/re_frame/bench/hicasso/alloc_pass_position.cjs --self-test` | 0 |
| `node hicasso/test/re_frame/bench/hicasso/alloc_pass_design.cjs --controls` | 0 |
| `node hicasso/test/re_frame/bench/hicasso/alloc_pass_design.cjs --admit` (session A quadruple) | 0 |
| `node hicasso/test/re_frame/bench/hicasso/alloc_pass_design.cjs --admit` (session B quadruple) | 0 |
| full eight-run `--declared` reading | 0 |
| `node hicasso/test/re_frame/bench/hicasso/alloc_null_floor.cjs --self-test` (shares the module) | 0 |
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | 0 — 1 page, 1 cited pin, 1 landed, 0 stranded |
| ESLint over both changed `.cjs` files | 0 |

**Each gate was shown to bite before its green was believed**, by a planted fault
restored and verified by blob hash rather than by reading a diff:

- `check_doc_slugs.py` — a planted broken anchor returned **exit 1** naming this
  page; restored, blob back to `2949fe0b5b`.
- `check_provenance_pins.py` — a planted stranded pin returned **exit 1** naming
  this page at the planted line; restored, blob back to `2949fe0b5b`.
- ESLint — a planted unused binding returned **exit 1** naming
  `alloc_pass_design.cjs`; restored, blob back to `678f580689`.
- The node runners print their own file paths in a failing stack, and two
  intermediate failures did so.

**And the census the re-adjudication rests on was cross-checked two ways.** It
was derived once in a throwaway script against the shipped `blocks`/`passTerm`
and once by the repaired reader; the two agree to the last digit on all four
figures. Its enumerator was exercised against counts derivable by hand before any
of its figures were believed: 48 × 46 = 2,208 strict against 48 × 48 = 2,304 with
the exclusion dropped (a difference of exactly 96), the executed configuration
reproducing the reader's own `meanRunTerm` to delta 0, exact antisymmetry across
the support, and the identical-run degeneracy.

`mkdocs build --strict` is **not** this page's gate — `mkdocs.yml`'s
`exclude_docs` carries `design/hicasso/`, read at source.

## Verified by hand, because nothing gates it

Nothing validates prose, tables or rendering. **Every table on the page was
checked for column-count consistency** — 13 tables, all rows in each matching
their header and separator, including the three added ones. **All four markdown
link targets are unchanged** and resolve (`check_doc_slugs.py` covers them).
No new headings and no new anchor links were added.
