### PR TITLE
docs(hicasso): a dated narrowing note on 2.9's published clock series (rf2-w01c)

### DIFF
--- a/docs/design/hicasso/product/topology-tournament.md
+++ b/docs/design/hicasso/product/topology-tournament.md
@@ -640,6 +640,60 @@ section is the window that ran it. It is written in the order it happened: the
 plan first, committed before the driver was invoked, then what the runs
 returned.
 
+> **[2026-08-22, `rf2-w01c` — the audit's second remedy, taken. A narrowing
+> ruling, not a re-run and not a re-score.]** The merged-PR audit of #8466
+> (2026-08-20) found that the series below did not satisfy its own
+> fixed-before-run plan — [§2.9.1](#291-the-plan-fixed-before-the-first-run)
+> pre-registered that the runs are serial and *"nothing else is run beside
+> them"*, and a second agent was demonstrably active on the box during run 1 —
+> and it named exactly two remedies: a fresh exclusive three-run series, or an
+> explicit methodological ruling narrowing the condition.
+> [Part 3](#part-3--the-re-take-rf2-w01c-the-exclusive-window) attempted the
+> first. That exclusive window ran on **2026-08-22 between 04:52 and 05:13**
+> and returned **two admissible runs of a pre-registered three**: two
+> invocations were voided by the condition's own peer-write rule, and
+> [§2.9.2](#292-two-attempts-and-only-the-second-one-publishes)'s *a series
+> completed later is two instruments* forbids finishing the third another day.
+>
+> **The ruling, given on `rf2-w01c` on 2026-08-22 — the pre-registered
+> exclusivity condition binds AGENT OVERLAP ONLY, not the whole box.** Read as
+> the whole box it is unsatisfiable on this machine: at the quietest moment the
+> project reaches, with no worker in flight at all, the box still carries
+> resident build servers and browser processes belonging to no live agent, so
+> that reading would retroactively void every window ever taken here, this
+> section's included. Under the ruling as given, Part 3's two runs stand as
+> **evidence rather than as a failed attempt**, and **no third window is
+> owed**. The ruling is the mayor's and the operator's to overturn; if it is
+> overturned, this note is the single thing to withdraw.
+>
+> **What the two exclusive runs reproduce.**
+> [§2.9.7](#297-the-floor-row-and-the-thing-it-turned-out-not-to-be)'s
+> falsification is **confirmed in all six readings** — the floor row is
+> arm-specific, always larger on the arm with more boundaries and reads. The
+> narrow/broad reversal holds in **all eight** readings, and `bulk` still
+> orders the arms. Every ordering [§2.9.8](#298-what-the-table-settles) states
+> is reproduced under exclusivity. **The one half that does not reproduce** is
+> §2.9.8's *"and the three runs agree"* — which is the incompleteness itself,
+> two runs having no third to agree with, rather than a disagreement about the
+> table.
+>
+> **The absolute cells moved with the box and the arm-to-arm ratios did not**,
+> measured on the published series' own statistic: raw cell spread reads a
+> published median of **9.0%** against the exclusive series' **28.6%**, while
+> ratio-cell spread reads **3.9%** published against **3.8%** exclusive.
+>
+> **The narrowing itself is one sentence: the defect the audit found in this
+> section's published series does not reach this section's conclusions** — and
+> the exclusive window is the evidence for that which the audit could not have
+> had, because at the time of the audit nobody had spent the window.
+>
+> **Nothing below is replaced and nothing is re-scored.** Two runs are not
+> three, so Part 3 is a **record** and not a window: every figure in §2.9.5 and
+> §2.9.6 stands exactly as published, and **no ledger row moves** in either
+> direction. See
+> [§3.4](#34-why-run-3-was-not-re-taken-and-the-series-is-incomplete) and
+> [§3.7](#37-the-adjudication-rule-by-rule-and-what-two-runs-may-close).
+
 #### 2.9.1 The plan, fixed before the first run
 
 Committed as its own commit, ahead of the first invocation, so that no stopping


### PR DESCRIPTION
The remaining half of `rf2-w01c`. The mayor's ruling of **2026-08-22** on that bead
answered the topoclock worker's ruling request — *the pre-registered exclusivity
condition binds AGENT OVERLAP ONLY, not the whole box* — and that ruling selects the
#8466 audit's **own second remedy**: a narrowing ruling plus a note, not a third full
window. **No third window is owed.** This PR is the note and nothing else.

## What it changes

One file, one hunk, **54 insertions and 0 deletions**: a dated amendment at the head of
§2.9, in the same blockquote form §2.9.7 and §2.9.9 already use on this page. The
existing text is byte-identical — the diff adds and removes nothing.

The note records, all of it drawn from the topoclock report on the bead and none of it
re-derived here:

- the exclusive window of **2026-08-22 04:52–05:13** returned **two admissible runs of a
  pre-registered three**, and under the ruling those two stand as **evidence rather than
  as a failed attempt**;
- §2.9.7's falsification is **confirmed in all six readings**; the narrow/broad reversal
  holds in **all eight**; `bulk` still orders the arms; every ordering §2.9.8 states is
  reproduced under exclusivity;
- **the one half that does not reproduce** is §2.9.8's *"and the three runs agree"*;
- the absolute cells moved with the box and the arm-to-arm **ratios did not** — raw cell
  spread published median **9.0%** against exclusive **28.6%**, ratio-cell spread **3.9%**
  published against **3.8%** exclusive;
- the narrowing: **the defect the audit found in §2.9's published series does not reach
  its conclusions**, and this window is the evidence the audit could not have had.

**No figure is replaced, no ledger row moves, no status moves and no cell is re-scored** —
two runs are not three, so Part 3 stays a RECORD. Nothing outside this file is touched:
`budgets.md`, the ledger and `clock_app.cljs` are all untouched.

**Written to be withdrawn cleanly.** The note names `rf2-w01c` and the ruling's date in
its own opening line, so if Mike overturns the ruling, withdrawing it is this one
blockquote and no archaeology.

## Gates — every exit code captured on the same command line as the redirect, and quoted from the file rather than from any harness report

| gate | captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` (control, before the plant) | **0** |
| `python scripts/check_doc_slugs.py` (**sabotage**, planted anchor) | **1** |
| `python scripts/check_doc_slugs.py` (final, restored tree) | **0** |
| `python scripts/check_provenance_pins.py --changed-since <merge-base>` (final) | **0** |
| `python scripts/check_provenance_pins.py --changed-since <merge-base>` (**sabotage**, planted pin) | **1** |

**Both gates were shown to bite, and the red is also the proof of which tree they read**,
since each fault existed only in this worktree — a run that had wandered into a sibling's
checkout would have come back green.

- **doc slugs**: a broken in-page anchor planted *mid-line on a line this PR authors*
  (`#298-what-the-table-settles` → `#298-clocknote-planted-bogus-anchor-1`; match count
  read as **1** before planting). Gate returned **exit 1**, naming the planted anchor at
  its file and line.
- **provenance pins**: its clean pass reports *1 page inspected, 2 cited pins* — a
  non-vacuous reading, since it names the page this PR changes. Exercised in the flagging
  direction anyway: a bogus `deadbeef…` pin planted in the new text returned **exit 1**,
  *1 unresolvable, 1 finding*, at its line.
- **Both restores verified by git blob hash**, not by reading a diff: the working file
  returned to `ec2702c32bcbc30ac11e20a8b75e5dd71ceb7b1e`, equal to
  `git rev-parse HEAD:docs/design/hicasso/product/topology-tournament.md`, after each
  plant. The tree was committed **before** either plant, so the restore could not discard
  the work under test.

**NOT the gate for this diff and deliberately not run:** `mkdocs build --strict`.
`mkdocs.yml`'s `exclude_docs` keeps `docs/design/**` out of the site, so a strict build
cannot see this change and its green would have inspected nothing. Reporting it would be
a wrong-gate nomination.

## Checked by hand, because no gate covers it

- **Links inside fenced blocks** — this is one of the two trees where a doc link inside a
  fence is itself reported, and both link gates strip fences before reading. Measured on
  the added lines: **0 fence markers**, so nothing this PR adds is hidden from the gate
  that passed. All **7** added links are in-page anchors and all are inside the gate's
  reach, which the sabotage run demonstrates directly by reddening on one of them.
- **Table column counts** — **0 table rows added and 0 removed**. No table is touched, so
  no column count can have moved.
- **Revert check against the merge base** (`origin/main...HEAD`, three-dot): **0 deletion
  lines**. This push undoes nothing a sibling landed. `origin/main` was re-checked at push
  time and had not moved from the merge base, so the gate results are about the tree that
  will land.
