### PR TITLE
docs(method): a category is not a measurement — earn the light-gate licence per item (rf2-fif4)

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -465,9 +465,11 @@ refilling is itself what fences the window. While a window needing a quiet machi
 and unstarted, an item whose gate is heavyweight is not a slot to refill but a cost charged
 to that window: hold the fleet thin on purpose, say so on the window's own item with what
 releases the hold, and keep dispatching work whose gate leaves the machine quiet.
-Documentation and prose changes typically arm no gated surface at all, so the fleet stays
-busy while the window waits — the instruction is to stop making the machine loud, not to
-stop working.
+Quiet is a property of the whole set of gates an item arms, and **no single classifier's
+answer describes that set** — enumerate what covers the item and confirm each of those
+gates leaves the machine quiet. Documentation and prose usually clear that bar and are what
+keeps the fleet busy while a window waits, but earn that per item rather than granting it
+per category. The instruction is to stop making the machine loud, not to stop working.
 
 Pick the shape by kind first, then priority, then size. The shapes are in
 [`dispatch-prompt-template.md`](dispatch-prompt-template.md).


### PR DESCRIPTION
Repairs the escape clause in `docs/the-mayor-method/loops.md` §2 "Shape and saturation".
The paragraph is right; its closing sentence was not.

## What was wrong

The clause read: *"Documentation and prose changes typically arm no gated surface at
all, so the fleet stays busy while the window waits."* That was inferred from one
measurement — `.github/scripts/report-changed-surfaces.sh` returning 0 of 28 keys for
`docs/the-mayor-method/loops.md`. That is **that classifier's** answer, and it is
`test.yml`'s classifier only. It is not a census of gates.

Three separate classifiers decide what a change runs in this repository, each with its
own path list:

| Classifier | Covers this path? |
|---|---|
| `test.yml` → `.github/scripts/report-changed-surfaces.sh` | no — 0 of 28 keys |
| `docs.yml` → `Detect docs surface` | **yes** — `docs/*` → `docs_surface=true` |
| `lint.yml` → `Detect lint surface` | no — matches none of its arms |

Plus one job with **no surface guard at all**, so no classifier speaks for it:
`test.yml`'s `verify-readme-links`, which runs `check_doc_slugs.py`.

## Premises verified at source, not quoted

* `.github/workflows/docs.yml:209` — the case list maps `docs/*` (and `spec/*`,
  `migration/*`, `mkdocs.yml`, `TESTING.md`, `README.md`, `CLAUDE.md`, `testbeds/*`,
  `tools/*/spec/*` and more) to `docs_surface=true`; the `MkDocs build` job at
  :216-219 is gated on exactly that output.
* `.github/scripts/report-changed-surfaces.sh:44-45` — its **own comment** names
  "docs.yml's `Detect docs surface` step (rf2-ihfw) and lint.yml's lint-surface
  classifier (rf2-4sl9)" as separate paths it does not cover.
* PR #8678, which landed the clause, **ran and passed** `Detect docs surface`
  (3m48s) and `MkDocs build` (2m1s). The refutation was in its own check rollup.
* `.github/workflows/lint.yml:216` — the doc arms are `skills/*|docs/core/*|docs/*/concepts.md`
  and `spec/Privacy.md|docs/api/*|docs/story/api/*`. This path matches none, so
  `lint_surface=false`. Prose, but a different answer again.

## The counterexample, re-measured here rather than quoted

`implementation/hicasso/spec/budgets.md` is prose (a 177 KB markdown page), is
**in `docs.yml`'s `docs_surface` case list**, and classifies as:

```
$ .github/scripts/report-changed-surfaces.sh implementation/hicasso/spec/budgets.md
cljs_node_test=true  cljs_browser=true  migration_hicasso_codemod=true
hicasso_controlled=true  hicasso_hmr=true          # 5 of 28, exit 0
```

Three of those five are browser lanes — `CLJS (shadow-cljs :browser-test, headless
Chromium)`, `CLJS hicasso controlled-input correctness (real Chromium + Firefox +
WebKit)`, `CLJS hicasso HMR contract through a real shadow reload (Chromium + Firefox
+ WebKit)` — and `CLJS (shadow-cljs :node-test)` measured **11m20s** on PR #8674.
Under the clause as merged, a prose edit there is nominated as the light escape and is
the heaviest change in the repository.

That control is also the instrument check the method requires: a classifier that can
answer "nothing here" was exercised once against an input it should flag, and it
flagged it.

## The repair

Three lines replaced by five — **net +2** in one existing paragraph, no new paragraph,
no new section. The categorical claim becomes a verification, which is the method's own
house style and is strictly stronger:

> Quiet is a property of the whole set of gates an item arms, and **no single
> classifier's answer describes that set** — enumerate what covers the item and confirm
> each of those gates leaves the machine quiet. Documentation and prose usually clear
> that bar and are what keeps the fleet busy while a window waits, but earn that per
> item rather than granting it per category. The instruction is to stop making the
> machine loud, not to stop working.

Documentation and prose stay named, because a rule that only restricts gets routed
around — but conditionally, as a bar usually cleared rather than a category exempt.
The closing licence is kept verbatim.

**The consequence is not inflated.** The real covering gates for this tree were measured
at about twenty seconds each. This is a defect in the reasoning and in the paths it
wrongly nominates, not a demonstrated wedge, and the replacement says nothing implying
documentation work is dangerous.

