### PR TITLE
hicasso guide ch04: the owned-key guarantee is per map key, not per React slot (rf2-6c12m.23)

### DIFF
--- a/docs/core/hicasso/04-controlled-inputs.md
+++ b/docs/core/hicasso/04-controlled-inputs.md
@@ -113,11 +113,15 @@ control slots. Merge the caller map first and the owned entries last:
         :placeholder "Todo title"}]
 ```
 
-Literal owned keys win by presence. A caller cannot replace the field's value,
-checked state, handler, key, or revision by supplying an alternative spelling
-such as `:onInput` or `"value"`; the controlled contract binds to the React
-slot reached by the authored literal. When callers should own a slot, do not
-write that literal in the wrapper.
+Literal owned keys win by presence: `:value`, `:disabled`, and `:on-input` are
+merged last, so a caller's entries under those same keys are replaced. That
+protection is per map key, not per React slot. A caller's `:onInput` or
+`"value"` is a different key, so it survives the merge and lands on the same
+React slot as the owned literal, and which of the two wins is decided by map
+iteration order. Forward maps in the same kebab-keyword spelling as Hiccup, as
+[chapter 02](02-views-and-reads.md#forward-attributes-with-owned-keys-last)
+says, or `dissoc` the alternate spellings before merging. When callers should
+own a slot, do not write that literal in the wrapper.
 
 Put the wrapper's own classes on the Hiccup tag so they compose with a caller's
 `:class`. Do not forward `:key` or [`::h/revision`](glossary.md#hrevision): both


### PR DESCRIPTION
## Summary

`docs/core/hicasso/04-controlled-inputs.md` §Forward caller attributes safely claimed a caller cannot replace an owned value, handler, key or revision by an alternative spelling such as `:onInput` or `"value"`. The taught plain `merge` with owned keys last never delivered that guarantee — it was only ever enforced by the `:&` merge key's owned-literal law, which rf2-6c12m.12 (PR #8746) is removing.

Verified at source at tip `8f9266219980` (`implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs`): `convert-props` walks the merged map with `(reduce-kv convert-entry #js {} merged)`; `convert-entry` resolves each keyword key to its `PropSlot` and does a plain `unchecked-set` of `.-js-name` on the emitted object (only the class slot composes). `:on-input` and `:onInput` resolve to the one `onInput` slot (`canonical-slot` / `cached-prop-name`), so after a plain merge both keys survive, both land on that slot, and whichever `reduce-kv` visits last wins — map iteration order. `merge-caller`'s own docstring records exactly this as the case its slot-level deny existed to close, and that deny only ever ran for `:&`.

The paragraph now says what the taught spelling actually does: the owned literal wins by presence when the caller forwards the SAME key; an alternate spelling is a different map key, survives the merge, and collides on the React slot with iteration order deciding; so forward maps in the same kebab-keyword spelling (as chapter 02 §Forward attributes with owned keys last already says, now linked) or `dissoc` the alternates. One paragraph, no new ceremony, no fenced block touched. Correct whether or not #8746 has merged, since neither spelling of the guide ever taught `:&`.

Bead: rf2-6c12m.23 (child of epic rf2-6c12m).

## Quality gates

Run from this branch at its final base (`origin/main` = `8f9266219980`, unmoved between edit and push), each with its exit code captured to a per-attempt file in the same shell:

| Gate | Exit |
| --- | --- |
| `python scripts/check_doc_slugs.py` (repo root) | 0 |
| `python -m mkdocs build --strict` (repo root; `docs/core` is inside `docs_dir`) | 0 — 0 warnings/errors, built in 23.69 s |
| `npm run test:hicasso-invariants` (`implementation/`; carries `check_guide_samples.py`) | 0 — self-test fired, 104 hicasso verbs at 413 sites across 29 pages resolve to a public def |

**Planted-fault control** (`check_doc_slugs.py`): with the edit committed, the new cross-chapter anchor was broken to `#forward-attributes-with-owned-keys-lasst` (match count 1 before the plant; blob hash `8689b622…` → `61d1e827…`), the gate returned **exit 1** naming `docs/core/hicasso/04-controlled-inputs.md:122 -> 02-views-and-reads.md#forward-attributes-with-owned-keys-lasst`; restored with `git checkout HEAD -- <file>` and verified by blob hash back to `8689b622141e6a7a8d88894fa8c6d0effb6f31c6`, equal to the committed object. So the gate read this tree and the anchor it now passes is the one it can see.

**What no gate checks**: none of the three validates prose. The sentence was re-read against `convert-entry` / `convert-props` / `canonical-slot` at the tip named above, and the claim it makes (same key → owned literal wins; alternate spelling → same slot, iteration order decides) is what that code does. The one link added resolves to an existing heading (`## Forward attributes with owned keys last` in chapter 02), verified by the gate above and by hand. No fenced block was moved or edited, so the sample gate's verbs-resolve rule saw the same 413 sites as before.