### PR TITLE
docs(method): a marker's discharge is not the end of the record; the newest occurrence governs

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -452,9 +452,10 @@ there and wrong about everything that mattered.
 So the marker is written by whoever SETS the hold, and **it is struck by whoever discharges it,
 in the same act** — not left standing with a correction beneath. If your tracker will not let you
 edit the original text, add the marker's negation in the same words, so that a scan for the
-banner returns both and a reader sees the pair rather than the header alone. **Treat a banner
-with no discharge beneath it as a claim about the past**: check who set it and whether what they
-were waiting for has since happened, before you report it as the current state.
+banner returns EVERY occurrence and **the newest one governs** — a hold can be set, discharged,
+and then set again on a different question, so finding a discharge is not finding the end. **Treat
+a banner with no discharge beneath it as a claim about the past**: check who set it and whether
+what they were waiting for has since happened, before you report it as the current state.
 
 **Verify before dispatching, not after.** Grep that the alleged broken symbol, missing
 file or stale convention is still there. If it already landed, close as a verified


### PR DESCRIPTION
The tenth mayor-method retrospective. Four observations, **one change, and it is a correction to arithmetic in a single clause rather than a new rule.** Three candidates were checked at source and rejected — all three because the rule is already there, and two of those state it with numbers I walked past. **4 insertions, 3 deletions, one file, no heading touched.**

Finding document written before any edit, as the method requires: `2026-08-24.mayor-method-retrospective-10-finding.md`. Evidence log appended during the pass, entries E69–E72, now 67 entries.

## What made this pass different

The board did not move — no dispatches, no worker completions, one merged change and it was mine. But unlike the last pass, the loops were genuinely *exercised*: a full merge sequence ran end to end, hygiene ran twice, and two loops caught errors in my own operation. **Every finding came from a loop catching me rather than from reading the documents**, which is a different generator from the mechanical text sweeps behind the last two passes, and a healthier one.

## The change: a paragraph that counts to two, sixty lines under a rule that says take the newest

Two sentences in the dispatch loop, sixty-one lines apart, in the same section:

| | what it says |
|---|---|
| the earlier | **"Read the newest note first, and order the item by the tracker's own timestamps"** — not by position, not by dates in the prose |
| the later, closing the marker remedy | add the marker's negation in the same words, *"so that a scan for the banner returns **both** and a reader sees **the pair** rather than the header alone"* |

**"Both" and "the pair" assert a count.** They tell the reader that finding the discharge is finding the end, and the paragraph's terminating test is built on that two-state model: banner standing, or banner discharged.

**The third state exists, and I met it this session.** A hold can be set, discharged, and set again on a different question. The item I met carried three occurrences of the banner phrase — every one of them the phrase being *retired* — and below all three, a new, live, unmarked hold.

So a reader applying that paragraph as written finds the discharge, sees "the pair", and reports the item FREE. The truth was HELD. **The remedy the section gives produces the wrong answer in that state**, which is worse than not covering it, and the direction is the costly one here: it sends a worker at an item the operator has not ruled on, which is the exact failure the marker apparatus exists to prevent.

## Why this is a correction, not an addition

The defect is arithmetic in one clause. The document **already carries the rule that resolves the third state** — order by timestamps, take the newest — sixty-one lines earlier in the same section. The marker paragraph contradicts it locally. Fix the count and the third state is handled by a mechanism already present, no new rule is introduced, and the terminating test survives unchanged as a special case of the general one.

```
-banner returns both and a reader sees the pair rather than the header alone. **Treat a banner
+banner returns EVERY occurrence and **the newest one governs** — a hold can be set, discharged,
+and then set again on a different question, so finding a discharge is not finding the end. **Treat
```

**The paragraph was re-wrapped so no line begins with the bolded lead**, deliberately. A bolded rule-lead at line start with no blank line before it renders as a continuation, and the previous change to this file existed to fix the single instance of that. Introducing a second one — even a legitimate continuation — would have invited a later pass to "repair" it by inserting a blank line, which would split this paragraph wrongly. The detector reads **0** on `loops.md` after this change, as it did before.

## Three candidates checked at source and rejected

**A rule that a two-read liveness test must span longer than the poller's cadence.** I violated this during the pass — two reads ten seconds apart on a poller whose cadence measures around forty seconds — and briefly treated the stillness as data. Checked: the tree already says **"Read that file twice, thirty to sixty seconds apart"**, with the numbers, and explains why one read is worthless and two are decisive. The rule is there, it is numeric, and I ignored it. Adding emphasis to a sentence that already carries an interval is the failure this brief warns against.

**A rule that a missing dispatch id is not a terminal state.** For more than twenty consecutive hygiene sweeps I closed with *no recorded id, no route, unreapable*. Checked: the tree says the opposite outright — *"the report is not missing — only unindexed"* — and gives the whole search procedure plus three tests for identifying the worker's own file. I ran it once I saw it: sixty transcripts searched, two contain the path, both fail the decisive test, so the absence is genuine and **established** rather than assumed. The conclusion did not change; the reasoning did. Nothing to add to the document.

**Anything about the check-count band.** The method-reread loop names it as the standing example of a constant going stale. The tree writes **no number at all**, says to measure it, and explains both the below-band and one-above-band readings. Observed directly this session — the same change read 19, then 87, then 88 across three ticks — and the document was right at every reading. Correct by construction; recorded so a later pass does not spend the minute.

## Nothing added to the README

It is for people. None of this belongs there, and it is unchanged.

## Quality gates

Exit codes are each runner's own, captured in-shell on the same command line — never through a pipe.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `check_doc_slugs.py` | **0** | **1** | **0** |
| `check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | **0** | — | — |

**Sabotage.** A broken anchor planted **mid-line** on a line this change authored, target match count read as exactly **1** beforehand — line endings are translated in this checkout, so an end-of-line anchor matches nothing. Exit 1 naming `docs\the-mayor-method\loops.md:455`, its own line, existing only on this branch. The edit was committed **before** the plant; restore verified by **blob hash** — `98e7b7c15e` on both sides — with the plant string gone and a post-restore diff against HEAD of **0 lines**.

`mkdocs build --strict` carries no sabotage column because it does not grade anchors at all: `validation.anchors` defaults to INFO and `--strict` promotes WARNING but not INFO, so a plant there would prove nothing. It exits 0 and its output names this page, so it did build it.

**Checked by hand, since nothing gates this prose:** diffed against the **merge base** and read for a silent revert — every context line is re-emitted verbatim and the only change is the intended substitution; **no heading added or changed** (0 heading lines in the diff; the file still carries 27), which matters because this tree's headings are extraction anchors cited from outside it, and the three so cited each still resolve; **no bare line-feeds** introduced in a CRLF file (count 0); longest new line 97 against the file's existing maximum of 120. It names no product, platform, path, tool or person.
