### PR TITLE
test(hicasso): one settlement path for the identifier-prefix suite's async rows

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/identifier_prefix_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/identifier_prefix_ssr_dom_cljs_test.cljs
@@ -304,9 +304,18 @@
 ;; There was no rejection arm anywhere in this file, so on a rejection the
 ;; handler was skipped, the `try` was never entered and the `finally` never
 ;; fired. Nothing ran: no `stop!`, no `release!`, no `done`. The row did not
-;; fail — it HUNG to `cljs.test`'s async timeout, reporting the timeout
-;; rather than the rejection, and it handed the next row a live root and a
-;; swallowing listener to take its census against.
+;; fail on its own account — it never settled, so `cljs.test`'s async runner
+;; had nothing to advance it with, and the next row was handed a live root
+;; and a swallowing listener to take its census against.
+;;
+;; On THIS lane it is worse than a hang, which is worth knowing before
+;; reading §6's sabotage as merely slow. An unsettled rejection is an
+;; unhandled one, so it reaches the page as an uncaught error, and the
+;; browser runner treats that as terminal (rf2-u0j8). Measured: the run
+;; stopped at this namespace with 85 announced, no summary line at all, and
+;; every namespace scheduled after it silently unrun — `shadow.test` runs
+;; the whole lane, and the closing summary, inside one `cljs.test/run-block`
+;; with no try/catch. So the cost of a rejection here was never one row.
 ;;
 ;; [[settle-row!]] is the one path all four now end with, and §6 is what
 ;; says it works — because its rejection arm is on no green path, and a
@@ -743,10 +752,11 @@
 ;; Under the shape this file carried before, nothing below the injection
 ;; runs at all. The rejection skips the fulfilment handler, so the `try` is
 ;; never entered and its `finally` never fires: no `stop!`, no `release!`,
