### PR TITLE
docs(method): the block-unit rule points at its remedy instead of duplicating it

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -543,9 +543,11 @@ what is still running.
 Pick the shape by kind first, then priority, then size. The shapes are in
 [`dispatch-prompt-template.md`](dispatch-prompt-template.md).
 
-**The unit is the block, not the file.** Two items dispatched into the same *paragraph*
-of one document conflicted, the second change could not merge, and by the time its worker
-was resumed the hygiene loop had reaped its worktree. Two costs from one scheduling error.
+**The unit is the block, not the file.** The tell is that the two items read as *nominally
+different concerns*, which is why the collision is invisible at the moment you schedule them,
+and cheap to avoid only there. What it cost once, and the sequencing remedy, are under
+*Fences* in [`dispatch-prompt-template.md`](dispatch-prompt-template.md) — deliberately not
+repeated here.
 
 **Dispatch immediately on clear.** A clear, unblocked item goes out now, not next tick.
 


### PR DESCRIPTION
The ninth mayor-method retrospective. Five observations, **one change**: the tree's only duplicated sentence, resolved into a pointer. Four candidates were checked at source and rejected — three because the rule is already there, one because the gap was in my reading. **5 insertions, 3 deletions, one file, no heading touched.**

Finding document written before any edit, as the method requires: `2026-08-24.mayor-method-retrospective-9-finding.md`. Evidence log appended during the pass, entries E64–E66, now 1666 lines across 61 entries.

## What made this pass different

Roughly thirty consecutive quiet dispatch ticks on a board that did not move — no merges, no dispatches, no worker completions. **Nothing was exercised, so nothing bent.** The one finding came from a mechanical hunt over the text rather than from running the loops, which is now the reliable technique when the board is static.

## The change: the tree's only duplicated sentence, already diverged

Extracted every bolded sentence of 25–150 characters from all four documents and counted duplicates. Across the whole tree exactly **one** appears twice — *"The unit is the block, not the file."* — with no near-duplicates.

**Both copies are mayor-facing**: one in the dispatch loop, one under *Fences* in the template, which is the section a mayor reads while writing a brief. This is not the README's legitimate restatement in a different register. It is one rule told to one reader twice, in two files.

**And they had already diverged, asymmetrically:**

| | the loop copy, at the point of use | the template copy |
|---|---|---|
| the rule | present | present |
| the cost it once carried | present | present |
| **the tell** — how to recognise it in advance | *absent* | *"because they were **nominally different concerns**"* |
| **the remedy** | *absent* | *"if two items touch the same section, **sequence them**"* |

What fell out of the copy that acts is the discriminator and the remedy — the parts hardest to compress and easiest to drop. That makes the loop copy an instance of a defect the document names one section later: **a hazard recorded without the test that discharges it**, which the tree elsewhere judges *worse than no remedy at all*. The tell is the whole of the recognition problem here, because the trap is precisely that the two items **look** like separate concerns.

## The repair is a shape the list already uses

The very next bullet does it:

> **And write the dispatch's record line as you dispatch it.** … What it must carry, which field the reap test uses, and why an untracked file needs its fields specified somewhere else at all, are under *Reaping* there — deliberately not repeated here, because a field list kept in two places is a field list that will disagree with itself.

State the rule, point at the fuller treatment, stop. Four lines above, its sibling duplicated instead of pointing. Now it points, and the two adjacent bullets behave the same way — with the tell added, since that is the half the loop reader cannot do without.

## Four candidates checked at source and rejected

**A rule about instruments returning false negatives.** Seven times in one night an instrument returned a plausible negative and nothing on screen disputed it — a case-sensitive search for a sentence retyped without its initial capital, a fixed context window, a single-line search over wrapped text, a query against JSON fields that do not exist, a filename pattern matching no file, a cosmetic pipe that replaced the exit code with the formatter's, and a clock printed without its date. Every one failed **absent-when-present**, the direction that manufactures work, and three were one step from a wrong report. Checked: the class is **already named**, generally and sharply, at the end of *Method reread* — *"a check executed carelessly returns the same reassuring answer as no check at all"* — plus five worked instances stated where they bite. An eighth statement is the exact failure this brief warns about.

**A note about my own broken probe.** The remedy I adopted for wrapped text — flatten the file, search the flat string — **did not work and said nothing**: these files are CRLF, so replacing the newline leaves the carriage return and a wrap-spanning phrase still matches nothing. Caught only because a probe denied a sentence I had read on screen twenty minutes earlier. The duplicate hunt behind the change ran on that same text; re-run with carriage returns stripped it returns the identical answer — 342 sentences, one duplicate, no near-duplicates — so the finding stands, but that was luck about what the extraction pattern tolerated. Reader-side, and the sentence above already covers it.

**A consequence for an unrecorded dispatch.** One worktree here is alive, polling, and has no record line, so it can be neither reaped nor messaged — only accumulated. Checked: the tree already requires the record line be written *as you dispatch* and gives the reason, the consequence follows from it, and the residue rule handles the outcome.

**A technique for establishing that nothing changed.** On a static board, "do not rely on memory" reads as a full re-read every hour forever. Checked: *Method reread* already names the technique for documents, and the backlog loop does not demand a per-item re-read — it demands the raw list and four questions. The gap was in my reading.

## Nothing added to the README

It is for people. None of this belongs there, and it is unchanged.

## Quality gates

Exit codes are each runner's own, captured in-shell on the same command line — never through a pipe, which this session measured as a live hazard rather than a theoretical one.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `check_doc_slugs.py` | **0** | **1** | **0** |
| `check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | **0** | — | **0** |

**Sabotage.** A broken in-page anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** beforehand — line endings are translated in this checkout, so an end-of-line anchor matches nothing. The gate returned exit 1 naming `docs\the-mayor-method\loops.md:547 -> #no-such-anchor-retro9`, its own line, existing only on this branch — which is what proves it read *this* tree. The edit was committed **before** the plant; restore verified by **blob hash** — `492895bc68` on both sides — with the plant string gone and a post-restore diff against HEAD of **0 lines**.

**On the mkdocs run:** its first attempt returned **127**, which is *command not found*, not a failed build. Captured properly it would have been easy to read as a red gate; re-run through the module it returns 0, and its output names `the-mayor-method\loops.md`, so it did build this page. `exclude_docs` was read at source to confirm this tree is not among the six it excludes.

**Not nominated:** no CLJS, browser, compile or lint lane. The changed-surface classifier reports every test surface false for a path under `docs/`.

**Checked by hand, since nothing gates this prose:** diffed against the **merge base** and read word-by-word for a silent revert — the diff is only the intended substitution, with every surrounding line re-emitted verbatim; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors cited from outside it, and the three cited anchors each still resolve to exactly one heading; **no bare line-feeds** introduced in a CRLF file (count 0); the change is prose outside any fence, and its one added link uses a target already present four times in this file. It names no product, platform, path, tool or person.
