### PR TITLE
refactor(hicasso): lift settle-row! into roots-frames-support (rf2-7ucn)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/identifier_prefix_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/identifier_prefix_ssr_dom_cljs_test.cljs
@@ -317,59 +317,9 @@
 ;; the whole lane, and the closing summary, inside one `cljs.test/run-block`
 ;; with no try/catch. So the cost of a rejection here was never one row.
 ;;
-;; [[settle-row!]] is the one path all four now end with, and §6 is what
+;; `sup/settle-row!` is the one path all four now end with, and §6 is what
 ;; says it works — because its rejection arm is on no green path, and a
 ;; repair to a branch nothing takes is untested by construction.
-
-(defn- settle-row!
-  "End an async row exactly ONCE, whatever `p` does. `opts` is
-  `{:row :done :release! :report!}`:
-
-    :row      names the row in the failure message. A shared settlement
-              still has to say WHICH row failed, which is the one thing a
-              hand-written rejection arm would give away for free.
-    :done     `cljs.test`'s own, called exactly once.
-    :release! this row's teardown, called exactly once. Every primitive it
-              reaches for is idempotent and says so — `mount/release!`,
-              `(:stop! watch)`, `(:close! capture)` — so a row whose BODY
-              already tore something down as part of an assertion (§4
-              unmounts both roots to take its census) names it here as well
-              and the second call is a no-op. Omit only where the row holds
-              nothing.
-    :report!  what to do with a rejection. Defaults to failing the row,
-              which is what a real row wants; §6 passes a recorder, because
-              for it the rejection is the subject.
-
-  One `.then` carrying BOTH handlers rather than a `.then` and a `.catch`:
-  the two are mutually exclusive, so a body that throws cannot also reach
-  the rejection arm and finish the row twice. The release and the `done`
-  sit on the far side of both, and `done` is in a `finally`, so a teardown
-  that throws still ends the row rather than leaving the runner to time it
-  out.
-
-  The failure is carried as `nil`-or-`[e]` rather than as the value itself,
-  because a promise rejected with `js/undefined` reads as `nil` in CLJS and
-  would otherwise settle silently.
-
-  **A local copy of `server-render-ssr-dom-cljs-test`'s helper of the same
-  name (rf2-sxhu, PR #8675), deliberately spelled identically** — same
-  parameters, same defaults, same `nil`-or-`[e]` carrier — so that lifting
-  the two into `roots-frames-support` when the remaining suites are
-  repaired is a deletion and a `:require`, not a reconciliation of two
-  designs. rf2-7ucn carries that lift and the count that justifies it."
-  [p {:keys [row done release! report!]}]
-  (let [report!  (or report!  (fn [e] (is false (str row " did not settle cleanly — " e))))
-        release! (or release! (fn [] nil))
-        finish!  (fn [failure]
-                   (try
-                     (when failure (report! (str (first failure))))
-                     (release!)
-                     (catch :default te
-                       (is false (str row " could not release — " te)))
-                     (finally (done))))]
-    (.then p
-           (fn [_] (finish! nil))
-           (fn [e] (finish! [e])))))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — the SERVER side alone (no DOM; runs under :node-test)
@@ -497,7 +447,7 @@
                                "obstruction this row records; server "
                                (pr-str server-id) ", client "
                                (pr-str (probe-id container)))))))
-                (settle-row!
+                (sup/settle-row!
                   {:row      "§2 — the bytes a consumer can bake today"
                    :done     done
                    :release! (fn []
@@ -552,7 +502,7 @@
                           (str "the client's own id must equal the server's; "
                                "server " (pr-str server-id) ", client "
                                (pr-str (probe-id container)))))))
-                (settle-row!
+                (sup/settle-row!
                   {:row      "§3 — bytes of the hydrating root's own shape"
                    :done     done
                    :release! (fn []
@@ -647,7 +597,7 @@
                       (is (= sup/released (sup/census))
                           (str "both roots down; residue was "
                                (pr-str (sup/census)))))))
-                (settle-row!
+                (sup/settle-row!
                   {:row      "§4 — two simultaneous hydrating roots"
                    :done     done
                    ;; The FULL handles, where the `finally` this replaced
@@ -728,7 +678,7 @@
                       (is (str/includes? (probe-id container) "pfx-b-")
                           (str "and it is the client's prefix; got "
                                (pr-str (probe-id container)))))))
-                (settle-row!
+                (sup/settle-row!
                   {:row      "§5 — a client prefix that disagrees with the bytes"
                    :done     done
                    :release! (fn []
@@ -740,7 +690,7 @@
 ;; 6 — THE LEAK CONTROL: a rejected adoption still releases the page
 ;; ---------------------------------------------------------------------------
 ;;
-;; §2 through §5 all FULFIL on a green run, so [[settle-row!]]'s rejection
+;; §2 through §5 all FULFIL on a green run, so `sup/settle-row!`'s rejection
 ;; arm is on no green path — and a repair to a branch nothing takes is
 ;; untested by construction. This row takes it.
 ;;
@@ -752,9 +702,9 @@
 ;; Under the shape this file carried before, nothing below the injection
 ;; runs at all. The rejection skips the fulfilment handler, so the `try` is
 ;; never entered and its `finally` never fires: no `stop!`, no `release!`,
-;; no `done`. Measured by removing [[settle-row!]]'s rejection arm and
+;; no `done`. Measured by removing `sup/settle-row!`'s rejection arm and
 ;; running the lane: the run stopped HERE, 85 namespaces in, with no summary
-;; line and every later namespace unrun — see the note above [[settle-row!]]
+;; line and every later namespace unrun — see the note above `sup/settle-row!`
 ;; for why an unsettled rejection is terminal on this runner rather than
 ;; merely slow.
 
@@ -767,7 +717,7 @@
             container      (sup/stamp-server-nodes! (sup/server-dom! html))
             watch          (sup/watch-mismatches!)
             ;; NOT `:swallow-uncaught? true`: this row manufactures a
-            ;; rejected PROMISE, which `settle-row!` handles, and no
+            ;; rejected PROMISE, which `sup/settle-row!` handles, and no
             ;; uncaught window error at all. Swallowing anywhere else is
             ;; the fail-open the browser runner's pageerror rule forbids.
             console-before (.-error js/console)
@@ -788,7 +738,7 @@
                            "is a RELEASE and not an empty page; got "
                            (pr-str (sup/census))))
                   (js/Promise.reject (js/Error. "adoption rejected on purpose"))))
-              (settle-row!
+              (sup/settle-row!
                 {:row      "the rejected-adoption control"
                  :done     (fn [] (swap! finishes inc))
                  :report!  (fn [e] (swap! reports conj e))
@@ -835,7 +785,7 @@
                              @stops " times"))
                     (is (identical? console-before (.-error js/console))
                         "`console.error` is the page's own again"))))
