### PR TITLE
fix(tests): cache-block the prod-mode browser test runners (rf2-2ohy)

### DIFF
--- a/implementation/core/test/re_frame/prod_elision_runner.cljs
+++ b/implementation/core/test/re_frame/prod_elision_runner.cljs
@@ -45,7 +45,40 @@
   If a lane ever needs an authoritative roster, the place to put it is the
   build's `:namespaces` key, which `find-test-namespaces` honours AHEAD of
   `:ns-regexp` — there a missing entry is a real, detectable omission
-  instead of a comment."
+  instead of a comment.
+
+  ## Why `{:dev/always true}` is load-bearing, in EVERY mode
+
+  `env/get-test-data` is a MACRO. It expands, at the moment this namespace
+  is compiled, into a literal map naming every test var the compiler knows
+  about — so the roster is frozen into this file's compiled JS. shadow-cljs
+  caches compiled namespaces per-namespace, and the cache key
+  (`shadow.build.compiler/make-cache-key-map`) is built from
+  `:immediate-deps`, which comes from the ns form's own requires. The test
+  namespaces are attached to this runner as `:extra-requires`
+  (`shadow.build.test-util/inject-extra-requires`), and those are used ONLY
+  to order compilation — they are not in `:immediate-deps`. So the roster
+  can change completely without invalidating this namespace's cache entry.
+
+  A namespace LEAVING the roster is the destructive direction: the stale
+  cached expansion still dereferences vars whose namespaces are no longer in
+  the bundle, and under `:advanced` that lands as an uncaught
+  `TypeError: Cannot read properties of undefined` inside `init` — before a
+  single test runs, so the lane aborts with no `cljs.test` summary at all.
+  That is rf2-2ohy: the Freehand / re-frame.ui removal took fourteen
+  `*-elision-prod-test` namespaces out of this lane, and every nightly from
+  2026-08-16 on restored a warm `.shadow-cljs` cache and served the
+  pre-removal runner.
+
+  `{:dev/always true}` is what stops it. Despite the name,
+  `shadow.build.compiler/is-cache-blocked?` reads that key with no mode
+  gate, so it blocks caching in `release` exactly as in `:dev`. The stock
+  runners `shadow.test.browser` and `shadow.test.node` both carry it for
+  this reason, as does this repo's own `re-frame.test-quiet.shadow-node`;
+  this runner and `re-frame.schemas-boundary-prod-runner` were written from
+  the stock runner's body without its ns metadata. Any namespace that
+  expands `shadow.test.env/get-test-data` needs this."
+  {:dev/always true}
   (:require [shadow.test :as st]
             [shadow.test.env :as env]))
 

--- a/implementation/schemas/test/re_frame/schemas_boundary_prod_runner.cljs
+++ b/implementation/schemas/test/re_frame/schemas_boundary_prod_runner.cljs
@@ -21,7 +21,29 @@
   cycle, so `-boundary-prod-test$` is what puts the smoke in this lane. The
   single require this namespace used to carry was accurate, which is the
   trap — it read as the mechanism while being a coincidence of there being
-  exactly one match."
+  exactly one match.
+
+  ## Why `{:dev/always true}` is load-bearing, in EVERY mode
+
+  `env/get-test-data` is a MACRO: it expands at compile time into a literal
+  map naming every test var the compiler knows about, freezing the roster
+  into this file's compiled JS. shadow-cljs keys its per-namespace compile
+  cache off `:immediate-deps` — the ns form's own requires — while the test
+  namespaces reach this runner as `:extra-requires`, which order compilation
+  and nothing else. The roster can therefore change completely without
+  invalidating this namespace's cache entry, and a namespace LEAVING it
+  leaves the stale expansion dereferencing vars that are no longer in the
+  bundle: an uncaught `TypeError: Cannot read properties of undefined` in
+  `init`, before any test runs, so the lane aborts with no `cljs.test`
+  summary. rf2-2ohy is that failure on the sibling
+  `re-frame.prod-elision-runner` lane, which see for the full account.
+
+  Despite its name `shadow.build.compiler/is-cache-blocked?` reads
+  `:dev/always` with no mode gate, so it blocks caching under `release` too.
+  The stock `shadow.test.browser` / `shadow.test.node` runners and this
+  repo's `re-frame.test-quiet.shadow-node` all carry it; any namespace
+  expanding `shadow.test.env/get-test-data` needs it."
+  {:dev/always true}
   (:require [shadow.test :as st]
             [shadow.test.env :as env]))
 


