### PR TITLE
bench(hicasso): publish a per-pair resolution figure beside :comparative (rf2-42w6)

### DIFF
--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane.cljs
@@ -65,7 +65,11 @@
   2. **Ranges, never a mean alone.** [[across-rounds]] answers min/max/mean
      per arm and flags `:straddles-1?`; overlapping ranges mean
      INDISTINGUISHABLE and a report must say so rather than quote the
-     mean as a winner.
+     mean as a winner. That flag asks whether ONE arm separated from an
+     empty frame, which a pair must clear before it carries any ratio at
+     all — but clearing it does not mean the pair could resolve the line
+     it is read against, and [[resolution]] is the second question.
+     Neither answers the other.
   3. **Every measured write is read back out of the DOM inside its own
      window.** [[verified-write!]] reads the written cell after the clock
      stops and before the sample is banked; [[tally]] carries the count
@@ -865,6 +869,67 @@
      :min (apply min vs) :max (apply max vs)
      :per-round vs
      :straddles-1? (and (<= (apply min vs) 1.0) (>= (apply max vs) 1.0))}))
+
+(defn resolution
+  "What size of difference in the arms' OWN work a run could have SEEN,
+  for one [[ratio-between]] pair. Answers
+
+      {:denominator :floor-p50 :denominator-p50 :own-work
+       :own-work-share :spread :resolves-at}
+
+  ## The question [[across-rounds]] does not ask
+
+  `:straddles-1?` asks whether ONE arm separated from an empty frame. A
+  bar row asks whether TWO arms separate from EACH OTHER at a stated
+  line. Those are different questions, and the first can answer yes while
+  the second answers no — measured on `slice-broad-clock-app` under
+  rf2-9wmqd, where a pair cleared the floor in all three evidence runs
+  and still could not resolve `1.25x`. The gate is a sound NECESSARY
+  condition and stays exactly where it is; this is the other half.
+
+  ## The arithmetic, and why the frame grid is the whole of it
+
+  A paint-bounded window is mostly the wait for the browser's next
+  rendering opportunity, and that wait is in BOTH arms, so it enters the
+  ratio as dead weight. Only `:own-work` — the denominator arm's median
+  above the floor's — can move a window-level ratio at all, and it is
+  `:own-work-share` of the window. So if the numerator's own work were
+  `k` times the denominator's, the published ratio would move by
+  `(k - 1) * :own-work-share` and no further. Set that against the
+  scatter the run actually showed — `:spread`, the width of
+  [[ratio-between]]'s `:per-round` — and
+
+      :resolves-at = 1 + :spread / :own-work-share
+
+  is the smallest `k` whose displacement is as large as the run's own
+  noise. A difference below it is inside the scatter, where an observed
+  `1.00x` is consistent with `1.00x` and with `k` alike.
+
+  ## IT DECIDES NOTHING, and may not
+
+  No line appears here and none may: `budgets.md` §7 routes every
+  distributional row to a pinned evidence run and forbids converting one
+  into a lane threshold. This is an HONESTY AID — a run saying what it
+  could have seen — and the reader compares it against the line THEIR row
+  is stated at. Two edges, stated rather than special-cased:
+  `:resolves-at` is `nil` when the denominator arm did not clear the
+  floor, because a pair with no work above the grid resolves nothing at
+  any size; and the figure is bounded below by the run's own scatter, so
+  rounds that happened to agree exactly report `1.0`, which says the
+  scatter bounds nothing rather than that any difference is visible."
+  [{:keys [denominator per-round]} summary floor-id]
+  (let [d      (get-in summary [denominator :p50])
+        floor  (get-in summary [floor-id :p50])
+        own    (- d floor)
+        share  (/ own d)
+        spread (- (apply max per-round) (apply min per-round))]
+    {:denominator     denominator
+     :floor-p50       (round4 floor)
+     :denominator-p50 (round4 d)
+     :own-work        (round4 own)
+     :own-work-share  (round4 share)
+     :spread          (round4 spread)
+     :resolves-at     (when (pos? share) (round4 (+ 1.0 (/ spread share))))}))
 
 ;; ---------------------------------------------------------------------------
 ;; Verified writes — "N unverified of M"

