### PR TITLE
docs(method): three tests identify a worker's own transcript, and counting alone is not one of them

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -958,6 +958,17 @@ method requires naming them — so identify a file as the WORKER'S OWN before an
 as that worker's report; reaping on a peer's mention of a worktree is reaping on someone else's,
 which is strictly worse than leaving the tree standing.
 
+**Three tests separate them, and the obvious one is not sufficient by itself.** COUNT the hits per
+file: a worker's own log names its worktree tens to hundreds of times where a peer names it once or
+twice, so the gap is two orders of magnitude rather than a judgement call. But **ranking by that
+count can still hand you the wrong file** — measured across eleven trees, the top scorer for one of
+them was a peer that had simply worked longer beside it. The decisive test is the report's own
+claim about where it ran: a worker states its worktree root, so a file whose report names a
+DIFFERENT root is not that worker's however often your path appears in it. And where a directory
+name has been reused, both incarnations match — separate those by the branch the tree carries NOW,
+because the earlier one names a branch that is no longer there and tends to end mid-flight rather
+than in a report.
+
 A transcript path the platform documents as an implementation detail is not a contract, and
 local-history retention sweeps typically DELETE rather than truncate — so whether to hold the report
 text somewhere of your own is the operator's call.


### PR DESCRIPTION
A hygiene pass ran the unindexed-transcript search at scale for the first time — eleven worktrees — and found the section states the requirement without the test. **11 insertions, 0 deletions, one file, no heading touched.**

## What the section already says

> **But the match is many-to-one, and most of its hits are not the worker's own** … so identify a file as the WORKER'S OWN before anything in it counts as that worker's report; reaping on a peer's mention of a worktree is reaping on someone else's, which is strictly worse than leaving the tree standing.

That names the hazard exactly and gives no way to tell the files apart. Standing in front of the search results, the reader still has to invent one.

## What eleven trees measured

**Counting works, and the separation is not marginal.** A worker's own log names its worktree **29 to 201** times. A peer names it **once or twice** — a brief lists the in-flight write surfaces because this method requires it, and a peer that merely enumerated the worktrees mentions it once. Two orders of magnitude, not a judgement call.

**But ranking by that count picked the wrong file once in eleven.** The highest scorer for one tree, at 201 hits, belonged to a peer that had simply worked longer beside it than the owner had worked at all. Volume is a filter, not an answer.

**The decisive test is the report's own claim about where it ran.** A worker states its worktree root, so a file whose report names a *different* root is not that worker's however often your path appears in it. That single check resolved the case above immediately, and it is cheap — one line near the end of the file you were going to read anyway.

**And a third case the section does not anticipate: a directory name gets reused.** Both incarnations then match, both at high volume. They separate on the branch the tree carries *now* — the earlier one names a branch that is no longer there, and its last message tends to be mid-flight rather than a report. One measured instance ended on *"CI is running with no failures so far"*, which is an interim status the reap test refuses anyway; the current incarnation's ended on *"Done."*

## The repair

One paragraph, at the point of use, carrying the three tests in the order you would apply them — count to filter, root to decide, branch to disambiguate a reused name. The middle one is the substance: it is the test that overrules the first, and without it the natural reading of "identify the file as the worker's own" is "take the one with the most hits", which is the reading that fails.

Nothing else in the section changes. No new heading, no restatement of the reap test itself, and no claim that the search is reliable — it is a route to a report, and the report is still what authorises anything.

## Quality gates

Exit codes are the runner's own, captured on the same command line.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `loops.md:968 -> #no-such-anchor-ownlog`, its own line, existing only on this branch, which is what proves the gate read this tree rather than a sibling's. Restore verified by **blob** hash against the pre-plant object — `0c50743847…` on both sides — with a residue grep returning 0.

The slug gate was sabotaged rather than mkdocs deliberately: `mkdocs.yml` sets no `anchors` key, so anchors sit at the MkDocs default of INFO while `--strict` promotes WARNING, not INFO. A planted anchor leaves the strict build at exit 0.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** **zero deletions** in the diff (`11  0`), read for silent reverts rather than for conflicts; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors; line wrap checked against the file's own maximum; the addition is prose outside any fence, which matters because this tree reports doc links inside fences; and it names no product, platform, path, tool or person — the counts are quoted as counts.
