### PR TITLE
docs(method): three repairs from a third pass running the loops

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -560,6 +560,15 @@ the ready view, not what you remember filing. On each one order the material by 
 own timestamps rather than by position, and re-enumerate any children; *Dispatch* above
 explains why.
 
+**And every note you leave here becomes the NEWEST text on that item.** The currency rules are
+written for the reader, and reader and writer are not symmetric: a reader can walk past a stale note
+that sits below newer text, but nothing defends against a stale note that IS the newest text — a
+newest-first walk lands on it and stops. So a note built by re-deriving an item's state from its
+DESCRIPTION, rather than from the notes that already overtook it, is newer by timestamp and older in
+substance, and it buries the true state under your own signature. **The tell is mechanical: a note
+repeating a figure some later note retracted is a note that re-derived instead of re-checking.**
+Cite the check you made, or say plainly that you are summarising and from what.
+
 Four things surface here and nowhere else.
 
 **A fence that has cleared.** The dispatch tick records the fence on the item and moves on,
@@ -662,6 +671,13 @@ and both readings went wrong in a single day here, in opposite directions.
    READING touches nothing**: twice in one day a worker grepping its own gate log was called stranded
    on twenty-three minutes of no writes.
 
+   **That clock says "no activity" in three voices and you can only tell them apart with a control.**
+   Besides the reading worker, a path that resolves to nothing answers identically — and so does a
+   span shorter than the worktree's own age, where every file is recent and the count is the
+   checkout rather than the worker. That last one is the counter-intuitive half, because it returns a
+   large number that reads as proof of life: measured once at *the same count* over fifteen minutes
+   and over six hours. Run the clock twice at different spans before believing either reading.
+
    **The most convincing false signature is on none of the discredited lists: a change fully green at
    the band, a clean worktree, a tip commit some minutes old, and the change still a DRAFT.** It reads
    as a worker that finished and forgot to publish — a real state, and the one step 2 exists to catch
@@ -721,6 +737,13 @@ a coherent change.
 ---
 
 ## 5. Hygiene
+
+**A measurement window makes this whole loop unsafe, and this is the only loop where that is not
+obvious.** Removing a worktree changes the worktree list, which a window registering an
+exclusivity condition captures at both of its brackets — so a reap during one is recorded as a
+violation and can cost the window its runs. The dispatch loop states the condition; nothing carries
+it here, and hygiene is the loop that performs the measured action. Hold the whole loop until the
+window reports. Nothing in it is urgent.
 
 ### Reaping
 


### PR DESCRIPTION
Third retrospective pass on `docs/the-mayor-method/`, from running the five loops rather than from reading them. **23 insertions, 0 deletions, one file, no heading touched.**

The finding document was written before the method tree was touched, as the method's own rule requires. Every candidate below was checked at source in the current tree, and **one was withdrawn on that check**.

## What changed, and why each is not something a mayor works out

**1. A note the mayor writes becomes the NEWEST text on an item** — added where the reread loop invokes the currency rules.

I dispatched a worker at an item's "mechanical half"; it opened no change and reported the premise false, because the work had merged the previous day. One tick later, the same thing on a sibling item — and for that one it was the **third** dispatch of the same half.

Both items already recorded their own discharge. What sat on top, as the newest text by mutation time, were two notes **I had written earlier the same session**, built by re-deriving each item's state from its DESCRIPTION rather than from the notes that had overtaken it.

The rule against this exists and is precise, and it is addressed to the **reader**. Reader and writer are not symmetric: a reader can walk past a stale note sitting below newer text, but nothing defends against a stale note that IS the newest text — a newest-first walk lands on it and stops. Only the writer can prevent that artefact. The clause carries the mechanical tell: *a note repeating a figure some later note retracted is a note that re-derived instead of re-checking.*

**2. The hygiene loop did not know measurement windows exist** — added at the head of that loop.

A window registering an exclusivity condition captures the worktree list at both brackets. Removing a worktree changes it. The dispatch loop states the condition and reaches the merge case in its own words; the hygiene loop mentions no window, bracket or measurement at all — and it is the loop that performs the measured action. I held reaping during a live window only because I had written the finding an hour earlier.

**3. The write clock answers "no activity" in three voices; the document named one** — one sentence extending the existing bullet.

Measured twice within forty minutes, in opposite directions. Pointed at a path whose suffix the directory did not carry, it reported zero writes in ninety minutes and I had already written "candidate strand". Pointed correctly at a worktree fifteen minutes old, it reported **599 files in fifteen minutes — and 599 in six hours**. The count was the checkout, not the worker. That second one is the counter-intuitive half: a large number that reads as proof of life and carries no information.

## What I deliberately did NOT change

**No deletion, and I looked** — the instruction licenses cutting and cutting is the stronger move. Nothing this session showed a rule to be dead, wrong or superseded; the three clauses added in the previous two passes were all exercised, one decisively. Proposing a cut without evidence is the same invention the exercise rules out.

**A fourth finding withdrawn at source.** I had "the merge loop does not know about measurement windows". The dispatch clause already says, in its own text, *"for such a window the fleet is empty rather than thin, and you merge nothing either."* Covered. One command caught it.

**Nothing about the three brief errors workers caught this session.** All three came from compressing my own earlier notes into briefs instead of re-reading at source — Finding 2 of the *previous* pass, reproducing at its reported rate. A fourth restatement is what that pass explicitly warned against.

**One counter-example worth recording**, because the standing finding across three passes is that text usually does *not* reach the reader: a measurement window voided two of three runs to peer writes, one clause was added, and the next window came back with its bracket intact — its own pre-registered record **naming the rule and reporting that it "held on its first outing"**. Same machine, one window apart, the only change being the sentence.

## Quality gates

Exit codes are the runner's own, captured with `echo $?` on the same command line.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `python -m mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** (an end-of-line anchor matches nothing where line endings are translated) on a line this change authored, match count read as exactly **1** before planting. The slug gate returned exit 1 naming `loops.md:679 -> #no-such-anchor-retro3` — its own line, existing only on this branch, which is what proves the gate read this worktree rather than a peer's. Restore verified by `git hash-object` against the committed blob, both `bf4fb8363d…`, then both gates re-run green.

The slug gate was sabotaged rather than mkdocs deliberately: `mkdocs.yml` sets no `anchors` key, so anchors sit at the MkDocs default of INFO and `--strict` promotes WARNING, not INFO. A planted anchor leaves the strict build at exit 0.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier reports all test surfaces false for this path, and `lint.yml`'s surface excludes the docs tree.

**Checked by hand, since nothing gates prose:** zero deletions in the merge-base diff (`origin/main...HEAD`), read for silent reverts rather than for conflicts; **no heading added or changed**, so no anchor cited from outside this tree can break; no table added or touched; the insertions are prose, not inside a fence — which matters because this tree reports doc links inside fences.

Evidence entries E26–E29 and the finding document are in the version-ignored working tree; their conclusions are reproduced above so this record stands alone.
