### PR TITLE
bench(p0): the ten published heap-control figures ARE re-adjudicated under strict (rf2-wmya0)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -133,16 +133,27 @@
 // the roof, `max` 4,700,000 over the floor, so the range meets the band.
 // Under strict that round is NAMED and the run is refused.
 //
-// NO PUBLISHED ROW IS RE-ADJUDICATED BY THIS, because none needs to be. The
-// published ranges are what settle it without re-running anything: a range
-// whose `min` and `max` both sit inside the band bounds EVERY round inside
-// it, and across this row's published series the widest excursion either way
-// is 4,690,838 B — 0.195% below a prediction gated at ±25%, better than two
-// orders of magnitude inside. So the strict verdict of every heap row ever
-// published is `ok`, and the tightening buys teeth for the next run rather
-// than a revision of the last one. That is what makes this row's half of
-// rf2-egdaq settleable by a worker at all; the CLOCK row's half was not,
-// which is why it went to the operator and was ruled on 2026-07-31.
+// THE TEN PUBLISHED HEAP-CONTROL FIGURES ARE RE-ADJUDICATED UNDER STRICT,
+// AND ALL TEN PASS. That is the operator's 2026-08-21 call, taken so that
+// the published evidence and the current rule agree with no two-rules
+// asterisk, and it is a SEPARATE call from the strict adoption above, which
+// landed earlier in PR #8574. NO WINDOW WAS RE-RUN, and none needed to be:
+// a published `[min–max]` whose two ends both sit inside the band bounds
+// EVERY round inside it, so the committed records settle it as they stand.
+// The widest excursion either way across this row's published series is
+// 4,690,838 B against a prediction of 4,700,000 B — 0.195% low, against a
+// band of ±25% and better than two orders of magnitude inside it. Nothing
+// flips: the strict verdict of every heap row ever published is `ok`, so the
+// re-adjudication buys agreement rather than a revision, and the tightening
+// still buys teeth for the next run.
+//
+// THAT CALL REACHES THE HEAP ROW ONLY. rf2-egdaq settled as a SPLIT — one
+// rule per instrument, not one rule for both arms — and the CLOCK row's half
+// REFUSED strict under the 2026-07-31 quantum ruling. THAT REFUSAL STANDS,
+// and nothing here reopens it. The heap half was settleable from committed
+// records, which is why a worker could take it; the clock half turned on what
+// strict would cost at the instrument's own resolution, which is why it went
+// to the operator.
 //
 // Read the two docstrings before quoting `:ok?` — each answer carries the
 // `:rule` that decided it precisely so a record cannot be read under the


### PR DESCRIPTION
Closes the remainder of **rf2-wmya0**. The docs half merged as PR #8660; the mayor fence deliberately deferred this one file because a live peer (rf2-63t1i, PR #8657) was writing across `implementation/core/` at the time. #8657 has since merged, so this is the last of the bead.

## What was stale

`implementation/core/test/re_frame/bench/p0_run.cjs`'s header block asserted, at `:136`:

> `// NO PUBLISHED ROW IS RE-ADJUDICATED BY THIS, because none needs to be.`

That is now the **opposite of the disposition**. Mike ruled `rf2-egdaq`'s half (b) on 2026-08-21 (Option A): the ten published P0 heap-control figures **ARE** re-adjudicated under the strict rule, and the record states it. PR #8655 amended the #8531 measurement record and PR #8660 the three residue doc pages.

The block's SUBSTANCE was never wrong — every published heap row is `ok` under strict either way. What was wrong was the STATUS it asserted, and the trailing framing that the tightening "buys teeth for the next run rather than a revision of the last one", which reads as a refusal of exactly the re-adjudication the operator ordered.

## The split is carried, not flattened

The ruling is a SPLIT, and a sentence saying "`rf2-egdaq` is settled" without it would be a new error replacing an old one. The replacement block states both arms, and keeps two facts the flattened reading merges:

- **HEAP arm** — the ten published heap-control figures are re-adjudicated under strict and all ten pass, widest excursion **4,690,838 B against a prediction of 4,700,000 B — 0.195% low** against a band of ±25%, with **no window re-run**. The strict *adoption* itself landed earlier, in **PR #8574**; the 2026-08-21 call is specifically the re-adjudication of the published figures, and the block says so in terms.
- **CLOCK arm** — strict was **REFUSED**, and **that refusal STANDS** under the 2026-07-31 quantum ruling. Nothing here reopens it.

Wording follows the register already landed on `does-arming-the-census-move-the-high-level.md` (#8655) and `p0-converged-witness-set.md` (#8660) rather than inventing a third phrasing.

## Scope

**Comment-only, in the header prose above `'use strict'`.** No figure, threshold, assertion, adjudication or behaviour is touched. `git diff -U0 | grep -vE '^[+-]//'` returns no changed line outside a `//` comment. +21/-10, one file.

## Sweep

The bead named one line; the whole file was swept, every pattern controlled against a site known to carry the claim before any empty result was believed. `grep` from the Git-Bash toolchain **aborted with SIGABRT (exit 134)** on this 5,259-line file — a crashed instrument that prints nothing and would have read as "no matches"; ripgrep was used instead.

| pattern | hits | positive control |
|---|---|---|
| `egdaq` (case-insensitive) | 6 — `:105`, `:144`, `:1014`, `:1023`, `:1068`, `:4478` | bit at `:144`, a line known to carry the claim |
| `adjudicat` (case-insensitive) | 33, incl. `:136` | bit at `:136`, the bead's named line |
| `settleable\|open question\|operator\|not settled\|holds open\|undecided\|awaits\|pending ruling\|unruled` | 11 | bit at `:144` `settleable` / `:145` `operator` |
| `4690838\|4,690,838\|0\.195\|8574\|2026-07-31\|quantum` | 7 | bit at `:140` (`4,690,838`, `0.195`) |
| `published (row\|record\|series\|range\|figure\|heap)\|re-run\|revision of\|buys teeth\|none needs` | 27 | bit at `:136`, `:142` |
| `strict` (case-insensitive) | 13 | bit at `:141` |

**Every stale site is inside `:136`–`:145`, and it is one contiguous block.** The other five `rf2-egdaq` references (`:105`, `:1014`, `:1023`, `:1068`, `:4478`) describe MECHANISM — which rule each row is entitled to, why the per-round array crosses instead of a summary, why the printer reads `verdict.rule` rather than asserting one — not STATUS, and none frames the bead as open. They are correct as they stand and are untouched.

## Gates

Exit codes captured by redirect-and-echo on one command line, in one shell; no gate piped through a filter.

| gate | exit |
|---|---|
| `npx eslint implementation/core/test/re_frame/bench/p0_run.cjs` | **0** |
| `node core/test/re_frame/bench/p0_ladder_structural.test.cjs` (the direct `require`r) | **0** — 100 passed |
| `npm run test:script-helpers` (from `implementation/`) | **0** |
| `scripts/test-fast-pr.sh` | see below |

`p0_run.cjs` has **no `--self-test` argument** — its only argument handling is `--only <clock\|heap\|fanout\|ladder\|alloc>` at `:192`, and every one of those launches Chromium and takes a real measurement window. Not nominated, and not run: no window was taken for this change.

Doc gates do not apply — no markdown is touched, and `check_doc_slugs.py`'s roots (`docs`, `spec`, `skills`, `migration`, `tools/*/spec`) do not include `implementation/**`.

## Planted-fault control

A `//` line comment is discarded by the reader, so the plant is to strip the `// ` prefix and make the prose live code. Stripping it from `:136` — a line inside the edited region — reddened **both** gates at **exit 1**, each naming the planted line and the worktree path:

- `p0_ladder_structural.test.cjs` → `SyntaxError: Unexpected identifier 'TEN'` at `p0_run.cjs:136`
- `eslint` → `136:5  error  Parsing error: Unexpected token TEN`

That is the discrimination: the fault existed only in this tree. Restored and verified by **`git hash-object` against the committed blob** — `74a5872cefe326c3d933c02000697205bdf6ed72`, working copy and index identical — not by reading a diff.