-              (settle-row!
+              (sup/settle-row!
                 {:row      "the rejected-adoption control's own settlement"
                  :done     done
                  :release! (fn []

--- a/implementation/hicasso/test/re_frame/hicasso/presence_ssr_seam_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/presence_ssr_seam_dom_cljs_test.cljs
@@ -387,59 +387,9 @@
 ;; The `finally` inside `server-bytes-under-a-hand-held-window!` is an
 ;; ordinary bracket for the same reason.
 ;;
-;; [[settle-row!]] is the one path all three async rows now end with, and §6
+;; `sup/settle-row!` is the one path all three async rows now end with, and §6
 ;; is what says it works — because its rejection arm is on no green path,
 ;; and a repair to a branch nothing takes is untested by construction.
-
-(defn- settle-row!
-  "End an async row exactly ONCE, whatever `p` does. `opts` is
-  `{:row :done :release! :report!}`:
-
-    :row      names the row in the failure message. A shared settlement
-              still has to say WHICH row failed, which is the one thing a
-              hand-written rejection arm would give away for free.
-    :done     `cljs.test`'s own, called exactly once.
-    :release! this row's teardown, called exactly once. Every primitive it
-              reaches for is idempotent and says so — `mount/release!`,
-              `(:stop! watch)`, `(:close! capture)` — so a row whose BODY
-              already tore something down as part of an assertion names it
-              here as well and the second call is a no-op. Omit only where
-              the row holds nothing, as §2 does.
-    :report!  what to do with a rejection. Defaults to failing the row,
-              which is what a real row wants; §6 passes a recorder, because
-              for it the rejection is the subject.
-
-  One `.then` carrying BOTH handlers rather than a `.then` and a `.catch`:
-  the two are mutually exclusive, so a body that throws cannot also reach
-  the rejection arm and finish the row twice. The release and the `done`
-  sit on the far side of both, and `done` is in a `finally`, so a teardown
-  that throws still ends the row rather than leaving the runner to time it
-  out.
-
-  The failure is carried as `nil`-or-`[e]` rather than as the value itself,
-  because a promise rejected with `js/undefined` reads as `nil` in CLJS and
-  would otherwise settle silently.
-
-  **A local copy of `server-render-ssr-dom-cljs-test`'s helper of the same
-  name (rf2-sxhu, PR #8675), deliberately spelled identically** — same
-  parameters, same defaults, same `nil`-or-`[e]` carrier — as
-  `identifier-prefix-ssr-dom-cljs-test`'s is (rf2-x43z, PR #8677), so that
-  lifting the copies into `roots-frames-support` is a deletion and a
-  `:require`, not a reconciliation of designs. rf2-7ucn carries that lift
-  and the count that justifies it."
-  [p {:keys [row done release! report!]}]
-  (let [report!  (or report!  (fn [e] (is false (str row " did not settle cleanly — " e))))
-        release! (or release! (fn [] nil))
-        finish!  (fn [failure]
-                   (try
-                     (when failure (report! (str (first failure))))
-                     (release!)
-                     (catch :default te
-                       (is false (str row " could not release — " te)))
-                     (finally (done))))]
-    (.then p
-           (fn [_] (finish! nil))
-           (fn [e] (finish! [e])))))
 
 ;; ---------------------------------------------------------------------------
 ;; §1 — a server render with NO window scoped over it installs no adoption
@@ -559,7 +509,7 @@
             ;; `settled-server-html!` releases the client root it used to
             ;; produce the settled bytes, and `server-bytes!` is a
             ;; `renderToString` with no DOM behind it.
-            (settle-row!
+            (sup/settle-row!
               {:row  "§2 — the client's settled bytes are not the server's"
                :done done}))))))
 
@@ -687,7 +637,7 @@
                               file rests on it"
                       (is (= "present" (text-in ca ".probe")))
                       (is (= "alpha" (text-in ca ".value"))))))
