### PR TITLE
docs(method): land the three cross-file pointers on the sections their prose names

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -59,8 +59,8 @@ push as they go because pushed commits are the only durable worker state, so *gr
 and *done* are separate facts and this criterion only ever measured the first.
 Marking a change ready for review is the worker's last act, and hosts refuse to merge
 a draft, so the interlock costs this loop nothing to remember. See
-*Publishing the change* in
-[`dispatch-prompt-template.md`](dispatch-prompt-template.md).
+[*Publishing the change*](dispatch-prompt-template.md#publishing-the-change) in
+`dispatch-prompt-template.md`.
 
 Resolve the head first — the branch name **and** the head revision — because
 clauses 4 and 5 are both keyed to it.
@@ -393,7 +393,8 @@ were ready, because a homegrown filter kept answering empty.
 
 **Read the newest note first, and order the item by the tracker's own timestamps** — not by
 position, and not by dates written in the prose. The mechanics are set out for the worker under
-*Common preamble* in [`dispatch-prompt-template.md`](dispatch-prompt-template.md), and they bind
+[*Common preamble*](dispatch-prompt-template.md#common-preamble) in
+`dispatch-prompt-template.md`, and they bind
 the mayor reading the item exactly as they bind the worker: `bd show | tail` is not a
 read-the-newest method, `bd history <id>` lists real mutation times newest-first,
 `bd history <id> --json` carries the snapshot that says *what* changed, and you walk adjacent
@@ -541,8 +542,8 @@ quietened the box, and not a census of what happens to be resident on it.** The 
 named just above does not reach this: a trunk tip and a worktree list say nothing about
 what is still running.
 
-Pick the shape by kind first, then priority, then size. The shapes are in
-[`dispatch-prompt-template.md`](dispatch-prompt-template.md).
+Pick the shape by kind first, then priority, then size. The shapes are under
+[*Dispatch shapes*](dispatch-prompt-template.md#dispatch-shapes) in `dispatch-prompt-template.md`.
 
 **The unit is the block, not the file.** The tell is that the two items read as *nominally
 different concerns*, which is why the collision is invisible at the moment you schedule them,


### PR DESCRIPTION
Found by the method-reread loop's step 2 — checking a rule I have been enforcing against what the tree actually does. **3 insertions, 3 deletions across three lines, one file, no heading touched, no rule changed.**

## The defect, and it is a repair left unfinished

An earlier change fixed one cross-file pointer whose prose named a section while its link went to the file root, so following it opened an 850-line document at the top and left the reader to search for the thing the sentence had just named. **Its three siblings were left.** Enumerating every cross-file reference in the tree finds fourteen; exactly one carried a fragment, and it was the one already repaired.

Three of the remaining thirteen have the same shape — the prose names a section, the link does not land on it:

| line | what the prose says | now lands on |
|---|---|---|
| 63 | *"See **Publishing the change** in …"* | `#publishing-the-change` |
| 396 | *"…set out for the worker under **Common preamble** in …"* | `#common-preamble` |
| 545 | *"The shapes are in …"* | `#dispatch-shapes` |

Each target heading was read at source and each occurs **exactly once** in that document, so no duplicate-heading suffix applies.

## What was checked and deliberately left alone

**One bare link in this file stays bare, and that is correct.** The pointer for *why a paraphrase fails* targets material in the template's opening, before its first heading — there is no section to land on, so a fragment would be an invention. After this change the file carries exactly **one** bare link to that document, which is that one.

**The other ten cross-references are whole-document references** — the opening prompt's "anything belonging to a brief lives in …", the README's index list, "the pasteable prompt is …". None names a single destination, and the README in particular is written for people and is not a place to bolt fragments onto an index.

## Why this is worth a change rather than a note

It is not only navigation. **A bare file link is unfalsifiable beyond existence; a fragment brings the pointer under gate coverage.** Measured in both directions on this branch rather than asserted:

- a **wrong fragment** on one of the three new links → **exit 1**, naming `loops.md:396` and the bad target;
- a **nonexistent file** on the one remaining bare link → **exit 1** as well.

So the gate checks *existence* on a bare link and *landing* only when a fragment is present. These three pointers move from the first kind to the second, which means a later edit that renames one of those headings now fails CI instead of quietly stranding three readers.

## Quality gates

Exit codes are each runner's own, captured in-shell on the same command line — never through a pipe.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `check_doc_slugs.py` | **0** | **1** | **0** |
| `check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | **0** | — | — |

**Sabotage tests this change's own claim** rather than the file generally: a wrong *cross-file fragment* planted on one of the three links this change created — precisely the failure the old bare form could not express. Target match count read as exactly **1** beforehand. Exit 1 naming `docs\the-mayor-method\loops.md:396`, a target existing only on this branch. The edit was committed **before** the plant; restore verified by **blob hash** — `c0d99aa23d` on both sides — with the plant string gone and a post-restore diff against HEAD of **0 lines**. The second plant above was restored and verified the same way.

`mkdocs build --strict` carries no sabotage column because it does not grade anchors at all: `validation.anchors` defaults to INFO and `--strict` promotes WARNING but not INFO. It exits 0.

**Checked by hand, since nothing gates this prose:** diffed against the **merge base** and read for a silent revert — three lines changed, every other line re-emitted verbatim; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors cited from outside it; the bolded-lead detector reads **0** on this file before and after, so no paragraph was accidentally split or joined; **no bare line-feeds** introduced in a CRLF file (count 0); longest line unchanged at 120. No rule text was altered — only where three pointers land. It names no product, platform, path, tool or person.
