### PR TITLE
docs(method): match a block's closing anchor as a heading

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -446,6 +446,20 @@ document is a measured constant that goes stale exactly where it has to be right
 extraction that silently returns the wrong two hundred lines is worse than either option
 that trade-off was weighing. Match the block's opening and closing text instead.
 
+**But match that closing text as a HEADING — anchored to the start of a line — because a block
+that documents its own boundaries contains its own end anchor.** The gate-mechanics block opens
+by naming where it stops and which neighbouring section it is not, so BOTH of its boundary
+strings occur twice in this file: once as the real heading, once inside that sentence. A plain
+search for the closing text stops at the mention, and the extraction returns the block's first
+five lines out of a hundred and sixty-four — 206 characters of 11,925 — while raising no error,
+because both anchors were found. Measured on this document.
+
+That is a worse failure than the stale line range this rule exists to avoid, and worse in the way
+that matters: a stale range returns the wrong two hundred lines, which reads wrong on sight, where
+this returns a plausible opening paragraph that reads like a short block. **So check the extracted
+SIZE before you paste it** — a block you can read in one screen is not the one you meant to send,
+and that check costs nothing where the paste costs a worker.
+
 ---
 
 ## The worktree boundary block


### PR DESCRIPTION
A method-reread pass found that following this document's own extraction instruction silently returns 1.7% of the block it asks for. **14 insertions, 0 deletions, one file, no heading touched.**

## The drift

`## Pasting a block` says:

> **Anchor the extraction to CONTENT, never to line numbers.** … Match the block's opening and closing text instead.

Doing exactly that, on this document, at the current tip:

| extraction | result |
|---|---|
| plain content anchors, as instructed | **206 characters, 5 lines** |
| closing text matched as a heading | **11,925 characters, 164 lines** |

**No error is raised, because both anchors were found.** The cause is that the gate-mechanics block opens by naming its own boundaries — where it stops, and which neighbouring section it is not — so *both* of its boundary strings occur twice in the file: once as the real heading, once inside that sentence. A block that documents its own boundaries contains its own end anchor.

Measured on both affected strings:

| string | plain occurrences | as a heading |
|---|---|---|
| `## Reviewing what comes back` | **2** | **1** |
| `## Quality gates — which gate` | **2** | **1** |

## Why this needs the document

This was hit for real while assembling a dispatch, and it is worse than the stale line range the rule exists to avoid — worse in the way that matters. A stale range returns the wrong two hundred lines, which reads wrong on sight. This returns a plausible opening paragraph that reads like a short block, and the paragraph it returns is the one *explaining* the block, so it looks like exactly what you asked for.

The failure also lands on the section the document is most emphatic about pasting in full: the same page argues that extraction beats retyping precisely because "a matched range cannot reword". A matched range cannot reword, but it can silently return 3% of the block and the worker is none the wiser.

The clause adds the mechanical requirement — anchor the closing match to the start of a line — and a check that costs nothing: **read the extracted size before pasting it.** A block you can read in one screen is not the one you meant to send.

## Quality gates

Exit codes are the runner's own, captured with `echo $?` on the same command line.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `dispatch-prompt-template.md:459 -> #no-such-anchor-anchorhead`, its own line, existing only on this branch, which is what proves the gate read this tree rather than a sibling's. Restore verified by **blob** hash against the pre-plant object — `52f82977bf…` on both sides — with a residue grep returning 0.

The slug gate was sabotaged rather than mkdocs deliberately: `mkdocs.yml` sets no `anchors` key, so anchors sit at the MkDocs default of INFO while `--strict` promotes WARNING, not INFO. A planted anchor leaves the strict build at exit 0.

**The fix was exercised against the document it describes**, which is the check that matters here: heading-anchored extraction of the gate-mechanics block returns 11,925 characters where the plain form returns 206.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** **zero deletions** in the diff (`14  0`), read for silent reverts rather than for conflicts; **no heading added or changed** (0 heading lines in the diff) — which matters more than usual here, since this page's headings are themselves extraction anchors; the addition is prose outside any fence, which matters because this tree reports doc links inside fences; and it names no product, platform, path or tool.
