### PR TITLE
test(hicasso): one settlement path for the last two adoption suites (rf2-8zhr, rf2-z17t)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/presence_ssr_seam_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/presence_ssr_seam_dom_cljs_test.cljs
@@ -332,6 +332,116 @@
   (some-> (.querySelector container sel) .-textContent))
 
 ;; ---------------------------------------------------------------------------
+;; Settlement — the ONE way out of an async row, taken on both outcomes
+;; ---------------------------------------------------------------------------
+;;
+;; §3 and §4 each hydrate a real root and wait on `sup/adopted!`, and each
+;; holds things the `:each` fixture will NOT take back: a MOUNTED React
+;; root, with the container `sup/server-dom!` minted still in the document
+;; — the fixture resets frames, disposes the adapter and empties the
+;; runtime, and none of that unmounts a root — and `console.error`,
+;; replaced by `sup/open-console-capture!`, together with the `window`
+;; "error" listener it registered. §3 opens its capture with
+;; `:swallow-uncaught? true`, so a listener that outlives its row goes on
+;; calling `preventDefault` on every later row's uncaught errors, which is
+;; precisely the fail-open the browser runner's pageerror rule exists to
+;; prevent.
+;;
+;; The mismatch watcher's trace listener is the one thing the fixture does
+;; sweep — `make-reset-runtime-fixture`'s `:before` calls
+;; `trace-tooling/clear-listeners!` — and it is still stopped on both paths
+;; here, because a row that leans on the fixture to stop its own watcher is
+;; measuring the fixture.
+;;
+;; These rows used to end INSIDE the fulfilment handler:
+;;
+;;   (-> (sup/adopted! ha)
+;;       (.then (fn [ok] (close!) (stop!)
+;;                       (try …assertions…
+;;                            (finally (mount/release! ha) (done))))))
+;;
+;; There was no rejection arm anywhere in this file, so on a rejection the
+;; handler was skipped, the `try` was never entered and the `finally` never
+;; fired. Nothing ran: no `close!`, no `stop!`, no `release!`, no `done`.
+;; The row did not fail — it HUNG to `cljs.test`'s async timeout, reporting
+;; the timeout rather than the rejection, and it handed the next row a live
+;; root and a swallowing listener to take its census against.
+;;
+;; On THIS lane it is worse than a hang, which is worth knowing before
+;; reading §6's sabotage as merely slow. An unsettled rejection is an
+;; unhandled one, so it reaches the page as an uncaught error, and the
+;; browser runner treats that as terminal (rf2-u0j8). Measured on the
+;; sibling suite: the run stopped at that namespace with 85 announced, no
+;; summary line at all, and every namespace scheduled after it silently
+;; unrun — `shadow.test` runs the whole lane, and the closing summary,
+;; inside one `cljs.test/run-block` with no try/catch. So the cost of a
+;; rejection here was never one row.
+;;
+;; §2 is on it too, and it is NOT an adoption row: it waits on
+;; `sup/settled-server-html!`, which can reject on its own account — its
+;; `.then` reads `.-innerHTML` and calls `mount/release!`. It holds nothing
+;; of its own, so it names no `:release!`.
+;;
+;; §1 and §5 are deliberately NOT on it: both are synchronous end to end —
+;; no `async`, no promise — so there is no settlement question to answer.
+;; The `finally` inside `server-bytes-under-a-hand-held-window!` is an
+;; ordinary bracket for the same reason.
+;;
+;; [[settle-row!]] is the one path all three async rows now end with, and §6
+;; is what says it works — because its rejection arm is on no green path,
+;; and a repair to a branch nothing takes is untested by construction.
+
+(defn- settle-row!
+  "End an async row exactly ONCE, whatever `p` does. `opts` is
+  `{:row :done :release! :report!}`:
+
+    :row      names the row in the failure message. A shared settlement
+              still has to say WHICH row failed, which is the one thing a
+              hand-written rejection arm would give away for free.
+    :done     `cljs.test`'s own, called exactly once.
+    :release! this row's teardown, called exactly once. Every primitive it
+              reaches for is idempotent and says so — `mount/release!`,
+              `(:stop! watch)`, `(:close! capture)` — so a row whose BODY
+              already tore something down as part of an assertion names it
+              here as well and the second call is a no-op. Omit only where
+              the row holds nothing, as §2 does.
+    :report!  what to do with a rejection. Defaults to failing the row,
+              which is what a real row wants; §6 passes a recorder, because
+              for it the rejection is the subject.
+
+  One `.then` carrying BOTH handlers rather than a `.then` and a `.catch`:
+  the two are mutually exclusive, so a body that throws cannot also reach
+  the rejection arm and finish the row twice. The release and the `done`
+  sit on the far side of both, and `done` is in a `finally`, so a teardown
+  that throws still ends the row rather than leaving the runner to time it
+  out.
+
+  The failure is carried as `nil`-or-`[e]` rather than as the value itself,
+  because a promise rejected with `js/undefined` reads as `nil` in CLJS and
+  would otherwise settle silently.
+
+  **A local copy of `server-render-ssr-dom-cljs-test`'s helper of the same
+  name (rf2-sxhu, PR #8675), deliberately spelled identically** — same
+  parameters, same defaults, same `nil`-or-`[e]` carrier — as
+  `identifier-prefix-ssr-dom-cljs-test`'s is (rf2-x43z, PR #8677), so that
+  lifting the copies into `roots-frames-support` is a deletion and a
+  `:require`, not a reconciliation of designs. rf2-7ucn carries that lift
+  and the count that justifies it."
+  [p {:keys [row done release! report!]}]
+  (let [report!  (or report!  (fn [e] (is false (str row " did not settle cleanly — " e))))
+        release! (or release! (fn [] nil))
+        finish!  (fn [failure]
+                   (try
+                     (when failure (report! (str (first failure))))
+                     (release!)
+                     (catch :default te
+                       (is false (str row " could not release — " te)))
+                     (finally (done))))]
+    (.then p
+           (fn [_] (finish! nil))
+           (fn [e] (finish! [e])))))
+
+;; ---------------------------------------------------------------------------
 ;; §1 — a server render with NO window scoped over it installs no adoption
 ;;      context, so presence enters
 ;; ---------------------------------------------------------------------------
@@ -422,7 +532,6 @@
               (fn [c] (= "present" (text-in c ".probe"))))
             (.then
               (fn [settled]
-                (try
                   (collector/reset-runtime!)
                   (reset! !phases {})
                   (let [real (server-bytes! [tray-screen {:tag :server}])]
@@ -445,8 +554,14 @@
                           (str "settled=" (pr-str (probe-text settled))
                                " real=" (pr-str (probe-text real))
                                " — an equality here is the repair, and it
-                               rewrites this row rather than relaxing it"))))
-                  (finally (done))))))))))
+                               rewrites this row rather than relaxing it"))))))
+            ;; No `:release!`: this row mounts nothing of its own.
+            ;; `settled-server-html!` releases the client root it used to
+            ;; produce the settled bytes, and `server-bytes!` is a
+            ;; `renderToString` with no DOM behind it.
+            (settle-row!
+              {:row  "§2 — the client's settled bytes are not the server's"
+               :done done}))))))
 
 ;; ---------------------------------------------------------------------------
 ;; §3 — hydrating the REAL server bytes diverges, and the adoption is lost
