### PR TITLE
test(hicasso): coverage and quality review — close the clear gaps (rf2-dr90)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/activity_suspense_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/activity_suspense_cljs_test.cljs
@@ -437,6 +437,32 @@
                (done))))))
 
 ;; ---------------------------------------------------------------------------
+;; 1c. The fence's own terminal refusal
+;; ---------------------------------------------------------------------------
+
+(deftest a-body-that-writes-on-every-run-exhausts-the-fence-and-is-refused-by-id
+  (seeded!)
+  (testing "[[writing-body]]'s docstring names the case: the generation
+            fence re-runs a body that observed a new commit, and a body
+            that writes on EVERY run cannot be fenced. The refusal is the
+            retry loop's own terminal arm, and nothing in the shipped
+            tree had ever driven it — the only exercise was the fenced
+            bench twin's, by message regex, against its own copy of the
+            runtime"
+    (let [always-writer (fn writer [_]
+                          (rf/with-frame frame-id (rf/dispatch-sync [:acs/bump :a]))
+                          [:p "writer"])
+          data          (try
+                          (collector/render-body frame-id always-writer {})
+                          ::returned-without-refusing
+                          (catch :default e (ex-data e)))]
+      (is (= :rf.error/hicasso-generation-fence-exhausted (:rf.error/id data)))
+      (is (= 're-frame.hicasso.impl.collector/render-body (:where data)))
+      (is (= :move-the-write-out-of-the-render (:recovery data)))
+      (is (= frame-id (:frame data))
+          "the refusal names the frame whose commits kept landing"))))
+
+;; ---------------------------------------------------------------------------
 ;; 2. Hidden work publishes no read sets
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/hicasso/test/re_frame/hicasso/client_only_arms_ssr_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/client_only_arms_ssr_cljs_test.cljs
@@ -205,6 +205,47 @@
     [:h2.title "Delete this invoice?"]
     [:button.confirm "Delete"]]])
 
