### PR TITLE
docs(method): record a fence where a scan will find it

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -415,6 +415,20 @@ items were genuinely dispatchable; the rest were fenced by something the tracker
 represent. **Record the fence on the item** when you find it, with what clears it, or
 every tick re-derives the same conclusion.
 
+**And record it where a scan will find it, on the item it fences, in the same words every
+time.** The tick that reads a fence back is scanning rather than reading — it has the whole
+list to get through — so a fence written truthfully in the middle of a long field is a fence
+that does not exist for the next tick, and the rule above is satisfied while its stated purpose
+fails. Measured on one item: probed for the six phrases its peers used to mark exactly that
+state, all six came back absent, and it read as the only free item on the board — the answer
+was there, in different words, and cost a full read of twenty-odd thousand characters to reach
+a conclusion one line could have given. A second item the same session cost a full read for the
+neighbouring reason: the sentence naming its hold sat on the item that fenced it rather than on
+the item fenced, where its own reader would never meet it. Pick one marker, put it at the top,
+and reuse it verbatim. What does the work is the sameness rather than the wording, because a
+scan is only ever as good as its phrase roster and it answers *clear* in the same voice whether
+the item is clear or the roster is short.
+
 **Verify before dispatching, not after.** Grep that the alleged broken symbol, missing
 file or stale convention is still there. If it already landed, close as a verified
 duplicate.


### PR DESCRIPTION
A method-reread pass found a rule that was followed to the letter while its stated purpose failed. **14 insertions, 0 deletions, one file, no heading touched.**

## The drift

The dispatch section says:

> **Record the fence on the item** when you find it, with what clears it, or every tick re-derives the same conclusion.

The act is named and the purpose is stated. The act does not achieve the purpose, and the gap is invisible because performing it feels complete — what you have written is true, in place, and well-formed.

Measured twice in one session:

- **One item was fully and truthfully annotated**, and a probe for the six phrases its peers used to mark exactly that state returned **absent on all six**. It read as the only free item on the board. The answer was in the field the whole time, in different words, and cost a full read of roughly twenty-three thousand characters to reach a conclusion one line could have given.
- **A second item cost a full read for the neighbouring reason**: the sentence naming its hold sat on the item that fenced it rather than on the item fenced, where its own reader would never meet it. Read from either item alone you get the wrong answer — one says it is gated, the other says what actually remains.

Neither was a missing record. Both were records a scan could not find.

## Why the document rather than a note

The tick that reads a fence back is *scanning*, not reading — it has the whole list to get through and no context on any single item. So findability is not a nicety on top of recording; it is the thing that makes recording work. The section already carries the adjacent half — *"recording a fence is worth nothing without the loop that reads it back"* — and this is its other side: the loop that reads it back has to be able to find it.

The clause lands on the writer's side, next to the rule it repairs, and says what to do rather than only what went wrong: one marker, at the top, reused verbatim. What does the work is the sameness rather than the wording, because a phrase scan answers *clear* in the same voice whether the item is clear or the roster is short.

## Quality gates

Exit codes are the runner's own, captured with `echo $?` on the same command line.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `loops.md:427 -> #no-such-anchor-scanfence`, its own line, existing only on this branch, which is what proves the gate read this tree rather than a sibling's. Restore verified by **blob** hash against the pre-plant object — `105050ae1d…` on both sides — with a residue grep returning 0.

The slug gate was sabotaged rather than mkdocs deliberately: `mkdocs.yml` sets no `anchors` key, so anchors sit at the MkDocs default of INFO while `--strict` promotes WARNING, not INFO. A planted anchor leaves the strict build at exit 0.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** **zero deletions** in the diff (`14  0`), read for silent reverts rather than for conflicts; **no heading added or changed** (0 heading lines in the diff), so no anchor cited from outside this tree can break; the addition is prose outside any fence, which matters because this tree reports doc links inside fences; and it names no product, platform, path or tool.