-                (settle-row!
+                (sup/settle-row!
                   {:row      "§3 — hydrating the real server bytes diverges"
                    :done     done
                    :release! (fn []
@@ -746,7 +696,7 @@
                     (testing "and kept the server's own nodes, which is what
                               adoption MEANS and what §3 lost"
                       (is (sup/every-server-node? ca ".screen, .value")))))
-                (settle-row!
+                (sup/settle-row!
                   {:row      "§4 — the same real server path with no tray"
                    :done     done
                    :release! (fn []
@@ -821,7 +771,7 @@
 ;;      the console and the watcher
 ;; ---------------------------------------------------------------------------
 ;;
-;; §2 through §4 all FULFIL on a green run, so [[settle-row!]]'s rejection
+;; §2 through §4 all FULFIL on a green run, so `sup/settle-row!`'s rejection
 ;; arm is on no green path — and a repair to a branch nothing takes is
 ;; untested by construction. This row takes it.
 ;;
@@ -847,7 +797,7 @@
             ca             (sup/stamp-server-nodes! (sup/server-dom! html))
             watch          (sup/watch-mismatches!)
             ;; NOT `:swallow-uncaught? true`: this row manufactures a rejected
-            ;; PROMISE, which `settle-row!` handles, and no uncaught window
+            ;; PROMISE, which `sup/settle-row!` handles, and no uncaught window
             ;; error at all. Swallowing anywhere else is the fail-open the
             ;; browser runner's pageerror rule forbids.
             console-before (.-error js/console)
@@ -867,7 +817,7 @@
                            "is a RELEASE and not an empty page; got "
                            (pr-str (sup/census))))
                   (js/Promise.reject (js/Error. "adoption rejected on purpose"))))
-              (settle-row!
+              (sup/settle-row!
                 {:row      "the rejected-adoption control"
                  :done     (fn [] (swap! finishes inc))
                  :report!  (fn [e] (swap! reports conj e))
@@ -913,7 +863,7 @@
                              @stops " times"))
                     (is (identical? console-before (.-error js/console))
                         "`console.error` is the page's own again"))))
