### PR TITLE
test(hicasso): browser-lane rows — overlay claimed-Tab yield + :on-dismiss freshness, and the three orphaned freeze witnesses (rf2-s2ta, rf2-xofa; rf2-i011 refused)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/boundary_intent_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/boundary_intent_dom_cljs_test.cljs
@@ -97,12 +97,16 @@
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.hicasso.impl.boundary :refer [boundary]]
             [re-frame.hicasso.hook-probe :as probe]
+            [re-frame.hicasso.impl.codec :as codec]
             [re-frame.hicasso.impl.mount :as mount]
             [re-frame.hicasso.impl.collector :as collector]
             [re-frame.hicasso.checkpoint-support :as support]
             [re-frame.core :as rf]
             [re-frame.hicasso :as h]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]))
 
 (def ^:private frame-id ::boundary-intent)
 (def ^:private other-frame-id ::boundary-intent-other)
@@ -128,6 +132,18 @@
 (rf/reg-event :hicasso.bdy/noted
               (fn [{:keys [db]} [_ tag]]
                 {:db (update db :noted (fnil conj []) tag)}))
+
+;; The StrictMode row's pair: `:on-error` is dispatched with the error
+;; appended, so the handler's second element IS the error; and a `:rearm`
+;; is a FAILED reset — the retry the caller scheduled with the cause
+;; still in place, `:attempt` moved and `:boom?` deliberately left true.
+(rf/reg-event :hicasso.bdy/record-error
+              (fn [{:keys [db]} [_ error]]
+                {:db (update db :errors (fnil conj []) (ex-message error))}))
+
+(rf/reg-event :hicasso.bdy/rearm
+              (fn [{:keys [db]} _]
+                {:db (update db :attempt inc)}))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -588,3 +604,76 @@
                  nowhere — quietly, because that is what was declared")
             (is (nil? (:noted (db frame-id))))
             (finally (mount/release! handle))))))))
