### PR TITLE
docs(method): scope the shared-scratch hazard to any directory you do not own, not one named area (rf2-n3uw)

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -530,6 +530,13 @@ peer, under exactly the bare name the rule forbids. **A rule scoped to a ROLE ex
 does not identify with the role** — when a hazard belongs to a shared resource, scope it to
 the resource.
 
+Naming one shared area re-creates that exemption one level down. Reaching for a system temp
+directory feels like stepping out of a shared area into a private one, and it is the reverse:
+every session on the machine writes there, where the session scratch area holds only the
+current session's agents. It changes the resource without changing the hazard, and it reads
+as exempt precisely because it is not the area the rule names — so the scope is **every
+directory you do not exclusively own**, not the one a rule happens to name.
+
 ---
 
 ## 3. Backlog reread


### PR DESCRIPTION
## What and why

`docs/the-mayor-method/loops.md` §2's block *You are one of the concurrent writers* fixed a
ROLE-scoped rule by re-scoping it to a RESOURCE — and then named exactly one resource, the
session-keyed scratch area. A write that lands in a system temp directory is not that area, so the
sentence reads as not addressed to it. That is the same exemption mechanism the block exists to
close, recurring one level down: scoping to one resource exempts whoever writes to another.

The direction is the counter-intuitive part, which is what earns three sentences in the document
rather than a note on the item. Reaching for a system temp directory feels like stepping out of a
shared area into a private one, and it is the reverse — that directory is shared across every
session on the machine, where the session scratch area holds only the current session's agents. It
is the wider exposure wearing the appearance of a private one.

Three sentences appended inside the existing block, after the generalisation it already carries. No
new section, no restatement of the naming rule itself, and no counts: the measured figures are
evidence on the item, and a number in generic method guidance goes stale exactly where it has to be
right. The added text is generic — no OS-specific paths, no repo-specific paths, no tool names.

One file, +7 / −0.

## Quality gates

Exit codes below are the runner's own, captured with `echo $?` on the same command line and via
redirection rather than a pipe (a pipeline reports its last stage, not the runner). Both run from
the repo root.

| Command | Exit |
|---|---|
| `python -m mkdocs build --strict` | 0 |
| `python scripts/check_doc_slugs.py` | 0 |

The changed path is inside `docs_dir` and absent from `mkdocs.yml`'s `exclude_docs`, verified at
tip, so both of these cover it.

Deliberately not run: the changed-surface classifier reports all 28 `test.yml` surfaces FALSE for
this path, and `lint.yml`'s surface (`implementation/`, `tools/`, `examples/`, `testbeds/`) does not
include `docs/`, so its expensive jobs skip job-side. No CLJS, browser or compile lane is armed by
this diff.

### Sabotage

With the real edit already committed, one bounded fault — a broken in-page anchor — was planted
mid-line on a line this change adds. Mid-line placement is deliberate: an anchor at end-of-line
matches nothing where line endings are translated. The match count was read as 1 before any gate ran.

- `python scripts/check_doc_slugs.py` → exit **1**, reporting
  `BROKEN ANCHOR: docs\the-mayor-method\loops.md:537 -> #sabotage-anchor-…`. Red, and it names both
  the file and the anchor that was planted — which is also what confirms the gate read this
  branch's checkout rather than a peer's.
- `python -m mkdocs build --strict` → exit **0**. It observes the same broken anchor but logs it at
  INFO, and `--strict` does not promote INFO, so mkdocs is **not** the anchor gate here;
  `check_doc_slugs.py` is the one that catches it. Recorded because a green mkdocs run on a broken
  anchor would otherwise read as coverage it does not provide.

The fault was then removed and the restoration verified with `git hash-object` against the committed
blob — identical — rather than by reading a diff, and not by a byte digest, since line endings are
translated in this checkout. The gate was re-run after restoring and returned to exit 0.

## Verified by hand

Nothing gates this document's prose, so:

- **Headings / anchors** — the addition introduces no heading, so no anchor is created, renamed or
  orphaned, and no existing link can be left dangling. The enclosing
  `### You are one of the concurrent writers` line is untouched.
- **Links** — the addition contains no link, in prose or otherwise. (`docs/the-mayor-method/` is one
  of only two trees where a doc link inside a fenced block is itself reported; moot here, as this
  change adds no fence.)
- **Tables** — no table row added or altered, so no column count changed anywhere in the page.
- **Register** — full sentences, failure mode named before the remedy, matching the surrounding
  block.

The diff was read against its merge base for reverts before pushing: pure addition, zero deleted
lines. Three changes landed in this file within the last day (#8678, #8679, #8681); this branch is
based on the tip carrying all three, and #8681 — the fence recorded on the item — is MERGED, so the
sequencing condition was met before work started.

Refs rf2-n3uw. Leaving this open rather than merging; the item stays open for the mayor.
