### PR TITLE
docs(method): an equality filter over a listing is still a window, and that zero is silent

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1129,6 +1129,19 @@ shape reversed deletes a live worker's branch on its sibling's verdict. **Ask fo
 field and compare it for equality yourself.** A search term substring-matches; only equality
 identifies.
 
+**But comparing it yourself still leaves you filtering a WINDOW, and that failure is the silent one.**
+A listing returns the most recent N changes; your equality test over it is correct and its answer is
+only as wide as the listing. Measured here: a filter over the four hundred most recent changes
+reported that nothing proposed two branches whose commits predate that window entirely — and a zero
+over the wrong range reads exactly like a zero over the right one. The sibling trap at least leaves a
+wrong row on screen; this leaves nothing at all. **So prefer an instrument that takes the identity as
+INPUT** — most forges accept the head reference as a query parameter, which asks the whole set at once
+and cannot be windowed. **Exercise it in both directions before trusting it**, because a query that
+silently matches nothing returns the reassuring answer to every question. Measured here: the equality
+query returned the one merged change for a branch that had one, and returned NOTHING for a prefix of
+that same branch name — where the search form returned SIX changes for that prefix and ranked the
+full branch's own first, which is the paragraph above reproduced at this tip.
+
 Then prune stale remote-tracking refs and clear any stray stashes.
 
 **Merge state is the test for a branch, never for a worktree.** Conflating the two is how the reaping


### PR DESCRIPTION
A method-reread pass found nothing changed in the tree since the last pass, so it spent itself on the other half of the loop body — checking a rule against what the tree does. This one had been exercised for real an hour earlier, in a hygiene tick, and the rule's *diagnosis* is exactly right while the *remedy* it prescribes has a second failure it does not name. **13 insertions, 0 deletions, one file, no heading touched.**

## What the rule says, and it is correct

> **Key destructive operations on identity, never on a name.** … A search for `head:feature-x` also returns the change for `feature-x2`, and may rank the sibling *first*… **Ask for the exact head-ref field and compare it for equality yourself.** A search term substring-matches; only equality identifies.

Reproduced at this tip, in the direction the paragraph warns about. Searching `head:worker/fence` returns **six** changes — and ranks `worker/fenceframe`'s own, merged an hour ago, **first**. A loop reading the top row would read MERGED for any of the other five.

## What doing it exposed

I did exactly what the paragraph says: pulled the listing, asked for the head-ref field, compared for equality myself. The comparison was correct and **the answer was wrong-ranged**. The listing was the four hundred most recent changes; the two branches I was asking about have tips dated eleven and fifteen days back, whose changes would sit *below* that window entirely.

So the filter reported "nothing proposes these branches" over a range that could not have contained the answer — and **a zero over the wrong range reads exactly like a zero over the right one.** That is the material difference between the two failures, and it runs the wrong way:

| | what you see when it fails |
|---|---|
| the sibling trap the paragraph names | a **wrong row**, on screen, available to be noticed |
| filtering a window | **nothing at all** — the reassuring answer, silently |

Widening the listing does not fix it. Each widening is another guess at a range, and it can only ever extend an absence, never establish one.

## The instrument that does establish it

Most forges accept the head reference as a **query parameter**, which takes the identity as INPUT rather than returning a page for you to filter. It asks the whole set at once and cannot be windowed.

**Exercised in both directions before being written down**, because a query that silently matches nothing answers every question with the reassuring one:

| probe | result |
|---|---|
| exact head ref of a branch that HAS a change | returns it — `#8726 closed merged=true` |
| a **prefix** of that same branch name | returns **nothing** — so the parameter is equality, not prefix matching |
| the same prefix through the **search** form | returns **six** changes, the full branch's own ranked first |

The third row is the paragraph above, reproduced. The second is what earns the first.

## What changed

One paragraph, placed immediately after the identity rule it extends. It states the window failure, names why it is the silent one, prescribes the instrument that takes identity as input, and requires exercising that instrument in both directions. The existing rule is untouched — it is right about the failure it names, and this is the failure it does not.

The paragraph is written to the *shape* rather than to one forge's spelling: "most forges accept the head reference as a query parameter" survives a CLI changing its flags, where a quoted invocation would not. This tree's own rule about measured constants going stale applies to command literals just as much as to counts.

## Quality gates

Exit codes are the runner's own, captured in-shell on the same command line — never through a pipe.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `scripts/check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** beforehand — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `docs\the-mayor-method\loops.md:1139 -> #no-such-anchor-headfilter`, its own line, existing only on this branch. The edit was committed **before** the plant; restore verified by **blob hash** — `72fd8faf32` on both sides — with the plant string gone and a post-restore diff against HEAD of **0 lines**.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier, run on this exact path, reports **28 outputs, 0 true**.

**Checked by hand, since nothing gates this prose:** a word-level diff of the change reports **additions only** — no word of the surrounding paragraphs is re-emitted or dropped, which is the check that catches a rewrap silently reverting text; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors cited from outside it; **no bare line-feeds** introduced in a CRLF file (count 0); longest added line **104** against the file's own unchanged maximum of **120**; the addition is prose outside any fence — which both link gates skip — and introduces no markdown link, so there is no new anchor to validate. The one table in this change body is in the body, not the diff; the diff adds no table and no list. It names no product, platform, path, tool or person: the forge is "most forges", the instrument is "a query parameter", and the counts are quoted as measurements.
