### PR TITLE
docs(method): drop the messaging tool from the signals that have never lied

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -886,8 +886,8 @@ does not announce itself as infrastructure. Gates die naming real, present files
 which twice read as a genuine regression to the worker that received it. Once it landed on a
 *negative control*, inverting a meta-test about exit codes.
 
-The signals that have never lied are reads rather than inferences: the agent's own completion
-report, and whether the messaging tool finds a live task to deliver to.
+The signal that has never lied is a read rather than an inference: the agent's own completion
+report.
 
 **And the report has to say the work is FINISHED.** An interim status, a progress note, a partial
 hand-off and a change-opened announcement are all the agent *speaking* rather than the agent


### PR DESCRIPTION
Seventh retrospective pass on `docs/the-mayor-method`, from running the five loops rather than from reading them. **2 insertions, 2 deletions, one file, no heading touched — the first pure deletion in seven passes.** The finding document was written before the method tree was touched, as the method's own rule requires.

## The frame

Five changes landed after the sixth pass, and **two root causes account for all of them.**

**A — the method models one actor, and the world has more.** Every rule keyed on *the worker* silently excludes a worktree held by the mayor, by an automated process, or by nobody. The exclusion never announces itself: it surfaces as an empty search, a well-formed but wrong identification, or a record shape with no slot for the case in hand. Three separate discoveries of one gap, in three places, in one night.

**B — the document describes a tool's behaviour from memory rather than from the tool.** In both instances the tool's own output was the better document, more precise about what it could not establish. Neither was found by re-reading.

## What this pass changes

Root cause B produced a contradiction that survived its own repair.

The stranded sweep now says at length that a send is **accepted and queued regardless**, that acceptance is a queue confirmation rather than a liveness report, and that the reply is the read. Sixty-one lines away, the reaping section still said:

> The signals that have **never lied** are reads rather than inferences: the agent's own completion report, **and whether the messaging tool finds a live task to deliver to.**

**The correction had been applied where the claim was USED and left standing where it is STATED.** That is a placement failure rather than a knowledge one: the repair was made at the point of use because that is where the failure bit, while the general statement lives in another section and nothing points from one to the other. The untouched copy is the one a reader meets first, because it is the summary — and it carried the strongest endorsement in the document.

**The repair is a deletion, and deliberately so.** The reaping section decides nothing with the messaging signal; its test is the agent's completion report. Listing the tool there as a co-equal never-lied signal is precisely what lent it authority in a section that never uses it. The sweep carries the full treatment, in the one place that acts on it. Zero mentions of the messaging tool as a liveness signal now remain in that section, measured.

## Why the section's size justified looking there, and why it is NOT being cut

Measured at the current tip, by share of the file:

| section | lines | share |
|---|---|---|
| **Reaping** | **147** | **11.9%** |
| The stranded sweep | 128 | 10.3% |
| Dispatch | 100 | 8.1% |
| Backlog reread | 97 | 7.8% |

Hygiene's four subsections total **248 lines, 20% of the document**, for the loop that reaped nothing on four consecutive passes and whose own body says a quiet tick is a complete tick. Reaping absorbed roughly forty of those lines in this one stretch.

**I read all 147 lines looking for a dead rule and did not find one.** Every paragraph carries a measured incident and a discriminator, and the six named wrong proxies are the reason four worktrees are standing today rather than destroyed. **Size is evidence about where failures happen, not about waste** — and hygiene is where an error is irreversible, which is exactly where a document should be long. What the measurement justified was looking hard at the largest section, where it found the one sentence that is both wrong and redundant with a fuller treatment elsewhere.

## What I deliberately did NOT change

**No general "not every tree has a worker" rule**, though root cause A is real and cost three separate repairs. The tree already states it where it bites: the mayor-occupied paragraph names the mayor as that tree's agent, gives the published-branch test, refuses occupancy as a proxy, and warns that automated processes hold worktrees too. A separate abstract statement would restate three paid-for paragraphs — the exact failure this method warns about.

**No restructuring of that paragraph**, though it now carries five claims in seventeen lines and reads like something patched twice rather than written once. Splitting it is cosmetic unless it changes what a reader finds, and every clause was paid for separately.

**Nothing about root cause B beyond the two repairs already merged.** "Read tool output as a source rather than a result" is advice about how to read — the class of thing a mayor works out once and does not need written down. It is in the evidence log for a future pass.

**Nothing about my own error rate.** Two premises of mine were overturned this stretch, one by the loop that ran an hour after I shipped it. Pass two's finding on brief errors shipped; passes three to six declined to restate it, and so does this one.

**README.md is untouched**, checked at source: no bulleted operational material, no bolded imperatives.

## Quality gates

Exit codes are the runner's own, captured in-shell on the same command line — **never through a pipe**, which this session got wrong once and caught: reading the status after piping a script into `tail` reports *tail's* status, and printed a reassuring zero for a run that had actually returned 1.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `scripts/check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `loops.md:889 -> #no-such-anchor-neverlied`, its own line, existing only on this branch. Restore verified by **blob** hash against the pre-plant object — `940ab24935…` on both sides — residue grep 0, post-restore diff against HEAD **0 lines**. The edit is committed before the plant, so the checkout reverts exactly the plant and nothing else.

**Anchors cited from outside the tree were checked, not assumed.** Two paths outside `docs/the-mayor-method/` cite a `loops.md` anchor, one of them the project's agent-instructions file. **Zero headings appear in the merge-base diff**, so no anchor can have been invalidated, and the gate that owns repo-root markdown passed independently.

`mkdocs build --strict` is nominated rather than assumed: `docs/the-mayor-method/` is **not** in `mkdocs.yml`'s `exclude_docs`, checked at source. The slug gate was the one sabotaged because `mkdocs.yml` sets no `anchors` key, leaving anchors at MkDocs' INFO default while `--strict` promotes only WARNING.

**Not nominated:** no CLJS, browser, compile or lint lane — the changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** the diff was taken **against the merge base** and read line by line for a silent revert rather than for a conflict — it is two lines replaced by two, the sentence singularised, with no other text disturbed; line count unchanged at 1237; no bare line-feeds introduced; longest line unchanged against the file's own maximum; and the sentence sits in prose outside any fence, which matters because this tree reports doc links inside fences. It names no product, platform, path, tool or person.
