### PR TITLE
docs(ci): make lint.yml's self-description true — two senses of "lint surface", and the fourth gated job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,18 @@ name: lint
 # Multi-linter CI gate.
 #
 # Three complementary linters run as parallel jobs — two over the Clojure
-# trees, one over the JavaScript ones:
+# trees, one over the JavaScript ones. They are not, however, the whole of what
+# this file gates, and reading the list below as the answer to "what does my
+# diff arm?" undercounts it (rf2-63il). Two further jobs sit alongside them.
+# `api-manifest` (Public-API manifest drift-check) is not a linter at all, yet
+# it is gated on the very same `lint_surface` output as clj-kondo and Splint,
+# so a change under implementation/ or tools/ arms FOUR gated jobs rather than
+# three — and the three linters do not even share one classifier between them,
+# since ESLint keys on the separately-computed `js_surface` instead.
+# `provenance-pins-corpus` runs only when the event is not a `pull_request`,
+# so despite a name that reads like a per-PR check it never runs on a PR, and
+# it is not among the `Lint required` aggregator's `needs:`. The three linters
+# themselves:
 #
 #   - clj-kondo: bug-class linter (unresolved symbols, arity mismatches,
 #     redefined vars, unused bindings). The `.clj-kondo/config.edn` at
@@ -42,13 +53,33 @@ name: lint
 #     must stay that way: fix a finding, or file a bead naming it, but
 #     never silence it with a disable comment.
 #
-# Lint surface: implementation/, tools/ (minus template/resources/),
-# examples/, testbeds/. Generated trees (.shadow-cljs/, target/,
-# node_modules/, .beads/, ai/) are excluded by virtue of the explicit
+# LINT SURFACE — ONE NAME, TWO DIFFERENT SETS (rf2-63il). The phrase names
+# both what the linters READ and what ARMS them on a PR, and those are not the
+# same set, so each is stated separately below. The distinction earns its words
+# because confusing the two fails OPEN: a worker who consults the shorter list
+# to decide whether a diff arms this gate concludes it does not, and skips a
+# gate that would have run.
+#
+# What clj-kondo and Splint LINT: implementation/, tools/ (minus
+# template/resources/), examples/, testbeds/. Generated trees (.shadow-cljs/,
+# target/, node_modules/, .beads/, ai/) are excluded by virtue of the explicit
 # `--lint` paths below. The `tools/template/resources/` deps-new
 # template tree is excluded explicitly — those `.cljs` files carry
 # `{{placeholder}}` substitutions and are not valid Clojure (see
 # tools/deps.edn for the matching shadow-cljs exclusion rationale).
+#
+# What ARMS `lint_surface` is wider. The `detect` classifier below lights on
+# those four trees and ALSO on `.clj-kondo/*` and on this very file,
+# `.github/workflows/lint.yml` — the shared kondo config and this workflow
+# govern how the linters behave, so a change to either has to re-run them —
+# and on `.splint.edn` plus the manifest-projection paths that arm the
+# api-manifest job (spec/API.md, the two api-manifest EDN files, skills/*,
+# docs/core/*, docs/*/concepts.md, spec/Privacy.md, docs/api/*,
+# docs/story/api/*). None of those is a lint TARGET: kondo lints no YAML and
+# no EDN config. Treat the classifier's `case` arms as the authority on this
+# set rather than any list up here — each arm carries the bead that added it,
+# and a copy kept at this distance from the code is what drifted in the first
+# place.
 #
 # REQUIRED-CHECK SHAPE (rf2-aemyt). The `pull_request` trigger is
 # deliberately UNFILTERED so the `Lint required` aggregator below posts a


### PR DESCRIPTION
Closes rf2-63il.

`lint.yml` understated itself in two ways, both fail-open: understating coverage
sends a worker to skip a gate that would have armed. This is prose only — 39 changed
lines, every one of them a comment.

## What the source actually said

Both of the bead's findings held, but finding 1 turned out sharper than it was filed,
and the repair it literally proposed would have introduced a new error.