--- a/implementation/hicasso/test/re_frame/bench/hicasso/lane_resolution_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/lane_resolution_cljs_test.cljs
@@ -1,0 +1,202 @@
+(ns re-frame.bench.hicasso.lane-resolution-cljs-test
+  "THE LANE'S RESOLUTION FIGURE, WITNESSED (rf2-42w6).
+
+  [[re-frame.bench.hicasso.lane/across-rounds]]'s `:straddles-1?` is the
+  gate a reader applies before quoting any comparative range, and it is a
+  SOUND NECESSARY CONDITION: an arm that never separated from an empty
+  frame carries no ratio about a substrate, and under `rf2-9wmqd` that
+  test refused a pair outright. What it cannot do is decide whether a
+  comparison had the POWER to see the line it is read against — one arm
+  against the floor and two arms against each other are different
+  questions. [[re-frame.bench.hicasso.lane/resolution]] answers the
+  second, and this file is what keeps it honest.
+
+  ## Why the figure needs a witness at all
+
+  Because the case that motivates it is one where every other published
+  number looks fine. A paint-bounded window is `~96%` frame grid, so the
+  wait for the next rendering opportunity sits in BOTH arms and enters
+  the ratio as dead weight; only the arms' work ABOVE the floor can move
+  a window-level ratio at all. A pair can therefore clear the floor in
+  every round, read a clean `1.00x`, and still be incapable of showing a
+  `1.5x` difference in the thing actually under test. Nothing on the
+  record says so unless something computes it.
+
+  ## The fixture is the measured case, not an invented one
+
+  [[locale-like]] carries `rf2-9wmqd`'s own published figures for the
+  `:locale` pair's first evidence run — a floor `p50` of `16.30 ms`, a
+  denominator arm at `17.05 ms`, and a per-round spread of `3.75`
+  percentage points. `the-fixture-reproduces-the-published-displacements`
+  below asserts it reproduces that window's `1.011` and `1.022` before
+  anything else asserts anything, so a fixture that drifted away from the
+  record it stands for fails here rather than going on passing.
+
+  ## AND EVERY CASE BELOW IS A FIGURE, NEVER A VERDICT
+
+  `budgets.md` §7 routes every distributional row to a pinned evidence
+  run and forbids converting one into a lane threshold, so
+  `resolution` may publish no band and no pass/fail.
+  `the-answer-carries-no-verdict` pins that bound as a test rather than
+  leaving it to a docstring: a boolean appearing in the answer is a gate
+  arriving by the back door, and it fails here.
+
+  ## NO READING IS TAKEN HERE, and none may be
+
+  This is a test over known inputs. It runs on a loaded box, touches no
+  clock, mounts nothing, and pins no figure any budget row reads."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.bench.hicasso.lane :as lane]))
+
+;; ---------------------------------------------------------------------------
+;; The fixture — rf2-9wmqd's `:locale` pair, evidence run 1
+;; ---------------------------------------------------------------------------
+
+(def summary
+  "Per-arm `:p50`s. The floor and the denominator arm are the only two
+  entries `resolution` reads, and `0.75 ms` between them is the window's
+  own published excess over floor."
+  {:idle-frame   {:p50 16.30}
+   :donor-locale {:p50 17.05}
+   :locale       {:p50 17.05}})
+
+(def round-ratios
+  "Three rounds of ARM-TO-FLOOR ratios, the shape `lane/normalise`
+  answers and the only shape `lane/ratio-between` accepts.
+
+  `:donor-locale` is held at `1.046` — `17.05 / 16.30`, so the two inputs
+  describe one run rather than two — and `:locale` is that times
+  `1.0000`, `1.0375` and `1.0200` in turn, which puts a `3.75` point
+  spread on the pair ratio and straddles `1.0`."
+  [{:locale 1.046    :donor-locale 1.046}
+   {:locale 1.085225 :donor-locale 1.046}
+   {:locale 1.06692  :donor-locale 1.046}])
+
+(defn locale-like []
+  (lane/resolution (lane/ratio-between round-ratios :locale :donor-locale)
+                   summary
+                   :idle-frame))
+
+;; ---------------------------------------------------------------------------
+;; The fixture discriminates before it is trusted
+;; ---------------------------------------------------------------------------
+
+(deftest the-fixture-reproduces-the-published-displacements
+  (testing "`rf2-9wmqd` published that a `1.25x` difference in the arms'
+           own work would move this pair's ratio to `1.011` and a `1.5x`
+           difference to `1.022`. Both fall straight out of
+           `:own-work-share`, so if the fixture ever stops standing for
+           that run this fails rather than the cases below quietly
+           testing something else."
+    (let [{:keys [own-work own-work-share]} (locale-like)]
+      (is (= 0.75 own-work)
+          "the denominator arm's median less the floor's, in ms")
+      (is (= 0.011 (lane/round4 (* 0.25 own-work-share)))
+          "a 1.25x difference displaces the window ratio to 1.011")
+      (is (= 0.022 (lane/round4 (* 0.5 own-work-share)))
+          "a 1.5x difference displaces it to 1.022"))))
+
+(deftest the-pair-clears-the-floor-and-still-cannot-resolve-the-line
+  (testing "THE WHOLE POINT. Both arms separate from an empty frame in
+           every round — `:over-floor` says so — and the pair still
+           could not have shown a `1.5x` difference in the arms' own
+           work, because `:resolves-at` sits above it. One test answering
+           yes and the other no on the SAME run is what makes them
+           different questions rather than two spellings of one."
+    (let [over-floor (lane/across-rounds round-ratios)]
+      (is (false? (:straddles-1? (:locale over-floor)))
+          "the measured arm separated from the floor in every round")
+      (is (false? (:straddles-1? (:donor-locale over-floor)))
+          "so did the donor arm — the shipped gate passes this pair")
+      (is (true? (:straddles-1? (lane/ratio-between round-ratios
+                                                    :locale :donor-locale)))
+          "and the pair itself reads ~1.00x, straddling 1.0")
+      (is (> (:resolves-at (locale-like)) 1.5)
+          "yet the run could not have resolved even the coarser of the
+           two lines this window was read against"))))
+
+;; ---------------------------------------------------------------------------
+;; The arithmetic
+;; ---------------------------------------------------------------------------
+
+(deftest resolves-at-is-the-difference-whose-displacement-equals-the-spread
+  (testing "The defining relation, asserted rather than restated: at
+           `k = :resolves-at` the displacement `(k - 1) * :own-work-share`
+           IS the scatter the run showed. Anything smaller is inside the
+           noise."
+    (let [{:keys [resolves-at own-work-share spread]} (locale-like)]
+      (is (= 0.0375 spread)
+          "the width of `ratio-between`'s `:per-round`")
+      (is (= 1.8525 resolves-at))
+      (is (= spread (lane/round4 (* (- resolves-at 1.0) own-work-share)))
+          "the figure and the spread are the same statement"))))
+
+(deftest the-floor-and-not-the-noise-is-what-makes-a-run-coarse
+  (testing "DISCRIMINATION. Hold the scatter fixed and lift the arms off
+           the floor: the identical spread now resolves `1.04x` instead
+           of `1.85x`. A figure that answered the same either way would
+           be reporting noise and nothing about the frame grid, which is
+           the term this whole finding is about."
+    (let [lifted (lane/resolution
+                   (lane/ratio-between round-ratios :locale :donor-locale)
+                   {:idle-frame {:p50 1.0} :donor-locale {:p50 10.0}}
+                   :idle-frame)]
+      (is (= 0.9 (:own-work-share lifted))
+          "nine tenths of the window is now the arms' own work")
+      (is (= 1.0417 (:resolves-at lifted)))
+      (is (= (:spread lifted) (:spread (locale-like)))
+          "and the run's scatter is byte-for-byte the one above"))))
+
+;; ---------------------------------------------------------------------------
+;; The edges, and the bound
+;; ---------------------------------------------------------------------------
+
+(deftest an-arm-at-or-below-the-floor-resolves-nothing-at-any-size
+  (testing "A pair with no work above the frame grid cannot be moved by
+           any difference whatever, so the honest answer is `nil` rather
+           than a large number that looks like an answer. `:own-work`
+           stays published either way, because it is the reason."
+    (let [pair (lane/ratio-between round-ratios :locale :donor-locale)
+          at   (lane/resolution pair {:idle-frame   {:p50 16.30}
+                                      :donor-locale {:p50 16.30}} :idle-frame)
+          below (lane/resolution pair {:idle-frame   {:p50 16.30}
+                                       :donor-locale {:p50 16.00}} :idle-frame)]
+      (is (nil? (:resolves-at at))
+          "exactly at the floor")
+      (is (= 0.0 (:own-work at)))
+      (is (nil? (:resolves-at below))
+          "and below it, where the arm is faster than an empty frame")
+      (is (neg? (:own-work below))
+          "the negative excess is published rather than clamped away"))))
+
+(deftest rounds-that-agree-exactly-report-one-and-claim-nothing
+  (testing "`:resolves-at` is bounded below by the run's own scatter, so
+           a run with no scatter reports `1.0`. That says the scatter
+           bounds nothing — not that any difference is visible — and the
+           `:spread` of `0.0` sitting beside it is what tells a reader
+           which of the two it is."
+    (let [flat (lane/resolution
+                 (lane/ratio-between [{:locale 1.046 :donor-locale 1.046}
+                                      {:locale 1.046 :donor-locale 1.046}]
+                                     :locale :donor-locale)
+                 summary
+                 :idle-frame)]
+      (is (= 0.0 (:spread flat)))
+      (is (= 1.0 (:resolves-at flat))))))
+
+(deftest the-answer-carries-no-verdict
+  (testing "`budgets.md` §7 forbids a distributional row a lane
+           threshold, so this figure may publish no band and no
+           pass/fail. The key set is pinned and every value is a number,
+           an arm id or `nil` — a boolean here would be a gate arriving
+           by the back door."
+    (let [answer (locale-like)]
+      (is (= #{:denominator :floor-p50 :denominator-p50 :own-work
+               :own-work-share :spread :resolves-at}
+             (set (keys answer))))
+      (is (= :donor-locale (:denominator answer))
+          "the figure names the arm it is stated against")
+      (is (empty? (filter boolean? (vals answer)))
+          "no verdict of any kind")
+      (is (every? number? (vals (dissoc answer :denominator)))
+          "and every other value is a figure"))))

--- a/implementation/hicasso/test/re_frame/bench/hicasso/slice_broad_clock_app.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/slice_broad_clock_app.cljs
@@ -243,8 +243,9 @@
   verdict, the control's verdict and the runtime label. Then two
   comparative figures — `:locale / :donor-locale` and
   `:theme / :donor-theme`, per round and as a range, through
-  `lane/ratio-between` — and every arm's range against the floor through
-  `lane/across-rounds`.
+  `lane/ratio-between` — every arm's range against the floor through
+  `lane/across-rounds`, and per pair what size of difference the run
+  could have SEEN, through `lane/resolution`.
 
   **No line is applied to any of them.** `U3`'s 100 ms `p95`, `C3`'s
   `1.25x` and `C4`'s `1.5x` appear nowhere in this file and none of them
@@ -267,16 +268,39 @@
 
   That is why `:over-floor` is published beside the comparative figures.
   It is `lane/across-rounds` over each arm's ratio to `:idle-frame`, and
-  its `:straddles-1?` flag is the resolution test: an arm whose range
+  its `:straddles-1?` flag is the FIRST of two tests: an arm whose range
   against an EMPTY FRAME includes 1.0 was not separated from the floor by
   this window, and no ratio between two such arms is a reading about
   anything. The `:structure` block's `:commit` leg is the other half —
   the application's own work, outside the frame grid entirely.
 
+  ## AND THE SECOND TEST, BECAUSE THE FIRST IS NOT SUFFICIENT
+
+  **`:straddles-1?` asks whether ONE arm cleared the floor. A bar row
+  asks whether TWO arms separate from EACH OTHER at a stated line, and a
+  pair can answer yes to the first and no to the second.** That is not
+  hypothetical: under `rf2-9wmqd` the `:locale` pair cleared the gate in
+  all three evidence runs and still could not resolve `1.25x`, because
+  the same `~96%` frame grid that flattens the ratio also flattens any
+  difference in it. A reader applying only `:straddles-1?` would have
+  quoted that as a pass.
+
+  So `:resolution` is published beside `:comparative`, one entry per
+  pair, from `lane/resolution` — see that function for the arithmetic.
+  Its `:resolves-at` is the smallest difference in the ARMS' OWN WORK
+  whose effect on the published ratio would have been as large as the
+  scatter this run actually showed. **Read it against the line YOUR row
+  is stated at**: a row read at `1.25x` off a run whose `:resolves-at` is
+  `1.85` is quoting the frame grid, whatever the ratio says. It carries
+  no line and no verdict of its own, and `budgets.md` §7 is why — every
+  distributional row is adjudicated in a pinned evidence run, never here.
+
   **If the shipped seed cannot separate the measured arms from the floor,
   the honest conclusion is that `C3` needs a broader population than the
   slice's feed page** — which is a finding about the row, and never a
-  licence to widen a band or to quote an unresolved ratio.
+  licence to widen a band or to quote an unresolved ratio. A pair that
+  clears the floor but whose `:resolves-at` sits above the row's line is
+  the same finding reached one step later.
 
   Owner: rf2-9wmqd."
   (:require [re-frame.adapter.uix :as uix-adapter]
@@ -422,16 +446,18 @@
 (def populations
   "Which visits each published figure is taken over.
 
-  `:summary`, `:structure`, `:comparative` and `:over-floor` are all
-  taken over the MEASURED visits, because the last two are built out of
-  the first two and a ratio whose numerator and denominator are drawn
-  from different populations is not a ratio. `:echo` is the verification
-  tally and covers every window, warm-up included: it is a count of
-  refusals rather than a distribution, so it decomposes nothing."
+  `:summary`, `:structure`, `:comparative`, `:over-floor` and
+  `:resolution` are all taken over the MEASURED visits, because each of
+  the last three is built out of the first two and a ratio whose
+  numerator and denominator are drawn from different populations is not
+  a ratio. `:echo` is the verification tally and covers every window,
+  warm-up included: it is a count of refusals rather than a
+  distribution, so it decomposes nothing."
   {:summary     :measured-visits
    :structure   :measured-visits
    :comparative :measured-visits
    :over-floor  :measured-visits
+   :resolution  :measured-visits
    :echo        :all-visits})
 
 ;; ---------------------------------------------------------------------------
@@ -1264,7 +1290,10 @@
             control (lane/control-verdict-strict blocked-ms
                                                  (control-per-round readings)
                                                  control-slack)
-            verdict (lane/guard! samples "slice broad update")]
+            verdict (lane/guard! samples "slice broad update")
+            summary (into {} (map (fn [[id xs]] [id (lane/summarise xs)])) by-arm)
+            compare {:locale (lane/ratio-between ratios :locale :donor-locale)
+                     :theme  (lane/ratio-between ratios :theme :donor-theme)}]
         (lane/record! :slice-broad
                       {:window      :interaction-to-paint
                        :population  {:hicasso {:app   're-frame.hicasso.examples.slice
@@ -1290,12 +1319,15 @@
                                                                 rounds)
                                            :measured-per-arm (* (:samples sampling) rounds))
                        :populations populations
-                       :summary     (into {} (map (fn [[id xs]] [id (lane/summarise xs)])) by-arm)
+                       :summary     summary
                        :structure   (echo/structure-over-measured arms sampling rounds
                                                                   (:aux @!state))
-                       :comparative {:locale (lane/ratio-between ratios :locale :donor-locale)
-                                     :theme  (lane/ratio-between ratios :theme :donor-theme)}
+                       :comparative compare
                        :over-floor  (lane/across-rounds ratios)
+                       :resolution  (into {}
+                                          (map (fn [[pair c]]
+                                                 [pair (lane/resolution c summary :idle-frame)]))
+                                          compare)
                        :control     control
                        :guard       (select-keys verdict [:refuse? :contaminated?
                                                           :unchecked? :tolerance])
@@ -1309,7 +1341,12 @@
                                          "Read :over-floor's :straddles-1? on a measured arm "
                                          "before quoting any :comparative range: an arm this "
                                          "window did not separate from an empty frame carries "
-                                         "no ratio about a substrate.")})
+                                         "no ratio about a substrate. Then read :resolution's "
+                                         ":resolves-at for that pair against the line your row "
+                                         "is stated at — clearing the floor does not mean the "
+                                         "pair could resolve the line, and a difference below "
+                                         ":resolves-at is inside this run's own scatter. "
+                                         "Neither figure is a verdict.")})
         (set! (.-HICASSO_GUARD_REFUSED js/window) (boolean (:refuse? verdict)))
         (set! (.-HICASSO_CONTROL_FAILED js/window) (not (:ok? control)))
         (lane/assert-verified! (:echo-tally @!state) "slice broad update")

