### PR TITLE
docs(method): count both sides of the canary the same way, and make the control a clock

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1060,6 +1060,19 @@ re-check the snapshot and **fail loudly if the signature moved**, naming the rec
 constant cannot detect a delta, and a top-level count alone cannot see files vanishing from under
 packages whose directories survive — so count immediate entries *and* recursive files.
 
+**And count both sides the SAME WAY.** A listing that hides entries does not merely undercount — it
+turns the comparison into an offset, and in one direction that offset CANCELS a real loss of its own
+size. Measured here on a tree of 103 immediate entries, two of them hidden: the hiding form reads 101
+before, and the showing form reads 101 again after two visible entries have been destroyed. No delta,
+two entries gone. The other direction is only a false alarm, which is the cheaper half and the one you
+will meet first — it cost a real detour here before the flags were compared.
+
+**So make the decisive control a clock rather than a count**: the newest modification time inside the
+tree, which a removal moves and a change of listing options cannot. Note which entry carries it before
+you start. On the tree measured here that entry was itself one of the two hidden ones, so the listing
+form that suppressed the count also suppressed the control — worth checking rather than assuming, in
+either direction.
+
 **Sweep with a narrow force flag, never a blanket one.** A disposable-only force removes a tree
 only when every untracked path is build or gate output, and refuses any tree holding a modified
 tracked file, a note or a draft. That guard is not hypothetical: when it was written, one worktree


### PR DESCRIPTION
A method-reread pass found nothing changed in the tree, so it spent itself checking a rule against what the tree does. The rule is the hygiene canary, exercised in a hygiene tick an hour earlier — and it turns out to have a direction that **passes silently through a real loss**. **13 insertions, 0 deletions, one file, no heading touched.**

## What the rule says, and it is right as far as it goes

> **Verify the shared tree's file count either side of a batch**, captured at runtime. A remembered constant cannot detect a delta, and a top-level count alone cannot see files vanishing from under packages whose directories survive — so count immediate entries *and* recursive files.

Two failures named, both real: a remembered constant, and a top-level-only count. What it does not say is that the two sides have to be counted the **same way**.

## The measurement

The shared tree here holds **103 immediate entries, two of them hidden** — measured, and the two are the executable-shim directory and the dependency-integrity record.

| listing form | reads |
|---|---|
| hiding hidden entries | **101** |
| showing them | **103** |

So the two forms differ by a constant offset of two. That offset does not merely distort the comparison; **in one direction it cancels a real loss of its own size**:

- before, counted with the hiding form → **101**
- two visible entries destroyed
- after, counted with the showing form → **101**

**No delta, two entries gone.** A canary that exists precisely to catch a silent deletion returns the reassuring answer to the deletion it was built for.

The reverse direction is only a false alarm — and it is the one you meet first. It fired here: a worker reported 103 against my 101 and read as a two-file loss, costing a real diagnostic detour before the flags were compared rather than the counts.

## The repair, and why it is a clock

Two paragraphs. The first says count both sides the same way, gives the cancellation with its numbers, and notes which direction is merely expensive.

The second moves the decisive test off the count entirely: **the newest modification time inside the tree**, which a removal moves and a change of listing options cannot. That is what actually settled the false alarm here — the tree's newest entry had not moved since 2026-08-11, which no count could have told me.

One measured detail earns its place: on this tree the entry carrying that newest timestamp **is itself one of the two hidden ones**, so the listing form that suppressed the count also suppressed the control. Stated as a measurement with "worth checking rather than assuming, in either direction" — not as a universal. The loop body warns specifically about unsatisfiable quantifiers, and *"the hiding form always hides the control"* would have been one.

## What I deliberately did not change

**The hygiene loop's branch rule, though this tick found an edge in it.** Two branches turned out to be verifiably MERGED — identified by exact head-ref equality — while their worktrees have no completion report, so the worktrees stay and a branch its own worktree occupies cannot be deleted. That is a genuine collision between *"delete merged worker branches"* and the residue rule.

It is not documented because **it announces itself**: the tool refuses, by name, and says which worktree holds the branch. Every failure this tree spends words on is silent or reassuring; a loud, self-diagnosing refusal is the kind a mayor solves in one read. Recorded on the dispatch ledger instead, so a later tick does not read "merged" and reach for the delete.

## Quality gates

Exit codes are the runner's own, captured in-shell on the same command line — never through a pipe.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `scripts/check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** beforehand — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `docs\the-mayor-method\loops.md:1064 -> #no-such-anchor-canaryflags`, its own line, existing only on this branch. The edit was committed **before** the plant; restore verified by **blob hash** — `bdefc22903` on both sides — with the plant string gone and a post-restore diff against HEAD of **0 lines**.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier, run on this exact path, reports **28 outputs, 0 true**.

**Checked by hand, since nothing gates this prose:** a word-level diff reports **additions only**, so no surrounding word was dropped or re-emitted — the check that catches a rewrap silently reverting text; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors cited from outside it; **no bare line-feeds** introduced in a CRLF file (count 0); longest added line **102** against the file's own unchanged maximum of **120**; the addition is prose outside any fence — which both link gates skip — and introduces no markdown link, so there is no new anchor to validate. The tables in this change body are in the body, not the diff. It names no product, platform, path, tool or person: the counts are quoted as measurements and the listing forms are described by what they do.
