### PR TITLE
docs(method): bootstrap names all three pasted blocks, with their scopes (rf2-db3o)

### DIFF
--- a/docs/the-mayor-method/README.md
+++ b/docs/the-mayor-method/README.md
@@ -270,8 +270,8 @@ Three siblings carry the operational detail:
   bite.
 - [`loops.md`](loops.md) — the 5 standing loops, and the merge criterion in full.
 - [`dispatch-prompt-template.md`](dispatch-prompt-template.md) — the worker-prompt shapes, the
-  worktree-boundary block, and the gate-mechanics block. The last 2 go into every editing
-  dispatch verbatim.
+  common preamble, the worktree-boundary block, and the gate-mechanics block. The last 3
+  travel verbatim: the preamble into every dispatch, the other 2 into every editing one.
 
 None of those 3 is specific to this repository. The concrete values they need — your gate
 command, your tracker's commands, your hot-zone file list — belong in your own project's

--- a/docs/the-mayor-method/bootstrap.md
+++ b/docs/the-mayor-method/bootstrap.md
@@ -22,9 +22,9 @@ cross-references. Decisions go in BOTH the tracker AND the merging change's body
 the change body is the durable version-history record.
 
 READ THE SIBLINGS, IN ORDER: `dispatch-prompt-template.md` (the worker prompts —
-paste the worktree-boundary block and the gate-mechanics block verbatim into every
-editing dispatch), then `loops.md` (the loop bodies and the merge criterion), then
-`README.md` for the longer why.
+paste the common preamble verbatim into every dispatch, and the worktree-boundary
+and gate-mechanics blocks verbatim into every editing one), then `loops.md` (the
+loop bodies and the merge criterion), then `README.md` for the longer why.
 
 DECISIONS. Every hold awaiting the operator — review gates, operator-run actions,
 held items — surfaces in chat and on its tracker item the moment it arises, and


### PR DESCRIPTION
Closes rf2-db3o.

## What was wrong

`## Pasting a block` in `dispatch-prompt-template.md` rosters **three** blocks that travel
verbatim into a dispatch: the **common preamble** into every one, the **worktree-boundary
block** and the **gate-mechanics block** into every *editing* one.

`bootstrap.md` — the pasteable opening prompt, and the first and often only operating
instruction a new mayor reads — named only the last two. `README.md`'s sibling roster named
the same two.

**The sentences were not false, which is why they survived.** The two named blocks *do* go
into every editing dispatch. The defect was silence at the entry point about the
widest-scope block, and it bit: three dispatches carried the stance, the boundary block and
the gate-mechanics block verbatim, and a hand-written two-sentence summary in place of the
preamble — exactly the paraphrase that section says extraction exists to prevent.

## What changed

Both edits state the **scope difference** — every dispatch versus every *editing* dispatch —
because that difference is precisely what made the two-block sentence read as complete.

- **`bootstrap.md`** (mandatory half): the `READ THE SIBLINGS` parenthetical now names all
  three with their scopes. One clause, rewrapped in place — **no added line**. `bootstrap.md`
  is a prompt, and every added line is paid for on every read.
