### PR TITLE
docs(method): a fix found in the reread is bounded in change, not in search

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1207,7 +1207,11 @@ Watch specifically for:
   this loop is the only place that checks whether it does.
 
 Report one or two lines unless you find real drift. If you find drift, fix the document or the command
-file — do not just note it.
+file — do not just note it. **And the fix is bounded in change, not in search.** What this loop finds is
+mechanical, so a defect in one place usually has siblings: [*"Bounded repair" bounds the change, not the
+search*](dispatch-prompt-template.md#name-the-discriminator) is set out for the worker and binds the
+mayor's own repairs exactly as it binds a worker's. Measured here: a pointer repaired in this loop left
+three identical siblings standing, and a later pass found them rather than the repair did.
 
 **But weigh WHICH artefact to change.** Where a reader-side rule has failed repeatedly, more text is
 usually not the repair. Two remedies landed the other way in one session: an item whose OLDEST field


### PR DESCRIPTION
The eleventh mayor-method retrospective. Six observations, **one change, and it is a pointer rather than a rule.** Five candidates were checked at source and rejected — four because the rule is already there, one because the divergence is with an artefact this tree cannot reach. **5 insertions, 1 deletion, one file, no heading touched.**

Finding document written before any edit, as the method requires: `2026-08-24.mayor-method-retrospective-11-finding.md`. Evidence log appended during the pass, entry E79, now 74 entries.

## What made the period productive, and it is repeatable

**The loops caught me four times, and each catch came from a different loop than the one that made the error.** The hygiene loop reaped a worktree on a completion signal I had invented; the method reread caught it an hour later. A backlog reread scanned the wrong field and reported a clean negative; the next backlog reread caught that. That cross-loop checking is the system working as designed, and it is why this pass's findings are about my own operation rather than about the documents.

## The change: a rule that exists, addressed to someone else

An audit filed a bug against one cross-file pointer in a change I had just merged. I fixed that pointer, explained at length why it mattered, closed the bug, and moved on. **I never asked how many others had the same shape.** Enumerated a day later: fourteen such pointers in the tree, exactly one carrying the fix, and **three more with the identical defect**.

The rule that would have caught it is already in the tree, verbatim:

> **"Bounded repair" bounds the change, not the search.** Grep the exact wording across tracked files, read every hit, settle each in the same change… every one was found by the *next* merged-change audit rather than by the repair before it. Three round-trips for what one grep closes.

That is the failure including its mechanism — my siblings were found by a later loop rather than by the repair, which is the round-trip that sentence measures.

**The root cause is not a missing rule.** That sentence lives in the worker-brief document, in the section about writing a brief. My repair was made by the **mayor**, on the method tree itself, in the loop that licenses exactly that — and that loop says only *"fix the document or the command file, do not just note it"*, which is silent on the scope of the fix. The reader who needed the rule was not the reader it addressed.

**The tree already has the idiom.** Elsewhere it says the read-the-newest mechanics are *"set out for the worker"* and *"bind the mayor reading the item exactly as they bind the worker."* One rule, one statement, an explicit cross-binding instead of a second copy — which is also the document's own reason for never stating a rule twice.

```
-file — do not just note it.
+file — do not just note it. **And the fix is bounded in change, not in search.** What this loop finds is
+mechanical, so a defect in one place usually has siblings: [*"Bounded repair" bounds the change, not the
+search*](dispatch-prompt-template.md#name-the-discriminator) is set out for the worker and binds the
+mayor's own repairs exactly as it binds a worker's. Measured here: a pointer repaired in this loop left
+three identical siblings standing, and a later pass found them rather than the repair did.
```

**The pointer carries a fragment, deliberately.** An earlier change in this tree established that a bare file link is unfalsifiable beyond existence while a fragment brings the pointer under gate coverage — and then left three siblings bare, which is the very defect this clause now names. Fixing that class was the previous change; this one is its rule.

## Five candidates checked at source and rejected

**A denominator rule.** Three instruments this session returned a confident zero over a population they had not read — a scan of the wrong field reported as a clean negative across thirty-seven items, of which **a quarter had an empty field**, so the scan inspected nothing at all on them and said so in the same voice as a real zero. Checked: the tree states this class twice concretely (an abbreviated revision that *"clears the clause vacuously"*; *"a zero over the wrong range reads exactly like a zero over the right one"*) and once generally, with the remedy **"write the question the instrument answers, in its own terms, beside the question you are asking."** Tested against my own case rather than waved at: *"in how many of these items does a ruling-word appear in the NOTES field"* beside *"does any close reason record a ruling"* exposes both the wrong field and the empty-population risk immediately. The remedy works; I did not apply it.

**Anything about invented proxies.** I reaped a worktree on a completion signal the harness emitted rather than one the agent wrote, having quoted the governing sentence an hour earlier. The tree names six discredited proxies and says the residue is cleared *"never by inventing a proxy."* Reader-side; the correction belongs on the sweep record, where it now is.

**A command file's narrower paraphrase.** One loop body states the branch rule with the change as its subject where the document makes containment the test — so a branch with no change at all reads as never-deletable, which the document does not say. The document is correct and internally consistent; the divergence is with an artefact outside this tree.

**A field that answers a different question.** Item assignment looked like a signal of who owes a decision and turned out to track only whether the item had ever been started — wrong in **both** directions on six of the ten items where it mattered. One more instance of a class already carrying five.

**The check-count band.** Correct by construction, re-verified: the tree writes no number, and the same change read 19, then 87, then 88 across three ticks with the document right at every reading.

## Nothing added to the README

It is for people. None of this belongs there, and it is unchanged.

## Quality gates

Exit codes are each runner's own, captured in-shell on the same command line — never through a pipe, which this session measured biting twice.

| Gate | Baseline | Sabotage | Restored |
|---|---|---|---|
| `check_doc_slugs.py` | **0** | **1** | **0** |
| `check_readme_links.py --ci` | **0** | — | **0** |
| `mkdocs build --strict` | **0** | — | — |

**Sabotage tests this change's own claim**: a wrong **cross-file fragment** planted on the very link this change created — the failure a bare file target could not express. Target match count read as exactly **1** beforehand. Exit 1 naming `docs\the-mayor-method\loops.md:1212` and the bad target, a line that exists only on this branch. The edit was committed **before** the plant; restore verified by **blob hash** — `55fc3f0190` on both sides — with the plant string gone and a post-restore diff against HEAD of **0 lines**.

`mkdocs build --strict` carries no sabotage column because it does not grade anchors at all: `validation.anchors` defaults to INFO and `--strict` promotes WARNING but not INFO. It exits 0 and its output names this page.

**Checked by hand, since nothing gates this prose:** diffed against the **merge base** and read for a silent revert — one line out, five in, every surrounding line re-emitted verbatim; **no heading added or changed** (0 heading lines in the diff), which matters because this tree's headings are extraction anchors cited from outside it, and the target heading occurs exactly once so no duplicate-suffix applies; the bolded-lead detector reads **0** before and after, so no paragraph was split or joined; **no bare line-feeds** introduced in a CRLF file (count 0); longest new line 106 against the file's existing maximum of 120. It names no product, platform, path, tool or person.