@@ -506,9 +621,17 @@
             (-> (sup/adopted! ha)
                 (.then
                   (fn [ok]
+                    ;; Closed and stopped HERE, and named in `:release!` as
+                    ;; well. Here, because the assertions below read
+                    ;; `@captured` and `@seen` and the capture has to be shut
+                    ;; across the render rather than across the rest of the
+                    ;; row; there, because both are idempotent — `close!` on a
+                    ;; `closed?` volatile, `stop!` by its own docstring — and
+                    ;; the rejection path never reaches this line. Leaving it
+                    ;; here alone is what let this row's `:swallow-uncaught?`
+                    ;; listener outlive it.
                     (close!)
                     (stop!)
-                    (try
                       (is (true? ok) "the root's own closer ran")
 
                       (testing "the client's FIRST pass read its window and was
@@ -563,9 +686,14 @@
                                 whole failure, and the reason no row in this
                                 file rests on it"
                         (is (= "present" (text-in ca ".probe")))
-                        (is (= "alpha" (text-in ca ".value"))))
-
-                      (finally (mount/release! ha) (done))))))))))))
+                        (is (= "alpha" (text-in ca ".value"))))))
+                (settle-row!
+                  {:row      "§3 — hydrating the real server bytes diverges"
+                   :done     done
+                   :release! (fn []
+                               (close!)
+                               (stop!)
+                               (mount/release! ha))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; §4 — the control: the same real server path, with no tray in the tree
@@ -600,9 +728,12 @@
             (-> (sup/adopted! ha)
                 (.then
                   (fn [ok]
+                    ;; Closed and stopped here and named in `:release!` too,
+                    ;; for §3's reason: the assertions below read `@captured`
+                    ;; and `@seen`, both primitives are idempotent, and the
+                    ;; rejection path never reaches this line.
                     (close!)
                     (stop!)
-                    (try
                       (is (true? ok) "the root's own closer ran")
 
                       (testing "React adopted the real server render silently"
@@ -614,9 +745,14 @@
 
                       (testing "and kept the server's own nodes, which is what
                                 adoption MEANS and what §3 lost"
-                        (is (sup/every-server-node? ca ".screen, .value")))
-
-                      (finally (mount/release! ha) (done))))))))))))
+                        (is (sup/every-server-node? ca ".screen, .value")))))
+                (settle-row!
+                  {:row      "§4 — the same real server path with no tray"
+                   :done     done
+                   :release! (fn []
+                               (close!)
+                               (stop!)
+                               (mount/release! ha))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; §5 — the PRODUCT server door, which does scope a window, and what that
@@ -679,3 +815,108 @@
         (is (not= (probe-text html) (probe-text bare))
             "the product door and the hand-rolled path must differ, or this
              row is measuring nothing")))))
+
+;; ---------------------------------------------------------------------------
+;; §6 — THE LEAK CONTROL: a rejected adoption still releases the root,
+;;      the console and the watcher
+;; ---------------------------------------------------------------------------
+;;
+;; §2 through §4 all FULFIL on a green run, so [[settle-row!]]'s rejection
+;; arm is on no green path — and a repair to a branch nothing takes is
+;; untested by construction. This row takes it.
+;;
+;; The rejection is injected AFTER the adoption completes, which is the
+;; harder case and not the weaker one: every resource the row owns is live
+;; and committed at that moment, so there is strictly MORE to release than
+;; there would be had `sup/adopted!` rejected before the root ever adopted.
+;;
+;; Under the shape this file carried before, nothing below the injection runs
+;; at all. The rejection skips the fulfilment handler, so the `try` is never
+;; entered and its `finally` never fires: no `close!`, no `stop!`, no
+;; `release!`, no `done`. The row does not go red — it hangs to `cljs.test`'s
+;; async timeout, reports the timeout instead of the rejection, and leaves the
+;; root mounted, the container in the document and `console.error` still
+;; replaced for whatever runs next.
+
+(deftest a-rejected-adoption-still-releases-the-root-console-and-watcher
+  (if-not (mount/browser?)
+    (sup/skip! "what a rejection can leak here is a real root and a real console")
+    (async done
+      (fresh!)
+      (let [html           (server-bytes! [plain-screen {}])
+            ca             (sup/stamp-server-nodes! (sup/server-dom! html))
+            watch          (sup/watch-mismatches!)
+            ;; NOT `:swallow-uncaught? true`: this row manufactures a rejected
+            ;; PROMISE, which `settle-row!` handles, and no uncaught window
+            ;; error at all. Swallowing anywhere else is the fail-open the
+            ;; browser runner's pageerror rule forbids.
+            console-before (.-error js/console)
+            capture        (sup/open-console-capture!)
+            stops          (atom 0)
+            finishes       (atom 0)
+            reports        (atom [])]
+        (collector/reset-runtime!)
+        (let [ha (mount/hydrate-root! ca frame-id [plain-screen {}])]
+          (-> (sup/adopted! ha)
+              (.then
+                (fn [ok]
+                  (is (true? ok) "premise: the root really did adopt")
+                  (is (not= sup/released (sup/census))
+                      (str "premise: the runtime is holding this root's cells "
+                           "and edges, so the census taken after the rejection "
+                           "is a RELEASE and not an empty page; got "
+                           (pr-str (sup/census))))
+                  (js/Promise.reject (js/Error. "adoption rejected on purpose"))))
+              (settle-row!
+                {:row      "the rejected-adoption control"
+                 :done     (fn [] (swap! finishes inc))
+                 :report!  (fn [e] (swap! reports conj e))
+                 :release! (fn []
+                             ((:close! capture))
+                             (swap! stops inc)
+                             ((:stop! watch))
+                             (mount/release! ha))})
+              ;; The cell reapers are armed at unmount and run past a bare
+              ;; macrotask, so the tables are read at the runtime's own horizon
+              ;; rather than one tick after the release.
+              (.then (fn [_] (sup/quiesced!)))
+              (.then
+                (fn [_]
+                  (testing "the rejection is REPORTED — which is the whole of
+                            what a hang gives away — and the row ends ONCE"
+                    (is (= 1 @finishes)
+                        (str "done ran " @finishes " times"))
+                    (is (= 1 (count @reports))
+                        (str "exactly one report; got " (pr-str @reports)))
+                    (is (re-find #"adoption rejected on purpose" (str (first @reports)))
+                        (str "naming what the adoption threw; got "
+                             (pr-str @reports))))
+
+                  (testing "and the page the NEXT row inherits holds nothing of
+                            this one. Two of these four are the row's alone to
+                            give back — the `:each` fixture resets frames,
+                            disposes the adapter and empties the runtime, but it
+                            never unmounts a React root and never hands
+                            `console.error` back. (The trace listener it does
+                            sweep, in its `:before`; `stop!` is asserted here
+                            all the same, because a row that leans on the
+                            fixture to stop its own watcher is measuring the
+                            fixture)"
+                    (is (= sup/released (sup/census))
+                        (str "no root: residue was " (pr-str (sup/census))))
+                    (is (empty? (sup/cell-frames))
+                        (str "no frame: the cell table still mentions "
+                             (pr-str (sup/cell-frames))))
+                    (is (= 1 @stops)
+                        (str "the mismatch watcher was stopped — `stop!` is what "
+                             "unregisters the trace listener; it ran "
+                             @stops " times"))
+                    (is (identical? console-before (.-error js/console))
+                        "`console.error` is the page's own again"))))
+              (settle-row!
+                {:row      "the rejected-adoption control's own settlement"
+                 :done     done
+                 :release! (fn []
+                             ((:close! capture))
+                             ((:stop! watch))
+                             (mount/release! ha))})))))))

--- a/implementation/hicasso/test/re_frame/hicasso/presence_ssr_seam_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/presence_ssr_seam_dom_cljs_test.cljs
@@ -532,29 +532,29 @@
               (fn [c] (= "present" (text-in c ".probe"))))
             (.then
               (fn [settled]
-                  (collector/reset-runtime!)
-                  (reset! !phases {})
-                  (let [real (server-bytes! [tray-screen {:tag :server}])]
+                (collector/reset-runtime!)
+                (reset! !phases {})
+                (let [real (server-bytes! [tray-screen {:tag :server}])]
 
-                    (testing "the harness's helper reports a SETTLED tray,
-                              because a client root played the enter
-                              transition before its markup was copied"
-                      (is (= "present" (probe-text settled))
-                          (str "got " (pr-str (probe-text settled)) " from " settled)))
+                  (testing "the harness's helper reports a SETTLED tray,
+                            because a client root played the enter
+                            transition before its markup was copied"
+                    (is (= "present" (probe-text settled))
+                        (str "got " (pr-str (probe-text settled)) " from " settled)))
 
-                    (testing "React's own server renderer reports an ENTERING
-                              tray for the very same tree under the very same
-                              frame — so the two producers are not
-                              interchangeable, and a hydration measured
-                              against the first is not a measurement of the
-                              second"
-                      (is (= "mounting" (probe-text real))
-                          (str "got " (pr-str (probe-text real)) " from " real))
-                      (is (not= (probe-text settled) (probe-text real))
-                          (str "settled=" (pr-str (probe-text settled))
-                               " real=" (pr-str (probe-text real))
-                               " — an equality here is the repair, and it
-                               rewrites this row rather than relaxing it"))))))
+                  (testing "React's own server renderer reports an ENTERING
+                            tray for the very same tree under the very same
+                            frame — so the two producers are not
+                            interchangeable, and a hydration measured
+                            against the first is not a measurement of the
+                            second"
+                    (is (= "mounting" (probe-text real))
+                        (str "got " (pr-str (probe-text real)) " from " real))
+                    (is (not= (probe-text settled) (probe-text real))
+                        (str "settled=" (pr-str (probe-text settled))
+                             " real=" (pr-str (probe-text real))
+                             " — an equality here is the repair, and it
+                             rewrites this row rather than relaxing it"))))))
             ;; No `:release!`: this row mounts nothing of its own.
             ;; `settled-server-html!` releases the client root it used to
             ;; produce the settled bytes, and `server-bytes!` is a
@@ -632,61 +632,61 @@
                     ;; listener outlive it.
                     (close!)
                     (stop!)
-                      (is (true? ok) "the root's own closer ran")
+                    (is (true? ok) "the root's own closer ran")
 
-                      (testing "the client's FIRST pass read its window and was
-                                born `:present`, against server bytes that said
-                                `mounting`. That is the seam, in one pair of
-                                readings"
-                        (is (= :present (first (get @!phases :client)))
-                            (str "the client's first phase; saw "
-                                 (pr-str (get @!phases :client)))))
+                    (testing "the client's FIRST pass read its window and was
+                              born `:present`, against server bytes that said
+                              `mounting`. That is the seam, in one pair of
+                              readings"
+                      (is (= :present (first (get @!phases :client)))
+                          (str "the client's first phase; saw "
+                               (pr-str (get @!phases :client)))))
 
-                      (let [complaints (filterv #(re-find #"Hydration failed" %) @captured)]
-                        (testing "so React could not adopt: it complained on the
-                                  page's own error channel, which
-                                  `report-recoverable-default!` delegates to
-                                  unconditionally"
-                          (is (pos? (count complaints))
-                              (str "expected React to report the divergence; captured "
-                                   (pr-str @captured))))
+                    (let [complaints (filterv #(re-find #"Hydration failed" %) @captured)]
+                      (testing "so React could not adopt: it complained on the
+                                page's own error channel, which
+                                `report-recoverable-default!` delegates to
+                                unconditionally"
+                        (is (pos? (count complaints))
+                            (str "expected React to report the divergence; captured "
+                                 (pr-str @captured))))
 
-                        (testing "and every complaint React made reached the
-                                  framework's instrumentation stream as Spec
-                                  011's `:rf.ssr/hydration-mismatch`, gated on
-                                  THIS root's window — which is the root
-                                  attribution: no other root could have emitted
-                                  it, because no other root holds this window"
-                          (is (= (count complaints) (count @seen))
-                              (str "React said " (count complaints)
-                                   ", the framework said " (count @seen)))
-                          (doseq [ev @seen]
-                            (let [tags (sup/tags-of ev)]
-                              (is (= :rf.ssr/hydration-mismatch (:operation ev)))
-                              (is (= 're-frame.hicasso.impl.mount/hydrate-root! (:where tags)))
-                              (is (= :warned-and-replaced (:recovery tags)))
-                              (is (string? (:error tags)))))))
+                      (testing "and every complaint React made reached the
+                                framework's instrumentation stream as Spec
+                                011's `:rf.ssr/hydration-mismatch`, gated on
+                                THIS root's window — which is the root
+                                attribution: no other root could have emitted
+                                it, because no other root holds this window"
+                        (is (= (count complaints) (count @seen))
+                            (str "React said " (count complaints)
+                                 ", the framework said " (count @seen)))
+                        (doseq [ev @seen]
+                          (let [tags (sup/tags-of ev)]
+                            (is (= :rf.ssr/hydration-mismatch (:operation ev)))
+                            (is (= 're-frame.hicasso.impl.mount/hydrate-root! (:where tags)))
+                            (is (= :warned-and-replaced (:recovery tags)))
+                            (is (string? (:error tags)))))))
 
-                      (testing "and the server's DOM was THROWN AWAY. The nodes
-                                on the page are not the nodes the bytes
-                                produced, so nothing was adopted — the whole
-                                point of shipping server markup is lost on this
-                                surface, and no value-level assertion anywhere
-                                can see it"
-                        (is (some? (.querySelector ca ".probe"))
-                            "premise: something is there to check, so the
-                             negative below is not vacuous")
-                        (is (false? (sup/server-node? (.querySelector ca ".probe")))
-                            "the probe node was re-created")
-                        (is (false? (sup/every-server-node? ca ".screen, .probe"))))
+                    (testing "and the server's DOM was THROWN AWAY. The nodes
+                              on the page are not the nodes the bytes
+                              produced, so nothing was adopted — the whole
+                              point of shipping server markup is lost on this
+                              surface, and no value-level assertion anywhere
+                              can see it"
+                      (is (some? (.querySelector ca ".probe"))
+                          "premise: something is there to check, so the
+                           negative below is not vacuous")
+                      (is (false? (sup/server-node? (.querySelector ca ".probe")))
+                          "the probe node was re-created")
+                      (is (false? (sup/every-server-node? ca ".screen, .probe"))))
 
-                      (testing "while the FINAL DOM reads exactly what a healthy
-                                adoption would have left — React's repair. This
-                                is the assertion that stays green through the
-                                whole failure, and the reason no row in this
-                                file rests on it"
-                        (is (= "present" (text-in ca ".probe")))
-                        (is (= "alpha" (text-in ca ".value"))))))
+                    (testing "while the FINAL DOM reads exactly what a healthy
+                              adoption would have left — React's repair. This
+                              is the assertion that stays green through the
+                              whole failure, and the reason no row in this
+                              file rests on it"
+                      (is (= "present" (text-in ca ".probe")))
+                      (is (= "alpha" (text-in ca ".value"))))))
                 (settle-row!
                   {:row      "§3 — hydrating the real server bytes diverges"
                    :done     done
@@ -734,18 +734,18 @@
                     ;; rejection path never reaches this line.
                     (close!)
                     (stop!)
-                      (is (true? ok) "the root's own closer ran")
+                    (is (true? ok) "the root's own closer ran")
 
-                      (testing "React adopted the real server render silently"
-                        (is (= [] (filterv #(re-find #"Hydration failed" %) @captured))
-                            (str "no complaint expected; captured " (pr-str @captured)))
-                        (is (= 0 (count @seen))
-                            (str "and no framework diagnostic; got "
-                                 (pr-str (mapv (comp :error sup/tags-of) @seen)))))
+                    (testing "React adopted the real server render silently"
+                      (is (= [] (filterv #(re-find #"Hydration failed" %) @captured))
+                          (str "no complaint expected; captured " (pr-str @captured)))
+                      (is (= 0 (count @seen))
+                          (str "and no framework diagnostic; got "
+                               (pr-str (mapv (comp :error sup/tags-of) @seen)))))
 
-                      (testing "and kept the server's own nodes, which is what
-                                adoption MEANS and what §3 lost"
-                        (is (sup/every-server-node? ca ".screen, .value")))))
+                    (testing "and kept the server's own nodes, which is what
+                              adoption MEANS and what §3 lost"
+                      (is (sup/every-server-node? ca ".screen, .value")))))
                 (settle-row!
                   {:row      "§4 — the same real server path with no tray"
                    :done     done

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
@@ -161,6 +161,105 @@
   (some-> (.querySelector container sel) .-textContent))
 
 ;; ---------------------------------------------------------------------------
+;; Settlement — the ONE way out of an async row, taken on both outcomes
+;; ---------------------------------------------------------------------------
+;;
+;; Every async row below mounts real roots, and each holds things the
+;; `:each` fixture will NOT take back: MOUNTED React roots, with the
+;; containers `sup/server-dom!` and `mount/fresh-container!` minted still
+;; in the document. The fixture resets frames, disposes the adapter and
+;; empties the runtime, and none of that unmounts a root. H2 also replaces
+;; `console.error` and registers a `window` "error" listener, and it opens
+;; that capture with `:swallow-uncaught? true` — so a listener that
+;; outlives its row goes on calling `preventDefault` on every later row's
+;; uncaught errors, which is precisely the fail-open the browser runner's
+;; pageerror rule exists to prevent.
+;;
+;; These rows used to end INSIDE the fulfilment handler:
+;;
+;;   (-> (sup/wait-until! both-committed?)
+;;       (.then (fn [ok] (try …assertions…
+;;                            (finally (mount/release! ha)
+;;                                     (mount/release! hb)
+;;                                     (done))))))
+;;
+;; There was no rejection arm anywhere in this file, so on a rejection the
+;; handler was skipped, the `try` was never entered and the `finally` never
+;; fired. Nothing ran: no `release!`, no `done`. The row did not fail — it
+;; HUNG to `cljs.test`'s async timeout, reporting the timeout rather than
+;; the rejection, and it handed the next row live roots to take its census
+;; against. H6 is the expensive one: `js/Promise.all` rejects if EITHER
+;; adoption does, so one rejection stranded FOUR handles.
+;;
+;; On THIS lane it is worse than a hang, which is worth knowing before
+;; reading H7's sabotage as merely slow. An unsettled rejection is an
+;; unhandled one, so it reaches the page as an uncaught error, and the
+;; browser runner treats that as terminal (rf2-u0j8). Measured on the
+;; sibling suite: the run stopped at that namespace with 85 announced, no
+;; summary line at all, and every namespace scheduled after it silently
+;; unrun — `shadow.test` runs the whole lane, and the closing summary,
+;; inside one `cljs.test/run-block` with no try/catch. So the cost of a
+;; rejection here was never one row.
+;;
+;; [[settle-row!]] is the one path every async row now ends with, and H7 is
+;; what says it works — because its rejection arm is on no green path, and
+;; a repair to a branch nothing takes is untested by construction.
+;;
+;; H4 is deliberately NOT on it: that row is synchronous end to end — no
+;; `async`, no promise — so its `try`/`finally` is an ordinary bracket and
+;; there is no settlement question to answer.
+
+(defn- settle-row!
+  "End an async row exactly ONCE, whatever `p` does. `opts` is
+  `{:row :done :release! :report!}`:
+
+    :row      names the row in the failure message. A shared settlement
+              still has to say WHICH row failed, which is the one thing a
+              hand-written rejection arm would give away for free.
+    :done     `cljs.test`'s own, called exactly once.
+    :release! this row's teardown, called exactly once. Every primitive it
+              reaches for is idempotent and says so — `mount/release!`,
+              `(:stop! watch)`, `(:close! capture)` — so a row whose BODY
+              already tore something down as part of an assertion names it
+              here as well and the second call is a no-op. Omit only where
+              the row holds nothing.
+    :report!  what to do with a rejection. Defaults to failing the row,
+              which is what a real row wants; H7 passes a recorder, because
+              for it the rejection is the subject.
+
+  One `.then` carrying BOTH handlers rather than a `.then` and a `.catch`:
+  the two are mutually exclusive, so a body that throws cannot also reach
+  the rejection arm and finish the row twice. The release and the `done`
+  sit on the far side of both, and `done` is in a `finally`, so a teardown
+  that throws still ends the row rather than leaving the runner to time it
+  out.
+
+  The failure is carried as `nil`-or-`[e]` rather than as the value itself,
+  because a promise rejected with `js/undefined` reads as `nil` in CLJS and
+  would otherwise settle silently.
+
+  **A local copy of `server-render-ssr-dom-cljs-test`'s helper of the same
+  name (rf2-sxhu, PR #8675), deliberately spelled identically** — same
+  parameters, same defaults, same `nil`-or-`[e]` carrier — as
+  `identifier-prefix-ssr-dom-cljs-test`'s is (rf2-x43z, PR #8677), so that
+  lifting the copies into `roots-frames-support` is a deletion and a
+  `:require`, not a reconciliation of designs. rf2-7ucn carries that lift
+  and the count that justifies it."
+  [p {:keys [row done release! report!]}]
+  (let [report!  (or report!  (fn [e] (is false (str row " did not settle cleanly — " e))))
+        release! (or release! (fn [] nil))
+        finish!  (fn [failure]
+                   (try
+                     (when failure (report! (str (first failure))))
+                     (release!)
+                     (catch :default te
+                       (is false (str row " could not release — " te)))
+                     (finally (done))))]
+    (.then p
+           (fn [_] (finish! nil))
+           (fn [e] (finish! [e])))))
+
+;; ---------------------------------------------------------------------------
 ;; H1 — two overlapping adoptions, each keeping its own DOM
 ;; ---------------------------------------------------------------------------
 
@@ -195,7 +294,6 @@
             (-> (sup/wait-until! both-committed?)
                 (.then
                   (fn [ok]
-                    (try
                       (is (true? ok)
                           (str "both roots must commit; cell frames were "
                                (pr-str (sup/cell-frames))))
@@ -219,9 +317,13 @@
                                 adoptions, exactly as it does across two ordinary
                                 mounts"
                         (is (= #{[frame-a label-q] [frame-b label-q]} (sup/cell-keys)))
-                        (is (= #{frame-a frame-b} (sup/frame-memo-frames))))
-
-                      (finally (mount/release! ha) (mount/release! hb) (done))))))))))))
+                        (is (= #{frame-a frame-b} (sup/frame-memo-frames))))))
+                (settle-row!
+                  {:row      "H1 — two overlapping adoptions, each keeping its own DOM"
+                   :done     done
+                   :release! (fn []
+                               (mount/release! ha)
+                               (mount/release! hb))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; H2 — two overlapping mismatches, two independent complaints
@@ -297,9 +399,17 @@
             (-> (sup/wait-until! both-committed?)
                 (.then
                   (fn [ok]
+                    ;; Closed and stopped HERE, and named in `:release!` as
+                    ;; well. Here, because the assertions below read
+                    ;; `@captured` and `@seen` and the capture has to be shut
+                    ;; across the render rather than across the rest of the
+                    ;; row; there, because both are idempotent — `close!` on a
+                    ;; `closed?` volatile, `stop!` by its own docstring — and
+                    ;; the rejection path never reaches this line. Leaving it
+                    ;; here alone is what let a `:swallow-uncaught?` listener
+                    ;; outlive the row.
                     (close!)
                     (stop!)
-                    (try
                       (is (true? ok) "both roots must commit")
 
                       ;; What REACT complained about, on the page's own error
@@ -344,9 +454,15 @@
                         (is (= "client-A" (text-in ca ".title")))
                         (is (= "client-B" (text-in cb ".title")))
                         (is (= "alpha" (text-in ca ".value")))
-                        (is (= "beta"  (text-in cb ".value")))))
-
-                      (finally (mount/release! ha) (mount/release! hb) (done))))))))))))
+                        (is (= "beta"  (text-in cb ".value")))))))
+                (settle-row!
+                  {:row      "H2 — two overlapping mismatches, two complaints"
+                   :done     done
+                   :release! (fn []
+                               (close!)
+                               (stop!)
+                               (mount/release! ha)
+                               (mount/release! hb))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; H3 — independent teardown of two hydrated roots
@@ -373,10 +489,13 @@
                     ;; runtime by fiat, and every count below would then
                     ;; read zero whatever the teardown did.
                     (mount/unmount! ha)
+                    ;; The inner chain is RETURNED from this handler, so the
+                    ;; outer promise adopts it and ONE `settle-row!` at the
+                    ;; outer tail settles the whole row. Two — one per chain —
+                    ;; would call `done` twice on the green path.
                     (-> (sup/quiesced!)
                         (.then
                           (fn [_]
-                            (try
                               (testing "frame A's keys are released and frame B's
                                         survive"
                                 (is (= #{[frame-b label-q]} (sup/cell-keys))
@@ -398,11 +517,13 @@
                                 (is (= "beta" (text-in cb ".value"))))
 
                               (testing "and tearing the survivor down leaves nothing"
-                                (is (= sup/released (sup/teardown-census! hb))))
-                              (finally
-                                (mount/release! ha)
-                                (mount/release! hb)
-                                (done)))))))))))))))
+                                (is (= sup/released (sup/teardown-census! hb)))))))))
+                (settle-row!
+                  {:row      "H3 — independent teardown of two hydrated roots"
+                   :done     done
+                   :release! (fn []
+                               (mount/release! ha)
+                               (mount/release! hb))}))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; H4 — a COMPLETED root's later recovery is not a mismatch, however many
@@ -547,7 +668,16 @@
   (async done
     (if-not (mount/browser?)
       (do (sup/skip! ":node-test has no DOM") (done))
-      (do
+      ;; `held` is what lets ONE settlement cover this row, and it is here
+      ;; because this row is the only one whose releasables are minted INSIDE
+      ;; the chain: `ha` needs the server's bytes, and those arrive as a
+      ;; promise. A `settle-row!` at the tail cannot close over bindings the
+      ;; chain makes, and the rejection path is exactly the path on which
+      ;; those `let`s were never entered — so each is recorded as it is
+      ;; created and `:release!` gives back whatever exists. Every other row
+      ;; in this file binds its handles before the chain and names them
+      ;; directly, which is the shape the two repaired sibling suites carry.
+      (let [held (atom {})]
         (fresh!)
         (reset! !phases {})
         (-> (sup/settled-server-html!
@@ -565,11 +695,13 @@
                       cb (mount/fresh-container!)
                       {:keys [seen stop!]} (sup/watch-mismatches!)
                       ha (mount/hydrate-root! ca frame-a [tray-screen {:tag :hydrated}])]
+                  (swap! held assoc :stop! stop! :ha ha)
                   (is (true? (roots/adopting? (:adoption ha)))
                       "premise: root A is adopting on THIS line, so what follows
                        happens inside its window by construction")
                   ;; An ORDINARY root, mounted inside root A's adoption window.
                   (let [hb (mount/root! cb frame-b [tray-screen {:tag :ordinary}])]
+                    (swap! held assoc :hb hb)
                     (testing "the ordinary sibling gets its ENTER phase, even
                               though a hydration is in flight elsewhere on the
                               page — the row the shipped page-global failed"
@@ -589,8 +721,10 @@
                     (-> (sup/adopted! ha)
                         (.then
                           (fn [ok]
+                            ;; Stopped here and named in `:release!` too —
+                            ;; `stop!` is idempotent by its own docstring, and
+                            ;; the rejection path never reaches this line.
                             (stop!)
-                            (try
                               (is (true? ok) "root A's own closer ran")
 
                               (testing "root A was BORN PRESENT: its tray never
@@ -643,12 +777,14 @@
                                       "premise: open, and its closer has not run")
                                   (mount/unmount! orphan)
                                   (is (false? (roots/adopting? window))
-                                      "teardown shut it")))
-
-                              (finally
-                                (mount/release! ha)
-                                (mount/release! hb)
-                                (done)))))))))))))))
+                                      "teardown shut it"))))))))))
+            (settle-row!
+              {:row      "H5 — presence adoption belongs to a subtree, not to the page"
+               :done     done
+               :release! (fn []
+                           (when-let [stop! (:stop! @held)] (stop!))
+                           (some-> (:ha @held) mount/release!)
+                           (some-> (:hb @held) mount/release!))}))))))
 
 ;; ---------------------------------------------------------------------------
 ;; H6 — THE EXECUTING SABOTAGE CONTROL for this risk family
