### PR TITLE
docs(method): mark the gate-mechanics block, and declare <TRUNK> (rf2-mmwt)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -7,6 +7,7 @@ a capable agent. Placeholders:
 - `<WORKTREE_PARENT>` — the directory holding worker worktrees (derive it from your
   version-control tool at dispatch time; never hardcode a path)
 - `<ASSIGNED_WORKTREE>` — this worker's worktree, a subdirectory of `<WORKTREE_PARENT>`
+- `<TRUNK>` — the branch a worker's change merges into
 - `<ITEM_ID>` — the tracker id
 
 > **Project-specifics live with the project, not here.** Your hot-zone file list,
@@ -629,6 +630,13 @@ A skipped gate needs a one-line reason in the change body. A silent skip fails r
 ---
 
 ## Quality gates — how a gate is run
+
+**This section is the gate-mechanics block.** Paste it verbatim into every editing dispatch,
+adapting only the placeholders, from this heading down to the rule before
+`## Reviewing what comes back`. **`## Quality gates — which gate` is not it and does not stand
+in for it**: that section is addressed to you as you nominate the gate, so pasting it in place
+of this one hands the worker your nomination reasoning and withholds every mechanic it needs to
+run anything at all.
 
 The gate menu settles *which* gate runs; this settles *how*. Scope it to the gate the brief
 names: the wedge paragraph assumes a gate heavy enough that two cannot coexist, and the


### PR DESCRIPTION
Closes rf2-mmwt.

