### PR TITLE
docs(method): a polling worker is silent on both activity clocks, and moves exactly one file

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -772,16 +772,30 @@ and both readings went wrong in a single day here, in opposite directions.
    read. Its absence proves nothing — not every dispatch claims — which is why the sweep starts from
    the worktrees in the first place.
 
-   **That clock says "no activity" in three voices and you can only tell them apart with a control.**
-   Besides the reading worker, a path that resolves to nothing answers identically — and so does a
-   span shorter than the worktree's own age, where every file is recent and the count is the
-   checkout rather than the worker. That last one is the counter-intuitive half, because it returns a
-   large number that reads as proof of life: measured once at *the same count* over fifteen minutes
-   and over six hours. **And the age itself is the worktree's CREATION time, not its
-   last-modification time**, which the very writes you are trying to detect keep bumping: the wrong
-   clock reads right on an idle tree, where the age does not matter, and seconds old on a live one,
-   where the age is the whole question. Run the clock twice at different spans before believing
-   either reading.
+   **That clock says "no activity" in four voices and you can only tell them apart with a control.**
+   Besides the reading worker and the poller treated just below, a path that resolves to nothing
+   answers identically — and so does a span shorter than the worktree's own age, where every file is
+   recent and the count is the checkout rather than the worker. That last one is the counter-intuitive
+   half, because it returns a large number that reads as proof of life: measured once at *the same
+   count* over fifteen minutes and over six hours. **And the age itself is the worktree's CREATION
+   time, not its last-modification time**, which the very writes you are trying to detect keep
+   bumping: the wrong clock reads right on an idle tree, where the age does not matter, and seconds
+   old on a live one, where the age is the whole question. Run the clock twice at different spans
+   before believing either reading.
+
+   **And "only reading" has a sibling that is not reading at all: a worker that POLLS.** It edits
+   nothing and commits nothing, so both clocks above stay still for hours — but a fetch is a write,
+   and it lands in exactly one place, the fetch-head file in that item's OWN metadata directory,
+   which every linked worktree has separately. Read that file twice, thirty to sixty seconds apart.
+   **Movement is proof of life and needs no corroboration**, which makes this the one test in this
+   section that answers without a control; stillness restores the ambiguity rather than resolving it,
+   so it only ever answers in one direction. **The file's PRESENCE says nothing** — every item has
+   one, frozen at the moment its worker stopped, which is exactly why one read is worthless and two
+   are decisive. Measured on a poller that six consecutive sweeps had read as silent, on both of the
+   other clocks, while it fetched every forty-two seconds. **And do not let the fetch-head trap under
+   *After each merge* talk you out of it**: that rule is about the SHARED file being unusable as a
+   merge TARGET because any concurrent process rewrites it. The per-item copy is unusable for that
+   same reason and useful for precisely it — here you are reading the rewriting, not the contents.
 
    **The most convincing false signature is on none of the discredited lists: a change fully green at
    the band, a clean worktree, a tip commit some minutes old, and the change still a DRAFT.** It reads


### PR DESCRIPTION
A method-reread pass checked a rule it had been enforcing against what the tree actually does, and found the stranded sweep's activity clock has a blind spot that fails in the direction which authorises reaping. **24 insertions, 10 deletions, one file, no heading touched** — one new paragraph, plus a stale count corrected in the paragraph above it.

## What was measured

A worktree had been read on **six consecutive stranded sweeps** and reported silent each time: newest file write `03:13:10`, git index `03:38:20`, both hours stale. Every sweep correctly declined to reap it, but on the reasoning *"cannot tell from spacing alone"* — the weakest possible ground, and one that was about to expire, since the discriminator it leaned on was a comparison against the longest silence that process had previously survived.

It was alive the whole time. Reading the fetch-head file in that worktree's own metadata directory three times:

| read | |
|---|---|
| 10:26:44 | |
| 10:27:26 | +42s |
| 10:28:08 | +42s |

A process in there runs a fetch every forty-two seconds.

## Why both existing clocks were blind to it

The section already warns that the corroboration is a **write** clock, so a worker that is only *reading* touches nothing. That is true and it is not this case. A poller is not reading — it writes, once per interval, to a file no activity sweep looks at, because the file lives in the repository metadata directory rather than the tree. It edits nothing and commits nothing, so the file-tree clock and the index clock both stay still for hours while the process is demonstrably running.

**The controls are what make this a discriminator rather than an anecdote.** Every worker worktree *has* that file, each one frozen at the moment its worker stopped — three of them here, at `08-21 09:37:38`, `08-21 09:15:58` and `08-22 00:29:33`. Worktrees created by a different harness had none at all. So presence says nothing; two reads a minute apart say everything.

## What the paragraph claims, and what it deliberately does not

**Movement is proof of life and needs no corroboration** — the only test in that section which answers without a control. **Stillness proves nothing**: it restores the ambiguity the other clocks already described rather than resolving it, so the test answers in one direction only. That asymmetry is stated explicitly, because a one-directional test read as two-directional is how a false-death signature gets manufactured.

One sentence heads off a collision with an existing rule. This document already warns about the *shared* fetch-head as a trap under **After each merge** — a scratch file any concurrent process rewrites, and therefore unusable as a merge target. A reader who has internalised that will resist using the same file as a signal. The resolution is that the per-item copy is unusable for exactly the same reason and useful for precisely it: here you are reading the rewriting, not the contents.

## The stale count, corrected in the same change

The paragraph above enumerates the voices in which that clock says "no activity" — the reading worker, a path that resolves to nothing, and a span shorter than the worktree's own age. The poller is a fourth. Adding it while leaving the sentence reading *"three voices"* would have introduced a measured constant gone stale, which is the standing example this very loop watches for. So the count moves to four and the new voice is named in the list, with the treatment below it.

**Verified mechanically that the rewrap reverted nothing.** A word-level diff of removed against added text reports exactly three changes: `three` → `four`, `worker,` → `worker and the poller treated just below,`, and the inserted paragraph. Every other word in those ten replaced lines is re-emitted verbatim.

## Quality gates

Exit codes are the runner's own, captured in-shell on the same command line — never through a pipe, which reports the pipe's status and prints a reassuring zero for a run that returned 1.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `scripts/check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | — | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** before planting — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `docs\the-mayor-method\loops.md:789 -> #no-such-anchor-pollclock`, its own line, existing only on this branch. The edit was committed **before** the plant, so the checkout reverts exactly the plant and nothing else; restore verified by **blob hash** — `12ebb51653…` on both sides — with a residue grep of 0 and a post-restore diff against HEAD of **0 lines**.

The slug gate was the one sabotaged because `mkdocs.yml` sets no `anchors` key, leaving anchors at MkDocs' INFO default while `--strict` promotes only WARNING — a planted anchor leaves the strict build at exit 0. The strict build is nominated rather than assumed: `docs/the-mayor-method/` is not in `exclude_docs`, and the build log names `the-mayor-method\loops.md` among the files it read.

**Not nominated:** no CLJS, browser, compile or lint lane — the changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** the diff was taken against the merge base and read line by line for a silent revert rather than for a conflict; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors cited from outside it; **no bare line-feeds introduced** (count 0) in a CRLF file; longest added line 104 against the file's own unchanged maximum of 120; the addition is prose outside any fence, which matters because this tree reports doc links inside fences; it introduces no markdown link, so there is no new anchor to validate; and it names no product, platform, path, tool or person — the cadence and the timestamps are quoted as measurements.
