### PR TITLE
test(hicasso): respell the last two ::h/mounting docstring mentions to ::motion/… (rf2-14fj)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs
@@ -110,7 +110,7 @@
   merging attribute overrides into a node.
 
   **That prop is why this row has an observable at all.** A NATIVE
-  presence child wears its phase as `::h/mounting` attributes, which React
+  presence child wears its phase as `::motion/mounting` attributes, which React
   patches in place and which are gone a macrotask later when the enter
   flip lands — so a row that waited for a commit and then read the DOM
   could not tell a child that was BORN present from one that entered and

--- a/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs
@@ -430,7 +430,7 @@
 
   [[server-html!]] cannot be used for such a tree. It reads `innerHTML`
   on the line after a `flushSync` render, and on an ordinary root that is
-  the FIRST pass — every child `:mounting`, wearing its `::h/mounting`
+  the FIRST pass — every child `:mounting`, wearing its `::motion/mounting`
   overrides. Hydrating against those bytes would compare a settled client
   tree with an entering server tree and manufacture a divergence no row
   here is about.


### PR DESCRIPTION
## What

Executes the worker half of rf2-14fj. PR #8739 executed naming-ledger row 31: the presence override keys are now `:re-frame.hicasso.motion/mounting` / `:re-frame.hicasso.motion/unmounting` and the `::h/…` pair is retired. Two prose-only docstring lines were fenced to the then-live hic-browser-rows worker (PR #8740) and still carried the old spelling. This PR is the one-word respell of each:

- `implementation/hicasso/test/re_frame/hicasso/roots_frames_support.cljs:433` — `::h/mounting` → `::motion/mounting`
- `implementation/hicasso/test/re_frame/hicasso/roots_frames_hydration_dom_cljs_test.cljs:113` — `::h/mounting` → `::motion/mounting`

Prose only; no code, keyword values, or behaviour changes. The bead's spelling (`::motion/…` each) matches the package's established prose idiom — `server.cljs`, `impl/codec.cljs` and `impl/presence.cljs` all spell the keys `::motion/…` in docstring prose without carrying the alias — and the hydration test file requires `[re-frame.hicasso.motion :as motion]`, so the spelling reader-resolves there as well.

Out of scope, deliberately untouched: the bead's operator-held docs/design half (facade-freeze.md, REWRITE-NOTES.md), the bench tree's deliberate prototype spellings, and everything else. The bead stays open — its design-pages half remains with Mike.

## Quality gates

- `npm run test:hicasso-compile` — captured exit code **0** (160 namespaces, 478 files compiled, 0 warnings). This is the covering gate for docstring-safety in test namespaces; the diff is prose inside docstrings/comments, so no behaviour suite is armed.
- No automated gate validates prose content itself. Both sentences were verified by hand after the edit and still read truthfully: the support-harness sentence describes first-pass children wearing their `::motion/mounting` attribute overrides (which is what the shipped codec now spells), and the hydration-test sentence describes a native presence child wearing its phase as `::motion/mounting` attributes (same).
- Post-edit sweep: no `::h/mounting` / `::h/unmounting` remains anywhere under `implementation/hicasso/` outside the bench tree and the naming-ledger's own retirement record.