### PR TITLE
docs(method): the self-naming frame is one block of three; where the payload is fenced, take the fence

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -449,10 +449,15 @@ reader's diligence, take construction; the context cost is the acknowledged pric
 brief is the mayor's scarce output.
 
 **But "verbatim" forbids WEAKENING a block, not adding to it — and the paragraphs addressed to YOU
-are not part of what travels.** Each block opens by naming itself and saying where it stops, so a
-mechanical extraction carries that frame along: paste it untouched and the worker receives
-instructions about pasting blocks into dispatches it will never make, and a pointer by name to a
-neighbouring section, which is the go-and-read-it this page has just forbidden. Drop that frame,
+are not part of what travels.** Where the payload is FENCED, the fence settles it: take the
+fence, and every line outside it is yours. Two of the three here are fenced, and their
+mayor-facing prose sits on opposite sides of the payload — rationale ahead of the fence in one,
+a whole paragraph after the closing fence in the other — so a habit about which end it lives at
+is wrong half the time. **Only the third, which has no fence, opens by naming itself and saying
+where it stops**, so a mechanical extraction carries that frame along: paste it untouched and the
+worker receives instructions about pasting blocks into dispatches it will never make, and a
+pointer by name to a neighbouring section, which is the go-and-read-it this page has just
+forbidden. Drop that frame,
 and add whatever caution the lane needs — the rationale above is paraphrase and non-receipt, and
 neither is defeated by a sentence making the block bite harder on the gate you actually nominated.
 Reword and omission are what is forbidden. **The test is whether the block still refuses everything


### PR DESCRIPTION
A method-reread pass found nothing changed in the tree since the last pass, so it spent itself on the other half of the loop body — checking a rule I have been enforcing against what the tree actually does. The rule was one I merged an hour and a half earlier, and it asserts a universal that holds for **one block of three**. **9 insertions, 4 deletions, one file, no heading touched, and every extraction range left byte-identical.**

## The drift, and it is the third of exactly this kind

The loop body warns that this check has twice found *"a rule the documents asserted universally that the tree did not support — one of them introduced by a merge the mayor approved."* This is the third, and the second of that kind. The sentence:

> Each block opens by naming itself and saying where it stops, so a mechanical extraction carries that frame along… and a pointer by name to a neighbouring section.

Counted at source. The three blocks have **three different shapes**:

| block | payload delimited by | mayor-facing prose, and where |
|---|---|---|
| the worktree boundary block | **a fence**, 52 lines / 2,930 chars | rationale *before* the fence, plus a note *after* it |
| the common preamble | **a fence**, 61 lines / 3,990 chars | one paragraph *after* the closing fence, none before |
| gate mechanics | **no fence** — heading down to the rule before the next section, 163 lines / 11,924 chars | the self-naming frame at the open |

So *"each block opens by naming itself"* is true of **one of three**, and so is *"a pointer by name to a neighbouring section"* — only the gate-mechanics frame names `## Quality gates — which gate` at it. The other two open with a fence or with rationale, and neither says where it stops, because the fence already does.

## Why it costs something rather than merely being loose

The universal was carrying the instruction. *"Drop that frame"* is actionable only if there is a frame at the open, and for two of the three there is not — so a reader who has internalised it either drops payload looking for one, or concludes the rule does not apply here and pastes what is actually there.

And the error has a direction. The common preamble's mayor-facing paragraph sits **after** the closing fence, at the tail. Someone taught that this prose lives at the *open* checks the open, finds a fence, pastes the heading-to-heading range and ships that paragraph — *"A pass that concludes only in the ignored tree concludes where nobody can read it…"*, addressed to the mayor, about audits lost in this project — into a worker's brief. That is precisely the failure the merged paragraph exists to prevent, reintroduced at the other end of the same block.

## What changed

The universal is replaced by the mechanism that actually covers all three, stated as a conditional so it cannot go stale the way a count does:

- **Where the payload is FENCED, the fence settles it: take the fence, and every line outside it is yours.** Two of the three are fenced.
- Their mayor-facing prose sits on **opposite sides** of the payload, which is said explicitly — *"so a habit about which end it lives at is wrong half the time"* — because a rule of thumb here is worse than none.
- **Only the third, which has no fence, opens by naming itself and saying where it stops.** The frame paragraph is now scoped to it, unchanged in every other word.

Everything load-bearing survives untouched: reword and omission are still what is forbidden, adding a lane-specific caution is still permitted, and the closing test — **whether the block still refuses everything it refused before you touched it** — is the same sentence it was.

**Verified mechanically that the rewrap reverted nothing.** A word-level diff of removed against added text reports exactly two substitutions — `Each block` → the fence clause, and `stops,` → `stops**,` — with every other word in the replaced region re-emitted verbatim.

## Two things this pass checked and found clean

**The measured constant is not stale**, which is the standing example the loop names. The document cites the gate-mechanics block as *"the block's first five lines out of a hundred and sixty-four — 206 characters of 11,925"*. Re-measured now, the block has not moved or grown. Its exact size depends on where you stop: **161 lines / 11,919 chars** under the sentence's own literal definition (heading down to the rule before the next section), **163 / 11,924** taking the heading-to-heading range, **11,925** with the trailing newline. The cited pair sits at the loose end of that spread rather than the literal one, but the numbers are carrying a ratio — five lines of a hundred and sixty-odd, 206 characters of twelve thousand — and no candidate in the spread changes it. Recorded as checked, deliberately not edited: this is the minutiae the stance says to close rather than action.

**The blocks and their pasters agree.** `bootstrap.md` and this page name the same three blocks with the same scope — the common preamble into every dispatch, the boundary and gate-mechanics blocks into every editing one — and `loops.md` §4's stance block is a fourth thing that travels, owned by a different file, which is consistent with *"three blocks below"*. The universal was asserted in exactly one place, so there was no second copy to diverge.

## Every extraction range is byte-identical

This matters more than usual: a change to the paste rule that moved the pasted text would be self-defeating. SHA-256 over each range, before and after:

| range | lines | chars | digest |
|---|---|---|---|
| boundary heading-range | 70 | 3,922 | `ab8dcd897da303ec` |
| preamble heading-range | 74 | 4,755 | `4140eed76b986c5f` |
| gate-mechanics heading-range | 163 | 11,924 | `77f947d1db45262c` |
| boundary fence, inclusive | 52 | 2,930 | `f04cc2b56b41f197` |
| preamble fence, inclusive | 61 | 3,990 | `b386a66383bb5288` |

Ranges located by heading and fence text rather than by line number, so the +5-line shift does not enter.

## Quality gates

Exit codes are the runner's own, captured in-shell on the same command line — never through a pipe.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `scripts/check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** beforehand — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `docs\the-mayor-method\dispatch-prompt-template.md:456 -> #no-such-anchor-fenceframe`, its own line, existing only on this branch. The edit was committed **before** the plant; restore verified by **blob hash** — `1ce6cc5fe5…` on both sides — with the plant string gone and a post-restore diff against HEAD of **0 lines**. The strict build's log names `dispatch-prompt-template` among the files it read, so that nomination is measured rather than assumed.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier, run on this exact path, reports **28 outputs, 0 true**.

**Checked by hand, since nothing gates this prose:** diffed against the merge base and read for a silent revert — the word-level diff above is that check; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors; **no bare line-feeds** introduced in a CRLF file (count 0); longest added line **97** against the file's own unchanged maximum of **134**; the addition is prose outside any fence — which the gates skip — and introduces no markdown link, so there is no new anchor to validate; and it names no product, platform, path, tool or person.
