### PR TITLE
docs(method): timestamp order does not establish currency (rf2-eod4)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -533,19 +533,28 @@ superseded instructions.
 BUT ORDER IT BY THE TRACKER'S TIMESTAMPS, NOT BY POSITION AND NOT BY DATES IN THE
 PROSE. The bottom of the output is NOT reliably the newest text — audit notes often
 append into the DESCRIPTION block while dated comments render after it, so the last
-lines on screen can be older than material higher up. `bd show <id> | tail` is not a
-read-the-newest method. Neither is grepping the text for dates: a date in the prose is
-CONTENT, not a mutation time, so an undated scope correction is invisible to it and an
-edited description can be the newest field on the bead. Use `bd history <id>`, which
-lists real mutation times newest-first, and `bd comments <id> --json` for comment
-`created_at`. THE PLAIN LISTING TELLS YOU A NEWER MUTATION EXISTS, NOT WHAT IT SAYS —
-it names no changed field, so for the change itself use `bd history <id> --json`, which
-carries a full snapshot per commit. WALK ADJACENT PAIRS NEWEST-FIRST UNTIL THE FIRST
-CHANGE TO A TEXT-BEARING FIELD (description, notes, acceptance, design): the history
-holds duplicate checkpoint snapshots and status-only mutations, so the newest pair alone
-can truthfully say nothing changed while a live instruction change sits behind it. If
-the bead has children, re-enumerate them too: a ruling is sometimes recorded as a NEW
-CHILD BEAD rather than as a note.
+lines on screen can be older than material higher up. Neither `bd show <id> | tail` nor
+a HEAD slice of the notes section is a read-the-newest method. Nor is grepping the text
+for dates: a date in the prose is CONTENT, not a mutation time, so an undated scope
+correction is invisible to it and an edited description can be the newest field on the
+bead. Use `bd history <id>`, which lists real mutation times newest-first, and
+`bd comments <id> --json` for comment `created_at`. THE PLAIN LISTING TELLS YOU A NEWER
+MUTATION EXISTS, NOT WHAT IT SAYS — it names no changed field, so for the change itself
+use `bd history <id> --json`, which carries a full snapshot per commit. WALK ADJACENT
+PAIRS NEWEST-FIRST UNTIL THE FIRST CHANGE TO A TEXT-BEARING FIELD (description, notes,
+acceptance, design): the history holds duplicate checkpoint snapshots and status-only
+mutations, so the newest pair alone can truthfully say nothing changed while a live
+instruction change sits behind it. If the bead has children, re-enumerate them too: a
+ruling is sometimes recorded as a NEW CHILD BEAD rather than as a note.
+
+TIMESTAMP ORDER DOES NOT ESTABLISH CURRENCY, so a perfect walk can still hand you
+superseded text: the newest note by mutation time can be a faithful re-derivation of a
+list an OLDER note already ruled stale. Where a note QUOTES or SUMMARISES another rather
+than citing a check it made itself, look for an intervening note that overtook it —
+prefer "verified at source at <tip>" over "from its own note on PR #NNNN". AND THE
+CHEAPEST GUARD IS THE TREE, NOT THE ITEM: before you brief or build X, check whether X
+ALREADY EXISTS AT TIP — one directory listing would have ended the dispatch that
+produced this rule.
 
 Where the item and this brief disagree, the ITEM governs — follow it, and say in your
 report what differed.


### PR DESCRIPTION
Closes rf2-eod4.

## What was wrong

The **READ THE ITEM BEFORE THE BRIEF** block in the common preamble — pasted verbatim into every editing dispatch — tells the reader to order by tracker timestamps and to walk adjacent history snapshots newest-first to the first change to a text-bearing field. Sound, and incomplete. **The incompleteness fails OPEN:** a note that is newest *by mutation time* can be a faithful re-derivation of text an earlier note already ruled stale. Timestamp order then points straight at it, and following the rule perfectly still produces a confident, well-formed, wrong dispatch.

Measured on rf2-9wmqd, read out of `bd history --json` rather than from prose:

| note time | content |
|---|---|
| 10:24 | "Do not brief from the WHAT THIS BEAD STILL OWES list above; it is stale" — concludes **item (c) alone** remains |
| 23:05 | re-derives the superseded three-item list from the older PR #8599 note; becomes the newest text on the bead |
| 23:11 | worker refuses at source: item (a) merged in PR #8605, item (b) in PR #8614, seventeen hours earlier |
| 23:13 | mayor retraction: "I ran bd history and read the MUTATION TIMESTAMPS, then read the notes with a head-of-section slice" |

## What this change adds

Two sentences and one fold, in the block's existing register, inside the same fence. No restructuring, no renumbering.

1. **The currency qualification**, with the narrowing in the CAPS lead-in rather than after it — CAPS is the skim layer in this fenced block, and a qualification placed after an unqualified lead-in is one many readers never reach. Plus the tell to look for: a note that *quotes or summarises* another rather than citing a check it made itself.
2. **The cheapest guard**, pointed at the tree rather than the item: before you brief or build X, check whether X already exists at tip.

And one fold rather than a new sentence: the block already said `bd show <id> | tail` is not a read-the-newest method. It now says the same of a **HEAD slice of the notes section**, which is the form actually used in the incident, folded into the sentence that was already there.

**Deliberately not added:** a second sentence about `bd comments <id> --json`. The block already directs the reader there for comment `created_at`, which covers a bead whose currency lives entirely in comments and has zero notes.

## Quality gates

| gate | captured exit | note |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | the gate for this surface — `docs/` is one of its roots |
| `python -m mkdocs build --strict` | **0** | 18.97s, "Documentation built" |
| `python scripts/check_readme_links.py --ci` | **0** | sanity only; not this path's surface |

Pass 3 / fail 0. Exit codes captured by redirecting each runner to a log and echoing `$?` on the same command line — never read off a pipeline.

**Does `mkdocs build --strict` cover this path? Yes, measured.** `mkdocs.yml` sets `docs_dir: docs`, and `docs/the-mayor-method/` appears nowhere in `exclude_docs` (whose six entries are `tools/playground/`, the two codemod trees, and `design/{freehand,hicasso,retirement}/`). The build produced `site/the-mayor-method/dispatch-prompt-template/index.html`, and that file contains the new text. The page is not in `nav`, which MkDocs reports at INFO and `--strict` does not fail on.

## Planted-fault control

Two plants, both asserted to have applied before the gate was believed, both restored and verified by hashing the bytes.

**Control A — in-fence, at a line this change actually edits.** A markdown link planted at the new paragraph's last line: `check_doc_slugs.py` **exit 1**, `LINK INSIDE A FENCE: docs\the-mayor-method\dispatch-prompt-template.md:556`. `docs/the-mayor-method/` is one of the two trees held to the stricter fence rule, so an in-fence link here is itself an error rather than an unvalidated one — the gate is *not* blind to this tree's fences the way it is elsewhere.

**Control B — prose, same file.** A broken link target planted just below the fence: **exit 1**, `BROKEN TARGET: docs\the-mayor-method\dispatch-prompt-template.md:578 -> ./no-such-page-readnewest.md`. Both reds name a fault that exists only in this worktree, which is what proves the gate read this tree.

Restore verified by blob hash rather than by reading a diff: `2afae68714e9ee7506948f80c0c63f801e8d79fc` before each plant and after each removal, identical both times, with a residue search for `PLANTED` returning no matches.

## Checked by hand, because nothing gates it

- **Code fence intact** — 4 fence lines in the file both before and after, at 461/512 and 521/576, i.e. two balanced pairs; the edited block sits at 533–557, inside the `521`–`576` pair. A broken fence here would propagate into every future brief.
- **No links added**, so the doc gate's fence-blindness to link *targets* costs nothing here.
- **Headings unchanged** — all 17 identical to `HEAD` after normalising line endings.
- **Line structure** — the paragraph was rewrapped to the file's existing 80–88 column band; widest new line is 88.
