### PR TITLE
docs(method): a queued measurement window makes an otherwise-free slot not free (rf2-fif4)

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -458,6 +458,17 @@ constraint a measurement window is already fenced under, seen from the other sid
 is held for a quiet machine, and a heavyweight gate is what makes the machine loud. Keep one
 vocabulary for the two rather than inventing a second.
 
+**A queued measurement window makes an otherwise-free slot not free.** The drain clause in
+the filter list does not reach this case — it lifts only once the exclusive items are all
+that remains — so where ordinary work is still available, nothing above holds you back and
+refilling is itself what fences the window. While a window needing a quiet machine is queued
+and unstarted, an item whose gate is heavyweight is not a slot to refill but a cost charged
+to that window: hold the fleet thin on purpose, say so on the window's own item with what
+releases the hold, and keep dispatching work whose gate leaves the machine quiet.
+Documentation and prose changes typically arm no gated surface at all, so the fleet stays
+busy while the window waits — the instruction is to stop making the machine loud, not to
+stop working.
+
 Pick the shape by kind first, then priority, then size. The shapes are in
 [`dispatch-prompt-template.md`](dispatch-prompt-template.md).
 


### PR DESCRIPTION
## What and why

`loops.md` §2 carries two passages that are each correct and that together leave a hole:

* the filter list's last entry excludes contended-exclusive items, but its drain clause only
  lifts **once the exclusive items are all that remains**;
* "Shape and saturation" says to **refill the instant a slot frees**.

Neither covers the common middle case: a measurement window is queued and unstarted, ordinary
dispatchable work exists with free surfaces and no operator hold, but every item of that work
runs a heavyweight gate. The drain clause does not authorise holding thin, because the exclusive
items are *not* all that remains; the saturation block positively instructs refilling; and the
paragraph directly above already says a heavyweight gate is contention for the *machine* and is
"what makes the machine loud". So refilling is what fences the window, and the document tells you
to refill. A mayor following the page exactly would saturate and fence the measurement lane
indefinitely.

This adds **one clause** — a single paragraph — supplying the consequence for the refill
decision, and names the light-gate escape so the rule is actionable rather than merely
restrictive.

**Placement.** On the saturation block rather than on the filter entry, because that is where the
wrong reading is manufactured: a reader who has reached the filter entry has already been told to
refill. Within the block it sits immediately after the heavyweight-gate paragraph, which is where
the vocabulary it depends on is established ("a window is held for a quiet machine, and a
heavyweight gate is what makes the machine loud") and which that paragraph itself asks be kept as
one vocabulary. The heavyweight paragraph is not restated.

**The escape, measured rather than asserted.** The changed-surface classifier arms **no** surface
at all for `docs/the-mayor-method/loops.md` — 0 of 28 keys true — against a control of **5** armed
surfaces (`cljs_node_test`, `cljs_browser`, `migration_hicasso_codemod`, `hicasso_controlled`,
`hicasso_hmr`) for a spec path under `implementation/`. Both runs exited 0, so the instrument was
exercised against an input it should flag rather than only against one it should not. Doc and
prose work therefore leaves the machine quiet, and the fleet can stay busy while a window waits:
the instruction is to stop making the machine loud, not to stop working.

## Scope

* One file, one paragraph, **11 insertions, 0 deletions**.
* No new section. **No heading moved or changed** — verified by diffing the file's `^#` lines
  against `HEAD`, which came back identical, so every anchor cited from outside this tree is
  intact.
* `README.md` untouched.
* Generic: no repository paths, tracker ids, shell syntax, tool invocations or change numbers in
  the added text.
* **Nothing became redundant.** The clause was checked against its three neighbours — the refill
  instruction, the heavyweight-gate paragraph and the filter list's drain clause. It qualifies the
  first, depends on the second and cites the third's boundary; none of them is now saying
  something this paragraph also says, so no cut is proposed.

## Quality gates

| Gate | Captured exit | Notes |
|---|---|---|
| `check_doc_slugs.py` (baseline, pre-plant) | **0** | `no broken links.` |
| `check_doc_slugs.py` (**sabotage**) | **1** | reddened on the planted fault |
| `check_doc_slugs.py` (post-restore) | **0** | |
| `check_doc_slugs.py` (post-rebase, final base) | **0** | |
| `mkdocs build --strict` (post-rebase, final base) | **0** | built in 19.86 s |

Every exit code above was captured in-shell on the runner's own command line and read back from
its own exit file; none is a harness-reported number, and no gate was piped through a filter.
Artefacts were named for this worktree and for the attempt.

**Gate selection, verified at source rather than from prose.** `docs` is in the doc-slug gate's
`DEFAULT_ROOTS`, and `docs/the-mayor-method` is one of the two entries in its
`FENCED_DOC_LINK_TREES`, so this tree is held to the stricter in-fence rule where a doc link
inside a fenced block is itself reported. `mkdocs.yml`'s `docs_dir` is `docs` and its
`exclude_docs` block lists six trees, none of them this one — so the strict build does cover this
page, and it was run. No CLJS or browser lane was run: this change arms no such surface (measured
above), and a heavyweight lane here would have fenced the very window the clause is about.

**The planted fault, and what makes its red discriminating.** The gate is silent on green and
prints no root, so the printed-root route was unavailable and the proof is the red. A single-line
anchor, placed mid-line so a translated line ending could not defeat it, was planted at a line
this change already edits; its match count was read as exactly 1 before the run, so it cannot have
silently no-opped. The gate came back exit 1 with `BROKEN ANCHOR: ...loops.md:466 ->
#planted-fault-no-such-heading`, naming what was planted, at a line that exists only in this
branch — a run that had wandered into another checkout would have come back green.

The working edits were committed **before** the plant, so the restore could not discard them. The
restore was verified by **blob** hash against the committed object — the restored file's hash
equals the committed blob's `81b0c64fc3726f27f8bd1c3d7148bb24b9f2c6ac`, and it is unchanged after
the rebase — not by reading a diff, since "unchanged" and "not attempted" produce the same diff.
A search for the planted string afterwards returned 0.

Gates were re-run on the **final base** after the rebase; the pre-rebase greens are not being
cited for the tree that is being proposed.

## Verified by hand, because nothing gates it

Nothing gates prose, anchors-in-context, table column counts or rendering, so these were checked
by hand:

* **Prose** read in place, in the block's own register — full sentences, the page's existing
  vocabulary (`measurement window`, `quiet machine`, `heavyweight gate`, `hold thin`), and the
  same em-dash and straight-apostrophe conventions the file already uses (0 curly apostrophes in
  the file, and none introduced).
* **Anchors in context**: the added text introduces **no** links and **no** headings — 0 `](`
  occurrences across the added lines — so it can neither create nor invalidate an anchor. The
  file's heading list is byte-identical to `HEAD`'s.
* **Tables**: no table line is touched anywhere in the diff (0 `|`-bearing lines added or
  removed), so no column count changed.
* Line wrapping matches the surrounding block, which wraps at ~93 columns.

## Diff against the merge base

Diffed three-dot against the merge base, read for what it would **revert** rather than for
conflicts: **0 deleted lines**, so nothing a sibling landed can be undone by this change. Nothing
landed on `docs/the-mayor-method/` between the merge base and the trunk tip; the two intervening
commits are tracker checkpoints.

## Premises checked

Every line-number and gate claim in the brief was re-verified at source rather than relied on.
All held, with one immaterial drift: the heavyweight-gate paragraph runs to line 459, not 458 as
cited. The classifier measurement was re-taken at this tip rather than quoted, and reproduced.
