### PR TITLE
docs(method): the send is not the read, and clause 3 was unsatisfiable

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -822,6 +822,21 @@ and both readings went wrong in a single day here, in opposite directions.
    and then ended its turn**, waiting for a completion event nothing sends. Seven such incidents in one
    day; every one recovered intact the moment somebody asked for a status.
 
+   **But whether that question has an answer depends on your messaging tool, and it may not.**
+   Measured twice here, a send to an agent stopped mid-turn was ACCEPTED — success returned and
+   delivery promised at the agent's *next tool round*, which for a stopped agent never comes.
+   Acceptance is a queue confirmation, not a liveness report. **The reply is the read; the send is
+   not**, and the asymmetry is total: a reply proves life, while silence proves only that nothing
+   has been delivered yet.
+
+   So the clause below is UNSATISFIABLE if you read *no live task* as something the tool reports
+   — where it behaves this way it never will, and a precondition that cannot be met either blocks
+   a legitimate redispatch forever or gets discharged by an invented proxy, which is the failure
+   this section exists to prevent. Read it instead as a request left unanswered across a window you
+   declare and stand behind, corroborated by the other discriminators. **The error is cheap in one
+   direction only, and it favours waiting**: a late reply costs nothing, because a live worker
+   resumes, while acting on a wrong *no task* destroys the run.
+
 3. **Only with no live task AND no tip movement:** push any existing commits — pure durability — then
    set the item back to open with a note on what was found and salvaged, and redispatch.
 


### PR DESCRIPTION
A method-reread pass checked a rule it had been enforcing that same hour against what the tool actually does, and found the rule's precondition cannot be satisfied. **15 insertions, 0 deletions, one file, no heading touched.**

## What the section says

The stranded sweep's second discriminator asks *"is there a live task to message?"*, and the reaping section puts it among the strongest claims it makes:

> The signals that have never lied are reads rather than inferences: the agent's own completion report, **and whether the messaging tool finds a live task to deliver to.**

Clause 3 then makes it a gate: *"Only with **no live task** AND no tip movement"* may you salvage and redispatch.

## What the tool actually does

**It does not answer that question.** Measured twice this session against an agent whose transcript ends mid-turn, a send was **accepted**: success returned, delivery promised *at the agent's next tool round* — which for a stopped agent never comes. The first send drew no reply in 54 minutes; the second is still queued.

**Acceptance is a queue confirmation, not a liveness report.** The reply is the read; the send is not. And the asymmetry is total: a reply proves life, while silence proves only that nothing has been delivered *yet*.

## Why this is worse than an overstatement

**Clause 3's precondition becomes unsatisfiable.** A mayor waiting for the tool to report *no live task* waits forever, and a precondition that cannot be met has exactly two outcomes — it blocks a legitimate redispatch indefinitely, or it gets discharged by an invented proxy. **Inventing a proxy is the failure this section exists to prevent**, and it already names six that were adopted in a single session, each plausible when adopted and each wrong.

So this one fails **closed** rather than open. The two preceding corrections in this tree both admitted something that should have been blocked; this one blocks something that should have been allowed, and pushes the reader toward the section's own catalogued mistake to get unblocked.

## The repair

Two paragraphs at the point of use — inside discriminator 2, immediately before the clause they repair. They state what acceptance is and is not, and then re-read *no live task* as **a request left unanswered across a window you declare and stand behind**, corroborated by the other discriminators rather than standing alone.

And the default is stated with its reason, because the error is cheap in one direction only: **it favours waiting.** A late reply costs nothing, since a live worker resumes from its own context — while acting on a wrong *no task* destroys the run, which is the one outcome the section calls strictly worse than leaving a tree standing.

**Nothing else changes.** The reap test keeps its single condition, the six wrong proxies are untouched, and no new signal is introduced — the change is about how to read one that was already there.

## What was checked and found clean

Reported because a pass that only reports its finding hides its coverage:

* **The stance block against every copy that pastes it.** `ai/stance.md`'s quoted block and the loop body that pastes it are byte-identical after whitespace normalisation — 372 characters, same digest. The method tree carries **no** copy of the stance text at all: zero hits for three distinct probes across both `loops.md` and the dispatch template. It points at the file instead of duplicating it, so there is no third copy to drift.
* **The check-count band.** Still pinned nowhere. One numeric hit in the tree and it is narrative — an incident reading *"85 of 86 concluded"* — not a constant a reader could take as current.

## Quality gates

Exit codes are the runner's own, captured in-shell on the same command line.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `scripts/check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `loops.md:838 -> #no-such-anchor-livetask`, its own line, existing only on this branch. Restore verified by **blob** hash against the pre-plant object — `adf0133105…` on both sides — residue grep 0, and the post-restore diff against HEAD reading **0 lines**, which is the check that catches the restore failure below.

**The edit is committed before the plant goes in.** Two passes ago a checkout-restore silently discarded the uncommitted change under test, leaving an empty diff that every gate then passed green. Committing first makes the checkout revert exactly the plant and nothing else.

`mkdocs build --strict` is nominated rather than assumed: `docs/the-mayor-method/` is **not** in `mkdocs.yml`'s `exclude_docs`, checked at source. The slug gate was the one sabotaged because `mkdocs.yml` sets no `anchors` key, leaving anchors at MkDocs' INFO default while `--strict` promotes only WARNING.

**Not nominated:** no CLJS, browser, compile or lint lane — the changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** **zero deletions** (`15  0`), read for a silent revert rather than for a conflict; **no heading added or changed**, which matters because this tree's headings are extraction anchors cited from outside it; longest added line **99** against the file's own maximum of 120; no bare line-feeds introduced; the insertion keeps the numbered list's three-space continuation indent so clause 3 still renders as item 3; and the addition is prose outside any fence, which matters because this tree reports doc links inside fences. It names no product, platform, path, tool or person.
