### PR TITLE
docs(method): absence of the fetch clock means the write was not made, not that no fetch ran (rf2-fj0l)

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -784,22 +784,25 @@ and both readings went wrong in a single day here, in opposite directions.
    before believing either reading.
 
    **And "only reading" has a sibling that is not reading at all: a worker that POLLS.** It edits
-   nothing and commits nothing, so both clocks above stay still for hours — but a fetch is a write,
-   and it lands in exactly one place, the fetch-head file in that item's OWN metadata directory,
-   which each linked worktree gets its own copy of the first time anything fetches from it. Read that
-   file twice, thirty to sixty seconds apart. **Movement is proof of life and needs no
-   corroboration**, which makes this the one test in this section that answers without a control;
-   stillness restores the ambiguity rather than resolving it, so it only ever answers in one
+   nothing and commits nothing, so both clocks above stay still for hours — but a fetch ordinarily
+   writes as it reads, into exactly one place: the fetch-head file in that item's OWN metadata
+   directory, which each linked worktree gets its own copy of the first time a fetch writes that
+   clock there. Read that file twice, thirty to sixty seconds apart. **Movement is proof of life and
+   needs no corroboration**, which makes this the one test in this section that answers without a
+   control; stillness restores the ambiguity rather than resolving it, so it only ever answers in one
    direction. **Its PRESENCE says nothing about life** — a stopped worker leaves its copy behind,
-   frozen at that worker's last fetch, which is why one read is worthless and two are decisive. **But
-   its ABSENCE is not nothing either, and it is not a broken probe**: it says only that nothing has
-   ever fetched from that tree, which is itself worth knowing about a tree you did not create —
-   measured here at four of seven, the three without being trees this method did not make. Measured
-   on a poller that six consecutive sweeps had read as silent, on both of the other clocks, while it
-   fetched every forty-two seconds. **And do not let the fetch-head trap under *After each merge*
-   talk you out of it**: that rule is about the SHARED file being unusable as a merge TARGET because
-   any concurrent process rewrites it. The per-item copy is unusable for that same reason and useful
-   for precisely it — here you are reading the rewriting, not the contents.
+   frozen at that worker's last fetch, which is why one read is worthless and two are decisive. **And
+   its ABSENCE says less than it looks like saying**: only that no fetch has written that clock
+   there, which is not the same as no fetch having run, because the write is suppressible by a flag
+   on the fetch itself — a poller configured that way is invisible to this test altogether. So read
+   absence as a reason to reach for another signal rather than as a history of the tree, though it
+   stays a hint about one you did not create: measured here at four of seven, the three without being
+   trees this method did not make. Measured on a poller that six consecutive sweeps had read as
+   silent, on both of the other clocks, while it fetched every forty-two seconds. **And do not let
+   the fetch-head trap under *After each merge* talk you out of it**: that rule is about the SHARED
+   file being unusable as a merge TARGET because any concurrent process rewrites it. The per-item
+   copy is unusable for that same reason and useful for precisely it — here you are reading the
+   rewriting, not the contents.
 
    **The most convincing false signature is on none of the discredited lists: a change fully green at
    the band, a clean worktree, a tip commit some minutes old, and the change still a DRAFT.** It reads


### PR DESCRIPTION
Closes rf2-fj0l, filed by the merged-PR audit of #8721 against a correction I had merged forty minutes earlier. **18 insertions, 15 deletions, one file, no heading touched, prose only.**

## The premise, checked at source before anything was edited

The audit's claim is that `git fetch` can update refs without writing the fetch-head clock, so an absent file cannot prove no fetch ever ran. Verified here rather than taken on trust: **git 2.53.0**, and `git fetch -h` lists `--[no-]write-fetch-head`. The counterexample is part of the ordinary interface, not a hypothetical deletion, and it lands squarely on the automated-poller case the paragraph is about — such a poller can fetch forever with the file never appearing.

The finding is correct and the over-claim was mine.

## What the paragraph said and what it says now

| | |
|---|---|
| before | each linked worktree gets its copy *"the first time anything fetches from it"* |
| after | *"the first time a fetch **writes that clock** there"*, with *"a fetch **ordinarily** writes as it reads"* |
| before | absence *"says only that nothing has ever fetched from that tree"* |
| after | absence *"says less than it looks like saying: only that no fetch has written that clock there, which is not the same as no fetch having run, because the write is suppressible by a flag on the fetch itself — a poller configured that way is invisible to this test altogether"* |

The guidance that follows changes with it: absence is now **a reason to reach for another signal rather than a history of the tree**, while still being a hint about a tree you did not create.

Everything load-bearing survives untouched, which is what the bead asked for: movement is still positive proof, stillness still establishes nothing, the one-directional asymmetry stands, and the four-of-seven measurement stays. The flag is described by what it does rather than by its spelling, so the sentence does not acquire a literal that can drift.

**No machinery and no policy gate**, as the bead directs. This is prose.

## Acceptance criteria, checked mechanically

| criterion | check | result |
|---|---|---|
| no longer says every fetch creates the file | `first time anything fetches from it` | **0** |
| no longer says absence proves no fetch ran | `ever fetched from that tree` | **0** |
| preserves the measurement | `four of seven` | **1** |
| preserves positive proof | `Movement is proof of life` | **1** |
| preserves the stillness rule | `stillness restores the ambiguity` | **1** |
| states the suppressible write | `the write is suppressible` | **1** |

**Verified mechanically that the rewrap reverted nothing.** A word-level diff of removed against added text reports only the intended substitutions and the inserted qualification; every other word in the fifteen replaced lines is re-emitted verbatim.

## A note on this being the third pass over one paragraph

#8720 added the test, #8721 corrected a universal in it, and this qualifies an inference. That is a lot of traffic for seventeen lines, and it is worth saying why it is not thrash. Each pass narrowed a claim rather than reversing one: the test itself has never changed, and the direction that authorises action — movement means alive — is the same sentence it was at the start. What has been repaired twice is the *negative* reading, first by conceding that some trees have no such file and now by conceding that having none proves less than it seemed to. Both repairs came from someone checking the tree instead of the prose, once by me and once by the audit.

## Quality gates

Exit codes are the runner's own, captured in-shell on the same command line — never through a pipe.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `scripts/check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | — | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** beforehand — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `docs\the-mayor-method\loops.md:796 -> #no-such-anchor-absence`, its own line, existing only on this branch. The edit was committed **before** the plant; restore verified by **blob hash** — `77287ab168…` on both sides — with the plant string gone and a post-restore diff against HEAD of **0 lines**.

**Not nominated:** no CLJS, browser, compile or lint lane — the changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** diff read line by line for a silent revert; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors cited from outside it; **no bare line-feeds** introduced in a CRLF file; longest line unchanged at the file's own maximum of 120; the change is prose outside any fence and introduces no markdown link, so there is no new anchor to validate; and it names no product, platform, path, tool or person.
