### PR TITLE
docs(hicasso): de-historicise src comments and docstrings

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso.cljc
@@ -14,11 +14,11 @@
   ## What this namespace is
 
   **The three authoring macros live HERE**, because this is the authoring
-  surface. `hframe` is the one name still awaiting its respelling:
-  naming-ledger row 18 RETIRES the verb rather than respelling it, in
-  favour of core's `rf/current-frame-id` and a zero-arity
-  `rf/capture-frame` — and that one waits on a seam, because zero-arity
-  `rf/capture-frame` refuses inside a Hicasso body today.
+  surface. `hframe` is provisional rather than settled: naming-ledger
+  row 18 retires the verb — in favour of core's `rf/current-frame-id`
+  and a zero-arity `rf/capture-frame` — and the retirement waits on a
+  seam, because zero-arity `rf/capture-frame` refuses inside a Hicasso
+  body.
 
   **Every other var below is an ALIAS.** This namespace adds no
   behaviour: each `def` names a value `re-frame.hicasso.impl.*` owns.
@@ -75,8 +75,8 @@
 ;; hand its macros to a consumer, and its `:clj` side is these three macros
 ;; and nothing else — no runtime namespace is required on the JVM, so there
 ;; is no JVM render path for a reader to mistake for one. A `.cljc` that
-;; carried more would invite a JVM-side implementation this arm does not
-;; have.
+;; carried more would invite a JVM-side implementation this package does
+;; not have.
 
 #?(:clj
    (defmacro defview
@@ -279,12 +279,11 @@
    (defmacro event
      "**The one callback form** (HD-024). `h/event` in the authoring
   surface, and `event` here — the same name, since the door is reached
-  qualified. It was `hfn` until naming-ledger row 1 was swept
- : the guide had always taught `h/fn`, which is a name the
-  door could never carry, because a bare `fn` shadows `cljs.core/fn` for
-  anyone who `:refer`s it. `h/handler` was rejected as a cross-adaptor
-  false friend — `handler` means return-ignored imperative work in the
-  established vocabulary, and this form's contract is `event`.
+  qualified. Naming-ledger row 1 settles the name: not `fn`, because a
+  bare `fn` shadows `cljs.core/fn` for anyone who `:refer`s it; and not
+  `handler`, a cross-adaptor false friend — `handler` means
+  return-ignored imperative work in the established vocabulary, and this
+  form's contract is `event`.
 
   **The name states ONE of the three contracts this form can carry**, and
   which one is selected by POSITION rather than by the name, so the three
@@ -439,11 +438,11 @@
         {:callbacks {:on-close :event}}
         {:slots #{:title}})   ;; <- minted; the :slots map was GONE
 
-  read back consistent — the head simply had no slots — and the markup
-  written at `:title` could never arrive. Two options maps are not
-  merged and never were. [[defview]]'s `[argv & body]` has no tail to
-  lose, which is what made this the one door in the family that
-  swallowed one; the refusal closes the gap `mint-host!`'s own
+  would read back consistent — the head simply has no slots — and the
+  markup written at `:title` could never arrive. Two options maps are
+  not merged. [[defview]]'s `[argv & body]` has no tail to
+  lose, which is what makes this the one door in the family that could
+  swallow one; the refusal closes the gap `mint-host!`'s own
   unknown-option message already gives the reason for — *reading past an
   option it does not know is how a policy comes to be set and never
   applied* — one layer above that guard.
@@ -506,7 +505,7 @@
                   (re-frame.hicasso.impl.error/declared!)))))))))
 
 ;; ---------------------------------------------------------------------------
-;; The vars — aliases, every one under its prototype name
+;; The vars — aliases, every one naming a value `impl.*` owns
 ;; ---------------------------------------------------------------------------
 
 #?(:cljs
@@ -659,25 +658,19 @@
      ;; for both halves — so the counterpart emits the tree this door
      ;; adopts, position for position.
      ;;
-     ;; The SPELLING is naming-ledger row 13 (`hydrate-root!`→`hydrate!`)
-     ;; applied as a default, as the ledger header says a recommendation
-     ;; is applied before the sitting, and as route rows 21 and 23 take
-     ;; it. The CONTRACT SHAPE is row 20's `(node config view)` with
-     ;; `:frame` + `:identifier-prefix`, kept as taught.
+     ;; The DOOR NAMES are `mount!` and `hydrate!` over impl's `root!`
+     ;; and `hydrate-root!`, and the CONTRACT SHAPE is `(node config
+     ;; view)` with a config map — naming-ledger rows 13 and 20 carry the
+     ;; ruling and the argument, kept as the guide teaches.
      ;;
-     ;; **Row 13's other half — `root!`→`mount!` — is not a rename.** The
+     ;; **`mount!` is a contract, not a respelling of `root!`.** The
      ;; guide teaches `h/mount!` over row 20's config map carrying