+
+;; ---------------------------------------------------------------------------
+;; 10 — once per FAILURE, measured where React re-runs renders: StrictMode
+;; ---------------------------------------------------------------------------
+;;
+;; `impl.boundary`'s namespace docstring stakes the guarantee on the
+;; lifecycle — `:on-error` fires from `componentDidCatch` and from nowhere
+;; else, StrictMode runs the failing render TWICE and `componentDidCatch`
+;; still fires ONCE — and cites its witness by name in the fenced bench
+;; tree (`arm1_lifecycle_dom_cljs_test/the-boundary-reports-once-under-strictmode`),
+;; whose green no longer transfers: the bench twin stopped being
+;; digest-pinned to the shipped class when the freeze manifest retired
+;; `arm1/boundary.cljs`. This is that witness restated against the shipped
+;; door — provenance, not a dependency — with the failed-reset arm folded
+;; in: a reset the caller schedules with the cause still in place is a NEW
+;; failure, so it reports exactly once more.
+
+(h/defview strict-guarded
+  "The retry shape under test, with `:on-error` wired: reads `:attempt` as
+  its `:reset-key` so a `:rearm` dispatch retries the child, and records
+  every report so ONCE is a count rather than a flag."
+  [_]
+  [boundary {:fallback  [:p.fb "caught"]
+             :reset-key (collector/sub [:hicasso.bdy/attempt])
+             :on-error  [:hicasso.bdy/record-error]}
+   [risky {}]])
+
+(defn- strict-root!
+  "`mount/root!`, wrapped in `React.StrictMode`. Written here rather than
+  in the shared mount door because StrictMode is this row's variable and
+  every other row in this file must keep measuring the ordinary tree —
+  the same reasoning `hframe-dom-cljs-test`'s W6 records for its copy."
+  [container frame-kw hiccup]
+  (let [root (react-dom-client/createRoot container)]
+    (react-dom/flushSync
+      (fn [] (.render root (react/createElement
+                             react/StrictMode nil
+                             (mount/provider frame-kw (codec/as-element hiccup))))))
+    {:root root :frame frame-kw :container container}))
+
+(deftest the-boundary-reports-once-per-failure-under-strictmode
+  ;; What reds this row is reporting from anything React runs more than
+  ;; once per failure — the render, in StrictMode, is the visible case.
+  ;; The instance-flag alternative is argued away in `impl.boundary`'s
+  ;; docstring; this row is the measurement that argument leans on.
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id)
+      (let [handle (strict-root! (mount/fresh-container!) frame-id [strict-guarded {}])]
+        (try
+          (mount/settle!)
+          (is (some? (query handle ".fb")) "the throw was caught")
+          (is (= ["the child threw"] (:errors (db frame-id)))
+              (str "ONE report, however many times StrictMode invoked the "
+                   "render that threw. Got: " (pr-str (:errors (db frame-id)))))
+
+          (testing "and a FAILED reset is a new failure, reporting exactly
+                    once more: the retry re-mounts the child, the cause is
+                    still in place, it throws again — one more record, not
+                    two for StrictMode's re-run and not zero for a boundary
+                    that stopped counting"
+            (rf/with-frame frame-id (rf/dispatch-sync [:hicasso.bdy/rearm]))
+            ;; Twice, for `click!`'s reason: the dispatch commits on the
+            ;; first settle; the moved `:reset-key` is then read by
+            ;; `componentDidUpdate`, whose own `setState` is a second
+            ;; commit, and the re-thrown child's report follows it.
+            (mount/settle!)
+            (mount/settle!)
+            (is (some? (query handle ".fb")) "it threw again; the fallback stands")
+            (is (= ["the child threw" "the child threw"] (:errors (db frame-id)))
+                (str "Got: " (pr-str (:errors (db frame-id))))))
+          (finally (mount/release! handle)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_dom_cljs_test.cljs
@@ -147,6 +147,11 @@
 ;; needs the overlay to survive its own dismissal so the teardown is a
 ;; separate, later event it can attribute.
 (rf/reg-event ::noted (fn [{:keys [db]} [_ k]] {:db (update-in db [:dismissed k] (fnil inc 0))}))
+;; The swap-freshness row's model: WHICH intent the popover's `:on-dismiss`
+;; carries is itself app state, so a dispatch can change it mid-flight and
+;; the row can ask which render's closure the platform's dismissal landed on.
+(rf/reg-sub ::dismiss-tag (fn [db _] (:dismiss-tag db)))
+(rf/reg-event ::retag (fn [{:keys [db]} [_ tag]] {:db (assoc db :dismiss-tag tag)}))
 (rf/reg-event ::clicked (fn [{:keys [db]} [_ k]] {:db (assoc-in db [:clicked k] true)}))
 (rf/reg-sub ::body-read (fn [db _] (:body-read db)))
 
@@ -732,6 +737,68 @@
             (is (zero? (get-in (db) [:dismissed :pb] 0))
                 "and no dismissal was reported for a close the application asked
                  for itself"))
+          (finally (mount/release! handle)))))))
+
+;; --- the dismissal closure is the CURRENT render's --------------------------
+
+(h/defview swap-dismiss-page [_]
+  ;; The subject popover's `:on-dismiss` carries a tag read from app-db,
+  ;; so a `::retag` dispatch re-renders it wired to a DIFFERENT intent
+  ;; while it stays open. `pop-u` is the dismissal driver: an unrelated
+  ;; auto popover joining the LIFO stack light-dismisses the open one —
+  ;; the same engine path the stack row above drives, chosen over a
+  ;; direct `hidePopover()` because the module's own teardown fires the
+  ;; identical event and the row above already proves THAT one routes
+  ;; nowhere.
+  [:div
+   [overlay/popover {:open?      (h/sub [::open? :ps])
+                     :on-dismiss [::dismissed (h/sub [::dismiss-tag])]
+                     :id         "pop-s"}
+    [:p "S"]]
+   [overlay/popover {:open?      (h/sub [::open? :pu])
+                     :on-dismiss [::noted :pu]
+                     :id         "pop-u"}
+    [:p "U"]]])
+
+(deftest a-dismissal-dispatches-the-intent-of-the-render-that-is-on-screen
+  ;; `impl.overlay/dismissal-handler` mints a fresh closure per render,
+  ;; deliberately: it closes over the intent and the frame dispatch THIS
+  ;; render saw, so an overlay whose `:on-dismiss` changed cannot dispatch
+  ;; the previous one. React swaps a listener for free; a stale intent
+  ;; would cost a wrong event. That sentence had no witness: every other
+  ;; row keeps one `:on-dismiss` for the life of its overlay, so a handler
+  ;; cached on first render would pass all of them.
+  (if-not (mount/browser?)
+    (skip! ":node-test has no popover API and no auto stack")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [swap-dismiss-page {}])]
+        (try
+          (mount/settle!)
+          (go! [::retag :old])
+          (go! [::opened :ps])
+          (is (.matches ($ "#pop-s") ":popover-open")
+              "premise: the subject is open, wired — this render — to the
+               :old intent")
+
+          (go! [::retag :new])
+          (is (.matches ($ "#pop-s") ":popover-open")
+              "premise: the re-render that re-wired :on-dismiss left the
+               overlay open — nothing here dismissed it")
+
+          ;; THE DISMISSAL, through the platform's own door.
+          (go! [::opened :pu])
+          (is (not (.matches ($ "#pop-s") ":popover-open"))
+              "premise: the unrelated auto popover light-dismissed the subject")
+
+          (is (= 1 (get-in (db) [:dismissed :new] 0))
+              "THE FRESHNESS. The dismissal dispatched the intent of the
+               render on screen when the platform closed it — the one wired
+               AFTER the retag")
+          (is (zero? (get-in (db) [:dismissed :old] 0))
+              "and the previous render's intent did not fire: a handler
+               cached at first render — or a closure over the first
+               render's props — would have dispatched :old here")
           (finally (mount/release! handle)))))))
 
 ;; --- the census ------------------------------------------------------------

