### PR TITLE
test(classifier): re-point and INVERT the complaint-register pin after the move (rf2-xomo)

### DIFF
--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -4755,23 +4755,39 @@ test('the cljs job runs BOTH hicasso gates the classifier arm schedules (rf2-8a6
 
 // ---------------------------------------------------------------------------
 // rf2-hic-021's complaint-catalogue contract, and the reverse edges that made a
-// classifier-gated home wrong for it (audit of PR #7808; repair under rf2-ibje).
+// classifier-gated home wrong for it (audit of PR #7808; repair under rf2-ibje;
+// re-measured after the register moved, rf2-xomo).
 //
 // `implementation/hicasso/scripts/check_complaint_catalogue.py` reads FOUR file
-// families. Exactly ONE of them — implementation/hicasso/** — arms
-// cljs_node_test, which is the output guarding the only job that hosted the
-// checker. The three rows below are the MEASUREMENT, pinned rather than
-// asserted: each is a file the checker reads and a tier that does not fire for
-// it, so each is a PR shape that could have broken the contract in silence.
+// families. TWO of them arm cljs_node_test, the output guarding the only job
+// that ever hosted the checker: the emit roots (hicasso/src + hicasso/test_kit/
+// src), and — since rf2-ps7ia moved the REGISTER out of docs/design/hicasso/
+// product/ and in beside the artefact — implementation/hicasso/spec/
+// complaints.md itself. Both ride the one `implementation/hicasso/*` arm, which
+// does not discriminate `.md`.
+//
+// So the hole is TWO families wide now, not three, and this test previously
+// asserted about an address the move had emptied — an assertion that went on
+// PASSING, because the classifier is a lexical path function that does not care
+// whether a path exists (rf2-xomo). The rows below are still the MEASUREMENT,
+// pinned rather than asserted: each is a file the checker reads and a tier that
+// does not fire for it, so each is a PR shape that could have broken the
+// contract in silence. The register's row is kept and INVERTED rather than
+// deleted, because a test that only ever asserts `false` passes just as well
+// against a classifier that has stopped arming anything at all.
 //
 // These rows must NOT be "fixed" by widening cljs_node_test. Arming a ~10-minute
 // CLJS compile for a Markdown edit is the trade TESTING.md's placement table
-// exists to refuse. The repair is the unconditional job asserted underneath.
+// exists to refuse — and the register now pays exactly that toll, plus three
+// Chromium lanes (cljs_browser, hicasso_controlled, hicasso_hmr), for a prose
+// edit. Whether to narrow the arm to `implementation/hicasso/spec/*.md` is an
+// open operator call (rf2-xomo finding 2), not something this test may settle
+// quietly. For the two families still in the hole the repair is unchanged: the
+// unconditional job asserted underneath.
 // ---------------------------------------------------------------------------
 
-test('the complaint catalogue reads three families that arm NO expensive tier (rf2-hic-021)', () => {
+test('the complaint catalogue reads two families that arm NO expensive tier (rf2-hic-021)', () => {
   for (const file of [
-    'docs/design/hicasso/product/complaints.md',
     'spec/009-Instrumentation.md',
     // The guide family the checker actually reads: its GUIDE_DIR followed the
     // corpus to docs/core/hicasso/ under rf2-0yp7w, and only REWRITE-NOTES.md
@@ -4788,6 +4804,18 @@ test('the complaint catalogue reads three families that arm NO expensive tier (r
         + 'unconditional hicasso-complaint-catalogue job instead',
     );
   }
+  // The register's own row, re-pointed and INVERTED (rf2-xomo). It left
+  // docs/design/hicasso/product/ under rf2-ps7ia and now rides
+  // `implementation/hicasso/*`, so it arms. This is also the control the two
+  // rows above need: without it a classifier that had stopped arming
+  // cljs_node_test for anything would satisfy them both and read as a pass.
+  assert.equal(
+    classify('implementation/hicasso/spec/complaints.md').cljs_node_test,
+    'true',
+    'the register moved beside the artefact and now arms the CLJS node-test '
+      + 'tier — if this reads false, the tier the two rows above are measured '
+      + 'against has stopped firing and their `false` means nothing',
+  );
 });
 
 test('hicasso-complaint-catalogue is UNCONDITIONAL and runs both modes (rf2-hic-021)', () => {
@@ -4804,7 +4832,9 @@ test('hicasso-complaint-catalogue is UNCONDITIONAL and runs both modes (rf2-hic-
     block,
     /^ {4}needs:/m,
     'hicasso-complaint-catalogue must not depend on detect_changed_surfaces — '
-      + 'three of the four file families its checker reads arm no output',
+      + 'two of the four file families its checker reads still arm no tier '
+      + 'that could host it (rf2-xomo re-measured the count after the '
+      + 'register moved beside the artefact)',
   );
   assert.doesNotMatch(
     block,


### PR DESCRIPTION
## What changed

`rf2-ps7ia` moved the hicasso operative contract out of `docs/design/hicasso/product/` and in beside the artefact under `implementation/hicasso/spec/`. The classifier mirror suite still pinned the complaint register at its **old** address — and the assertion went on **passing**, because the classifier is a lexical path function: a row naming a path that no longer exists is answered exactly like one that was never armed. Stale premise concealed by a green gate, which is the whole reason it was worth a bead.

One file: `implementation/scripts/_changed-surfaces.test.cjs`.

## Measured at the classifier, both directions

Probed by handing the script **paths** (not revisions), invoked by absolute path:

| path | result |
| --- | --- |
| `implementation/hicasso/spec/complaints.md` | `cljs_node_test=true`, plus `cljs_browser`, `migration_hicasso_codemod`, `hicasso_controlled`, `hicasso_hmr` |
| `docs/design/hicasso/product/complaints.md` | every output `false` |
| `spec/009-Instrumentation.md` | `cljs_node_test=false` (arms `implementation_jvm`) — still correct as pinned |
| `docs/core/hicasso/02-views-and-reads.md` | every output `false` — still correct as pinned |
| `implementation/hicasso/src/re_frame/hicasso/core.cljs` | identical arm set to the register — the positive control proving the instrument discriminates |

## The repair

The register's row is **re-pointed and inverted** rather than deleted. Keeping it as a positive assertion also supplies the control the two surviving rows lacked: a classifier that stopped arming `cljs_node_test` for anything at all would have satisfied a test made entirely of `false` expectations.

The comment block above it is corrected in the same commit. It said the checker reads FOUR file families of which exactly ONE arms `cljs_node_test`; the register's move makes that **two**, since it now rides the same `implementation/hicasso/*` arm as the emit roots (`hicasso/src` + `hicasso/test_kit/src`). The count in the sibling test's assertion message is corrected for the same reason, and its "arm no output" tightened to "arm no tier that could host it" — measured, `spec/009-Instrumentation.md` does arm `implementation_jvm`.

## One file, not the pair — and why

`.github/scripts/report-changed-surfaces.sh` and this test are the one-toucher pair, and the rule exists because changing either alone lands a tree where the suite contradicts the script. Here the direction is the reverse: the **test** contradicted the script's actual behaviour, and this commit makes it agree. The script needs no change — its only two `docs/design/hicasso` mentions both name `async-routing-recipes.md`, which did not move and is still tracked at that address.

Verified repo-wide (excluding `.beads/`, with a positive control on the pattern): `implementation/scripts/_changed-surfaces.test.cjs:4774` was the **only** surviving reference to any of the five moved documents at its old address. The two other old-address mentions are correct as written — `.github/workflows/docs.yml:84` is a deliberate historical note explaining why the new path is armed, and `scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh:669` is a synthetic path in a throwaway git tree.

## Over-arming: reported, not settled

A markdown-only edit under `implementation/hicasso/spec/` now queues **three Chromium lanes** (`cljs_browser`, `hicasso_controlled`, `hicasso_hmr`) plus `cljs_node_test` and `migration_hicasso_codemod`, because the `implementation/hicasso/*` arm does not discriminate `.md`. TESTING.md's "when in doubt, over-classify" and the placement table's refusal to arm a ~10-minute CLJS compile for a Markdown edit point opposite ways here, so this is an operator call, not a defect. It is recorded in the comment and left open rather than settled by narrowing a predicate.

## Gates

| gate | captured exit | result |
| --- | --- | --- |
| `node implementation/scripts/_changed-surfaces.test.cjs` (baseline, pre-edit) | `0` | 292 passed |
| same, **planted fault** (path re-pointed, assertion left un-inverted) | `1` | 1 failed — named this exact test |
| same, post-fix | `0` | 292 passed |
| `npm run test:script-policy` (full chain, ~3 min) | `0` | all passed; `changed-surfaces tests: 292 passed` inside it |
| same, post-rebase | `0` | 292 passed |

Exit codes are the runner's own, captured to a file on the same command line as the redirect — never a pipeline's and never the harness's. The planted-fault red is the discrimination proving the gate read this branch's bytes; the restore was verified byte-identical by `git hash-object` against the committed blob, not by reading a diff.

Test count is unchanged at 292 because no `test()` was added or removed. Nothing gates the prose in this file, so the comment rewrite was checked by hand.

Closes rf2-xomo.
