### PR TITLE
docs(method): the worktree age the write-clock needs is creation, not last modification (rf2-fhy9)

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -676,7 +676,11 @@ and both readings went wrong in a single day here, in opposite directions.
    span shorter than the worktree's own age, where every file is recent and the count is the
    checkout rather than the worker. That last one is the counter-intuitive half, because it returns a
    large number that reads as proof of life: measured once at *the same count* over fifteen minutes
-   and over six hours. Run the clock twice at different spans before believing either reading.
+   and over six hours. **And the age itself is the worktree's CREATION time, not its
+   last-modification time**, which the very writes you are trying to detect keep bumping: the wrong
+   clock reads right on an idle tree, where the age does not matter, and seconds old on a live one,
+   where the age is the whole question. Run the clock twice at different spans before believing
+   either reading.
 
    **The most convincing false signature is on none of the discredited lists: a change fully green at
    the band, a clean worktree, a tip commit some minutes old, and the change still a DRAFT.** It reads


### PR DESCRIPTION
Closes rf2-fhy9.

One sentence added to the existing write-clock bullet in the stranded-sweep loop. Nothing else in
`docs/the-mayor-method/loops.md` moves: no new bullet, no new section, no heading touched. The
"Run the clock twice at different spans" sentence is preserved verbatim — it re-wraps, which is why
the diff shows one deletion.

## The premises, checked at source

Both held. The clause at the write-clock bullet does name a span "shorter than the worktree's own
age" and does name no way to get that age, and the obvious filesystem answer — last modification —
is bumped by writes inside the directory, so it is right on an idle worktree and wrong on a live
one. That inversion is the whole point of the sentence, and it is what the added text states.

## The shape I chose, and why not the other one

I took the **filesystem creation-versus-last-modification distinction**, not the "read the age from
the mayor's own dispatch record" alternative, and I did not write both.

The dispatch record is real and it does carry a dispatch timestamp in this project's practice. But
the method's own mandate for that record — under *Reaping* — is one line per dispatch mapping a
worktree to an agent, written at dispatch time. It mandates no timestamp at all, so a clause
pointing at it would be citing a field the method does not require anyone to write.

The decisive argument is narrower, and it is already on this page two paragraphs below the bullet:
**one worker is not one worktree** — a worker may build a second tree for its gate run, and that
tree has no dispatch line. The sweep is told to start from the worktrees precisely *because* the
mayor's own records are incomplete, so an age read from those records fails on exactly the
unfamiliar tree whose age you most need. A filesystem answer works on every tree the sweep
enumerates. That also settles the two-sentence question: the record route is not a second half of a
complete answer, it is a weaker version of the same answer, so it does not clear the higher bar.

The distinction is written as the rule; no tool's flag appears.

## Gates

Run from the repository root of the worker worktree. Exit codes captured with `echo $?` on the same
command line as the run, redirected to per-worktree, per-attempt artefacts; none taken from a
harness report.

| Run | `python scripts/check_doc_slugs.py` | `python -m mkdocs build --strict` |
|---|---|---|
| Baseline (own edit committed) | 0 | 0 |
| Sabotage (planted broken anchor) | **1** | 0 — see below |
| Restored | 0 | 0 |
| Re-run on final base after rebase | 0 | 0 |

**The control.** A broken in-page anchor was planted mid-line, on a line this change authored, after
committing the change so the restore could not discard it. The match count was read before the plant
(1, not 0). The slug gate went red naming the plant by file, line and anchor. Since the plant existed
only in this worktree, that red is the proof the gate read *this* tree and not a sibling's.

**`--strict` does not gate anchors, measured rather than assumed.** The same plant was run against
the strict build: it exited **0** while printing the broken anchor at INFO on stdout. `mkdocs.yml`
sets no `anchors` key, so anchors sit at MkDocs' INFO default and `--strict` promotes WARNING, not
INFO. The slug gate is the anchor gate for this page; the strict build is here only to prove the page
still compiles.

**Restore verified by content hash, not by reading a diff** — version control's own blob hash of the
working file against the committed object, identical both times the plant was restored, and a
residue grep for the planted token returning 0.

## Checked by hand — nothing gates this document's prose

- **Merge-base diff read for what it would REVERT** (`git diff origin/main...HEAD`, three-dot, against
  the point the branch left the trunk): one hunk, five added lines and one deleted line whose text is
  re-emitted verbatim inside the addition. Nothing another change landed is undone.
- **No heading added or changed.** This matters because three cross-file anchors elsewhere in the
  repository target this page (`#after-each-merge` twice and `#1-merge`, all from the repo-root agent
  instructions). The heading list was diffed against the trunk: identical text, only line numbers
  shift by four. Both targeted headings verified present.
- **No OS-specific, repo-specific or operator-specific content.** The added sentence names the
  distinction (creation versus last modification) and never a flag, a path, a platform or a person —
  the page is OS-neutral by its own header's rule.
- Column counts and rendering are unaffected: the edit is prose inside an existing paragraph, no
  table and no fence. Worth noting that `docs/the-mayor-method/` is one of the two trees where a doc
  link inside a fenced block *is* reported by the slug gate; this edit adds no fence and no link.

## Gates deliberately not nominated

No CLJS, browser, compile or lint lane. The changed-surface classifier reports every test surface
false for a path under `docs/`, and `lint.yml`'s surface excludes the docs tree, so those lanes would
skip rather than pass and citing them would be citing a vacuous green.
