### PR TITLE
docs(method): a tip revision names the work, not the occupant

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -976,11 +976,17 @@ test's blocking condition, and the tree becomes permanently unreapable — the e
 level up: an absent transcript is a fact about the SEARCH, and one of the things it can mean is
 that nobody was ever there. **The rule does not bend, because for that tree the mayor IS the
 agent** and its authorising report is the mayor's own knowledge that the work is finished. What has
-to come first is identification: read what the tree's tip revision actually carries, which names
-the work and therefore its author, instead of concluding anything from an empty result. **And do
-not promote occupancy into a proxy.** A tree sitting at the trunk with nothing of its own is the
-ordinary state of a worker just created and not yet committed — the most dangerous tree to remove,
-not the safest. It corroborates an identification; it never substitutes for one.
+to come first is identification, and the tip revision alone will not do it: it names the WORK, not
+the occupant, because an auditor, a reviewer, a bisect or a monitor all sit at a commit they did
+not write. Ask instead whether the tree is on the branch the work was PUBLISHED from — an author's
+is, and a process inspecting that work carries a branch of its own, named for the thing it
+inspects. **And do not promote occupancy into a proxy.** A tree sitting at the trunk with nothing
+of its own is the ordinary state of a worker just created and not yet committed — the most
+dangerous tree to remove, not the safest. It corroborates an identification; it never substitutes
+for one. **Expect automated processes to hold worktrees too**, at commits they did not author and
+under directory names they recycle: one observed here reappeared at a path two minutes after that
+path was cleared, and its predecessor had been mistaken for the author's own tree on exactly the
+tip-revision reasoning this paragraph now refuses.
 
 A transcript path the platform documents as an implementation detail is not a contract, and
 local-history retention sweeps typically DELETE rather than truncate — so whether to hold the report


### PR DESCRIPTION
A merge-loop tick found the sentence merged one hour earlier to be wrong, and the evidence arrived by itself: the worktree that prompted it **reappeared two minutes after it was removed**. **11 insertions, 5 deletions, one file, no heading touched** — the deletions are the block being corrected, its surviving text re-emitted.

## What the previous change said

> read what the tree's tip revision actually carries, **which names the work and therefore its author**

## Why that is false

**A tip revision names the work. It says nothing about who is standing in the tree.** An auditor, a reviewer, a bisect and a monitor all sit at a commit they did not write — and sitting at the *author's* commit is exactly what a process inspecting that author's change looks like.

The tree that produced the original finding was read as *"the tip carries my own work, so I was the occupant"*. It was not. It was held by an **automated post-merge audit process, parked at the commit it was auditing**, on a branch named for that audit rather than for the work.

## What the reappearance proved

| | |
|---|---|
| audit committed and finished | **01:12:38** |
| the tree removed, concluding "the occupant was the mayor" | **03:11** |
| a NEW tree at the SAME path, on a differently-named audit branch | **03:13:05** |
| its total activity since | a reset to HEAD, then nothing |

**The removal was safe — but by timing, not by the test used.** The audit had committed two hours earlier, nothing was in flight, patch-equivalence read zero either way and the tree was clean. Apply the same reasoning ninety minutes sooner and it destroys a live run, which is precisely the outcome the section's six named wrong proxies exist to prevent. A test that is right only when you happen to run it late is not a test.

## The repair

**The discriminator becomes the branch the work was published from.** An author's tree carries it; a process inspecting that work carries a branch of its own, named for the thing it inspects. That separates the two cases here cleanly and needs nothing the sweep does not already have in front of it.

And the paragraph now says the thing the section nowhere said: **automated processes hold worktrees too** — at commits they did not author, and under directory names they recycle. A path you clear can be occupied again by something that was never dispatched.

**The occupancy guard added last hour survives verbatim**, re-wrapped only: a tree at the trunk with nothing of its own is the ordinary state of a worker just created, the most dangerous tree to remove rather than the safest.

## What this is an instance of

Two consecutive method changes have now been corrected by the loop that ran next — the ledger contract forty minutes after it merged, and this one an hour after. Both were written by someone who had *just* performed a discrimination and wrote down the half they had used, not the half that makes it sound. That is the pattern the reread loop's watch-list already names; this PR is it firing on its own output, which is the case the list was extended to cover.

## Quality gates

Exit codes are the runner's own, captured in-shell on the same command line.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `scripts/check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `loops.md:989 -> #no-such-anchor-occupant`, its own line, existing only on this branch. Restore verified by **blob** hash against the pre-plant object — `eaaf57233f…` on both sides — residue grep 0.

**The restore method was fixed this tick, having failed last tick.** Reverting a plant with a checkout also discards an *uncommitted* change under test, leaving an empty diff that every gate then passes green. The edit is therefore **committed before the plant goes in**, which makes the checkout restore exactly the plant and nothing else — confirmed here by the post-restore diff against HEAD reading **0 lines**.

`mkdocs build --strict` is nominated rather than assumed: `docs/the-mayor-method/` is **not** in `mkdocs.yml`'s `exclude_docs`, checked at source. The slug gate was the one sabotaged because `mkdocs.yml` sets no `anchors` key, leaving anchors at MkDocs' INFO default while `--strict` promotes only WARNING.

**Not nominated:** no CLJS, browser, compile or lint lane — the changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** the diff was read line by line **for a silent revert rather than for a conflict** — every deleted line's content reappears, including the occupancy guard, which is why deletions are non-zero here; **no heading added or changed**; longest added line **100** against the file's own maximum of 120; no bare line-feeds introduced; the addition is prose outside any fence, which matters because this tree reports doc links inside fences. It names no product, platform, path, tool or person.
