### PR TITLE
docs(method): a dispatched run's checks are absent from the rollup by construction, not late

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -157,6 +157,17 @@ report what it does not yet know is coming. One change here read `ok=78 canc=0
 fail=0 pend=0 total=78` — settled by every field it exposed — while the branch's own
 run listing showed two runs queued. Merging there ships it two workflows short.
 
+**And the checks may not be LATE — they may be absent by construction.** A run triggered by
+something other than the change event — a manual dispatch, a schedule — executes against the same
+head revision and contributes NOTHING to that change's rollup, ever. The rollup is not behind; it
+will never mention that run however long you wait. Measured here: a change whose rollup sat at the
+FULL band, every check passed or skipped, terminal state clean, while a dispatched run against its
+exact head revision ran on for a further sixteen minutes and put not one check in the rollup — whose
+entire contents came from the four workflows the change event had triggered. **That is the opposite
+reading from the case above, and the more dangerous one**: a short count announces itself and sends
+you looking, where a full one closes the question. The heading is the rule and the count is not the
+trigger, so query the runs whatever the count says.
+
 So query the branch's runs as well as the rollup, and key that query to the branch
 **and** to the current head revision. It fails in both directions and both have
 already bitten:


### PR DESCRIPTION
A method-reread pass checked clause 4 against a merge that had just exercised it for real, and the clause's stated mechanism does not cover what happened. **11 insertions, 0 deletions, one file, no heading touched.**

## What the clause says

> A queued run's checks are not attached to the head commit **yet**, so the rollup cannot report what it does not **yet** know is coming. One change here read `ok=78 canc=0 fail=0 pend=0 total=78` — settled by every field it exposed — while the branch's own run listing showed two runs queued.

That is a timing story with a short-count symptom: 78 against a band of 80, and the missing checks are on their way. Clause 1 points here on exactly that symptom — *"read it first when the count is short"*.

## What actually happened

A change merged this session sat at the **full band**, every check passed or skipped, terminal state clean — and a workflow run against its **exact head revision** ran on for a further **sixteen minutes**.

The rollup was not behind. It was never going to mention that run at all. Measured on the change itself:

| | |
|---|---|
| rollup total | **88** — the full band |
| checks contributed by the still-running workflow | **0** |
| workflows the rollup's 88 checks came from | `tests` 73, `lint` 7, `docs` 5, `portability` 3 — **all four triggered by the change event** |
| the still-running run's trigger | **manual dispatch**, against the same head revision |

A run triggered by something other than the change event contributes nothing to that change's rollup, ever. Waiting does not help, and neither does re-reading the count.

## Why this is the more dangerous direction

The documented case **announces itself**: a short count is visibly short, and it sends you to clause 4. This one closes the question instead — a full band with a clean terminal state is precisely the reading that says *stop looking*. Had I taken the count as the trigger, the change would have merged sixteen minutes before the evidence for its own acceptance criterion existed.

**The clause's heading was right the whole time.** *"A settled rollup is not a quiet branch"* covers this case exactly; it is the body that narrows it, with two instances of "yet" and a worked example that is short by two. The remedy the clause already prescribes — query the branch's runs, keyed to the branch **and** the current head revision — is what found it, unchanged. Only the trigger and the mechanism needed widening.

So the addition says the checks may be **absent by construction rather than late**, gives the measurement, names the direction of the error, and ends with the operative line: **the heading is the rule and the count is not the trigger, so query the runs whatever the count says.**

## What I deliberately did not change

**Clause 1's "read it first when the count is short" stays.** In its own context it is correct — it is diagnosing a short count, and it is right to send the reader here. The risk is the *inverse* reading, and the honest place to close that is inside clause 4, where a reader goes to learn what the clause is for. Editing both would state one rule in two places, which is how two copies come to disagree.

**No new heading, no restructuring.** The clause is already well-organised; this is one paragraph placed immediately after the case it generalises.

## Quality gates

Exit codes are the runner's own, captured in-shell on the same command line — never through a pipe.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `scripts/check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | — | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** beforehand — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `docs\the-mayor-method\loops.md:166 -> #no-such-anchor-dispatchrun`, its own line, existing only on this branch. The edit was committed **before** the plant; restore verified by **blob hash** — `0d1af96008…` on both sides — with the plant string gone and a post-restore diff against HEAD of **0 lines**.

**Not nominated:** no CLJS, browser, compile or lint lane — the changed-surface classifier reports every test surface false for a path under `docs/`, measured on this path rather than assumed.

**Checked by hand, since nothing gates this prose:** diffed against the **merge base** and read for a silent revert — `11 insertions, 0 deletions`, so there is nothing to revert; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors cited from outside it; **no bare line-feeds** introduced in a CRLF file; longest added line **102** against the file's own maximum of 120; the addition is prose outside any fence and introduces no markdown link, so there is no new anchor to validate; and it names no product, platform, path, tool or person — the counts and the sixteen minutes are quoted as measurements.
