### PR TITLE
docs(method): measure load, not a census of what is resident

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -501,9 +501,16 @@ Measured on an idle project with no worker in flight, no work outstanding and tw
 removed minutes earlier: well over a hundred resident processes and a port still bound, not
 one of them a gate anybody had armed. So a mayor can follow every word of this section —
 hold the fleet thin, enumerate what the item arms, empty the fleet, merge nothing — and
-still hand the window a loud machine. **Measure the machine itself at both brackets, not
-the fleet that was supposed to have quietened it.** The test named just above does not
-reach this: a trunk tip and a worktree list say nothing about what is still running. And
+still be handed a machine it has measured nothing about. **But do not stop at counting
+those processes, which is the same error one level down and is how this clause was first
+written.** A five-second per-process census of that same box put total load at 2.6 cores of
+24: the hundred-odd processes accounted for 0.14 of it between them, the largest single
+consumer was an editor, and they were resident and IDLE. Presence is not load, and a count
+answers presence — so stopping there swaps one proxy for another while feeling like
+measurement, and it feels like measurement precisely because the instruction was to measure
+the machine. **Measure LOAD, at both brackets — not the fleet that was supposed to have
+quietened the box, and not a census of what happens to be resident on it.** The test
+named just above does not reach this: a trunk tip and a worktree list say nothing about what is still running. And
 the fleet count is not wrong, which is what makes it hard to catch — it answers a question
 about your own dispatching, accurately, and is being read as an answer about the box.
 


### PR DESCRIPTION
The clause added three passes ago is right about what to distrust and wrong about what it measured — and the error is the clause's own subject, one level down. **10 insertions, 3 deletions, one file, no heading touched.**

## What was wrong

*An empty fleet is not a quiet machine* argued that emptying the fleet proves nothing about the box, illustrated it with a count, and concluded:

> Measured on an idle project … well over a hundred resident processes and a port still bound … **still hand the window a loud machine.**

The count was right. **The conclusion was not.** A five-second per-process census of that same box:

| | |
|---|---|
| Total load | **2.6 busy cores of 24** — about 89% idle |
| The hundred-odd resident processes, combined | **0.14 cores** |
| Largest single consumer | an editor, at **1.3 cores** |

They are resident and **idle**. Presence is not load, and a count answers presence. The clause replaced one proxy for machine state — the fleet count — with another, in a paragraph whose entire argument is that proxies for machine state should be distrusted.

The reading is corroborated rather than a one-off: an independent measurement window on the same machine, taken by a different agent for a different purpose, reported 2.29 busy cores of 24 with one editor language service at 1.07 and every agent process summing to 0.52.

## Why it was hard to see

Counting processes *feels* like measuring the machine, and it feels that way **because the instruction says to measure the machine**. That is the same trap the backlog section already names in another place — an instruction specific enough to be actionable tells you exactly what to do, so doing it feels like compliance and you stop one step short of the thing that would change the answer.

So the repair is not to soften the clause. It is to name the step: **measure load**, not the fleet and not a census of what happens to be resident.

The clause now says so, and says plainly that counting is how it was first written — a rule that admits where it went wrong is harder to repeat.

## What is unchanged

The core survives and is untouched: an empty fleet is not evidence about the machine; the processes a gate starts outlive it; the trunk tip and worktree list the section names as a test say nothing about what is still running; and the fleet count is not *wrong*, which is what makes it hard to catch.

## Quality gates

Exit codes are the runner's own, captured with `echo $?` on the same command line.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `loops.md:508 -> #no-such-anchor-loadnotcount`, its own line, existing only on this branch, which is what proves the gate read this tree rather than a sibling's. Restore verified by **blob** hash against the pre-plant object — `19e0b46b27…` on both sides — with a residue grep returning 0.

The slug gate was sabotaged rather than mkdocs deliberately: `mkdocs.yml` sets no `anchors` key, so anchors sit at the MkDocs default of INFO while `--strict` promotes WARNING, not INFO. A planted anchor leaves the strict build at exit 0.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose.** This change has **3 deletions**, so the revert check is the one that mattered and was done line by line: both deleted lines carry the two claims being corrected — `still hand the window a loud machine` and `Measure the machine itself at both brackets` — and both are deliberately gone rather than re-emitted, which a grep confirms returns 0 for each. Nothing a sibling landed is touched. **No heading added or changed** (0 heading lines in the diff). The added lines are prose outside any fence, which matters because this tree reports doc links inside fences. Line wrap was checked against the file's own maximum and one over-long line was rewrapped. And the text names no product, platform, path or tool — the census is quoted as cores and a process class.
