### PR TITLE
docs(method): verbatim forbids weakening a block, not adding to it, and the frame addressed to the mayor does not travel

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -448,6 +448,16 @@ the block forbids. Between a failure prevented by construction and one prevented
 reader's diligence, take construction; the context cost is the acknowledged price, and a
 brief is the mayor's scarce output.
 
+**But "verbatim" forbids WEAKENING a block, not adding to it — and the paragraphs addressed to YOU
+are not part of what travels.** Each block opens by naming itself and saying where it stops, so a
+mechanical extraction carries that frame along: paste it untouched and the worker receives
+instructions about pasting blocks into dispatches it will never make, and a pointer by name to a
+neighbouring section, which is the go-and-read-it this page has just forbidden. Drop that frame,
+and add whatever caution the lane needs — the rationale above is paraphrase and non-receipt, and
+neither is defeated by a sentence making the block bite harder on the gate you actually nominated.
+Reword and omission are what is forbidden. **The test is whether the block still refuses everything
+it refused before you touched it.**
+
 **Anchor the extraction to CONTENT, never to line numbers.** A line range against a living
 document is a measured constant that goes stale exactly where it has to be right, and an
 extraction that silently returns the wrong two hundred lines is worse than either option


### PR DESCRIPTION
A method-reread pass checked a rule against what the tree does, and this time the rule had been exercised for real: assembling an actual dispatch brief an hour earlier. **10 insertions, 0 deletions, one file, no heading touched, and every extraction range left byte-identical.**

## What the rule says and what doing it required

Three blocks travel into a dispatch. The instruction is to extract them mechanically and paste them **verbatim**, "adapting only the placeholders" — a phrase that appears twice.

Assembling a real brief, I did neither of the things that phrase permits and both of the things it appears to forbid: I **dropped** each block's opening frame, and I **added** three cautions specific to the lane being briefed. The brief was better for both, which is the tell that the rule as written is not the rule as meant.

## Why the frame cannot travel

Each block opens by naming itself and saying where it stops — and that opening sits **inside the range it defines**. The gate-mechanics block begins:

> **This section is the gate-mechanics block.** Paste it verbatim into every editing dispatch, adapting only the placeholders, from this heading down to the rule before `## Reviewing what comes back`. **`## Quality gates — which gate` is not it and does not stand in for it**: that section is addressed to you as you nominate the gate…

Extract from the heading, as instructed, and that comes with it. Paste it untouched and the worker receives instructions about pasting blocks into dispatches it will never make, plus a neighbouring section named at it — which is the "sending the worker to the FILE" the same page forbids four paragraphs earlier. The frame is addressed to the mayor; it is not payload.

## Why adding is not the failure the rule guards

The page states its own rationale, and it is narrower than its wording: **extraction prevents paraphrase** ("a matched range cannot reword, where a mayor retyping two hundred lines of gate mechanics can and does"), and **pasting prevents non-receipt** ("a block that is in the prompt cannot be un-received").

A sentence added to make the block bite harder on the gate actually nominated defeats neither. What the three additions did in practice: warned that a planted fault proves nothing unless the *release* build's module graph pulls the namespace in; noted that the failure under investigation is itself the abort-with-no-summary shape the block describes, so namespace counts against a control matter more than the log's last line; and stated that line endings are translated in this checkout, which is what makes the end-of-line anchor caution live rather than theoretical. None of those weakens anything.

So the repair states the boundary the rationale already implies: **reword and omission are forbidden; the frame addressed to you does not travel; and the test is whether the block still refuses everything it refused before you touched it.**

## What this change deliberately is not

**Not a restructuring of the blocks.** Moving each frame above its heading would make the extraction range pure payload without any new rule — an ordering repair, which is usually the better kind. It is rejected here because it trades one defect for a worse one: the frame repeats the heading text, so hoisting it above the heading puts a decoy *before* the real opening anchor, and a forward search would then start the extraction too early. Today only the closing anchor is contaminated, and the page already documents that trap with a measurement. A repair that invalidates a paid-for warning to remove a smaller problem is not a repair.

**Not a licence to rewrite.** The addition names the one test and keeps it narrow.

**Every extraction range is byte-identical.** The three blocks measure 71, 75 and 164 lines before and after — the addition sits outside all of them, which matters more than usual here, because a change to the paste rule that moved the pasted text would be self-defeating.

## Quality gates

Exit codes are the runner's own, captured in-shell on the same command line — never through a pipe.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `scripts/check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | — | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** beforehand — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `docs\the-mayor-method\dispatch-prompt-template.md:455 -> #no-such-anchor-pasteframe`, its own line, existing only on this branch. The edit was committed **before** the plant; restore verified by **blob hash** — `66f3a30236…` on both sides — with the plant string gone and a post-restore diff against HEAD of **0 lines**. The strict build's log names `dispatch-prompt-template` among the files it read, so the nomination is measured rather than assumed.

**Not nominated:** no CLJS, browser, compile or lint lane. Measured rather than asserted this time: the changed-surface classifier, run on this path, reports **28 outputs, 0 true**, with a control on a core source file reading 14 true.

**Checked by hand, since nothing gates this prose:** diffed against the **merge base** and read for a silent revert — `10 insertions, 0 deletions`, so there is nothing to revert; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors; **no bare line-feeds** introduced in a CRLF file; longest added line **100** against the file's own unchanged maximum of **136**; the addition is prose outside any fence and introduces no markdown link, so there is no new anchor to validate; and it names no product, platform, path, tool or person.