**Finding 1 — confirmed, and the diagnosis is one level deeper than "two missing
entries".** The `detect` classifier arm reads
`implementation/*|tools/*|examples/*|testbeds/*|.clj-kondo/*|.github/workflows/lint.yml`,
exactly as filed. But the `Lint surface:` paragraph was not describing that arm — it
describes the `--lint` target paths, and says so ("excluded by virtue of the explicit
`--lint` paths below"). As an account of what clj-kondo and Splint lint, it was
**accurate**: the job passes `--lint` for exactly `implementation`, `examples`,
`testbeds` and the `tools/*` subtrees minus `template/resources`.

The real defect is that **one phrase names two different sets**. The paragraph
immediately below it uses "the lint surface" for the classifier's arming set, and the
`detect` job is literally named "Detect lint surface" with output `lint_surface`. Those
sets are not the same, and the arming one is much wider than the filed correction
suggests — five `case` arms, sixteen patterns: `.splint.edn`, `spec/API.md`, the two
api-manifest EDN files, `skills/*`, `docs/core/*`, `docs/*/concepts.md`,
`spec/Privacy.md`, `docs/api/*` and `docs/story/api/*` all light `lint_surface` too.

So simply appending `.clj-kondo/*` and `.github/workflows/lint.yml` to that list, as
the bead proposed, would have been **wrong in both directions**: still omitting ten
further arming patterns, and newly claiming clj-kondo lints a YAML workflow and an EDN
config dir, which it does not. The two senses are now stated separately, and the
classifier's `case` arms are named as the authority so a list copied up to the header
cannot drift again.

**Finding 2 — confirmed as filed.** `api-manifest` is gated on
`needs.detect.outputs.lint_surface == 'true'`, the same output as clj-kondo and Splint,
and it is not a linter; `provenance-pins-corpus` is gated on
`github.event_name != 'pull_request'` and so never runs on a PR. Two things worth adding
that the bead did not name: ESLint keys on `js_surface`, not `lint_surface`, so the
three linters do not share one classifier either; and `provenance-pins-corpus` is not in
the `Lint required` aggregator's `needs:`.

**One bead error.** Its finding-2 heading says the file "HAS SIX JOBS" while its own
prose enumerates seven. Seven is right: `detect`, `clj-kondo`, `splint`, `eslint`,
`api-manifest`, `provenance-pins-corpus`, `lint-required`.

## Quality gates

Comments-only, so the central claim is that **workflow behaviour is unchanged**. That is
asserted structurally rather than by eye: a YAML parser discards comments, so if the
parsed document is equal before and after, no job, trigger, `if:`, `needs:` or path list
can have moved.

```
$ python scripts/check_workflow_yaml.py            ; echo $?   -> 0
$ python scripts/check_workflow_yaml.py --self-test; echo $?   -> 0   (5 cases)
$ python scripts/check_workflow_job_timeouts.py    ; echo $?   -> 0   (117 jobs / 11 files)
$ python -c "<yaml.safe_load origin/main vs HEAD, assert equal>"; echo $?  -> 0
```

The structural comparison is controlled: a deliberately mutated copy
(`jobs['api-manifest']['if'] = 'false'`) compares unequal, so the equality test does
discriminate rather than trivially passing.

Diff shape, controlled in both directions:

```
$ git diff --numstat origin/main...HEAD          -> 35  4  .github/workflows/lint.yml
$ <changed lines NOT matching ^[+-]\s*#>         -> 0      (nothing but comments changed)
$ <changed lines matching ^[+-]\s*#>             -> 39     (control: the sweep does match)
```

All four removed lines are re-stated verbatim in the replacement paragraphs, so nothing
is reverted.

**Gate scoping — what was deliberately NOT nominated.** `check_doc_slugs.py` has roots
`docs/`, `spec/`, `skills/`, `migration/`, `tools/*/spec`; `check_readme_links.py --ci`
covers repo-root and beside-source markdown; `mkdocs build --strict` has `docs_dir: docs`.
`.github/workflows/lint.yml` is outside all three, and is not markdown, so each would
have exited green having inspected nothing. The two workflow validators above walk
`.github/workflows/*.{yml,yaml}` with no exclusions, so this path is genuinely in scope.

### Sabotage — and what it did not establish

Two plants, each committed-then-restored, each on a target verified unique (1 match)
before planting.

**Plant 1 (the honest negative).** `" [ { : |` inserted mid-line *inside one of the new
comments*. Both gates stayed **green** — exit 0 and exit 0. This confirms the limit
rather than the coverage: YAML discards `#` lines before any parser reads them, so **no
gate in this repo can see the text this PR changes**. The prose is unverifiable by
machine, and is asserted by the source reading above instead.

**Plant 2 (proves the gates read this tree).** An unmatched quote in the `name:` *value*
at line 1, two lines above the edited header block. `check_workflow_yaml.py` → exit
**1**, naming the file and position (`.github/workflows/lint.yml: line 7, column 65`);
`check_workflow_job_timeouts.py` → exit **2**, its documented parse-error arm. So both
gates demonstrably read this worktree's copy of this file, and a green from them is a
real read rather than a vacuous pass.

Restore verified by `git hash-object` against the committed blob
(`44ef4c13bd397b45efc538e669aef1ad6ba19657`), matching, working tree clean.

### This change gates itself

The classifier names `.github/workflows/lint.yml`, so this PR arms its own lint surface —
which is the second half of finding 1, checked rather than assumed. Replaying the
`detect` classifier over this diff locally gives `lint_surface=true`, `js_surface=false`,
so **clj-kondo, Splint and api-manifest must RUN on this PR and ESLint must skip**. If
they skip instead, that contradicts finding 1 and the PR should not merge on my say-so.
Confirmed against the PR's actual run before reporting.

Manual verification: anchors and prose read by hand; no tables, links or nav involved.
