### PR TITLE
docs(method): a right answer to a different question

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -45,6 +45,13 @@ The order is what makes it accurate. Each step is a check the next depends on.
    Does the file say what you think? Is the count still true? Is the ruling you cite
    *ruled*, or only recommended? A recommendation and a decision read identically in
    a summary and are opposite in force.
+   **Then one question of a different kind: is this work still OUTSTANDING?** The four
+   above ask whether a claim is TRUE. A note saying "X is all that remains" was true when
+   it was written and says nothing about now, so checking it at source confirms the wrong
+   thing. Check the TREE. The sentence that says so is addressed to you and sits in the
+   common preamble below — inside the block you extract and paste without reading, because
+   its audience looks like the worker. A dispatch went out for work that had merged the
+   previous day, and the worker's deliverable was refuting the premise.
 3. **Establish the fence by asking who is live, not what is open.** A listing of open
    changes misses a worker that has not pushed yet.
 4. **Name the discriminator**, if the task is "find every X".

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -526,9 +526,8 @@ answers presence — so stopping there swaps one proxy for another while feeling
 measurement, and it feels like measurement precisely because the instruction was to measure
 the machine. **Measure LOAD, at both brackets — not the fleet that was supposed to have
 quietened the box, and not a census of what happens to be resident on it.** The test
-named just above does not reach this: a trunk tip and a worktree list say nothing about what is still running. And
-the fleet count is not wrong, which is what makes it hard to catch — it answers a question
-about your own dispatching, accurately, and is being read as an answer about the box.
+named just above does not reach this: a trunk tip and a worktree list say nothing about
+what is still running.
 
 Pick the shape by kind first, then priority, then size. The shapes are in
 [`dispatch-prompt-template.md`](dispatch-prompt-template.md).
@@ -1057,6 +1056,18 @@ no check at all.
 
 These belong to no single loop and bite in all of them.
 
+
+**An instrument can be RIGHT and still answer a different question from the one you asked.** The
+rule about an instrument that says *"nothing here"* covers the case where its answer is wrong.
+This is the other case, and the remedy for the first is inert against it: exercise the instrument
+against an input it should flag and it comes back GREEN, because nothing is malfunctioning. Four
+in one session, one from each of four loops — a count of running workers read as *the machine is
+quiet*; a count of resident processes read as *the machine is busy*; a marker scan finding a
+banner read as *this item is held*; a note true when written read as *true now*. Every answer was
+correct and every reading was wrong. **Write the question the instrument answers, in its own
+terms, beside the question you are asking.** The gap is invisible in the answer and obvious the
+moment both sentences are on the page. This is the harder half to catch, because a wrong answer
+gives you something to be suspicious of and a right one does not.
 **A dependency can outlive what it was enforcing.** An item blocked "until X lands" stays blocked if X
 is later reopened by an audit for an unrelated residual — even though the thing it was waiting for
 shipped. Force the close and **write the reasoning on the item**: what the dependency was enforcing,


### PR DESCRIPTION
Fifth retrospective pass on `docs/the-mayor-method`, from running the five loops rather than from reading them. **21 insertions, 3 deletions, two files, no heading touched.** The finding document was written before the method tree was touched, as the method's own rule requires.

## The frame this pass has to report first

Four of this session's seven method repairs were **corrections to rules merged earlier in the same session**:

| merged | corrected by | the limit |
|---|---|---|
| *an empty fleet is not a quiet machine* | *measure load, not a resident census* | it proved its point with a **count** |
| *record a fence where a scan will find it* | *strike the marker when the hold is discharged* | a scan finds a **stale** marker just as well |

Both originals were right. Both had a cost that appeared only on use, and both costs were the same kind. That kind is the first repair below.

## What changed

**1. An instrument can be right and still answer a different question** — added to the cross-loop section, whose stated remit is *"these belong to no single loop and bite in all of them."*

Four failures, one from each of four loops, all one shape:

| the instrument answered | it was read as |
|---|---|
| how many workers am I running | is the machine quiet |
| how many processes exist | is the machine busy |
| does this string appear on the item | is this item held |
| what was true when this note was written | what is true now |

**Every one of those answers was correct.** None was a malfunction, a mistyped pattern or an empty result.

The method already has a rule for the neighbouring family — *"ANY instrument that can answer 'nothing here' gives the same answer when misused… Exercise any such instrument once against an input it should flag."* That covers a **wrong** answer, and **its remedy is inert here**: exercise all four against an input they should flag and every one comes back **green**, because nothing is malfunctioning. A rule whose remedy passes on the failure is worse than a missing one, since running it feels like diligence.

