### PR TITLE
docs(method): three repairs from a fourth pass running the loops

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -569,6 +569,16 @@ substance, and it buries the true state under your own signature. **The tell is 
 repeating a figure some later note retracted is a note that re-derived instead of re-checking.**
 Cite the check you made, or say plainly that you are summarising and from what.
 
+**And check, ONCE, whether your tracker's update verb appends or REPLACES.** Every rule above
+assumes an item accumulates — that notes accrete, that currency is a walk over that accumulation.
+That is a property of the TOOL, not of the item, and where the verb replaces, the walk you are
+teaching a reader to make runs over text you have already deleted. Expect no error and no warning:
+the item afterwards looks well-maintained, because what remains is your note, correctly formatted,
+saying something true. Both mayors on one project hit this, months apart, and the second read the
+first's account of it four hours after repeating it. **If your tracker exports to a versioned file,
+the loss is fully recoverable** — the pre-damage text sits in any checkpoint predating the write, so
+this is a reason to check the verb rather than to panic about the damage.
+
 Four things surface here and nowhere else.
 
 **A fence that has cleared.** The dispatch tick records the fence on the item and moves on,
@@ -594,6 +604,16 @@ the first pile. For the ones that genuinely need the operator, record what the h
 costing: which items are behind it, and what stops if it stays. A hold with no cost written
 on it reads as free, and the cheapest-looking item in a list is the one that stays there
 longest.
+
+**But read WHY the hold was set before you write what it costs, because the count reads the
+same either way.** An oversight and a deliberate dormancy put the identical number of items
+behind a hold, so a queue length alone converts into urgency whichever one you are looking at.
+Where the item records a disposition — parked pending a decision nobody has taken yet, with a
+reactivation trigger and an act that does not expire — the queue behind it is parked by the same
+decision and there is no cost until somebody wants the thing it gates. **Cost is only cost
+against a want.** This is the harder half to catch, because the instruction above tells you
+exactly what to count, and counting feels like compliance: a mayor who stops the moment it has
+the number stops one paragraph short of the disposition that changes what the number means.
 
 In-progress items are read here too, but their liveness question belongs to the stranded
 sweep in the next loop. Read them for scope and for fences; leave *is this worker still
@@ -669,7 +689,13 @@ and both readings went wrong in a single day here, in opposite directions.
    design, so a still tip is the *expected* reading for the commonest healthy state. Corroborate with
    worktree activity, and note that **the corroboration is a WRITE clock, so a worker that is only
    READING touches nothing**: twice in one day a worker grepping its own gate log was called stranded
-   on twenty-three minutes of no writes.
+   on twenty-three minutes of no writes. **So look for a signal OUTSIDE the worktree too — where your
+   tracker records that a worker claimed its item, only a running agent could have done that, and it
+   lands in the tracker rather than the tree, where no file-activity clock can ever see it.** That is
+   the one positive signal a purely reading worker still produces, and the opening minutes of every
+   dispatch are exactly when you need it, because the first thing every brief tells a worker to do is
+   read. Its absence proves nothing — not every dispatch claims — which is why the sweep starts from
+   the worktrees in the first place.
 
    **That clock says "no activity" in three voices and you can only tell them apart with a control.**
    Besides the reading worker, a path that resolves to nothing answers identically — and so does a


### PR DESCRIPTION
Fourth retrospective pass on `docs/the-mayor-method/`, from running the five loops rather than from reading them. **27 insertions, 1 deletion, one file, no heading touched.**

The finding document was written before the method tree was touched, as the method's own rule requires. Every candidate was checked at source in the current tree, and **two were withdrawn on that check**.

## The frame this pass has to report first

Three passes running have concluded that the dominant failure is *a rule that exists and does not reach the reader*. That reproduced twice more — and both of those are withdrawn below, precisely because the rule is present and already general.

But one finding this pass is a different animal, and it is the reason the pass was worth running. **I followed an instruction faithfully and the instruction produced a misleading artefact.** That is not a rule failing to arrive; it is a rule arriving intact and being wrong about half the cases it covers.

## What changed

**1. The hold-cost rule asks for a numerator and no denominator** — added where the backlog reread prices a genuine hold.

The clause tells the mayor to record which items sit behind a hold and what stops if it stays. I did that on a release-coordinate item, counted the queue, wrote "one sentence unblocks five items", and repeated it to the operator across many ticks as the largest lever on the board. The item's own disposition, further up the same field, said it was a deliberately dormant gate with a reactivation trigger and an operator act that "never expires". Nothing was blocked.

