### PR TITLE
docs(method): watch for a hazard recorded without the test that discharges it

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1097,6 +1097,14 @@ Watch specifically for:
   *every*, check the quantifier.**
 * **Blocks that have diverged from the command files that paste them.** Two copies of one rule
   disagree within days.
+* **A hazard recorded without the test that discharges it.** *"Beware X"* with nothing saying how
+  to tell X from the legitimate case that looks identical. Whoever wrote it had just performed that
+  test, so it read as part of the observation rather than as a separate thing needing words; the
+  reader arrives having performed none of it and must reconstruct the test while looking at the very
+  evidence the hazard produces. Three in one session, all in one section, and the one I had read
+  within the hour was the one I walked into. This document already says a remedy written without its
+  discriminator **is worse than no remedy at all** — that judgement applies to its own prose, and
+  this loop is the only place that checks whether it does.
 
 Report one or two lines unless you find real drift. If you find drift, fix the document or the command
 file — do not just note it.


### PR DESCRIPTION
Sixth retrospective pass on `docs/the-mayor-method`, from running the five loops rather than from reading them. **8 insertions, 0 deletions, one file, no heading touched.** The finding document was written before the method tree was touched, as the method's own rule requires.

## The frame this pass has to report first

Five changes to the method tree or the project's concrete-values file landed after the fifth pass. **Three of them are one shape:**

| the text said | what it did not say |
|---|---|
| *"beware a per-agent scratch sink that merely shares the id"* | so what does an **empty** one mean? |
| *"identify a file as the WORKER'S OWN"* | by what test? |
| *"THIS BULLET is its contract"* | does it describe the file, or bind the next line? |

Each cost something measured.

The first had me dismiss **fifteen worktrees** as having no completion report, when fourteen of them opened with the sentence the reap test demands — *"Done."*, *"Work complete."*, *"The whole re-take is discharged."* **I had read that warning within the hour.** The second left me inventing three tests, of which the obvious one — rank by hit count — picks the wrong file about **one time in eleven**; the top scorer for one tree, at 201 hits, belonged to a peer that had simply worked longer beside it than the owner had worked at all. The third stated a five-field shape that **87% of the rows do not have**, which is the direction that invites a positional parse and a confident wrong answer.

## The root cause, and it is a writing failure rather than a reading one

Each of those sentences was written by someone who had **just performed the discrimination**. Having just done it, the test feels like part of the observation rather than a separate thing needing words. The reader arrives having performed none of it, meets the hazard, and has to reconstruct the test at the moment they are least able to — while looking at the very evidence the hazard produces. Fifteen empty files in a row do not read as *"the trap I was warned about"*; they read as *the answer*.

**And the two non-empty ones are what sealed it.** A wholly empty result would have looked broken and sent me looking for a better source. A 2-of-17 result looked like a *survey*: the fact of the matter, unevenly retained.

## Why this is a placement repair and not a new rule

**The tree already carries the principle. Twice.** Its brief-writing guidance has a section titled ***Name the discriminator*** — *"the discriminator is the question that separates a real hit from a legitimate one… without one, a worker sweeping a register will 'fix' it into a lie."* And inside one specific remedy sits the sharpest statement of it anywhere in the tree: ***"a 'cancel and re-run' written without that discriminator is worse than no remedy at all, because the reflex it teaches burns another wall-clock hour."***

Both are aimed at something **other than the method's own prose** — one at briefs, one at one remedy. So this is the *rule exists and did not reach the reader* case, and restating the principle would be the exact failure the method warns about. What was missing is a place that applies it **to the tree itself**.

**One bullet, in the method-reread loop's *watch specifically for* list**, beside the stale constant, the unsatisfiable quantifier and the diverged block. Those three all check the tree against what it claims; this is the fourth of that family and the only one that reads the tree's own prose for a missing half.

**It is not a duplicate of the clause added in pass five.** That one — *an instrument can be right and still answer a different question* — is about **reading an instrument**. This is about **writing a rule**. They meet in the middle, and the remedies differ: one says write the question beside the answer, this one says write the test beside the hazard.

## What I deliberately did NOT change

**No deletion, and I ran the test rather than skipping it.** Six passes have produced roughly twenty additions and one cut, and the brief presses on that every time. Across ~50 loop ticks I exercised all five merge clauses (clause 3 earned its keep three times — the terminal state read as not-ready with the rollup already at the band, and resolved on a poll), the six named wrong proxies for reaping (one of them is precisely why a worktree with no commits and no proposed change **stays**), patch-equivalence over ancestry, the write clock, fence recording, hold-cost pricing, anchored block extraction, the stance-pasting rule, the banner and discharge rules, and the dated-defer rule on the day the date rolled over. **Nothing showed itself dead.** The asymmetry is not evidence of bloat; it is what a document looks like when its rules keep being used, and manufacturing a cut to balance a ledger is the invention the brief rules out.

**One genuine overlap found and left.** Two adjacent paragraphs in the reaping section now state the same mechanism — that a *partly* non-empty result is what makes a wrong conclusion self-consistent — with different incident counts. Two lines in a twelve-hundred-line file, each half carrying its own measurement. That is the minutiae the stance says not to litigate.

**Nothing about the closed-dependency search.** Scanning every closed item's close reason for a mention of any open one was new this pass — 980 items — and it returned nothing: no hidden ruling, no released fence. That is a negative result worth recording **on the item**, which I did, so the next pass does not pay for the same answer. The loop already directs you there and was right to.

**Nothing about my own error rate.** Two of my premises were refuted this stretch, one by a worker and one by me. Pass two's finding on brief errors shipped; passes three through five all declined to restate it, and so does this one.

**README.md is untouched**, checked at source: no bulleted operational material, no bolded imperatives. It is prose for people and stays that way. **No new sections** — the repair is one bullet inside a list that already exists.

## Quality gates

Exit codes are the runner's own, captured in-shell on the same command line — never a harness-reported number, a disagreement measured repeatedly and always failing open.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `mkdocs build --strict` | **0** | — | **0** |
| `scripts/check_readme_links.py --ci` | **0** | — | **0** |

**Sabotage, planted to prove the gate read THIS tree.** A broken in-page anchor placed **mid-line** on a line this change authored, match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `loops.md:1107 -> #no-such-anchor-retro6`, its own line, existing only on this branch. Restore verified by **blob** hash against the committed object — `d776f5169a…` on both sides — with a residue grep of 0 and a clean worktree.

The slug gate was sabotaged rather than mkdocs deliberately: `mkdocs.yml` sets no `anchors` key, so anchors sit at the MkDocs default of INFO while `--strict` promotes WARNING, not INFO. A planted anchor leaves the strict build at exit 0.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose.** Diffed against the **merge base** and read for silent reverts: `8 0` — zero deletions, so there is nothing to revert. **No heading added or changed** (0 heading lines in the diff), which matters more than usual because this tree's headings are extraction anchors cited from outside it. Longest added line is 100 characters against the file's own maximum of 120. The addition is prose outside any fence, which matters because this tree reports doc links inside fences. And it names no product, platform, path, tool or person.
