### PR TITLE
docs(method): not every worktree has a fetch clock, and the absence is a signal not a broken probe

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -786,16 +786,20 @@ and both readings went wrong in a single day here, in opposite directions.
    **And "only reading" has a sibling that is not reading at all: a worker that POLLS.** It edits
    nothing and commits nothing, so both clocks above stay still for hours — but a fetch is a write,
    and it lands in exactly one place, the fetch-head file in that item's OWN metadata directory,
-   which every linked worktree has separately. Read that file twice, thirty to sixty seconds apart.
-   **Movement is proof of life and needs no corroboration**, which makes this the one test in this
-   section that answers without a control; stillness restores the ambiguity rather than resolving it,
-   so it only ever answers in one direction. **The file's PRESENCE says nothing** — every item has
-   one, frozen at the moment its worker stopped, which is exactly why one read is worthless and two
-   are decisive. Measured on a poller that six consecutive sweeps had read as silent, on both of the
-   other clocks, while it fetched every forty-two seconds. **And do not let the fetch-head trap under
-   *After each merge* talk you out of it**: that rule is about the SHARED file being unusable as a
-   merge TARGET because any concurrent process rewrites it. The per-item copy is unusable for that
-   same reason and useful for precisely it — here you are reading the rewriting, not the contents.
+   which each linked worktree gets its own copy of the first time anything fetches from it. Read that
+   file twice, thirty to sixty seconds apart. **Movement is proof of life and needs no
+   corroboration**, which makes this the one test in this section that answers without a control;
+   stillness restores the ambiguity rather than resolving it, so it only ever answers in one
+   direction. **Its PRESENCE says nothing about life** — a stopped worker leaves its copy behind,
+   frozen at that worker's last fetch, which is why one read is worthless and two are decisive. **But
+   its ABSENCE is not nothing either, and it is not a broken probe**: it says only that nothing has
+   ever fetched from that tree, which is itself worth knowing about a tree you did not create —
+   measured here at four of seven, the three without being trees this method did not make. Measured
+   on a poller that six consecutive sweeps had read as silent, on both of the other clocks, while it
+   fetched every forty-two seconds. **And do not let the fetch-head trap under *After each merge*
+   talk you out of it**: that rule is about the SHARED file being unusable as a merge TARGET because
+   any concurrent process rewrites it. The per-item copy is unusable for that same reason and useful
+   for precisely it — here you are reading the rewriting, not the contents.
 
    **The most convincing false signature is on none of the discredited lists: a change fully green at
    the band, a clean worktree, a tip commit some minutes old, and the change still a DRAFT.** It reads


### PR DESCRIPTION
A method-reread pass checked the one thing that had changed since the last pass — a change I merged myself an hour earlier — and found it asserts a universal the tree does not support. **14 insertions, 10 deletions, one file, no heading touched.**

## The drift, and it is the case the loop warns about by name

The method-reread body says this check has twice found *"a rule the documents asserted universally that the tree did not support — one of them introduced by a merge the mayor approved."* This is the third, and it is the second of that kind.

PR #8720 added a liveness test built on the per-worktree fetch clock. Two of its sentences quantify over every worktree:

> …the fetch-head file in that item's OWN metadata directory, **which every linked worktree has separately**.

> **The file's PRESENCE says nothing** — **every item has one**, frozen at the moment its worker stopped…

Counted at source at the current tip: **7 registered linked worktrees, 4 with a fetch-head file, 3 without.** Forty-three per cent do not have one. The method's own bullet on this failure — two lines from where the count was checked, in the same file — describes it almost exactly: *"Unsatisfiable quantifiers. 'Every gate prints X' when a third of them do not."*

## Why it is worth a change rather than a footnote

The universal was not decoration; it was carrying the argument. *"Every item has one"* is what licensed *"presence says nothing"* — if all of them have the file, presence can't discriminate and only movement can. Once some have none, that reasoning is still right about presence and **wrong about absence**, which the paragraph had ruled out of existence.

And the error costs something specific in the direction a reader meets it. Someone who believes the universal, runs the probe and finds no file concludes the probe is broken or the path is wrong, and goes looking for a bug. What the absence actually says is that **nothing has ever fetched from that tree** — the file is created by the first fetch performed from it — which is real information about a tree you did not create. A sweep run four hours after #8720 merged read exactly that case and read it correctly, on three trees made by a different harness; the document it had just merged says that case cannot arise.

## What changed

Both universals are corrected in place, and the absence is promoted from impossible to informative:

- *"which every linked worktree has separately"* → *"which each linked worktree gets its own copy of the first time anything fetches from it"* — which states the mechanism instead of a count, so it cannot go stale the way a count does.
- The presence sentence now says **presence says nothing about life** (a stopped worker leaves its copy frozen at its last fetch), followed by **absence is not nothing either, and it is not a broken probe**, with the four-of-seven measurement.

The load-bearing claims of #8720 are untouched: movement is still proof of life needing no corroboration, stillness still resolves nothing, and the one-directional asymmetry still stands.

**Verified mechanically that the rewrap reverted nothing.** A word-level diff of removed against added text reports only the intended substitutions — `every` → `each`, `has separately.` → the mechanism clause, `**The file's PRESENCE says nothing**` → `**Its PRESENCE says nothing about life**`, `every item has one,` → `a stopped worker leaves its copy behind,` — plus the inserted absence clause. Every other word in the ten replaced lines is re-emitted verbatim. An earlier attempt at this patch dropped two fragments mid-paragraph; the word-level diff is what caught it, and the attempt was reverted to a zero-line diff before starting again.

## Quality gates

Exit codes are the runner's own, captured in-shell on the same command line — never through a pipe.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `scripts/check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | — | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** beforehand — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `docs\the-mayor-method\loops.md:796 -> #no-such-anchor-quantifier`, its own line, existing only on this branch. The edit was committed **before** the plant; restore verified by **blob hash** — `032c0f63ee…` on both sides — with a post-restore diff against HEAD of **0 lines** and the plant string gone.

One note on the residue check, because the obvious form of it lies here: grepping for the bare word `quantifier` returns **2** after a clean restore, and both hits are the method's own *Unsatisfiable quantifiers* bullet at lines 1152–1154 — the rule this change repairs. The residue grep has to be for the **plant string**, not a word inside it, or a correct restore reads as a failed one.

**Not nominated:** no CLJS, browser, compile or lint lane — the changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** the diff was read line by line for a silent revert rather than for a conflict; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors cited from outside it; **no bare line-feeds** introduced (count 0) in a CRLF file; longest line unchanged at the file's own maximum of 120; the change is prose outside any fence; it introduces no markdown link, so there is no new anchor to validate; and it names no product, platform, path, tool or person — the counts are quoted as counts.