--- a/implementation/hicasso/test/re_frame/bench/hicasso/slice_broad_window_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/bench/hicasso/slice_broad_window_dom_cljs_test.cljs
@@ -658,10 +658,11 @@
     (is (pos? clock/rounds))))
 
 (deftest the-record-labels-which-population-each-figure-is-taken-over
-  (testing "`:summary`, `:structure`, `:comparative` and `:over-floor` are
-           all taken over the measured visits, because the last two are
-           built out of the first two and a ratio whose numerator and
-           denominator are drawn from different populations is not a ratio.
+  (testing "`:summary`, `:structure`, `:comparative`, `:over-floor` and
+           `:resolution` are all taken over the measured visits, because
+           each of the last three is built out of the first two and a ratio
+           whose numerator and denominator are drawn from different
+           populations is not a ratio.
            `:echo` deliberately is not: it is a count of refusals rather
            than a distribution, and a verification is worth more the more
            windows it covers."
@@ -669,5 +670,6 @@
             :structure   :measured-visits
             :comparative :measured-visits
             :over-floor  :measured-visits
+            :resolution  :measured-visits
             :echo        :all-visits}
            clock/populations))))


### PR DESCRIPTION
## What this is

`rf2-42w6`. The clock lane's `:over-floor` / `:straddles-1?` gate asks whether **one arm** separated from an empty frame. A `:comparative` row asks whether **two arms** separate from **each other** at a stated line. Those are different questions, and a pair can answer yes to the first and no to the second — under `rf2-9wmqd` the `:locale` pair cleared the gate in all three evidence runs and still could not resolve `1.25x`, because a paint-bounded window is `~96%` frame grid and only the arms' work *above the floor* can move the ratio at all. A reader applying only the shipped gate would have quoted that as a pass.