--- a/implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/overlay_focus_dom_cljs_test.cljs
@@ -141,6 +141,10 @@
 (rf/reg-event ::opened (fn [{:keys [db]} _] {:db (assoc db :open? true)}))
 (rf/reg-event ::closed (fn [{:keys [db]} _] {:db (assoc db :open? false)}))
 (rf/reg-event ::dismissed (fn [{:keys [db]} _] {:db (assoc db :open? false)}))
+;; The claimed-Tab row's observable: the panel control's OWN handling of
+;; the key it claimed. Counted rather than flagged, so a double delivery
+;; would be visible too.
+(rf/reg-event ::tab-claimed (fn [{:keys [db]} _] {:db (update db :tab-claims (fnil inc 0))}))
 
 ;; The two pages differ in the OVERLAY and in nothing else: the same
 ;; three panel controls, the same three page controls, the same flag.
@@ -299,6 +303,32 @@
      ;; notices if it ever stops being a stop.
      [:legend [:button#legend-button {:type "button"} "Legend"]]
      [:button#ghost {:type "button"} "Ghost"]]]
+   [:button#after {:type "button"} "After"]])
+
+(h/defview a-page-with-a-modal-whose-last-control-claims-tab [_]
+  ;; A LAST CONTROL THAT HANDLES Tab ITSELF, which is ordinary panel
+  ;; markup: a grid, a combobox or an embedded editor claims the key for
+  ;; its own internal focus movement and says so with `preventDefault`.
+  ;; The claim is written declaratively — the key-map form, whose lowered
+  ;; handler prevents the default and dispatches — and the promise under
+  ;; test is overlay.cljs's own: *the wrap yields to a press one of them
+  ;; has already claimed with `preventDefault`*.
+  ;;
+  ;; The claimer is LAST on purpose. That puts the claimed press on the
+  ;; edge the wrap fires at, so a wrap that failed to yield would not be
+  ;; merely impolite: it would aim focus at `confirm` while the control's
+  ;; own handling ran — one press moving focus two ways at once.
+  [:div
+   [:button#before {:type "button"} "Before"]
+   [:button#trigger {:type "button" :on-click [::opened]} "Open"]
+   [overlay/modal {:open?      (h/sub [::open?])
+                   :on-dismiss [::dismissed]
+                   :label      "Claimed Tab"}
+    [:button#confirm {:type "button"} "Delete"]
+    [:input#reason {:type "text" :aria-label "Reason"}]
+    [:button#cancel {:type "button"
+                     :on-key-down {"Tab" [::h/prevent [::tab-claimed]]}}
+     "Cancel"]]
    [:button#after {:type "button"} "After"]])
 
 ;; `:async? true` — the MAP shape — because the trusted-input row below
@@ -961,6 +991,56 @@
             (catch :default e
               (is false (str "the disabled-fieldset row threw: "
                              (.-message e)))
+              (finish))))))))
+
+;; ---------------------------------------------------------------------------
+;; The wrap's yield — a press a panel control has already claimed
+;; ---------------------------------------------------------------------------
+
+(deftest a-real-tab-a-panel-control-has-claimed-does-not-wrap
+  ;; THE YIELD, measured on the flag the module actually reads.
+  ;; `impl.overlay/wrap-tab!` reads the NATIVE event's `defaultPrevented`
+  ;; rather than the synthetic copy React takes at construction — a
+  ;; measured distinction: the child's `preventDefault` runs during the
+  ;; same dispatch the panel's handler is part of, so only the native
+  ;; flag has moved by the time the wrap asks. No other row can see any
+  ;; of this — every wrap row presses keys nothing claims, and the
+  ;; popover rows have no wrap at all.
+  (if-not (browser?)
+    (skip! ":node-test has no modality, and no engine to press a key at")
+    (if-not (trusted/bridge?)
+      (trusted/unwitnessed! "the wrap's yield to a claimed press")
+      (async done
+        (let [m      (hm/mount! [a-page-with-a-modal-whose-last-control-claims-tab {}])
+              finish (fn [] (hm/unmount! m) (done))]
+          (try
+            (open! m)
+            (.focus ($ m "#cancel"))
+            (is (= "cancel" (label-of (active)))
+                (str "premise: on the edge the wrap fires at. Active: "
+                     (label-of (active))))
+
+            (trusted/press-once!
+              "Tab"
+              (fn []
+                (try
+                  (hm/settle! m)
+                  (is (= 1 (:tab-claims (rf/app-db-value (:frame m))))
+                      "premise: the press reached the control and its claim
+                       dispatched, exactly once — so the reading below is of
+                       a delivered key, not of a bridge that never fired")
+                  (is (= "cancel" (label-of (active)))
+                      (str "THE YIELD. Tab off the panel's last control is "
+                           "the edge every other row measures the wrap "
+                           "firing at, landing on `confirm` — and this "
+                           "press was claimed by the control itself, so "
+                           "the wrap stands down and focus does not move: "
+                           "not to `confirm`, and — the engine's default "
+                           "action being prevented too — not to anything "
+                           "else. Active: " (label-of (active))))
+                  (finally (finish)))))
+            (catch :default e
+              (is false (str "the claimed-tab row threw: " (.-message e)))
               (finish))))))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
@@ -466,6 +466,36 @@
                               (is (= "B2" (text-in cb ".title")))
                               (is (= "beta" (text-in cb ".value"))))
 
+                            ;; THE DISCRIMINATING HALF, and the reason the two
+                            ;; assertions above are not yet a witness of
+                            ;; `mount/tree`'s hydrated-root shape: a `render!`
+                            ;; that REMOUNTED the adopted tree — the measured
+                            ;; failure `mount/tree`'s docstring records, a bare
+                            ;; provider handed to a root that adopted under the
+                            ;; Fragment-wrapped closer — would also run the body
+                            ;; once and also paint "B2"/"beta". Node identity
+                            ;; and the memo bail-out are what a remount cannot
+                            ;; fake. (The technique is the fenced
+                            ;; `arm1/hydrate-dom-cljs-test`'s §5 rider, restated
+                            ;; against the shipped door — provenance, not a
+                            ;; dependency.)
+                            (testing "and still ADOPTED through that render: a
+                                      props-equal render! bails at the memo with
+                                      zero body runs, and every node is still the
+                                      SERVER's — neither render remounted the
+                                      tree the adoption established"
+                              (let [ran (sup/body-runs-delta!
+                                          (fn [] (mount/render! hb [screen {:title "B2"}])))]
+                                (is (zero? ran)
+                                    (str "a props-equal render! after adoption "
+                                         "ran no body; read " ran)))
+                              (is (sup/every-server-node? cb ".screen, .title, .value")
+                                  "and the surviving root's nodes still answer to
+                                   the server-node mark — a render! that handed
+                                   this root a bare provider where its Fragment
+                                   wrapper stood would have replaced every one of
+                                   them"))
+
                             (testing "and tearing the survivor down leaves nothing"
                               (is (= sup/released (sup/teardown-census! hb)))))))))
                 (sup/settle-row!

--- a/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/test_kit_mounted_dom_cljs_test.cljs
@@ -417,6 +417,71 @@
                                   (done)))))))))))
 
 ;; ---------------------------------------------------------------------------
