### PR TITLE
docs(hicasso): roster every registered id in budgets.md sec.7 (rf2-q0vc)

### DIFF
--- a/implementation/hicasso/spec/budgets.md
+++ b/implementation/hicasso/spec/budgets.md
@@ -1275,8 +1275,8 @@ and no figure may be scaled from one onto the other.
 
 | Family | Enforcement home |
 |---|---|
-| Deterministic rows D1–D26 | ordinary blocking PR gates; framework in `rf2-hic-089`, full gates in `rf2-85og2` (`rf2-hic-071`'s measurement remainder, split there on its 2026-08-14 close) |
-| Distributional rows S1–S8, U1–U4 | pinned interleaved evidence runs on P-DEV-1; never converted into flaky PR thresholds |
+| Deterministic rows D1–D26, U5, U6, I9 | ordinary blocking PR gates; framework in `rf2-hic-089`, full gates in `rf2-85og2` (`rf2-hic-071`'s measurement remainder, split there on its 2026-08-14 close) |
+| Distributional rows S1–S8, U1–U4, C1–C8 | pinned interleaved evidence runs on P-DEV-1; never converted into flaky PR thresholds |
 | Shell breach disposition | `rf2-0xx2` |
 | K3 per-read record | `rf2-hic-070` — [`k3-disposition.md`](../../../docs/design/hicasso/product/k3-disposition.md), whose §8 makes the 10% same-witness per-read rule executable for `rf2-85og2` (`rf2-hic-071` until its 2026-08-14 close) |
 
@@ -1284,6 +1284,15 @@ Row by row, with each verdict beside its line, that table is
 [§9's ledger](budgets.md#9-the-budget-line-reconciliation-ledger). The routing
 above is what the ledger's own gate enforces: a deterministic row must name a
 witness a pull request runs, and a distributional row must not.
+
+The two family rosters are exhaustive over the 49 registered ids, and they are
+spelled out rather than left to be inferred because the gate settles the
+question by exclusion: `check_budget_ledger.py` holds the deterministic roster
+as a closed list, and every registered id absent from that list takes the
+distributional rule. The comparative rules C1–C8 therefore sit beside S1–S8 and
+U1–U4 rather than in a family of their own — the gate has two families, not
+three — and the two rows after them say who settles C5's and C6's outcomes, not
+which lane their readings may be taken in.
 
 ---
 


### PR DESCRIPTION
## What and why

`budgets.md` §7's routing table rostered **38 of the 49 registered ids**: `D1–D26`
as deterministic and `S1–S8, U1–U4` as distributional. The comparative rules
`C1–C8` were named in no row, and neither were `U5`, `U6` and `I9`.

`check_budget_ledger.py` already enforced the right answer, but **by exclusion
rather than by roster**. The lane test is a strict binary —
`deterministic = rid in DETERMINISTIC_IDS`, then `if deterministic: … else:` —
and the `else` arm's failure text calls the row *"a distributional row"* and
cites **sec. 7** for a routing sec. 7 did not state. So a reader who checked the
prose found nothing and a reader who checked the gate found the rule. That
asymmetry is the defect this fixes.

Both rosters now mirror `DETERMINISTIC_IDS` exactly and cover all 49 ids:
deterministic `D1–D26, U5, U6, I9` (29), distributional `S1–S8, U1–U4, C1–C8` (20).

## The one judgement call, settled at source

`C1/C2/C7/C8` join the **existing distributional row beside C3 and C4** — no
fourth family row. Four things in the source decided it, none of them prose:

1. The gate's classification is binary. There is no third family in the code, so
   a fourth family row would assert a routing the gate does not implement — the
   same defect in mirror image.
2. The `else` arm names them: *"L6 %s is a distributional row wired to the
   PR-gate lane."*
3. The gate's own self-test already treats `C1` as the representative
   distributional row, planted beside `S1` on adjacent lines.
4. Empirically, every C row that names a lane names `P-DEV-1 evidence run` —
   the distributional row's home. None names `PR gate`.

`C5` and `C6` keep the dispositions the last two rows give them; those rows say
who settles an outcome, not which lane a reading may be taken in, so there is no
double-routing.

## Beyond the bead

The bead named six unreachable ids (`C1, C2, C3, C4, C7, C8`). Reading the gate's
partition against the table turned up **three more**: `U5`, `U6` and `I9` are in
no §7 row either, and they are on the **deterministic** side — the side the gate
checks *positively* (witness must exist and be selected by a merge-blocking
build). Repairing only the C half would have left the identical defect standing
in the same table, findable by the same method, so both roster lines are fixed.

## Quality gates

Exit codes captured with `echo $?` on the same command line as the runner.

| Command | Exit |
|---|---|
| `python implementation/hicasso/scripts/check_budget_ledger.py` | `0` |
| `python scripts/check_readme_links.py --ci` | `0` |

**Ledger totals unchanged — no cell moved.** Identical string before and after:

```
OK: 49 ledger rows -- 32 MET, 5 BREACH, 3 UNRESOLVED, 9 UNPINNED.
```

### Gate nomination verified, not assumed

`check_doc_slugs.py` is **not** the gate here: its `DEFAULT_ROOTS` is
`("docs", "spec", "skills", "migration")` — top-level roots, so
`implementation/hicasso/spec/budgets.md` is outside them and it exits 0 on a
broken link. `check_readme_links.py --ci` **does** cover this file: it is in
`_iter_source_markdown`'s roster (git-tracked non-`README.md` markdown beside
source). Both confirmed by reading the source, then by the sabotage below.

### Sabotage — each gate proven to read this worktree and refuse a wrong answer

Plants were made mid-line against the committed blob, match counts read before
running, and each restore verified with `git hash-object` against
`git rev-parse HEAD:<path>` rather than a diff.

1. **Lane fault on `I9`** (an id this PR adds to the *deterministic* roster) —
   flipped off `PR gate`. Ledger gate **exit 1**:
   *"L6 I9 is a deterministic row in the 'P-DEV-1 evidence run' lane…"*
2. **Lane fault on `C2`** (an id this PR adds to the *distributional* roster) —
   wired to `PR gate`. Ledger gate **exit 1**:
   *"L6 C2 is a distributional row wired to the PR-gate lane…"*

   Those two reds are the gate independently corroborating **both** roster lines
   written here: it calls `I9` deterministic and `C2` distributional in its own
   words.
3. **Broken `.md` target** planted in the new paragraph. Links gate **exit 1**,
   naming `budgets.md:1295` and the missing path — so it read this worktree.
4. **Negative control.** A flatly false roster — `C1–C8` claimed *deterministic*
   in §7 — still returns the ledger gate **exit 0**. The gate does not read §7's
   table at all. That is precisely why this defect could exist, and it is why the
   hand checks below are the only coverage this table's prose has.

### Checked by hand, because nothing gates it

- **Column counts:** every one of the six §7 table lines has exactly **2 cells**
  against a 2-column header — header, separator and all four body rows counted
  individually, not sampled.
- **Characters:** en dash `U+2013` for ranges (`D1–D26`, `C1–C8`), em dash
  `U+2014` for asides, matching the file's existing convention.
- **Line endings:** the file is CRLF; `CRLF=2522`, bare `LF=0` after the edit, so
  no mixed endings were introduced.
- Prose, table rendering and nav are ungated generally — reviewed by reading.

### What this local run does NOT cover

Local green is not CI. A prose edit to this file arms five `test.yml` surfaces —
`cljs_node_test`, `cljs_browser`, `migration_hicasso_codemod`, `hicasso_controlled`,
`hicasso_hmr` (three browser lanes plus a long compile) — and it is in `docs.yml`'s
docs surface as well. **None of those were run locally; CI owns them.** That toll is
the subject of an open operator call (`rf2-7rzg`) and is untouched here.

## Scope

`implementation/hicasso/spec/budgets.md` §7 only, **+11 / −2**. The two deletions
are the two roster rows being rewritten. No line, band or threshold changed; no
ledger cell moved; no other section touched. Diffed against the merge base after
rebasing onto the current `origin/main`, and read for silent reverts — upstream
did not touch this file.

Refs `rf2-q0vc`. Bead not closed.