`lane/resolution` computes, per `ratio-between` pair, the smallest difference in the arms' **own work** whose effect on the published ratio would be as large as the scatter the run actually showed:

    :resolves-at = 1 + :spread / :own-work-share

## Which of the bead's three shapes, and what decided it

The bead left the shape open — (a) publish a figure, (b) leave the arithmetic to the reader in the driver's docstring, (c) both — as a worker's design call within fixed bounds. **Chosen: (c), and the source decided both halves.**

**(b) alone is refused by the evidence.** The driver's docstring *already* carries a reader caveat — the section headed `THE ONE THING A READER MUST CHECK BEFORE QUOTING ANY RATIO HERE` — and the published record *already* repeats it inline in `:note`. A reader who followed both still could not tell that the `:locale` pair was unresolvable, because the test they were pointed at answers a different question. Fixing a failed prose caveat by adding a second prose caveat beside it is the same instrument again.

**(a) alone is refused by this file's own stated failure mode.** `lane/assert-verified!`'s docstring records what happens to a number that is published and never read: the echo tally *"was PUBLISHED and never ADJUDICATED"* and a row could report `400 unverified of 400` while the driver exited 0. The bounds here forbid adjudicating this figure, so prose is the *only* thing that can make it load-bearing rather than decorative.

So the figure ships **and** the docstring says how to read it against the line the reader's own row is stated at.