### PR DESCRIPTION
Fixes rf2-2ohy. The nightly `expensive tests` lane has been red for seven consecutive nights (08-16 through 08-22, last green 08-15), aborting in `test:browser-prod-elision` with an uncaught `TypeError: Cannot read properties of undefined (reading 'me')` inside `init`, before a single test ran.

## Root cause

`shadow.test.env/get-test-data` is a **macro**. It expands, at the moment the runner namespace is compiled, into a literal map naming every test var the compiler knows about — so the test roster is frozen into the runner's compiled JS.

shadow-cljs keys its per-namespace compile cache off `:immediate-deps`, which `shadow.build.resolve/stack-pop` populates from the ns form's own requires. The `:browser-test` target attaches the discovered test namespaces to the runner as **`:extra-requires`** (`shadow.build.test-util/inject-extra-requires`), and those are consumed only by `shadow.build.compiler/par-compile-one` to order compilation — they never enter `:immediate-deps`. So the test roster can change completely without invalidating the runner's cache entry.

A namespace **leaving** the roster is the destructive direction: the stale cached expansion still dereferences vars whose namespaces are no longer in the bundle. Under `:advanced` that is a property read on `undefined`, uncaught, inside `init` — so the lane stops with zero namespaces announced and no `cljs.test` summary at all.

PR #8322 (2026-08-16) removed the Freehand / re-frame.ui trees, taking **fourteen** `*-elision-prod-test` namespaces out of this lane. `expensive-tests.yml` restores `implementation/.shadow-cljs` across runs with `restore-keys: ${{ runner.os }}-story-xray-shadow-`, so from 08-16 on every nightly served the pre-removal runner out of a warm cache. That is why the first red is the day of the removal, and why a clean local run of the same command has been green throughout.

## The fix

`{:dev/always true}` on the ns. Despite the name, `shadow.build.compiler/is-cache-blocked?` reads that key with **no mode gate**, so it blocks caching under `release` exactly as under `:dev`. This is not a new idea — it is what the stock runners already do, and what this repo's own node runner already does:

| runner | `{:dev/always true}` before this PR |
|---|---|
| `shadow.test.browser` (stock, jar) | yes |
| `shadow.test.node` (stock, jar) | yes |
| `re-frame.test-quiet.shadow-node` (ours) | yes — with a comment saying it is *required* because `get-test-data` is a macro |
| `re-frame.prod-elision-runner` (ours) | **no** |
| `re-frame.schemas-boundary-prod-runner` (ours) | **no** |

Both were written from the stock runner's *body* without its ns metadata. `git grep get-test-data` over tracked `.cljs`/`.cljc` returns exactly those five namespaces, so this inventory is complete and there is no sixth site.

No workflow, cache-key or `shadow-cljs.edn` change: those would treat the symptom. The cache is not wrong to be warm; the runner was wrong to be cacheable.

## Verification

Reproduced and then fixed by removing one `*-elision-prod-test` namespace — the same event PR #8322 caused, at 1/14 scale — against a warm cache. Exit codes captured from the runner itself, not reported by the harness:

| | runner recompiled | browser run | exit |
|---|---|---|---|
| before fix, full roster | — | Ran 91 tests, 289 assertions, 0 failures | 0 |
| **before fix, one ns removed** | **0 compiled** | **ABORTED, 0 namespaces, `TypeError: Cannot read properties of undefined (reading '$j')` at `init`** | **1** |
| after fix, one ns removed | 1 compiled | Ran 88 tests, 285 assertions, 0 failures | 0 |
| after fix, full roster (final base) | 1 compiled | Ran 91 tests, 289 assertions, 0 failures | 0 |

