### PR TITLE
docs(method): a worktree the mayor occupied has no agent, and the empty search says so

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -969,6 +969,19 @@ name has been reused, both incarnations match — separate those by the branch t
 because the earlier one names a branch that is no longer there and tends to end mid-flight rather
 than in a report.
 
+**A worktree the MAYOR occupied has no agent, so the search comes back empty for that reason
+alone.** Work an operator declines to delegate still needs a tree, and such a tree never had a
+worker to write a transcript. The empty search then reads as *no report exists*, which is the reap
+test's blocking condition, and the tree becomes permanently unreapable — the empty-sink error one
+level up: an absent transcript is a fact about the SEARCH, and one of the things it can mean is
+that nobody was ever there. **The rule does not bend, because for that tree the mayor IS the
+agent** and its authorising report is the mayor's own knowledge that the work is finished. What has
+to come first is identification: read what the tree's tip revision actually carries, which names
+the work and therefore its author, instead of concluding anything from an empty result. **And do
+not promote occupancy into a proxy.** A tree sitting at the trunk with nothing of its own is the
+ordinary state of a worker just created and not yet committed — the most dangerous tree to remove,
+not the safest. It corroborates an identification; it never substitutes for one.
+
 A transcript path the platform documents as an implementation detail is not a contract, and
 local-history retention sweeps typically DELETE rather than truncate — so whether to hold the report
 text somewhere of your own is the operator's call.


### PR DESCRIPTION
A method-reread pass checked a finding it had queued from the previous loop, found the finding's proposed test was **wrong**, and shipped the narrower repair the evidence actually supported. **13 insertions, 0 deletions, one file, no heading touched.**

## What the section says now

The reaping rule is that only a worker's own completion report authorises removing its worktree, and the identification paragraph gives three tests for finding that report — count the hits, read the report's claim about where it ran, disambiguate a reused directory name by the branch the tree carries now.

**Every one of those presupposes a worker exists.**

## The tree that had no worker

A residue tree carried a STAYS verdict through three consecutive sweeps, each recording the same accurate reason: *no own transcript findable by path or by branch name; no change of any state.* Both halves were true. The conclusion was wrong.

Its tip revision carried the previous loop's own method change — work an operator declines to delegate, which still needs a tree. The directory name and the branch label were leftovers from an earlier occupant, which is why "no change of any state" read as damning when it was merely accurate: **no change had ever used that branch name.**

So the search could not have succeeded. There was no agent, hence no transcript. And the empty search reads as *no report exists*, which is precisely the reap test's blocking condition — the tree acquires a STAYS that nothing will ever lift. **It is the empty-sink error one level up:** that one said an empty file keyed by the id is a fact about the file; this one is that an empty *search* is a fact about the search, and one of the things it can mean is that nobody was ever there.

## The finding I queued was wrong, and catching it is the substance of this pass

The sweep loop recorded a proposed discriminator: *is the tree's tip an ancestor of the trunk? Then it carries nothing and is reapable whoever occupied it.* Checked against the tree in this loop, that test is **dangerous**:

* **A worktree created from the trunk and not yet committed to sits exactly there.** Ancestor, nothing unique, patch-equivalence zero on both sides. That is the state of a worker in its first minutes — the most destructive possible tree to remove, and the one this section's six named wrong proxies exist to protect.
* **The document already condemns ancestry**, seventy lines further down, as the wrong test for branch deletion, superseded by patch-equivalence. Shipping it upward into the reaping section would have put two contradicting uses of one signal in one file.

What actually made the tree reapable was never the ancestry. It was **knowing who the occupant was** — and the ancestry only corroborated that.

## The repair, which does not bend the rule

The rule stands unchanged, because for such a tree **the mayor is the agent**: its authorising report is the mayor's own knowledge that the work is finished. What was missing is the step before it — identify the occupant by reading what the tree's tip revision carries, which names the work and therefore its author, rather than concluding anything from an empty result.

And the guard is stated explicitly, because this is exactly how a seventh wrong proxy would get adopted: **occupancy corroborates an identification and never substitutes for one.**

One paragraph, at the point of use, immediately after the three tests. No new heading, no second condition added to the reap test, and no change to the residue rule — an agent that genuinely vanishes still leaves an unreapable tree, and that still clears on operator authority.

## Quality gates

Exit codes are the runner's own, captured in-shell on the same command line.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `scripts/check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `loops.md:983 -> #no-such-anchor-occupancy`, its own line, existing only on this branch, which is what proves the gate read this tree rather than a sibling's.

**One thing worth recording about the restore.** Reverting the plant with a checkout **also discarded the uncommitted change under test**, leaving an empty diff that every gate then passed. Caught by reading the diffstat rather than the exit codes. The edit was re-applied and the restore verified by **blob hash against the pre-plant object** — `68c1ba0ab5…` on both sides — with a residue grep of 0. A checkout is the wrong restore for an uncommitted edit; commit first, or replace the planted string back.

`mkdocs build --strict` is nominated here rather than merely noted: `docs/the-mayor-method/` is **not** in `mkdocs.yml`'s `exclude_docs`, checked at source, so the build does render this page. The slug gate was the one sabotaged because `mkdocs.yml` sets no `anchors` key, leaving anchors at the MkDocs default of INFO while `--strict` promotes WARNING — a planted anchor leaves the strict build at exit 0.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** **zero deletions** (`13  0`), read for silent reverts rather than for conflicts; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors cited from outside it; longest added line **100** against the file's own maximum of 120; no bare line-feeds introduced; the addition is prose outside any fence, which matters because this tree reports doc links inside fences. It names no product, platform, path, tool or person.
