### PR TITLE
docs(method): strike the marker when the hold is discharged

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -429,6 +429,22 @@ and reuse it verbatim. What does the work is the sameness rather than the wordin
 scan is only ever as good as its phrase roster and it answers *clear* in the same voice whether
 the item is clear or the roster is short.
 
+**But a marker makes a DISCHARGED hold findable exactly as well as a live one, and that is the
+cost of the rule above rather than an argument against it.** A scan cannot tell the two apart:
+the banner is the same string either way, and the note that discharged it is somewhere below,
+where the scan was introduced precisely so nobody has to read. Measured: an item sat in the
+awaiting-a-decision pile for a whole session, reported to the operator that way every tick,
+while a note further down recorded the ruling and said in terms that the header was discharged
+and the work should be dispatched. The scan found the header. It was right that the header was
+there and wrong about everything that mattered.
+
+So the marker is written by whoever SETS the hold, and **it is struck by whoever discharges it,
+in the same act** — not left standing with a correction beneath. If your tracker will not let you
+edit the original text, add the marker's negation in the same words, so that a scan for the
+banner returns both and a reader sees the pair rather than the header alone. **Treat a banner
+with no discharge beneath it as a claim about the past**: check who set it and whether what they
+were waiting for has since happened, before you report it as the current state.
+
 **Verify before dispatching, not after.** Grep that the alleged broken symbol, missing
 file or stale convention is still there. If it already landed, close as a verified
 duplicate.


### PR DESCRIPTION
The scannable-banner rule added two passes ago has a cost, and it cost a whole session before anyone noticed. **16 insertions, 0 deletions, one file, no heading touched.**

## What happened

The rule says to record a fence where a scan will find it — one marker, at the top, reused verbatim — because a fence buried in prose is a fence the next tick re-derives. That rule is sound and stays.

**But a marker makes a DISCHARGED hold findable exactly as well as a live one.** A scan cannot tell them apart: the banner is the same string either way, and the note that discharged it sits somewhere below — precisely where the scan exists so nobody has to read.

Measured on one item this session:

| | |
|---|---|
| Its description header | `AWAITING MIKE / NOT DISPATCHABLE` |
| A note further down | the ruling, plus *"the header is DISCHARGED; dispatch per the execution shape"* |
| What the scan found | the header |
| What was reported to the operator, every tick, for a session | "awaiting your ruling" |

The scan was right that the header was there and wrong about everything that mattered. Worse, the work behind it had already been done and merged the same day the "still outstanding" note was written — so a dispatch went out to scope work that was already in the trunk, and the worker's deliverable was refuting the premise.

## The repair

Two sentences of mechanism, not a new rule:

1. **The marker is struck by whoever discharges the hold, in the same act** — not left standing with a correction beneath it. Where the tracker will not let you edit the original text, add the marker's negation *in the same words*, so a scan for the banner returns both and the reader sees the pair rather than the header alone.
2. **Treat a banner with no discharge beneath it as a claim about the past.** Check who set it and whether what they were waiting for has since happened, before reporting it as the current state.

This is the cost of the banner rule stated honestly beside it, rather than an argument against it. Without the marker the fence is invisible; with it, a stale marker is authoritative-looking. The second failure is cheaper than the first, and it is cheaper still once the discharge is part of the same act.

## What I deliberately did NOT add

**Nothing about read-only dispatches, and I checked before deciding.** A read-only pass this session was invisible to both liveness discriminators for its whole life — its tip never moves because it commits nothing, and the write clock never registers because it writes nothing. That looks like a gap, but the section already says the corroboration is a *write* clock and already directs the reader to a signal outside the worktree. A third restatement is what an earlier pass explicitly warned against.

## Quality gates

Exit codes are the runner's own, captured with `echo $?` on the same command line.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `loops.md:444 -> #no-such-anchor-stalebanner`, its own line, existing only on this branch, which is what proves the gate read this tree rather than a sibling's. Restore verified by **blob** hash against the pre-plant object — `c71b05114e…` on both sides — with a residue grep returning 0.

The slug gate was sabotaged rather than mkdocs deliberately: `mkdocs.yml` sets no `anchors` key, so anchors sit at the MkDocs default of INFO while `--strict` promotes WARNING, not INFO. A planted anchor leaves the strict build at exit 0.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** **zero deletions** in the diff (`16  0`), read for silent reverts rather than for conflicts; **no heading added or changed** (0 heading lines in the diff); line wrap checked against the file's own maximum; the addition is prose outside any fence, which matters because this tree reports doc links inside fences; and it names no product, platform, path or tool.