-     ;; `:frame` AND `:initial-events`, where a bare `root!` takes the
-     ;; frame POSITIONALLY and implements `:initial-events` nowhere, so a
-     ;; var rename alone would publish this name against every taught call
-     ;; site and fail at runtime under a green compile — new behaviour
-     ;; wearing a spelling's clothes. Row 20 settles it and is ruled *keep
-     ;; as taught*, on the ground that `:initial-events` is **borrowed
-     ;; from core's `frame-root` vocabulary rather than minted here**. So
-     ;; the door below takes the contract, `impl.mount/ensure-frame!`
-     ;; supplies the behaviour by calling `rf/make-frame` exactly as a
-     ;; consumer's own boot line does, and inventory row HS-10 goes with
-     ;; the name.
+     ;; `:frame` AND `:initial-events`, where impl's `root!` takes the
+     ;; frame POSITIONALLY — so the door below takes the taught contract
+     ;; and `impl.mount/ensure-frame!` supplies the seeding behaviour by
+     ;; calling `rf/make-frame` exactly as a consumer's own boot line
+     ;; does. Row 20's ground: `:initial-events` is **borrowed from
+     ;; core's `frame-root` vocabulary rather than minted here**.
 
      (def ^{:doc "`h/mount!` — **the root door**: ensure a frame,
   associate it with a DOM container and one root view, and answer the
@@ -694,9 +687,9 @@
 
   **`:frame`** is the frame keyword this root scopes, and mounting
   ENSURES it: the frame is created if it does not exist, or JOINED as it
-  stands if another root already uses it. Nothing else in this arm makes
-  a frame, so a consumer's boot line names the id once here rather than
-  twice — to `rf/make-frame` and again to the root door.
+  stands if another root already uses it. Nothing else in the package
+  makes a frame, so a consumer's boot line names the id once here rather
+  than twice — to `rf/make-frame` and again to the root door.
 
   **`:initial-events`** is an ordered vector of ordinary event vectors,
   dispatched synchronously into the frame **when this mount CREATES it**,
@@ -722,7 +715,7 @@
 
   [[hydrate!]]'s reason exactly, and the two doors are the same case seen
   twice: `impl.mount/root!` is `(container frame-kw hiccup opts)` — the
-  prototype's positional shape — and row 20 keeps the guide's config map,
+  impl tier's positional shape — and row 20 keeps the guide's config map,
   because a config map is what lets `:initial-events` and
   `:identifier-prefix` join without an arity each. So the adaptation is
   three lines here and impl keeps one caller shape for its own witnesses

--- a/implementation/hicasso/src/re_frame/hicasso/evidence.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/evidence.cljs
@@ -241,8 +241,8 @@
 
 (defn scope?
   "True when `s` is a scope a projection may claim: one of [[scopes]], or
-  a NON-EMPTY map naming the slice it covers — `{:frame :app/main}`,
-  `{:retained-runs 12}`.
+  a NON-EMPTY plain map (a record is refused) naming the slice it covers
+  — `{:frame :app/main}`, `{:retained-runs 12}`.
 
   An empty map is refused. `{}` is a scope that says nothing, and a
   completeness claim relative to nothing is a completeness claim about

--- a/implementation/hicasso/src/re_frame/hicasso/forms.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/forms.cljs
@@ -22,24 +22,23 @@
 
   ## The scope this module ships under
 
-  **The forms module is V0 scope**, and
-  `docs/design/hicasso/draft-guide/05-forms.md` stands as its draft spec —
-  the code catches up to the chapter rather than the chapter being
-  rewritten onto the doors. For this feature only, that overrides the
-  second-caller extraction gate `specification.md` §7 states and the
-  post-v0 positioning in `decisions.md`; the extraction gate stands
-  everywhere else. A single caller would otherwise refuse the extraction,
-  `h/reg-state` being already the addressed-draft door, but the governing
-  ground is different: a guide teaching a namespace the code lacks is the
-  defect.
+  **The forms module is V0 scope**, and the chapter at
+  `docs/core/hicasso/05-forms.md` stands as its spec — the chapter
+  governs, and the code is written to it. For this feature only, that
+  overrides the second-caller extraction gate `specification.md` §7
+  states and the post-v0 positioning in `decisions.md`; the extraction
+  gate stands everywhere else. A single caller would otherwise refuse
+  the extraction, `h/reg-state` being already the addressed-draft door,
+  but the governing ground is different: a guide teaching a namespace
+  the code lacks is the defect.
 
   The buffered/draft/baseline/revision LAW is D016
   (`docs/design/freehand/decisions/D016-buffered-and-revision-controls.md`),
   and it governs semantics wherever the chapter is silent. The three
-  landed recipes at
-  `implementation/hicasso/test/re_frame/hicasso/examples/forms/` are the
-  substrate this view was extracted FROM; they stay, because they teach
-  the underlying doors and this module is written on exactly those doors.
+  recipes at
+  `implementation/hicasso/test/re_frame/hicasso/examples/forms/` teach
+  the underlying doors directly, and this module is written on exactly
+  those doors — the recipes are its substrate, not superseded by it.
 
   ## Nothing new underneath — the module is an ARRANGEMENT
 
@@ -59,8 +58,8 @@
     React's own dispatcher in `re-frame.hicasso.forms-cljs-test` §hooks.
   - **No refusal id.** The chapter says so in terms — *the module's
     common failures are behavioural rather than separately named runtime
-    errors* — and the two refusals this surface can raise are already
-    shipped and catalogued: a bad `:control` is
+    errors* — and the two refusals this surface can raise are minted by
+    the substrate and catalogued there: a bad `:control` is
     `:rf.error/hicasso-state-bad-key` (from `reg-state`, at the READ, on
     the field's first render), and `::h/revision` on something that is
     not a controlled text field is

--- a/implementation/hicasso/src/re_frame/hicasso/impl/boundary.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/boundary.cljs
@@ -3,8 +3,9 @@
 
   HD-020(c) rules that \"the runtime ships one internal class-based
   boundary exposed as `h/boundary` (`:fallback`/`:reset-key`/`:on-error`);
-  it is the P1 witness's *real error boundary*\". validation.md's
-  `:foreign/host-and-error-boundary` row names it by that description.
+  it is the P1 witness's *real error boundary*\". The P1 witness roster
+  (`re-frame.bench.hicasso.front.witnesses`) names it by that
+  description, in its `:foreign/host-and-error-boundary` row.
   This is it, and it is deliberately the smallest thing that satisfies
   the three keys. The decision's words are quoted as it wrote them; the
   export is spelled `h/error-boundary`, which is what the naming ledger
@@ -29,8 +30,8 @@
 
   **A class component calls no hooks, so this costs the ≤2-hook shell
   budget exactly nothing** — the boundary is not a boundary *shell*, it
-  reads no subscription, mints no registration and takes no cell. That
-  stayed true when the frame binding below arrived: `contextType` is a
+  reads no subscription, mints no registration and takes no cell. The
+  frame binding below keeps that true: `contextType` is a
   property of the component, not a hook call, so it is invisible at
   React's dispatcher. `arm1_lifecycle_dom_cljs_test` counts a healthy
   page there and `boundary_intent_dom_cljs_test` counts one in its
@@ -164,7 +165,7 @@
   from an event handler, from a `setTimeout`, or from anything the
   browser calls outside React's own work loop — an intent handler that
   throws lands in the browser's error channel, not here. That is React's
-  boundary, not this arm's, and the arm inherits it exactly."
+  boundary, not this runtime's, and the runtime inherits it exactly."
   (:require [re-frame.adapter.context :as adapter-context]
             [re-frame.hicasso.impl.codec :as codec]
             [re-frame.hicasso.impl.collector :as collector]
@@ -198,9 +199,9 @@
   the two shapes that can fire. Returns `props`, so the one call site
   reads as the read it already was.
 
-  The doseq is `mint-host!`'s, deliberately — this is the same refusal
-  class one surface over, and the comparator whose absence here was the
-  defect. Cost is one `contains?` per key of a map that legally holds
+  The doseq is `mint-host!`'s, deliberately — the same refusal class one
+  surface over, kept in the same shape so the two surfaces refuse
+  identically. Cost is one `contains?` per key of a map that legally holds
   four, on a component that renders when its own props or its caught
   error change; the walk of `:children` in the same render is orders of
   magnitude more work."

--- a/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs
@@ -1,24 +1,25 @@
 (ns re-frame.hicasso.impl.codec
-  "THE HICCUP CODEC — the shared front half's hiccup interpreter.
+  "THE HICCUP CODEC — the package's hiccup interpreter.
   Runtime interpretation of arbitrary hiccup into React elements, over
   reagent-slim's *measured* tag/prop/child plumbing.
 
-  ## What was taken, and what was deliberately left
+  ## The plumbing's provenance, and what is deliberately absent
 
-  Taken from `reagent2.impl.template`, because it is the plumbing the P0
-  and HD-008 instruments actually clocked: the `#id.class` tag regex and
-  its parse; the kebab→camel prop-name rule with its `aria`/`data`
-  exemptions, its `--custom-property` passthrough and its three seeded
-  entries; the `:style` map→JS-object conversion; the class coercion and
-  the shorthand merge; the single-pass sequence expansion that does not
-  truncate on an interior `nil`; and the 0/1/N `createElement` arms with
-  the `.apply` path for long child lists.
+  The plumbing is reagent-slim's `reagent2.impl.template` — the plumbing
+  the P0 and HD-008 instruments actually clocked: the `#id.class` tag
+  regex and its parse; the kebab→camel prop-name rule with its
+  `aria`/`data` exemptions, its `--custom-property` passthrough and its
+  three seeded entries; the `:style` map→JS-object conversion; the class
+  coercion and the shorthand merge; the single-pass sequence expansion
+  that does not truncate on an interior `nil`; and the 0/1/N
+  `createElement` arms with the `.apply` path for long child lists.
 
-  **Left behind, by ruling and on purpose**: the component protocol, the
+  **Absent, by ruling and on purpose**: the component protocol, the
   ratoms, and the scheduler. None of them is here, none of them is
-  reachable from here, and the codec requires nothing from a donor.
+  reachable from here, and the codec requires nothing from reagent-slim
+  at runtime.
 
-  The argv-equality memoization is NOT among them. HD-006 as amended
+  The argv-equality memoization is NOT absent. HD-006 as amended
   makes a value-equality bail-out the boundary **default**, because
   without one a page-chrome write re-runs the page and all 300 card
   boundaries beneath it with every card's inputs value-equal. It is one
@@ -32,11 +33,11 @@
   `__rfArgv` crossing, and the adapters' reserved-head and keyword-prop
   diagnostics (public-boundary policy for a shipped adapter; this codec
   has no public boundary, and the pre-alpha stance is to trust the
-  programmer). `defhost` — HD-011's taught door — is NOT absent any
-  more: [[mint-host!]] is the declaration and the host head is the
-  fourth element class, §Host heads below. Nor is the
+  programmer). `defhost` — HD-011's taught door — is NOT among the
+  absences: [[mint-host!]] is the declaration and the host head is the
+  fourth element class, §Host heads below. Neither is the
   `[:>]` raw escape, which HD-011 keeps explicitly secondary and which
-  is now built as [[raw-element]] — the same crossing with the
+  is built as [[raw-element]] — the same crossing with the
   declaration erased.
   Neither is HD-011's SSR placeholder: `:server` is a declaration option
   with two values, and `:fallback` is its sibling. Under `:client-only` [[mint-host-gate!]] is the
@@ -57,19 +58,21 @@
     tag-cache    \"div#main.wide\" -> ParsedTag
     prop-cache   \"on-click\"      -> PropSlot
 
-  A [[PropSlot]] is the React name the cache always held plus the four
+  A [[PropSlot]] is the React name plus the four
   classifications that are pure functions of the same literal — reserved
   slot, event position, ref slot, class slot.
   Same keys, same lifetime, same guard; one lookup answers everything a
   per-prop walk would otherwise re-derive per element per render.
 
-  That is the whole of the accelerant HD-004 permits in the lean arm.
+  That is the whole of the accelerant HD-004 permits here.
   There is **no template extraction, no hole plan, no node reference, and
-  no direct DOM write** — any of those *is* the PATCH strategy and has to
+  no direct DOM write** — any of those *is* a template/PATCH rendering
+  strategy, the road `architecture.md` records as not taken, and has to
   say so. There is no memoization of converted props objects and no
   memoization of elements: `convert-props` mints a fresh object per
-  element per render, exactly as the measured donor does, so the clock
-  this codec is compared on is the clock that was measured.
+  element per render, exactly as the measured `reagent2.impl.template`
+  does, so the clock this codec is compared on is the clock that was
+  measured.
 
   **The third cache HD-004 names — cached stable component heads — costs
   nothing here, and that is the interesting part.** reagent-slim needs
@@ -81,15 +84,14 @@
   head position a loud error rather than auto-wrapping it: auto-wrapping
   is precisely the thing that would need the cache back.
 
-  ## The arm boundary
+  ## The analysis/emission boundary
 
   Analysis — tag parse, prop names, class merge, child realization, head
-  classification — is arm-neutral and is what both tournament arms share.
-  **Emission is not**, and this file emits React elements, i.e. Arm 1's
-  representation. Hicasso/PATCH reuses the analysis and
-  brings its own emitter; that is the honest shape of \"the arm's element
-  representation\" in architecture.md, and it is the reason the two are
-  kept visibly apart below rather than interleaved.
+  classification — is emitter-neutral. **Emission is not**, and this file
+  emits React elements: the package's element representation, in
+  architecture.md's sense. A different emitter could take the analysis
+  wholesale and bring its own emission — that separability is the reason
+  the two are kept visibly apart below rather than interleaved.
 
   ## The one behaviour emission adds
 
@@ -225,8 +227,8 @@
   `constructor` would otherwise reach an object's prototype. That roster
   is the whole predicate.
 
-  Three `===` string compares rather than the set lookup this began as
- : a set lookup pays a string hash for a roster of three —
+  Three `===` string compares rather than a set lookup, because a set
+  lookup pays a string hash for a roster of three —
   36.9 ns against 9.6 on the census page's own literals, measured by
   `walk_profile_app`'s micro table.
 
@@ -273,7 +275,7 @@
 
 (def ^:private re-tag
   "`tag`, optional `#id`, optional `.class.class`. The `#id` must precede
-  the classes, as in the donor and in stock Reagent."
+  the classes, as in `reagent2.impl.template` and in stock Reagent."
   #"([^\s\.#]+)(?:#([^\s\.#]+))?(?:\.([^\s#]+))?")
 
 (deftype ParsedTag [tag id className])
@@ -294,8 +296,8 @@
   distinct tag literal the build ever renders.
 
   One property read answers the hit, because [[empty-cache]] has no
-  prototype to serve a wrong one. The three poisoning names still never
-  reach the cache — the refusal moved to the miss branch, which is the
+  prototype to serve a wrong one. The three poisoning names never
+  reach the cache — the refusal sits on the miss branch, which is the
   only branch that writes."
   [hiccup-tag]
   (let [k   (cache-key hiccup-tag)
@@ -320,7 +322,7 @@
 
 (deftype PropSlot [js-name reserved? event? ref? class?]
   ;; What the prop cache holds for one prop literal: the React
-  ;; React name, PLUS the four classifications a per-prop walk would
+  ;; name, PLUS the four classifications a per-prop walk would
   ;; otherwise re-derive per element per render — is the
   ;; emitted slot reserved, is the position an event position, is it the
   ;; ref slot, is it the class slot. Each is a pure function of the
@@ -388,7 +390,7 @@
   already checked the spelling.
 
   One property read answers the hit ([[empty-cache]]). A reserved name
-  is minted on every sight rather than cached, exactly as before: the
+  is minted on every sight rather than cached: the
   refusal sits on the miss branch, which is the only branch that writes,
   and the slot it mints carries `reserved?` so the emitted props object
   — which DOES have a prototype — never receives the name either."
@@ -405,7 +407,8 @@
   "[[re-frame.hicasso.impl.slot/prop-name]] behind the codec-work
   cache (HD-004).
 
-  **Only a keyword or a symbol is cached**, which is the donor's shape and
+  **Only a keyword or a symbol is cached**, which is
+  `reagent2.impl.template`'s shape and
   is load-bearing here. The cache is keyed by `(name k)` while the rule
   answers a STRING differently from the keyword of the same
   name — a string is already a React name, so `\"on-input\"` stays
@@ -514,16 +517,16 @@
   "Fold the tag's `#id`/`.class` shorthand into the object the walk just
   emitted, and return it.
 
-  **On the emitted object, and that is the whole repair.** The rule has
-  always been *an explicit id wins over the shorthand, and the shorthand
-  class is prepended to a declared one*; stated over the props MAP it read
-  `:id`, `:class` and `:className` and saw exactly three of the spellings
-  this codec accepts. `[:div#tag.foo {:& {\"id\" \"caller\" \"className\"
-  \"bar\"}}]` walked straight past it: neither key was seen, the shorthand
-  was added as a second entry landing on the same React slot, and which
-  one survived was decided by the order the props map happened to iterate
-  in — the explicit id could lose to `#tag`, and the caller's class could
-  replace `.foo` instead of composing with it.
+  **On the emitted object, and that placement carries the rule.** The
+  rule is *an explicit id wins over the shorthand, and the shorthand
+  class is prepended to a declared one*; stated over the props MAP it
+  reads `:id`, `:class` and `:className` and sees exactly three of the
+  spellings this codec accepts. `[:div#tag.foo {:& {\"id\" \"caller\"
+  \"className\" \"bar\"}}]` walks straight past that form of it: neither
+  key is seen, the shorthand is added as a second entry landing on the
+  same React slot, and which one survives is decided by the order the
+  props map happens to iterate in — the explicit id can lose to `#tag`,
+  and the caller's class can replace `.foo` instead of composing with it.
 
   Asked of the emitted object there is nothing left to resolve. Every
   spelling has already been through [[canonical-slot]] on its way into
@@ -532,10 +535,10 @@
   ([[convert-entry]]) whatever it was written as. One `undefined?` test
   and one `class-names` answer both halves for every spelling at once.
 
-  It also deletes the map surgery the walk profile priced at most of
-  [[convert-props]]'s cost — the `dissoc`/`assoc` pair that rebuilt the
-  attribute map of every element carrying a shorthand — and with it the
-  fast lane that existed to dodge it."
+  It also avoids the map surgery a map-level fold needs — the
+  `dissoc`/`assoc` pair rebuilding the attribute map of every element
+  carrying a shorthand, which the walk profile prices at most of
+  [[convert-props]]'s cost — and with it any fast lane to dodge it."
   [^js o ^ParsedTag parsed]
   (when-some [id (.-id parsed)]
     (when (undefined? (unchecked-get o id-slot))
@@ -568,11 +571,11 @@
 
   `string?` is asked first: a string is the overwhelming prop
   value on a census page — `href`, `class`, `data-testid`, `src`, `type`
-  — and it previously proved itself *not* a fn, map, keyword, symbol or
-  collection on its way to `:else`, two of those being the dear
+  — and asked any later it would prove itself *not* a fn, map, keyword,
+  symbol or collection on its way to `:else`, two of those being the dear
   native-satisfies? protocol checks. One `typeof` answers it; every other
-  branch pays that one `typeof` and keeps its old order, so the answer is
-  unchanged for every input."
+  branch pays that one `typeof` and keeps its order, so the answer is
+  the same for every input."
   [v]
   (cond
     (string? v)              v
@@ -600,9 +603,10 @@
   This is HD-010(a)'s law — `:key`, `:ref`, controlled `:value`/`:checked`
   and owned event handlers are unoverridable — applied to *every* merge
   rather than only under theming, and it is the whole point of the
-  ruling. The predecessor needs the author to choose between three merge
-  forms depending on where the target is, and the penalty for choosing
-  wrong is SILENT: caret and IME protection simply stop, with no
+  ruling. HD-023's record prices the alternative it rejects: a design
+  where the author chooses between three merge forms depending on where
+  the target is, and where the penalty for choosing wrong is SILENT —
+  caret and IME protection simply stop, with no
   diagnostic anywhere. Making the law unconditional deletes that class —
   the controlled-input door cannot be forfeited by a merge at all,
   because a merge cannot reach an owned literal.
@@ -834,8 +838,8 @@
   all, which is the branch nearly every attribute on a census page
   takes. The paths [[intent/lower-prop]] IS entered on reproduce its
   answers by construction: it re-asks `event-prop?` and re-takes the
-  same branch this slot was minted from. A string key keeps the donor's
-  uncached path, byte for byte.
+  same branch this slot was minted from. A string key keeps
+  `reagent2.impl.template`'s uncached path, byte for byte.
 
   **The class slot is a position, like the ref slot beside it.** Its
   value is coerced by [[class-names]] — a string, a keyword, a symbol or
@@ -902,8 +906,9 @@
   Two things about the order. Intent lowering happens *inside* the single
   walk, so the codec does not traverse the props map a second time to
   find the event positions. And [[merge-caller]] runs FIRST — before any
-  prop-name conversion — which is what lets one rule cover the class the
-  predecessor needs a third form for. A forwarded `:className` is merged
+  prop-name conversion — which is what lets ONE rule cover the case that
+  otherwise demands a merge form of its own (HD-023's record prices
+  that). A forwarded `:className` is merged
   as the key it was written as and then converted by *this position's*
   grammar; nothing canonicalises it into `:class` on the way through and
   hands the wrong name onward.
@@ -924,11 +929,12 @@
 
   The walk-cost profile (`walk_profile_app`, census page: 1,202
   elements, 567 of them with no attribute map, 924 with a `.class`
-  shorthand, 71 with a declared `:class`) priced this function at 67.5%
-  of the whole interpreter walk, most of it the map surgery the
-  shorthand merge performed on elements whose only class IS the
-  shorthand. That surgery is **gone**: the shorthand is folded onto the
-  object the walk emits rather than into the map the walk reads, so
+  shorthand, 71 with a declared `:class`) prices a map-surgery shorthand
+  merge — performed on elements whose only class IS the shorthand — at
+  most of this function's 67.5% share of the whole interpreter walk.
+  That surgery is what folding onto the EMITTED object avoids: the
+  shorthand is folded onto the object the walk emits rather than into
+  the map the walk reads, so
   there is no `dissoc`/`assoc` pair on any path and no shape to peel a
   lane off for. What is left is one lane and one short-circuit:
 
@@ -941,8 +947,8 @@
 
   React's own `key` contract: the LITERAL `:key` is dropped in-loop (one
   keyword-identity test) rather than by a `dissoc` that copies the map;
-  any other spelling lands in the emitted props exactly as it always
-  did, and [[native-element]] still reads the literal `:key` off the
+  any other spelling lands in the emitted props like any other prop,
+  and [[native-element]] reads the literal `:key` off the
   original map.
 
   Per prop, one [[prop-slot]] lookup answers the React name AND the
@@ -954,7 +960,7 @@
   [[re-frame.hicasso.impl.intent/lower-prop]] at all. The slot's
   `event?` flag is gated on `keyword?` at the call site — a symbol shares
   the cache entry but is not an event position — and a string-keyed prop
-  takes the donor's uncached path unchanged.
+  takes `reagent2.impl.template`'s uncached path unchanged.
 
   ## The `:&` door is shut on the revision, loudly
 
@@ -1006,7 +1012,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn mark-boundary!
-  "Record that `f` — a React function component an arm's `defview` minted
+  "Record that `f` — a React function component `defview` minted
   — is a legal hiccup head. Returns `f`, so a `defview` can end with it."
   [f]
   (unchecked-set f "hicassoBoundary" true)
@@ -1126,7 +1132,7 @@
   stale UI and an extra render is always the safe branch. `areEqual`
   inverts that polarity, so failing open here is answering **false**.
 
-  **This is the incumbent's shape, not an invention.** Reagent 2.0.1's
+  **This is stock Reagent's shape, not an invention.** Reagent 2.0.1's
   `functional-render-memo-fn` is a `React.memo` `areEqual` doing `=` over
   the whole argv inside a `try` that answers `false` on a throw — the same
   comparison, the same guard and the same polarity. UIx 1.4.4's
@@ -1148,7 +1154,8 @@
   leave every body below reading the frame it left. One `identical?` on a
   keyword closes it, ahead of the `=` that can throw.
 
-  The incumbent pays that one comparison on two `undefined`s, which is
+  A context-fed boundary pays that one comparison on two `undefined`s,
+  which is
   the honest price of keeping ONE comparator rather than two: a second
   memo path would be a second place for the fail-open ruling to rot."
   [^js prev ^js next]
@@ -1296,16 +1303,17 @@
 ;; adoption swaps the type. That is free when the thing torn down is an
 ;; inert skeleton; it is not free when it is the application, and it is
 ;; why `:server :children` — "render `props.children` in place of the
-;; component" — was refused rather than adopted: it restores the markup
+;; component" — is refused rather than adopted: it restores the markup
 ;; without the provider above it, so every consumer below reads the
 ;; context DEFAULT server-side (silent-absent becomes silent-wrong), and
 ;; then remounts the whole just-hydrated subtree at adoption.
 ;;
-;; **The price, stated because it changed**: the door used
-;; to mint no wrapper, no fiber and no hook — the foreign component was
-;; the element's own type. A gated declaration mints ONE gate, so a
+;; **The price, stated so nobody assumes it is zero**: a gated
+;; declaration mints ONE gate, so a
 ;; Client-only crossing costs one fiber and one hook; a `:render`
-;; crossing costs neither. HD-020(b)'s ≤2 budget is a statement
+;; crossing costs neither — there the foreign component is the
+;; element's own type, the zero-wrapper, zero-fiber, zero-hook shape.
+;; HD-020(b)'s ≤2 budget is a statement
 ;; about Hicasso's BOUNDARY shells and is untouched either way: the gate
 ;; is not a boundary, holds no subscription, and reads no frame.
 
@@ -1317,8 +1325,8 @@
 (declare host-head?)
 
 (def ^:private callback-contracts
-  "The three contracts a declaration may name — the position table's
-  roster in `front.intent`, verbatim."
+  "The three contracts a declaration may name —
+  [[re-frame.hicasso.impl.intent]]'s position-table roster, verbatim."
   #{:event :handler :render})
 
 (def ^:private host-options
@@ -1384,7 +1392,7 @@
 ;; subtree?* — had no answer at all.
 ;;
 ;; The three vars below give it one, and the shape is chosen to say what
-;; HICASSO does rather than what any predecessor did:
+;; HICASSO itself does:
 ;;
 ;;   - **Per DECLARATION, not per root and not per site.** The crossing
 ;;     state is closed over by [[mint-host-gate!]]'s gate, and `mint-host!`
@@ -1418,14 +1426,14 @@
   `nil` in a production build where nothing observes it.
 
   TWO BOOLEANS AND NOT A THREE-STATE KEYWORD, which is not a style
-  preference — the keyword version of this cell was written first and it
-  never fired ONCE. Its transitions were guarded with `identical?`, which
+  preference — a keyword cell with transitions guarded by `identical?`
+  silently never fires. `identical?`
   is reference equality: keyword literals are only the same OBJECT when
   the build emits them through a shared constants table, and a dev build
-  does not, so `(identical? :fresh @cell)` compared two distinct
-  `Keyword` instances and answered `false` at every site. The cell stayed
-  on its initial value for the whole run, the announce never armed, and
-  nothing was emitted — silently, because the failure of a trace to fire
+  does not, so `(identical? :fresh @cell)` compares two distinct
+  `Keyword` instances and answers `false` at every site. The cell stays
+  on its initial value for the whole run, the announce never arms, and
+  nothing is emitted — silently, because the failure of a trace to fire
   looks exactly like a page with no crossing on it. Booleans have no
   identity to get wrong."
   []
@@ -1481,7 +1489,8 @@
   `form` structurally and refuses a `defview` or `defhost` head at any
   position, naming the host, the head and where it sits.
 
-  Structural rather than evaluating, and that is the whole repair. The
+  Structural rather than evaluating, and that distinction is the whole
+  mechanism. The
   fallback's other refusals are what [[as-element]] happens to evaluate
   on its way to an element — an intent vector raises
   `:rf.error/hicasso-intent-outside-boundary` because there is no
@@ -1490,10 +1499,10 @@
   where the declaration is. A boundary head is neither: it is an element
   whose body runs LATER, so that walk never looks inside it and every
   refusal it carries is deferred past the declaration, which is the one
-  thing a mint-time walk exists to prevent. What was enforced was
-  therefore never a rule about content; it was a property of the walk.
+  thing a mint-time walk exists to prevent. Left to evaluation alone,
+  what is enforced is a property of the walk, never a rule about content.
 
-  Two facts made the absence a defect rather than a narrow rule
+  Two facts make that gap a defect rather than a narrow rule
   (measured, `re-frame.hicasso.fallback-contents-cljs-test`):
 
   1. **The declared placeholder is not a value.** [[mint-host-gate!]]
@@ -1501,13 +1510,14 @@
      is *\"a placeholder that differs per site is not a placeholder\"*.
      One declaration carrying a boundary head renders `ALPHA` in one
      frame, `BRAVO` in another and `ALPHA-TWO` after a write — the
-     justification falsified by what it permitted.
-  2. **It did not survive the arm's other boundary variant.** A
+     justification falsified by what it permits.
+  2. **It does not survive the frame-fed boundary variant.** A
      frame-fed head ([[mark-frame-prop!]]) reads `intent/*frame*` at
      ELEMENT-creation time, which in a fallback is mint time, where the
-     var is `nil` — so it baked `nil` in, minted happily, and threw
+     var is `nil` — so it bakes `nil` in, mints happily, and throws
      `:rf.error/no-frame-prop` one render into the server response.
-     Whether a boundary head in a fallback worked at all was a property
+     Whether a boundary head in a fallback works at all becomes a
+     property
      of which mint it came from, which is not a rule an author can hold.
 
   The refusal is walk-scoped, so it catches that frame-fed variant for
@@ -1828,12 +1838,12 @@
   HD-016's node handle, and neither is a callback position. `__proto__`,
   `prototype` and `constructor` are the names [[host-entry]] skips
   BEFORE it reads any declaration, because the props object handed to
-  React has a prototype even though the caches no longer do — so a
+  React has a prototype even though the caches carry none — so a
   contract declared at one of them would mint, read correct, and never
   once be applied. That is the same silent declaration `:slots` refuses
-  at [[declared-slots]], one roster over, and the recovery
-  the id already carried — *declare contracts on ordinary props only* —
-  is the sentence both conditions were always waiting for."
+  at [[declared-slots]], one roster over, and one recovery
+  — *declare contracts on ordinary props only* —
+  answers both conditions."
   [host-name k why data]
   (fail! :rf.error/hicasso-host-structural-callback
          're-frame.hicasso.impl.codec/mint-host!
@@ -1898,8 +1908,8 @@
    ;; below hands a non-map to `keys`, and what the author gets is
    ;; whichever internal error `keys` raises on their value — not a
    ;; declaration refusal naming the offending form, which is the whole
-   ;; point of the extent `defhost` opens. `h/reg-state` has carried
-   ;; exactly this guard since it was written
+   ;; point of the extent `defhost` opens. `h/reg-state` carries
+   ;; exactly this guard
    ;; ([[re-frame.hicasso.impl.state/reg-state]],
    ;; `:rf.error/hicasso-state-bad-option`); this is that guard on the
    ;; comparable surface, and `nil` is legal here for the same reason it
@@ -2000,17 +2010,17 @@
   [[mint-host!]] refuses an option key it does not know, and the reason
   its own message gives — *reading past an option it does not know is
   how a policy comes to be set and never applied* — is the reason this
-  exists one layer above it. `defhost`'s macro destructured `[component
-  opts]` off a variadic tail and dropped everything after the second
-  form, so
+  exists one layer above it. `defhost`'s macro destructures `[component
+  opts]` off a variadic tail, so unrefused, everything after the second
+  form is silently dropped:
 
       (h/defhost modal Modal
         {:callbacks {:on-close :event}}
         {:slots #{:title}})
 
-  minted, read back consistent (the head simply has no slots), and the
-  markup written at `:title` could never arrive. Two options maps are
-  not merged and never were; the second was read by nothing.
+  mints, reads back consistent (the head simply has no slots), and the
+  markup written at `:title` can never arrive. Two options maps are
+  not merged; the second is read by nothing.
 
   ## Why this fires at namespace LOAD and not at macroexpansion
 
@@ -2105,7 +2115,7 @@
   joined site strings the design proposed. The reason is a clocked one:
   an ALREADY-WARNED site is re-encountered on every render of a list the
   author has not fixed yet, and building `(str owner \"|\" member \"|\"
-  kind)` to look it up allocated a string per member per render — 420
+  kind)` to look it up allocates a string per member per render — 420
   ns/member, a third of dev lowering, on precisely the list the author is
   sitting in front of. These lookups key on the owner string and the head
   object as they already are, so the repeat path allocates nothing."
@@ -2116,8 +2126,10 @@
   "Dev-only seam: name the view whose body is being lowered, or `nil` to
   clear. A no-op in production builds.
 
-  **For the arm's runtime shell and for the tests, never for authors** —
-  the same class as [[reset-caches!]]. The arm's `run-once` sets it before
+  **For the package's runtime shell and for the tests, never for
+  authors** —
+  the same class as [[reset-caches!]]. The collector's `run-once` sets it
+  before
   a body's hiccup is lowered and clears it in the `finally` it already
   has, so an `as-element` reached outside a body run — the root, an
   outward bridge, a deferred lowering inside `presence` or an error
@@ -2170,7 +2182,7 @@
   `uuid` in particular is the canonical entity identifier: warning on
   `{:key (:id entity)}` because that id happens to be a UUID would be
   the false positive that teaches authors to ignore the warning, and a
-  guard everyone routes around is worse than the silence this repair
+  guard everyone routes around is worse than the silence this check
   closes. A `symbol` coerces exactly as the `keyword` [[plain-key?]]
   already admits does.
 
@@ -2257,11 +2269,11 @@
   in silence. The shape that makes that a bug rather than a gap is the
   FOREIGN JS ENTITY OBJECT: `createElement` does `key = '' + key`, so
   every plain object reaches `Object.prototype.toString` and every member
-  of the list is keyed `[object Object]`. Distinct rows, one key. The
-  codec was already careful never to PRINT such a value ([[key-shape]]);
-  it simply never reached the printing.
+  of the list is keyed `[object Object]`. Distinct rows, one key — and
+  a value that falls out of the `cond` never reaches [[key-shape]]'s
+  careful never-print discipline at all.
 
-  Every non-nil value [[plain-key?]] rejects now goes exactly one of two
+  Every non-nil value [[plain-key?]] rejects goes exactly one of two
   ways — classified safe by [[stable-object-key?]], or named by
   [[key-shape]], which is total. Nothing falls through.
 
@@ -2281,8 +2293,8 @@
   CONTENT-DERIVED and therefore distinct per member — a `js/Date`, a JS
   array, a CLJS map — collides with nothing, so React never warns, and
   the row silently remounts the moment the author edits the entity. That
-  is the same hazard the `:rf.warning/hicasso-entity-key` row already
-  existed for, and the foreign object is simply its unhandled case.
+  is the hazard the `:rf.warning/hicasso-entity-key` row
+  exists for, and the foreign object is simply its sharpest case.
 
   The reason to warn on BOTH rather than defer the collision half to
   React is cost, and here it is zero: see the ordering note below. The
@@ -2335,18 +2347,19 @@
   member leaves, on a `typeof`. [[boundary-head?]]'s own-property read is
   asked LAST, so an unkeyed `[:li …]` costs one `fn?` and no more.
 
-  THE TOTALITY REPAIR IS FREE, and the ordering is why. Both new arms sit
+  TOTALITY IS FREE, and the ordering is why. The classification arms sit
   INSIDE the `cond`, which is reached only by a member already known to
   be boundary-headed AND already known to carry a non-plain `:key`. The
-  keyed steady state never arrives — it left at [[plain-key?]], three
-  `typeof`s up. The unkeyed fast path never arrives at the new arms
-  either: `nil?` is still the FIRST arm, so an unkeyed boundary member
-  short-circuits exactly where it did before. Neither of the two
-  populations in the table above executes one added instruction, so the
+  keyed steady state never arrives — it leaves at [[plain-key?]], three
+  `typeof`s up. The unkeyed fast path never arrives at them
+  either: `nil?` is the FIRST arm, so an unkeyed boundary member
+  short-circuits there. Neither of the two
+  populations in the table above executes one classification
+  instruction, so the
   numbers stand as clocked.
 
-  The one population whose cost MOVED is a list keyed by `uuid`, and it
-  got cheaper. `coll?` — the dearest predicate on this path, because
+  A list keyed by `uuid` pays almost nothing either, by
+  placement. `coll?` — the dearest predicate on this path, because
   anything without the `ICollection` marker falls through to
   `native-satisfies?` — is NOT asked on the walk. Asked there, a
   legitimate UUID-keyed member would pay it on every member of every
@@ -2540,8 +2553,8 @@
 
   Not nothing, and it was measured rather than assumed. Three walks
   A/B/C'd in one process on an otherwise idle box, rounds interleaved,
-  best of seven per round, four whole repetitions. A is the value-only
-  walk this replaced, B walks keys unconditionally, C is B with the
+  best of seven per round, four whole repetitions. A is a value-only
+  walk that skips keys, B walks keys unconditionally, C is B with the
   `keyword?` short-circuit above and is what ships.
 
   **All three arms are written in the measuring namespace, including the
@@ -2615,7 +2628,7 @@
         v)))
 
 ;; ---------------------------------------------------------------------------
-;; Emission — React elements (Arm 1's representation)
+;; Emission — React elements
 ;; ---------------------------------------------------------------------------
 
 (defn- expand-seq
@@ -2634,8 +2647,8 @@
   member about to be pushed. Threading an `i` would have put an increment
   per child on the production path for a dev message's benefit. As
   written, `goog.DEBUG` folds to `false` under `:advanced`, the whole line
-  goes, and what is left is character for character the loop that was here
-  before the warning existed. `(first items)` is read twice in a dev build
+  goes, and what is left is character for character the loop with no
+  check in it. `(first items)` is read twice in a dev build
   and once in production for the same reason — it is a field read on a seq
   the loop has already forced, while `next` is the step that allocates."
   [s]
@@ -2648,7 +2661,8 @@
     a))
 
 (defn- make-element
-  "`createElement` with the donor's three arms: no children, one child,
+  "`createElement` with `reagent2.impl.template`'s three arms: no
+  children, one child,
   and the `.apply` path that builds an argument array for the rest. The
   loop is deliberate — a long keyed list is the hot case."
   [component js-props argv first-child]
@@ -2716,14 +2730,14 @@
 
 (defn- boundary-element [argv]
   (let [has-props? (props-map? argv 1)
-        ;; The SAME merge, at the crossing. This is the case the
-        ;; predecessor needs a third rule for: its spread forms are
-        ;; element forms whose content is the attribute grammar, so
+        ;; The SAME merge, at the crossing. This is the case that breaks
+        ;; a spread implemented as an ELEMENT FORM whose content is the
+        ;; attribute grammar (HD-023's record prices that design):
         ;; sending a remainder through one on the way to a declared
         ;; foreign head rewrites `:className` into the `:class` slot and
-        ;; the component never sees the prop it reads — which is why
-        ;; "neither spread form is legal there" and an ordinary `merge`
-        ;; is prescribed instead. `:&` has no such problem because it is
+        ;; the component never sees the prop it reads — forcing a third
+        ;; rule, "neither spread form is legal there, use an ordinary
+        ;; `merge`". `:&` has no such problem because it is
         ;; not a spread: it is a key in the props map, merged before any
         ;; conversion, and the conversion that follows is the POSITION's
         ;; own — a props map handed to a boundary or a declared foreign
@@ -2751,8 +2765,8 @@
         js-props   #js {"rfProps" body-props}]
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
     ;; THE FRAME AS DATA. Only for a head that asked for
-    ;; it, so the context-fed incumbent's element carries exactly what it
-    ;; always carried and the two variants are comparable. `intent/*frame*`
+    ;; it, so a context-fed head's element carries no extra slot
+    ;; and the two variants stay comparable. `intent/*frame*`
     ;; is bound by the ancestor body this element is being created inside;
     ;; at the root there is no ancestor body and [[root-element]] binds it.
     (when (frame-prop-head? head)
@@ -2801,13 +2815,14 @@
 
   ## The named value crosses whole
 
-  This branch read `(name v)` for every named value at every host prop,
-  which is stock Reagent's rule — and it silently deleted half of a
+  Stock Reagent's rule — `(name v)` for every named value at every host
+  prop — is deliberately NOT taken: it silently deletes half of a
   namespaced keyword's identity at the one crossing where that identity
-  is most often the point. `[provider {:value :theme/dark}]` handed the
-  provider `\"dark\"`, `:other/dark` handed it `\"dark\"` too, and every
-  consumer below read a plausible string that two distinct values now
-  share. Nothing threw. A crossing that answers two inputs with one
+  is most often the point. Under it, `[provider {:value :theme/dark}]`
+  hands the
+  provider `\"dark\"`, `:other/dark` hands it `\"dark\"` too, and every
+  consumer below reads a plausible string that two distinct values
+  share. Nothing throws. A crossing that answers two inputs with one
   output is not a conversion, it is a collision.
 
   **The rule is the shallow default's own rule, applied one level up.**
@@ -2827,13 +2842,13 @@
   ([[convert-prop-value]]) and the answer the server serializer gives, so
   the two crossings agree on every attribute both can carry.
 
-  **`className` no longer arrives here at all**.
+  **`className` never arrives here at all**.
   [[host-entry]] takes the class slot ahead of this function and hands it
   to [[class-names]], which is the coercion the native walk takes and the
-  only one that answers a COLLECTION correctly — the arm the named-value
-  rule above could never reach, since a collection is not a named value.
+  only one that answers a COLLECTION correctly — the case the named-value
+  rule above can never reach, since a collection is not a named value.
   The slot stays on the roster because the roster states which SLOTS are
-  bound for HTML attributes, which is still true of `className` and is
+  bound for HTML attributes, which is true of `className` and is
   what keeps this function's answer right if it is ever asked directly.
 
   **No dev warning accompanies this**, and the omission is deliberate.
@@ -2947,8 +2962,8 @@
   an attribute), a keyword or symbol key is answered by its cached
   [[prop-slot]] — React name plus `reserved?`/`event?`/`ref?` in one
   read — and a reserved emitted slot is never written, because the props
-  object handed to React does have a prototype even though the caches no
-  longer do.
+  object handed to React does have a prototype even though the caches
+  carry none.
 
   The one difference from [[convert-entry]] is the whole of HD-011: what
   a position MEANS here comes from the DECLARATION rather than from the
@@ -2966,14 +2981,14 @@
 
   `className` is the one slot whose value has a coercion of its own —
   [[class-names]] — rather than the position's ordinary conversion, and
-  that coercion belongs to the SLOT rather than to either walk. It was
-  taken at the native position only, so the two crossings answered the
-  same authored shape differently: `{:class [\"a\" nil :b]}` reached a
-  native tag as `\"a b\"` and reached a declared foreign component as the
+  that coercion belongs to the SLOT rather than to either walk. Taken
+  at the native position only, the two crossings answer the
+  same authored shape differently: `{:class [\"a\" nil :b]}` reaches a
+  native tag as `\"a b\"` and reaches a declared foreign component as the
   JS array `[\"a\", null, \"b\"]` — `clj->js`'s answer, and not a class
   string at all. React writes that array to the DOM as `\"a,,b\"`
-  wherever the component passes it on, so nothing threw and the styling
-  was simply wrong.
+  wherever the component passes it on, so nothing throws and the styling
+  is simply wrong.
 
   The principle is already settled at
   `className`, `id`, `role` and the `data-*`/`aria-*` families: the value
@@ -3009,11 +3024,10 @@
   refuses a contract at one, so the only shape either arm can be
   unreachable for is one that never minted.
 
-  **That sentence is exact, and it was not always true.** It was written
-  when only the slot half of the guard existed, and it claimed the whole
-  correspondence on the strength of it — so between that fix landing and
-  this one the code documented a guarantee it did not provide, and
-  `{:callbacks {:constructor :event}}` minted, read correct, and could
+  **That sentence is exact only because BOTH rosters are guarded.**
+  Guarded on the slot roster alone it would claim a correspondence the
+  code does not provide:
+  `{:callbacks {:constructor :event}}` would mint, read correct, and
   never reach the component. A claim about what CANNOT happen has to name
   every declaration that could make it happen; if a third roster is ever
   added, this paragraph is the one that has to grow with it.
@@ -3678,13 +3692,15 @@
 
   Costed over the census page's whole child roster
   (`walk_vs_reagent_app` candidate table: 1,908 children, of which 567
-  strings, 1,201 vectors, 69 numbers, 71 seqs): the shipping order 22.5
+  strings, 1,201 vectors, 69 numbers, 71 seqs): a vector-first order
+  22.5
   ns/child, this order **8.9** — and on the strings alone 31.7 -> 5.3.
   The vectors pay one extra `typeof` and the whole population still
-  reads 2.5x cheaper. This is the stage on which stock Reagent was
-  furthest ahead of us: its `as-element` asks one `js-val?`
+  reads 2.5x cheaper. The strings are also where the comparison against
+  stock Reagent is sharpest: its `as-element` asks one `js-val?`
   (`goog/typeOf x !== \"object\"`) and returns a string on the first
-  branch, and it read 8.8 ns/string against our 33.5.
+  branch — 8.8 ns/string against the 33.5 a vector-first order pays
+  here.
 
   That order is preserved EXACTLY, in [[child-kind]]. What this function
   pays for naming the discrimination once is one direct call and one
@@ -3715,7 +3731,7 @@
   [[re-frame.hicasso.impl.intent/with-frame]]. This is the one
   creator that is not, so it is the one creator that has to NAME the
   frame — which an outward bridge takes explicitly anyway. Binding it
-  here rather than in the arm's mount keeps the reason next to the
+  here rather than in the package's mount keeps the reason next to the
   mechanism.
 
   `*dispatch*` is deliberately NOT bound: the frame is an identity the
@@ -3741,8 +3757,8 @@
 ;; vector in every body already goes through. That is what makes "one
 ;; props/children ABI" (native-boundary law, clause 5) true by
 ;; construction rather than by inspection: there is no second element
-;; builder to keep in step, `rfProps` is written in exactly the one place
-;; it was written before, and the bridge inherits every refusal the codec
+;; builder to keep in step, `rfProps` is written in exactly one place
+;; ([[boundary-element]]), and the bridge inherits every refusal the codec
 ;; already raises at the coordinates the complaint register already
 ;; records — a head outside the closed set refuses as
 ;; `:rf.error/hicasso-bad-head` from [[vec->element]], from out here as

--- a/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
@@ -39,9 +39,9 @@
 
   Residence: `implementation/hicasso/src`, the package's own source root.
   No production build requires it — Hicasso is bundle-isolated and
-  EXPERIMENTAL — and nothing here reaches the benchmark tree the copy
-  came from, which `implementation/hicasso/scripts/check_freeze.py`
-  enforces.
+  EXPERIMENTAL — and nothing here reaches the benchmark tree
+  (`re-frame.bench.hicasso.*`), which
+  `implementation/hicasso/scripts/check_freeze.py` enforces.
 
   ## The shell, and the ≤2-hook budget (HD-020)
 
@@ -88,10 +88,10 @@
   inside a `when`, inside a `for`, and inside an inlined helper — is the
   only read surface acceptable on ergonomics, and grouped `use-subs`
   sits below the usability bar.
-  So [[sub]] is the surface this arm engineers for and [[use-subs]] is
-  kept as the control it is measured against. That inverts which tier is
-  defended; it waives none of HD-002's correctness gates, and the
-  tripwire still overrides the clock.
+  So [[sub]] is the surface this runtime engineers for and [[use-subs]]
+  is kept as the control it is measured against. That choice waives none
+  of HD-002's correctness gates, and the tripwire still overrides the
+  clock.
 
   ### The ownership state machine (clause (a))
 
@@ -142,19 +142,19 @@
   `n` [[acquire-cell!]]s, each pushing one slot onto a cell's reader
   list. There is **no cheap route for \"19 of 20 keys unchanged\"**, and a
   page whose rows change read set on a data change pays it per row. That
-  is the honest price and the thing to watch on the bulk rows. What it no
-  longer includes is the pair of whole-map rebuilds of a second
-  process-global map that the separate index charged on the same commit.
+  is the honest price and the thing to watch on the bulk rows. It
+  includes no whole-map rebuild of any second process-global map: the
+  reader lists on the cells are the only index there is.
 
   A durable per-boundary id would make the difference live, and it is
-  **unavailable at this arm's fences rather than merely unbuilt**. It has
+  **unavailable at this runtime's fences rather than merely unbuilt**. It has
   to survive a re-subscribe, so it cannot live on the registration; the
   shell has no per-instance storage that is not a hook, and a third hook
   breaks the HD-020 budget the ledger witness enforces; and threading one
   into `subscribe` would mean `subscribe` closing over something other
   than the read set, which is what makes it a shared, identity-stable
   pure function of a value in the first place. Buying the diff costs the
-  two properties this arm exists to demonstrate, so it is not bought —
+  two properties the design guarantees, so it is not bought —
   and nothing needs it, because the subscribe/cleanup pair React already
   performs is the whole operation.
 
@@ -164,7 +164,7 @@
   a set with itself — slower, still correct. The compare is what decides
   a match, and it is deliberately not *replaced* by a content hash, whose
   failure mode would be a silently missing edge. A hash does choose which
-  entries the compare is run against ([[scratch-bucket-key]]), which is a
+  entries the compare is run against ([[bucket-key-of]]), which is a
   different job with a different failure mode — a collision costs a
   second entry, never a wrong one.
 
@@ -183,11 +183,11 @@
   look perfectly correct on the first render, because the values are right
   once realised; it would simply never update again.
 
-  This arm is safe by construction: [[run-once]] closes the window around
+  This runtime is safe by construction: [[run-once]] closes the window around
   `codec/as-element`, and the codec is eager everywhere it walks —
   `expand-seq` drives a seq to exhaustion, `realize-children` folds one
   into a vector, a seq at a *native* prop position goes through
-  `clj->js`, and `front.codec/realize-deep` forces every lazy sequence
+  `clj->js`, and `impl.codec/realize-deep` forces every lazy sequence
   reachable from a *boundary's* props before the crossing hands them on.
   A lazy read is therefore forced inside the window by the same pass that
   turns hiccup into elements, and moving the codec call out of `run-once`
@@ -215,7 +215,7 @@
   satisfied. Structure is repaired there — `realize-deep` forces it at
   the crossing — and an explicit deferral is REFUSED there, by the same
   walk, because forcing a `delay` would change what the author wrote.
-  `front.codec/refuse-deferred!`, and `arm1/deferred-read-cljs-test`.
+  `impl.codec/refuse-deferred!`, and `arm1/deferred-read-cljs-test`.
 
   ### The cold read, and what it costs (clause (a) consequence)
 
@@ -225,13 +225,13 @@
   read of a key nothing holds yet is a **cold probe** ([[cold-read!]]):
   reuse a live sub-cache reaction by deref alone when one
   exists, else compute PURE against one coherent frame-state snapshot
-  through one render-scoped memo — the cold-probe discipline the internal
-  observation port carried before it was retired (rf2-63t1i), reached now
-  through the core seam it too used (`re-frame.subs/compute-sub-with-memo`). The probe
+  through one render-scoped memo — the cold-probe discipline, reached
+  through the core seam built for it
+  (`re-frame.subs/compute-sub-with-memo`). The probe
   creates no cache entry, takes no reference, installs no watch and
   leaves no disposal obligation, so an abandoned render leaves the world
-  exactly as it found it — and unlike the `subscribe-once` crossing it
-  replaces (profiled on the acceptance shape's 141-read mount,
+  exactly as it found it — and unlike a `subscribe-once` crossing
+  (profiled on the acceptance shape's 141-read mount,
   `read_profile_app.cljs`), it does not pay a reaction build, a cache
   insert, an in-tick evict and a dispose cascade per read to arrive at a
   value it retains nothing of. Acquisition happens at commit, without a
@@ -241,14 +241,14 @@
   when the commit acquires and takes its baseline. What the probe
   removes is the second *construction*, not the second compute. The
   shipping React spine attacks the same double build with a render-phase
-  escrow, and this arm deliberately does **not** copy it:
+  escrow, and this runtime deliberately does **not** copy it:
   an escrow is a render-phase ref-count mutation, which is the one thing
   the state machine above forbids — the probe moves the read the other
   way, to a path that mutates nothing at all, transiently or otherwise.
   It is also not a collector charge — `useSyncExternalStore` has the
   identical render/commit shape, so grouped and the scalar comparator
-  inherit it — and the escrow belongs to the shared front half rather
-  than to this arm.
+  inherit it — and the escrow belongs to the spine rather than to this
+  package.
 
   ## The re-render path
 
@@ -257,11 +257,11 @@
         -> the dirty CELLS' own reader lists -> dirty boundary set
         -> registration notify (React's onStoreChange)
         -> React re-renders exactly those boundaries
-        -> bodies re-run -> hiccup -> front.codec -> React reconciles
+        -> bodies re-run -> hiccup -> impl.codec -> React reconciles
 
   The dirty *sub-key* set is push-cheap: a key is marked only when the
   sub layer's own equality cutoff let a change through. Notifications are
-  batched by [[with-commit]], which the arm's frame-locked dispatch wraps
+  batched by [[with-commit]], which the runtime's frame-locked dispatch wraps
   around every intent, so one user action is one flush however many
   subscriptions it moved.
 
@@ -271,8 +271,8 @@
   *inside a body* — a commit landing between two of one render's reads.
   The other is the **render→commit gap** — a commit landing after the
   body returned and before React runs the effect that acquires its
-  edges. The predecessor guarded the second by re-reading every
-  subscription at commit; this arm may not (HD-002), so it needs
+  edges. Re-reading every subscription at commit would guard the second,
+  but a commit-phase deref is forbidden (HD-002), so the runtime needs
   something else there.
 
   Both windows are judged against one number, [[re-frame.hicasso.impl.generation/commit-basis]]:
@@ -288,8 +288,8 @@
   render→commit gap?* — because it answers without watching anything.
   [[re-frame.hicasso.impl.generation/registry-epoch]] counts `:sub` registrations, which are neither a
   flush nor an install, so a `reg-sub` in the gap would otherwise move no
-  term at all. The second term is what the runtime was
-  missing, and it is why the basis is not just the generation:
+  term at all. The second term is what the generation alone cannot
+  supply, and it is why the basis is not just the generation:
 
   > The generation only moves when `flush!` bumps it, `flush!` only runs
   > from `mark-dirty!`, and `mark-dirty!`'s only caller is the
@@ -329,11 +329,11 @@
 
   ### The other two axes, and which half of each the basis carries
 
-  The predecessor compared three things. The other two — a `:sub`
-  registration (its `:registry-epoch`) and a same-id frame reincarnation
-  (its `:node-key`) — split cleanly by whether the boundary in question
-  **already holds a cell** for the key, and the two halves want opposite
-  answers.
+  Writes are not the only movement invariant 5 must see. The other two
+  axes — a `:sub` registration (Spec 006's registry epoch) and a same-id
+  frame reincarnation (its `:node-key`) — split cleanly by whether the
+  boundary in question **already holds a cell** for the key, and the two
+  halves want opposite answers.
 
   For a boundary that holds one, **adding a term closes nothing**: each
   transition leaves the cell holding a reaction that can no longer answer
@@ -351,8 +351,8 @@
   [[re-frame.hicasso.impl.generation/commit-basis]] — the basis TIES across a reincarnation, so no
   arithmetic over these terms could report it.
 
-  What each transition does to a *held* cell, and what the arm hears when
-  it happens:
+  What each transition does to a *held* cell, and what the runtime hears
+  when it happens:
 
   | transition | what the cell is left holding | what announces it |
   |---|---|---|
@@ -360,19 +360,19 @@
   | **frame destruction** (incl. a same-id reincarnation) | a container wired to the frame that no longer exists, answering the destroyed incarnation's db | the reaction's own disposal |
   | `:sub` **first registration** | the substrate's uncached nil-recovery, which was never wired to anything and can never see the handler that has now arrived | nothing — so [[first-registration!]] listens for the registration itself |
 
-  So the arm takes the substrate's own events instead of a term.
+  So the runtime takes the substrate's own events instead of a term.
   [[invalidate-cell!]] is the one repair all three reach:
   [[wire-cell!]] arms it per unique key against the reaction's disposal,
   which covers the two transitions that dispose; the third disposes
   nothing — `registrar/add-replacement-hook!` fires only when a previous
-  handler existed — so the arm hangs it off
+  handler existed — so the runtime hangs it off
   `registrar/add-registration-hook!` ([[sub-registered!]]), narrowed to
   first-time `:sub` registrations and to the cells that hold the id being
   registered. It costs no React hook and no per-boundary object.
 
   The gap half rides the same hook, one line earlier, as a `vswap!` on
-  [[re-frame.hicasso.impl.generation/registry-epoch]] — so the arm reads a registry count it keeps itself
-  and `observation/registry-epoch*` stays `^:private`. **What is
+  [[re-frame.hicasso.impl.generation/registry-epoch]] — a registry count the runtime keeps itself
+  rather than a new public reader on a production namespace. **What is
   rejected is the OTHER placement**: a registry term in
   every key's *live* contribution to [[make-snapshot]], which moves every
   mounted boundary in the application on every `reg-sub`. This term is in
@@ -482,12 +482,12 @@
       nil)))
 
 (defn frame-row
-  "The arm's one memo row for `frame-kw` — `{:incarnation :ops :dispatch}`,
+  "The runtime's one memo row for `frame-kw` — `{:incarnation :ops :dispatch}`,
   pinned to the incarnation live right now.
 
   [[re-frame.hicasso.impl.frames/frame-row]] owns the table and the
   incarnation discipline; this is the door that supplies the closure factory,
-  so every caller in the arm reads the SAME row and the bundle can never
+  so every caller in the runtime reads the SAME row and the bundle can never
   describe a different incarnation than the closure that calls it."
   [frame-kw]
   (frames/frame-row frame-kw mint-frame-dispatch))
@@ -642,16 +642,15 @@
   performed twice — once when the cell is born and once when the
   substrate disposes the reaction out from under it.
 
-  **Activation comes first, and it is not optional** — \"ACTIVATE, then
-  watch, then observe\" (rf2-8cnxg; first stated by the internal observation
-  port, retired 2026-08-21, so this is now one of the sites that states it).
+  **Activation comes first, and it is not optional** — ACTIVATE, then
+  watch, then observe.
   A subscription under the ratom family IS a bare `reagent.ratom/Reaction`,
   built deliberately without `:auto-run`, and a Reaction learns its sources
   only through `deref-capture`: a plain deref taken outside `*ratom-context*`
   runs the body raw and leaves `watching` nil. The reaction is then not in
   app-db's watcher set, so the watch below never fires, [[mark-dirty!]] never
   fires — that watch is its only caller — and no write after the mount ever
-  becomes re-render work. Measured: the arm painted once and was deaf
+  becomes re-render work. Measured: the runtime painted once and was deaf
   thereafter. `interop/activate-derived-value!` is the substrate's own op for
   this and is a routed no-op on the React-hook spine, which wires one watch
   per source at construction.
@@ -660,7 +659,7 @@
   notification, and before the baseline deref so that deref reads a settled
   node — the activation left it clean, so the baseline recomputes nothing.
 
-  The disposal hook is the arm's counterpart to the two axes
+  The disposal hook is the runtime's counterpart to the two axes
   `commit-basis` cannot see, and it is deliberately an
   *event* rather than a term in the epoch sum: the substrate already
   tells us, exactly and only when it happens, and a term would have to be
@@ -697,7 +696,7 @@
      reaches here through [[first-registration!]] instead.
 
   The first two leave the cell holding a container whose `-dispose` has
-  already run `(reset! watchers {})`, so the watch this arm installed is
+  already run `(reset! watchers {})`, so the watch this runtime installed is
   gone and `mark-dirty!` can never fire for that key again. Measured,
   before this hook existed: the boundary read the RETIRED computation
   forever and no later write notified it. That is why neither axis was
@@ -727,7 +726,7 @@
   other two is a frame fact — so `getSnapshot` ties, React schedules
   nothing at the instant the successor seats, and the committed fiber
   goes on holding the predecessor's value until the rebuild moves the
-  number. This was a `setTimeout 0`, which hands the correction to a
+  number. A `setTimeout 0` here would hand the correction to a
   LATER task, and the event loop is free to update the rendering between
   tasks: the predecessor's value could reach the screen, and on a
   tenant or account switch that is another tenant's data, briefly, with
@@ -743,7 +742,7 @@
   the three hooks named above and was measured red; the unwound stack is
   the whole of what the deferral buys, and the microtask checkpoint is
   the earliest moment the stack is unwound. The narrowing that costs is
-  that the rewire window is now the current checkpoint rather than a
+  that the rewire window is the current checkpoint rather than a
   whole task, so a successor seated in a LATER task finds the cell
   disposed — and recovers, through [[cold-read!]]'s probe on the next
   render, which is the same recovery a key that never had a cell gets."
@@ -774,7 +773,7 @@
   `registrar/add-replacement-hook!` — the hook the
   sub-cache eviction that [[invalidate-cell!]] rides is built on — fires
   only when a previous handler existed. A *first* `reg-sub` for a query
-  therefore evicts nothing, disposes nothing, and would reach an arm that
+  therefore evicts nothing, disposes nothing, and would reach a runtime that
   listened for disposals alone by no route whatsoever.
 
   It has something to reach because a boundary can hold the miss. The
@@ -782,7 +781,7 @@
   query emits `:rf.error/no-such-sub`, recovers to a nil-yielding
   reaction, and **deliberately does not cache it**, precisely so that a
   later registration is observed by the next `subscribe`
-  (`subs/build-and-cache!*`). This arm has exactly one property that
+  (`subs/build-and-cache!*`). This runtime has exactly one property that
   breaks that assumption — a cell holds its reaction for the life of
   every boundary reading the key, and never subscribes again — so the
   recovery the substrate declined to cache was cached anyway, in a cell,
@@ -832,7 +831,7 @@
   nil)
 
 (defn- sub-registered!
-  "The arm's whole listening post on the registry, and the two halves of
+  "The runtime's whole listening post on the registry, and the two halves of
   the registry axis in one place because they are one event.
 
   **Bump then scan.** [[re-frame.hicasso.impl.generation/registry-epoch]] counts every `:sub` registration,
@@ -857,7 +856,7 @@
 ;; Arm it once per process, at load. `defonce` is the arming, so the var
 ;; exists for its side effect and is deliberately never read — the hook
 ;; vector is the only thing that holds the fn. The hook is the substrate's
-;; own extension point and the arm installs nothing else global; it costs
+;; own extension point and the runtime installs nothing else global; it costs
 ;; a keyword compare on every registration of any kind, a `vswap!` on
 ;; every `:sub` one, and the scan above only on a first-time `:sub`.
 #_:clj-kondo/ignore
@@ -867,7 +866,7 @@
 (defn- acquire-cell!
   "**Commit-phase only.** Take (building if necessary) the durable
   reference for `sub-key` on `reg`'s behalf, and attach the one watch
-  that turns the sub layer's equality cutoff into this arm's dirty set.
+  that turns the sub layer's equality cutoff into this runtime's dirty set.
   Acquire without deref: the render already knows the value.
 
   Taking the reference and recording the edge are **one act**: `reg` is
@@ -924,11 +923,11 @@
                    ;;
                    ;; The watch then hands us old and new, so the movement
                    ;; test is free. It is made here rather than trusted to
-                   ;; the layer below because this arm uses the
+                   ;; the layer below because this runtime uses the
                    ;; notification ITSELF as the dirty signal: the shipping
                    ;; spine can tolerate a notification that did not move,
                    ;; since `useSyncExternalStore` re-compares snapshots
-                   ;; after it, and this arm cannot.
+                   ;; after it, and this runtime cannot.
                    ;;
                    ;; [[wire-cell!]] performs that deref, that watch and the
                    ;; disposal hook, because a cell is attached to the
@@ -1061,7 +1060,7 @@
                       (flush!))))))
 
 (defn dispatch!
-  "The arm's frame-locked dispatch — HD-019's synchronous door. The event
+  "The runtime's frame-locked dispatch — HD-019's synchronous door. The event
   drains synchronously inside the caller's turn (the discrete browser
   event, for an intent) and the store notification runs before that turn
   ends, so React commits the echo in the same turn.
@@ -1087,12 +1086,10 @@
 
   1. **A live sub-cache reaction is reused by deref alone.** Some other
      holder (a cell on another boundary mid-anything, a tool, a test)
-     keeps the reaction warm; the acquire/release round trip
-     `subscribe-once` performed to reach the same deref bumped a
-     ref-count both ways for nothing. The peek is exactly the port's
-     (`observation/probe`), and single-threaded CLJS is what makes the
-     unguarded deref safe: nothing can evict between the `get` and the
-     `@`.
+     keeps the reaction warm; a `subscribe-once` reaching the same deref
+     would bump a ref-count both ways for nothing. Single-threaded CLJS
+     is what makes the unguarded deref safe: nothing can evict between
+     the `get` and the `@`.
   2. **A truly cold key computes PURE** — `subs/compute-sub-with-memo`
      against ONE coherent frame-state snapshot, minted lazily on the
      run's first cold read ([[run-once]] resets the box, so a fence
@@ -1138,9 +1135,9 @@
   newer one, fresh box included. The values a probe computes are what
   the sub-cache reaction would have answered against the same committed
   state — `compute-sub` and the reactive path share the input grammar,
-  the recover-to-nil contracts and the schema validation, which is why
-  the port could stake commit-free Tier-1 reads on the equivalence
-  first."
+  the recover-to-nil contracts and the schema validation, which is what
+  makes the equivalence a contract of the seam rather than a
+  coincidence."
   [frame-kw query-v]
   (let [frame-record (frame/frame frame-kw)]
     (if (nil? frame-record)
@@ -1182,7 +1179,7 @@
   against the run's one frame-state snapshot, retains nothing, and so
   leaves an abandoned render's world as it found it.
 
-  A cell [[invalidate-cell!]] has dropped the reaction of takes the cold
+  A cell whose reaction [[invalidate-cell!]] has dropped takes the cold
   path too, and that is the whole of what an invalidated read needs to be
   correct: the probe computes against the registration and the frame
   incarnation that are live NOW, so a render in the window between
@@ -1244,9 +1241,9 @@
 ;; ---------------------------------------------------------------------------
 
 (defonce !entries
-  ;; read-sequence hash -> vector of entries. See [[scratch-bucket-key]]
-  ;; for why the key is a hash of the WHOLE sequence and not, as it once
-  ;; was, the first sub-key.
+  ;; read-sequence hash -> vector of entries. See [[bucket-key-of]] for
+  ;; why the key is a hash of the WHOLE sequence rather than the first
+  ;; sub-key.
   (atom {}))
 
 (defn- bucket-key-of
@@ -1274,14 +1271,14 @@
   no allocation, which is what keeps the steady-state hit path at zero
   bytes.
 
-  **Why the first sub-key was not enough.** Bucketing on
-  `(aget scratch 0)` made the scan's cost a function of how an author
-  ordered their `let` bindings. A row body reading its per-row key first
-  put one entry in each bucket; the same body reading a page-wide key
-  first — one line moved — put every live row's entry in ONE bucket, and
-  every probe then passed the length test and the index-0 test and failed
-  only at the last key. Mounting N such rows cost `sum(i)` probes, and
-  N = 300 is a rung this programme benchmarks. Same page, same edges,
+  **Why the first sub-key is not enough.** Bucketing on
+  `(aget scratch 0)` makes the scan's cost a function of how an author
+  orders their `let` bindings. A row body reading its per-row key first
+  puts one entry in each bucket; the same body reading a page-wide key
+  first — one line moved — puts every live row's entry in ONE bucket, and
+  every probe then passes the length test and the index-0 test and fails
+  only at the last key. Mounting N such rows costs `sum(i)` probes, and
+  N = 300 is a rung the benchmark suite measures. Same page, same edges,
   same DOM, ~150x the entry-lookup work. Hashing the whole sequence makes
   the bucket a function of the read set rather than of its first element,
   and `the-bucket-scan-does-not-grow-with-the-number-of-boundaries`
@@ -1325,7 +1322,7 @@
   meets, where a `setTimeout 0` escrow reaper beats
   `createRoot().render()`'s passive flush and costs `bodyRuns` 2.00N on
   every consumer mount; 4 ms is the SHORTEST delay measured to win there,
-  at N = 1 and N = 300 alike, and this arm adopts that number rather than
+  at N = 1 and N = 300 alike, and this runtime adopts that number rather than
   inventing one.
 
   ## A MARGIN, NOT A CONTRACT
@@ -1382,8 +1379,8 @@
   set.
 
   The bucket is [[bucket-key-of]]'s hash of the whole read sequence,
-  so what a lookup scans is the set of read sequences that COLLIDE — not,
-  as it once was, the set of live boundaries that happen to share a first
+  so what a lookup scans is the set of read sequences that COLLIDE —
+  never the set of live boundaries that happen to share a first
   key. `drop-entry!`'s rebuild of the bucket vector is O(1) for the same
   reason.
 
@@ -1469,11 +1466,11 @@
   `subscribe`: the edge-set replacement in full, done by the pair. See
   the ns docstring, clause (b).
 
-  **Abandoned renders are safe structurally rather than by a guard.** The
-  retired index needed a liveness check in `record-reads` so a stale
-  body run could not resurrect an unmounted boundary's edges; here there
-  is no render-phase write to guard, because the only write is inside
-  this closure and React calls it at commit and nowhere else."
+  **Abandoned renders are safe structurally rather than by a guard.** A
+  design that wrote edges during the render would need a liveness check
+  so a stale body run could not resurrect an unmounted boundary's edges;
+  here there is no render-phase write to guard, because the only write is
+  inside this closure and React calls it at commit and nowhere else."
   [^js entry]
   (fn subscribe [on-store-change]
     (let [reads (.-set entry)
@@ -1497,7 +1494,7 @@
   get back the same cleanup React would hold.
 
   It exists because the commit path, the index wiring and the
-  zero-leaked-reference assertion are the parts of this arm most worth
+  zero-leaked-reference assertion are the parts of this runtime most worth
   proving cheaply and deterministically, and every one of them is
   answerable without a browser, a root, or a render. The DOM suites then
   prove that React drives *this* seam rather than re-proving what the
@@ -1594,7 +1591,7 @@
   double-invoke correct here rather than additive.
 
   The two `goog.DEBUG` lines around the lowering are the codec's key
-  warnings asking who is lowering. This is the arm's sole
+  warnings asking who is lowering. This is the runtime's sole
   body-lowering site — `render-body` is its only caller, and the fence's
   re-runs are idempotent set/clear pairs — so the clear rides the
   `finally` the frame reset already needed, and a throwing body, a thrown
@@ -1690,7 +1687,7 @@
   ## Always on, and why
 
   The SSR adoption row has to read body runs out of the build it
-  actually drives, and the arm's builds are `:advanced` with
+  actually drives, and the package's builds are `:advanced` with
   `goog.DEBUG false` — so a `goog.DEBUG`-gated instrument is not an
   instrument there, it is dead code the compiler removes. Against a
   declared dev-build witness row, **the counter wins**, because a
@@ -1835,7 +1832,7 @@
   "Turn a body fn into a boundary: a React function component, marked as a
   legal hiccup head and given the codec's stable memo wrapper. Minted
   once, at definition — which is why the codec's third HD-004 cache
-  (stable component heads) has nothing to do in this arm, and why HD-016
+  (stable component heads) has nothing to do in this runtime, and why HD-016
   can make a plain function in head position a loud error instead of
   auto-wrapping it.
 
@@ -1858,9 +1855,10 @@
 
   ## Why bailing out on PROPS is safe when bodies read SUBSCRIPTIONS
 
-  This is the question the repair has to answer, because a memo that
+  This is the question the bail-out has to answer, because a memo that
   bailed while a subscription moved would freeze a row on screen — the
-  exact failure class this arm has repaired four times. It is safe
+  exact failure class [[invalidate-cell!]] and [[first-registration!]]
+  exist to close. It is safe
   because props are not the only channel into the shell, and memo blocks
   only one of them:
 
@@ -1870,7 +1868,7 @@
     React consults `checkScheduledUpdateOrContext` BEFORE it consults the
     comparator, so a fiber with pending work re-renders and the
     comparator is never even asked. A row whose reads moved cannot be
-    bailed out, whatever its props say. Donor precedent: reagent-slim's
+    bailed out, whatever its props say. Precedent: reagent-slim's
     default update check is argv `=`, and reactive invalidation bypasses
     it via `forceUpdate` — the same shape, by design.
   - **The frame** arrives through `useContext`, and React propagates a
@@ -1895,7 +1893,7 @@
   carrying a custom comparator stays a `MemoComponent` rather than
   collapsing to React's `SimpleMemoComponent`, so React keeps a wrapper
   fiber above the component's own. That is React's retention rather than
-  this arm's, and it is recorded in [[re-frame.hicasso.impl.inventory/retained-inventory]] under
+  this runtime's, and it is recorded in [[re-frame.hicasso.impl.inventory/retained-inventory]] under
   `:react/memo-fiber` instead of being left for a heap ladder to
   discover.
 
@@ -1904,7 +1902,7 @@
   Spec 009 §What gets bracketed names four hot paths; three of them
   (`:event`, `:sub`, `:fx`) are core's and are already live for a
   Hicasso app, because they sit in the router, the subs layer and the fx
-  layer this arm consumes unchanged. The fourth — `:render` — is the
+  layer this runtime consumes unchanged. The fourth — `:render` — is the
   **view substrate's**, and it is bracketed here so a Hicasso app's
   per-view render reaches the User-Timing stream like every other
   re-frame2 app's. It is a `:render` in the spec's own terms: the bucket is keyed
@@ -2009,7 +2007,7 @@
   too, and the bracket is here for the same reason it is there: this is
   the wrapper the substrate emits, `view-name` is already closed over, so
   the OFF bundle is byte-for-byte the call that preceded it. The two mint
-  fns are the arm's two view-substrate wrappers, and a `:render` bucket
+  fns are the runtime's two view-substrate wrappers, and a `:render` bucket
   wired to one of them and not the other would report half a page."
   [view-name body-fn]
   (when ^boolean js/goog.DEBUG (unchecked-set body-fn "displayName" view-name))
@@ -2018,7 +2016,7 @@
                       (frame-prop-shell body-fn js-props)))
         ;; The same dev-only origin wrapper [[mint-view!]] applies, and here
         ;; for the reason its docstring gives about the `:render` bucket: a
-        ;; shape wired to one of the arm's two view-substrate wrappers and
+        ;; shape wired to one of the runtime's two view-substrate wrappers and
         ;; not the other would attribute half a page's refusals to nothing.
         component (if interop/debug-enabled?
                     (error/traced-boundary view-name component)
@@ -2108,7 +2106,7 @@
   would read every Hicasso view edit as an idempotent reload and decline
   to refresh. Naming `:hicasso/component` as the executable slot makes
   the tag truthful without a second HMR surface, without a hicasso-side
-  replacement hook, and without putting anything in `:handler-fn`
+  replacement hook, and without putting anything in `:handler-fn`.
   The registrar reads the key this
   registration named; it learns nothing about Hicasso.
 
@@ -2147,16 +2145,13 @@
   owns the act of emptying it, so this fn cannot silently miss a slot
   somebody adds elsewhere.
 
-  **It does NOT touch the hydration adoption window**. It used
-  to, because the window was one boolean for the whole page and a fixture
-  that threw mid-hydration would otherwise leave the page permanently
-  adopting. A window now belongs to the root that minted it and is
-  reachable only from that root's handle, so there is nothing page-wide
-  left to rescue: a root whose construction threw left an unreachable
-  object, and a root that is torn down is closed by
-  `impl.mount/unmount!`. Reaching in from here would be the opposite of
-  the repair — a reset in one root shutting a sibling root's window while
-  it is still adopting."
+  **It does NOT touch the hydration adoption window**. A window
+  belongs to the root that minted it and is reachable only from that
+  root's handle, so there is nothing page-wide to rescue: a root whose
+  construction threw left an unreachable object, and a root that is torn
+  down is closed by `impl.mount/unmount!`. Reaching in from here would be
+  cross-root interference — a reset in one root shutting a sibling root's
+  window while it is still adopting."
   []
   (doseq [[_ cell] @!cells] (dispose-cell! cell))
   (reset! !cells {})

--- a/implementation/hicasso/src/re_frame/hicasso/impl/controlled.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/controlled.cljs
@@ -50,8 +50,8 @@
      no-op, because it only assigns when the two differ
      (`react-dom-client.development.js:1661-1667`), and a no-op there is
      what lets the caret survive;
-  3. put the caret back **by offset from the END of the string**, which
-     is Arm 2's algorithm and Reagent's before it — the offset a
+  3. put the caret back **by offset from the END of the string** —
+     Reagent's own algorithm, because the offset is what a
      normalisation that changes the length preserves, where an absolute
      position does not.
 
@@ -66,9 +66,10 @@
   **stale the moment step 1 commits a new one**. Writing it back is not
   a missing improvement, it is a regression: on a keystroke the model
   took verbatim it wipes the character the user just typed.
-  `front/controlled_dom_cljs_test` reproduces exactly that, by handing
-  [[converge-to!]] the closure's value instead of the record's — one
-  argument different, and the accepted keystroke disappears.
+  `re-frame.hicasso.controlled-dom-cljs-test` reproduces exactly that,
+  by handing [[converge-to!]] the closure's value instead of the
+  record's — one argument different, and the accepted keystroke
+  disappears.
 
   Comparing the field against what the handler saw does not answer it
   either. `(= (.-value node) dom-value)` is **true in both cases**: on a
@@ -100,7 +101,7 @@
 
   **So the price the option was quoted at is not charged here.** What
   remains is the dependency, and [[last-rendered]] is the one place that
-  names it. `front/controlled_dom_cljs_test` asserts the invariant
+  names it. `arm1_controlled_grid_dom_cljs_test` asserts the invariant
   directly, on a live element, across a re-render that moves the value —
   so if React ever stopped mirroring, a row named for the invariant goes
   red rather than five rows going subtly wrong.
@@ -310,8 +311,8 @@
   given.
 
   What does happen is measured on the hydration harness rather than on a
-  hand-rolled `hydrateRoot`, because hand-rolled arms disagree about node
-  identity in opposite directions on consecutive runs:
+  hand-rolled `hydrateRoot`, because hand-rolled hydration harnesses
+  disagree about node identity in opposite directions on consecutive runs:
   `arm1/hydrate_dom_cljs_test` §6, where *mid-adoption* is a fact rather
   than a wait — `hydrate-root!` returns before the tree is adopted, so a
   synchronous dispatch on the next line cannot be raced.
@@ -344,7 +345,7 @@
   namespace docstring for the four lines of `react-dom` that maintain
   it. The one place this namespace depends on that behaviour, so it is
   the one place a row has to pin, and
-  `front/controlled_dom_cljs_test/the-record-is-the-elements-own-and-is-not-the-closures`
+  `arm1_controlled_grid_dom_cljs_test/the-record-is-reacts-own-mirror-and-is-not-the-handlers-closure`
   pins it.
 
   `js/undefined` on anything that is not a live form control — a
@@ -770,8 +771,8 @@
 
   The one reader an element-tree test needs, so that walking what the
   codec emitted stays a question about the DOM rather than about this
-  namespace. `front/census_article_editor_cljs_test` picks its inputs
-  out of a rendered fieldset with it."
+  namespace. `re-frame.hicasso.controlled-dom-cljs-test` reads every
+  emitted element's tag through it."
   [e]
   (let [t (.-type e)]
     (or (when (fn? t) (unchecked-get t native-tag-key))

--- a/implementation/hicasso/src/re_frame/hicasso/impl/error.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/error.cljc
@@ -50,7 +50,7 @@
   [[fail!]] refuses to mint an incomplete refusal (dev builds). The
   alternative — asserting completeness in a test per refusal id — checks
   the refusals somebody remembered to enumerate and nothing else, which
-  is precisely how the shape drifted into six copies. The guard is on the
+  is precisely how a shape drifts into copies. The guard is on the
   one door every refusal now passes through, so a refusal minted without
   a recovery cannot reach a user under any code path, tested or not.
 

--- a/implementation/hicasso/src/re_frame/hicasso/impl/evidence.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/evidence.cljs
@@ -51,7 +51,9 @@
 (defonce !evidence-sink (atom nil))
 
 (defn set-evidence-sink!
-  "Attach (or with nil, detach) the evidence sink."
+  "Attach (or with nil, detach) the evidence sink: a fn of one event map,
+  keyed by `:event` (`:commit` or `:edges-changed`), called synchronously
+  from the collector's tap points."
   [f]
   (reset! !evidence-sink f)
   nil)

--- a/implementation/hicasso/src/re_frame/hicasso/impl/frames.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/frames.cljs
@@ -79,8 +79,8 @@
 ;;              :ops         <bundle>         `rf/capture-frame`'s
 ;;                                            {:frame :dispatch :dispatch-sync
 ;;                                             :subscribe}, pinned to it
-;;              :dispatch    <closure>        the arm's ambient dispatch over
-;;                                            THAT bundle}
+;;              :dispatch    <closure>        the runtime's ambient dispatch
+;;                                            over THAT bundle}
 ;;
 ;; The residue ledger counts this table under the `:frame-ops` token, priced as
 ;; "one capture-frame bundle and one ambient dispatch per frame" — one row is

--- a/implementation/hicasso/src/re_frame/hicasso/impl/generation.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/generation.cljs
@@ -40,12 +40,11 @@
   nil)
 
 (defn registry-epoch
-  "**The arm's own count of `:sub` registrations** — first-time and
+  "**The runtime's own count of `:sub` registrations** — first-time and
   replacement alike — and the third term of [[commit-basis]].
 
-  It is the arm's rather than the substrate's on purpose.
-  `observation/registry-epoch*` counts exactly this and is `^:private`;
-  the arm already installs a registration hook for
+  It is the runtime's rather than the substrate's on purpose: the
+  runtime already installs a registration hook for
   [[re-frame.hicasso.impl.collector/first-registration!]], so the counter
   is a `vswap!` on a hook that runs anyway rather than a new public
   reader on a production namespace. Monotone, like both other terms."
@@ -68,7 +67,7 @@
   runtime's flush [[generation]], plus `frame`'s own physical-install
   epoch (`re-frame.frame/frame-commit-epoch`, the substrate's read-evidence
   counter, bumped once per frame-state install
-  at both write chokepoints), plus the arm's [[registry-epoch]].
+  at both write chokepoints), plus the runtime's [[registry-epoch]].
 
   The generation alone cannot carry it, and the reason is structural
   rather than a matter of degree: the generation moves only through

--- a/implementation/hicasso/src/re_frame/hicasso/impl/intent.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/intent.cljs
@@ -26,8 +26,9 @@
 
   ## ONE callback form, and the position selects the contract (HD-024)
 
-  When a vector is not enough, the predecessor asks the author to pick
-  from a roster of FOUR forms, each with a different contract — one
+  When a vector is not enough, a roster design (the one this ruling
+  rejects) asks the author to pick from FOUR forms, each with a
+  different contract — one
   returning an event vector, one whose return is ignored, one that is
   pure and runs during a foreign render, one that passes a function
   through by identity — and then adds a FIFTH rule about *where the
@@ -80,7 +81,7 @@
   omit**: [[re-frame.hicasso.impl.codec/convert-prop-value]]
   already passes functions to React by identity, deliberately, so that
   `React.memo` and every downstream bail-out that compares handler
-  identity keep working. The behaviour the predecessor spells as a fourth
+  identity keep working. The behaviour a roster design spells as a fourth
   roster form is the default here. The census agrees with the omission —
   zero foreign components across 85 idiomatic files.
 
@@ -226,8 +227,7 @@
   deferral and `preventDefault`-then-dispatch stay routing's law, stated
   once. A hook that vanished between render and click (dev hot-reload of
   the routing artefact) degrades to native navigation — the browser
-  follows the real `href` — after running the veto, exactly as the
-  prototype's seam degraded.
+  follows the real `href` — after running the veto.
 
   The `:veto` slot is where the two heads compose, and the composition is
   the existing grammar: `[::h/prevent [:app/event]]` there lowers to the
@@ -271,7 +271,7 @@
   nil)
 
 (def ^:private ambient-frame-refusal
-  "The detail this arm hands core's refusal tier. One
+  "The detail this package hands core's refusal tier. One
   module-level constant, so the prose — which is nearly all of it — is
   built once at load and never per body. [[with-frame]] stamps the
   rendering boundary's own frame onto a copy of it; that
@@ -286,8 +286,9 @@
 
   IT HAS TO ADDRESS THREE DOORS, NOT TWO. The ambient scope is
   one door with three consumers — a read, a dispatch, and a CARRY — and
-  this text was written for the first two. An author who trips the refusal
-  through `rf/capture-frame` is doing neither: `capture-frame` is Spec
+  the reason's opening advice speaks to the first two. An author who
+  trips the refusal through `rf/capture-frame` is doing neither:
+  `capture-frame` is Spec
   002's *one public carry primitive*, and the reason its 0-arity resolves
   ambiently is to CAPTURE, not to read and not to dispatch. Advice that
   says \"read through the collector, dispatch through an intent\" names
@@ -318,7 +319,7 @@
 
 (defn with-frame
   "Run `body-fn` with the boundary's render context bound ambiently. Two
-  doors: an ARM binds both the frame keyword and its frame-locked
+  doors: the RUNTIME binds both the frame keyword and its frame-locked
   `dispatch` (the 3-arity — the one [[route-link]] and the navigate head
   need); a lowering test that only drives closures may bind the dispatch
   alone (the 2-arity), and anything frame-keyword-dependent it lowers
@@ -329,7 +330,7 @@
   where ambient `rf/subscribe` / `rf/dispatch` must stop resolving. It is
   bound HERE, fused into the binding this function already performs, rather
   than through `frame/call-with-ambient-frame-refused` around the call:
-  `binding` pushes and pops its whole set once, so the fence costs the arm
+  `binding` pushes and pops its whole set once, so the fence costs the runtime
   no additional frame — the general seam exists for substrates that are not
   already binding something.
 
@@ -343,10 +344,11 @@
   naming THIS boundary's frame still answers inside a body. The refusal
   deletes the ambient FIND, not the carrying.
 
-  A BODY HAS ONE FRAME, AND NOW BY CONSTRUCTION. The one thing
-  the sentence above did not cover: an `rf/with-frame :b` ENCLOSING a
-  boundary that renders `:a`. Core was behaving exactly as EP-0002 says —
-  `:b` was carried, so `:b` answered — but the boundary is rendering `:a`,
+  A BODY HAS ONE FRAME, BY CONSTRUCTION. The one case the
+  sentence above does not cover: an `rf/with-frame :b` ENCLOSING a
+  boundary that renders `:a`. Left to carrying alone, core behaves
+  exactly as EP-0002 says — `:b` is carried, so `:b` answers — but the
+  boundary is rendering `:a`,
   and the collector's reads, the lowered intents and the presence tray all
   target `:a`. One body, two frames, chosen by which spelling the author
   reached for, and silent. It is reachable from any host that renders a
@@ -421,7 +423,7 @@
   [[re-frame.hicasso/event]] is spelled `event`: the product
   name is qualified (`h/frame`), and a bare `frame` would shadow the
   `re-frame.frame` alias that this namespace — and every other namespace
-  in the arm — already carries.
+  in the package — already carries.
 
   ## What it is FOR, and the honest layering (design §6)
 
@@ -467,7 +469,7 @@
   [[*frame*]] is rebound to the
   **supplying** boundary while a foreign component invokes a render
   callback ([[render-callback]]), where the runtime's own `rstate.frame`
-  is nil — the foreign render runs outside the arm's render pass. So
+  is nil — the foreign render runs outside Hicasso's render pass. So
   reading the binding answers the OWNER's frame inside a render callback
   for free, and answers it immune to tree position, adapter, renderer and
   timing. [[re-frame.hicasso.impl.route-link/route-link]] is the
@@ -524,7 +526,7 @@
   can impose a contract on it — and returns `f` ITSELF, an ordinary
   function, which is the whole of the deletion.
 
-  The predecessor's roster carriers are marker OBJECTS, so handing one to
+  A roster design's carriers are marker OBJECTS, so handing one to
   a position the library does not walk produces the engine's own
   `TypeError` naming nothing the author wrote. There is nothing here that
   can fail to be callable: outside every walked position this value is a
@@ -763,9 +765,8 @@
 
 (defn- target-value
   "The event target's current value — `.value`, except on the two controls
-  where `.value` is not it. One is corrected, one is refused
- , and the difference between those two answers is the whole
-  of this docstring.
+  where `.value` is not it. One is corrected, one is refused, and the
+  difference between those two answers is the whole of this docstring.
 
   ## The file input, refused
 
@@ -815,7 +816,7 @@
 
   A selection is a LIST, and `[]` when nothing is picked. That is not
   invented here: `spec/004B-UI-Tree-and-Conversion.md` rules it for the
-  same DOM control on the sibling substrate — \"a `<select multiple>`'s
+  same DOM control in its conversion contract — \"a `<select multiple>`'s
   value is not a scalar — what is selected is the *list* of chosen option
   values\", with the empty selection the empty collection rather than
   `\"\"`. Fed straight back as `:value` it round-trips, because
@@ -899,7 +900,7 @@
   browser set it, and the modern half of this gate would never fire —
   leaving only the legacy signal, on browsers that happen to send it.
   Measured at
-  `arm1_controlled_grid_dom_cljs_test/reacts-synthetic-keyboard-event-drops-is-composing`.
+  `re-frame.bench.hicasso.arm1.controlled-grid-dom-cljs-test/reacts-synthetic-keyboard-event-drops-is-composing`.
 
   A raw DOM event has no `nativeEvent`, so it falls back to itself and
   the node-side unit tests read exactly as they did."
@@ -1254,11 +1255,10 @@
 (defn lower-declared-prop
   "Lower one prop whose contract a `defhost` declaration named — the
   position table's second row. Kept separate from [[lower-prop]] so the
-  declaration is what decides, rather than the prop's spelling: the
-  predecessor's own rule is that a host's callback contract is 'a finite
-  map from EXACT prop names to `:event` or `:handler`; never inferred
-  from an `on*` name', and that rule survives here because the position,
-  not the value, carries the contract.
+  declaration is what decides, rather than the prop's spelling: a
+  host's callback contract is a finite map from EXACT prop names to
+  `:event` or `:handler`, never inferred from an `on*` name — the
+  position, not the value, carries the contract.
 
   **The contract is the OUTER dispatch and the carrier the inner one**,
   which is the whole law made structural. Dispatching on the value first

--- a/implementation/hicasso/src/re_frame/hicasso/impl/inventory.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/inventory.cljs
@@ -3,7 +3,7 @@
   in one file so they can be read against each other.
 
   [[retained-inventory]] is the DECLARATION: every boundary-exclusive
-  token this arm holds, enumerated rather than asserted, plus the tokens
+  token this runtime holds, enumerated rather than asserted, plus the tokens
   that are emphatically shared and the ones that are absent. [[stats]],
   [[entry-buckets]] and [[residue]] are the MEASUREMENT, read off the
   live tables. A heap ladder is only as honest as the agreement between
@@ -37,7 +37,7 @@
             [re-frame.hicasso.impl.generation :as generation]))
 
 (defn retained-inventory
-  "Every boundary-exclusive token this arm retains, enumerated rather than
+  "Every boundary-exclusive token this runtime retains, enumerated rather than
   asserted (architecture.md, Arm 1). `:shared` names what is emphatically
   *not* per boundary, because that is the half a heap ladder reads wrong
   if nobody writes it down.
@@ -50,15 +50,15 @@
   every row a read sequence of its own and an entry of its own. Filed as
   `:shared` it would under-count per-boundary retention by one entry per
   boundary, on exactly the rung being measured, in the direction that
-  flatters this arm. Filed here it over-counts in the coincident-sequence
-  case, which is the direction a candidate's own instrument should err
+  flatters this runtime. Filed here it over-counts in the coincident-sequence
+  case, which is the direction the runtime's own instrument should err
   in.
 
   **The `:what` strings are DATA, held byte-for-byte against the measured
   table.** Thirteen of the fourteen are identical to
   `re-frame.bench.hicasso.arm1.runtime/retained-inventory`'s, and the
-  fourteenth — `:react/use-context` — differs only by the namespace the
-  copy renamed. That tree is the artefact the heap ladders were read off,
+  fourteenth — `:react/use-context` — differs only in the namespace it
+  names. That tree is the artefact the heap ladders were read off,
   so a ladder is compared against these rows on the assumption they still
   say what the measurement said. Rewriting one for its prose silently
   moves the baseline a published row was taken against; whoever needs one
@@ -180,7 +180,7 @@
 (defn residue
   "What must be zero after a clean teardown. `:cell-refs` is the standing
   zero-leaked-subscription-ref-counts assertion; `:boundaries` and
-  `:edges` are the dependency edges' half of it — now read off the same
+  `:edges` are the dependency edges' half of it — read off the same
   memberships, which is why a leak cannot show in one and hide in the
   other."
   []
@@ -196,7 +196,7 @@
   macrotask after an unclaimed render still counts entries the runtime
   is about to drop. A baseline taken there is a state the runtime never
   returns to, and an instrument gating on residue EQUALITY against it
-  throws on the first arm whose row outlives the horizon.
+  throws the first time an entry outlives the horizon.
 
   Exported so a caller settles against the runtime's own horizon rather
   than against a copy of it, because a copy drifts. Nothing here becomes

--- a/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
@@ -1,9 +1,10 @@
 (ns re-frame.hicasso.impl.mount
-  "ARM 1's ROOT — one operation, an idempotent teardown (HD-021(b)).
+  "THE PACKAGE'S ROOT — one operation, an idempotent teardown
+  (HD-021(b)).
 
   `root!` ENSURES a frame, associates it with a DOM node and a hiccup
   tree, and returns the handle every other door here takes. That is the
-  whole execution contract this arm needs; the names stay unfrozen
+  whole execution contract the package needs; the names stay unfrozen
   (HD-021 pins the semantics, not the spelling).
 
   ## Three of these vars ARE the public door
@@ -174,7 +175,7 @@
 ;; must be given the prefix its server render used, or every `useId` in
 ;; the tree resolves to a different string on the client and React
 ;; recovers by throwing the server's nodes away. Neither is a fact about
-;; this arm. These doors are what let a caller say the word.
+;; this package. These doors are what let a caller say the word.
 ;;
 ;; **The PREFIX's server half is React's too, and it needs no door
 ;; here.** It is spelled on whichever server caller bakes the bytes:
@@ -197,9 +198,9 @@
   nothing to say.
 
   Nil rather than an empty object, because both root doors branch on it
-  to call React's BARE arity — the arrangement [[hydrate-root!]] has
-  always had for production, where the reporter compiles away and the
-  shipped call is the two-argument one it was before any option existed.
+  to call React's BARE arity — the arrangement [[hydrate-root!]] relies
+  on for production, where the reporter compiles away and the shipped
+  call is the bare two-argument one.
 
   String keys through `unchecked-set`, for the reason the `displayName`
   stamps in this file use it: the string key is what keeps the property
@@ -225,10 +226,9 @@
   substrate's ENSURE boundaries and they already read exactly this way —
   *creates the frame if absent, REUSES it if present without re-seeding*,
   taking `rf/make-frame`'s own opts, `:initial-events` among them
-  (EP-0027). This arm was the odd one out: its client root could scope a
-  frame but never make one, so every consumer boot in the package wrote
-  `rf/make-frame` and then `root!` with the frame id spelled twice. Both
-  halves of that pair are here now, and `:initial-events` reaches
+  (EP-0027). This door reads the same way, so a consumer's boot line
+  names the frame id once — to the root door — rather than to
+  `rf/make-frame` and then again to `root!`. `:initial-events` reaches
   `make-frame` UNTOUCHED — no default, no coercion, no second spelling
   and no re-validation, the pass-through discipline
   [[root-options]] already applies to `:identifier-prefix`. EP-0027's
@@ -243,10 +243,10 @@
   the frame the first root created. The guide teaches the opposite in as
   many words (*\"a later root that names the same frame joins its current
   state and does not replay `:initial-events`\"*), so absence is asked
-  first. `frame/frame-incarnation-token` is the arm's own liveness
-  question — nil for absent, destroyed, or another actor's provisional
-  record — and it is what [[re-frame.hicasso.impl.frames/frame-row]]
-  already asks one layer down.
+  first. `frame/frame-incarnation-token` is the liveness question the
+  package asks — nil for absent, destroyed, or another actor's
+  provisional record — and it is what
+  [[re-frame.hicasso.impl.frames/frame-row]] already asks one layer down.
 
   ## Synchronous, and that is what buys \"before first paint\"
 
@@ -278,7 +278,7 @@
   [[ensure-frame!]] and before React renders anything — ordinary events,
   in the order given, run once when this mount CREATES the frame and
   never when it joins one. It is core's `:initial-events`
-  reaching `rf/make-frame` untouched, not a spelling this arm owns.
+  reaching `rf/make-frame` untouched, not a spelling this package owns.
 
   `:identifier-prefix` is handed straight to `createRoot` as React's
   `identifierPrefix`. A page mounting two roots gives them
@@ -327,7 +327,7 @@
 ;; component is a function, so the write was a type error the compiler
 ;; happens not to enforce. Both emit the same `(x["displayName"] = ...)`,
 ;; and it is the STRING key that keeps the property off Closure's renamer
-;; under `:advanced` — the reason the arm's other stamps
+;; under `:advanced` — the reason the package's other stamps
 ;; (`collector/mint-view!`, `codec/memoize-boundary!`) are spelled this way.
 (unchecked-set adoption-window-closer "displayName" "hicasso/adoption-window-closer")
 
@@ -337,17 +337,18 @@
 ;;
 ;; React reports the adoption divergences it RECOVERS FROM — a text
 ;; mismatch, or a missing / extra / wrong-type element — through the root's
-;; `onRecoverableError`. Left with no root options this door got React's
-;; DEFAULT handler, so a mismatch was an uncaught window error and NOTHING
-;; ELSE: Spec 011's `:rf.ssr/hydration-mismatch` never fired, and a mismatch
-;; was invisible to every tool that reads the instrumentation stream.
+;; `onRecoverableError`. With no root options that channel is React's
+;; DEFAULT handler, so a mismatch would be an uncaught window error and
+;; NOTHING ELSE: Spec 011's `:rf.ssr/hydration-mismatch` would never fire,
+;; and a mismatch would be invisible to every tool that reads the
+;; instrumentation stream. The reporter below is what closes that gap.
 ;;
-;; The shape below is the spine's (`re-frame.substrate.spine`,
-;; `native-hydration-reporter` / `hydrate-root-options`), because this arm is
-;; a React-element root exactly as a native UIx root is: no hashable client
-;; render-tree, so adoption IS the verification channel. Attribute-only
-;; divergences are outside it by React's own contract and stay outside it
-;; here (Spec 011 §Hydration-mismatch detection).
+;; The shape is the spine's (`re-frame.substrate.spine`,
+;; `native-hydration-reporter` / `hydrate-root-options`), because this
+;; package's root is a React-element root exactly as a native UIx root is:
+;; no hashable client render-tree, so adoption IS the verification channel.
+;; Attribute-only divergences are outside it by React's own contract and
+;; stay outside it here (Spec 011 §Hydration-mismatch detection).
 
 (defn- report-recoverable-default!
   "React's own default reporting, replicated.
@@ -397,9 +398,9 @@
       here would mislabel a completed root's later recovery whenever any
       sibling was still adopting** — which is what a page-global
       reference count would have bought.
-    - Never emitting is the other failure, and it is the one that was
-      shipping: a page-wide boolean let root A's closer silence root B's
-      genuine mismatch.
+    - Never emitting is the other failure: a page-wide BOOLEAN lets
+      root A's closer silence root B's genuine mismatch, which is why
+      the window is per-root rather than a page-wide flag.
 
   The delegation is unconditional in both cases — installing ANY
   `onRecoverableError` takes React's default off, so the fail-open rule
@@ -422,8 +423,8 @@
   `interop/debug-enabled?` and the only thing left to install would be a
   replica of the default React would have run anyway. The spine gates the
   same way, one clause wider: it also installs for a host-authored
-  `:on-recoverable-error`, and this arm has no host-authored callback to
-  compose with.
+  `:on-recoverable-error`, and this package has no host-authored callback
+  to compose with.
 
   **`:identifier-prefix` is NOT gated, and that asymmetry is the point.**
   The reporter is a diagnostic and a release build is
@@ -469,7 +470,7 @@
   subscription and needs no frame, and a nil-rendering component with no
   frame dependency is the smallest thing that can carry the effect.
 
-  ## It carries two root options — one the arm's, one the CALLER's
+  ## It carries two root options — one the package's, one the CALLER's
 
   [[hydration-reporter]] rides as the root's `onRecoverableError`, so a
   divergence React recovers from surfaces as Spec 011's
@@ -494,7 +495,7 @@
   ## Matching the prefix is NECESSARY and it is not SUFFICIENT
 
   The prefix half of the pair does meet in React's own vocabulary, and
-  needs nothing from this arm: a consumer names `identifierPrefix` on
+  needs nothing from this package: a consumer names `identifierPrefix` on
   `react-dom/server`'s own render and the same string here — the
   [[root-options]] section comment is where that is set out.
 
@@ -513,12 +514,13 @@
   decided once for both halves, the closer occupies the same tree
   position on both sides, and the adoption provider presence reads to
   start an adopted child `:present` rather than `:mounting` has its
-  server counterpart. `hydration-tree-parity-ssr-dom-cljs-test` is the
-  witness.
+  server counterpart. `re-frame.hicasso.server-render-ssr-dom-cljs-test`
+  is the witness — its rows pin the hydrating shape and that the entry's
+  bytes hydrate through `h/hydrate!` without a mismatch.
 
-  **This door is on the `re-frame.hicasso` facade as `h/hydrate!`**,
-  under naming-ledger row 13's `hydrate-root!`→`hydrate!` spelling and
-  row 20's `(node config view)` contract shape.
+  **This door is on the `re-frame.hicasso` facade as `h/hydrate!`** —
+  the spelling naming-ledger row 13 rules, over row 20's `(node config
+  view)` contract shape.
 
   ## The handle carries `:adoption` — this root's OWN window
 
@@ -536,7 +538,7 @@
 
   **Minted unconditionally, unlike the spine's** — which mints only when
   it is going to install a reporter, because its window has no other
-  reader. This arm's window has a PRODUCTION reader: presence starts an
+  reader. This window has a PRODUCTION reader: presence starts an
   adopted child `:present` rather than `:mounting`, which is behaviour a
   release build must keep. So the window and its provider ride in
   production and only the reporter is debug-gated."
@@ -563,7 +565,7 @@
   teardown that emptied the tables first answers `0` whether it released
   anything or not, and that is a gate that cannot go red.
   It is also what makes teardown ROOT-scoped in a multi-root page —
-  every table this arm holds is one-per-page and keyed by frame, so a
+  every table the package holds is one-per-page and keyed by frame, so a
   door that reset them would tear down every sibling root's state along
   with its own.
 
@@ -615,8 +617,8 @@
   nil)
 
 (defn dispatch!
-  "Dispatch through the arm's synchronous door and commit the echo. The
-  witness door; an intent written in a view reaches
+  "Dispatch through the package's synchronous door and commit the echo.
+  The witness door; an intent written in a view reaches
   `collector/dispatch!` on its own."
   [handle event]
   (collector/dispatch! (:frame handle) event)
@@ -632,6 +634,6 @@
 
 (defn browser?
   "Is there a real DOM here? `:node-test` has none, and every DOM claim in
-  this arm degrades to a stated skip there rather than a false green."
+  this package degrades to a stated skip there rather than a false green."
   []
   (and (exists? js/document) (some? (.-createElement js/document))))

--- a/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/overlay.cljs
@@ -10,8 +10,8 @@
   these components.** The ≤2-hook budget I9 polices is the *boundary
   shell's*, and neither of these is a boundary shell: they read no
   subscription, mount no registration and take no cell.
-  `collector/shell` is untouched and its dispatcher-level ledger still
-  counts exactly two there, which
+  `collector/shell`'s dispatcher-level ledger counts exactly two there
+  regardless, which
   `re-frame.hicasso.overlay-dom-cljs-test` asserts rather than assumes.
   `impl.presence-react` is the precedent and spends four; the ceiling's
   own words are that an optional capability may not add a hook *to every
@@ -95,13 +95,13 @@
   handler takes only `newState == \"closed\"` — the one filter in the file,
   and the sabotage that widens it dispatches `:on-dismiss` on OPEN.
 
-  A first draft carried a second guard, a per-node mark set before the
-  module's own `hidePopover()` so a teardown could not be read as a
-  dismissal. **No sabotage could redden it**: React does not deliver an
-  event from a fiber it is in the middle of deleting, so the case never
-  arises. The mark is gone and the measurement replaced it — the teardown
-  rows of `re-frame.hicasso.overlay-dom-cljs-test` red the day that stops
-  being true."
+  There is deliberately no second guard — no per-node mark set before
+  the module's own `hidePopover()` to keep a teardown from being read as
+  a dismissal. **No sabotage could redden one**: React does not deliver
+  an event from a fiber it is in the middle of deleting, so the case
+  never arises. The measurement stands where the mark would — the
+  teardown rows of `re-frame.hicasso.overlay-dom-cljs-test` red the day
+  that stops being true."
   (:require [re-frame.adapter.context :as adapter-context]
             [re-frame.hicasso.impl.codec :as codec]
             [re-frame.hicasso.impl.collector :as collector]
@@ -195,11 +195,12 @@
   name.
 
   **No `:anchor` is nil; an `:anchor` that names no element REFUSES.**
-  The two are not one absence, and answering nil to both is
-  what made the second invisible: an author who wrote no anchor asked for
-  the UA's default position and got it, while an author who wrote one
-  asked to be positioned against a trigger and got that same default in
-  silence. A typo in a DOM id read exactly like a design choice.
+  The two are not one absence, and answering nil to both would make
+  the second invisible: an author who writes no anchor asks for the
+  UA's default position and gets it, while an author who writes one
+  asks to be positioned against a trigger and would get that same
+  default in silence. A typo in a DOM id would read exactly like a
+  design choice.
 
   It refuses from the REF CALLBACK, which is the only place the question
   can be asked: the id resolves against a document React has already
@@ -518,14 +519,14 @@
   a Tab that does nothing.
 
   **That confirmation is a floor, and reading it as a licence to feed
-  this a loose candidate set is the mistake this handler made twice.**
+  this a loose candidate set is the standing trap here.**
   It saves a wrap aimed at nothing. It cannot save one aimed at the
   wrong CONTROL — and it cannot save the case where a surplus candidate
-  is never aimed at at all, because the surplus DISPLACED THE EDGE and
-  the press off the real edge matches nothing. The second is the subtler
-  one and cost two beads: the failure happens one step before the
-  landing this confirmation guards, so no amount of care here reaches
-  it. [[sequential-tab-stops]] carries that account.
+  is never aimed at at all, because the surplus DISPLACES THE EDGE and
+  the press off the real edge matches nothing. The second is the
+  subtler failure: it happens one step before the landing this
+  confirmation guards, so no amount of care here reaches it.
+  [[sequential-tab-stops]] carries that account.
 
   A press a control inside the panel has already claimed is left alone:
   the native event's `defaultPrevented` is read rather than the synthetic
@@ -534,9 +535,9 @@
 
   **First and last are read off SEQUENTIAL order, not document order.**
   They are different lists — a radio group is three elements and one
-  stop — and taking the second for the first is how this handler came to
-  send Tab from a modal's last control onto an unchecked radio, and
-  Shift+Tab from its checked one onto `<body>`."
+  stop — and taking document order for sequential sends Tab from a
+  modal's last control onto an unchecked radio, and Shift+Tab from its
+  checked one onto `<body>`."
   [^js e]
   (when (and (= "Tab" (.-key e))
              (not (.. e -nativeEvent -defaultPrevented)))
@@ -611,7 +612,7 @@
                 claimed (claim-anchor! (unchecked-get cell "anchorId") ident)]
             (unchecked-set cell "claimed" claimed)
             ;; BOTH HALVES OF ONE CLAIM, OR NEITHER. `claim-anchor!`
-            ;; answers nil for exactly one case now — no `:anchor` at
+            ;; answers nil for exactly one case — no `:anchor` at
             ;; all — because an `:anchor` that names no element raises
             ;; `:rf.error/hicasso-overlay-anchor-missing` rather than
             ;; returning. Writing the panel's half alone
@@ -638,15 +639,14 @@
   `:on-dismiss` when the overlay OPENS, which is the wrong direction this
   filter exists to stop.
 
-  **The module's own teardown needs no filter, and that was measured
-  rather than reasoned.** `hidePopover()` in the ref cleanup does fire the
-  identical event, so a first draft carried a per-node closing mark to
-  tell the two apart — and no sabotage could redden that mark, because
-  React does not deliver an event from a fiber it is in the middle of
-  deleting. It was unreachable code defending a case that does not arise,
-  and it is gone. `re-frame.hicasso.overlay-dom-cljs-test` holds the
-  measurement rather than the mark: the teardown rows red the day it stops
-  being true.
+  **The module's own teardown needs no filter, and that is measured
+  rather than reasoned.** `hidePopover()` in the ref cleanup does fire
+  the identical event, so a per-node closing mark to tell the two apart
+  looks necessary — and is not, because React does not deliver an event
+  from a fiber it is in the middle of deleting. Such a mark would be
+  unreachable code defending a case that does not arise.
+  `re-frame.hicasso.overlay-dom-cljs-test` holds the measurement rather
+  than a mark: the teardown rows red the day it stops being true.
 
   A fresh closure per render, deliberately: it closes over the intent and
   the frame dispatch THIS render saw, so an overlay whose `:on-dismiss`

--- a/implementation/hicasso/src/re_frame/hicasso/impl/portal.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/portal.cljs
@@ -44,7 +44,8 @@
   `:server` describes [[portal-body]] — the component the head renders —
   and that component *is* safe to run on the server: on the server it
   renders the caller's `:fallback`, or nothing, and never reaches for a
-  container. The published matrix row (`Portal helper | Client-only`)
+  container. The published matrix row (dispositions.md HS-20,
+  `Portal helper | Client-only`)
   describes the SURFACE, and the surface is client-only because the
   portalled subtree never reaches the response.
 

--- a/implementation/hicasso/src/re_frame/hicasso/impl/presence.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/presence.cljs
@@ -86,8 +86,8 @@
 ;; are this module's vocabulary, but the codec's prop walk has to
 ;; recognise them — it is where an override written OUT OF THIS
 ;; MODULE'S REACH is refused — and this namespace requires the codec
-;; rather than the other way round. One home, so the respelling
-;; `naming-ledger.md` row 31 holds open cannot land on half of them.
+;; rather than the other way round. One home, so a respelling of the
+;; pair — naming-ledger row 31's to settle — cannot land on half of them.
 
 (def mounting-key
   "`::h/mounting` — the attribute overrides applied while a child is

--- a/implementation/hicasso/src/re_frame/hicasso/impl/presence_react.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/presence_react.cljs
@@ -13,7 +13,7 @@
   `collector/shell` is untouched and the dispatcher-level ledger still
   counts exactly two there. The second `useContext` is the root-scoped
   adoption window; it is paid HERE, by the optional component that reads
-  it, and nowhere else in the arm.
+  it, and nowhere else in the package.
 
   The two lifecycle hooks are legitimate under HD-003's placement rule
   rather than in spite of it: presence is animation lifecycle, which is
@@ -29,23 +29,23 @@
   body — but it is **lowered in THIS component's render**, one React
   render later, after that body's dynamic extent has unwound. So
   `intent/*dispatch*` is unbound at the moment the codec walks it, and
-  before this hook existed an intent at an event position on ANY presence
-  child raised `:rf.error/hicasso-intent-outside-boundary` at render, and
-  an `h/event` at one raised it at invocation. Loud, never silent — and it
-  meant the tray this whole ruling is sold on,
+  without this hook an intent at an event position on ANY presence
+  child would raise `:rf.error/hicasso-intent-outside-boundary` at
+  render, and an `h/event` at one would raise it at invocation. Loud,
+  never silent — but it would mean the tray this whole ruling is sold on,
 
       [:div.toast {:key id :on-click [:toasts/dismiss id]} …]
 
-  could not be written. The retained half is where it bit hardest: a
-  child the author has already removed from app-db is still on screen and
-  still clickable for `:timeout-ms`, and its dismiss button is exactly
-  the control an exiting toast wants.
+  could not be written. The retained half is where it would bite
+  hardest: a child the author has already removed from app-db is still
+  on screen and still clickable for `:timeout-ms`, and its dismiss
+  button is exactly the control an exiting toast wants.
 
   The frame is therefore resolved once, from the substrate's single
   internal context — the same object `collector/shell` reads and
-  `arm1.boundary` takes through `contextType` — and re-bound around the
-  one `as-element` call below, with `collector/frame-dispatch`'s memoised
-  frame-locked dispatch. That is HD-020(a)'s rule applied where the
+  `impl.boundary`'s class takes through `contextType` — and re-bound
+  around the one `as-element` call below, with
+  `collector/frame-dispatch`'s memoised frame-locked dispatch. That is HD-020(a)'s rule applied where the
   lowering actually happens rather than where the hiccup was written.
 
   **No frame in scope is not an error here.** Presence reads nothing, so
@@ -61,8 +61,9 @@
   every pass and the terminal bound stops being terminal. But a value
   derived from props does not need an effect to store it: React's own
   guidance is to adjust state *while rendering* when a prop changes, and
-  that is what happens here — [[front.presence/step]] is idempotent, so
-  the comparison converges after one extra pass and never loops. An
+  that is what happens here — [[re-frame.hicasso.impl.presence/step]] is
+  idempotent, so the comparison converges after one extra pass and never
+  loops. An
   effect would cost a paint with the wrong tree in it.
 
   The effect that remains does the two things only a clock can: it flips
@@ -118,7 +119,8 @@
         ;; client pass render each child's `::h/mounting` overrides
         ;; (`opacity: 0`, typically) over DOM that carries none.
         ;;
-        ;; The fix is the machine's own [[front.presence/settle]], the
+        ;; The fix is the machine's own
+        ;; [[re-frame.hicasso.impl.presence/settle]], the
         ;; function the enter flip already uses, applied one render
         ;; earlier. So this is ADOPTION BEHAVIOUR — a different starting
         ;; phase for a tree that is being adopted — and not a second

--- a/implementation/hicasso/src/re_frame/hicasso/impl/roots.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/roots.cljs
@@ -108,8 +108,8 @@
   ;; which [[adopting?]] reads as closed — so every tree with no provider
   ;; above it (every ordinary mount, every Hicasso boundary anywhere) gets
   ;; the right answer with no provider, no object and no branch. Only a
-  ;; hydrating root installs one. This is the shape the compiled tier's
-  ;; phase context already uses for the same fact.
+  ;; hydrating root installs one — the same absence-means-closed discipline
+  ;; `re-frame.substrate.spine` holds its root-local adoption flag to.
   (react/createContext nil))
 
 (defn with-adoption

--- a/implementation/hicasso/src/re_frame/hicasso/impl/route_link.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/route_link.cljs
@@ -15,8 +15,7 @@
 
   ## A plain function, deliberately — not a boundary
 
-  Freehand's `v/route-link` is a `defview`; here that would be the wrong
-  citation. A Hicasso boundary costs two hooks and a row in every
+  A Hicasso boundary costs two hooks and a row in every
   boundary count, and the census's 106 links live INSIDE rows that are
   already boundaries — an author byline is not a unit of re-render. So
   `route-link` is a plain function like
@@ -36,14 +35,15 @@
     the same two
     definitions, and the packaging graph stays
     `hicasso -> core late-bind <- routing` (Conventions §Packaging).
-  - **From Freehand (taken): render-time capture and render-time
+  - **Owned here: render-time capture and render-time
     refusal.** The frame is captured at RENDER (a click fires after the
     render scope has unwound); a missing routing artefact fails at the
     LINK SITE with `:rf.error/routing-artefact-missing`; and the
-    route-click one-intent law is kept — see [[on-click-roster!]].
-    **(Declined:** the fn-only `:on-click` roster. Freehand narrows to
-    fn / `v/handler` because it has no in-band spelling for
-    \"cancel-and-replace\"; Hicasso does — `[::h/prevent [:app/event]]`
+    route-click one-intent law holds — the click produces the one
+    routing intent, see [[on-click-roster!]].
+    **(Declined:** a fn-only `:on-click` roster. That narrowing is only
+    forced on a surface with no in-band spelling for
+    \"cancel-and-replace\"; Hicasso has one — `[::h/prevent [:app/event]]`
     is the declarative veto, and it is admitted.**)**
   - **From Replicant (taken, via HD-026): behaviour as a
     namespaced-keyword-headed vector.** The anchor's click carries a
@@ -150,7 +150,7 @@
   at the site that wrote the link, with the render stack, before any
   anchor exists. A BARE intent vector is the taught mistake and gets the
   teaching diagnostic: the click already produces the one routing intent
-  (Freehand's route-link law, kept)."
+  — the route-click one-intent law."
   [on-click]
   (when-not (or (nil? on-click)
                 (intent/prevent-head? on-click)

--- a/implementation/hicasso/src/re_frame/hicasso/impl/state.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/state.cljc
@@ -71,14 +71,14 @@
   must be recorded — retire the concern and write a named domain event.
   This sugar is for the assignments that mean nothing but themselves.
 
-  ## What was REJECTED, and stays rejected
+  ## Clear is an EVENT, never a sentinel value
 
   Clear is a FRAMEWORK-NAMED EVENT, `[::h/clear ::concern ikey]`, and not
-  a sentinel VALUE. The rejected variant put `::h/clear` in the value
+  a sentinel VALUE. A sentinel would put `::h/clear` in the value
   position of the ordinary setter — which reads beautifully right up to
   the first concern whose values are keywords, at which point setting the
   concern to a legitimate value would silently `dissoc` it instead. That
-  is a fail-silent hazard of exactly the class this whole ruling exists to
+  is a fail-silent hazard of exactly the class this namespace exists to
   delete, so there is no sentinel here and no \"convenience\" arity that
   accepts one."
   (:require [re-frame.events :as events]
@@ -101,7 +101,7 @@
   :re-frame.hicasso/clear)
 
 ;; ---------------------------------------------------------------------------
-;; Errors — the lane's shape (front.presence/fail!)
+;; Errors
 ;; ---------------------------------------------------------------------------
 
 ;; `fail!` is `re-frame.hicasso.impl.error`'s — one constructor for the whole
@@ -242,8 +242,8 @@
   refresh, which is what a namespace reload is. Re-registering it with a
   DIFFERENT `:default` **refuses**: the un-set instances of a live widget
   would otherwise start reading a different value with nothing on screen
-  to say why. That is the stricter of the two behaviours the ruling
-  allowed, and its cost is honest — changing a `:default` in a
+  to say why. That is deliberately the stricter of the two defensible
+  behaviours, and its cost is honest — changing a `:default` in a
   hot-reloading dev session needs a page reload.
 
   Returns `concern`.

--- a/implementation/hicasso/src/re_frame/hicasso/motion.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/motion.cljs
@@ -81,9 +81,9 @@
   `impl.presence-react` as their emitter, so the two files stay put.
 
   **The override keys are `::h/mounting` and `::h/unmounting`**, as the
-  example above shows. The door moved to this namespace; the vocabulary
-  did not, and a respelling to `::motion/…` waits on the naming ledger
-  (row 31)."
+  example above shows — the `re-frame.hicasso` spellings, even under this
+  door; naming-ledger row 31 is where a respelling to `::motion/…` would
+  be settled."
   (:require [re-frame.hicasso.impl.presence-react :as impl-presence-react]))
 
 (def ^{:doc "`motion/presence` — retain exiting keyed children for

--- a/implementation/hicasso/src/re_frame/hicasso/native.cljc
+++ b/implementation/hicasso/src/re_frame/hicasso/native.cljc
@@ -73,9 +73,8 @@
   it carries the package's one refusal shape whole — id, the fn that
   refused, the reason, an actionable recovery, and the ambient view and
   coordinate
-  when a declaration extent is open. Seven ids — five reserved for this
-  tier by the complaint register before it existed, plus the two the
-  declaration door minted when it gained its rosters:
+  when a declaration extent is open. Seven ids, every one registered in
+  the package's complaint register:
 
   | Id | Raised when |
   |---|---|
@@ -185,9 +184,9 @@
   | [[declared-server]] | [[defcomponent]] emits a call to it, likewise — and deliberately at LOAD rather than at expansion, so the refusal carries the declaration's coordinate |
   | [[prop-slots]] | named by NO expansion — both callers are in this file — and public for a different reason: the three-way parity row drives the shared rule as its own arm, and a fixture reaching it only through one of its two callers would be pinning that caller |
 
-  Everything else in this namespace is private, and [[check-child!]]
-  joined them here: it is named by no expansion, reached by nothing
-  outside this file, and its publicity bought nothing."
+  Everything else in this namespace is private, [[check-child!]]
+  included: it is named by no expansion and reached by nothing outside
+  this file, so publicity would buy it nothing."
   (:require [re-frame.hicasso.impl.error :as error]
             [re-frame.hicasso.impl.slot :as slot])
   #?(:clj (:require [re-frame.source-coords :as source-coords]))
@@ -293,10 +292,10 @@
   ClojureScript seqs, which are ES6-iterable and are therefore React
   children already.
 
-  **Private, and that is a classification rather than a narrowing.**
-  Its two callers are both in this file — [[$]] on child
-  FORMS at expansion, [[checked]] on values at render — so no expansion
-  names it in a consumer's namespace and nothing outside reaches it."
+  **Private, and that is a classification.** Its two callers are both
+  in this file — [[$]] on child FORMS at expansion, [[checked]] on
+  values at render — so no expansion names it in a consumer's namespace
+  and nothing outside reaches it."
   [c where]
   (cond
     (map? c)
@@ -348,7 +347,7 @@
        "`React.createElement`, reached from an [[$]] expansion.
 
   The macro knows the child count statically, so the common shapes are
-  fixed arities and only six-or-more children pay for an array. Not a
+  fixed arities and only four-or-more children pay for an array. Not a
   consumer surface: write [[$]], which is the form the fence is defined
   on."
        ([type props] (react/createElement type props))
@@ -402,9 +401,8 @@
        #{:client-only :render})
 
      (defn declared-server
-       "The `:server` policy `decl` carries, VALIDATED — the two rosters
-  `mint-host!` has, at the one declaration door in the package that had
-  neither.
+       "The `:server` policy `decl` carries, VALIDATED — the same two
+  rosters `mint-host!` holds the `defhost` door to.
 
   Absent means `:client-only`: the conservative answer, so an author who
   writes nothing and an author who writes the default explicitly get the
@@ -420,7 +418,7 @@
   at all, so a compile-time refusal would be witnessed by nothing this
   repo runs.
 
-  ## And it is now READ
+  ## And it is READ
 
   The value is stamped on the tier marker, where a tool reads it, and
   [[component]] branches on it: `:render` answers the author's own
@@ -735,11 +733,11 @@
   the first pass of a fresh mount. The chunk is a client artefact and the
   server never reaches for one.
 
-  **That gate is the mechanism and the marker merely describes it.** The
-  marker alone was the defect: React's `lazyInitializer` runs during
+  **That gate is the mechanism and the marker merely describes it.** A
+  marker alone enforces nothing: React's `lazyInitializer` runs during
   `renderToString` like any other render, so an ungated head reached from
   a native parent — `(n/$ heavy-chart …)` under a `:render` island —
-  fetched the chunk on the server and wrote React's switched-to-client
+  fetches the chunk on the server and writes React's switched-to-client
   template into the response. Measured in
   [[re-frame.hicasso.lazy-boundary-dom-cljs-test]], whose control renders
   a raw `react/lazy` in the same shape and counts the call this one does

--- a/implementation/hicasso/src/re_frame/hicasso/overlay.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/overlay.cljs
@@ -68,8 +68,8 @@
 
   ## What follows from the posture, and is witnessed
 
-  `re-frame.hicasso.overlay-dom-cljs-test` is the witness; each claim
-  below names the row that holds it, and the browser lane is where they
+  `re-frame.hicasso.overlay-dom-cljs-test` is the witness for the claims
+  below, and the browser lane is where they
   are decided — the node lane has no top layer, so every claim about one
   degrades to a stated skip there.
 
@@ -164,13 +164,13 @@
   ## An `:anchor` that names no element REFUSES
 
   The alternative is a silent no-op — the panel opening in the top layer
-  at the UA's default position, visibly unanchored, saying nothing. Per
-  `implementation/hicasso/spec/complaints.md` promoting the reservation
-  is ONE act and not three: the emitter, the `spec/009-Instrumentation.md`
-  row and the move of the register row to `live` land together, because
-  R3 and R6 of `check_complaint_catalogue.py` red on either half alone.
-  The spelling is the naming packet's — ledger rows 30 and 40 apply their
-  defaults, and row 30 records it as the corpus's single deliberate mint.
+  at the UA's default position, visibly unanchored, saying nothing.
+  `:rf.error/hicasso-overlay-anchor-missing` is a live row of
+  `implementation/hicasso/spec/complaints.md` and of
+  `spec/009-Instrumentation.md`'s catalogue, and
+  `check_complaint_catalogue.py` holds the emitter and both rows in
+  step; naming-ledger row 30 records the id as the corpus's single
+  deliberate mint.
 
   `:rf.error/hicasso-overlay-anchor-missing` is raised from
   [[re-frame.hicasso.impl.overlay/claim-anchor!]] — the ref callback, the
@@ -179,7 +179,7 @@
   one is asking for the default position rather than failing to find a
   trigger.
 
-  ## `:exit-ms` is still not here
+  ## `:exit-ms` is deliberately not here
 
   Retaining a leaving node for its exit animation is
   `re-frame.hicasso.motion`'s subject and already has a machine, a

--- a/implementation/hicasso/src/re_frame/hicasso/server.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/server.cljs
@@ -112,8 +112,8 @@
   once. Mirroring the fork here instead would have re-created the exact
   failure the repair is for, one file further along.
 
-  The second candidate stays unruled and is not foreclosed: making the
-  closer a wrapper would change the client tree and this module would
+  The second candidate repair — making the closer a wrapper — is not
+  foreclosed: it would change the client tree and this module would
   follow it for free, because it does not know what the shape is.
 
   ## The adoption window is OPEN around `renderToString`
@@ -121,8 +121,8 @@
   A server render is the FIRST HALF OF AN ADOPTION, so it runs in the
   window the client's hydrating half runs in — one window per request,
   scoped over that request's tree. `impl.roots/open-adoption-window!`
-  names this module as the second minter and records it as *decided,
-  not built*; this is the building.
+  names this module as one of the window's TWO minters, beside the
+  hydrating client root.
 
   Without it the two halves disagree about motion. Presence starts a
   child `:mounting` and applies that child's `::h/mounting` attribute
@@ -180,8 +180,8 @@
   This module is that tier: `codec/root-element` hands React an element
   and the tree is walked INSIDE `renderToString`, so at no point does a
   data tree describing the page exist for anything to hash. The
-  prototype measured what a hash here would be worth — the dogfood
-  screen and a ~1,200-element feed page both hashed `83b865f8`, because
+  measured worth of a hash here is nothing — the dogfood
+  screen and a ~1,200-element feed page both hash `83b865f8`, because
   the root's canonical form is `[#fn[] {}]` — and a constant that always
   agrees is a fail-open gate wearing the shape of a check.
 
@@ -205,8 +205,11 @@
   mirrors that shell's envelope closely enough to be recognisable and
   is deliberately minimal: no head model, no attribute bags, no
   `:body-end` hook. **No streaming** — `renderToPipeableStream` is out
-  of scope per the adversarial review, and out of scope here means
-  absent, not deferred."
+  of scope for this module, and out of scope here means absent, not
+  deferred: every request-written owner is safe precisely because the
+  render never awaits — the S3 property
+  `docs/design/hicasso/product/globals.md` records — and adopting a
+  streaming renderer is the one change that would put that at risk."
   (:require [re-frame.core :as rf]
             [re-frame.hicasso.impl.mount :as mount]
             [re-frame.hicasso.impl.roots :as roots]

--- a/implementation/hicasso/src/re_frame/hicasso/substrate.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/substrate.cljs
@@ -35,7 +35,7 @@
   every deref, which is right for a headless SSR render and wrong under a live
   view. `re-frame.hicasso.impl.collector/wire-cell!` installs a watch on the
   reaction it subscribes and marks its cell dirty when the value moves; under
-  plain-atom that watch fires never, so the arm paints once and is deaf
+  plain-atom that watch fires never, so the runtime paints once and is deaf
   thereafter.
 
   Watchability alone would not settle it either. A `reagent.ratom/Reaction` is

--- a/implementation/hicasso/src/re_frame/hicasso/tool.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/tool.cljs
@@ -98,8 +98,9 @@
   because the classification model is fail-open — an event that declared
   nothing ships its arguments raw through the egress chokepoint — and a
   door that promised *no application data* while routing an undeclared
-  payload through would be making the promise falsely. The suite's
-  seeded-value row caught exactly that before this door shipped.
+  payload through would be making the promise falsely.
+  `re-frame.hicasso.tool-reads-cljs-test/no-read-carries-a-value` seeds
+  a secret and pins exactly that.
 
   **No read VALUE is carried by any read here, at all.** What a boundary
   read is a fact about the boundary; what it read AS is arbitrary
@@ -498,16 +499,15 @@
   "One retained run, as an intent row: WHICH event, and how many arguments
   it carried — never the arguments themselves.
 
-  **This is the one place the door was measurably wrong before its own
-  witness ran, and the correction is worth stating.** Carrying the
-  dispatched VECTOR through
+  **The dispatched VECTOR is deliberately not carried through
   `classification/redact-event-by-registration` — the single event-vector
-  egress chokepoint, and the obvious thing to reach for — leaks. The
-  chokepoint applies the classification the event's REGISTRATION declared,
-  and EP-0025's model is fail-open: an event that declared nothing ships
-  its arguments raw. So a seeded secret dispatched under an unclassified
-  event id reached this envelope verbatim, and the suite's seeded-value
-  row caught it.
+  egress chokepoint, and the obvious thing to reach for — because that
+  path leaks.** The chokepoint applies the classification the event's
+  REGISTRATION declared, and EP-0025's model is fail-open: an event that
+  declared nothing ships its arguments raw. A seeded secret dispatched
+  under an unclassified event id would reach this envelope verbatim, and
+  `re-frame.hicasso.tool-reads-cljs-test/no-read-carries-a-value` pins
+  that it does not.
 
   An id and an arity are enough for the question this read answers —
   *what was dispatched, in what order* — and they make the door's promise
@@ -558,10 +558,10 @@
 
   The id is allocated process-monotonically at queue time
   (`re-frame.router`), so it IS the dispatch order across every frame —
-  which is what lets this read promise order and mean it. The previous
-  shape concatenated whole per-frame rings in frame-id ORDER, so with two
-  frames live the stream claimed a sequence that never happened; frame-id
-  order is alphabetical, not temporal.
+  which is what lets this read promise order and mean it. Concatenating
+  whole per-frame rings would not: with two frames live the stream would
+  claim a sequence that never happened, because frame-id order is
+  alphabetical, not temporal.
 
   A row whose bundle carries no id cannot be joined or placed, so it
   keeps its own identity and sorts last rather than merging with every


### PR DESCRIPTION
## What this is

A file-by-file comment and docstring polish of `implementation/hicasso/src` — 27 of its 28 files. Prose-only: no code form, no non-docstring string, no reordering; `git diff` shows +577/−565 across docstrings and `;;` comments.

## What changed

- change-narration ("previously", "was replaced by", "the copy renamed") rewritten as timeless present-tense description, keeping the why each note carried
- tracker ids, audit references, PR numbers and bare dates removed, with the evidence restated in place (the pinning test cited by namespace where one exists)
- bench-experiment vocabulary (arm / candidate / donor / predecessor / incumbent) recast as package vocabulary where it narrated history; live bench witness citations kept
- dead references repaired to verified live ones: `front/controlled_dom_cljs_test` → `re-frame.hicasso.controlled-dom-cljs-test`, `hydration-tree-parity-ssr-dom-cljs-test` → `re-frame.hicasso.server-render-ssr-dom-cljs-test`, `front.codec`/`front.intent`/`front.presence` wikilinks → their `impl.*` homes, retired `re-frame.observation` and compiled-tier references generalised onto their stated reasoning
- genuine docstring defects fixed: `native.cljc` `el` arity claim (four-or-more children allocate, not six-or-more), two garbled sentences in `impl/collector.cljs`, a stale forms draft-guide path now pointing at `docs/core/hicasso/05-forms.md`

## Deliberately unchanged

- `impl/slot.cljc` — the last donor-pinned row of `frozen-sources.edn`; any edit trips the freeze gate's sunset clause, which is a ruling (tracked separately), not a polish
- `retained-inventory`'s `:what` strings in `impl/inventory.cljs` — measured data held against the bench baseline; its own contract is re-measure, never re-word
- the `rf2:builder-bypass-ok` marker block in `impl/error.cljc` — machine-read by `check_thrown_error_messages.py`, byte-for-byte
- design-record ids (HD-nnn, naming-ledger rows, EP-nnnn, D016) — verified to exist before being kept

## Verification

Run in this branch's worktree:

- `check_freeze.py` (self-test + run): green — the pinned row still matches its donor
- `check_lint_export.py`, `check_optional_module_reachability.py`, `check_complaint_catalogue.py`: green — emit-site anchors undisturbed
- `shadow-cljs compile node-test browser-test`: both green, 0 warnings (1,995 and 1,084 files) — no reader/delimiter damage

Anchors and citations in the edited prose were verified by hand against the tree (the doc link gates do not cover source docstrings).