### PR TITLE
docs(method): a husk is not an rm -rf, and the tool has a path the section did not name

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1046,9 +1046,14 @@ locked, waited out for two days, and were all simply dirty:
 * **Partial** — a *husk*. The tool deregistered the worktree and deleted its metadata, then hit the
   lock and stopped. It no longer appears in the worktree listing, pruning has nothing to clear, and a
   status check inside it *fails and prints nothing* — which is exactly why a clean/dirty test reads a
-  husk as clean. Retrying is futile; an ordinary recursive delete once the lock clears is all that
-  remains. **A partial removal kills a running gate exactly as a complete one does** — never read it
-  as "nothing happened".
+  husk as clean. Retrying the ordinary path is futile — the registered-worktree check refuses a
+  husk forever. **But do not reach for a raw recursive delete, which is the operation the top of
+  this section forbids**: a husk still holds every file the worktree had, any linked dependency
+  directory among them, so a plain delete follows that link and empties what it points at. Reach
+  for the tool's acknowledged-husk path, which disarms the link before deleting anything; the
+  paragraph below states the two conditions it is gated on, and a tool that offers no such path
+  is one to fix rather than to work around. **A partial removal kills a running gate exactly as a
+  complete one does** — never read it as "nothing happened".
 
 **A husk is identified, never inferred.** "The tool does not list it, and it has no metadata" is true
 of a husk and equally true of an ordinary directory, a mistyped argument and an unrelated project.


### PR DESCRIPTION
A method-reread pass checked a remedy against the tool it governs, and the remedy turned out to be both wrong and dangerous. **8 insertions, 3 deletions, one file, no heading touched** — the deletions are the sentence being replaced plus two lines re-wrapped, all surviving text re-emitted.

## What the bullet said

> **Partial** — a *husk*. … Retrying is futile; **an ordinary recursive delete once the lock clears is all that remains.**

## Why that is wrong

**The tool does have a husk path.** Exercised this pass: handed an unregistered directory it returns exit 1, reports three separate facts about what it found, and then names the escape — an acknowledged-husk mode, refused unless the caller acknowledges the path **and** the directory still holds a kilobyte of content the repository recognises as its own, read from version control's own object database.

**And the section already knew.** The very next paragraph describes those two conditions almost verbatim — *"refuse an unregistered path outright unless the caller acknowledges it and its contents are recognisable as this repository's, established from version control's own object database."* That is written to whoever builds the tool. The bullet above it is written to the person holding the husk, and it sent them somewhere else.

## Why that is dangerous

**A husk keeps every file the worktree had, a linked dependency directory among them.** A raw recursive delete follows that link and empties what it points at.

That is the exact operation the **top of this same section** forbids:

> **never remove a worktree with the plain command.** It follows the link and deletes *through* it, emptying the shared tree it points at — silently, exiting successfully, breaking every local build

So the section opens by forbidding delete-through-a-link, and forty lines later recommends it as the only remaining option. The acknowledged path **disarms the link first**; the raw delete does not. This has happened twice for real on this project, which is why the opening warning exists at all.

## The repair

The bullet now says retrying the *ordinary* path is futile and why — the registered-worktree check refuses a husk forever — then points at the acknowledged path, states plainly that the raw delete is the forbidden operation rather than a shortcut, and adds that **a tool offering no such path is one to fix rather than to work around**, so the guidance stays useful where the tooling is different.

**Nothing else changes.** The four refusal modes stay four, their distinctions stay as written, and the identification rule in the next paragraph is untouched — this only replaces the remedy the husk bullet ends on.

## How this was found, since a remedy that reads fine is hard to doubt

The preceding hygiene pass verified the removal script's unregistered-path guard rather than assuming it — a guard relied on every time the mayor declines to point the script at leftover directories. Handed a fabricated path it refused with *"Nothing was touched."*; handed a real unregistered directory under `--dry-run` it refused again and **named the discriminator it lacked** before offering the acknowledged path. Reading that output is what exposed a capability the method never mentions.

## Quality gates

Exit codes are the runner's own, captured in-shell on the same command line — **and not through a pipe**, which this pass got wrong once and caught: `$?` after piping a script into `tail` reports *tail's* status, and printed a reassuring `exit=0` for a run that had actually returned 1.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `scripts/check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `loops.md:1055 -> #no-such-anchor-huskpath`, its own line, existing only on this branch. Restore verified by **blob** hash against the pre-plant object — `6269f52493…` on both sides — residue grep 0, and the post-restore diff against HEAD reading **0 lines**. The edit is committed before the plant goes in, so the checkout reverts exactly the plant.

`mkdocs build --strict` is nominated rather than assumed: `docs/the-mayor-method/` is **not** in `mkdocs.yml`'s `exclude_docs`, checked at source. The slug gate was the one sabotaged because `mkdocs.yml` sets no `anchors` key, leaving anchors at MkDocs' INFO default while `--strict` promotes only WARNING.

**Not nominated:** no CLJS, browser, compile or lint lane — the changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** the diff was read line by line **for a silent revert rather than for a conflict** — the closing sentence *"A partial removal kills a running gate exactly as a complete one does — never read it as 'nothing happened'"* survives verbatim, which is why deletions are non-zero here; **no heading added or changed**, which matters because this tree's headings are extraction anchors cited from outside it; longest added line **97** against the file's own maximum of 120; no bare line-feeds introduced; the addition keeps the bullet's two-space continuation indent so the list still renders; and it is prose outside any fence, which matters because this tree reports doc links inside fences. It names no product, platform, path, tool or person.