The clause carries the test that separates the two: **write the question the instrument answers, in its own terms, beside the question you are asking.** Each of the four gaps is invisible in the answer and obvious once both sentences are on the page — and this is the harder half to catch, because a wrong answer gives you something to be suspicious of and a right one does not.

**And the local special case is folded into it.** The observation already existed in the tree — once, about *one* instrument, inside a paragraph on measurement windows. I wrote that sentence myself this session and then made the same mistake three more times with three other instruments, because it reads as a fact about fleet counts. Those three lines are **deleted**; the general rule names the fleet count as one of its four instances, so nothing is lost and the rule now sits where a reader in any loop will reach it.

**2. A rule addressed to the mayor lived only inside the block the mayor pastes** — added to the brief-writing order's claim-checking step.

I dispatched a scoping pass for work that had merged the previous day, having verified the fence, the destination, the file census, the classifier surface and the gate coverage — everything except whether the work was still outstanding. The check was in the brief I wrote, pasted verbatim: *"**before you brief** or build X, check whether X ALREADY EXISTS AT TIP."*

It is addressed to the **mayor**, and it lives at exactly one place: inside the common preamble, the block the mayor extracts mechanically and pastes without reading because its audience looks like the worker. Meanwhile the brief-writing order, which the mayor does read, asks four claim-checking questions — all of them *is this claim true?* None asks whether the work is still outstanding, which is a different kind: the note saying so was true when written, so checking it at source confirms the wrong thing.

The document already knows that block binds the mayor — step 1 says so in terms. It made the link for the timestamp material and not for this. **This is a placement repair, not a new rule.**

## What I deliberately did NOT change

**Only one deletion, and I looked for more with the test the brief sets.** Across roughly forty loop ticks I exercised the write-clock material, the reaping rule, branch patch-equivalence, all five merge clauses and every clause added in passes two through four. Merge clause 3 earned its keep twice in one hour — the terminal state read `UNKNOWN` with the rollup already at the band, and a poll turned it `CLEAN`. Nothing else showed itself dead, and proposing a cut without evidence is the same invention the brief rules out.

**Nothing about the extraction trap** — the mandated block extraction returned 206 characters of 11,925 because a block that documents its own boundaries contains its own end anchor. Repaired in place when found, earlier this session.

**Nothing about read-only dispatches.** One was invisible to both liveness discriminators for its entire life — its tip never moved because it committed nothing, the write clock never registered because it wrote nothing. That looks like a gap and is not: the section already says the corroboration is a *write* clock and already points outside the worktree. A third restatement is what pass three warned against.

**Nothing about my brief-error rate**, four this session. Pass two's finding shipped; passes three and four both declined to restate it. Repair 2 is adjacent and structurally different — not that I compress sources badly, but that a check I needed was filed under someone else's instructions.

**README.md is untouched**, and no new sections were added.

## Quality gates

Exit codes are the runner's own, captured with `echo $?` on the same command line.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `loops.md:1068 -> #no-such-anchor-retro5`, its own line, existing only on this branch, which proves the gate read this tree rather than a sibling's. **Both** files restored and verified by **blob** hash against their pre-plant objects — `8f943cf0cd…` and `3ff9341ff2…` — with a residue grep returning 0.

The slug gate was sabotaged rather than mkdocs deliberately: `mkdocs.yml` sets no `anchors` key, so anchors sit at the MkDocs default of INFO while `--strict` promotes WARNING, not INFO. A planted anchor leaves the strict build at exit 0.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier reports every test surface false for a path under `docs/`.

**Re-ran the extraction this change edits.** One repair touches the file whose block-extraction contract broke earlier this session, so the three blocks were re-extracted afterwards: worktree-boundary 3,923 chars / 71 lines, common preamble 4,756 / 75, gate mechanics 11,925 / 164. Unbroken.

**Checked by hand, since nothing gates this prose.** This change has **3 deletions**, so the revert read was line by line: all three are the special case being folded, one of them rewrapped and re-emitted, and greps confirm the surviving sentence is still present (1) while the folded one is gone (0). **No heading added or changed** (0 heading lines in the diff), which matters more than usual because this tree's headings are extraction anchors. Line wrap checked against the file's own maximum. The additions are prose outside any fence, which matters because this tree reports doc links inside fences. And the text names no product, platform, path, tool or person.