@@ -752,17 +888,126 @@
                        (pr-str (get @!phases :under-root-scoped))))
               (is (= "mounting" (text-in (:container (:hb disarmed)) ".probe"))))
 
+            ;; `js/Promise.all` rejects if EITHER adoption does, and this row
+            ;; holds FOUR handles — so a single rejected adoption stranded all
+            ;; four, which is why this is the most expensive row in the file
+            ;; to leave unsettled.
             (-> (js/Promise.all #js [(sup/adopted! (:ha armed))
                                      (sup/adopted! (:ha disarmed))])
                 (.then
                   (fn [oks]
-                    (try
                       (is (= [true true] (vec oks))
                           "both hydrating roots must reach their own closer, or
-                           this row left an open window behind")
-                      (finally
-                        (mount/release! (:hb armed))
-                        (mount/release! (:ha armed))
-                        (mount/release! (:hb disarmed))
-                        (mount/release! (:ha disarmed))
-                        (done))))))))))))
+                           this row left an open window behind")))
+                (settle-row!
+                  {:row      "H6 — the page-global sabotage control"
+                   :done     done
+                   :release! (fn []
+                               (mount/release! (:hb armed))
+                               (mount/release! (:ha armed))
+                               (mount/release! (:hb disarmed))
+                               (mount/release! (:ha disarmed)))}))))))))
+
+;; ---------------------------------------------------------------------------
+;; H7 — THE LEAK CONTROL: a rejected adoption still releases BOTH roots
+;; ---------------------------------------------------------------------------
+;;
+;; H1 through H6 all FULFIL on a green run, so [[settle-row!]]'s rejection
+;; arm is on no green path — and a repair to a branch nothing takes is
+;; untested by construction. This row takes it.
+;;
+;; It is written on `js/Promise.all` over TWO adoptions because that is H6's
+;; shape and the most expensive one in this file: `Promise.all` rejects if
+;; EITHER adoption does, so one rejection is enough to strand every handle
+;; the row holds. The rejection is injected AFTER both adoptions complete,
+;; which is the harder case and not the weaker one — every root is live and
+;; committed at that moment, so there is strictly MORE to release than there
+;; would be had an adoption rejected before either root adopted.
+;;
+;; Under the shape this file carried before, nothing below the injection runs
+;; at all. The rejection skips the fulfilment handler, so the `try` is never
+;; entered and its `finally` never fires: no `release!`, no `done`. The row
+;; does not go red — it hangs to `cljs.test`'s async timeout, reports the
+;; timeout instead of the rejection, and leaves two roots mounted and their
+;; containers in the document for whatever runs next.
+
+(deftest a-rejected-adoption-still-releases-both-roots-and-the-watcher
+  (if-not (mount/browser?)
+    (sup/skip! "what a rejection can leak here is two real roots")
+    (async done
+      (fresh!)
+      (let [html-a   (sup/server-html! frame-a [screen {:title "A"}])
+            html-b   (sup/server-html! frame-b [screen {:title "B"}])
+            ca       (sup/stamp-server-nodes! (sup/server-dom! html-a))
+            cb       (sup/stamp-server-nodes! (sup/server-dom! html-b))
+            watch    (sup/watch-mismatches!)
+            ;; NOT `:swallow-uncaught? true`: this row manufactures a
+            ;; rejected PROMISE, which `settle-row!` handles, and no uncaught
+            ;; window error at all. Swallowing anywhere else is the fail-open
+            ;; the browser runner's pageerror rule forbids.
+            stops    (atom 0)
+            finishes (atom 0)
+            reports  (atom [])]
+        (collector/reset-runtime!)
+        (let [ha (mount/hydrate-root! ca frame-a [screen {:title "A"}])
+              hb (mount/hydrate-root! cb frame-b [screen {:title "B"}])]
+          (-> (js/Promise.all #js [(sup/adopted! ha) (sup/adopted! hb)])
+              (.then
+                (fn [oks]
+                  (is (= [true true] (vec oks)) "premise: both roots really did adopt")
+                  (is (not= sup/released (sup/census))
+                      (str "premise: the runtime is holding these roots' cells "
+                           "and edges, so the census taken after the rejection "
+                           "is a RELEASE and not an empty page; got "
+                           (pr-str (sup/census))))
+                  (js/Promise.reject (js/Error. "adoption rejected on purpose"))))
+              (settle-row!
+                {:row      "the rejected-adoption control"
+                 :done     (fn [] (swap! finishes inc))
+                 :report!  (fn [e] (swap! reports conj e))
+                 :release! (fn []
+                             (swap! stops inc)
+                             ((:stop! watch))
+                             (mount/release! ha)
+                             (mount/release! hb))})
+              ;; The cell reapers are armed at unmount and run past a bare
+              ;; macrotask, so the tables are read at the runtime's own horizon
+              ;; rather than one tick after the release.
+              (.then (fn [_] (sup/quiesced!)))
+              (.then
+                (fn [_]
+                  (testing "the rejection is REPORTED — which is the whole of
+                            what a hang gives away — and the row ends ONCE"
+                    (is (= 1 @finishes)
+                        (str "done ran " @finishes " times"))
+                    (is (= 1 (count @reports))
+                        (str "exactly one report; got " (pr-str @reports)))
+                    (is (re-find #"adoption rejected on purpose" (str (first @reports)))
+                        (str "naming what the adoption threw; got "
+                             (pr-str @reports))))
+
+                  (testing "and the page the NEXT row inherits holds nothing of
+                            this one. The roots are the row's alone to give
+                            back — the `:each` fixture resets frames, disposes
+                            the adapter and empties the runtime, but it never
+                            unmounts a React root. (The trace listener it does
+                            sweep, in its `:before`; `stop!` is asserted here
+                            all the same, because a row that leans on the
+                            fixture to stop its own watcher is measuring the
+                            fixture)"
+                    (is (= sup/released (sup/census))
+                        (str "neither root left: residue was " (pr-str (sup/census))))
+                    (is (empty? (sup/cell-frames))
+                        (str "no frame: the cell table still mentions "
+                             (pr-str (sup/cell-frames))))
+                    (is (= 1 @stops)
+                        (str "the mismatch watcher was stopped — `stop!` is what "
+                             "unregisters the trace listener; it ran "
+                             @stops " times")))))
+              (settle-row!
+                {:row      "the rejected-adoption control's own settlement"
+                 :done     done
+                 :release! (fn []
+                             ((:stop! watch))
+                             (mount/release! ha)
+                             (mount/release! hb))})))))))

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
@@ -294,30 +294,30 @@
             (-> (sup/wait-until! both-committed?)
                 (.then
                   (fn [ok]
-                      (is (true? ok)
-                          (str "both roots must commit; cell frames were "
-                               (pr-str (sup/cell-frames))))
+                    (is (true? ok)
+                        (str "both roots must commit; cell frames were "
+                             (pr-str (sup/cell-frames))))
 
-                      (testing "each root ADOPTED its own server DOM — the nodes
-                                are the very nodes the markup produced, which no
-                                re-render could reconstruct"
-                        (is (sup/every-server-node? ca ".screen, .title, .value")
-                            "root A kept the server's nodes")
-                        (is (sup/every-server-node? cb ".screen, .title, .value")
-                            "root B kept the server's nodes"))
+                    (testing "each root ADOPTED its own server DOM — the nodes
+                              are the very nodes the markup produced, which no
+                              re-render could reconstruct"
+                      (is (sup/every-server-node? ca ".screen, .title, .value")
+                          "root A kept the server's nodes")
+                      (is (sup/every-server-node? cb ".screen, .title, .value")
+                          "root B kept the server's nodes"))
 
-                      (testing "and neither root's adoption reached into the
-                                other's tree"
-                        (is (= "A" (text-in ca ".title")))
-                        (is (= "B" (text-in cb ".title")))
-                        (is (= "alpha" (text-in ca ".value")))
-                        (is (= "beta"  (text-in cb ".value"))))
+                    (testing "and neither root's adoption reached into the
+                              other's tree"
+                      (is (= "A" (text-in ca ".title")))
+                      (is (= "B" (text-in cb ".title")))
+                      (is (= "alpha" (text-in ca ".value")))
+                      (is (= "beta"  (text-in cb ".value"))))
 
-                      (testing "the cell table split by frame across the two
-                                adoptions, exactly as it does across two ordinary
-                                mounts"
-                        (is (= #{[frame-a label-q] [frame-b label-q]} (sup/cell-keys)))
-                        (is (= #{frame-a frame-b} (sup/frame-memo-frames))))))
+                    (testing "the cell table split by frame across the two
+                              adoptions, exactly as it does across two ordinary
+                              mounts"
+                      (is (= #{[frame-a label-q] [frame-b label-q]} (sup/cell-keys)))
+                      (is (= #{frame-a frame-b} (sup/frame-memo-frames))))))
                 (settle-row!
                   {:row      "H1 — two overlapping adoptions, each keeping its own DOM"
                    :done     done
@@ -410,51 +410,51 @@
                     ;; outlive the row.
                     (close!)
                     (stop!)
-                      (is (true? ok) "both roots must commit")
+                    (is (true? ok) "both roots must commit")
 
-                      ;; What REACT complained about, on the page's own error
-                      ;; channel — the control the row is read against.
-                      (let [react-complaints (filterv #(re-find #"Hydration failed" %) @captured)]
+                    ;; What REACT complained about, on the page's own error
+                    ;; channel — the control the row is read against.
+                    (let [react-complaints (filterv #(re-find #"Hydration failed" %) @captured)]
 
-                      (testing "BOTH divergences were detected and reported —
-                                React saw two, and the reporter delegates
-                                unconditionally, so two reach the page"
-                        (is (= 2 (count react-complaints))
-                            (str "two roots diverged, so two React complaints; got "
-                                 (pr-str (mapv #(subs % 0 (min 60 (count %))) @captured)))))
+                    (testing "BOTH divergences were detected and reported —
+                              React saw two, and the reporter delegates
+                              unconditionally, so two reach the page"
+                      (is (= 2 (count react-complaints))
+                          (str "two roots diverged, so two React complaints; got "
+                               (pr-str (mapv #(subs % 0 (min 60 (count %))) @captured)))))
 
-                      (testing "and the framework's own stream carried exactly
-                                what the page did. This is the rf2-6tmu repair:
-                                each root's Spec 011 emit is gated on the window
-                                THAT root minted, so no root's closer can shut
-                                another root's window and no divergence React
-                                reported goes missing"
-                        (is (= (count react-complaints) (count @seen))
-                            (str "every divergence React reported reached the
-                                  instrumentation stream; React said "
-                                 (count react-complaints) ", the framework said "
-                                 (count @seen)))
-                        (is (= 2 (count @seen))
-                            (str "`:rf.ssr/hydration-mismatch` count; got "
-                                 (count @seen) " — "
-                                 (pr-str (mapv (comp :error sup/tags-of) @seen)))))
+                    (testing "and the framework's own stream carried exactly
+                              what the page did. This is the rf2-6tmu repair:
+                              each root's Spec 011 emit is gated on the window
+                              THAT root minted, so no root's closer can shut
+                              another root's window and no divergence React
+                              reported goes missing"
+                      (is (= (count react-complaints) (count @seen))
+                          (str "every divergence React reported reached the
+                                instrumentation stream; React said "
+                               (count react-complaints) ", the framework said "
+                               (count @seen)))
+                      (is (= 2 (count @seen))
+                          (str "`:rf.ssr/hydration-mismatch` count; got "
+                               (count @seen) " — "
+                               (pr-str (mapv (comp :error sup/tags-of) @seen)))))
 
-                      (testing "and what did fire is the framework diagnostic
-                                Spec 011 names, tier-discriminated by its door"
-                        (doseq [ev @seen]
-                          (let [tags (sup/tags-of ev)]
-                            (is (= :rf.ssr/hydration-mismatch (:operation ev)))
-                            (is (= 're-frame.hicasso.impl.mount/hydrate-root! (:where tags)))
-                            (is (= :warned-and-replaced (:recovery tags)))
-                            (is (string? (:error tags))))))
+                    (testing "and what did fire is the framework diagnostic
+                              Spec 011 names, tier-discriminated by its door"
+                      (doseq [ev @seen]
+                        (let [tags (sup/tags-of ev)]
+                          (is (= :rf.ssr/hydration-mismatch (:operation ev)))
+                          (is (= 're-frame.hicasso.impl.mount/hydrate-root! (:where tags)))
+                          (is (= :warned-and-replaced (:recovery tags)))
+                          (is (string? (:error tags))))))
 
-                      (testing "RECOVERY, unlike complaint, IS independent: each
-                                root recovered to its OWN client model, not to
-                                its sibling's"
-                        (is (= "client-A" (text-in ca ".title")))
-                        (is (= "client-B" (text-in cb ".title")))
-                        (is (= "alpha" (text-in ca ".value")))
-                        (is (= "beta"  (text-in cb ".value")))))))
+                    (testing "RECOVERY, unlike complaint, IS independent: each
+                              root recovered to its OWN client model, not to
+                              its sibling's"
+                      (is (= "client-A" (text-in ca ".title")))
+                      (is (= "client-B" (text-in cb ".title")))
+                      (is (= "alpha" (text-in ca ".value")))
+                      (is (= "beta"  (text-in cb ".value")))))))
                 (settle-row!
                   {:row      "H2 — two overlapping mismatches, two complaints"
                    :done     done
@@ -496,28 +496,28 @@
                     (-> (sup/quiesced!)
                         (.then
                           (fn [_]
-                              (testing "frame A's keys are released and frame B's
-                                        survive"
-                                (is (= #{[frame-b label-q]} (sup/cell-keys))
-                                    (str "got " (pr-str (sup/cell-keys)))))
+                            (testing "frame A's keys are released and frame B's
+                                      survive"
+                              (is (= #{[frame-b label-q]} (sup/cell-keys))
+                                  (str "got " (pr-str (sup/cell-keys)))))
 
-                              (testing "and root B is still ADOPTED — its nodes are
-                                        still the server's, so the sibling's
-                                        teardown did not force it through a
-                                        re-render"
-                                (is (sup/every-server-node? cb ".screen, .title, .value")))
+                            (testing "and root B is still ADOPTED — its nodes are
+                                      still the server's, so the sibling's
+                                      teardown did not force it through a
+                                      re-render"
+                              (is (sup/every-server-node? cb ".screen, .title, .value")))
 
-                              (testing "and still live: a render into the surviving
-                                        root re-runs its body and keeps its own
-                                        frame's value"
-                                (let [ran (sup/body-runs-delta!
-                                            (fn [] (mount/render! hb [screen {:title "B2"}])))]
-                                  (is (= 1 ran)))
-                                (is (= "B2" (text-in cb ".title")))
-                                (is (= "beta" (text-in cb ".value"))))
+                            (testing "and still live: a render into the surviving
+                                      root re-runs its body and keeps its own
+                                      frame's value"
+                              (let [ran (sup/body-runs-delta!
+                                          (fn [] (mount/render! hb [screen {:title "B2"}])))]
+                                (is (= 1 ran)))
+                              (is (= "B2" (text-in cb ".title")))
+                              (is (= "beta" (text-in cb ".value"))))
 
-                              (testing "and tearing the survivor down leaves nothing"
-                                (is (= sup/released (sup/teardown-census! hb)))))))))
+                            (testing "and tearing the survivor down leaves nothing"
+                              (is (= sup/released (sup/teardown-census! hb)))))))))
                 (settle-row!
                   {:row      "H3 — independent teardown of two hydrated roots"
                    :done     done
@@ -725,59 +725,59 @@
                             ;; `stop!` is idempotent by its own docstring, and
                             ;; the rejection path never reaches this line.
                             (stop!)
-                              (is (true? ok) "root A's own closer ran")
+                            (is (true? ok) "root A's own closer ran")
 
-                              (testing "root A was BORN PRESENT: its tray never
-                                        rendered a :mounting phase at all, so no
-                                        enter transition replayed over DOM the
-                                        user already watched arrive"
-                                (is (= :present (first (get @!phases :hydrated)))
-                                    (str "root A's first render; saw "
-                                         (pr-str (get @!phases :hydrated))))
-                                (is (not (contains? (set (get @!phases :hydrated))
-                                                    :mounting))
-                                    "and no later render entered one either"))
+                            (testing "root A was BORN PRESENT: its tray never
+                                      rendered a :mounting phase at all, so no
+                                      enter transition replayed over DOM the
+                                      user already watched arrive"
+                              (is (= :present (first (get @!phases :hydrated)))
+                                  (str "root A's first render; saw "
+                                       (pr-str (get @!phases :hydrated))))
+                              (is (not (contains? (set (get @!phases :hydrated))
+                                                  :mounting))
+                                  "and no later render entered one either"))
 
-                              (testing "so the client's first pass AGREED with the
-                                        server's bytes — the adopted nodes are the
-                                        server's own, and nothing diverged"
-                                (is (sup/every-server-node? ca ".screen, .probe"))
-                                (is (= 0 (count @seen))
-                                    (str "no hydration mismatch; got "
-                                         (pr-str (mapv (comp :error sup/tags-of)
-                                                       @seen)))))
+                            (testing "so the client's first pass AGREED with the
+                                      server's bytes — the adopted nodes are the
+                                      server's own, and nothing diverged"
+                              (is (sup/every-server-node? ca ".screen, .probe"))
+                              (is (= 0 (count @seen))
+                                  (str "no hydration mismatch; got "
+                                       (pr-str (mapv (comp :error sup/tags-of)
+                                                     @seen)))))
 
-                              (testing "closing root A's window changed nothing
-                                        about root B: B still completed its own
-                                        enter transition, on its own clock"
-                                (is (false? (roots/adopting? (:adoption ha))))
-                                (is (= [:mounting :present]
-                                       (vec (distinct (get @!phases :ordinary))))
-                                    (str "root B entered and then settled; saw "
-                                         (pr-str (get @!phases :ordinary))))
-                                (is (= "present" (text-in cb ".probe"))))
+                            (testing "closing root A's window changed nothing
+                                      about root B: B still completed its own
+                                      enter transition, on its own clock"
+                              (is (false? (roots/adopting? (:adoption ha))))
+                              (is (= [:mounting :present]
+                                     (vec (distinct (get @!phases :ordinary))))
+                                  (str "root B entered and then settled; saw "
+                                       (pr-str (get @!phases :ordinary))))
+                              (is (= "present" (text-in cb ".probe"))))
 
-                              (testing "and TEARDOWN BEFORE THE PASSIVE EFFECT
-                                        leaves no open window behind. A root
-                                        unmounted before its hydration commit
-                                        never gets its closer, so `unmount!`
-                                        owns the shut — driven here on a handle
-                                        with no root, which is what a closer
-                                        that never ran leaves behind (the
-                                        `:root nil` idiom `teardown-census!`
-                                        uses), rather than on a live root whose
-                                        mid-hydration teardown would be
-                                        measuring React's unmount instead"
-                                (let [window (roots/open-adoption-window!)
-                                      orphan {:frame     frame-a
-                                              :container (mount/fresh-container!)
-                                              :root      nil
-                                              :adoption  window}]
-                                  (is (true? (roots/adopting? window))
-                                      "premise: open, and its closer has not run")
-                                  (mount/unmount! orphan)
-                                  (is (false? (roots/adopting? window))
-                                      "teardown shut it"))))))))))
+                            (testing "and TEARDOWN BEFORE THE PASSIVE EFFECT
+                                      leaves no open window behind. A root
+                                      unmounted before its hydration commit
+                                      never gets its closer, so `unmount!`
+                                      owns the shut — driven here on a handle
+                                      with no root, which is what a closer
+                                      that never ran leaves behind (the
+                                      `:root nil` idiom `teardown-census!`
+                                      uses), rather than on a live root whose
+                                      mid-hydration teardown would be
+                                      measuring React's unmount instead"
+                              (let [window (roots/open-adoption-window!)
+                                    orphan {:frame     frame-a
+                                            :container (mount/fresh-container!)
+                                            :root      nil
+                                            :adoption  window}]
+                                (is (true? (roots/adopting? window))
+                                    "premise: open, and its closer has not run")
+                                (mount/unmount! orphan)
+                                (is (false? (roots/adopting? window))
+                                    "teardown shut it"))))))))))
             (settle-row!
               {:row      "H5 — presence adoption belongs to a subtree, not to the page"
                :done     done
@@ -896,9 +896,9 @@
                                      (sup/adopted! (:ha disarmed))])
                 (.then
                   (fn [oks]
-                      (is (= [true true] (vec oks))
-                          "both hydrating roots must reach their own closer, or
-                           this row left an open window behind")))
+                    (is (= [true true] (vec oks))
+                        "both hydrating roots must reach their own closer, or
+                         this row left an open window behind")))
                 (settle-row!
                   {:row      "H6 — the page-global sabotage control"
                    :done     done


### PR DESCRIPTION
Repairs the last two suites in the unsettled-adoption class: every async row in
`roots_frames_hydration_dom_cljs_test` and `presence_ssr_seam_dom_cljs_test` now
ends in `settle-row!`, spelled verbatim as in the two suites already repaired
(rf2-sxhu PR #8675, rf2-x43z PR #8677).

`rf2-8zhr` and `rf2-z17t`.

## Why this is not tidy-up

An unsettled rejection is an **unhandled** one. It reaches the page as an
uncaught error and the browser runner treats that as terminal: measured on the
sibling suite, the run stopped at that namespace with 85 namespaces announced,
**no summary line at all**, and every later namespace silently unrun. The cost
of a rejection here was never one row — it is a browser-lane truncation whose
log still looks plausible, because there is no count left to compare against.

## Per-chain judgement, not a sweep

Only three of the ten chains across the two files are fed by `sup/adopted!`, so
each was assessed at source and the verdict is recorded with its reason.

**`roots_frames_hydration_dom_cljs_test` — 7 chains, 5 settlements, 1 row out**

| chain | source promise | verdict |
|---|---|---|
| H1 `:196`, H2 `:298`, H3 `:369` | `sup/wait-until!` | **in** — its executor calls `pred?` synchronously, and the row had no rejection arm either way |
| H3 `:377` | `sup/quiesced!` | **in**, under H3's single settlement — the inner promise is *returned* from the outer handler, so the outer adopts it and a second `settle-row!` would call `done` twice |
| H4 `:448` | none | **out** — no promise at all. Synchronous end to end, no `async`; its `try`/`finally` is an ordinary bracket |
| H5 `:556`, `:590` | `sup/settled-server-html!`, `sup/adopted!` | **in** — `settled-server-html!` can reject on its own account: its `.then` reads `.-innerHTML` and calls `mount/release!` |
| H6 `:757` | `js/Promise.all` of two `adopted!` | **in** — rejects if *either* does, and this row holds **four** handles |

**`presence_ssr_seam_dom_cljs_test` — 3 chains, 3 settlements**

| chain | source promise | verdict |
|---|---|---|
| §2 `:423` | `sup/settled-server-html!` | **in** — not an adoption row, but the source can reject. Holds nothing of its own, so it names no `:release!` |
| §3 `:507`, §4 `:601` | `sup/adopted!` | **in** — `close!`/`stop!` sat inside the fulfilment handler, and §3's capture is `:swallow-uncaught? true` |
| §1, §5; the `finally` at `:323` | none | **out** — synchronous end to end; `:323` is an ordinary bracket inside `server-bytes-under-a-hand-held-window!` |

H5 is the one row with **no precedent** in either repaired sibling: its
releasables are minted *inside* the chain, because `ha` needs the server's bytes
and those arrive as a promise, so a tail `settle-row!` cannot close over them.
They are recorded in a `held` atom as they are created and `:release!` gives back
whatever exists — the rejection path being exactly the path on which those `let`s
were never entered.

`close!` and `stop!` stay where they are and are *also* named in `:release!`.
Both are idempotent at source: `close!` on a `closed?` volatile, `stop!` by its
own docstring.

## No assertion changed

Proven mechanically, not by eye: every balanced `(is …)` form extracted from both
revisions and diffed. Append hunks only, zero removals from the before side.

- hydration: **69 forms in, 69 out unaltered and in order, 10 added**
- presence: **38 forms in, 38 out unaltered and in order, 11 added**

The extractor was exercised in both directions before being trusted (59 forms on
the repaired sibling, 0 on a file with none, 1 on a planted file with exactly
one). The dedent is a separate commit in each file so this proof lands against
the repair alone; `git diff -w` on both dedent commits is empty, and every changed
line there is its predecessor with two leading spaces removed.

## Quality gates

Run from `implementation/`. Every exit code below is the runner's own, captured
with `echo $?` on the same command line, on the final rebased base
(`f40207d501`).

```
node scripts/compile-node-test.cjs node-test-hicasso out/node-test-hicasso.js   # exit 0
node out/node-test-hicasso.js                                                   # exit 0
```

`Ran 1335 tests containing 5426 assertions. 0 failures, 0 errors.`

Baseline on the pristine tree before any edit: `1333 tests / 5424 assertions`,
exit 0. The delta is exactly the two new control rows, which self-skip under node
— `sup/skip!` is one `(is true …)` apiece, so +2 tests and +2 assertions is the
arithmetic those two skips predict.

The gate was confirmed to read *this* worktree rather than a peer's: the compile
prints its config path, and it is this checkout's `shadow-cljs.edn`.

### Sabotage, in both directions

Both plants were made on a clean tree, mid-line, with the match count read first
— the first pattern I tried matched **two** lines, not one, which is why the
count is read before planting rather than after. Each restore was verified with
`git hash-object` against the committed blob, not by eye and not by diff.

| plant | row | expectation | result |
|---|---|---|---|
| A — `"mounting"` → `"SABOTAGE-mounting"` at §1 `:485` | runs under node | red | **exit 1, 1 failure**, counts unchanged at 1335/5426 |
| B — same plant at §2 `:551` | browser-gated | green | **exit 0**, counts unchanged at 1335/5426 |

Counts identical across control and both plants, so nothing truncated silently:
plant A flipped exactly one assertion from pass to fail.

**Plant B's green is the measurement, not a pass.** It is a deliberate negative
control, and it bounds this whole gate: the node lane cannot see the browser-gated
rows — which is *all* the adoption rows repaired here. On this lane these two
namespaces get a **compile plus no-regression** check and nothing more; the
settlement behaviour itself, including every `settle-row!` rejection arm and both
new controls, executes only in the browser lane.

### What local-green omits

`test:browser` was **not** run — cold Chromium dominates worker wall-clock and CI
owns it. Per the surfaces these two files arm, the required checks this local gate
does not cover are `cljs_browser` (the lane that actually executes these rows),
`migration_hicasso_codemod`, `hicasso_controlled` and `hicasso_hmr`. The node lane
run above is `cljs_node_test` only. **Local-green here is not CI-green**, and
`cljs_browser` is the check that matters most for this change.

## Scope

Repaired in place; **the lift was not done**. `rf2-7ucn` decides whether
`settle-row!` moves into `roots-frames-support` and explicitly wants both suites
repaired first, so it now has three landed call sites to decide against. The
helper is spelled identically in all four suites — verified byte-identical
between the two already on main — so that lift stays a deletion and a `:require`
rather than a reconciliation.
