### PR TITLE
docs(method): a hold that expires on a date while its reason does not

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -669,6 +669,21 @@ against a want.** This is the harder half to catch, because the instruction abov
 exactly what to count, and counting feels like compliance: a mayor who stops the moment it has
 the number stops one paragraph short of the disposition that changes what the number means.
 
+**And the mirror of that case: a hold that expires on a DATE while its reason does not.** Where
+the tracker can defer an item until a date, the date is a hold it enforces and then silently
+stops enforcing. An item parked for something no date can settle therefore returns to the ready
+list on its own, carrying its priority and an empty blocker column — and reading as MORE
+legitimate than an ordinary item, because a reappearance looks like something happened. Nothing
+happened; a date passed. Measured on one board: four deferred items, three of them sharing a
+single date, every one with no dependency recorded, and two of them the heads of chains holding
+four more items behind them. Each needed an operator act the date says nothing about.
+
+**So read the defer dates across the whole deferred set rather than on the item in front of
+you** — they cluster, because they get set in batches, and a cluster lapsing together makes the
+list look suddenly and misleadingly rich. Where the reason will outlive the date, write that on
+the item BEFORE the date arrives. Afterwards nothing in the list prompts anybody, which is the
+whole difficulty: this is the one hold that removes its own evidence.
+
 In-progress items are read here too, but their liveness question belongs to the stranded
 sweep in the next loop. Read them for scope and for fences; leave *is this worker still
 alive?* to the loop that owns it.


### PR DESCRIPTION
A method-reread pass found the mirror of a case the backlog section already covers, and only one of the pair was written down. **15 insertions, 0 deletions, one file, no heading touched.**

## The gap

The hold-cost material covers a hold whose *act* does not expire:

> Where the item records a disposition — parked pending a decision nobody has taken yet, with a reactivation trigger and **an act that does not expire** — the queue behind it is parked by the same decision…

Nothing covers the opposite: **a hold that does expire, on a date, while the reason for it does not.**

Where a tracker can defer an item until a date, that date is a hold it enforces and then silently stops enforcing. An item parked for something no date can settle returns to the ready list on its own, carrying its priority and an empty blocker column — and it reads as *more* legitimate than an ordinary ready item, because a reappearance looks like something happened. Nothing happened. A date passed.

## What was measured

Testing every defer date on one board against the clock, which had not been done before:

| | |
|---|---|
| Deferred items carrying a date | **6** |
| Lapsing on one single date | **3** |
| Of those, with **no dependency recorded** | **3** |
| Of those, heads of chains holding further items | **2** |
| Already lapsed | **0** — this was caught *before* it fired |

Two more items shared that date and did **not** surface, because they carry real dependency edges. That contrast is the whole point: the graph holds what it can express, and a reason that lives in prose is exactly what it cannot.

Each of the three needed an operator act — a ruling, or a publish decision — about which the date says nothing at all.

## The repair

Two paragraphs beside the clause they mirror. The instruction is the part that does the work: **read the defer dates across the whole deferred set rather than on the item in front of you.** They cluster, because they get set in batches, and a cluster lapsing together makes the list look suddenly and misleadingly rich.

And write the reason on the item **before** the date arrives, because afterwards nothing in the list prompts anybody. That is the difficulty in one line: this is the one hold that removes its own evidence.

## Quality gates

Exit codes are the runner's own, captured with `echo $?` on the same command line.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `loops.md:685 -> #no-such-anchor-deferdate`, its own line, existing only on this branch, which is what proves the gate read this tree rather than a sibling's. Restore verified by **blob** hash against the pre-plant object — `d974bdc867…` on both sides — with a residue grep returning 0.

The slug gate was sabotaged rather than mkdocs deliberately: `mkdocs.yml` sets no `anchors` key, so anchors sit at the MkDocs default of INFO while `--strict` promotes WARNING, not INFO. A planted anchor leaves the strict build at exit 0.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** **zero deletions** in the diff (`15  0`), read for silent reverts rather than for conflicts; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors; line wrap checked against the file's own maximum; the addition is prose outside any fence, which matters because this tree reports doc links inside fences; and it names no product, platform, path, tool or person — the measurement is quoted as counts, and the dates are not named.