## The bounds were not moved

No threshold, no band, no pass/fail. `:resolves-at` carries no line; `C3`'s `1.25x` and `C4`'s `1.5x` appear nowhere in the instrument, exactly as before. `budgets.md` §7 still routes every distributional row to a pinned evidence run. The bound is pinned as a test rather than left to prose — `the-answer-carries-no-verdict` fails if a boolean ever appears in the answer.

**No measurement was run and no published figure moves.** The record's existing values are untouched: `:summary` and `:comparative` are the same expressions, merely `let`-bound so the new key can reuse them.

## Shared surface: nothing else emits differently

The bead cautioned that the same mechanism serves `slice_echo_clock_app` and `ledger_frame_clock_app`. Checked at source, and the answer is stronger than "no change":

- `lane/resolution` is a **new pure function with no existing caller**. The `lane.cljs` diff is two hunks; the only removed line is a docstring sentence fragment that was extended. **No existing function body changed.**
- Neither sibling driver publishes `:comparative` or `:over-floor` **at all** — `slice_echo` publishes `:summary`/`:structure`/`:control`/`:guard`/`:echo`, `ledger_frame` publishes `:summary`/`:entry`/`:advance`/`:control`/`:guard`/`:verification`. The mechanism the bead names is used by `slice_broad` alone of those three.
- Swept in both directions: `:resolution` appears 5x in `slice_broad_clock_app.cljs` and **0x** in either sibling; `lane/resolution` has exactly **one** production call site.