-;; no `done`. The row does not go red — it hangs to `cljs.test`'s async
-;; timeout, reports the timeout instead of the rejection, and leaves the
-;; root mounted, the container in the document and `console.error` still
-;; replaced for whatever runs next.
+;; no `done`. Measured by removing [[settle-row!]]'s rejection arm and
+;; running the lane: the run stopped HERE, 85 namespaces in, with no summary
+;; line and every later namespace unrun — see the note above [[settle-row!]]
+;; for why an unsettled rejection is terminal on this runner rather than
+;; merely slow.
 
 (deftest a-rejected-adoption-still-releases-the-root-console-and-watcher
   (if-not (mount/browser?)

--- a/implementation/hicasso/test/re_frame/hicasso/identifier_prefix_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/identifier_prefix_ssr_dom_cljs_test.cljs
@@ -273,6 +273,96 @@
   nil)
 
 ;; ---------------------------------------------------------------------------
+;; Settlement — the ONE way out of an async row, taken on both outcomes
+;; ---------------------------------------------------------------------------
+;;
+;; Every async row below hydrates a real root and waits on `sup/adopted!`,
+;; and each of them holds things the `:each` fixture will NOT take back:
+;;
+;;   * a MOUNTED React root, with the container `sup/server-dom!` minted
+;;     still in the document — the fixture resets frames, disposes the
+;;     adapter and empties the runtime, and none of that unmounts a root;
+;;   * `console.error`, replaced by `sup/open-console-capture!`, and the
+;;     `window` "error" listener it registered. §2 and §5 open theirs with
+;;     `:swallow-uncaught? true`, so a listener that outlives its row goes
+;;     on calling `preventDefault` on every later row's uncaught errors —
+;;     which is precisely the fail-open the browser runner's pageerror rule
+;;     exists to prevent.
+;;
+;; The mismatch watcher's trace listener is the one thing the fixture does
+;; sweep — `make-reset-runtime-fixture`'s `:before` calls
+;; `trace-tooling/clear-listeners!` — and it is still stopped on both paths
+;; here, because a row that leans on the fixture to stop its own watcher is
+;; measuring the fixture.
+;;
+;; These rows used to end INSIDE the fulfilment handler:
+;;
+;;   (-> (sup/adopted! handle)
+;;       (.then (fn [ok] … (try …assertions…
+;;                              (finally (stop!) (mount/release! handle) (done))))))
+;;
+;; There was no rejection arm anywhere in this file, so on a rejection the
+;; handler was skipped, the `try` was never entered and the `finally` never
+;; fired. Nothing ran: no `stop!`, no `release!`, no `done`. The row did not
+;; fail — it HUNG to `cljs.test`'s async timeout, reporting the timeout
+;; rather than the rejection, and it handed the next row a live root and a
+;; swallowing listener to take its census against.
+;;
+;; [[settle-row!]] is the one path all four now end with, and §6 is what
+;; says it works — because its rejection arm is on no green path, and a
+;; repair to a branch nothing takes is untested by construction.
+
+(defn- settle-row!
+  "End an async row exactly ONCE, whatever `p` does. `opts` is
+  `{:row :done :release! :report!}`:
+
+    :row      names the row in the failure message. A shared settlement
+              still has to say WHICH row failed, which is the one thing a
+              hand-written rejection arm would give away for free.
+    :done     `cljs.test`'s own, called exactly once.
+    :release! this row's teardown, called exactly once. Every primitive it
+              reaches for is idempotent and says so — `mount/release!`,
+              `(:stop! watch)`, `(:close! capture)` — so a row whose BODY
+              already tore something down as part of an assertion (§4
+              unmounts both roots to take its census) names it here as well
+              and the second call is a no-op. Omit only where the row holds
+              nothing.
+    :report!  what to do with a rejection. Defaults to failing the row,
+              which is what a real row wants; §6 passes a recorder, because
+              for it the rejection is the subject.
+
+  One `.then` carrying BOTH handlers rather than a `.then` and a `.catch`:
+  the two are mutually exclusive, so a body that throws cannot also reach
+  the rejection arm and finish the row twice. The release and the `done`
+  sit on the far side of both, and `done` is in a `finally`, so a teardown
+  that throws still ends the row rather than leaving the runner to time it
+  out.
+
+  The failure is carried as `nil`-or-`[e]` rather than as the value itself,
+  because a promise rejected with `js/undefined` reads as `nil` in CLJS and
+  would otherwise settle silently.
+
+  **A local copy of `server-render-ssr-dom-cljs-test`'s helper of the same
+  name (rf2-sxhu, PR #8675), deliberately spelled identically** — same
+  parameters, same defaults, same `nil`-or-`[e]` carrier — so that lifting
+  the two into `roots-frames-support` when the remaining suites are
+  repaired is a deletion and a `:require`, not a reconciliation of two
+  designs. rf2-7ucn carries that lift and the count that justifies it."
+  [p {:keys [row done release! report!]}]
+  (let [report!  (or report!  (fn [e] (is false (str row " did not settle cleanly — " e))))
+        release! (or release! (fn [] nil))
+        finish!  (fn [failure]
+                   (try
+                     (when failure (report! (str (first failure))))
+                     (release!)
+                     (catch :default te
+                       (is false (str row " could not release — " te)))
+                     (finally (done))))]
+    (.then p
+           (fn [_] (finish! nil))
+           (fn [e] (finish! [e])))))
+
+;; ---------------------------------------------------------------------------
 ;; 1 — the SERVER side alone (no DOM; runs under :node-test)
 ;; ---------------------------------------------------------------------------
 
@@ -353,9 +443,14 @@
             (-> (sup/adopted! handle)
                 (.then
                   (fn [ok]
+                    ;; Closed HERE and named in `:release!` as well. Here,
+                    ;; because the assertions below read `@captured` and the
+                    ;; window has to be shut across the render rather than
+                    ;; across the rest of the row; there, because `close!` is
+                    ;; idempotent and the rejection path never reaches this
+                    ;; line.
                     (close!)
                     (is (true? ok) "the root's own adoption window shut")
-                    (try
                       (testing "React complains, and the complaint is attributed
                                 to this arm's own door rather than left as an
                                 uncaught window error"
@@ -392,9 +487,14 @@
                             (str "they differ all the same, which is the "
                                  "obstruction this row records; server "
                                  (pr-str server-id) ", client "
-                                 (pr-str (probe-id container)))))
-
-                      (finally (stop!) (mount/release! handle) (done))))))))))))
+                                 (pr-str (probe-id container)))))))
+                (settle-row!
+                  {:row      "§2 — the bytes a consumer can bake today"
+                   :done     done
+                   :release! (fn []
+                               (close!)
+                               (stop!)
+                               (mount/release! handle))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — THE DIAGNOSIS: bytes of the root's own shape hydrate silently
@@ -416,7 +516,6 @@
             (-> (sup/adopted! handle)
                 (.then
                   (fn [ok]
-                    (try
                       (is (true? ok) "the root's own adoption window shut")
 
                       (testing "the adoption was real — these are the very nodes
@@ -443,9 +542,13 @@
                         (is (= server-id (probe-id container))
                             (str "the client's own id must equal the server's; "
                                  "server " (pr-str server-id) ", client "
-                                 (pr-str (probe-id container)))))
-
-                      (finally (stop!) (mount/release! handle) (done))))))))))))
+                                 (pr-str (probe-id container)))))))
+                (settle-row!
+                  {:row      "§3 — bytes of the hydrating root's own shape"
+                   :done     done
+                   :release! (fn []
+                               (stop!)
+                               (mount/release! handle))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — §2.4's clause, as written: TWO SIMULTANEOUS hydrating roots
@@ -489,7 +592,6 @@
                 (.then (fn [_] (sup/adopted! hb)))
                 (.then
                   (fn [ok]
-                    (try
                       (is (true? ok) "both roots adopted")
 
                       (testing "each root adopted its OWN server DOM"
@@ -535,13 +637,29 @@
                         (mount/unmount! hb)
                         (is (= sup/released (sup/census))
                             (str "both roots down; residue was "
-                                 (pr-str (sup/census)))))
-
-                      (finally
-                        (stop!)
-                        (mount/release! (assoc ha :root nil))
-                        (mount/release! (assoc hb :root nil))
-                        (done))))))))))))
+                                 (pr-str (sup/census)))))))
+                (settle-row!
+                  {:row      "§4 — two simultaneous hydrating roots"
+                   :done     done
+                   ;; The FULL handles, where the `finally` this replaced
+                   ;; passed `(assoc h :root nil)`. That spelling was right
+                   ;; for the one path it could be reached on: the body above
+                   ;; unmounts both roots to take its census, so by the time
+                   ;; the old `finally` ran there was no root left to unmount
+                   ;; and `:root nil` said so. On a rejection the body may
+                   ;; never reach those unmounts, and `:root nil` would then
+                   ;; skip the React unmount entirely and leak a live root
+                   ;; into the next row. The full handle is correct on BOTH
+                   ;; paths: `mount/unmount!` is idempotent by its own
+                   ;; docstring — `roots/close-adoption-window!` is
+                   ;; nil-tolerant, and React's `root.unmount()` is a no-op
+                   ;; once the root is down — so the success path's second
+                   ;; call costs nothing and the rejection path's first one
+                   ;; is the whole point.
+                   :release! (fn []
+                               (stop!)
+                               (mount/release! ha)
+                               (mount/release! hb))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5 — the NEAR-MISS: a legal prefix that is the wrong one
@@ -574,8 +692,10 @@
             (-> (sup/adopted! handle)
                 (.then
                   (fn [_]
+                    ;; Closed here for §2's reason, and named in `:release!`
+                    ;; as well because `close!` is idempotent and the
+                    ;; rejection path never reaches this line.
                     (close!)
-                    (try
                       (testing "the divergence is REPORTED, and attributed to this
                                 arm's own door"
                         (is (seq (filterv #(re-find #"Hydration failed" %) @captured))
@@ -598,6 +718,117 @@
                                  "server's; both read " (pr-str server-id)))
                         (is (str/includes? (probe-id container) "pfx-b-")
                             (str "and it is the client's prefix; got "
-                                 (pr-str (probe-id container)))))
+                                 (pr-str (probe-id container)))))))
+                (settle-row!
+                  {:row      "§5 — a client prefix that disagrees with the bytes"
+                   :done     done
+                   :release! (fn []
+                               (close!)
+                               (stop!)
+                               (mount/release! handle))}))))))))
 
