### PR TITLE
docs(method): correct a fabricated interval in the clause that merged twenty minutes ago

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -574,8 +574,11 @@ assumes an item accumulates — that notes accrete, that currency is a walk over
 That is a property of the TOOL, not of the item, and where the verb replaces, the walk you are
 teaching a reader to make runs over text you have already deleted. Expect no error and no warning:
 the item afterwards looks well-maintained, because what remains is your note, correctly formatted,
-saying something true. Both mayors on one project hit this, months apart, and the second read the
-first's account of it four hours after repeating it. **If your tracker exports to a versioned file,
+saying something true. Two mayors on one project hit this two DAYS apart, and the second read the
+first's account of it four hours after repeating it. The short interval is the alarming half: a
+fresh, accurate account of the hazard was sitting in the same tracker and still did not reach the
+next reader, which is why this belongs here rather than only on an item. **If your tracker exports
+to a versioned file,
 the loss is fully recoverable** — the pre-damage text sits in any checkpoint predating the write, so
 this is a reason to check the verb rather than to panic about the damage.
 


### PR DESCRIPTION
A method-reread pass found a false detail in the change that merged twenty minutes before it — and the change was mine. **5 insertions, 2 deletions, one file, no heading touched.**

## What was wrong

PR #8699 added a clause about a tracker update verb that replaces rather than appends. It closed with:

> Both mayors on one project hit this, **months apart**, and the second read the first's account of it four hours after repeating it.

"Months apart" is fabricated. Checked at source: the earlier account was written on its item no later than `2026-08-20T22:45:20Z`, and the recurrence was on `2026-08-22`. **Two days, not months.**

## Why it is worth a change rather than a shrug

The false detail was not merely inaccurate, it was inaccurate **in the direction that weakens the clause**. Months apart reads as an unlucky coincidence across a long gap. Two days apart is the alarming reading: a fresh, accurate account of the hazard was sitting in the same tracker, on an item the second mayor would go on to read, and it still did not arrive in time.

That is the document's own standing finding — a rule that exists and does not reach the reader — reproducing on the shortest interval yet observed, and it is the actual argument for putting the hazard in the method rather than leaving it on an item. The corrected sentence now carries that argument instead of burying it.

## How it was found

The method-reread loop's step 2 — check the rules you have been enforcing against what the tree actually does — with the loop's own warning in mind that this has twice caught *a rule the documents asserted that the tree did not support, one of them introduced by a merge the mayor approved*. This is a third instance of exactly that, and the merge in question was twenty minutes old.

The mechanical prompt was noticing that the merged clause asserted a measurable fact about timing that I had never measured. Every other claim in that clause was measured; this one was written from impression.

## Quality gates

Exit codes are the runner's own, captured with `echo $?` on the same command line.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, match count read as exactly **1** before planting. The gate returned exit 1 naming `loops.md:579 -> #no-such-anchor-retro4b` — its own line, existing only on this branch, which is what proves the gate read this tree rather than a sibling's. Restore verified by **blob** hash against the pre-plant object, `69cf41c231…` on both sides, with a residue grep returning 0.

The slug gate was sabotaged rather than mkdocs deliberately: `mkdocs.yml` sets no `anchors` key, so anchors sit at the MkDocs default of INFO and `--strict` promotes WARNING, not INFO. A planted anchor leaves the strict build at exit 0 — measured three times this session on three different files.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** the merge-base diff read for silent **reverts** — the two deletion lines are the two lines being rewritten, and their surviving text is re-emitted verbatim in the replacement; **no heading added or changed**, so no anchor cited from outside this tree can break; the addition is prose outside any fence, which matters because this tree reports doc links inside fences; and it carries no repo-, tool-, OS- or operator-specific content.