## Quality gates

Exit codes captured with `echo $?` on the same command line as the run, not reported by the harness.

| command | exit |
|---|---|
| `npm run test:hicasso-compile` (final, on the rebased base) | **0** |
| `npm run test:hicasso-compile` (sabotage control) | **1** |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` | **0** |
| `node out/node-test.js --test=re-frame.bench.hicasso.lane-resolution-cljs-test` | **0** — `Ran 7 tests containing 23 assertions. 0 failures, 0 errors.` |

The compile gate covered all 160 lane namespaces with zero warnings, the new test file among them (it is auto-covered: the gate walks the directory rather than carrying a roster).

**Sabotage.** Edits were committed first, then `(round4 floor)` was changed to `(round4 floorx)` mid-line — 1 match confirmed before running. The gate went **red**, naming `lane.cljs:927` in this worktree (`Use of undeclared Var … /floorx` → `BUILD REFUSED`), which is also what proves the gate read *this* checkout and not another. Restored and verified by `git hash-object` against the committed blob: `227686a785…` both sides, zero residual matches.

The focused test run went through the route `shadow-cljs.edn` mandates (`--test=` at runtime, never a narrowed `:ns-regexp` against the shared build id, per `rf2-6t03c`).

## What local green does NOT cover

**Local-green is not CI.** The gates above omit:

- **The browser lane** (`:browser-test` / `-dom-cljs-test$`), which is not run locally by instruction. That matters specifically here: `slice_broad_window_dom_cljs_test.cljs`'s `the-record-labels-which-population-each-figure-is-taken-over` pins the published-figure roster by **whole-map equality**, and this PR adds `:resolution :measured-visits` to both halves. Both halves were compared by hand and match exactly, but the assertion itself is CI's to run.
- The full `npm run test:cljs` node suite (only the new namespace was executed from the compiled build), `test:hicasso-invariants` (incl. `check_budget_ledger.py`), `test:hicasso-lint`, and every other required check.

## One finding, reported rather than actioned

`docs/design/hicasso/studio/the-u3-c3-c4-window-on-the-slice-broad-clock.md` §7.8 says of this computation: *"what it does not do is compute it, so it falls to whoever reads a run."* That is true of the window it records and stays true as a dated account — the same sentence continues *"filed as a finding … rather than fixed here"*, and this PR is that finding being fixed. It was left untouched deliberately: a studio page is a record of one window, the bead named its surface as the two `.cljs` files, and editing it would arm `check_provenance_pins.py` for no correctness gain. Flagging it so the mayor can decide whether a dated pointer is wanted there.