-                      (finally (stop!) (mount/release! handle) (done))))))))))))
+;; ---------------------------------------------------------------------------
+;; 6 — THE LEAK CONTROL: a rejected adoption still releases the page
+;; ---------------------------------------------------------------------------
+;;
+;; §2 through §5 all FULFIL on a green run, so [[settle-row!]]'s rejection
+;; arm is on no green path — and a repair to a branch nothing takes is
+;; untested by construction. This row takes it.
+;;
+;; The rejection is injected AFTER the adoption completes, which is the
+;; harder case and not the weaker one: every resource the row owns is live
+;; and committed at that moment, so there is strictly MORE to release than
+;; there would be had `sup/adopted!` rejected before the root ever adopted.
+;;
+;; Under the shape this file carried before, nothing below the injection
+;; runs at all. The rejection skips the fulfilment handler, so the `try` is
+;; never entered and its `finally` never fires: no `stop!`, no `release!`,
+;; no `done`. The row does not go red — it hangs to `cljs.test`'s async
+;; timeout, reports the timeout instead of the rejection, and leaves the
+;; root mounted, the container in the document and `console.error` still
+;; replaced for whatever runs next.
+
+(deftest a-rejected-adoption-still-releases-the-root-console-and-watcher
+  (if-not (mount/browser?)
+    (sup/skip! "what a rejection can leak here is a real root and a real console")
+    (async done
+      (fresh!)
+      (let [html           (root-shaped-server-html! frame-a [id-page {}] "pfx-a-")
+            container      (sup/stamp-server-nodes! (sup/server-dom! html))
+            watch          (sup/watch-mismatches!)
+            ;; NOT `:swallow-uncaught? true`: this row manufactures a
+            ;; rejected PROMISE, which `settle-row!` handles, and no
+            ;; uncaught window error at all. Swallowing anywhere else is
+            ;; the fail-open the browser runner's pageerror rule forbids.
+            console-before (.-error js/console)
+            capture        (sup/open-console-capture!)
+            stops          (atom 0)
+            finishes       (atom 0)
+            reports        (atom [])]
+        (collector/reset-runtime!)
+        (let [handle (mount/hydrate-root! container frame-a [id-page {}]
+                                          {:identifier-prefix "pfx-a-"})]
+          (-> (sup/adopted! handle)
+              (.then
+                (fn [ok]
+                  (is (true? ok) "premise: the root really did adopt")
+                  (is (not= sup/released (sup/census))
+                      (str "premise: the runtime is holding this root's cells "
+                           "and edges, so the census taken after the rejection "
+                           "is a RELEASE and not an empty page; got "
+                           (pr-str (sup/census))))
+                  (js/Promise.reject (js/Error. "adoption rejected on purpose"))))
+              (settle-row!
+                {:row      "the rejected-adoption control"
+                 :done     (fn [] (swap! finishes inc))
+                 :report!  (fn [e] (swap! reports conj e))
+                 :release! (fn []
+                             ((:close! capture))
+                             (swap! stops inc)
+                             ((:stop! watch))
+                             (mount/release! handle))})
+              ;; The cell reapers are armed at unmount and run past a bare
+              ;; macrotask, so the tables are read at the runtime's own
+              ;; horizon rather than one tick after the release.
+              (.then (fn [_] (sup/quiesced!)))
+              (.then
+                (fn [_]
+                  (testing "the rejection is REPORTED — which is the whole of
+                            what a hang gives away — and the row ends ONCE"
+                    (is (= 1 @finishes)
+                        (str "done ran " @finishes " times"))
+                    (is (= 1 (count @reports))
+                        (str "exactly one report; got " (pr-str @reports)))
+                    (is (str/includes? (str (first @reports))
+                                       "adoption rejected on purpose")
+                        (str "naming what the adoption threw; got "
+                             (pr-str @reports))))
+
+                  (testing "and the page the NEXT row inherits holds nothing of
+                            this one. Two of these four are the row's alone to
+                            give back — the `:each` fixture resets frames,
+                            disposes the adapter and empties the runtime, but it
+                            never unmounts a React root and never hands
+                            `console.error` back. (The trace listener it does
+                            sweep, in its `:before`; `stop!` is asserted here
+                            all the same, because a row that leans on the
+                            fixture to stop its own watcher is measuring the
+                            fixture)"
+                    (is (= sup/released (sup/census))
+                        (str "no root: residue was " (pr-str (sup/census))))
+                    (is (empty? (sup/cell-frames))
+                        (str "no frame: the cell table still mentions "
+                             (pr-str (sup/cell-frames))))
+                    (is (= 1 @stops)
+                        (str "the mismatch watcher was stopped — `stop!` is what "
+                             "unregisters the trace listener; it ran "
+                             @stops " times"))
+                    (is (identical? console-before (.-error js/console))
+                        "`console.error` is the page's own again"))))
+              (settle-row!
+                {:row      "the rejected-adoption control's own settlement"
+                 :done     done
+                 :release! (fn []
+                             ((:close! capture))
+                             ((:stop! watch))
+                             (mount/release! handle))})))))))