-              (settle-row!
+              (sup/settle-row!
                 {:row      "the rejected-adoption control's own settlement"
                  :done     done
                  :release! (fn []

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
@@ -201,63 +201,13 @@
 ;; inside one `cljs.test/run-block` with no try/catch. So the cost of a
 ;; rejection here was never one row.
 ;;
-;; [[settle-row!]] is the one path every async row now ends with, and H7 is
+;; `sup/settle-row!` is the one path every async row now ends with, and H7 is
 ;; what says it works — because its rejection arm is on no green path, and
 ;; a repair to a branch nothing takes is untested by construction.
 ;;
 ;; H4 is deliberately NOT on it: that row is synchronous end to end — no
 ;; `async`, no promise — so its `try`/`finally` is an ordinary bracket and
 ;; there is no settlement question to answer.
-
-(defn- settle-row!
-  "End an async row exactly ONCE, whatever `p` does. `opts` is
-  `{:row :done :release! :report!}`:
-
-    :row      names the row in the failure message. A shared settlement
-              still has to say WHICH row failed, which is the one thing a
-              hand-written rejection arm would give away for free.
-    :done     `cljs.test`'s own, called exactly once.
-    :release! this row's teardown, called exactly once. Every primitive it
-              reaches for is idempotent and says so — `mount/release!`,
-              `(:stop! watch)`, `(:close! capture)` — so a row whose BODY
-              already tore something down as part of an assertion names it
-              here as well and the second call is a no-op. Omit only where
-              the row holds nothing.
-    :report!  what to do with a rejection. Defaults to failing the row,
-              which is what a real row wants; H7 passes a recorder, because
-              for it the rejection is the subject.
-
-  One `.then` carrying BOTH handlers rather than a `.then` and a `.catch`:
-  the two are mutually exclusive, so a body that throws cannot also reach
-  the rejection arm and finish the row twice. The release and the `done`
-  sit on the far side of both, and `done` is in a `finally`, so a teardown
-  that throws still ends the row rather than leaving the runner to time it
-  out.
-
-  The failure is carried as `nil`-or-`[e]` rather than as the value itself,
-  because a promise rejected with `js/undefined` reads as `nil` in CLJS and
-  would otherwise settle silently.
-
-  **A local copy of `server-render-ssr-dom-cljs-test`'s helper of the same
-  name (rf2-sxhu, PR #8675), deliberately spelled identically** — same
-  parameters, same defaults, same `nil`-or-`[e]` carrier — as
-  `identifier-prefix-ssr-dom-cljs-test`'s is (rf2-x43z, PR #8677), so that
-  lifting the copies into `roots-frames-support` is a deletion and a
-  `:require`, not a reconciliation of designs. rf2-7ucn carries that lift
-  and the count that justifies it."
-  [p {:keys [row done release! report!]}]
-  (let [report!  (or report!  (fn [e] (is false (str row " did not settle cleanly — " e))))
-        release! (or release! (fn [] nil))
-        finish!  (fn [failure]
-                   (try
-                     (when failure (report! (str (first failure))))
-                     (release!)
-                     (catch :default te
-                       (is false (str row " could not release — " te)))
-                     (finally (done))))]
-    (.then p
-           (fn [_] (finish! nil))
-           (fn [e] (finish! [e])))))
 
 ;; ---------------------------------------------------------------------------
 ;; H1 — two overlapping adoptions, each keeping its own DOM
@@ -318,7 +268,7 @@
                               mounts"
                       (is (= #{[frame-a label-q] [frame-b label-q]} (sup/cell-keys)))
                       (is (= #{frame-a frame-b} (sup/frame-memo-frames))))))
-                (settle-row!
+                (sup/settle-row!
                   {:row      "H1 — two overlapping adoptions, each keeping its own DOM"
                    :done     done
                    :release! (fn []
@@ -455,7 +405,7 @@
                       (is (= "client-B" (text-in cb ".title")))
                       (is (= "alpha" (text-in ca ".value")))
                       (is (= "beta"  (text-in cb ".value")))))))
-                (settle-row!
+                (sup/settle-row!
                   {:row      "H2 — two overlapping mismatches, two complaints"
                    :done     done
                    :release! (fn []
@@ -490,7 +440,7 @@
                     ;; read zero whatever the teardown did.
                     (mount/unmount! ha)
                     ;; The inner chain is RETURNED from this handler, so the
-                    ;; outer promise adopts it and ONE `settle-row!` at the
+                    ;; outer promise adopts it and ONE `sup/settle-row!` at the
                     ;; outer tail settles the whole row. Two — one per chain —
                     ;; would call `done` twice on the green path.
                     (-> (sup/quiesced!)
@@ -518,7 +468,7 @@
 
                             (testing "and tearing the survivor down leaves nothing"
                               (is (= sup/released (sup/teardown-census! hb)))))))))
-                (settle-row!
+                (sup/settle-row!
                   {:row      "H3 — independent teardown of two hydrated roots"
                    :done     done
                    :release! (fn []
@@ -671,7 +621,7 @@
       ;; `held` is what lets ONE settlement cover this row, and it is here
       ;; because this row is the only one whose releasables are minted INSIDE
       ;; the chain: `ha` needs the server's bytes, and those arrive as a
-      ;; promise. A `settle-row!` at the tail cannot close over bindings the
+      ;; promise. A `sup/settle-row!` at the tail cannot close over bindings the
       ;; chain makes, and the rejection path is exactly the path on which
       ;; those `let`s were never entered — so each is recorded as it is
       ;; created and `:release!` gives back whatever exists. Every other row
@@ -778,7 +728,7 @@
                                 (mount/unmount! orphan)
                                 (is (false? (roots/adopting? window))
                                     "teardown shut it"))))))))))
-            (settle-row!
+            (sup/settle-row!
               {:row      "H5 — presence adoption belongs to a subtree, not to the page"
                :done     done
                :release! (fn []
@@ -899,7 +849,7 @@
                     (is (= [true true] (vec oks))
                         "both hydrating roots must reach their own closer, or
                          this row left an open window behind")))
-                (settle-row!
+                (sup/settle-row!
                   {:row      "H6 — the page-global sabotage control"
                    :done     done
                    :release! (fn []
@@ -912,7 +862,7 @@
 ;; H7 — THE LEAK CONTROL: a rejected adoption still releases BOTH roots
 ;; ---------------------------------------------------------------------------
 ;;
-;; H1 through H6 all FULFIL on a green run, so [[settle-row!]]'s rejection
+;; H1 through H6 all FULFIL on a green run, so `sup/settle-row!`'s rejection
 ;; arm is on no green path — and a repair to a branch nothing takes is
 ;; untested by construction. This row takes it.
 ;;
@@ -942,7 +892,7 @@
             cb       (sup/stamp-server-nodes! (sup/server-dom! html-b))
             watch    (sup/watch-mismatches!)
             ;; NOT `:swallow-uncaught? true`: this row manufactures a
-            ;; rejected PROMISE, which `settle-row!` handles, and no uncaught
+            ;; rejected PROMISE, which `sup/settle-row!` handles, and no uncaught
             ;; window error at all. Swallowing anywhere else is the fail-open
             ;; the browser runner's pageerror rule forbids.
             stops    (atom 0)
@@ -961,7 +911,7 @@
                            "is a RELEASE and not an empty page; got "
                            (pr-str (sup/census))))
                   (js/Promise.reject (js/Error. "adoption rejected on purpose"))))
-              (settle-row!
+              (sup/settle-row!
                 {:row      "the rejected-adoption control"
                  :done     (fn [] (swap! finishes inc))
                  :report!  (fn [e] (swap! reports conj e))
@@ -1004,7 +954,7 @@
                         (str "the mismatch watcher was stopped — `stop!` is what "
                              "unregisters the trace listener; it ran "
                              @stops " times")))))
-              (settle-row!
+              (sup/settle-row!
                 {:row      "the rejected-adoption control's own settlement"
                  :done     done
                  :release! (fn []

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
@@ -2,10 +2,17 @@
   "THE MULTI-ROOT WITNESS HARNESS — the observables, and the reasons they
   are these observables.
 
-  Two suites read this file: `roots-frames-isolation-dom-cljs-test` and
-  `roots-frames-hydration-dom-cljs-test`. It exists because both of them
-  have to answer the same awkward question, and answering it twice by
-  hand is how the two answers drift apart.
+  It was written for two suites — `roots-frames-isolation-dom-cljs-test`
+  and `roots-frames-hydration-dom-cljs-test` — because both of them have
+  to answer the same awkward question, and answering it twice by hand is
+  how the two answers drift apart. That reason held for the rest of the
+  package's DOM arm too, and this is now the harness the whole of it
+  reads: `git grep -l roots-frames-support` over this directory is the
+  roster, not a list here, and the name has outlived its scope rather
+  than describing it. So a helper belongs here when the DOM suites would
+  otherwise each spell it themselves — [[settle-row!]] is the plainest
+  case, four verbatim copies collapsed into one — and NOT merely because
+  it mentions roots or frames.
 
   ## The awkward question
 
@@ -94,6 +101,81 @@
   false green."
   [why]
   (is true (str "a multi-root claim needs a real React DOM — " why)))
+
+(defn settle-row!
+  "End an async row exactly ONCE, whatever `p` does. `opts` is
+  `{:row :done :release! :report!}`:
+
+    :row      names the row in the failure message. A shared settlement
+              still has to say WHICH row failed, which is the one thing a
+              hand-written rejection arm gave away for free.
+    :done     `cljs.test`'s own, called exactly once.
+    :release! this row's teardown, called exactly once. Every primitive it
+              reaches for is idempotent and says so — `mount/release!`,
+              `h/unmount!`, `(:stop! watch)`, `(:close! capture)` — so a
+              row whose BODY already tore something down as part of an
+              assertion names it here as well and the second call is a
+              no-op. Omit only where the row holds nothing.
+    :report!  what to do with a rejection. Defaults to failing the row,
+              which is what a real row wants; a suite's rejection control
+              passes a recorder, because for it the rejection is the
+              subject.
+
+  One `.then` carrying BOTH handlers rather than a `.then` and a `.catch`:
+  the two are mutually exclusive, so a body that throws cannot also reach
+  the rejection arm and finish the row twice. The release and the `done`
+  sit on the far side of both, and `done` is in a `finally`, so a teardown
+  that throws still ends the row rather than leaving the runner to time it
+  out.
+
+  The failure is carried as `nil`-or-`[e]` rather than as the value itself,
+  because a promise rejected with `js/undefined` reads as `nil` in CLJS and
+  would otherwise settle silently.
+
+  ## Why an unsettled row is worse than a slow one, and why this is shared
+
+  On the browser lane an unsettled rejection is an UNHANDLED one, so it
+  reaches the page as an uncaught error and the runner treats that as
+  terminal (rf2-u0j8). Measured on `identifier-prefix-ssr-dom-cljs-test`:
+  the run stopped at that namespace with 85 announced, no summary line at
+  all, and every namespace scheduled after it silently unrun — `shadow.test`
+  runs the whole lane, and the closing summary, inside one
+  `cljs.test/run-block` with no try/catch. So the cost of a rejection was
+  never one row, which is why every async row in the SSR and hydration
+  suites ends here rather than in a hand-written `.catch`.
+
+  This definition was four verbatim copies, one per adopting suite, spelled
+  identically on purpose so the lift would be a deletion rather than a
+  reconciliation of designs (rf2-sxhu, rf2-x43z, rf2-8zhr, rf2-z17t;
+  collapsed by rf2-7ucn).
+
+  ## Where its own coverage lives, and why it is not here
+
+  This namespace holds no `deftest`s, and the rejection arm is on NO green
+  path — a repair to a branch nothing takes is untested by construction. So
+  each adopting suite keeps its OWN rejection control, written against that
+  suite's row shape and its own releasables: the two rows under
+  `server-render-ssr-dom-cljs-test`'s §6, and one apiece in
+  `identifier-prefix-ssr-dom-cljs-test` (§6),
+  `presence-ssr-seam-dom-cljs-test` (§6) and
+  `roots-frames-hydration-dom-cljs-test` (H7). Those controls are not
+  duplicates of one another — each manufactures its rejection from the
+  handles its own lane holds, and what they assert is that THIS function
+  reports once and releases everything that lane had open. Centralising
+  them would mean a control that releases nothing real."
+  [p {:keys [row done release! report!]}]
+  (let [report!  (or report!  (fn [e] (is false (str row " did not settle cleanly — " e))))
+        release! (or release! (fn [] nil))
+        finish!  (fn [failure]
+                   (try
+                     (when failure (report! (str (first failure))))
+                     (release!)
+                     (catch :default te
+                       (is false (str row " could not release — " te)))
+                     (finally (done))))]
+    (.then p
+           (fn [_] (finish! nil))
+           (fn [e] (finish! [e])))))
 
 ;; ---------------------------------------------------------------------------
 ;; Kernel observables — the cell table, read as a SHAPE

--- a/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
@@ -403,52 +403,10 @@
 ;;     the runner twice and lands its report on whichever row is running
 ;;     by then.
 ;;
-;; [[settle-row!]] is the one path all of them now end with, and the two
+;; `sup/settle-row!` is the one path all of them now end with, and the two
 ;; rows under it are what say it works — because neither branch is on any
 ;; green path, and a repair to a branch nothing takes is untested by
 ;; construction.
-
-(defn- settle-row!
-  "End an async row exactly ONCE, whatever `p` does. `opts` is
-  `{:row :done :release! :report!}`:
-
-    :row      names the row in the failure message. A shared settlement
-              still has to say WHICH row failed, which is the one thing
-              four hand-written `.catch`es gave away for free.
-    :done     `cljs.test`'s own, called exactly once.
-    :release! this row's teardown, called exactly once. Every primitive
-              it reaches for is idempotent and says so — `h/unmount!`,
-              `(:stop! watch)`, `(:close! capture)` — so a row whose BODY
-              already tore something down as part of an assertion (§4's
-              `(is (nil? (h/unmount! handle)))`) names it here as well
-              and the second call is a no-op. Omit only where the row
-              holds nothing.
-    :report!  what to do with a rejection. Defaults to failing the row,
-              which is what a real row wants; the two controls below pass
-              a recorder, because for them the rejection is the subject.
-
-  One `.then` carrying BOTH handlers rather than a `.then` and a
-  `.catch`: the two are mutually exclusive, so a body that throws cannot
-  also reach the rejection arm. The release and the `done` sit on the far
-  side of both, and `done` is in a `finally`, so a teardown that throws
-  still ends the row rather than leaving the runner to time it out.
-
-  The failure is carried as `nil`-or-`[e]` rather than as the value
-  itself, because a promise rejected with `js/undefined` reads as `nil`
-  in CLJS and would otherwise settle silently."
-  [p {:keys [row done release! report!]}]
-  (let [report!  (or report!  (fn [e] (is false (str row " did not settle cleanly — " e))))
-        release! (or release! (fn [] nil))
-        finish!  (fn [failure]
-                   (try
-                     (when failure (report! (str (first failure))))
-                     (release!)
-                     (catch :default te
-                       (is false (str row " could not release — " te)))
-                     (finally (done))))]
-    (.then p
-           (fn [_] (finish! nil))
-           (fn [e] (finish! [e])))))
 
 (deftest a-throwing-body-finishes-the-row-once-and-not-twice
   ;; THE DOUBLE-FINISH CONTROL. No DOM in it — this is the promise
@@ -460,10 +418,10 @@
           reports  (atom [])]
       (-> (js/Promise.resolve true)
           (.then (fn [_] (throw (js/Error. "the body threw"))))
-          (settle-row! {:row      "the throwing-body control"
-                        :done     (fn [] (swap! finishes inc))
-                        :release! (fn [] (swap! releases inc))
-                        :report!  (fn [e] (swap! reports conj e))})
+          (sup/settle-row! {:row      "the throwing-body control"
+                            :done     (fn [] (swap! finishes inc))
+                            :release! (fn [] (swap! releases inc))
+                            :report!  (fn [e] (swap! reports conj e))})
           (.then
             (fn [_]
               (testing "a body that throws finishes the row ONCE. The shape
@@ -480,8 +438,8 @@
                 (is (str/includes? (str (first @reports)) "the body threw")
                     (str "naming the error the body raised; got "
                          (pr-str @reports))))))
-          (settle-row! {:row "the throwing-body control's own settlement"
-                        :done done})))))
+          (sup/settle-row! {:row "the throwing-body control's own settlement"
+                            :done done})))))
 
 (deftest a-rejected-adoption-leaves-the-next-row-a-clean-page
   ;; THE LEAK CONTROL. The rejection is injected AFTER the adoption
@@ -514,14 +472,14 @@
                                 "the rejection is a RELEASE and not an empty "
                                 "page; got " (pr-str (sup/census))))
                        (js/Promise.reject (js/Error. "adoption rejected on purpose"))))
-              (settle-row! {:row      "the rejected-adoption control"
-                            :done     (fn [] (swap! finishes inc))
-                            :report!  (fn [e] (swap! reports conj e))
-                            :release! (fn []
-                                        ((:close! capture))
-                                        (swap! stops inc)
-                                        ((:stop! watch))
-                                        (h/unmount! handle))})
+              (sup/settle-row! {:row      "the rejected-adoption control"
+                                :done     (fn [] (swap! finishes inc))
+                                :report!  (fn [e] (swap! reports conj e))
+                                :release! (fn []
+                                            ((:close! capture))
+                                            (swap! stops inc)
+                                            ((:stop! watch))
+                                            (h/unmount! handle))})
               ;; The cell reapers are armed at unmount and run past a bare
               ;; macrotask, so the table is read at the runtime's own
               ;; horizon rather than one tick after the release.
@@ -550,12 +508,12 @@
                              @stops " times"))
                     (is (identical? console-before (.-error js/console))
                         "`console.error` is the page's own again"))))