+;; W3b — the reset gate: a verdict on one mount must not blind a sibling's
+;; ---------------------------------------------------------------------------
+;;
+;; `assert-clean!` resets the page-wide runtime after the LAST open mount
+;; is read, and only then — `!open`'s whole account in
+;; `re-frame.hicasso.test.mounted` (the rf2-2rtt6.48 shape: a census taken
+;; after a reset answers zero whether the teardown released anything or
+;; not, the gate that cannot go red). Every row above takes its verdicts
+;; in an order an EARLY reset would also satisfy: no row plants a leak
+;; under one mount, takes a sibling's verdict first, and then requires the
+;; leaked mount's reading to still move. This row is that ordering.
+;;
+;; ORDER IS THE ROW. B mounts first and takes its baseline; the leak is
+;; planted inside B's window (W3's orphan, verbatim); A mounts AFTER the
+;; leak, so A's own baseline absorbs it and A's verdict is honestly clean.
+;; A's verdict is taken FIRST — `!open` drops to one, B unread — and the
+;; reset must hold, because a reset here empties the very census B's
+;; reading is about to take: B's leak — real, planted, still leaked —
+;; would read as clean.
+
+(deftest l3-the-reset-gate-holds-while-a-sibling-mount-awaits-its-verdict
+  (if-not (mount/browser?)
+    (sup/skip! ":node-test has no React DOM")
+    (async done
+      (let [mb     (seeded 1)
+            orphan (mount/root! (mount/fresh-container!) (:frame mb) [row {:id 2}])
+            _      (hm/unmount! mb)
+            ma     (seeded 2)]
+        (hm/unmount! ma)
+        (-> (hm/assert-clean! ma)
+            (.then
+              (fn [ra]
+                (is (true? (:clean? ra))
+                    (str "premise: A is clean — the orphan predates A's own "
+                         "baseline, so nothing here is A's residue. Got: "
+                         (pr-str (:leaked ra))))
+                (-> (hm/residue mb)
+                    (.then
+                      (fn [rb]
+                        (is (false? (:clean? rb))
+                            "THE GATE. B's reading still moves: A's verdict
+                             — one mount read, one still waiting — did not
+                             reset the page-wide tables out from under it")
+                        (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1 :entries 1}
+                               (:leaked rb))
+                            (str "and it is still W3's precise arithmetic, "
+                                 "read against B's own baseline — a reset "
+                                 "between the two verdicts zeroes both "
+                                 "sides and reads clean. baseline "
+                                 (pr-str (:baseline rb))
+                                 " now " (pr-str (:now rb))))
+
+                        ;; Restore, then FINALISE — the discipline W3
+                        ;; states: the tests for a cleanliness instrument
+                        ;; have to be clean themselves, and B's verdict is
+                        ;; what lets the gate reach zero and reset.
+                        (mount/release! orphan)
+                        (-> (hm/assert-clean! mb)
+                            (.then (fn [after]
+                                     (is (true? (:clean? after))
+                                         "the induced fault was repaired
+                                          before the verdict")
+                                     (done))))))))))))))
+
+;; ---------------------------------------------------------------------------
 ;; W4 — render!: a props change through the same root
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Three-bead cluster from rf2-dr90's coverage audit, all browser-lane. Rebased onto trunk fede993628 (post-#8737; the only trunk delta since dispatch was rf2-mnmi's collector.cljs wording — no file overlap with this diff).