## My own complete covering gate set — enumerated, which is what the repaired clause demands

| Gate | Covers this change? | Result |
|---|---|---|
| `docs.yml` `MkDocs build` (`mkdocs build --strict`) | **yes** — `docs_dir: docs`, and `exclude_docs` lists six trees, none of them `the-mayor-method` | exit 0, built in 25.25 s |
| `test.yml` `verify-readme-links` → `check_doc_slugs.py --verbose` | **yes** — `docs` is in `DEFAULT_ROOTS`, and `FENCED_DOC_LINK_TREES` is exactly `docs/design/hicasso` and `docs/the-mayor-method`, so the stricter in-fence rule applies here | exit 0, "no broken links" |
| `test.yml` `verify-readme-links` → `check_doc_slugs.py --self-test` | same job | exit 0, 146 self-tests |
| `test.yml` `verify-readme-links` → `check_readme_links.py --ci` | no — docs-gate roots are excluded from its roster, but it shares the job | exit 0 |
| `test.yml` surface-gated lanes (28 keys) | no — 0 armed, exit 0 | none run |
| `lint.yml` clj-kondo / Splint / api-manifest | no — `lint_surface=false` | none run |
| `docs.yml` `provenance-pins` (`check_provenance_pins.py`) | no — scoped to `docs/design/hicasso/` | none run |

Both covering gates are light **by measurement, not by category** — about 25 s and about
20 s. That is the distinction this change is about.

## Gate mechanics

Every exit code captured in-shell on the runner's own command line, never piped through
a filter, never read from a harness report.

* `check_doc_slugs.py --verbose`: baseline **exit 0** → sabotage **exit 1** → post-restore
  **exit 0** → post-rebase **exit 0**.
* `mkdocs build --strict`: baseline **exit 0** (22.70 s) → sabotage **exit 1** →
  post-rebase **exit 0** (25.25 s).

**Planted faults — one per covering gate, because neither prints a root it could be
checked against.** The file is CRLF, so both anchors were planted mid-line and the match
count was read as exactly **1** before each run, so neither plant can have silently
no-opped. Edits were committed **before** either plant.

* Doc-slug gate: a same-page fragment. Returned exit 1 naming
  `BROKEN ANCHOR: docs\the-mayor-method\loops.md:469 -> #planted-fault-covering-no-such-heading`.
* MkDocs: a link to a non-existent page. Returned exit 1 naming
  `Doc file 'the-mayor-method/loops.md' contains a link 'planted-fault-covering-no-such-page.md' …`
  then `Aborted with 1 warnings in strict mode!`.

The red **is** the discrimination: both faults existed only on this branch, at a line
number that exists only on this branch, so a run that had wandered into the mayor
checkout or a sibling worktree would have come back green. MkDocs additionally lists
`the-mayor-method/loops.md` among the pages it built, so its runtime observed this
tree's copy.

Both restores verified by **blob hash** against the committed object — working blob and
the committed `docs/the-mayor-method/loops.md` blob both
`0b85c0e5293bd74a4b7e23a4154e7dfbe964352b`, unchanged again after the rebase — never by
reading a diff. Searching for the planted string afterwards returned 0.

## By hand, because nothing gates it

Nothing validates prose, register, anchors-in-context, rendering, nav or table column
counts, so these were checked by hand:

* **Headings**: the file's heading lines diffed against the committed version —
  **identical text**, no heading added, removed or reworded. Only line numbers shift
  (+2 below the edit), which no anchor depends on. `README.md` untouched (the diffstat
  is one file).
* **Links and anchors**: 0 links and 0 headings added by the diff, so no anchor can have
  been created or invalidated. (The two planted links were removed and hash-verified.)
* **Tables**: 0 table lines in the diff, so no column count moved.
* **The tables in THIS description** were counted by hand: 2 columns declared and 2 in
  every row of the classifier table; 3 declared and 3 in every row of the covering-set
  table.
* **Wrapping**: replacement lines are 88/88/91/89/86 columns against the block's existing
  81-93.
* **Register**: full sentences, em-dash usage matching the file, one mid-paragraph bold
  for the load-bearing turn as the adjacent paragraph already does. 0 curly apostrophes
  introduced (the file has none).
* **Genericity**: the added text carries no repository path, tracker id, workflow
  filename, shell syntax, change number or platform detail.

## Merge-base diff, read for reverts rather than conflicts

Three-dot against the merge base: **5 insertions, 3 deletions, one file**. The three
deletions are the replaced sentence and nothing else. Nothing landed on
`docs/the-mayor-method/` between the merge base and the trunk tip — the one intervening
commit is a tracker checkpoint. Rebased onto the current trunk and both gates re-run on
the final base.

## Redundancy check

The minimality test licenses deleting as readily as adding, so the replacement was checked
against its three neighbours: the refill instruction it qualifies, the heavyweight-gate
paragraph it depends on, and §1's *"a surface-armed job is skipped on every change that
touches none of its surfaces"*. That last one is the closest, and it is about reading a
skip on the trunk rather than about deciding what a dispatch will arm — the two do not
overlap. **No cut is proposed.**

No `node_modules` junction was created (doc-only), so none to remove.

Closes rf2-fif4.