+(h/defview undismissable-modal-page
+  "The `closedby` ladder's no-dismissal arm: with no `:on-dismiss` there
+  is nowhere to route a close request, so the dialog is told to honour
+  none and the open flag cannot acquire a second owner."
+  []
+  [:div.owner
+   [overlay/modal {:open? (h/sub [:hicasso.arms/open?])
+                   :label "Processing"}
+    [:p.wait "Do not close this tab."]]])
+
+(h/defview light-dismiss-modal-page
+  "The ladder's opt-in arm: `:light-dismiss?` widens `closedby` to the
+  platform's `any`, so a backdrop click can dismiss."
+  []
+  [:div.owner
+   [overlay/modal {:open?          (h/sub [:hicasso.arms/open?])
+                   :on-dismiss     [:invoice/cancelled]
+                   :light-dismiss? true
+                   :label          "Quick filter"}
+    [:p.hint "Click anywhere outside to dismiss."]]])
+
+(h/defview manual-popover-page
+  "The popover half of the same choice: no `:on-dismiss` means `manual` —
+  in the top layer, dismissing for nothing."
+  []
+  [:div.owner
+   [overlay/popover {:open? (h/sub [:hicasso.arms/open?])}
+    [:ul {:role "menu"} [:li.choice "Unread"]]]])
+
+(h/defview author-placed-popover-page
+  "An author's `:style {:position-area …}` written beside the
+  `:placement` that also produces one — `element-attrs`' documented
+  precedence subject."
+  []
+  [:div.owner
+   [overlay/popover {:open?      (h/sub [:hicasso.arms/open?])
+                     :on-dismiss [:menu/dismissed]
+                     :placement  :bottom-start
+                     :style      {:position-area "block-start"}}
+    [:ul {:role "menu"} [:li.choice "Unread"]]]])
+
 (h/defview island
   "The Hicasso boundary that sits UNDER the Activity host, so that a row
   measuring bytes is measuring a real read rather than a literal."
@@ -362,6 +403,44 @@
       (is (not (re-find #"<dialog[^>]* open" html))
           (str "and no `open` attribute, so the engine paints none of it
                 until `showModal` runs on the client: " html)))))
+
+(deftest the-dismissal-word-ladder-is-complete-in-the-server-bytes
+  (testing "the rows above pin the DEFAULT arms — `closerequest` on the
+            modal and `auto` on the popover. These are the other three,
+            which nothing had ever exercised: the whole dismissal policy
+            is one platform attribute, so each arm is decidable as server
+            bytes, and an arm that rots is a desync between the app's
+            open flag and the platform's own close behaviour"
+    (testing "a modal with no :on-dismiss honours no close request"
+      (fresh! true)
+      (let [html (server-html [undismissable-modal-page {}])]
+        (is (re-find #"<dialog closedby=\"none\"" html)
+            (str "nowhere to route a dismissal, so none is honoured: " html))))
+    (testing "the :light-dismiss? opt-in is the platform's `any`"
+      (fresh! true)
+      (let [html (server-html [light-dismiss-modal-page {}])]
+        (is (re-find #"<dialog closedby=\"any\"" html)
+            (str "the author asked for backdrop dismissal: " html))))
+    (testing "a popover with no :on-dismiss is `manual` — in the top
+              layer, dismissing for nothing"
+      (fresh! true)
+      (let [html (server-html [manual-popover-page {}])]
+        (is (re-find #"<div popover=\"manual\"" html)
+            (str "no dismissal route, so no light dismiss either: " html))))))
+
+(deftest an-authors-position-area-beats-the-placement-that-produced-one
+  (testing "`element-attrs`' documented precedence, measured in the bytes
+            where both candidates land in the same attribute: the author's
+            `:style` keys merge LAST, so a hand-written `:position-area`
+            wins over the `:placement` table's answer"
+    (fresh! true)
+    (let [html (server-html [author-placed-popover-page {}])]
+      (is (re-find #"position-area:block-start" html)
+          (str "the author's word is in the bytes: " html))
+      (is (not (re-find #"block-end span-inline-end" html))
+          (str "and the placement's is NOT — which is what merge order
+                means, and what a subject without :placement could never
+                decide: " html)))))
 
 (deftest an-anchored-popover-produces-deterministic-server-bytes
   (testing "**THE PROPERTY, and it is the property rather than a name.**

--- a/implementation/hicasso/test/re_frame/hicasso/evidence_sink_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/evidence_sink_cljs_test.cljs
@@ -1,0 +1,149 @@
+(ns re-frame.hicasso.evidence-sink-cljs-test
+  "THE EVIDENCE SINK SEAM (HD-005), against the PRODUCTION collector.
+
+  `re-frame.hicasso.impl.evidence` is two lines — a holder and a setter —
+  and the tap points are the collector's own: `:edges-changed` where a
+  commit's `subscribe` records its reads, `:commit` where a flush names
+  its dirty cells and readers. Those two event shapes are the seam's
+  vocabulary; anything written against them attaches to the fused table
+  unchanged.
+
+  ## Why this file exists at all
+
+  The law below was first discharged in the bench tree —
+  `re-frame.bench.hicasso.arm1.cell-table-laws-cljs-test`'s HD-005 row —
+  against the bench twin's OWN copy of the runtime. The freeze pin that
+  once made that green transfer to the shipped collector was retired
+  (frozen-sources.edn is down to `front/slot.cljc`), so the production
+  seam had NO test that could go red if its tap points drifted from the
+  documented vocabulary: not the detached silence, not either event
+  shape, not the empty-read-set guard. This file is that law, restated
+  against `re-frame.hicasso.impl.evidence/set-evidence-sink!` and the
+  production collector doors.
+
+  ## The detached path is the subject, not an arrangement
+
+  The seam's whole design claim is what the DETACHED path costs: one
+  deref and one nil test at each tap point, with nothing built when no
+  sink listens. A test cannot count a deref, but it can pin the
+  behavioural half — with no sink attached the table does its work and
+  says nothing, and detaching an attached sink restores that silence —
+  which is the half a redesign through a shared `evidence!` door would
+  break first."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.evidence :as impl-evidence]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private frame-id ::evidence-sink)
+
+(rf/reg-sub :es/item (fn [db _] (:item db)))
+
+(rf/reg-event :es/seed (fn [_ [_ db]] {:db db}))
+(rf/reg-event :es/bump (fn [{:keys [db]} _] {:db (update db :item inc)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; Harness — the same two collector doors React drives
+;; ---------------------------------------------------------------------------
+
+(defn- seeded!
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:es/seed {:item 1}]))
+  frame-id)
+
+(defn- mount!
+  "Probe `body-fn` through [[collector/render-body]] and COMMIT it —
+  `subscribe` is what fires the `:edges-changed` tap, exactly as React's
+  passive effect would. Answers `{:stop! … :notified …}`."
+  [body-fn]
+  (collector/render-body frame-id body-fn {})
+  (let [!notified (atom 0)
+        stop!     (collector/commit-boundary! (collector/last-reads)
+                                              (fn [] (swap! !notified inc)))]
+    {:stop! stop! :notified !notified}))
+
+(defn- k [query-v] [frame-id query-v])
+
+;; ---------------------------------------------------------------------------
+;; The law
+;; ---------------------------------------------------------------------------
+
+(deftest the-evidence-seam-is-detached-by-default-and-attachable-without-redesign
+  (seeded!)
+  (let [!seen (atom [])]
+    (testing "the premise: nothing is attached — the default this whole
+              file is about"
+      (is (nil? @impl-evidence/!evidence-sink)))
+
+    (testing "with no sink attached the table does its work and says nothing"
+      (let [b (mount! (fn [_] (h/sub [:es/item]) nil))]
+        (rf/with-frame frame-id (rf/dispatch-sync [:es/bump]))
+        (is (= 1 @(:notified b)) "the boundary was really notified — the
+                                  silence below is the seam's, not a dead
+                                  table's")
+        (is (= [] @!seen))
+        ((:stop! b))))
+
+    (testing "an attached sink sees the edge change at commit and the
+              dirty set at flush, in the documented shapes"
+      (impl-evidence/set-evidence-sink! (fn [ev] (swap! !seen conj ev)))
+      (try
+        (let [b (mount! (fn [_] (h/sub [:es/item]) nil))]
+          (rf/with-frame frame-id (rf/dispatch-sync [:es/bump]))
+          ;; The message prints only the :event tags — an event's
+          ;; :boundary is a live registration whose cells point back at
+          ;; it, and stringifying that cycle overflows the stack.
+          (is (= 2 (count @!seen))
+              (str "one edge event and one commit event, no more: "
+                   (mapv :event @!seen)))
+          (let [[edges commit] @!seen]
+            (is (= :edges-changed (:event edges)))
+            (is (= #{(k [:es/item])} (:added edges)))
+            (is (= #{} (:dropped edges))
+                "this wiring never drops: a narrowed read set is a fresh
+                 registration, and the old one's cleanup took its
+                 memberships with it")
+            (is (some? (:boundary edges)))
+            (is (= :commit (:event commit)))
+            (is (= #{(k [:es/item])} (:dirty-subs commit)))
+            ;; Compared by count + identity rather than as set equality:
+            ;; a failing set compare would pr-str the registrations, and
+            ;; their cells point back at them.
+            (is (= 1 (count (:dirty-boundaries commit))))
+            (is (identical? (:boundary edges) (first (:dirty-boundaries commit)))
+                "the commit names the SAME registration the edge event
+                 carried — the two events join on the boundary, which is
+                 what lets a consumer fuse them into one table"))
+          ((:stop! b)))
+        (finally (impl-evidence/set-evidence-sink! nil))))
+
+    (testing "a boundary that read nothing emits no edge change — the
+              seam reports change, not traffic"
+      (reset! !seen [])
+      (impl-evidence/set-evidence-sink! (fn [ev] (swap! !seen conj ev)))
+      (try
+        (let [b (mount! (fn [_] [:li "static"]))]
+          (is (= [] @!seen))
+          ((:stop! b)))
+        (finally (impl-evidence/set-evidence-sink! nil))))
+
+    (testing "detaching restores silence"
+      (reset! !seen [])
+      (impl-evidence/set-evidence-sink! (fn [ev] (swap! !seen conj ev)))
+      (impl-evidence/set-evidence-sink! nil)
+      (let [b (mount! (fn [_] (h/sub [:es/item]) nil))]
+        (rf/with-frame frame-id (rf/dispatch-sync [:es/bump]))
+        (is (= 1 @(:notified b)) "the table still works")
+        (is (= [] @!seen) "and says nothing again")
+        ((:stop! b))))))

--- a/implementation/hicasso/test/re_frame/hicasso/fallback_contents_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/fallback_contents_cljs_test.cljs
@@ -322,6 +322,28 @@
       (is (re-find #"ALPHA" html) (str "control: " html)))))
 
 ;; ---------------------------------------------------------------------------
+;; 3b — the shell's own guard, positively
+;; ---------------------------------------------------------------------------
+
+(deftest a-frame-fed-boundary-with-no-frame-in-its-props-refuses-by-id
+  (testing "the OTHER half of section 3's story: outside the fallback
+            position the mint bakes the frame into the element's props,
+            and the shell's guard is what stands when an element reaches
+            React without one — an outward bridge minting by hand, or the
+            hole this file closed. Its shape had never been POSITIVELY
+            pinned anywhere: section 3 asserts only that the id is NOT
+            this one on the declaration path, which a renamed or gutted
+            refusal satisfies vacuously. The guard runs before either of
+            the shell's hooks, which is what makes it assertable here
+            with no React render"
+    (let [data (error-data #(collector/frame-prop-shell
+                              (fn [_] [:p "unreachable"])
+                              #js {}))]
+      (is (= :rf.error/no-frame-prop (:rf.error/id data)))
+      (is (= 're-frame.hicasso.impl.collector/frame-prop-shell (:where data)))
+      (is (= :mint-the-root-element-with-a-frame (:recovery data))))))
+
+;; ---------------------------------------------------------------------------
 ;; 4 — every legitimate fallback position, proven ONE AT A TIME
 ;;
 ;; A refusal is only as good as what it leaves alone. One row per shape a

--- a/implementation/hicasso/test/re_frame/hicasso/intent_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/intent_cljs_test.cljs
@@ -152,7 +152,17 @@
         h     (lowered (dispatching !seen) :on-submit [:todo/create])]
     (h (ev {:prevented !prevented}))
     (is (true? @!prevented) "the browser's navigation is prevented")
-    (is (= [[:todo/create]] @!seen) "and the intent still dispatches")))
+    (is (= [[:todo/create]] @!seen) "and the intent still dispatches"))
+  (testing "and the camel spelling — the migrating author's — is the same
+           law. `prevent-by-default?` matches the two names separately, so
+           the :onSubmit arm can rot alone while every kebab row stays
+           green; a regression here fails as a real form submission"
+    (let [!seen (recorder)
+          !prevented (atom false)
+          h     (lowered (dispatching !seen) :onSubmit [:todo/create])]
+      (h (ev {:prevented !prevented}))
+      (is (true? @!prevented) ":onSubmit prevents the browser's navigation too")
+      (is (= [[:todo/create]] @!seen) "and the intent still dispatches"))))
 
 (deftest no-other-event-position-prevents-by-default
   (let [!prevented (atom false)]

--- a/implementation/hicasso/test/re_frame/hicasso/presence_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/presence_cljs_test.cljs
@@ -135,6 +135,14 @@
     (let [s (presence/step s [(toast 1 "a") (toast 3 "c") (toast 4 "d")] 120 timeout-ms)]
       (is (= [1 2 3 4] (:order s)) "and a genuinely new child is appended"))))
 
+(defn- refusal-data
+  "Run `f` and answer the ex-data of the refusal it raised — or a marker
+  keyword, so a row that fails says WHICH way it failed rather than
+  reading `nil` off a success."
+  [f]
+  (try (f) ::returned-without-refusing
+       (catch :default e (ex-data e))))
+
 (deftest nil-children-are-not-entries-and-unkeyed-children-are-a-loud-error
   (is (= {1 :mounting}
          (presence/phases (presence/step presence/initial
@@ -143,14 +151,34 @@
   (is (thrown-with-msg? js/Error #"no :key"
                         (presence/step presence/initial [[:div.toast "x"]] 0 timeout-ms)))
   (is (thrown-with-msg? js/Error #"keyed hiccup vector"
-                        (presence/step presence/initial ["a string"] 0 timeout-ms))))
+                        (presence/step presence/initial ["a string"] 0 timeout-ms)))
+  (testing "each refusal carries ITS OWN id, recovery and offending child —
+            the discriminator a tool branches on, which the message rows
+            above cannot hold apart: swapping the two ids between the
+            complaints would leave both regexes green"
+    (let [unkeyed (refusal-data
+                    #(presence/step presence/initial [[:div.toast "x"]] 0 timeout-ms))]
+      (is (= :rf.error/hicasso-presence-child-unkeyed (:rf.error/id unkeyed)))
+      (is (= :put-a-key-in-the-child-props-map (:recovery unkeyed)))
+      (is (= [:div.toast "x"] (:child unkeyed))))
+    (let [not-hiccup (refusal-data
+                       #(presence/step presence/initial ["a string"] 0 timeout-ms))]
+      (is (= :rf.error/hicasso-presence-child-not-hiccup (:rf.error/id not-hiccup)))
+      (is (= :give-every-presence-child-a-keyed-hiccup-vector (:recovery not-hiccup)))
+      (is (= "a string" (:child not-hiccup))))))
 
 (deftest timeout-ms-is-mandatory-and-positive
   (is (= 300 (presence/check-timeout! 300)))
   (doseq [bad [nil 0 -1 "300"]]
     (is (thrown-with-msg? js/Error #"positive :timeout-ms"
                           (presence/check-timeout! bad))
-        (str "refused: " (pr-str bad)))))
+        (str "refused: " (pr-str bad)))
+    (let [data (refusal-data #(presence/check-timeout! bad))]
+      (is (= :rf.error/hicasso-presence-timeout-required (:rf.error/id data))
+          (str "with its own id, for " (pr-str bad)))
+      (is (= :give-presence-a-positive-timeout-ms (:recovery data)))
+      (is (= bad (:timeout-ms data))
+          "and the offending value, so a red names what was written"))))
 
 ;; ---------------------------------------------------------------------------
 ;; The phase transform
@@ -163,6 +191,19 @@
             what an override is"
     (is (= [:div.toast {:key 1 :class "toast--exit" :inert true :aria-hidden true} "a"]
            (presence/with-phase (toast 1 "a") :unmounting))))
+  (testing ":mounting — the enter map is merged the same way. This is the
+            arm the exit rows cannot witness: an `override-for` answering
+            nil at :mounting still STRIPS the override keys, so every
+            strip assertion in this file stays green while enter styling
+            dies wholesale — the positive merge is the only pin"
+    (is (= [:div.toast {:key 1 :class "toast--enter"} "a"]
+           (presence/with-phase
+             [:div.toast {:key 1
+                          :re-frame.hicasso/mounting {:class "toast--enter"}}
+              "a"]
+             :mounting))
+        "the mounting map's contents arrive on the element, with the
+         override key itself gone"))
   (testing "an override still cannot reach :key or :ref — the same law :&
             carries, for the same reason: those address node identity, not
             appearance"

--- a/implementation/hicasso/test/re_frame/hicasso/readset_group_census_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/readset_group_census_cljs_test.cljs
@@ -44,7 +44,10 @@
 
 (def ^:private frame-id ::readset-census)
 
-(doseq [i (range 24)]
+;; 65 rather than the 24 the census rows need: the bucket-scan law at the
+;; bottom of this file grows a 64-entry cache whose read sequences share a
+;; first key, and each needs a distinct second one.
+(doseq [i (range 65)]
   (rf/reg-sub (keyword "rsc" (str "k" i)) (fn [db [_]] (get db i))))
 
 (rf/reg-event :rsc/seed (fn [_ [_ db]] {:db db}))
@@ -321,3 +324,39 @@
         "every membership is shareable by the generous reading, and
          grouping still costs one — which is why the verdict is taken on
          both denominators and not on this one")))
+
+;; ---------------------------------------------------------------------------
+;; The entry cache's own scan law
+;; ---------------------------------------------------------------------------
+
+(deftest the-bucket-scan-does-not-grow-with-the-number-of-boundaries
+  ;; The law was discharged in the bench tree against the twin runtime's
+  ;; own copy (`arm1/runtime_cljs_test`), and the freeze pin that made
+  ;; that green transfer to the shipped collector was retired — so the
+  ;; regression this hash specifically guards, first-key bucketing
+  ;; degrading an N-row list to an N-deep scan (the whole quadratic in
+  ;; rf2-2rtt6.46, a defect that actually shipped), had no live pin.
+  ;; Restated here against `inventory/entry-buckets` and the production
+  ;; entry cache. Probe-only renders, deliberately: the cache is minted
+  ;; at render, so no commit is needed and none is taken.
+  (seeded!)
+  (testing "an entry lookup compares against the read sequences that
+            COLLIDE, not against every live boundary that happens to
+            share a first key — the page-wide-key-then-per-row-key shape
+            one moved `let` binding produces"
+    (dotimes [i 8]
+      (collector/render-body frame-id (reading [(q 0) (q (inc i))]) {}))
+    (let [small (inventory/entry-buckets)]
+      (is (= 8 (:entries (inventory/stats)))
+          "eight distinct read sequences, eight entries")
+      (is (= 1 (:max-bucket small))
+          "and the deepest bucket holds ONE — the whole-sequence hash
+           separates what a first-key hash would pile up")
+      (dotimes [i 56]
+        (collector/render-body frame-id (reading [(q 0) (q (+ 9 i))]) {}))
+      (let [large (inventory/entry-buckets)]
+        (is (= 64 (:entries (inventory/stats))))
+        (is (= (:max-bucket small) (:max-bucket large))
+            (str "the scan is " (:max-bucket large) " deep at 64 rows and "
+                 (:max-bucket small) " at 8 — growth here is the quadratic
+                 coming back"))))))

--- a/implementation/hicasso/test/re_frame/hicasso/route_link_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/route_link_cljs_test.cljs
@@ -15,6 +15,7 @@
             [re-frame.hicasso.impl.intent :as intent]
             [re-frame.hicasso.impl.route-link :as link]
             [re-frame.core :as rf]
+            [re-frame.late-bind :as late-bind]
             [re-frame.routing :as routing]
             [re-frame.test-support :as test-support]))
 
@@ -261,3 +262,115 @@
         "a plain left click is routing's to take: preventDefault fired and the
          url-requested dispatch went to the captured frame (the route change
          itself is the DOM witness's claim)")))
+
+;; ---------------------------------------------------------------------------
+;; The imperative veto — the roster's other admitted half
+;; ---------------------------------------------------------------------------
+
+(defn- with-activate-link
+  "Run `thunk` with `f` published at `:routing/activate-link!` — nil
+  included, which is the detached-artefact arrangement — restoring the
+  previous registration in `finally` so the suite's other rows keep
+  running against routing's real seam."
+  [f thunk]
+  (let [previous (late-bind/get-fn :routing/activate-link!)]
+    (late-bind/set-fn! :routing/activate-link! f)
+    (try (thunk)
+         (finally (late-bind/set-fn! :routing/activate-link! previous)))))
+
+(deftest a-function-veto-rides-the-vector-and-reaches-the-seam-by-identity
+  (testing "the roster's IMPERATIVE half (HD-024: whoever holds the event
+           owns it) had no exercise anywhere — every veto row used nil or
+           the prevent head, so `on-click-roster!`'s fn arm and
+           `lower-veto`'s could rot with every declarative row green. A
+           plain function at :on-click renders, and rides the navigate
+           vector's :veto slot by identity"
+    (let [veto      (fn a-veto [_e] nil)
+          [_ attrs] (rendered {:to :conduit.profile/show :params {:username "jane"}
+                               :on-click veto}
+                              "jane")]
+      (is (identical? veto (:veto (second (:on-click attrs))))
+          "the author's own function, untouched — where the declarative
+           head is lowered into a closure, the imperative veto IS the
+           closure already")))
+  (testing "and the lowered click hands that same function to routing's
+           `activate-link!` as the veto argument, the rest of the navigate
+           map beside it. The composition itself — veto first, stand down
+           on defaultPrevented — is routing's own tested law; hicasso's
+           half, pinned here, is that the imperative veto arrives at the
+           seam intact"
+    (let [veto  (fn a-veto [_e] nil)
+          !seam (atom nil)
+          [h _] (lowered-click {:to :conduit.profile/show :params {:username "jane"}
+                                :on-click veto})]
+      (with-activate-link
+        (fn [_e veto-fn frame payload native?]
+          (reset! !seam {:veto-fn veto-fn :frame frame
+                         :payload payload :native? native?})
+          nil)
+        #(h (ev {})))
+      (let [{:keys [veto-fn frame payload native?]} @!seam]
+        (is (identical? veto veto-fn) "the fn crossed the seam by identity")
+        (is (= frame-id frame))
+        (is (= [:rf.route/url-requested {:url    "/profile/jane"
+                                         :to     :conduit.profile/show
+                                         :params {:username "jane"}}]
+               payload))
+        (is (false? native?))))))
+
+;; ---------------------------------------------------------------------------
+;; The two ways routing can be gone, and neither is a throw
+;; ---------------------------------------------------------------------------
+
+(deftest a-detached-click-with-no-routing-hook-degrades-to-native-and-still-runs-the-veto
+  (testing "`navigate-handler`'s own promise: when `:routing/activate-link!`
+           is unbound at CLICK time — the routing artefact hot-reloaded
+           away between render and click — the closure stands aside, so
+           the browser follows the anchor's real href. No throw, no
+           interception, no dispatch"
+    (let [[h !seen]  (lowered-click {:to :conduit.profile/show :params {:username "jane"}})
+          !prevented (atom false)]
+      (with-activate-link nil #(h (ev {:prevented !prevented})))
+      (is (false? @!prevented)
+          "nothing intercepted the click — native navigation is the degrade")
+      (is (= [] @!seen) "and nothing dispatched")))
+  (testing "…and the veto still runs. The imperative fn is invoked with
+           the event"
+    (let [!ran  (atom false)
+          [h _] (lowered-click {:to :conduit.profile/show :params {:username "jane"}
+                                :on-click (fn [_e] (reset! !ran true) nil)})]
+      (with-activate-link nil #(h (ev {})))
+      (is (true? @!ran))))
+  (testing "…and the declarative prevent veto still cancels and dispatches
+           its replacement intent — the app's reaction survives the
+           routing artefact's absence, which is what keeps the degrade a
+           navigation policy rather than a lost click"
+    (let [[h !seen]  (lowered-click {:to :conduit.profile/show :params {:username "jane"}
+                                     :on-click [intent/prevent-head [:conduit/track "jane"]]})
+          !prevented (atom false)]
+      (with-activate-link nil #(h (ev {:prevented !prevented})))
+      (is (true? @!prevented))
+      (is (= [[:conduit/track "jane"]] @!seen)))))
+
+(deftest a-missing-routing-artefact-fails-at-the-link-site-naming-the-artefact-and-the-to
+  (testing "route-link's other absence: no `:routing/link-model` at RENDER
+           means the artefact is off the classpath, and the refusal is
+           the link site's own — the id a tool branches on, the link's
+           :to, and the two coordinates the author needs to repair it.
+           Asserted as ex-data rather than a message regex, per the
+           refusal-shape convention"
+    (let [previous (late-bind/get-fn :routing/link-model)]
+      (try
+        (late-bind/set-fn! :routing/link-model nil)
+        (let [data (try
+                     (rendered {:to :conduit.profile/show :params {:username "jane"}} "jane")
+                     ::returned-without-refusing
+                     (catch :default e (ex-data e)))]
+          (is (= :rf.error/routing-artefact-missing (:rf.error/id data)))
+          (is (= :conduit.profile/show (:to data))
+              "the refusal names the link's own :to")
+          (is (re-find #"day8/re-frame2-routing" (str (:reason data)))
+              "…and the dependency to add")
+          (is (re-find #"re-frame\.routing" (str (:reason data)))
+              "…and the namespace to require at boot"))
+        (finally (late-bind/set-fn! :routing/link-model previous))))))

--- a/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
@@ -375,6 +375,80 @@
              (.indexOf document (str "id=\"" ssr-constants/payload-script-id "\""))
              (.indexOf document "/js/app.js"))))))
 
+(deftest a-hostile-value-cannot-break-out-of-the-envelope
+  (testing "a `</script` inside an ALLOWLISTED app-db value is escaped in
+            the payload script body — the EDN-aware escaper's whole job,
+            and until this row nothing in the shipped tree exercised it:
+            deleting the `escape-edn-script-body` call would have redded
+            only the fenced bench donor's pin"
+    (let [evil "</script><script>window.pwned=1</script>"
+          {:keys [document payload]}
+          (server/render (request :snapshot {:label evil :secret "x"}))]
+      (is (= evil (get-in payload [:rf/app-db :label]))
+          "the premise: the hostile value IS on the allowlisted wire —
+           without this the absence below could be the allowlist's doing")
+      (is (not (str/includes? document "</script><script>"))
+          "the raw breakout sequence reaches no position in the document")
+      (is (str/includes? document "\\u003c/script")
+          "because inside the EDN string literal every < is the reader's
+           six-character escape, which round-trips to the same value")))
+  (testing "the document envelope's own text and attribute positions
+            escape too — the title through `escape-html`"
+    (let [{:keys [document]}
+          (server/render (request :title "Bob's <Feed> & Friends"))]
+      (is (str/includes? document "<title>Bob&#39;s &lt;Feed&gt; &amp; Friends</title>")
+          (str "every reserved character in its HTML spelling: " document))
+      (is (not (str/includes? document "<Feed>"))
+          "and the raw angle pair reaches nothing")))
+  (testing "`or`, not `:or` — a caller with one options map threads nil
+            through for every option it did not set, so the KEY is
+            supplied and destructuring defaults never fire; the module's
+            own comment records the page silently getting id=\"\" when
+            this regressed"
+    (let [{:keys [document]}
+          (server/render (request :title nil :app-element-id nil))]
+      (is (str/includes? document "<div id=\"app\">")
+          "the app element default survives an explicit nil")
+      (is (str/includes? document "<title>Hicasso SSR</title>")
+          "and so does the title default"))))
+
+(deftest frame-opts-ride-under-the-modules-id-and-the-wire-keys-ride-the-payload
+  (testing "`:frame-opts` merges UNDER the module's :id and
+            :initial-events — a request needing :url-strategy or
+            :fx-overrides declares them the way any frame does, and a
+            copy-pasted :id or :initial-events in them cannot hijack the
+            per-request frame or replace the seed. The invariant is one
+            `assoc`, and nothing pinned it"
+    (let [{:keys [document payload frame-id]}
+          (server/render (request :frame-opts {:id             ::hijack
+                                               :initial-events [[::relabel "hijacked"]]}))]
+      (is (not= ::hijack frame-id)
+          "the per-request gensym rules the frame id")
+      (is (= wire-frame (:rf/frame-id payload))
+          "and the wire id stays the caller's stable one")
+      (is (str/includes? document "alpha")
+          "the seed is the module's snapshot")
+      (is (not (str/includes? document "hijacked"))
+          "and the frame-opts' events vector never ran")))
+  (testing "`:version` and `:schema-digest` ride the payload under the
+            wire keys the hydrate side reads — the version COERCED to the
+            schema's integer (Spec-Schemas pins `:rf/version` as `:int`,
+            and a whole-number string is parsed rather than rejected)"
+    (let [{:keys [payload]}
+          (server/render (request :version "7" :schema-digest "digest-abc"))]
+      (is (= 7 (:rf/version payload)))
+      (is (= "digest-abc" (:rf/schema-digest payload))))
+    (testing "an omitted `:version` still ships the slot — the SSR
+              artefact's own protocol constant, so both wire ends agree
+              with no host wiring; an `(or version …)` here once silently
+              defeated the version-mismatch check"
+      (let [{:keys [payload]} (server/render (request))]
+        (is (pos-int? (:rf/version payload)))))
+    (testing "while an omitted `:schema-digest` omits the KEY — the
+              no-participation shape, not a nil stamped on the wire"
+      (let [{:keys [payload]} (server/render (request))]
+        (is (not (contains? payload :rf/schema-digest)))))))
+
 ;; ---------------------------------------------------------------------------
 ;; 3b — HOW EVERY ASYNC ROW BELOW ENDS
 ;; ---------------------------------------------------------------------------

--- a/implementation/hicasso/test/re_frame/hicasso/tool_reads_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/tool_reads_cljs_test.cljs
@@ -139,6 +139,17 @@
       (is (nil? (:loss e)))
       (is (= [] (:boundaries e)))))
 
+  (testing "a rendered-but-not-yet-committed boundary is OUTSIDE the scope
+            — the docstring's own sentence, and until this row nothing
+            discriminated refs-gating from entries-not-existing. A
+            regression to counting unclaimed entries silently inflates
+            the roster `:complete? true` is staked on"
+    (collector/render-body frame-id (fn [_] (h/sub [:tr/row 0]) nil) {})
+    (is (pos? (:entries (inventory/residue)))
+        "the premise: the probe left a REAL entry in the cache")
+    (is (= [] (:boundaries (tool/read-mounted-boundaries)))
+        "which the roster does not count, because no reference claims it"))
+
   (let [a (mount! (fn [_] (h/sub [:tr/left]) nil))
         b (mount! (fn [_] (h/sub [:tr/left]) nil))
         c (mount! (fn [_] (h/sub [:tr/left]) (h/sub [:tr/right]) nil))]
@@ -164,6 +175,31 @@
     (testing "an unmounted boundary leaves the roster"
       (a) (b) (c)
       (is (= [] (:boundaries (tool/read-mounted-boundaries)))))))
+
+(deftest two-read-orders-of-one-edge-set-collapse-to-one-row-that-says-so
+  (seeded!)
+  (testing "the runtime's entry compare is ORDERED, so `left,right` and
+            `right,left` are two live entries — but their edge SETS are
+            equal, and the edge set is this door's identity. The row must
+            collapse them and SAY it did: `:read-orders` was asserted
+            nowhere above 1, so the collapse arm of `entry-rows` could
+            rot into duplicate DOM ids for a panel and an ambiguous join
+            for a consumer with every existing row green"
+    (let [a (mount! (fn [_] (h/sub [:tr/left]) (h/sub [:tr/right]) nil))
+          b (mount! (fn [_] (h/sub [:tr/right]) (h/sub [:tr/left]) nil))
+          e (tool/read-mounted-boundaries)]
+      (is (= 2 (:entries (inventory/residue)))
+          "the premise: the runtime really holds TWO entries — without
+           this, one row could mean the orders were never distinguished")
+      (is (= 1 (count (:boundaries e)))
+          "one row per distinct edge set, whatever the read order")
+      (let [row (first (:boundaries e))]
+        (is (= [(bk [:tr/left]) (bk [:tr/right])] (:key (:boundary row))))
+        (is (= 2 (:instances row)) "both boundaries are counted in it")
+        (is (= 2 (:read-orders row))
+            "and the row says it folded two orders, which is the honest
+             rendering of a collapse the identity demanded"))
+      (a) (b))))
 
 (deftest the-mounted-roster-names-what-it-cannot-know
   (seeded!)
@@ -508,6 +544,44 @@
             (str read-name " must be byte-identical across two calls — a roster "
                  "ordered by a hash map's seq is not"))))
     (a) (b) (c)))
+
+(deftest roster-order-is-a-total-order-and-not-an-insertion-accident
+  ;; [[every-read-is-deterministic]] calls each read twice over the SAME
+  ;; map instances, and a hash map's seq is order-stable within one
+  ;; process — so that row cannot detect the hazard its own message
+  ;; names: a roster ordered by iteration order prints identically twice
+  ;; and still differs between two processes that built the same state.
+  ;; This row builds the same logical population twice, in OPPOSITE
+  ;; mount orders, and requires the projected orders to agree — which
+  ;; only a real total order over the rows can deliver.
+  (let [bodies   [(fn [_] (h/sub [:tr/left]) nil)
+                  (fn [_] (h/sub [:tr/right]) nil)
+                  (fn [_] (h/sub [:tr/row 0]) nil)
+                  (fn [_] (h/sub [:tr/row 1]) nil)
+                  (fn [_] (h/sub [:tr/row 2]) nil)]
+        orders   (fn []
+                   {:roster (mapv (comp :key :boundary)
+                                  (:boundaries (tool/read-mounted-boundaries)))
+                    :edges  (mapv :sub-id (:edges (tool/read-read-attribution)))})
+        build!   (fn [bs] (seeded!) (mapv mount! bs))
+        forward  (let [stops (build! bodies)
+                       o     (orders)]
+                   (run! #(%) stops)
+                   o)
+        _        (collector/reset-runtime!)
+        backward (let [stops (build! (vec (rseq bodies)))
+                       o     (orders)]
+                   (run! #(%) stops)
+                   o)]
+    (is (= 5 (count (:roster forward)))
+        "non-vacuous: five distinct rows are being ordered")
+    (is (= 5 (count (:edges forward)))
+        "and five attribution edges — the three :tr/row parameterizations
+         stay three cells even though they project one :sub-id")
+    (is (= forward backward)
+        "two constructions of one logical state must project the same
+         BYTES in the same order — insertion order leaking into the
+         roster is exactly what `ordered` exists to delete")))
 
 (deftest no-read-takes-a-consumer-discriminator
   (testing "ONE door: Xray and Pair cannot be handed different shapes"


### PR DESCRIPTION
## What this is

The landing half of rf2-dr90's hicasso test review: the suite was audited module-by-module against `implementation/hicasso/src`, and the CLEAR gaps — roster arms with zero exercise anywhere, behaviours only reachable through the happy path, refusals pinned by message regex where the id is the machine contract, and laws whose only pins were orphaned in the fenced bench tree when the freeze rows retired — are closed here. The larger / ruling-needing remainder is filed as beads (ids on rf2-dr90): rf2-4e5b, rf2-s2ta, rf2-xofa, rf2-x7y5, rf2-mnmi, rf2-i011.

All changes live under `implementation/hicasso/test/**` (node-lane suites; `bench/**` and `src/**` untouched). One new file: `evidence_sink_cljs_test.cljs`.

## Landed

- **route_link**: imperative fn-veto arms (render acceptance by identity; arrival at the `activate-link!` seam with the rest of the navigate map), `navigate-handler`'s unbound-hook degrade (native navigation, veto still runs in both spellings), `routing-artefact-missing` pinned as ex-data naming the `:to` and both repair coordinates.
- **intent**: the `:onSubmit` camel auto-prevent arm — matched separately from the kebab spelling, previously able to rot alone.
- **presence**: positive `:mounting` override merge (an `override-for` answering nil at `:mounting` satisfied every existing strip assertion while killing enter styling wholesale); the three machine refusals pinned by `:rf.error/id` + `:recovery` + offending value.
- **client_only_arms_ssr**: the `closedby` ladder's three unexercised arms (modal `none`/`any`, popover `manual`) as server bytes; author `:style {:position-area}` beating `:placement`.
- **evidence_sink** (new): the HD-005 seam law against the production collector — detached silence, both event shapes with the cross-event boundary join, the empty-read-set guard, detach restoring silence. Previously pinned only against the fenced bench twin's own runtime copy.
- **activity_suspense**: the generation fence's terminal refusal (a body that writes on every run) by id/where/recovery.
- **fallback_contents**: `:rf.error/no-frame-prop` pinned positively (the only prior assertion anywhere was its absence on a legal path).
- **readset_group_census**: the bucket-scan law — `:max-bucket` stays 1 from 8 to 64 shared-first-key entries (the rf2-2rtt6.46 quadratic's live pin); sub roster widened 24→65 for it.
- **server_render_ssr**: envelope escaping on the shipped module (an allowlisted `</script` breakout is `\u003c`-escaped in the EDN body while the value round-trips; title escaping; the or-not-`:or` defaults regression), the `:frame-opts` merge-under invariant (a copy-pasted `:id`/`:initial-events` cannot hijack the request frame), `:version` int coercion + always-present constant, `:schema-digest` key-omission.
- **tool_reads**: `:read-orders` collapse asserted above 1 with the two-entries premise; a rendered-but-uncommitted boundary outside the mounted roster's scope (refs-gating vs entry-existence); roster order pinned against reversed construction (the existing two-calls determinism row cannot see iteration-order leaks — a same-process hash-map seq is order-stable).

Anchors and prose verified by hand; no doc-gate surface is touched (all changes are `.cljs` test files, outside both link gates' rosters).

## Quality gates (all exit codes captured from the runs themselves)

| Gate | Exit | Result |
|---|---|---|
| `npm run test:cljs` (full node-test, final tree) | 0 | 11839 tests, 59961 assertions, 0 failures, 0 errors |
| `npm run test:hicasso-compile` | 0 | 160 namespaces, 0 warnings |
| `npm run test:hicasso-invariants` | 0 | all checks + self-tests pass |
| `npm run test:hicasso-lint` | 0 | pass |
| Focused `node-test-hicasso`, 10 touched namespaces | 0 | 143 tests, 901 assertions, 0 failures |
| Planted-fault control (same 10 namespaces) | 1 | 35 failures — exactly the 17 planted deftests, suite shape intact (143/901) |

Chromium gates (`test:hicasso-controlled`, `test:hicasso-hmr`) not run: the diff touches neither testbed surface — every change is a node-lane test file, and the one `_dom_`-tagged file's new rows are pure `renderToString` byte assertions. The browser-test lane runs them in CI.

## Controls

`src/**` was fenced for this worker (concurrent doc-polish pass), so each control removes the pinned property from the TEST'S SUBJECT or flips the pinned expectation to a wrong concrete value — proving each assertion reads the behaviour rather than passing vacuously. 17 plants across the 10 files, one batch run, each red landing in exactly its target deftest (per-deftest tally in the run log); e.g. the hostile-value row went red only on the escaped-marker assertion when handed a benign value, and the `closedby` plant redded only the `none` arm. Restores verified by git blob hash against HEAD per file (clean-filtered `hash-object` vs `rev-parse HEAD:path`), not by diff. The stronger src-side mutation controls (delete `ordered`, nil the `:mounting` arm, drop the escaper call) are recorded on rf2-dr90 for a src-unfenced pass.
