### PR TITLE
docs(hicasso): record rf2-egdaq as settled-as-a-split on the three residue pages (rf2-wmya0)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1612,7 +1612,9 @@ why the separation is claimed between runs and not within one. The per-round
 ranges are weaker evidence than that and are printed rather than leaned on —
 run 2's includes 1.0.
 
-**The positive control, and the rule it passed under (`rf2-egdaq`).** `:ctl-2x`
+**The positive control, and the rule it passed under (`rf2-egdaq` — SETTLED
+2026-08-21 as a split: strict on the heap arm, overlap kept on clock legs sitting
+inside Chrome's 100 µs clamp).** `:ctl-2x`
 predicts 2.00x by construction and passed in all three runs: measured 8.250 ms
 against a predicted 8.100, 8.350 against 8.500, and 8.500 against 8.600 — every
 one within 2% of its own prediction. That verdict was `lane/control-verdict`'s

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -772,15 +772,15 @@ has never been.
 | **Verification** | **0 unverified of 7,860** — 600 M1 mounts + 600 M2 mounts + 630 broad writes + 6,030 narrow writes |
 | **Positive controls** | **this sweep's** four rows × two segments = eight, **eight passes** under the overlap rule; see below for the strict reading. Not the page's live count — the [positive-control table](#the-positive-controls) carries the ensemble's **eighty** |
 
-**The M2 control that rf2-egdaq holds open reads differently on this sweep,
-and the ruling is still the operator's.** The published M2 control range
+**The M2 control that rf2-egdaq turned on reads differently on this sweep,
+and the ruling has since been taken.** The published M2 control range
 `[1.333 – 2.000]` sits against a ±25% band whose floor is `1.4559`: it passes
 the overlap rule `lane/control-verdict` implements and fails a strict
 every-round-inside reading. **This sweep's M2 controls are `[1.500 – 2.000]`
 (Reagent segment) and `[1.600 – 2.000]` (UIx segment) — both wholly inside the
 band, so both pass under *either* reading.** That is reported, not used: a
 re-run producing a friendlier control is not an argument for a rule, and
-rf2-egdaq is not settled here. **Eighty controls have since been measured on the
+rf2-egdaq was not settled here. **Eighty controls have since been measured on the
 balanced ensemble and they say something this one sweep could not** — the strict
 reading fails 7 of 20 M2 controls, with a worst round 19.9% below the band floor;
 [the breakdown](#the-strict-reading-over-eighty-controls-rf2-egdaq) is under the
@@ -788,6 +788,25 @@ positive controls. The broad row's controls on this sweep, `[1.600
 – 2.500]` and `[1.667 – 2.500]`, miss the strict reading by `0.0014` — the
 lattice point above a `2.4986` ceiling on a floor of two to three quanta, the
 same quantisation artefact the denominator page records.
+
+> **THE RULING HAS SINCE BEEN TAKEN, AND IT IS A SPLIT — 2026-08-21 (`rf2-egdaq`,
+> recorded here under `rf2-wmya0`).** Nothing above is withdrawn and no figure on
+> this page moves; what changed is the standing of the question, not any reading.
+> `rf2-egdaq` resolved to **one rule per instrument** rather than one rule for both
+> arms. The **heap** arm went STRICT — `lane/control-verdict-strict`, every round
+> inside the ±25% band — because on a byte counter overlap is not a weaker gate but
+> an absent one: a round reading ~0 B passes it beside five good ones, which is the
+> exact failure the control exists to catch. The **clock** arm, which is what every
+> control on this page is, **REFUSED strict and keeps overlap**, under the
+> 2026-07-31 quantum ruling, where a low round on a leg one to three of Chrome's
+> 100 µs quanta wide is the clock's resolution rather than a defect. **That refusal
+> stands.** The operator's separate 2026-08-21 call re-adjudicates the ten published
+> **heap** control figures under strict — all ten pass, widest excursion
+> **4,690,838 B against 4,700,000 B predicted, 0.195% low** — with no window re-run,
+> and it reaches no clock row. So the paragraph above is still right that this one
+> sweep settles nothing, and
+> [the eighty-control breakdown](#the-strict-reading-over-eighty-controls-rf2-egdaq)
+> below is a large part of what the clock arm's refusal was decided ON.
 
 ### The denominator reproduces rf2-2rtt6.2
 
@@ -1379,10 +1398,30 @@ universal, which is the more useful statement anyway.
 ### The strict reading, over eighty controls (rf2-egdaq)
 
 `lane/control-verdict` adjudicates a control by **overlap** with the ±25% band;
-**rf2-egdaq** holds open the question of whether to require **every round**
+**rf2-egdaq** held open the question of whether to require **every round**
 inside it. The ensemble is the first sample large enough to say what that choice
 would cost, so it is stated here as an observation. **The ruling is the
 operator's and nothing below decides it.**
+
+> **THE RULING WAS TAKEN, AND THIS SECTION IS PART OF WHAT IT WAS DECIDED ON —
+> 2026-08-21 (`rf2-egdaq`, recorded here under `rf2-wmya0`).** Everything below is
+> left exactly as measured and nothing here is withdrawn. The paragraph above is
+> left standing rather than repaired because it records that this section PRECEDED
+> the ruling; its present tense — "holds on", "the held ruling" — should be read as
+> past throughout the section. **The answer is a SPLIT, one rule per instrument,
+> not one rule for both arms.** The **heap** arm went STRICT under
+> `lane/control-verdict-strict`, because a byte counter makes overlap an absent gate
+> rather than a weak one: a round reading ~0 B passes beside five good ones, and a
+> good round vouching for a dead one is the failure that control exists to catch.
+> The **clock** arm — which is every control on this page — **REFUSED strict and
+> keeps overlap**, under the 2026-07-31 quantum ruling, and **that refusal stands**.
+> The eighty controls below are a large part of the evidence it turned on: 80 of 80
+> under overlap and 64 of 80 under strict, every miss LOW and every one on the two
+> rows whose legs are one to three of Chrome's 100 µs quanta, while the
+> 20-plus-quantum rows pass strict 40 of 40. The operator's separate 2026-08-21 call
+> covers the **heap** arm's published rows only — ten figures re-adjudicated under
+> strict, all ten passing, widest excursion 4,690,838 B against 4,700,000 B
+> predicted, 0.195% low, no window re-run — and it re-adjudicates nothing here.
 
 | row | band | strict passes | worst single round |
 |---|---|---|---|
@@ -2170,7 +2209,7 @@ from the repository rather than merely stated by it.
 | **Canonical-DOM parity** | `{:problems [] :ok? true}` on all 40 — in both segments and across the seam |
 | **Verification** | **0 unverified of 92,160** — per run 720 M1 mounts + 504 M2 mounts + 756 broad writes + 7,236 narrow writes = 9,216, times ten |
 | **Segment-order control** | **no refusal on any row of any run**; `magnitude-resolved? true` on **37 of 40**, and `:balanced-design? true` on all 40 |
-| **Positive controls** | **80, and 80 passes** under `lane/control-verdict`'s overlap rule; 64 of 80 under the strict every-round-inside reading — [the breakdown](#the-strict-reading-over-eighty-controls-rf2-egdaq) |
+| **Positive controls** | **80, and 80 passes** under `lane/control-verdict`'s overlap rule; 64 of 80 under the strict every-round-inside reading, which `rf2-egdaq`'s split adjudication **REFUSED for this clock arm** under the 2026-07-31 quantum ruling — [the breakdown](#the-strict-reading-over-eighty-controls-rf2-egdaq) |
 
 The instrument, by content hash. These are the blobs every one of the ten runs
 was measured at:

--- a/docs/design/hicasso/studio/p0-reagent-on-subs-baseline.md
+++ b/docs/design/hicasso/studio/p0-reagent-on-subs-baseline.md
@@ -217,8 +217,10 @@ under an instrument that cannot narrow the question without saying so.
 ### The controls, under both readings of the rule
 
 `lane/control-verdict` implements the **overlap** rule; HD-008 states a
-**strict** every-round-inside rule; **rf2-egdaq** is the open operator question
-of which governs. Both readings are reported here rather than adjudicated:
+**strict** every-round-inside rule; **rf2-egdaq** was the open operator question
+of which governs, and it has **since been settled as a split** — see the
+correction at the end of this section. Both readings are reported here rather
+than adjudicated:
 
 | run | row | predicted | measured range | ±25% band | overlap rule | strict rule |
 |---|---|---|---|---|---|---|
@@ -234,10 +236,28 @@ would fail a strict reading fail it by **0.0014**, and they fail it for a reason
 that is arithmetic rather than instrumental: the bulk floor's p50 is two to
 three of Chrome's 100 µs quanta, so the control's ratio can only land on a
 coarse lattice, and `2.5` is the lattice point immediately above a ceiling of
-`2.4986`. That is the shape of evidence rf2-egdaq needs and it points against
+`2.4986`. That is the shape of evidence rf2-egdaq needed and it points against
 tightening: **a strict rule would retroactively fail a control this page already
 published as passing**, on a quantisation artefact rather than on a loss of
 signal. Nothing here installs it.
+
+> **SETTLED SINCE, AND AS A SPLIT — 2026-08-21 (`rf2-egdaq`, recorded here under
+> `rf2-wmya0`).** No figure or verdict above moves and the six controls stand
+> exactly as published; the correction is to the STANDING of the question, which
+> the section above reports as open. `rf2-egdaq` resolved to **one rule per
+> instrument** rather than one rule for both arms. The **heap** arm went STRICT —
+> `lane/control-verdict-strict`, every round inside the band — because on a byte
+> counter overlap is not a weaker gate but an absent one: a round reading ~0 B
+> passes it beside five good ones. The **clock** arm, which is what every control
+> on this page is, **REFUSED strict and keeps overlap**, under the 2026-07-31
+> quantum ruling, and **that refusal stands**. So the reading above is the one that
+> prevailed: the two `0.0014` misses are the lattice of a floor two to three of
+> Chrome's 100 µs quanta wide, not a loss of signal, and a rule that failed them
+> would be failing the instrument's resolution. The operator's separate 2026-08-21
+> call re-adjudicates the ten published **heap** control figures under strict — all
+> ten pass, widest excursion 4,690,838 B against 4,700,000 B predicted, 0.195% low
+> against a ±25% band, no window re-run — and it reaches no clock row, so nothing
+> on this page is re-adjudicated.
 
 ## The control that could not fail, and the teardown that said nothing
 
@@ -375,7 +395,9 @@ It is the same signature the converged page records on its own M2 row, it agrees
 with the published verdict (*indistinguishable*), and it is exactly why **this
 row is graded diagnostic and must not be quoted against the bar.**
 
-Controls under both readings of rf2-egdaq's open question: M1 `1.963×
+Controls under both readings of rf2-egdaq's question — [since settled as a
+split](#the-controls-under-both-readings-of-the-rule), with overlap kept on this
+clock arm: M1 `1.963×
 [1.857 – 2.357]` and M2 `1.733× [1.500 – 2.000]` pass under **either** rule;
 bulk `2.000× [1.500 – 2.500]` passes the overlap rule and misses the strict one
 by **0.0014** — the same lattice artefact recorded above, on a floor of two to


### PR DESCRIPTION
`rf2-egdaq`'s half (b) was ruled on 2026-08-21 and PR #8655 amended the one
measurement record the ruling named. Three pages outside that fence still framed
the bead as an OPEN operator question. **None of them is wrong about a
measurement.** All three were stale about the STATUS, and no figure, verdict or
measured claim is touched here — the diff adds two dated blockquote blocks and
changes six status clauses.

## The split is carried, not flattened

A sentence saying "`rf2-egdaq` is settled" without the split would be a new error
replacing an old one, so every added block states both arms:

- **The HEAP arm went STRICT** — `lane/control-verdict-strict`, every round
  inside the ±25% band — because on a byte counter overlap is not a weaker gate
  but an absent one: a round reading ~0 B passes it beside five good ones.
- **The CLOCK arm REFUSED strict and keeps overlap**, under the 2026-07-31
  quantum ruling, and **that refusal STANDS**.

**Every control on both studio pages is a clock control**, so the arm that
governs them is the one where overlap was kept — which is why
`p0-converged-witness-set.md`'s eighty-control breakdown is re-framed from *"this
is undecided"* to *"this is a large part of what the refusal was decided ON"*
rather than being called settled-for-strict. The operator's separate 2026-08-21
call re-adjudicates the ten published **heap** figures under strict — all ten
pass, widest excursion 4,690,838 B against 4,700,000 B predicted, 0.195% low, no
window re-run — and it reaches no clock row on either page.

## Two registers, decided per site

An **index row** asserts current standing and is repaired in place; a
**measurement record** asserts what was concluded on a date and is amended with a
dated block, because rewriting it destroys the evidence that it preceded its
runs. The discriminator applied here is at clause granularity: *does the sentence
report what the page measured or what the page itself declined to do* (leave
standing, amend beside it) *or is its only content the current standing of the
governance question* (repair in place, as #8655 did with its one clause).

| site | kind | treatment |
|---|---|---|
| `p0-converged-witness-set.md` — the sweep's M2 paragraph | measurement record, with two status clauses | clauses to past tense; dated block after the paragraph |
| `p0-converged-witness-set.md` — *The strict reading, over eighty controls* | measurement record | "The ruling is the operator's and nothing below decides it" **left standing**; dated block after it |
| `p0-converged-witness-set.md` — provenance summary row | measurement record | figures untouched; one status clause appended naming the refusal |
| `p0-reagent-on-subs-baseline.md` — *The controls, under both readings of the rule* | measurement record, with one status clause | clause repaired; "Nothing here installs it" **left standing**; dated block closing the section |
| `p0-reagent-on-subs-baseline.md` — re-certification controls line | status clause | repaired in place, linked to the block above |
| `decisions.md` §HD-023 | decisions ledger — asserts current standing by its own header | bare `(rf2-egdaq)` pointer repaired in place |

The heading `### The strict reading, over eighty controls (rf2-egdaq)` is
**deliberately unchanged**: it is the anchor target of the link PR #8655 landed
in `does-arming-the-census-move-the-high-level.md`.

## Gates

Exit codes captured by redirect-and-echo in one shell, all re-run on the final
base after rebasing onto `origin/main`.

| gate | captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** — 3 pages, 42 pins, 0 findings; no pin stranded, none added |
| `python scripts/check_readme_links.py --ci` | **0** |
| table column re-count, 3 files | **0** — 83 tables, 0 ragged |

**`mkdocs build --strict` is not the gate and was not nominated**: `mkdocs.yml`'s
`exclude_docs` carries `design/hicasso/`, read at source.

**Planted-fault controls, both directions, both restores verified by
`git hash-object` against the committed blob.** A broken anchor planted on an
added link line reds `check_doc_slugs.py` at exit 1, naming the planted target at
that exact line; a stranded pin planted in an added blockquote reds
`check_provenance_pins.py` at exit 1, naming it UNRESOLVABLE. The table counter
was exercised against a ragged fixture and exits 1 on it. The `rf2-egdaq` sweep
was controlled in both directions — 15 hits across the corpus, and a nonsense
pattern exits 1 at zero.

**Verified by hand, since nothing gates prose:** both anchors exist and are
unique in their target files; the one edited table row is in a two-column table
and stays two columns; no added text carries a hex token, a SHA or a figure.

## Out of fence

`implementation/core/test/re_frame/bench/p0_run.cjs` still says *"NO PUBLISHED
ROW IS RE-ADJUDICATED BY THIS"* and is stale in the same way. It is deliberately
not touched — `rf2-63t1i` (#8657) is writing across that tree — and is already
recorded on `rf2-wmya0`, which should stay OPEN for it.