-              (settle-row! {:row      "the rejected-adoption control's own settlement"
-                            :done     done
-                            :release! (fn []
-                                        ((:close! capture))
-                                        ((:stop! watch))
-                                        (h/unmount! handle))})))))))
+              (sup/settle-row! {:row      "the rejected-adoption control's own settlement"
+                                :done     done
+                                :release! (fn []
+                                            ((:close! capture))
+                                            ((:stop! watch))
+                                            (h/unmount! handle))})))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — the far side: the bytes hydrate through the PUBLIC door
@@ -590,11 +548,11 @@
             ;; not this row's teardown; the teardown is named again here
             ;; so a rejection still gets one, and `unmount!` is
             ;; idempotent by contract.
-            (settle-row! {:row      "§4's hydration row"
-                          :done     done
-                          :release! (fn []
-                                      ((:stop! watch))
-                                      (h/unmount! handle))}))))))
+            (sup/settle-row! {:row      "§4's hydration row"
+                              :done     done
+                              :release! (fn []
+                                          ((:stop! watch))
+                                          (h/unmount! handle))}))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4b — THE READING: the id itself, read off the bytes and read back off
@@ -698,11 +656,11 @@
 
                        (testing "and nothing reached Spec 011's channel"
                          (is (= [] ((:stop! watch)))))))