--- a/implementation/hicasso/test/re_frame/hicasso/identifier_prefix_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/identifier_prefix_ssr_dom_cljs_test.cljs
@@ -451,43 +451,43 @@
                     ;; line.
                     (close!)
                     (is (true? ok) "the root's own adoption window shut")
-                      (testing "React complains, and the complaint is attributed
-                                to this arm's own door rather than left as an
-                                uncaught window error"
-                        (is (seq (filterv #(re-find #"Hydration failed" %) @captured))
-                            (str "React itself must have reported the divergence "
-                                 "on the page's own channel; got "
-                                 (pr-str (mapv #(subs % 0 (min 60 (count %)))
-                                               @captured))))
-                        (is (seq @seen)
-                            "the divergence must reach Spec 011's channel")
-                        (let [tags (sup/tags-of (first @seen))]
-                          (is (= 're-frame.hicasso.impl.mount/hydrate-root!
-                                 (:where tags))
-                              (str "attributed to source; got " (pr-str (:where tags))))
-                          (is (= :warned-and-replaced (:recovery tags))
-                              "React had already patched the DOM by the time the
-                               callback ran, so that is the recovery reported")))
+                    (testing "React complains, and the complaint is attributed
+                              to this arm's own door rather than left as an
+                              uncaught window error"
+                      (is (seq (filterv #(re-find #"Hydration failed" %) @captured))
+                          (str "React itself must have reported the divergence "
+                               "on the page's own channel; got "
+                               (pr-str (mapv #(subs % 0 (min 60 (count %)))
+                                             @captured))))
+                      (is (seq @seen)
+                          "the divergence must reach Spec 011's channel")
+                      (let [tags (sup/tags-of (first @seen))]
+                        (is (= 're-frame.hicasso.impl.mount/hydrate-root!
+                               (:where tags))
+                            (str "attributed to source; got " (pr-str (:where tags))))
+                        (is (= :warned-and-replaced (:recovery tags))
+                            "React had already patched the DOM by the time the
+                             callback ran, so that is the recovery reported")))
 
-                      (testing "and the PREFIX is not what diverged. Read after a
-                                real client render, so it is the client's own
-                                answer and not an untouched server byte"
-                        (relabel! frame-a "alpha'")
-                        (is (= "alpha'" (text-in container ".value"))
-                            "premise: the dispatch painted, so a render happened")
-                        (is (= "alpha'" (text-in container ".label"))
-                            "premise: the ISLAND re-rendered too — its prop moved")
-                        (is (str/includes? server-id "pfx-a-")
-                            "the server's id carried the prefix")
-                        (is (str/includes? (probe-id container) "pfx-a-")
-                            (str "and so does the client's — the pass-through "
-                                 "reached both doors; got "
-                                 (pr-str (probe-id container))))
-                        (is (not= server-id (probe-id container))
-                            (str "they differ all the same, which is the "
-                                 "obstruction this row records; server "
-                                 (pr-str server-id) ", client "
-                                 (pr-str (probe-id container)))))))
+                    (testing "and the PREFIX is not what diverged. Read after a
+                              real client render, so it is the client's own
+                              answer and not an untouched server byte"
+                      (relabel! frame-a "alpha'")
+                      (is (= "alpha'" (text-in container ".value"))
+                          "premise: the dispatch painted, so a render happened")
+                      (is (= "alpha'" (text-in container ".label"))
+                          "premise: the ISLAND re-rendered too — its prop moved")
+                      (is (str/includes? server-id "pfx-a-")
+                          "the server's id carried the prefix")
+                      (is (str/includes? (probe-id container) "pfx-a-")
+                          (str "and so does the client's — the pass-through "
+                               "reached both doors; got "
+                               (pr-str (probe-id container))))
+                      (is (not= server-id (probe-id container))
+                          (str "they differ all the same, which is the "
+                               "obstruction this row records; server "
+                               (pr-str server-id) ", client "
+                               (pr-str (probe-id container)))))))
                 (settle-row!
                   {:row      "§2 — the bytes a consumer can bake today"
                    :done     done
@@ -516,33 +516,33 @@
             (-> (sup/adopted! handle)
                 (.then
                   (fn [ok]
-                      (is (true? ok) "the root's own adoption window shut")
+                    (is (true? ok) "the root's own adoption window shut")
 
-                      (testing "the adoption was real — these are the very nodes
-                                the bytes produced, which no re-render could
-                                reconstruct"
-                        (is (sup/every-server-node? container ".page, .value, .probe")
-                            "the server's nodes survived, probe included"))
+                    (testing "the adoption was real — these are the very nodes
+                              the bytes produced, which no re-render could
+                              reconstruct"
+                      (is (sup/every-server-node? container ".page, .value, .probe")
+                          "the server's nodes survived, probe included"))
 
-                      (testing "and React had nothing to complain about, which is
-                                what isolates §2's mismatch to the tree shape:
-                                one structural difference is all that changed"
-                        (is (empty? @seen)
-                            (str "matching shape and matching prefix must produce "
-                                 "no mismatch; got "
-                                 (pr-str (mapv #(:error (sup/tags-of %)) @seen)))))
+                    (testing "and React had nothing to complain about, which is
+                              what isolates §2's mismatch to the tree shape:
+                              one structural difference is all that changed"
+                      (is (empty? @seen)
+                          (str "matching shape and matching prefix must produce "
+                               "no mismatch; got "
+                               (pr-str (mapv #(:error (sup/tags-of %)) @seen)))))
 
-                      (testing "the id agrees ACROSS A REAL CLIENT RENDER, which
-                                is the only reading that separates *the client
-                                minted the same id* from *nobody touched the
-                                server's text*"
-                        (relabel! frame-a "alpha'")
-                        (is (= "alpha'" (text-in container ".label"))
-                            "premise: the island re-rendered")
-                        (is (= server-id (probe-id container))
-                            (str "the client's own id must equal the server's; "
-                                 "server " (pr-str server-id) ", client "
-                                 (pr-str (probe-id container)))))))
+                    (testing "the id agrees ACROSS A REAL CLIENT RENDER, which
+                              is the only reading that separates *the client
+                              minted the same id* from *nobody touched the
+                              server's text*"
+                      (relabel! frame-a "alpha'")
+                      (is (= "alpha'" (text-in container ".label"))
+                          "premise: the island re-rendered")
+                      (is (= server-id (probe-id container))
+                          (str "the client's own id must equal the server's; "
+                               "server " (pr-str server-id) ", client "
+                               (pr-str (probe-id container)))))))
                 (settle-row!
                   {:row      "§3 — bytes of the hydrating root's own shape"
                    :done     done
@@ -592,52 +592,52 @@
                 (.then (fn [_] (sup/adopted! hb)))
                 (.then
                   (fn [ok]
-                      (is (true? ok) "both roots adopted")
+                    (is (true? ok) "both roots adopted")
 
-                      (testing "each root adopted its OWN server DOM"
-                        (is (sup/every-server-node? ca ".page, .value, .probe")
-                            "root A kept the server's nodes")
-                        (is (sup/every-server-node? cb ".page, .value, .probe")
-                            "root B kept the server's nodes"))
+                    (testing "each root adopted its OWN server DOM"
+                      (is (sup/every-server-node? ca ".page, .value, .probe")
+                          "root A kept the server's nodes")
+                      (is (sup/every-server-node? cb ".page, .value, .probe")
+                          "root B kept the server's nodes"))
 
-                      (testing "and neither adoption complained — two prefixes,
-                                each stable across its own seam"
-                        (is (empty? @seen)
-                            (str "two matching prefixes must produce no mismatch; "
-                                 "got "
-                                 (pr-str (mapv #(:error (sup/tags-of %)) @seen)))))
+                    (testing "and neither adoption complained — two prefixes,
+                              each stable across its own seam"
+                      (is (empty? @seen)
+                          (str "two matching prefixes must produce no mismatch; "
+                               "got "
+                               (pr-str (mapv #(:error (sup/tags-of %)) @seen)))))
 
-                      (testing "the ids are DISTINCT and each is its own root's.
-                                Read after a dispatch into each root, so both are
-                                the client's own answer rather than the server's
-                                untouched bytes"
-                        (relabel! frame-a "alpha'")
-                        (relabel! frame-b "beta'")
-                        (is (= "alpha'" (text-in ca ".label"))
-                            "premise: root A's island re-rendered")
-                        (is (= "beta'" (text-in cb ".label"))
-                            "premise: root B's island re-rendered")
-                        (is (= server-a (probe-id ca)) "root A held its id")
-                        (is (= server-b (probe-id cb)) "root B held its id")
-                        (is (not= (probe-id ca) (probe-id cb))
-                            (str "two roots on one page must not mint the same "
-                                 "id; both read " (pr-str (probe-id ca))))
-                        (is (str/includes? (probe-id ca) "pfx-a-"))
-                        (is (str/includes? (probe-id cb) "pfx-b-")))
+                    (testing "the ids are DISTINCT and each is its own root's.
+                              Read after a dispatch into each root, so both are
+                              the client's own answer rather than the server's
+                              untouched bytes"
+                      (relabel! frame-a "alpha'")
+                      (relabel! frame-b "beta'")
+                      (is (= "alpha'" (text-in ca ".label"))
+                          "premise: root A's island re-rendered")
+                      (is (= "beta'" (text-in cb ".label"))
+                          "premise: root B's island re-rendered")
+                      (is (= server-a (probe-id ca)) "root A held its id")
+                      (is (= server-b (probe-id cb)) "root B held its id")
+                      (is (not= (probe-id ca) (probe-id cb))
+                          (str "two roots on one page must not mint the same "
+                               "id; both read " (pr-str (probe-id ca))))
+                      (is (str/includes? (probe-id ca) "pfx-a-"))
+                      (is (str/includes? (probe-id cb) "pfx-b-")))
 
-                      (testing "§2.4's *exact cleanup on unmount*, and the fact
-                                that teardown is root-scoped: A's unmount leaves
-                                B's runtime standing, and the census is exact only
-                                once both are down. Read before any `release!`,
-                                because `release!` empties the tables by fiat and
-                                a census after it cannot go red"
-                        (mount/unmount! ha)
-                        (is (not= sup/released (sup/census))
-                            "root B is still live, so the runtime is not empty")
-                        (mount/unmount! hb)
-                        (is (= sup/released (sup/census))
-                            (str "both roots down; residue was "
-                                 (pr-str (sup/census)))))))
+                    (testing "§2.4's *exact cleanup on unmount*, and the fact
+                              that teardown is root-scoped: A's unmount leaves
+                              B's runtime standing, and the census is exact only
+                              once both are down. Read before any `release!`,
+                              because `release!` empties the tables by fiat and
+                              a census after it cannot go red"
+                      (mount/unmount! ha)
+                      (is (not= sup/released (sup/census))
+                          "root B is still live, so the runtime is not empty")
+                      (mount/unmount! hb)
+                      (is (= sup/released (sup/census))
+                          (str "both roots down; residue was "
+                               (pr-str (sup/census)))))))
                 (settle-row!
                   {:row      "§4 — two simultaneous hydrating roots"
                    :done     done
@@ -696,29 +696,29 @@
                     ;; as well because `close!` is idempotent and the
                     ;; rejection path never reaches this line.
                     (close!)
-                      (testing "the divergence is REPORTED, and attributed to this
-                                arm's own door"
-                        (is (seq (filterv #(re-find #"Hydration failed" %) @captured))
-                            (str "React itself must have reported it; got "
-                                 (pr-str (mapv #(subs % 0 (min 60 (count %)))
-                                               @captured))))
-                        (is (seq @seen)
-                            "a prefix that disagrees with the bytes must complain")
-                        (let [tags (sup/tags-of (first @seen))]
-                          (is (= 're-frame.hicasso.impl.mount/hydrate-root!
-                                 (:where tags))
-                              (str "attributed to source; got "
-                                   (pr-str (:where tags))))
-                          (is (= :warned-and-replaced (:recovery tags)))))
+                    (testing "the divergence is REPORTED, and attributed to this
+                              arm's own door"
+                      (is (seq (filterv #(re-find #"Hydration failed" %) @captured))
+                          (str "React itself must have reported it; got "
+                               (pr-str (mapv #(subs % 0 (min 60 (count %)))
+                                             @captured))))
+                      (is (seq @seen)
+                          "a prefix that disagrees with the bytes must complain")
+                      (let [tags (sup/tags-of (first @seen))]
+                        (is (= 're-frame.hicasso.impl.mount/hydrate-root!
+                               (:where tags))
+                            (str "attributed to source; got "
+                                 (pr-str (:where tags))))
+                        (is (= :warned-and-replaced (:recovery tags)))))
 
-                      (testing "and the recovery is visible: the id on the page is
-                                the CLIENT's prefix, not the bytes'"
-                        (is (not= server-id (probe-id container))
-                            (str "the disagreeing client id must have replaced the "
-                                 "server's; both read " (pr-str server-id)))
-                        (is (str/includes? (probe-id container) "pfx-b-")
-                            (str "and it is the client's prefix; got "
-                                 (pr-str (probe-id container)))))))
+                    (testing "and the recovery is visible: the id on the page is
+                              the CLIENT's prefix, not the bytes'"
+                      (is (not= server-id (probe-id container))
+                          (str "the disagreeing client id must have replaced the "
+                               "server's; both read " (pr-str server-id)))
+                      (is (str/includes? (probe-id container) "pfx-b-")
+                          (str "and it is the client's prefix; got "
+                               (pr-str (probe-id container)))))))
                 (settle-row!
                   {:row      "§5 — a client prefix that disagrees with the bytes"
                    :done     done


### PR DESCRIPTION
## The fault

`identifier_prefix_ssr_dom_cljs_test` has four async adoption rows, and **there is
no rejection arm anywhere in the file** — `grep -c -F '.catch'` returns `0` against
`6` on the sibling `server_render_ssr_dom_cljs_test` that PR #8675 repaired, so the
pattern reaches this corpus and the zero is a reading rather than a broken search.

Each row ended inside its fulfilment handler:

```clojure
(-> (sup/adopted! handle)
    (.then (fn [ok] … (try …assertions…
                           (finally (stop!) (mount/release! handle) (done))))))
```

On a rejection the handler is skipped, so the `try` is never entered and its
`finally` never fires. **Nothing runs at all** — no `stop!`, no `release!`, no
`done` — with three consequences:

1. **The failure is opaque.** The row does not go red on its own account.
2. **The watcher and the root leak into the next row**, whose census is then
   measuring residue. §4 leaks two roots.
3. **What the adoption threw is lost.**

Measured, consequence 1 is worse than "it hangs". The sabotage run below restores
the pre-repair shape, and the unhandled rejection reaches the page as an uncaught
error, which this runner treats as terminal (rf2-u0j8): **the whole lane stops at
this namespace.** It announced 85 namespaces, the last being this one, and every
namespace scheduled after that never executed. There is no `Ran N tests` line at
all — against 1070 tests / 6059 assertions on the repaired tree. So consequence 2
understates it too: on the browser lane there is no next row to inherit anything.

A fourth consequence was not in the original write-up, and it is the sharpest.
§2 and §5 open their console capture with `:swallow-uncaught? true`. A capture
that outlives its row leaves `console.error` replaced *and* a `window` "error"
listener calling `preventDefault` on every later row's uncaught errors — the
browser runner's pageerror rule silently disarmed for the rest of the run.

One correction while I was at it. The sibling's control describes this fixture as
one that "does not unmount a root, unregister a trace listener, or hand
`console.error` back". The trace-listener third is wrong for
`make-reset-runtime-fixture`: its shared reset body calls
`trace-tooling/clear-listeners!`, and under `:async? true` that runs in `:before`,
so a leaked watcher *is* swept. §6 asserts `stop!` ran anyway — a row that leans on
the fixture to stop its own watcher is measuring the fixture — and says so in the
row rather than repeating the overstatement. The sibling's prose is outside this
fence and untouched.

## The repair

`settle-row!` is the one path all four now end with: one `.then` carrying **both**
handlers, so a throwing body cannot also reach the rejection arm and finish the
row twice; the release and the `done` beyond both; `done` in a `finally`; and a
`:row` label carrying what each site said by hand.

Two things worth reading rather than skimming:

- **§4 releases the FULL handles** where the `finally` it replaces passed
  `(assoc h :root nil)`. That spelling was correct on the one path it could be
  reached on — the body unmounts both roots to take its census, so by then there
  was no root left to unmount. On a rejection the body may never reach those
  unmounts, and `:root nil` would skip the React unmount entirely and leak a live
  root. `mount/unmount!` is idempotent by its own docstring, so the full handle is
  right on both paths.
- **`close!` stays at the top of the `.then` AND is named in `:release!`.** It is
  idempotent by construction (a `closed?` volatile), so the fulfilment path still
  bounds the capture across the render while the rejection path still hands
  `console.error` back.

## §6, the leak control

The four rows all fulfil on a green run, so `settle-row!`'s rejection arm is on no
green path — and a repair to a branch nothing takes is untested by construction.
§6 takes it: it injects the rejection **after** the adoption has completed, which
is the harder case, because every resource the row owns is live and committed at
that moment and there is strictly more to release.

It asserts the row reports what was thrown, ends exactly once, and leaves behind
no root, no frame, no listener and no replaced console.

## Judgement: re-applied locally, not lifted — and why

`settle-row!` now exists twice, verbatim. The lift into `roots-frames-support` is
filed as **rf2-7ucn** rather than done here, for two reasons:

1. **This bead's fence is one namespace.** Lifting while the sibling's copy stands
   gives the corpus two definitions of one helper — worse than either clean answer
   — and removing that copy is outside the fence.
2. **Where the helper lives its controls have to live too**, and
   `roots_frames_support.cljs` holds no `deftest`s by convention. That is a design
   call, not a mechanical move.

The brief warned against lifting on the strength of two files. **It is not two.**
Measured with the same fixed-string instrument over the package's test tree:

| file | `sup/adopted!` | `.catch` | status |
|---|---|---|---|
| `server_render_ssr_dom_cljs_test` | 7 | 6 | repaired, rf2-sxhu |
| `identifier_prefix_ssr_dom_cljs_test` | 5 | 0 | repaired here |
| `roots_frames_hydration_dom_cljs_test` | 3 | 0 | **same fault** → rf2-8zhr |
| `presence_ssr_seam_dom_cljs_test` | 2 | 0 | **same fault** → rf2-z17t |
| `instance_key_payload_ssr_dom_cljs_test` | 1 | 3 | different shape — see below |

So the shape reaches **four** namespaces. Both untouched ones are reported and
left alone per the fence. `instance_key_payload` is *not* the same fault and
should not be swept in: its rows settle exactly once and do report the rejection;
only their teardown is skipped on that path, and an inline comment argues that
case deliberately.

The two copies are spelled identically on purpose, so rf2-7ucn is a deletion and a
`:require` rather than a reconciliation of two designs.

## No assertion changed — proven mechanically

Every **balanced** `(is …)` form was extracted from both revisions with a
reader-aware scanner (strings, escapes, character literals and `;;` comments all
modelled) and diffed:

```
base=48  new=59
hunk kinds present: a          <- append only; zero '<' lines
```

48 forms in, 48 forms out unaltered and in order; 11 added (2 inside `settle-row!`,
9 in §6). The scanner was exercised in both directions before being believed —
green on the known-good revision, and it names the right line on an input with one
paren removed. The diff itself was exercised too: altering a single word in one
base assertion turns the append-only `a` into a `c`.

## Gates

All on the final rebased base, each phase run separately with its exit code
captured on its own command line — never through a pipe, and the captured number
is the one quoted:

| gate | captured exit | reading |
|---|---|---|
| `shadow-cljs compile browser-test` | 0 | 1084 files, 0 warnings |
| `serve-and-run-browser-tests.cjs` | 0 | Ran 1070 tests containing 6059 assertions. 0 failures, 0 errors. |
| `npm run test:cljs` (node lane) | 0 | Ran 11817 tests containing 59593 assertions. |

Both browser logs name this worktree's own `shadow-cljs.edn` and
`out/browser-test`, which is how the run is known to have read this tree — so the
plant was not needed for discrimination and served only the acceptance's "fails
before the repair".

The sabotage control ran the pre-repair condition — `settle-row!`'s rejection arm
removed, restoring "no rejection arm anywhere in the file". §6 goes red under it:
captured exit `1` against `0` on the repaired tree, naming `adoption rejected on
purpose` at this namespace's own compiled module. Both halves of a believable
sabotage hold — the git **blob** hash proves the source changed, and the compile
reporting `2 compiled` rather than `0` proves the runtime observed it.

The plant's match count was read before the gate was spent, which is what caught
it matching **zero** times on the first attempt: the anchor carried a bare `LF`
against a `CRLF` checkout, so it refused rather than no-opping into a green run
that would have read as "the control does not bite". The restore was verified by
hashing back to the committed blob, not by reading a diff.

One number to be careful with: the harness reported exit `0` for the very
background task whose captured run exit was `1`, because that shell's last command
was the `echo` that wrote the exit file. The captured numbers are the ones quoted
here.

`report-changed-surfaces.sh`, handed the changed **path** (it takes paths, not
revisions — handed revisions it reports every surface false, which is
indistinguishable from a genuinely unaffected change), arms `cljs_browser`,
`cljs_node_test`, `implementation_jvm`, `migration_hicasso_codemod`,
`hicasso_controlled` and `hicasso_hmr`. The first two are the load-bearing ones and
both were run locally; CI owns the rest.

Nothing outside `implementation/hicasso/test/re_frame/hicasso/identifier_prefix_ssr_dom_cljs_test.cljs`
is touched — no markdown, so neither `check_doc_slugs.py` nor
`check_readme_links.py` is the gate here. The one table in this PR description was
column-counted by hand: 7 rows, 4 columns throughout.

rf2-x43z