`README.md` and `bootstrap.md` both instruct the mayor to paste **"the gate-mechanics block"**
verbatim into every editing dispatch. The name resolved nowhere in `dispatch-prompt-template.md`,
so a mayor obeying that instruction had no block to find — and obeying the template's *own*
extraction rule (`## Pasting a block`: *"Anchor the extraction to CONTENT, never to line
numbers"*) had nothing to anchor to for one of the two blocks it is told to paste every time.

This marks the block and declares the one placeholder that was in use but undeclared. Eight
inserted lines, zero deleted; no section added, moved, restructured or rewritten.

## What changed

1. **`## Quality gates — how a gate is run` is now marked as the gate-mechanics block**, with a
   paste instruction at the head of the section mirroring the boundary block's. It names the
   block, gives its closing anchor (the rule before `## Reviewing what comes back`), and says why
   the split falls there rather than one section earlier — pasting `## Quality gates — which
   gate` instead sends the worker the mayor's nomination reasoning and withholds the mechanics.

2. **`<TRUNK>` is declared in the header placeholder list**, in the same voice as the other four.

## Premises, checked at source

All checked against the tree at the merge base. Every premise held.

| Premise | Measured |
|---|---|
| `gate-mechanics block` resolves nowhere in the template | `grep -ic 'gate.mechanics block'` → **0** in the template, **1** each in `README.md` and `bootstrap.md` |
| Both sibling sentences say what the item quotes | verified verbatim at `README.md:273` and `bootstrap.md:25` |
| Marking is asymmetric | paste-marker sweep → exactly **one** in-section hit (`Paste this verbatim…`, in `## The worktree boundary block`), against `## Pasting a block`'s plural *"**Several** blocks below travel verbatim"* |
| `<TRUNK>` is in use and undeclared | `<UPPER_CASE>` sweep → 5 distinct tokens, 4 declared; `<TRUNK>` used once, inside the block this marks as pasteable |
| No cross-file anchor links into this file's headings | `grep -rnoE 'dispatch-prompt-template\.md#[a-z0-9-]+'` → empty, and the same pattern against `loops.md#` returns 3 hits, so the zero is genuine |

**Shape chosen: marking, not renaming.** A rename would have been anchor-safe (no cross-file
anchor depends on these headings), but the `which gate` / `how a gate is run` pairing is
deliberate and the mayor needs the first half when writing a brief. Renaming one half would break
the pair and bury the nomination guidance.

**One thing found that was not in the item**, reported rather than actioned: `## Common preamble`
carries no paste marker either, so `## Pasting a block`'s *"several"* is still ahead of the
markers by one. It is out of scope here — `README.md:273` and `bootstrap.md:25` name exactly two
blocks, and both are now marked — but it may be worth its own item.

## Verification of the repair

- `gate-mechanics block` now resolves in the template (1 hit, at the marking).
- The paste-marker sweep now returns **two** in-section markers rather than one; the asymmetry is
  gone. The marking deliberately reuses the phrase `verbatim into every editing dispatch` so a
  mechanical sweep finds both blocks with one pattern.
- All five `<UPPER_CASE>` tokens are declared in the header.

## Quality gates

Both gates run from the repository root, in the foreground, to completion. Each exit code was
captured with `echo $?` on the same command line as the run and redirected to a per-worktree,
per-attempt file; **no number below is one the harness reported about the run.**

| Run | `check_doc_slugs.py` | `mkdocs build --strict` |
|---|---|---|
| Baseline (change applied, committed) | **exit 0** | **exit 0** |
| Sabotage (planted broken anchor) | **exit 1** | **exit 0** — see below |
| Restored | **exit 0** | **exit 0** |

Pass/fail: `check_doc_slugs.py` — 0 broken links, 0 broken anchors. `mkdocs build --strict` —
site built, 0 warnings.

**The control bites.** A broken in-page anchor was planted mid-line, on a line this change
authored, after committing the real edit. The plant was confirmed to have applied genuinely
before the run — the file's *blob* hash changed, and the fixed-string plant anchor was confirmed
to match exactly once beforehand, so the plant could not silently no-op. `check_doc_slugs.py`
went red naming precisely what was planted:

```
BROKEN ANCHOR: docs\the-mayor-method\dispatch-prompt-template.md:634 -> #no-such-heading-rf2-mmwt
```

That red is the discrimination: the fault existed only in this worktree, so a run that had
wandered into a sibling checkout would have come back green.

**The restore was verified by hashing bytes, not by reading a diff** — this checkout translates
line endings (`core.autocrlf=true`, CRLF working tree over LF blobs), so the comparison used
version control's own *blob* hash against the committed object. Pre-plant and post-restore blob
hashes are identical, the working tree is clean, and zero plant residue remains.

**`--strict` saw the planted anchor and still exited 0**, logging it at INFO:

```
INFO - Doc file 'the-mayor-method/dispatch-prompt-template.md' contains a link
       '#no-such-heading-rf2-mmwt', but there is no such anchor on this page.
```

This is the documented behaviour — `mkdocs.yml` sets no `anchors` key, so anchors sit at MkDocs'
INFO default and `--strict` promotes WARNING, not INFO — and it is recorded here because it also
discriminates in the other direction: naming this worktree's planted anchor proves the strict
build read *this* tree. `docs/the-mayor-method/` is not in `exclude_docs` (which lists
`tools/playground/`, two codemod trees, `design/freehand/`, `design/hicasso/`, `design/retirement/`),
so the page is genuinely built.

**Not nominated, deliberately**: no CLJS, browser, compile or lint lane. The changed-surface
classifier reports every test surface false for a path under `docs/`, and `lint.yml`'s surface
excludes the docs tree. Running any of them would have exited green having verified nothing.

## Checked by hand — nothing gates this document's prose

- **Merge-base diff read for what it would REVERT**, not for conflicts: `git diff <base>...HEAD`
  is 8 insertions / 0 deletions, with **zero** deletion lines in the patch. Trunk landed only a
  tracker-database checkpoint since the base and **nothing under `docs/`**, so there is nothing
  this push could undo. (Measured against the merge base, not the trunk tip; the two-dot form
  against the tip shows this change's own additions in reverse and is easy to misread as a trunk
  deletion.)
- **Headings**: none added, removed or changed. A diff of the file's heading list at the base
  against HEAD is identical, and no added line begins with `#`. The two `##` tokens in the new
  paragraph are inside inline-code spans, mid-line, and are references rather than headings.
- **Genericity**: the added lines carry no OS-specific, repo-specific or operator-specific
  content — no absolute paths, no platform names, no project or tracker identifiers, no personal
  names. Checked mechanically, and each pattern was exercised once against a file it should hit,
  so the zeroes are measurements rather than a broken search.
- **Table column counts and anchors in this body** were checked by hand. The new prose sits
  outside every fence; `docs/the-mayor-method/` is one of the two trees where a doc link inside a
  fence *is* reported, and nothing was added inside one.
