### PR TITLE
docs(method): name the three pasted blocks in 'Pasting a block' (rf2-4j1v)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -426,12 +426,13 @@ re-introduces exactly the worktree-activity sweep the merge loop deliberately do
 
 ## Pasting a block
 
-Several blocks below travel **verbatim** into every dispatch. Get them there by
-**extracting mechanically, then pasting the result into the prompt.** Both halves are
-mandatory and they close different failures: the extraction is what makes paraphrase
-impossible — a matched range cannot reword, where a mayor retyping two hundred lines of
-gate mechanics can and does — and the paste is what makes non-receipt impossible, because
-a block that is in the prompt cannot be un-received.
+Three blocks below travel **verbatim** into a dispatch: the **common preamble** into every
+one, the **worktree boundary block** and the **gate-mechanics block** into every editing
+one. Get them there by **extracting mechanically, then pasting the result into the
+prompt.** Both halves are mandatory and they close different failures: the extraction is
+what makes paraphrase impossible — a matched range cannot reword, where a mayor retyping
+two hundred lines of gate mechanics can and does — and the paste is what makes non-receipt
+impossible, because a block that is in the prompt cannot be un-received.
 
 **Sending the worker to the FILE is not a substitute.** A worker that skims it, or reads
 part of it, has not received the block at all, and nothing in the transcript distinguishes


### PR DESCRIPTION
Closes rf2-4j1v.

## What changed

`docs/the-mayor-method/dispatch-prompt-template.md`, one paragraph. The opening of
`## Pasting a block` loses its bare plural and gains the roster:

> Three blocks below travel **verbatim** into a dispatch: the **common preamble** into every
> one, the **worktree boundary block** and the **gate-mechanics block** into every editing one.

The rest of the paragraph is unchanged in wording and rewrapped only because the longer first
sentence pushed the wrap; the diff is 7 insertions for 6 deletions, all inside that one
paragraph.

## Why the roster rather than a third marker

The section's own third rule forbids anchoring an extraction to line numbers, so before this
change the in-section paste markers were the entire roster a mayor extracting mechanically had
— and they numbered two while three blocks are in fact pasted. `## Common preamble` carried
none. A plural standing one line above an incomplete set leaves that mayor unable to tell
whether it has them all.

A third marker would close the count only for a reader who then re-counts. Naming the three
closes it permanently and puts the list in one place.

**The roster also carries a distinction a flat count cannot, and this is the argument from the
file against the marker shape.** The two existing markers both read "verbatim into every
*editing* dispatch". This file's read-only shapes — Shape 3 (Audit) and Shape 4 (Cluster
reviewer) — take neither the boundary block nor the gate mechanics, while `loops.md` and
`bootstrap.md` both say the stance is pasted into every dispatch *preamble*. So the preamble's
reach is wider than the other two's, and reusing the markers' shared sweep phrase on the
preamble would have overstated it. The roster states both reaches in one sentence.

**Both existing markers are left exactly as they stand**, and neither is redundant. The shared
phrase `verbatim into every editing dispatch` is still the sweep that finds the marked set, and
the gate-mechanics marker carries a closing anchor (`down to the rule before ## Reviewing what
comes back`) that no roster sentence could supply. The roster names the blocks for a reader;
the markers give an extraction its opening and closing anchors.

Nothing was moved between sections, no section was added, and no block's content was rewritten.

## Quality gates

Every number below was captured with `echo $?` on the same command line as the run, redirected
to a per-worktree, per-attempt exit file. None is a figure reported about the run by anything
else.

| run | `python scripts/check_doc_slugs.py` | `python -m mkdocs build --strict` |
| --- | --- | --- |
| baseline (edit committed, tree clean) | **0** | **0** |
| sabotage (broken in-page anchor planted mid-line on an authored line) | **1** | **0** |
| restored | **0** | **0** |

**The control discriminates.** The plant was a link to `#planted-fault-no-such-heading`, placed
mid-line inside `**common preamble**` on a line this change authored, so the fault existed in no
other checkout. The slug gate came back:

```
1 broken anchor link(s) found:

  BROKEN ANCHOR: docs\the-mayor-method\dispatch-prompt-template.md:429 -> #planted-fault-no-such-heading
```

A run that had wandered into another checkout would have been green, so the red is positive
evidence the gate read this worktree.

**The plant genuinely applied, and the restore genuinely restored** — checked by *blob* hash,
not by reading a diff. Pre-plant and post-restore blob `54ecefec404186502831eba4c82dba2f72df856d`,
post-plant blob `bab9ae6bbab446058fd317c0540a6a3003f200c7`, and the restored working blob equals
the committed one. The edit was committed before anything was planted, so the restore could not
discard it.

**`--strict` does not gate anchors, confirmed by measurement rather than by assumption.** On the
sabotaged tree the strict build printed

```
INFO -  Doc file 'the-mayor-method/dispatch-prompt-template.md' contains a link
        '#planted-fault-no-such-heading', but there is no such anchor on this page.
```

and still exited **0**. That is also the strict build's own proof it read this worktree, since
it saw the plant. `check_doc_slugs.py` is therefore the only anchor gate for this page, and it
runs unguarded on every PR in `test.yml`'s `verify-readme-links` job. The baseline build log
lists `the-mayor-method\dispatch-prompt-template.md` among the pages it built, so the page is
not excluded.

**Not nominated, and why.** No CLJS, browser, compile or lint lane. The changed-surface
classifier reports every test surface false for a path under `docs/`, and `lint.yml`'s surface
excludes the docs tree. Nothing else in the repository is touched.

## Checked by hand — nothing gates this document's prose

- **The merge-base diff was read for what it would REVERT, not for conflicts.** `git diff
  origin/main...HEAD` is the one paragraph above and nothing else. The merge base, the branch
  point and `origin/main` are all still the same commit, so nothing landed underneath this
  branch. The immediately preceding commit on this file added a `<TRUNK>` declaration to the
  header list and the gate-mechanics marker; both are verified present and outside this diff,
  and a sweep for the markers' shared phrase still returns exactly 2.
- **No heading was added, changed or removed** — the diff contains no `#` line in either
  direction. A grep for cross-file links into this file's anchors returns 0, run against a
  positive control (`loops.md#`, which returns 3) so the zero is a check that passed rather than
  a pattern that missed.
- **The addition is generic**: it names only blocks defined in this same file, and carries no
  OS-specific, repository-specific or operator-specific content, no paths and no commands. A
  fixed-string sweep of the added lines for such tokens returns nothing.
- **Table column counts and rendering**: the one table in this PR body is 3 columns throughout;
  the page itself gains no table and no list.

## A note for whoever writes the next brief against this file

The working tree here stores this file with **CRLF** line endings. The gate-mechanics block's
caution about end-of-line anchors is live, not theoretical: the first patch attempt anchored a
multi-line replacement joined with `\n`, matched zero times, and said so only because the script
asserted on the match count. Read the count before running anything.