- **`README.md`** (the worker's call — I chose to change it): the roster bullet gains the
  preamble and the sentence becomes `The last 3 travel verbatim: the preamble into every
  dispatch, the other 2 into every editing one.` Still three lines, **no added line**.

**Why I changed `README.md`.** The bound left it open, and the argument against is real —
README is deliberately the human-readable overview and bloat costs. But its current sentence
has the *same failure shape* the item diagnoses: an enumeration that is true as far as it
goes and therefore reads as complete. `bootstrap.md` itself sends the reader to `README.md`
"for the longer why", so it sits on the same reading path; repairing one entry point while
leaving the other enumerating two-of-three re-creates the trap one door over. The cost is
about fifteen words and zero net lines, and no new information a reader could not already
work out — only the scope difference that the item identifies as the load-bearing part.

`dispatch-prompt-template.md` is **untouched** — its roster is correct and is the thing being
matched. No new section, nothing moved, no restructuring, and no tracker-command names in
`bootstrap.md`'s parenthetical.

## Gates

Both run from the repository root. Every exit code below was captured with `echo $?` on the
run's own command line, redirect and echo in one shell — never a number reported about the run.

| Run | `check_doc_slugs.py` | `mkdocs build --strict` |
|---|---|---|
| Baseline (final base, post-rebase) | **0** | **0** |
| Sabotage 1 — `bootstrap.md:25`, inside the fence | **1** | not run (see below) |
| Sabotage 2 — `README.md:273`, in prose | **1** | **0** |
| Restored | **0** | **0** |

**Two plants, one per file I changed**, each a broken in-page anchor placed **mid-line** on a
line this change authored — an end-of-line anchor matches nothing where line endings are
translated. The match count was read before every patch and before both plants; all four
patches reported exactly 1 and refused otherwise.

- **Sabotage 1** landed inside `bootstrap.md`'s fence, since that file is largely one
  pasteable fence. The gate reported it as a fenced doc link (`rf2-mmyc`) — the rule that
  makes `docs/the-mayor-method/` one of the two trees where a link inside a fence *is*
  reported — naming `bootstrap.md:25` and the planted anchor.
- **Sabotage 2** landed in `README.md`'s bullet, which is prose, and drew the plain
  `BROKEN ANCHOR` report naming `README.md:273`.

**The red is the discrimination.** The slug gate prints no root, so a planted fault is the
only route it affords; the fault existed solely in this worktree, so a run that had wandered
into a sibling checkout would have come back green. `mkdocs` affords the other route — it
prints its build directory, and that line named this worktree on every run.

**`--strict` confirmed not to gate anchors, measured rather than assumed.** On the sabotage-2
tree it *named* the broken anchor — `contains a link '#…', but there is no such anchor on this
page` — and still **exited 0**, because that sits at MkDocs' INFO default and `--strict`
promotes WARNING, not INFO. `check_doc_slugs.py` is the only anchor gate for this page.

**Restores verified by blob hash against the committed object**, not by a byte digest of the
working file and not by reading a diff — a patch that never applied reads clean. Edits were
committed *before* anything was planted. Both files' post-restore working blob hashes equal
their committed blob hashes, and the tree is clean.

**Gates re-run on the final base.** The branch was rebased onto `origin/main` *before* the
baseline, so every number above describes the tree that ships. The only commit that had
landed in the interval was a tracker checkpoint touching nothing in `docs/the-mayor-method/`.

**Not nominated, deliberately**: no CLJS, browser, compile or lint lane. The changed-surface
classifier reports every test surface false for a `docs/` path, and `lint.yml`'s surface
excludes the docs tree.

## Checked by hand — nothing gates this document's prose

- **Merge-base diff read for what it would REVERT**, not for conflicts: `git diff
  origin/main...HEAD` is 5 insertions / 5 deletions across the two files, and every removed
  line is exactly the text being replaced. Nothing a sibling landed is undone.
- **No heading was added or changed.** Verified rather than assumed, with a positive control
  so a zero is a check that passed and not a pattern that missed: the heading lists of both
  files diff **identical** against `HEAD`, at unchanged line numbers (15 headings in
  `bootstrap.md`, 16 in `README.md` — the control confirms the pattern finds them). A
  repo-wide search found **no anchored cross-file link** into either file, with a control
  showing the same pattern shape does find `loops.md#` references.
- **No OS-specific, repo-specific or operator-specific content, and no tracker-command
  names**, in either addition — scanned across fifteen patterns, all zero, with a positive
  control on three strings that are present.
- **Anchors and prose read by hand**, since no gate covers them.
- **Which side of the fence:** the `bootstrap.md` edit is **inside** the file's `text` fence
  (lines 11–85); the `README.md` edit is **outside** any fence. Both were exercised.
