### PR TITLE
docs(method): detach rule as terminal condition; stop events outrank sweep clocks; no condensed blocks

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -448,6 +448,13 @@ the block forbids. Between a failure prevented by construction and one prevented
 reader's diligence, take construction; the context cost is the acknowledged price, and a
 brief is the mayor's scarce output.
 
+**And no dispatch is small enough to earn a condensed block.** The temptation is strongest
+exactly where the block most dwarfs the task — a two-line edit behind a two-hundred-line block —
+and condensing there is the paraphrase the mechanical extraction exists to prevent, arriving
+dressed as proportionality. One mayor did it once, on a session's smallest dispatch, having
+pasted the full block on every larger one; the worker behaved anyway, and the outcome does not
+validate the shortcut.
+
 **But "verbatim" forbids WEAKENING a block, not adding to it — and the paragraphs addressed to YOU
 are not part of what travels.** Where the payload is FENCED, the fence settles it: take the
 fence, and every line outside it is yours. Two of the three here are fenced, and their
@@ -695,6 +702,14 @@ notification does not always arrive, and a turn that has ended has nothing left 
 such worker was recovered intact the moment somebody asked it for a status. Word this as the
 sanctioned path, not as a concession; a worker who thinks it has erred reads for how to atone and
 straight past the instruction that would save it.
+
+**And state the rule as a terminal condition, because the strand has variants: the turn ends only
+once the exit file exists and its number is quoted.** Stated as a forbidden wait — *do not end the
+turn waiting for a completion notification* — it fails open on the first wait nobody wrote down: a
+worker that ARMED A MONITOR on its exit file and ended its turn presented as compliant and
+stranded identically, because a watcher owned by an agent stops when its agent does. Measured
+twice in one session, both briefs carrying this block verbatim; the second worker read the
+enumerated wording as licence for the un-enumerated variant.
 
 **A gate heavy enough that two cannot coexist WEDGES rather than fails** — no progress, no exit
 file, no error, from a run that was healthy a minute ago. This is contention for the MACHINE, so

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -857,6 +857,13 @@ and both readings went wrong in a single day here, in opposite directions.
    and then ended its turn**, waiting for a completion event nothing sends. Seven such incidents in one
    day; every one recovered intact the moment somebody asked for a status.
 
+   **Where the harness itself delivers an agent-stopped event, that event outranks every clock in this
+   section for that agent.** An event defined to fire only when nothing of the agent's remains alive is
+   not one more signal to weigh: arriving from a worker whose last message says it is WAITING for
+   something, it is the diagnosis itself — the awaited wake no longer exists, whatever the worker
+   believed it had armed. Resume without further discrimination; the clocks above are for workers whose
+   harness reports nothing.
+
    **But whether that question has an answer depends on your messaging tool, and it may not.**
    Measured twice here, a send to an agent stopped mid-turn was ACCEPTED — success returned and
    delivery promised at the agent's *next tool round*, which for a stopped agent never comes.


### PR DESCRIPTION
## What this is

Three bounded additions to the mayor-method docs from a session retrospective, all from measured incidents rather than speculation.

1. **Gate-mechanics block** (dispatch-prompt-template.md): the detach rule is restated as a terminal condition — the turn ends only once the exit file exists and its number is quoted. The enumerated form ("do not wait for a completion notification") failed open twice in one session on a variant nobody wrote down: a worker armed a monitor on its exit file and ended its turn, presenting as compliant. Same fail-open shape, and same inversion remedy, as the merge criterion's clause 3.
2. **Stranded sweep** (loops.md §4): where the harness delivers an agent-stopped event defined to fire only when nothing of the agent's remains alive, that event outranks the sweep's clocks — from a worker that says it is waiting, the event is the diagnosis itself. Resume without discrimination.
3. **Pasting a block** (dispatch-prompt-template.md): no dispatch is small enough to earn a condensed block; the temptation is strongest exactly where the block most dwarfs the task, and the outcome of the one observed shortcut does not validate it.

Sibling sweep: three remaining occurrences of the old wording each verified correct in place (a different rule; the sentence the new paragraph qualifies; the mayor-side description now supplemented). Generic throughout — no OS, repository or operator specifics.

## Quality gates

- check_doc_slugs.py (docs link/anchor gate, the covering gate for this tree): captured exit 0 pre-plant, exit 1 on a planted broken anchor naming loops.md and the plant, exit 0 after restore; restore verified by git blob hash equality (5338c93465ab936947a6d0a75e0fe823e2e74880).
- Prose content has no automated gate: both new paragraphs and the sweep addition were re-read in place against the surrounding register, and the three standing sibling occurrences read for correctness by hand.