-              (settle-row! {:row      "§4b-2's reading row"
-                            :done     done
-                            :release! (fn []
-                                        ((:stop! watch))
-                                        (h/unmount! handle))})))))))
+              (sup/settle-row! {:row      "§4b-2's reading row"
+                                :done     done
+                                :release! (fn []
+                                            ((:stop! watch))
+                                            (h/unmount! handle))})))))))
 
 (deftest the-hand-rolled-bytes-lose-the-id-through-the-same-door
   ;; THE CONTROL. Same public door, same helpers, same run — the other
@@ -768,12 +726,12 @@
               ;; A rejection here would leave `console.error` replaced for
               ;; every row that follows, which is the one leak in this file
               ;; that no fixture takes back.
-              (settle-row! {:row      "§4b-3's control row"
-                            :done     done
-                            :release! (fn []
-                                        ((:close! capture))
-                                        ((:stop! watch))
-                                        (h/unmount! handle))})))))))
+              (sup/settle-row! {:row      "§4b-3's control row"
+                                :done     done
+                                :release! (fn []
+                                            ((:close! capture))
+                                            ((:stop! watch))
+                                            (h/unmount! handle))})))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5 — THE DOCUMENTED ROUND TRIP: payload script → state → DOM
@@ -861,9 +819,9 @@
                                  whole claim, since a frame seeded after the
                                  adopt would have diverged on this text"
                          (is (= [] ((:stop! watch)))))))
