### PR TITLE
docs(method): four repairs from a second pass running the loops

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -544,7 +544,12 @@ use `bd history <id> --json`, which carries a full snapshot per commit. WALK ADJ
 PAIRS NEWEST-FIRST UNTIL THE FIRST CHANGE TO A TEXT-BEARING FIELD (description, notes,
 acceptance, design): the history holds duplicate checkpoint snapshots and status-only
 mutations, so the newest pair alone can truthfully say nothing changed while a live
-instruction change sits behind it. If the bead has children, re-enumerate them too: a
+instruction change sits behind it. AND A WALK THAT ENDS WITHOUT FINDING ONE HAS FOUND
+NOTHING, NOT “NO CHANGE” — say which of the two you have. Histories accumulate
+machine-written no-ops, so a walk bounded anywhere short of the item’s beginning reports
+“no text-bearing change” on an item that has several, and that reads as the revert
+signature whose remedy is to re-close. On a long history, search the text for the marker
+you expect rather than walking to it. If the bead has children, re-enumerate them too: a
 ruling is sometimes recorded as a NEW CHILD BEAD rather than as a note.
 
 TIMESTAMP ORDER DOES NOT ESTABLISH CURRENCY, so a perfect walk can still hand you
@@ -787,6 +792,11 @@ moved most. In the dominant toolchain that is the three-dot form, `<TRUNK>...HEA
 * Which numbers are captured, and which are reported by the harness?
 * What did it decline to do, and why? A report with no refusals, on a task that had a plausible one, is worth a second
   look.
+* Are you about to quote a figure or a phrase OUT of this report and into the next brief? Then it is a claim like
+  any other and the question is what produced it. A sequence of measurements and a correction to one measurement
+  read identically once compressed to a line: one mayor turned four per-window figures into “the number moved”
+  and briefed a worker to fix a figure that was correct. Reports invite this — they are dense, confident, and
+  written by an agent that has just spent its whole context being careful.
 * What did it find that you did not ask for? File those **with the owning item named in the new item**, so a later
   audit reopening that owner is recognisable as the same finding rather than a second one. One mayor skipped that and
   created a duplicate of its own within hours.

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -506,6 +506,17 @@ script.
 At the tail of a drain, dispatch is one-unblocks-the-next, not fan-out. Hold, surface what
 needs the operator, and do not manufacture work.
 
+### You are one of the concurrent writers
+
+The scratch area dispatched agents share is keyed to the SESSION, not to a worktree, and the
+mayor writes there too — change bodies, working notes, gate artefacts — while N workers do.
+Every naming rule you paste into a brief binds you equally. The block that carries it is
+written in a second person aimed at a dispatched agent, so it does not read as addressed to
+you: one mayor enforced that rule on eight dispatches and then lost its own change body to a
+peer, under exactly the bare name the rule forbids. **A rule scoped to a ROLE exempts whoever
+does not identify with the role** — when a hazard belongs to a shared resource, scope it to
+the resource.
+
 ---
 
 ## 3. Backlog reread
@@ -885,6 +896,15 @@ Watch specifically for:
 
 Report one or two lines unless you find real drift. If you find drift, fix the document or the command
 file — do not just note it.
+
+**But weigh WHICH artefact to change.** Where a reader-side rule has failed repeatedly, more text is
+usually not the repair. Two remedies landed the other way in one session: an item whose OLDEST field
+was rewritten to open with its disposition, after three workers had been dispatched at work that
+should not exist and each had correctly refused; and a commit guard that refused an edit the rule had
+already forbidden in words. Both changed the artefact a reader meets rather than the instruction they
+had read and recited. **And a guard is not a rule that cannot fail**: one added on an evening was RUN
+the next hour and misread, because a check executed carelessly returns the same reassuring answer as
+no check at all.
 
 ---
 


### PR DESCRIPTION
Second mayor-method retrospective, done by the mayor personally as the task requires. Finding document written before any edit; evidence log appended as the session ran.

**+31 / −1 across two files. No new sections — every repair is a clause inside a block that already exists.** `README.md` untouched. No heading altered; one subsection added, so no anchor cited from outside the tree can break.

## The frame this pass had to answer first

Six evidence entries each concluded *"the rule exists and did not reach the reader"*, and the log says a fifth restatement is the wrong response. Three of the six are genuinely different failures wearing one description. What is worth reporting is a different observation: **two remedies worked this session where instruction had failed, and neither was a rule** — an item whose oldest field was rewritten to open with its disposition (after three workers had each correctly refused work that should not exist), and a commit guard that refused an edit the rule had already forbidden in words.

Against that, a sharp warning: the guard added on one evening was **run** the next hour and **misread**. A guard executed carelessly returns the same reassuring answer as no guard at all.

## The four repairs

**1. A bounded walk that finds nothing has found NOTHING, not "no change".** The walk rule already warns the newest *pair* can truthfully say nothing changed; it says nothing about the newest *N*. I walked 25 of an item's 7267 mostly-no-op history entries, found no text-bearing change, and reported the mechanical-revert signature — whose remedy is to re-close, destroying a live audit finding while looking like tidiness. A worker later walked every pair and found two changes, the newer being the audit's.

**2. A worker's report is a SOURCE you quote from, not only a work product you review.** The existing prompts all evaluate the report; none covers lifting a fact *out* of it into the next brief. Four per-window measurements and one corrected measurement read identically compressed to a line — I turned the former into the latter and briefed a worker to fix a figure that was correct.

**3. The mayor is one of the concurrent writers.** The scratch naming rule sits in a block written in a second person aimed at a dispatched agent, so it does not read as addressed to the mayor — who writes to the same session-keyed directory while N workers do. I enforced that rule on eight dispatches and then lost my own change body to a peer, under exactly the bare name it forbids. **A rule scoped to a role exempts whoever does not identify with the role.**

**4. Where a reader-side rule keeps failing, weigh WHICH artefact to change.** Guidance about choosing a repair, which is what a retrospective is for, and not derivable from a document whose own instrument is instruction.

## Deliberately NOT changed

**The closing recap, examined seriously and kept.** Seventeen bullets restating rules stated in full above, several grown into second copies, and a recap is a divergence hazard by construction — the method's own reread loop names that. I never consulted it in nine hours. **But that is evidence about running, not onboarding**, and that document's tail is explicitly onboarding material. Deleting an onboarding index on the strength of nine hours of operation measures the wrong thing; if it is dead weight, a *new* mayor failing to find a rule through it is the evidence to wait for.

Four candidates rejected as already covered, checked at source: the bounded-repair census rule, the brief-error rate (the method's own headline finding reproducing at the rate it reports), the canary counting-method gap (excluded as something a mayor works out), and comments-on-an-item-with-no-notes.

## Gates — captured exit codes, redirect and echo on one command line

| gate | exit |
|---|---|
| `check_doc_slugs.py` | **0** |
| `python -m mkdocs build --strict` | **0** (20.69s; `mkdocs` is not on PATH, the module form is) |

**Two planted faults, each at a line this change actually edits, each asserted to apply before the run was believed.**

- Prose, in the new subsection → **exit 1**, `BROKEN TARGET: loops.md:518`.
- Inside the pasteable fence, on the edited walk rule → **exit 1**, `LINK INSIDE A FENCE: dispatch-prompt-template.md:552`. This tree is one of the two held to the stricter in-fence rule, so an in-fence link is a usable control here where it would be invisible elsewhere.

Both restored; the second verified by `git hash-object` against the committed blob (`1a2793163e…`, matched), residue greps zero, gate back to 0, tree clean.

## Read for silent reverts

Diffed against the merge base. **One deletion**, and it is a re-wrap rather than a loss: the original line carried both the end of the replaced sentence and the start of the next. Verified the two clauses that shared it survive — the children re-enumeration and the new-child-bead clause both present at count 1 in base and now.