### PR TITLE
hic(bench): three bench instruments still framed rf2-egdaq as open (rf2-fc7w)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/inpage_ladder_aggregate.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/inpage_ladder_aggregate.cjs
@@ -38,13 +38,17 @@
 // **The rules are the page's, reproduced exactly, and deliberately not
 // improved.** `lane/control-verdict`'s `:ok?` asks whether the measured
 // range OVERLAPS the ±slack band; `hd8-rows/positive-control!` asks the
-// stricter question, whether EVERY round sits inside it. `lane.cljs` records
-// the disagreement between them as a KNOWN DEFECT reserved to an operator
-// ruling (rf2-egdaq / rf2-2rtt6.1) because tightening it turns a published
-// pass into a published failure. This file reconstructs a check that was
-// never run; it is not the place to also change the rule it reconstructs, so
-// it applies the OVERLAP rule the page applied and no other. A tighter
-// prospective policy is that open ruling's to make.
+// stricter question, whether EVERY round sits inside it. rf2-egdaq settled
+// that disagreement on 2026-08-21, and it settled as a SPLIT — one rule per
+// instrument, not one rule for both arms. The HEAP arm went strict; the
+// CLOCK arm REFUSED strict under the 2026-07-31 quantum ruling, where a low
+// round is the clock's resolution rather than a defect, and THAT REFUSAL
+// STANDS. This ladder is a clock instrument, so OVERLAP is the rule the
+// ruling LEAVES IN PLACE for it — not a defect it still carries, and not a
+// question awaiting an answer. This file reconstructs a check that was never
+// run; it is not the place to also change the rule it reconstructs, so it
+// applies the OVERLAP rule the page applied and no other — and that is now
+// the ruled rule as well as the published one.
 //
 // ## And it FAILED OPEN on a structural omission (rf2-409ab, audit item 2)
 //