## What landed

**rf2-i011 — refused with evidence (no code; bead closed).** tool.cljs's unjoinable-intent branch is NOT reachable through trace-tooling/trace-buffer's bundling: push-to-ring! drops id-less events at push (the B3 ruling — Spec 009 'frameless events SKIP the rings entirely', tooling.cljc:251-259), and bundles are minted only from ring run-keys, so a bundle's :dispatch-id is non-nil by construction. Full four-leg evidence is on the bead. The branch stays as defence-in-depth; no test was forced through an impossible path.

**rf2-s2ta — two overlay rows.**
- overlay_focus_dom: a trusted Tab off the modal's last stop, claimed by the control itself (key-map prevent form), does not wrap — measured on the native event's defaultPrevented, the flag wrap-tab! actually reads. The claim's own dispatch is asserted so the non-move is a delivered key, not a bridge that never fired.
- overlay_dom: a popover whose :on-dismiss was re-wired while open dispatches the CURRENT render's intent on light dismissal, not the previous one (dismissal-handler's fresh-closure-per-render sentence, previously unwitnessed). Driven through the auto stack. Framed-only: it does not prejudge either outcome of the open rf2-4e5b ruling on the frameless case.

**rf2-xofa — the three orphaned browser witnesses, ported.**
- roots_frames_hydration H3: props-equal render! after adoption = zero body runs + every node still the server's (the discriminating pair a full remount cannot fake; arm1/hydrate §5's rider restated at the shipped door).
- boundary_intent row 10: once-per-caught-failure under StrictMode, plus exactly one more report after a failed reset.
- test_kit_mounted W3b: the assert-clean! reset gate holds while a sibling mount awaits its verdict (leak under B, A's verdict first, B's reading must still move — the ordering an early reset would pass).

