### PR TITLE
hic: name shipped doors in the two no-frame reason texts (rf2-mnmi)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs
@@ -1754,7 +1754,7 @@
     (fail! :rf.error/no-frame-context
            where
            (str "A Hicasso boundary rendered with no frame in scope. Mount the "
-                "tree under a frame boundary — `arm1.mount/root!` installs one.")
+                "tree under a frame boundary — `h/mount!` installs one.")
            :mount-under-a-frame
            {})
     frame-kw))
@@ -1806,8 +1806,7 @@
                 "props. Every boundary element below the root is minted by an "
                 "ancestor body, which carries the frame; the root and any "
                 "outward React bridge mint theirs outside a body and must name "
-                "it (`front.codec/root-element`, which `arm1.mount/render!` "
-                "calls).")
+                "it (`h/mount!`'s `:frame` is how the root does).")
            :mint-the-root-element-with-a-frame
            {})
     frame-kw))


### PR DESCRIPTION
## What

rf2-mnmi residual item (3), plus one same-class hit found in the re-verify. Two consumer-facing error reason texts in `implementation/hicasso/src/re_frame/hicasso/impl/collector.cljs` told the author to look at bench-tree names a consumer cannot require:

- `:rf.error/no-frame-prop` cited `front.codec/root-element` and `arm1.mount/render!` — the bead's named residual.
- `:rf.error/no-frame-context` cited `arm1.mount/root!` — the same defect one error up, caught in the re-read; the fix is bounded to the same file.

Both now name the shipped door: `h/mount!` is what installs a frame boundary, and its `:frame` is how the root names the frame its minted boundary elements carry (established by reading `re-frame.hicasso`'s facade — `mount!` is "the root door" over `impl.mount/root!`, and `impl.mount/render!` mints the root element via `impl.codec/root-element`). The `h/` spelling is the package's taught alias and matches the existing error-string voice ("Write an h/event…"). The no-frame-prop text keeps its "the root and any outward React bridge … must name it" clause, which `impl.codec/as-component`'s docstring depends on.

## Scope check at tip

Bead items (1) and (2) re-verified ALREADY FIXED at the branch base (0 hits for the stale `controlled.cljs` citation and the stale `mount.cljs` witness name; positive controls — the correct test rows — each returned their expected hit, so the greps reach the corpus). Item (3) was the only live residual, and the sweep for `front.`/`arm1.`/`arm2.` bench aliases across `implementation/hicasso/src` found no other RUNTIME-STRING hits — remaining matches are maintainer docstrings citing bench witnesses by full name, which is deliberate.

## Catalogue

Complaint ids and `:recovery` keywords are untouched, so the complaint catalogue does not move: `check_complaint_catalogue.py` exit 0 before and after the edit, and no file under `implementation/hicasso/spec/` is touched.

## Quality gates

Run from `implementation/` in the worker worktree, exit codes captured from the runs themselves (per-attempt log + exit files):

| Gate | Result |
| --- | --- |
| `python hicasso/scripts/check_complaint_catalogue.py` (post-edit) | exit 0 |
| `npm run test:hicasso-invariants` (post-edit, pre-rebase) | exit 0 |
| `npm run test:hicasso-compile` (post-edit, pre-rebase) | exit 0 |
| `npm run test:hicasso-invariants` — planted-fault control | exit 1 |
| `npm run test:hicasso-invariants` (re-run on final rebased base) | exit 0 |
| `npm run test:hicasso-compile` (re-run on final rebased base) | exit 0 |

Planted-fault control: with work committed first, a one-character corruption of the pinned recovery keyword at the exact edited emit site (`:mint-the-root-element-with-a-frame` → `…-framex`, match count 1 verified before the run) turned the invariants gate red with R10 naming the corrupted keyword and `:rf.error/no-frame-prop` — the fault existed only in this worktree, so the red also proves the gate read this tree. Restore verified by git blob hash: the working file's content hash equals the committed object's blob hash `2e979cabce7744a8615490ac088b6e7752663541` (that token is a blob id, not a commit). The compile gate independently printed this worktree's paths in its roster line on both runs.

No test, spec, docs, workflow or hot-zone file is touched; the diff is two reason strings in one src file.

Closes rf2-mnmi.