### PR TITLE
docs(method): the closure bullet points at its remedy instead of restating it

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -665,9 +665,8 @@ thing it was waiting for shipped, and only a full read notices. The remedy, and 
 needs its reasoning written onto the item, is under *Tracker mechanics* below.
 
 **A closure that reverted.** Verifying at the moment you close is not enough, so re-check
-what this session closed. **But read the item's notes before re-closing anything.** On a
-project that audits its merged changes, most reappearances are the audit working rather
-than a lost write, and re-closing one destroys a real finding while looking like tidiness.
+what this session closed. **But read the item's notes before re-closing anything** — what a
+reappearance usually is, and what the reflex destroys, is under *Tracker mechanics* below.
 
 **A hold that is costing more than it is holding.** Separate *needs a decision* from *needs
 work under a decision already made* — the second is dispatchable now, and it tends to sit in


### PR DESCRIPTION
The eighth mayor-method retrospective. Six new observations, **one change, and it is a deletion.** Four candidates were checked at source and rejected — three because the rule is already there, one because the tree has already decided the other way. **2 insertions, 3 deletions, one file, no heading touched.**

Finding document written before any edit, as the method requires: `2026-08-23.mayor-method-retrospective-8-finding.md`. Evidence log appended during the pass, entries E56–E61, now 1507 lines.

## The change: one rule, two statements, already disagreeing

The bolded sentence *"But read the item's notes before re-closing anything"* occurs **twice** in `loops.md`, byte-identical — once in the medium loop's four-things list, once under *Tracker mechanics*. Both carried the same reasoning: re-closing destroys a real finding and looks like tidiness.

**The two copies no longer agreed.**

| | how often a reappearance is legitimate |
|---|---|
| the loop copy, at the point of use | *"**most** reappearances are the audit working rather than a lost write"* |
| the mechanics copy | *"twelve did in one session, and **every one** was a legitimate audit reopening the item that owned a residual"* |

*Most* invites the reader to work out which ones are the exceptions. *Every one* says there were none. The weaker of the two sat in the loop a mayor actually runs — the worse direction for a rule whose entire purpose is to stop a reflex.

**This is the failure the tree predicts.** Its own reasoning for never stating a rule in two places is that two copies come to disagree. Here they had, inside one file.

## The repair is a shape the section already uses

The sibling bullet **one line above** shows it:

> **A dependency that has outlived what it was enforcing.** The item is still blocked, the thing it was waiting for shipped, and only a full read notices. The remedy, and why it needs its reasoning written onto the item, is under *Tracker mechanics* below.

Name the thing. Say what it looks like. Point at the remedy. Stop. The closure bullet duplicated instead of pointing; now it points, and the two adjacent bullets behave the same way.

**What stays and what goes.** The operative instruction stays at the point of use — a mayor re-checking closures needs *"read the notes before re-closing"* in front of them. What goes is the duplicated reasoning and the weaker quantifier. A bare instruction has nothing to diverge into; a restated argument does, and did.

**Why not delete the other copy instead.** The mechanics copy is the richer one: it carries the measurement, and the chains observation that a fix lands, its audit reopens for a second carrier, and that fix's audit reopens for a third. Cutting the copy that knows more to keep the copy that knows less would be tidiness of exactly the kind the rule warns against.

## Four candidates checked at source and rejected

**A third statement of the read-the-newest rule.** Twice in one afternoon I read an item by tailing the tracker's output, landed in its comments section, and reported delivered work as owed. Checked: the tree carries that rule **in duplicate** — once inside the block pasted verbatim into every dispatch, naming the exact mechanism, and once in the dispatch loop saying the mechanics *"bind the mayor reading the item exactly as they bind the worker."* Neither reached me. A third statement is plainly not the repair, and *Method reread* already says why: *"where a reader-side rule has failed repeatedly, more text is usually not the repair."* What actually corrected me both times was an artefact — a banner on the item — which is the remedy that paragraph already names.

**A rule for a fence that was false when written.** One item's fence read *"neither is closed"* about a dependency that had closed two days earlier, and re-testing a fence's *condition* can never catch that, because it asks a different question. Checked: covered. The same loop already instructs **cite the check you made, or say plainly that you are summarising and from what** — a fence citing its check would have carried its own refutation.

**A rule for a gate invisible from both list views.** Every blocked item reduced to two questions; each question was deferred (absent from the open list) while the items it held were blocked (absent from the ready list). Checked: not a defect. The medium loop already reads the raw open list *and* the defer dates across the whole deferred set, and it surfaced both in a single pass the first time it looked. The short tick is not supposed to see this — that is what the medium loop is for.

**De-specifying the tracker.** I formed a candidate that the tree violates its own generic constraint by naming concrete tracker commands. Checked: the tree names its tracker deliberately — the README introduces it by name, and the common-preamble block is written in its commands throughout. Tracker-specific by design, not by drift.

## One thing recorded so a later pass does not misread it

*Method reread* step 1 — check what changed since the last pass — returned the same answer five times running in this stretch: one commit, mine, the change the loop merged last time. Every finding came from step 2. **That is not evidence the step is dead.** Where one author edits the tree, "what changed" is necessarily "what I last merged", and a diff against your own work cannot surprise you. Step 1's value is conditional on other authors, and a method used by more than one mayor needs it. Recorded in the finding document rather than acted on.

## Nothing added to the README

It is for people. None of this belongs there, and it is unchanged.

## Quality gates

Exit codes are the runner's own, captured in-shell on the same command line — never through a pipe, and never taken from a harness-reported number.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | **1** | **0** |
| `scripts/check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** beforehand — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `docs\the-mayor-method\loops.md:669 -> #no-such-anchor-retro8`, its own line, existing only on this branch — which is what proves the gate read *this* tree rather than a cached one. The edit was committed **before** the plant; restore verified by **blob hash** — `10e9ef8087` on both sides — with the plant string gone and a post-restore diff against HEAD of **0 lines**.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier, run on this exact path, reports **28 outputs, 0 true**.

**Checked by hand, since nothing gates this prose:** diffed against the **merge base** and read word-by-word for a silent revert — the word-level diff shows only the intended substitution, with every surrounding word re-emitted verbatim; **no heading added or changed** (0 heading lines in the diff), and the three anchors cited into this file from outside the tree (`#1-merge`, `#after-each-merge`, `#reaping`) each still resolve to exactly one heading; **no bare line-feeds** introduced in a CRLF file (count 0); the change is prose outside any fence — which both link gates skip — and introduces no markdown link, so there is no new anchor to validate. It names no product, platform, path, tool or person.

**Made in a worktree, not in place.** The retrospective brief allows a doc-only change on an unheld tree to be made directly, but this checkout's commit boundary is an allow-list permitting the mayor to stage only the tracker export. An earlier pass recorded exactly this: the mayor invented two exemptions — *"one sentence"* and *"method work"* — and the hook refused the commit outright. The project's guard outranks the convenience.
