### PR TITLE
docs(method): an empty fleet is not a quiet machine

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -478,6 +478,21 @@ for such a window the fleet is empty rather than thin, and you merge nothing eit
 the window record that condition as a test rather than an assurance, capturing the trunk
 tip and the worktree list at both brackets, so a violation is reported rather than assumed.
 
+**An empty fleet is not a quiet machine.** Everything above treats loudness as something
+the mayor causes — gates it arms, work it dispatches — so the remedy it reaches for is to
+dispatch less and finally nothing. That closure does not hold, because the processes a gate
+starts routinely outlive it: the run ends, the change merges, the worktree is reaped, and
+build servers and browser processes stay resident with nothing left pointing at them.
+Measured on an idle project with no worker in flight, no work outstanding and two worktrees
+removed minutes earlier: well over a hundred resident processes and a port still bound, not
+one of them a gate anybody had armed. So a mayor can follow every word of this section —
+hold the fleet thin, enumerate what the item arms, empty the fleet, merge nothing — and
+still hand the window a loud machine. **Measure the machine itself at both brackets, not
+the fleet that was supposed to have quietened it.** The test named just above does not
+reach this: a trunk tip and a worktree list say nothing about what is still running. And
+the fleet count is not wrong, which is what makes it hard to catch — it answers a question
+about your own dispatching, accurately, and is being read as an answer about the box.
+
 Pick the shape by kind first, then priority, then size. The shapes are in
 [`dispatch-prompt-template.md`](dispatch-prompt-template.md).
 


### PR DESCRIPTION
A method-reread pass found a rule whose remedy the tree does not support. **15 insertions, 0 deletions, one file, no heading touched.**

## The drift

The measurement-window section reasons about loudness entirely as something the mayor *causes* — gates it arms, work it dispatches. Every remedy follows from that: hold the fleet thin, enumerate what the item arms, confirm each gate leaves the machine quiet, and for a window registering no peer writes, *"the fleet is empty rather than thin, and you merge nothing either."*

The closure is that an empty fleet yields a quiet machine. **It does not.**

Measured on an idle project — no worker in flight, no work outstanding, no open change proposals, and two worktrees removed minutes earlier:

| | |
|---|---|
| Workers in flight | **0** |
| Open change proposals | **0** |
| Resident build-server processes | **22** |
| Resident browser processes | **109** |
| Ports still bound | **1** |

Not one was a gate anybody had armed. The processes a gate starts outlive it: the run ends, the change merges, the worktree is reaped, and the build servers and browser processes stay resident with nothing left pointing at them.

So a mayor can follow every word of the section and still hand a window a loud machine. The section's own instruction to *"record that condition as a test rather than an assurance, capturing the trunk tip and the worktree list at both brackets"* does not reach it either — neither a trunk tip nor a worktree list says anything about what is still running.

## Why it needs the document rather than a note

This is the class the reread loop is looking for: a rule stated universally that the tree does not support, where the instrument is not wrong and is being asked the wrong question. The fleet count answers a question about the mayor's own dispatching, accurately. It gets read as an answer about the box, and it reads clean in exactly the situation where the box is loud — because both the reaping and the merging that make the fleet count fall are what leave the processes behind.

The added clause carries that as the reason it is hard to catch, not just the fact.

## Quality gates

Exit codes are the runner's own, captured with `echo $?` on the same command line.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing and reading the count first is what catches that. The gate returned exit 1 naming `loops.md:490 -> #no-such-anchor-quietbox`, its own line, existing only on this branch, which is what proves the gate read this tree rather than a sibling's. Restore verified by **blob** hash against the pre-plant object — `89d0a6057f…` on both sides — with a residue grep returning 0.

The slug gate was sabotaged rather than mkdocs deliberately: `mkdocs.yml` sets no `anchors` key, so anchors sit at the MkDocs default of INFO while `--strict` promotes WARNING, not INFO. A planted anchor leaves the strict build at exit 0.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** **zero deletions** in the diff (`15  0`), read for silent reverts rather than for conflicts; **no heading added or changed** (0 heading lines in the diff), so no anchor cited from outside this tree can break; the addition is prose outside any fence, which matters because this tree reports doc links inside fences; and it carries no repo-, tool-, OS- or operator-specific content — the measurement is quoted as counts and kinds, with no product, platform or path named.
