### PR TITLE
docs(method): the reaping escape survives a missing agent id, but the content match is many-to-one (rf2-qche)

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -778,6 +778,16 @@ eight while their real transcripts sat complete elsewhere, *also* empty for a cu
 that finished normally, and for the eighth held a hardlink to the real transcript, so the wrong
 file returned one plausible non-empty result and made the wrong conclusion self-consistent.
 
+**When no id was recorded at all, the report is not missing — only unindexed.** Search the
+transcripts for the worktree's own path, which a dispatch names and so does the report that ends
+the work, then read a bounded TAIL of a file that matches rather than opening it, because these are
+append-only logs of whole sessions and routinely run to megabytes. **But the match is many-to-one,
+and most of its hits are not the worker's own** — the dispatching session's own transcript names
+that path, and so does every peer brief that lists the in-flight write surfaces, because this
+method requires naming them — so identify a file as the WORKER'S OWN before anything in it counts
+as that worker's report; reaping on a peer's mention of a worktree is reaping on someone else's,
+which is strictly worse than leaving the tree standing.
+
 A transcript path the platform documents as an implementation detail is not a contract, and
 local-history retention sweeps typically DELETE rather than truncate — so whether to hold the report
 text somewhere of your own is the operator's call.


### PR DESCRIPTION
Closes rf2-qche (do not auto-close — the mayor closes this).

## What changed

One paragraph, two sentences, added to the reaping run in the hygiene loop's section of
`docs/the-mayor-method/loops.md` — immediately after the existing transcript escape and its
id-mechanics caveats, and before the caveat that a documented transcript path is not a contract,
so that caveat now covers this route too.

The method authorises reaping only on the worker's own quotable completion report, and offers an
escape: reading the agent's transcript is a READ and satisfies the test. But that escape was keyed
to an agent id the dispatch-time mapping file usually does not carry, so a worktree dispatched
before ids were recorded was unreapable by anybody, forever. The addition says the report is not
missing but merely unindexed — it is reachable by searching transcript CONTENT for the worktree's
own path — and, in the same breath, that the match is many-to-one because this method requires
peer briefs to name each other's in-flight write surfaces, so a file must be identified as the
WORKER'S OWN before anything in it counts as that worker's report. It also carries the second
hazard: locate then read a bounded TAIL, never open one whole.

Ten insertions, zero deletions. No section added, no restatement of the reaping rule.

Written generic, as the page requires: no OS-specific or repository-specific paths, no tool names
peculiar to this repository, no operator's name, and **no counts** — the census the item cited was
already stale when the work started, and this page is method guidance rather than a status report,
so the text states a bare mechanism that cannot go stale.

## Quality gates

Both gates genuinely cover this path: it sits inside `docs_dir` and is absent from `mkdocs.yml`'s
`exclude_docs` block (checked in `mkdocs.yml`, not recalled). The changed-surface classifier
reports all 28 `test.yml` surfaces FALSE for this path, so no CLJS, browser or compile lane is
armed; none was run, the machine being inside a quiet-box measurement window.

Exit codes captured with `echo $?` on the same command line as the run:

| Gate | Baseline | Sabotage | Restore |
|---|---|---|---|
| `python scripts/check_doc_slugs.py` | 0 | 1 | 0 |
| `python -m mkdocs build --strict` | 0 | n/a | 0 |

Sabotage: one bounded fault — a broken in-page anchor `[bounded TAIL](#zzz-no-such-anchor-xyzzy)`
planted at a line already being edited. Match count for the replaced phrase read as exactly 1
before the run, so it could not silently no-op, and the anchor was planted MID-LINE because this
checkout translates line endings. The gate went RED at exit 1 and named precisely what was
planted, at this file and at the new line 783 — a line that exists only in this branch, which is
also what confirms the gate read this worktree rather than another. Restore verified by
`git hash-object` against the committed blob (both `49c8cf95acc38e1dd69b17ea78b5e1db62b41d28`),
not by reading a diff and not by a byte digest. Own edits were committed before the fault was
planted.

`mkdocs build --strict` additionally listed `the-mayor-method\loops.md` among the pages it built,
confirming it too read this worktree. Builds: 21.22 s and 19.84 s.

## Verified by hand, because nothing gates it

Nothing validates this document's prose, tables or rendering, so:

- **Headings**: zero added or altered — `git diff origin/main...HEAD | grep -c '^+#'` reads 0. No
  heading anchor anywhere in the repository can therefore have been invalidated.
- **Links**: zero added — `grep -cE '^\+.*\]\('` reads 0. Nothing for either link gate to check.
- **Tables**: zero table lines touched — `grep -cE '^\+.*\|'` reads 0, so no column count changed.
- **Fences**: zero fence markers added, and a fence-marker count over the preceding 780 lines reads 0, so the insertion
  is unambiguously in prose. This matters here specifically: `docs/the-mayor-method/` is one of only
  two trees where a doc link inside a fence is itself reported.
- **Register and wrapping**: full sentences, failure mode named before the remedy, bolded lead
  clauses, wrapped to the surrounding 94–99 columns.

## Premises re-derived at source

The item's own figures did not reproduce, and the mechanism it argues for came out stronger:

- **Its census is stale, as the dispatch said.** It cited 35 registered worktrees with three
  carrying an agent id; the register read 35 lines again at the time of writing, having moved in
  both directions during the session. This is exactly why the text cites no number.
- **Its content-search figure is wrong by more than an order of magnitude, in the direction that
  matters.** It recorded that searching for one worktree name returns SIX files. Measured over the
  full transcript corpus for this project, that same name returns **105** files, spread across the
  dispatching session's transcript, a second session's transcript, and dozens of sibling worker
  transcripts. The many-to-one hazard is therefore considerably worse than the item diagnosed,
  which is why the guard sentence is phrased as identify-before-you-count rather than as a caution.
- **A negative control discriminates, with one instructive exception.** A worktree name that cannot
  exist returned exactly one file — the searching agent's own transcript, which contains the search
  string because the search was typed into it. Every other file correctly returned nothing. This is
  a guaranteed false positive for whoever runs the route, and it is already covered by the text: the
  reaper is normally the dispatcher, and the sentence names the dispatching session's own transcript
  as the first hit that is not the worker's own.
- **Its size figures do not reproduce, and the hazard is larger than stated.** It recorded median 32
  bytes and a maximum of ~23.6 MB. Measured over this project's transcript corpus: median ~0.79 MB,
  maximum ~100 MB, 4.4 GB across 3,981 files, none empty. The item's numbers appear to describe a
  different tree — plausibly the per-agent scratch sink the page already warns about, whose files
  are tiny. Opening one whole is a worse idea than the item argued, so the text states the structural
  reason (append-only logs of whole sessions) rather than any figure.
- **The item's fence is cleared.** It fenced on worker `covering` holding this file for rf2-fif4;
  that item is CLOSED and its change merged, and no commit between the branch point and the trunk
  touched this file.

## Revert check

Two changes landed in this exact file during the same session, so the branch was fast-forwarded to
the trunk before any edit and the diff was read against the merge base for silent deletions:
`git diff --numstat origin/main...HEAD` reads `10 0` on the single file. Pure addition; nothing
reapplied, nothing reverted.