An oversight and a deliberate dormancy put the identical number of items behind a hold, so a queue length alone converts into urgency whichever one you are looking at. Every word of the existing clause is about the danger of *under*-pricing and there is no counterpart for over-pricing. **Cost is only cost against a want.**

The clause carries why a mayor does not work this out: the instruction is specific and actionable, which is what makes it dangerous — it names exactly what to count, so counting feels like compliance, and a mayor who stops the moment it has the number stops one paragraph short of the disposition that changes what the number means.

**2. Every read-side rule assumes an item accumulates, and nothing said the accumulation is the tool's** — added beside the writer-side clause from the previous pass, which is its natural neighbour.

I destroyed roughly 72,800 characters of accumulated notes across five items in one session, using an update verb that replaces rather than appends and whose help text reads "Additional notes". Nothing errored. All five were recovered from the tracker's versioned export. A previous mayor on this project made the identical mistake, and their account survives only because they restored it by hand the same way — I read that account four hours after repeating it.

Every currency rule the document teaches assumes notes accrete. That is a property of the tool, not of the item, and where the verb replaces, the walk you are teaching a reader to make runs over text you have already deleted. The loss is invisible afterwards because what remains is your note, correctly formatted, saying something true. The clause carries the remedy as well as the hazard: a versioned export makes it fully recoverable, so this is a reason to check the verb rather than to panic about the damage.

**3. Every liveness signal in the stranded sweep is inside the worktree** — one sentence extending the existing corroboration bullet.

A worker six minutes old read zero files written in two minutes, zero in six, tip unmoved, worktree clean — every write-clock signature of a dead worker. It was alive, and the only positive evidence was that its item was claimed, which lands in the tracker rather than the tree where no file-activity clock can see it. The sweep starts from the worktrees for good reason, and that framing makes every signal it names a worktree signal. Meanwhile the first instruction in every brief is to *read*, so the opening minutes of every dispatch are exactly when the write clock is blind — the ordinary case, not the unlucky one. Its absence proves nothing, which the clause says.

## What I deliberately did NOT change

**Two candidates withdrawn on checking at source**, both the same shape:

| Observed | Why it is not a finding |
|---|---|
| The tracker search matched titles only, so its zero read as "nobody filed it" | Already generalised as far as it can go: *"ANY instrument that can answer 'nothing here' gives the same answer when misused… Exercise any such instrument once against an input it should flag."* Fourth instance of a rule that exists and did not reach the reader, and the second pass said plainly that a fifth restatement is the wrong response. |
| I cited session-injected tool output as the committed instruction file | The brief-writing order already says *"Check every factual claim you are about to write… Does the file say what you think?"* — the exact check I skipped. |

**No deletion, and I looked with the test the brief sets.** The three clauses added in the previous two passes that sit nearest to today's material — the newest-text clause, the three-voices clause and the creation-versus-modification clause — were all exercised this session, the last two decisively. I also checked whether repair 1 supersedes the existing "reads as free" sentence: it does not, because that sentence is the reason for pricing at all.

**Nothing about the three worker refutations this session.** Workers overruled a shape I recommended, refuted a premise using this page's own text, and declined a mirror on a fact I did not know. Each was correct and each saved a bad change. A document that already says *"a refusal is a deliverable, not a failure"* needs nothing added when the mechanism performs.

## Quality gates

Exit codes are the runner's own, captured with `echo $?` on the same command line.

| Gate | Baseline | Sabotage | Restored | Re-run in the worktree |
|---|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** | **0** |
| `mkdocs build --strict` | **0** | **0** | **0** | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored. The first anchor tried returned a match count of **0** because the phrase wrapped across two lines — caught for free by reading the count before running anything, which is why that rule is there. The replacement matched exactly once. The slug gate returned exit 1 naming `loops.md:579 -> #no-such-anchor-retro4-plant`: its own line, existing only on this branch, which is what proves the gate read this tree rather than a sibling's.

**`--strict` named the planted anchor and still exited 0**, which is the documented anchors-ungated behaviour measured again here, and doubles as proof the build read the sabotaged tree.

Restore verified by **blob** hash against the pre-plant object — `8c543d1618…` on both sides — with a residue grep returning 0.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier reports every test surface false for a path under `docs/`, measured against a control that returns true.

**Checked by hand, since nothing gates this prose:** the merge-base diff read for silent **reverts** — one deletion line, and its text is re-emitted verbatim inside the addition that replaced it, so nothing a sibling landed is undone; **no heading added or changed** (0 heading lines in the diff, against a control finding 27 in the file), so no anchor cited from outside this tree can break; and the added lines carry no repo-, tool-, OS- or operator-specific content, swept against a control that fires.