Audit for further orphaned donor witnesses: remaining arm1 DOM citations in src (boundary hook counts, controlled-grid family, composition suppression) already have shipped DOM witnesses (boundary_intent row 7, controlled_dom_cljs_test); node-lane citations were rf2-dr90's landed sweep. Nothing further to port.

Declined (routed mid-flight, premise checked): folding rf2-14fj's two prose-only ::h/mounting respells — its source PR #8739 was still OPEN at check time, and prose presuming an unmerged change would drift if that PR moves; rf2-14fj stays the sequenced follow-up its own fence line describes.

## Quality gates

All exit codes below are captured from per-attempt exit files, not harness-reported.

On the rebased final base (fede993628 + these two commits):
- `npm run test:browser` — **exit 0** — Ran 1078 tests containing 6112 assertions, 0 failures, 0 errors
- `npm run test:cljs` — **exit 0** — Ran 11843 tests containing 59971 assertions, 0 failures, 0 errors
- `npm run test:hicasso-compile` — **exit 0** — 160 namespaces, zero warnings

Pre-rebase (base 6eb0a2a402, identical tree content):
- `npm run test:browser` clean baseline — **exit 0** — 1078/6112, 0 failures
- `shadow-cljs compile browser-test` after each commit — **exit 0**, 0 warnings (both commits)

**Planted-fault controls — one bounded plant per row's subject property, all five in one sabotage run: `npm run test:browser` — exit 1, 10 failures, 0 errors, 94 files recompiled (the runtime observed the plants). Each plant reddened its own row:**
1. wrap-tab! yield guard removed → `a-real-tab-a-panel-control-has-claimed-does-not-wrap` red: `(not (= "cancel" "confirm"))` — the wrap fired despite the claim.
2. dismissal-handler cached at first render → `a-dismissal-dispatches-the-intent-of-the-render-that-is-on-screen` red both ways: new intent 0, old intent 1.
3. render! handed a hydrated root the bare provider → H3 `tearing-down-one-hydrated-root-leaves-the-other-adopted-and-live` red at the new server-node assertion (the pre-existing H3 assertions stayed green — exactly the gap the bead named).
4. report! called from render → `the-boundary-reports-once-per-failure-under-strictmode` red on both arms, plus the two expected collateral over-report reds in the same file (rows 8 and 9's :on-error paths).
5. assert-clean! reset gate removed → `l3-the-reset-gate-holds-while-a-sibling-mount-awaits-its-verdict` red on both gate assertions, with ZERO other test_kit rows moving — confirming every pre-existing row was satisfiable by an early reset.

All four planted files restored via `git checkout HEAD --` and verified by git blob hash (`git hash-object --path` equals `git rev-parse HEAD:<path>` for all four); the green runs above are of the restored tree.

## Manual checks

No gated markdown touched; the diff is five CLJS test/test_kit files, no src changes.