-              (settle-row! {:row      "§5's round-trip row"
-                            :done     done
-                            :release! (fn []
-                                        ((:stop! watch))
-                                        (h/unmount! handle)
-                                        (remove!))})))))))
+              (sup/settle-row! {:row      "§5's round-trip row"
+                                :done     done
+                                :release! (fn []
+                                            ((:stop! watch))
+                                            (h/unmount! handle)
+                                            (remove!))})))))))


### PR DESCRIPTION
`settle-row!` stood as **four** verbatim `defn-` copies. This collapses them into
one public `defn` in `re-frame.hicasso.roots-frames-support` and prefixes the 26
call sites. No behaviour changes.

## The four bodies were genuinely identical

Checked mechanically rather than by eye: each `(defn- settle-row! …)` form was
extracted by a string-aware balanced-paren scan and hashed with its docstring
elided.

| suite | form | code (docstring elided) |
|---|---|---|
| `identifier_prefix_ssr_dom_cljs_test.cljs` | 2669 chars | 615 chars, `sha256:349e7ef4f1e7` |
| `presence_ssr_seam_dom_cljs_test.cljs` | 2653 chars | 615 chars, `sha256:349e7ef4f1e7` |
| `roots_frames_hydration_dom_cljs_test.cljs` | 2641 chars | 615 chars, `sha256:349e7ef4f1e7` |
| `server_render_ssr_dom_cljs_test.cljs` | 2209 chars | 615 chars, `sha256:349e7ef4f1e7` |

One hash across all four — same parameter list, same defaults, same
`nil`-or-`[e]` carrier. Only the docstrings differed, and only in which rows and
teardown primitives they named.

## It is less than a deletion plus a `:require`

All four suites **already** carry `[re-frame.hicasso.roots-frames-support :as sup]`,
and the target already `:refer-macros`es `is` (it is what `skip!` is built on). So
no `ns` form changes anywhere in the diff.

## Where the shared definition lives, and what decided it

`roots-frames-support`, and the deciding fact is that it is **already** the DOM
arm's common harness rather than the two-suite file its docstring claimed:
`git grep -l roots-frames-support` over
`implementation/hicasso/test/re_frame/hicasso/` returns **22 files**, the four
adopters among them.

So the objection worth taking seriously — two of the four suites are not
"roots frames" by name — turns out to be about the *name*, not the *scope*. The
namespace has outlived its name. Hosting the helper there adds no reader and no
require; a new `settlement-support` namespace would have added one of each, for
a 15-line function. That is the whole of the decision, and the ns docstring is
corrected to say what the file has become and what now belongs in it (a helper
the DOM suites would otherwise each spell themselves — not merely one that
mentions roots or frames).

**Visibility.** The lifted `settle-row!` is public. The namespace holds 24 public
`defn`s and no `defn-` at all, so private would have been the anomaly, not the
default.

## Call-site-shaped state: checked all 26 sites

