### PR TITLE
docs(method): a gate test answers loudness, not whether a peer write breaks a measurement bracket (rf2-1yct)

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -470,6 +470,13 @@ answer describes that set** — enumerate what covers the item and confirm each 
 gates leaves the machine quiet. Documentation and prose usually clear that bar and are what
 keeps the fleet busy while a window waits, but earn that per item rather than granting it
 per category. The instruction is to stop making the machine loud, not to stop working.
+But that test answers loudness alone, and a window may register more than quiet. Where
+one registers that no peer writes inside its bracket, **any write voids the run however
+cheap it is** — merging a change and creating a worktree each cost the machine almost
+nothing and each is a write, so a rule ordered by cost gets those two exactly backwards;
+for such a window the fleet is empty rather than thin, and you merge nothing either. Have
+the window record that condition as a test rather than an assurance, capturing the trunk
+tip and the worktree list at both brackets, so a violation is reported rather than assumed.
 
 Pick the shape by kind first, then priority, then size. The shapes are in
 [`dispatch-prompt-template.md`](dispatch-prompt-template.md).


### PR DESCRIPTION
Closes rf2-1yct (bead left open per brief).

## What this fixes

`loops.md` §2's heavyweight-gate paragraph tells the mayor to decide whether an item may be
dispatched beside a measurement window by enumerating the gates the item arms and confirming
each leaves the machine quiet. That is a correct test for machine **loudness** and the wrong
test for an **exclusivity condition**, which a peer *write* violates however cheap the write is.

This was measured, not reasoned. A window voided pre-registered runs because peers wrote inside
its brackets — one a PR merge, one the creation of a worktree for an unrelated doc-only item
that armed no test surface at all. Every invocation exited 0 and there was no rig fault; the
series still came back incomplete. The gate test passed and was the wrong question.

The counter-intuitive point the wording carries: a merge is the single cheapest thing a mayor
does on the machine and one of the most destructive things it can do to a bracket. Any rule
ordered by cost gets that exactly backwards.

Three sentences appended to the existing paragraph — no new section, no restatement of the gate
test, and no counts (figures live on the bead, where they cannot go stale in generic guidance).
The third sentence records the bracket-integrity idea: capture the trunk tip and the worktree
list at both brackets so the condition is *tested* rather than asserted. That is a judgement
call beyond the bead's proposed wording, taken because the next window registered exactly this
condition, captured exactly those quantities at both brackets, and came back clean.

## Quality gates

Path is inside `docs_dir` and not in `mkdocs.yml`'s `exclude_docs`, so both doc gates apply.
Exit codes captured with `echo $?` on the same command line as the runner.

| command | exit |
|---|---|
| `python -m mkdocs build --strict` | `0` |
| `python scripts/check_doc_slugs.py` | `0` |

**Sabotage, because two clean exits prove nothing on their own.** Committed first, then planted
a broken same-file anchor mid-line on a line this PR adds (match count read as `1` before the
run). `check_doc_slugs.py` returned exit `1`, naming `docs/the-mayor-method/loops.md:479 ->
#zz-no-such-anchor-bracketgate` — the gate reads this worktree and does go red on a fault.
The slug gate was sabotaged rather than mkdocs deliberately: `mkdocs.yml`'s `validation.links`
sets only `unrecognized_links: warn` and carries no `anchors` key, so anchors sit at the MkDocs
default of INFO and `--strict` promotes WARNING, not INFO. `check_doc_slugs.py` is the only
anchor gate. Restore verified by `git hash-object` against the committed blob (identical), with
`git status` clean and no residue of the planted string.

No CLJS, browser or lint lane run: all `test.yml` surfaces are false for this path, and
`lint.yml`'s surface is `implementation/`, `tools/`, `examples/`, `testbeds/`.

## Checked by hand, because nothing gates prose

- **Headings** — heading *text* is byte-identical to `origin/main`; only line numbers shift by 7.
- **Tables** — the `|` count is identical to `origin/main`, so no table row or column count changed.
- **Fences** — no fenced block opens anywhere before the insertion point, so the addition is
  unambiguously prose. This matters here because `docs/the-mayor-method/` is one of only two trees
  where a doc link inside a fence is itself reported.
- **Links and anchors** — the added lines contain no `[`, `|` or `#` characters at all: no link,
  no table cell, no heading, and therefore no anchor for either gate to resolve.
- **Diff direction** — diffed against the merge base (`origin/main...HEAD`), not the working tree.
  Four PRs landed in this file in the hours before this change, so a stale region would reapply as
  a silent deletion. The diff is 7 insertions and **0 deletions**; nothing is reverted.

## Wording notes

Generic throughout — no OS-specific or repo-specific paths, no tool names peculiar to this repo,
no operator's name.
