### PR TITLE
docs(method): an empty file keyed by the agent id is not evidence that no report exists

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -914,6 +914,16 @@ eight while their real transcripts sat complete elsewhere, *also* empty for a cu
 that finished normally, and for the eighth held a hardlink to the real transcript, so the wrong
 file returned one plausible non-empty result and made the wrong conclusion self-consistent.
 
+**An empty file keyed by the id says nothing whatever about whether a report exists** — it is a
+fact about that file. Measured again later, at larger scale: the sink read empty for fifteen of
+seventeen worktrees, every one of those fifteen transcripts sat complete elsewhere, and fourteen of
+them opened with the completion sentence the test demands. The two non-empty ones are what made it
+read as a survey rather than an artefact — a wholly empty result would have looked broken and sent
+the reader looking. So the id names a FILE only once you know which file is the agent's OWN; until
+then it names a directory to search. Read emptiness as *not found here*, never as *not written* —
+the cost of the wrong reading is the whole point of this section, since it converts "no report
+exists" into a standing residue that nothing will ever clear.
+
 **When no id was recorded at all, the report is not missing — only unindexed.** Search the
 transcripts for the worktree's own path, which a dispatch names and so does the report that ends
 the work, then read a bounded TAIL of a file that matches rather than opening it, because these are


### PR DESCRIPTION
A method-reread pass found a rule that is correct, that the mayor had read, and that still did not reach the point of use — and the same pass paid for it. **10 insertions, 0 deletions, one file, no heading touched.**

## What happened

The hygiene loop reaps a worktree only on a quotable completion report. The section already tells you the agent id buys a **transcript** rather than a live conversation, and it already warns:

> **beware a per-agent scratch sink that merely shares the id** — one was empty for seven of those eight while their real transcripts sat complete elsewhere … so the wrong file returned one plausible non-empty result and made the wrong conclusion self-consistent.

I read that section, then read the sink anyway. Of seventeen worktrees with a recorded id, **fifteen returned a zero-byte file**, and I reported that no quotable report existed for any of them.

The real transcripts were complete on disk the whole time, at a path that names the file as the agent's own rather than merely keying it by id. **Fourteen of the fifteen opened with the completion sentence the test demands** — *"Done."*, *"Work complete."*, *"The whole re-take is discharged."*

## Why the existing warning did not carry

Two reasons, and the second is the one worth writing down.

**The warning is an observation; it names the trap without naming the inference.** A reader who has met it still has to supply "…therefore an empty result means nothing" for themselves, at the moment they are looking at fifteen empty files in a row.

**And the non-empty minority is what disguised it.** Two of the seventeen came back with real content. A wholly empty result would have looked broken and sent me looking for a better source; a 2-of-17 result looked like a *survey* — like the fact of the matter, unevenly retained. The earlier incident recorded the same shape from the other side, where one hardlink made the wrong file's answer self-consistent.

## The repair

One paragraph at the point of use, stating the inference the observation implies: **an empty file keyed by the id is a fact about that file and says nothing about whether a report exists.** The id names a file only once you know which file is the agent's *own*; until then it names a directory to search. Read emptiness as *not found here*, never as *not written*.

The cost clause is included deliberately, because it is asymmetric: the wrong reading converts "no report exists" into a standing residue that nothing will ever clear.

## What the correction was worth, since a method change should be paid for

Re-run against the agents' own transcripts, **thirteen** worktrees produced a quotable completion sentence and every one corroborated: change **MERGED** on exact head-reference equality, patch-equivalence showing zero genuinely-new commits, clean tree. All thirteen reaped through the removal script; the `node_modules` canary read **101 immediate / 2933 recursive** before and after, captured at runtime either side.

Two were held back rather than swept along, which is the rule working: one had no sentence to quote — only a report that *looked* complete — and one opened with a change-ready announcement and said in terms that two items remained.

## Quality gates

Exit codes are the runner's own, captured on the same command line.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `loops.md:923 -> #no-such-anchor-emptysink`, its own line, existing only on this branch, which is what proves the gate read this tree rather than a sibling's. Restore verified by **blob** hash against the pre-plant object — `138ac7a901…` on both sides — with a residue grep returning 0.

The slug gate was sabotaged rather than mkdocs deliberately: `mkdocs.yml` sets no `anchors` key, so anchors sit at the MkDocs default of INFO while `--strict` promotes WARNING, not INFO. A planted anchor leaves the strict build at exit 0.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** **zero deletions** in the diff (`10  0`), read for silent reverts rather than for conflicts; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors; line wrap checked against the file's own maximum; the addition is prose outside any fence, which matters because this tree reports doc links inside fences; and it names no product, platform, path, tool or person.
