### PR TITLE
docs(method): point the block-unit remedy link at the Fences fragment (rf2-8d9n)

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -546,7 +546,7 @@ Pick the shape by kind first, then priority, then size. The shapes are in
 **The unit is the block, not the file.** The tell is that the two items read as *nominally
 different concerns*, which is why the collision is invisible at the moment you schedule them,
 and cheap to avoid only there. What it cost once, and the sequencing remedy, are under
-*Fences* in [`dispatch-prompt-template.md`](dispatch-prompt-template.md) — deliberately not
+[*Fences*](dispatch-prompt-template.md#fences) in `dispatch-prompt-template.md` — deliberately not
 repeated here.
 
 **Dispatch immediately on clear.** A clear, unblocked item goes out now, not next tick.


### PR DESCRIPTION
Fixes `rf2-8d9n`, filed by the merged-PR audit of #8730 against that PR's one intended change. **1 insertion, 1 deletion, one file, no heading touched.**

## The defect, and the audit was right

#8730 replaced a duplicated explanation with a pointer — *"the sequencing remedy is under Fences in dispatch-prompt-template.md"* — and deliberately stopped carrying the cost and the remedy, because the link was meant to own navigation to them. But the Markdown target was the bare file. The named heading sits at line 208 of an 850-line document, so following the pointer opened the template at its top and left the reader to search for the content that had just been removed.

That makes it the core of the change rather than polish: a deduplication is only safe if the pointer lands.

## The fix

The visible label becomes the link, which is the second of the two remedies the bead offered:

```
-*Fences* in [`dispatch-prompt-template.md`](dispatch-prompt-template.md)
+[*Fences*](dispatch-prompt-template.md#fences) in `dispatch-prompt-template.md`
```

The slug was read at source rather than assumed: the heading is `## Fences`, it produces `fences`, and it is the only heading matching that text, so no `_N` disambiguation suffix applies. The deduplication is preserved — neither the cost nor the remedy is restored to `loops.md`.

## The sharpest thing in the bead is about the gate, not the link

> `check_doc_slugs.py` remains green because the file exists; it cannot establish that this link reaches the section the prose names.

That is exactly right, and it has a consequence worth stating: **a bare file link is unfalsifiable here, and a fragment link is not.** With `#fences` present the gate now validates that the pointer reaches a real heading, so this change does not merely improve navigation — it moves the pointer from outside gate coverage to inside it. Measured, not assumed: planting a wrong fragment on this very link returns exit 1 naming `dispatch-prompt-template.md#no-such-fragment-8d9n`.

**And my own verification was aimed at the wrong thing.** A method-reread pass an hour ago "verified the pointer resolves" by opening the template and confirming *Fences* contained the paragraph. That tests the destination, not the link, and it returned a confident green over exactly this defect. The audit caught what the check was not looking at.

## Quality gates

Exit codes are each runner's own, captured in-shell on the same command line — never through a pipe.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `check_doc_slugs.py` | **0** | **1** | **0** |
| `check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | — | — | **0** |

**Sabotage.** The discriminating fault was chosen to test the bead's actual claim rather than the file generally: a **wrong fragment on this very link**, which is precisely the failure a bare file target could not express. The gate returned exit 1 naming `docs\the-mayor-method\loops.md:549`, its own line, existing only on this branch. The edit was committed **before** the plant; restore verified by **blob hash** — `748345430d` on both sides — with the plant string gone and a post-restore diff against HEAD of **0 lines**.

**Checked by hand, since nothing gates this prose:** diffed against the **merge base** — one line out, one line in, every surrounding line re-emitted verbatim, so there is nothing to silently revert; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors cited from outside it; **no bare line-feeds** introduced in a CRLF file (count 0); longest line 120, matching the file's existing maximum. It names no product, platform, path, tool or person.