`roots-frames-hydration` **H5** holds its releasables in a `held` atom because it
mints them *inside* the chain — `ha` needs the server's bytes, which arrive as a
promise — so a tail settlement cannot close over them. That is a call-site shape,
not a helper variant: H5 passes the ordinary `{:row :done :release!}` and the
helper is untouched by it. **It is not absorbed, and it is the only shape of its
kind among the 26 sites** — every other row binds its handles before the chain
and names them directly.

## Coverage stays distributed, deliberately

This namespace holds no `deftest`s, and `settle-row!`'s rejection arm is on no
green path. Each suite therefore keeps its **own** rejection control, written
against that suite's row shape and its own releasables: two rows under
`server-render`'s §6, and one apiece in `identifier-prefix` (§6),
`presence-ssr-seam` (§6) and `roots-frames-hydration` (H7). These are not
duplicates of one another — each manufactures its rejection from the handles its
own lane holds. Centralising them would produce a control that releases nothing
real. The reasoning is recorded on the function so the next reader does not have
to re-derive it.

## No behaviour change — shown mechanically

**Static.** Every assertion-bearing form moves rather than changes. Each suite
loses exactly the helper's two `(is …)` forms; the support namespace gains them
once:

| file | `(is ` | `(deftest` | `(testing` | `(async` |
|---|---|---|---|---|
| `identifier_prefix_…` | 59 → 57 | 7 → 7 | 18 → 18 | 5 → 5 |
| `presence_ssr_seam_…` | 49 → 47 | 6 → 6 | 18 → 18 | 4 → 4 |
| `roots_frames_hydration_…` | 79 → 77 | 7 → 7 | 26 → 26 | 6 → 6 |
| `server_render_ssr_…` | 89 → 86 | 14 → 14 | 33 → 33 | 6 → 6 |
| `roots_frames_support` | 2 → 4 | 0 → 0 | 0 → 0 | 0 → 0 |

`server_render`'s −3 is −2 assertions plus one **docstring prose** line that
happened to contain `(is (nil? (h/unmount! handle)))` as an example inside the
deleted docstring. Confirmed by auditing every removed line in the diff that
contains `(is `: eight are the four helper bodies, one is that prose line, and
nothing else was removed.

**Runtime.** Identical, to the assertion:

```
before   Ran 1335 tests containing 5426 assertions.  0 failures, 0 errors.
after    Ran 1335 tests containing 5426 assertions.  0 failures, 0 errors.
```

**Whitespace.** `server_render`'s eight call sites open their opts map on the
same line, so `sup/` shifted the map continuations by four columns and they were
re-indented to match. `git diff -w --numstat` reads `9 / 51` for that file
against `43 / 85` unignored — the extra churn is indentation only.

## Quality gates

Run from `implementation/`. Every exit code below is the runner's own, captured
with `echo $?` on the same command line as the command it belongs to.

```
node scripts/compile-node-test.cjs node-test-hicasso out/node-test-hicasso.js
  exit 0     (549 files, 20 compiled, 0 warnings)
node out/node-test-hicasso.js
  exit 0     Ran 1335 tests containing 5426 assertions. 0 failures, 0 errors.
```

Both re-run on the final rebased base (`b780070e17`), not only on the original one.

### Sabotage, and what it proved beyond the usual

Committed first, then planted **mid-line** (an end-of-line anchor matches nothing
in this CRLF working tree) inside the *lifted* definition in
`roots_frames_support.cljs`: `(when failure (report! …)` → `(when-not failure …`.
Match count read before running — exactly **1** occurrence corpus-wide, which is
itself evidence the four copies are gone. Reverse control for the planted spelling
returned zero beforehand.

```
node out/node-test-hicasso.js     exit 1
  Ran 1335 tests containing 5427 assertions. 3 failures, 0 errors.
  FAIL in (a-throwing-body-finishes-the-row-once-and-not-twice) …:437 and :438
```

Restored, and the restore verified by `git hash-object` against the committed
blob — `2ef75aecb2cd62cd29ea1f71049813137560fa95` on both sides — rather than by a
diff, since "unchanged" and "not attempted" produce the same diff.

**This says more than a compile check.** The failing rows are in
`server-render-ssr-dom-cljs-test`'s `a-throwing-body-finishes-the-row-once-and-not-twice`,
which carries **no `mount/browser?` gate** and so executes on the node lane —
driving the lifted helper's *rejection* arm. So for this change the node lane is
not merely compile-plus-no-regression: it executes the shared definition, and a
fault planted in it goes red at exit 1 with the failure named. It also confirms
the gate read this worktree, as does the `shadow-cljs - config:` line in the
compile log.

### What this local gate does NOT cover

Local green is not CI. The changed paths classify to **six** surfaces
(`.github/scripts/report-changed-surfaces.sh`, controlled in both directions):

```
implementation_jvm=true  cljs_node_test=true  cljs_browser=true
migration_hicasso_codemod=true  hicasso_controlled=true  hicasso_hmr=true
```

I ran a focused slice of `cljs_node_test` only — the `node-test-hicasso` build, not
the full `node-test` build. **Not run locally:** `implementation_jvm`,
`cljs_browser`, `migration_hicasso_codemod`, `hicasso_controlled`, `hicasso_hmr`.
The browser lane is where the other three suites' rejection controls actually
execute (all are `mount/browser?`-gated), and CI owns it.

Carries rf2-7ucn. Bead left open for the mayor.
