### PR TITLE
docs(method): the dependency rule is its own rule, not the tail of the one above

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1234,6 +1234,7 @@ correct and every reading was wrong. **Write the question the instrument answers
 terms, beside the question you are asking.** The gap is invisible in the answer and obvious the
 moment both sentences are on the page. This is the harder half to catch, because a wrong answer
 gives you something to be suspicious of and a right one does not.
+
 **A dependency can outlive what it was enforcing.** An item blocked "until X lands" stays blocked if X
 is later reopened by an audit for an unrelated residual — even though the thing it was waiting for
 shipped. Force the close and **write the reasoning on the item**: what the dependency was enforcing,


### PR DESCRIPTION
Found by the method-reread loop's step 2 — checking a rule I have been enforcing against what the tree actually does. **1 insertion, one file, no heading touched, no word changed.**

## The defect

`**A dependency can outlive what it was enforcing.**` is a standalone rule in *Tracker mechanics*, and it is one of the four things the backlog-reread loop is explicitly sent to look for. It had no blank line before it, so Markdown joins it to the end of the preceding paragraph — an unrelated rule about instruments that answer a different question from the one you asked.

Rendered, the two become one paragraph and the dependency rule stops presenting as a rule at all. Measured rather than asserted: the glued source renders **1** paragraph, the fixed source renders **2**.

## Why this is drift and not house style

Extracted every line in the tree that opens a bolded rule and checked whether a blank line precedes it.

| file | glued / total |
|---|---|
| `README.md` | 0 / 0 |
| `bootstrap.md` | 0 / 14 |
| `loops.md` | **1 / 106** |
| `dispatch-prompt-template.md` | 3 / 52 |

One anomaly in 106. Its own siblings three, six and ten lines below are all blank-line separated. It arrived with the commit that made the method usable on any repository and added the loop bodies, so it has rendered wrongly for eleven days.

## The three in the template are deliberately left alone

Recorded so a later pass does not "fix" them. All three are genuine mid-paragraph emphasis rather than rule leads:

- *"**Exactly** stays regardless, because it is what lets a reader jump…"* — continues the sentence before it about the verbatim heading.
- *"**Every disagreement surfaced as exit 0.**"* — continues the sentence before it about disagreements.
- *"**That re-check is the load-bearing half…**"* — anaphoric; *that re-check* is the one the previous sentence just introduced, so sharing its paragraph is the correct reading.

Inserting blank lines there would split three arguments mid-thought. The detector over-reports on purpose; the judgement is what filters it.

## Quality gates

Exit codes are each runner's own, captured in-shell on the same command line — never through a pipe.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `check_doc_slugs.py` | **0** | **1** | **0** |
| `check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | **0** | — | — |

**Nothing gates paragraph structure, and that is the honest statement of this change's coverage.** No gate in the repo would have caught the defect and none confirms the repair; the detector above is a one-off written for this pass, not a check that runs. What the gates establish is only that the edit broke nothing.

**Sabotage** therefore tests that the gate reads *this* tree rather than a cached one: a broken anchor planted **mid-line** on the very line this change moved, target match count read as exactly **1** beforehand — line endings are translated in this checkout, so an end-of-line anchor matches nothing. Exit 1 naming `docs\the-mayor-method\loops.md:1238`, a line number that exists only on this branch because the insertion shifted it. The edit was committed **before** the plant; restore verified by **blob hash** — `abb7c019d6` on both sides — with the plant string gone and a post-restore diff against HEAD of **0 lines**.

**On the mkdocs run:** it exits 0 and its output names `the-mayor-method\loops.md`, so it did build this page. It is listed without a sabotage column because it does not grade anchors at all — `validation.anchors` defaults to INFO and `--strict` promotes WARNING but not INFO — so a sabotage there would have proved nothing.

**Checked by hand, since nothing gates this prose:** the diff against the merge base is a single empty line and nothing else — no word, no punctuation and no heading changed (0 heading lines in the diff), which matters because this tree's headings are extraction anchors cited from outside it. The file is CRLF and stays CRLF: **0 bare line-feeds** after the edit. It names no product, platform, path, tool or person.