@@ -242,8 +246,9 @@ function perRoundRatio(raw, id, floorId, roundIds) {
  * OVERLAP, not every-round: `ok` asks whether the measured range meets the
  * ±`slack` band anywhere, which is the weaker of the two rules this
  * programme uses and the one this instrument published under. See the header
- * — the stricter reading is a KNOWN DEFECT reserved to rf2-2rtt6.1, and
- * applying it here would retroactively fail an already-published run.
+ * — rf2-egdaq settled as a SPLIT and REFUSED strict for the CLOCK arm, which
+ * is this one, so overlap is the ruled rule here; and applying the stricter
+ * reading would in any case retroactively fail an already-published run.
  *
  * A non-finite measurement needs no separate test: `NaN <= hi` and
  * `NaN >= lo` are both false, so a control that did not produce numbers

--- a/implementation/hicasso/test/re_frame/bench/hicasso/inpage_ladder_exit_path.test.cjs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/inpage_ladder_exit_path.test.cjs
@@ -26,11 +26,14 @@
 //
 // THE RETROACTIVITY FENCE IS ALSO PINNED. The control rule reconstructed
 // here is `lane/control-verdict`'s OVERLAP rule, not the stricter
-// every-round reading — the two disagree and the disagreement is a KNOWN
-// DEFECT reserved to rf2-2rtt6.1 (rf2-egdaq). Run D contains a round at
-// 1.2653 that sits below the band floor and passes anyway, and a test below
-// pins exactly that, so a later worker who "tightens" the rule discovers
-// they are front-running an open operator ruling rather than fixing a bug.
+// every-round reading — the two disagree, and rf2-egdaq settled that
+// disagreement as a SPLIT, one rule per instrument: the HEAP arm went
+// strict, and the CLOCK arm REFUSED strict under the 2026-07-31 quantum
+// ruling, a refusal that STANDS. This ladder is a clock instrument, so
+// overlap is the ruled rule for it. Run D contains a round at 1.2653 that
+// sits below the band floor and passes anyway, and a test below pins exactly
+// that, so a later worker who "tightens" the rule discovers they are
+// overturning a settled ruling rather than fixing a bug.
 //
 // Wired into implementation/package.json via `test:script-helpers`.
 
@@ -122,13 +125,14 @@ test('the control rule is OVERLAP, exactly as `lane/control-verdict` spells it',
 });
 
 test('THE RETROACTIVITY FENCE: run D holds a round below the band and still passes', () => {
-  // rf2-egdaq / rf2-2rtt6.1. `lane.cljs` records overlap-vs-strict as a KNOWN
-  // DEFECT reserved to an operator ruling, because tightening it turns a
-  // PUBLISHED pass into a published failure. Run D is that case on this
-  // instrument: its worst round reads 1.2653 against a band floor of 1.4819.
-  // If this test ever goes red because someone made the rule stricter, the
-  // change is front-running an open ruling — take it to rf2-2rtt6.1, do not
-  // relax this test.
+  // rf2-egdaq settled overlap-vs-strict as a SPLIT: the HEAP arm went strict,
+  // the CLOCK arm REFUSED strict under the 2026-07-31 quantum ruling, and
+  // THAT REFUSAL STANDS. This is a clock instrument, so overlap is its ruled
+  // rule — and tightening it would still turn a PUBLISHED pass into a
+  // published failure. Run D is that case here: its worst round reads 1.2653
+  // against a band floor of 1.4819. If this test ever goes red because
+  // someone made the rule stricter, the change overturns that ruling — take
+  // it to the operator, do not relax this test.
   const out = agg.checkRun('D', read('D'));
   assert.ok(out.control.ok, 'run D passes under the overlap rule the page published under');
   assert.ok(

--- a/implementation/hicasso/test/re_frame/bench/hicasso/walk_profile_control_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/walk_profile_control_cljs_test.cljs
@@ -24,12 +24,15 @@
   [[strict-rule-beats-overlap]] is the reason this file is not merely
   belt-and-braces. `lane/control-verdict`'s `:ok?` asks whether the
   measured range OVERLAPS the band; the walk profile's control asks
-  whether EVERY ROUND clears the bar. Its own docstring records the
-  overlap rule as a KNOWN DEFECT reserved to an operator ruling
-  (rf2-egdaq / rf2-2rtt6.1), so this control could not adopt it and could
-  not tighten it either. It took the stricter rule from birth instead —
-  legal precisely because it is NEW and has no published row to
-  re-adjudicate.
+  whether EVERY ROUND clears the bar. rf2-egdaq has since settled that
+  disagreement, and it settled as a SPLIT — one rule per instrument, not
+  one rule for both arms: the HEAP arm went strict, and the CLOCK arm
+  REFUSED strict under the 2026-07-31 quantum ruling, a refusal that
+  STANDS. That split adjudicates the p0 heap and clock rows and does not
+  reach this control, which was the stricter rule already and stays it.
+  It took that rule from birth — legal precisely because it is NEW and has
+  no published row to re-adjudicate — rather than adopting the lane's
+  overlap rule or retroactively tightening it.
 
   That test drives ONE dataset through BOTH rules and asserts they
   disagree on it: overlap passes, every-round refuses. A worker who


### PR DESCRIPTION
Mechanical half of rf2-fc7w. Three hicasso bench instruments still described `rf2-egdaq` as an **open** operator ruling reserved to `rf2-2rtt6.1`. It was ruled on 2026-08-21 and both beads are now closed.

## What the ruling actually was, and why both arms appear at every site

`rf2-egdaq` settled as a **SPLIT** — one rule per instrument, not one rule for both arms:

- **HEAP arm** — went strict, and the ten published heap-control figures are **re-adjudicated** under strict with all ten passing, worst margin 0.195% low (4,690,838 B against a prediction of 4,700,000 B), **no window re-run**. The strict *adoption* landed earlier in PR #8574; the 2026-08-21 call is specifically the re-adjudication, and the two are kept distinct.
- **CLOCK arm** — strict was **REFUSED** under the 2026-07-31 quantum ruling, and **that refusal STANDS**.

All three files here are **clock-side** instruments applying the OVERLAP rule, which is exactly what the ruling preserved for them. So each site now carries **both** arms: saying only that the bead is settled, or naming only the heap re-adjudication, would replace one error with another. The register follows `implementation/core/test/re_frame/bench/p0_run.cjs:136-156` and the ruling's own record in `docs/design/hicasso/studio/does-arming-the-census-move-the-high-level.md`.

## Behaviour is unchanged, and that is checked rather than asserted

- The decimal-literal multiset is **identical** before and after in all three files (12 / 35 / 60 literals).
- Both `.cjs` files are **byte-identical outside comments** (code-line count 401→401 and 314→314, sequences equal).
- The only non-`;;` change is the `walk_profile` **ns docstring**, which is prose in a string literal.
- No figure, threshold, assertion or applied rule is touched. `1.2653`, `1.4819`, `CTL_PREDICTED`, `CONTROL_SLACK` and `GUARD_TOLERANCE` all stand.

`inpage_ladder_aggregate.cjs`'s own reasoning — "This file reconstructs a check that was never run; it is not the place to also change the rule it reconstructs" — is preserved verbatim in the rewritten block.

## Five sites, two of which were not in the original report

| File | Site | Was |
|---|---|---|
| `inpage_ladder_aggregate.cjs` | header, now `:38-51` | "KNOWN DEFECT reserved to an operator ruling"; "that open ruling's to make" |
| `inpage_ladder_aggregate.cjs` | `controlVerdict` JSDoc, now `:244-251` | "KNOWN DEFECT reserved to rf2-2rtt6.1" — **not previously reported** |
| `inpage_ladder_exit_path.test.cjs` | header fence, now `:27-36` | "reserved to rf2-2rtt6.1"; "front-running an open operator ruling" — the `:30` half **not previously reported** |
| `inpage_ladder_exit_path.test.cjs` | run-D pin, now `:127-135` | "reserved to an operator ruling"; "front-running an open ruling — take it to rf2-2rtt6.1" |
| `walk_profile_control_cljs_test.cljs` | ns docstring, now `:24-35` | "KNOWN DEFECT reserved to an operator ruling (rf2-egdaq / rf2-2rtt6.1)" |

`walk_profile_control_cljs_test.cljs:125` keeps its bare `(rf2-egdaq)` citation: that is accurate provenance for why the control does not call `lane/control-verdict`, not a stale status claim.

The `walk_profile` docstring deliberately does **not** claim the split endorses its stricter rule. It copies the studio page's own move — the split adjudicates the p0 heap and clock rows and does not reach this control, whose stricter rule was legal from birth because it re-adjudicates no published row.

## Deliberately out of scope

`lane.cljs` is untouched. Its `:1139-1147` passage ("THE STRICTER RULE IS THE RIGHT ONE") against `:1240` ("the 2026-07-31 ruling on rf2-egdaq keeps it there on evidence") is a disagreement about what was decided, not a stale status line — an operator judgement. **rf2-fc7w stays open for it.**

Where these files previously attributed the "known defect" framing to `lane.cljs`'s own text, the new prose attributes the settlement to `rf2-egdaq` directly. That avoids asserting anything about `lane.cljs`'s current wording while that half is still open.

## Gates

| Gate | Captured exit |
|---|---|
| ESLint over both changed `.cjs` files | **0** |
| ESLint over both, **planted fault** | **1** — parse error at each planted line |
| `implementation/hicasso/.../inpage_ladder_exit_path.test.cjs` direct | **0** — 25 passed |
| `npm run test:script-helpers` | **0** — 427 log lines, chain ran to its final element |
| `compile-node-test.cjs node-test` (cold) | **0** — 1994 files, 0 warnings |
| `node out/node-test.js --test=re-frame.bench.hicasso.walk-profile-control-cljs-test` | **0** — 12 tests, 39 assertions, 0 failures |
| same compile, **planted fault** | **1** — reader error naming this worktree's file |
| recompile + re-run after restore | **0** / **0** — 12 tests, 39 assertions, 0 failures |

**Planted-fault controls.** A comment-only diff still admits one. For the `.cjs` files, stripping the `// ` prefix turns prose into live code: planted at `inpage_ladder_aggregate.cjs:43` and `inpage_ladder_exit_path.test.cjs:31` — lines inside the regions edited here — ESLint went red with `Parsing error` naming both files at exactly those lines, and the paths it printed were this worktree's. For the `.cljs` file the analogue is an unescaped `"` inside the ns docstring, planted on `:30`, a line this PR rewrote: the build went red with `Invalid symbol` and named this worktree's path. Restores were verified with `git hash-object` against the committed blobs rather than by reading a diff — all three matched.

**CLJS lane choice.** `:node-test-hicasso` is *not* a narrower lane for this namespace — its `ns-regexp` is `^re-frame\.hicasso\..+-cljs-test$` and this ns is `re-frame.bench.hicasso.walk-profile-control-cljs-test`. Measured against all eight `ns-regexp` values in `shadow-cljs.edn`, only the consolidated `:node-test` build's `cljs-test$` selects it. `shadow-cljs.edn:670-675` names the sanctioned narrowing — compile the full build once, then select at **runtime** with `--test=<ns>`, which needs no recompile and cannot poison the shared build cache. That is the route taken.

**Not nominated:** `check_doc_slugs.py` and `check_readme_links.py`. No markdown changes, and `implementation/**` is outside the docs gate's roots regardless. Nothing gates prose — wording, both-arms coverage and the surviving cross-references were checked by hand.

A note for whoever greps this corpus next: comment prose hard-wraps at ~78 columns, so `reserved to an operator ruling` returns **0** on `inpage_ladder_aggregate.cjs` (where it *is* present, split across `:42/:43`) while returning 1 and 1 on the other two — the non-zero hits make the pattern look validated. Separately, Git-Bash `grep` aborted with SIGABRT (exit 134) on these files, printing nothing, which is indistinguishable from a clean no-match unless the exit code is captured. `rg` was used throughout, with every sweep controlled against the specific file believed to carry the claim.