The middle row is the CI failure reproduced locally: same abort, same "0 namespaces announced", same `Object.<mangled> [as init]` frame. The minified property differs (`$j` locally, `me` in CI) because the name is assigned by Closure per bundle — that is the same defect, not a different one.

Row 3 is the discrimination that matters: the plant exists only in this checkout, and the identical plant that went red before the fix goes green after it, with the runner recompiling (`0 compiled` → `1 compiled`) on a source file that did not change.

The removed file was restored and verified by git blob hash (`71ef65e9…`), not by reading a diff.

Full gates, foreground, exit code captured on the same command line:

- `npm run test:browser-prod-elision` — exit 0, 91 tests / 289 assertions
- `npm run test:browser-schemas-boundary-prod` — exit 0, 8 tests / 15 assertions (the sibling runner this PR also fixes)

Both re-run after the rebase onto the final base. Both lanes are also PR-gated in `test.yml`, and `report-changed-surfaces.sh` classes this diff `cljs_prod=true`, so CI covers them here as well as nightly.

## Alerting — the third acceptance item

**Filed as its own bead, rf2-4a0c; not fixed here.** The premise that the alerting failed does **not** hold. Issue #8423 was opened 2026-08-16T16:01:50Z — the first red night — labelled `nightly-red`, assigned, and naming the exact failing step; it was edited nightly and last carried `reds=7 greens=0`. The alerting self-test passed on all seven runs.

What did fail is downstream of the alert, and the alerter's body says it in its own words: *"It is edited in place — which notifies nobody"*. So seven reds produced exactly one notification, on night one, and nothing escalates an open `nightly-red` issue or bridges it into the beads tracker, which is where work is actually dispatched from. Whether to add escalation — and which of three shapes — is an operator call with a real spam trade-off, so rf2-4a0c carries the evidence and asks for a ruling rather than picking one.

## Verified by hand

The two changed files are CLJS, so no doc-link gate covers them. Both docstrings were read back for prose and the one markdown-style table in this PR body has consistent column counts.

## CI verification (added after the PR opened)

`workflow_dispatch` of `expensive tests` on this branch — [run 32615840802](https://github.com/day8/re-frame2/actions/runs/32615840802) — **completed success**, the first green `expensive tests` run since 08-15.

It is green against the *same warm cache the seven red nightlies used*, which is what makes it evidence rather than a coincidence. None of this PR's files are in that cache key's `hashFiles` set (`shadow-cljs.edn`, `deps.edn`, `package-lock.json`, `tools/story/**`, `tools/xray/**`, `implementation/core/src/**`), so the run took an **exact-key hit**:

```
Cache hit for: Linux-story-xray-shadow-bf4724a0ae74948951ceeabcb6e49ea4e1869a429b4bb6566c5d019277cf4a6f
Cache restored from key: Linux-story-xray-shadow-bf4724a0ae74948951ceeabcb6e49ea4e1869a429b4bb6566c5d019277cf4a6f
```

The gate's own output, against the 08-22 red for comparison:

| | compiled | result |
|---|---|---|
| 08-22 nightly (red) | 308 files, **191** compiled | ABORTED, 0 namespaces, `TypeError … (reading 'me')` |
| this branch (green) | 308 files, **192** compiled | Ran 91 tests containing 289 assertions. 0 failures, 0 errors. |

The single extra compiled namespace is the runner that used to be served from cache — the fix, visible in the build line. The 91 / 289 matches the local figure exactly.

The PR's own checks are 88/88 green, including `CLJS (shadow-cljs :browser-test-prod-elision, …)` and `CLJS (shadow-cljs :browser-test-schemas-boundary-prod, …)`.
