### PR TITLE
test(hicasso): HMR testbed island and the Xray native-island test in raw React (rf2-6c12m.28)

### DIFF
--- a/implementation/hicasso/testbed/hicasso_hmr_testbed/core.cljs
+++ b/implementation/hicasso/testbed/hicasso_hmr_testbed/core.cljs
@@ -59,8 +59,7 @@
             [re-frame.frame :as frame]
             [re-frame.hicasso :as h]
             [re-frame.hicasso.impl.collector :as collector]
-            [re-frame.hicasso.impl.inventory :as inventory]
-            [re-frame.hicasso.native :as n]))
+            [re-frame.hicasso.impl.inventory :as inventory]))
 
 ;; ---------------------------------------------------------------------------
 ;; The two frames — the routing row's whole premise
@@ -266,11 +265,13 @@
            :instances (into {} (map (fn [{:keys [frame]}]
                                       [frame (get-in @!instances [frame :current])]))
                             frames)
-           ;; The native tier's objects, frozen the same way and for the
-           ;; same reason: every one of them is documented to be REPLACED
-           ;; by a save, and identity is the only instrument that can say
-           ;; so. Held as the raw JS object the module answers, so a head
-           ;; added there appears here without a second roster to keep.
+           ;; The island's objects — the function, its `react/memo` record
+           ;; and the two `react/lazy` heads — frozen the same way and for
+           ;; the same reason: each is a top-level `def` the save
+           ;; re-evaluates, so every one of them is REPLACED by a save, and
+           ;; identity is the only instrument that can say so. Held as the
+           ;; raw JS object the module answers, so a head added there
+           ;; appears here without a second roster to keep.
            :heads    (views/live-heads)
            :islands  (into {} (for [{:keys [frame]} frames
                                     slot island-slots]
@@ -293,29 +294,21 @@
     (count (filter (fn [r] (some #(identical? % r) before)) now))))
 
 (defn- head-report
-  "Which of the native tier's objects survived the save, and what each one
-  still says about itself.
+  "Which of the island's objects survived the save — the function, its
+  `react/memo` record, the two `react/lazy` heads, and the head the app
+  actually RENDERS.
 
-  The two halves answer different bead questions and are deliberately in
-  one place. `same?` is rf2-y5x6j's and rf2-iq0a's shared claim that a
-  reload REPLACES — `n/component`, `n/memo` and `n/defcomponent` each say
-  so in their own docstring and none of them was measured under a real
-  recompile. `name`, `server` and `displayName` are rf2-iq0a's other half:
-  the tier marker has to be READABLE on the far side of a save, because a
-  marker that a reload silently dropped would leave Xray naming an
-  anonymous boundary where an island is, and nothing on the page would
-  look any different."
+  One question per head, answered as a boolean: is it the same object the
+  baseline captured? `same?` is rf2-y5x6j's and rf2-iq0a's shared claim
+  that a reload REPLACES. That is React's own remount rule — a top-level
+  `def` the save re-evaluates is a fresh allocation, never a lookup by
+  name — and until this gate nothing had measured it under a real
+  recompile."
   [base]
-  (let [now  (views/live-heads)
-        was  (:heads base)
-        read (fn [k]
-               (let [head   (unchecked-get now k)
-                     marker (n/marker head)]
-                 {:same?       (identical? (unchecked-get was k) head)
-                  :name        (some-> marker (unchecked-get "name"))
-                  :server      (some-> marker (unchecked-get "server"))
-                  :displayName (unchecked-get head "displayName")}))]
-    (into {} (map (fn [k] [k (read k)]))
+  (let [now (views/live-heads)
+        was (:heads base)]
+    (into {} (map (fn [k] [k {:same? (identical? (unchecked-get was k)
+                                                  (unchecked-get now k))}]))
           ["islandBody" "islandMemo" "hostHead" "escapeHead" "rendered"])))
 
 (defn- identity-report

--- a/implementation/hicasso/testbed/hicasso_hmr_testbed/views.cljs
+++ b/implementation/hicasso/testbed/hicasso_hmr_testbed/views.cljs
@@ -42,19 +42,19 @@
   | [[field]] | the focused controlled input — caret, selection and composition across a save |
   | [[hook-child]] / [[hook-host]] | a child's `useState` inside a host crossing |
   | [[imperative-note]] / [[note-host]] | the active imperative host: a live instance, held through a callback `:ref`, with a side effect React does not know about |
-  | [[island-body]] | the NATIVE-TIER island, and the one component every wrapper is carried across (rf2-iq0a) |
-  | [[host-head]] / [[escape-head]] | that island behind `n/lazy`, so the `React.lazy` bridge meets a real recompile (rf2-y5x6j) |
+  | [[island-body]] | the island — a raw React function component, and the one component every wrapper is carried across (rf2-iq0a) |
+  | [[host-head]] / [[escape-head]] | that island behind a raw `react/lazy`, so the `React.lazy` bridge meets a real recompile (rf2-y5x6j) |
   | [[app]] | the head whose re-mint is the whole cause, rendered once per frame so frame routing is readable per root |
 
-  The two foreign components are written with React's own primitives and
-  no Hicasso in them at all, which is what makes them a fair witness for
-  \"React facts die with the fiber\" ([I6](../../../implementation/hicasso/spec/invariants.md)):
+  The foreign components — the hook child, the imperative host and the
+  island — are written with React's own primitives and no Hicasso in
+  them at all, which is what makes them a fair witness for \"React facts
+  die with the fiber\" ([I6](../../../implementation/hicasso/spec/invariants.md)):
   the runtime is not being asked to preserve anything it could have
   preserved."
   (:require ["react" :as react]
             [re-frame.core :as rf]
-            [re-frame.hicasso :as h]
-            [re-frame.hicasso.native :as n]))
+            [re-frame.hicasso :as h]))
 
 ;; ---------------------------------------------------------------------------
 ;; The hot line
@@ -166,19 +166,28 @@
           "p" #js {"data-testid" "note" "ref" node-ref} "")))))
 
 ;; ---------------------------------------------------------------------------
-;; The native-tier island, and the `React.lazy` bridge it arrives through
+;; The island, and the `React.lazy` bridge it arrives through
 ;; ---------------------------------------------------------------------------
 ;;
-;; ONE component, carried across every wrapper the ABI has (rf2-iq0a), and
-;; reached through a real `n/lazy` payload so the code-splitting bridge
+;; ONE component, carried across every wrapper React has (rf2-iq0a), and
+;; reached through a real `react/lazy` payload so the code-splitting bridge
 ;; meets a real recompile (rf2-y5x6j). The chain is
 ;;
-;;   island-body   n/defcomponent   the author's function, tier marker and all
-;;     -> island   n/memo           the memo record, marker carried across
-;;     -> *-head   n/lazy           the Client-only gate over a react/lazy payload
+;;   island-body   defn             a raw React function component over
+;;                                  react/createElement, no Hicasso in it
+;;     -> island   react/memo       the memo record around it
+;;     -> *-head   react/lazy       a lazy record over the payload, one per crossing
 ;;     -> crossed  defhost AND [:>] both crossings, so neither door is assumed
-;;                                  to behave like the other
+;;                                  to behave like the other: the defhost one
+;;                                  declares `:server :client-only` and gates
+;;                                  the head behind it, the [:>] one is the
+;;                                  door with the declaration erased
 ;;   with a callback `:ref` through both, and the save's re-mint over the top.
+;;
+;; Every link is a top-level `def` in this namespace, so a save re-evaluates
+;; each one and the object at that position is NEW — allocation, never a
+;; lookup by name. That is React's own remount rule, and it is the whole of
+;; the island's HMR contract: the gate measures it by identity.
 ;;
 ;; ## The island holds NO SUBSCRIPTION, and that is a decision
 ;;
@@ -210,43 +219,45 @@
   []
   @!island-loads)
 
-(n/defcomponent island-body
-  "THE ISLAND — a native-tier component, declared through the tier's own
-  macro with an explicit server policy so the policy is a fact a driver
-  can read back after a save rather than a default nobody wrote.
+(defn- island-body
+  "THE ISLAND — a raw React function component: a plain `defn` over
+  `react/createElement`, with no Hicasso in it. Its server policy is
+  declared where a crossing declares one, on [[island-host]].
 
   Its `useState` instance id is minted from the counter that outlives the
   reload, exactly as [[HookChild]]'s is, so a rebuilt island and a
   preserved one are told apart by a number rather than by a repaint."
-  {:server :client-only}
   [^js props]
   (let [[id _] (react/useState next-instance-id!)]
-    (n/$ "div" #js {"data-testid" (.-slot props)
-                    "ref"         (.-nodeSink props)}
-         (n/$ "span" #js {"data-testid" (str (.-slot props) "-instance")}
-              (str id))
-         (n/$ "span" #js {"data-testid" (str (.-slot props) "-gen")}
-              generation-label))))
+    (react/createElement
+      "div" #js {"data-testid" (.-slot props)
+                 "ref"         (.-nodeSink props)}
+      (react/createElement "span" #js {"data-testid" (str (.-slot props) "-instance")}
+                           (str id))
+      (react/createElement "span" #js {"data-testid" (str (.-slot props) "-gen")}
+                           generation-label))))
 
 (def island
-  "The memo wrapper. `n/memo` rather than `react/memo` because the tier
-  marker and the display name have to survive the wrapping — and because
-  `n/memo`'s own docstring says this record MUST NOT survive a hot reload,
-  which until now nothing measured under one."
-  (n/memo island-body))
+  "The memo wrapper — `react/memo` and nothing else. A memo record is the
+  element type React reconciles on; a save re-evaluates this `def` and
+  allocates a fresh record around the fresh function, so the record MUST
+  NOT survive a hot reload, and the gate measures that by identity."
+  (react/memo island-body))
 
 (defn- load-island!
   "The chunk fetch, counted.
 
   A resolved promise rather than a network round trip: what is under test
-  is the BRIDGE — `n/lazy`'s payload, its Client-only gate, React's
-  Suspense and the re-mint — and a real `shadow.lazy/load` would add a
-  second module to the build without adding anything to the claim. The
-  loader is the one part of the shape that is stubbed, and it is stubbed
-  where `lazy_boundary_dom_cljs_test`'s `deferred-loader` stubs it."
+  is the BRIDGE — `react/lazy`'s payload, the Client-only gate `defhost`
+  puts in front of it, React's Suspense and the re-mint — and a real
+  `shadow.lazy/load` would add a second module to the build without
+  adding anything to the claim. The loader resolves to the module record
+  `React.lazy` reads, `#js {:default island}`; it is the one part of the
+  shape that is stubbed, and it is stubbed where
+  `lazy_boundary_dom_cljs_test`'s `deferred-loader` stubs it."
   []
   (vswap! !island-loads inc)
-  (js/Promise.resolve island))
+  (js/Promise.resolve #js {:default island}))
 
 ;; TWO heads over ONE loader, which is `lazy_boundary_dom_cljs_test`'s own
 ;; shape for the same reason: it puts the payload's identity on the table.
@@ -255,22 +266,23 @@
 ;; of them and costs one.
 
 (def host-head
-  "The head behind the `defhost` crossing."
-  (n/lazy load-island!))
+  "The head behind the `defhost` crossing — a raw `react/lazy` record."
+  (react/lazy load-island!))
 
 (def escape-head
   "The head behind the `[:>]` crossing — the one the sabotage pins."
-  (n/lazy load-island!))
+  (react/lazy load-island!))
 
 ;; --- the sabotage: a head that survived the reload -------------------------
 ;;
-;; The fault rf2-y5x6j asks for, and it is the one the tier's own docstring
-;; names: `n/component` says caching a head by name "would preserve identity
-;; across a reload and quietly contradict the recorded contract". This is
-;; that runtime, toggled at run time — the app renders the head it captured
-;; before the save instead of the one the save minted. Recoverable, unlike
-;; the lost-cleanup sabotage: disarming restores the live head and the next
-;; save re-mints normally.
+;; The fault rf2-y5x6j asks for: a bridge that caches a head BY NAME. That
+;; would preserve identity across a reload and quietly contradict React's
+;; remount rule — a `def` the save re-evaluates is a new object, and React
+;; replaces the subtree at that position. This is that runtime, toggled at
+;; run time — the app renders the head it captured before the save instead
+;; of the one the save minted. Recoverable, unlike the lost-cleanup
+;; sabotage: disarming restores the live head and the next save re-mints
+;; normally.
 
 (defonce ^:private !pinned-escape-head (volatile! nil))
 
@@ -325,8 +337,13 @@
 
 (h/defhost island-host
   "The `defhost` crossing over the lazy head — a declaration, with the
-  island's props ABI and its `:ref` passing straight through the gate."
-  host-head)
+  island's server policy written where a crossing declares one.
+  `:server :client-only` is the default and needs no writing; it is
+  written so the policy is a fact a reader can see rather than a default
+  nobody wrote. The island's props ABI and its `:ref` pass straight
+  through the gate."
+  host-head
+  {:server :client-only})
 
 (h/defview field
   "The focused controlled input. An ordinary `:value` off a subscription

--- a/implementation/hicasso/testbed/hmr_spec.cjs
+++ b/implementation/hicasso/testbed/hmr_spec.cjs
@@ -511,15 +511,8 @@ async function frameRoutingAcrossASave(page, w, ctx) {
 }
 
 // ---------------------------------------------------------------------------
-// 7. The native tier and the React.lazy bridge, through a real recompile
+// 7. The island and the React.lazy bridge, through a real recompile
 // ---------------------------------------------------------------------------
-
-// The name `n/defcomponent` computes for the island — `<ns>/<sym>`, the
-// tier's address rule, written out for the same reason `hmr_remount`'s
-// `view-name` is: the marker has to be readable under the IDENTICAL name
-// after a save, and a constant derived from whatever came back would agree
-// with itself no matter what the reload did to it.
-const ISLAND_NAME = 'hicasso-hmr-testbed.views/island-body';
 
 // rf2-y5x6j and rf2-iq0a in one section, because they are one fixture.
 //
@@ -528,9 +521,13 @@ const ISLAND_NAME = 'hicasso-hmr-testbed.views/island-body';
 // landed in `lazy_boundary_dom_cljs_test`, which then stated the hot-reload
 // fact in PROSE: "the retry a rejected chunk needs is a NEW HEAD, which is
 // the same allocation a hot reload performs". Nothing had performed one.
-// Separately, `n/component`, `n/memo` and `n/defcomponent` each promise in
-// their own docstring that a reload REPLACES what they mint, and the native
-// tier appeared nowhere in this gate at all.
+// Separately, the island is a raw React function component behind a
+// `react/memo` record and two `react/lazy` heads — top-level `def`s in the
+// reloaded namespace, every one — and React's own remount rule says a save
+// REPLACES each of them: the def re-evaluates, the element type at that
+// position is a new object, and React rebuilds the subtree. Allocation,
+// never a lookup by name. Nothing had measured that under a real recompile
+// either.
 //
 // Both claims are about the same event, so they are measured on the same
 // save. The instrument is the LOADER COUNT and OBJECT IDENTITY, never the
@@ -564,17 +561,6 @@ async function nativeLazyIslandAcrossASave(page, w, ctx) {
   w.eq(await islandLoads(page), loadsBefore,
     'CONTROL — and nothing re-fetched the chunk, so the count below is the save\'s');
 
-  // THE PREMISE, before the save: the marker is there to be lost. A row
-  // asserting it is readable afterwards says nothing unless it was
-  // readable first.
-  w.eq(quiet.heads.islandBody.server, 'client-only',
-    'the island declares its server policy and the marker carries it');
-  w.eq(quiet.heads.islandBody.name, ISLAND_NAME, 'under the tier\'s address rule');
-  w.eq(quiet.heads.hostHead.server, 'client-only',
-    'and the lazy head is Client-only — its own policy, not the island\'s');
-  w.eq(quiet.heads.hostHead.name, ISLAND_NAME,
-    'with the arrived component\'s name filled into the head\'s own marker');
-
   await ctx.save();
   await waitForIslands(page);
 
@@ -585,7 +571,7 @@ async function nativeLazyIslandAcrossASave(page, w, ctx) {
   // The bead requires this row to state one and assert it, rather than
   // assert whichever happened. It is THE BOUNDARY RE-LOADS. A head is a
   // top-level `def` in the reloaded namespace, so the save re-evaluates it
-  // and `n/lazy` allocates a fresh `react/lazy` record; a fresh payload is
+  // and `react/lazy` allocates a fresh record; a fresh payload is
   // Uninitialized, so React calls the loader again and the chunk is
   // fetched a second time. The loaded module does NOT survive the save.
   //
@@ -603,27 +589,12 @@ async function nativeLazyIslandAcrossASave(page, w, ctx) {
     'the defhost crossing\'s lazy head was re-minted by the save');
   w.eq(after.heads.escapeHead['same?'], false, 'and the [:>] crossing\'s');
   w.eq(after.heads.islandMemo['same?'], false,
-    'and the memo record — `n/memo`\'s docstring says it must NOT survive a '
-    + 'hot reload, which nothing had run one to check');
+    'and the `react/memo` record — a memo record is the element type React '
+    + 'reconciles on, so it must NOT survive a hot reload, and nothing had run '
+    + 'one to check');
   w.eq(after.heads.islandBody['same?'], false,
-    'and the island `n/defcomponent` minted — allocation, never a lookup by name');
-
-  // ------------------------------------------------------------------
-  // rf2-iq0a: the tier survives the save as a DESCRIPTION of itself
-  // ------------------------------------------------------------------
-  //
-  // The objects are all new; what must be unchanged is what they SAY. A
-  // reload that dropped the marker would leave Xray naming an anonymous
-  // boundary where an island is, and the page would look identical.
-  w.eq(after.heads.islandBody.name, ISLAND_NAME,
-    'the re-minted island carries the same tier name — an address, not an identity');
-  w.eq(after.heads.islandBody.server, 'client-only', 'and the same server policy');
-  w.eq(after.heads.islandBody.displayName, ISLAND_NAME, 'and the same display name');
-  w.eq(after.heads.hostHead.server, 'client-only',
-    'the fresh lazy head is Client-only before anything has arrived in it');
-  w.eq(after.heads.hostHead.name, ISLAND_NAME,
-    'and its marker took the re-arrived component\'s name, so the head names '
-    + 'the island on the far side of the save too');
+    'and the island function itself — allocation, never a lookup by name, '
+    + 'which is React\'s own remount rule');
 
   // The subtree really was rebuilt, read three independent ways: React's
   // own fiber state, the DOM node the ref is attached to, and the ref
@@ -666,14 +637,16 @@ async function nativeLazyIslandAcrossASave(page, w, ctx) {
 // rf2-y5x6j's third acceptance clause: break the bridge's reload path and
 // the row above fails BY NAME.
 //
-// The fault modelled is the one the tier's own docstring names.
-// `n/component` says caching a head by name "would preserve identity across
-// a reload and quietly contradict the recorded contract" — so the sabotage
-// is a runtime that does exactly that, holding the head it had before the
-// save and rendering it afterwards. Everything else is untouched: the
-// module still re-evaluates, `n/lazy` still mints a fresh head, and the
-// `defhost` crossing beside it still takes the new one. Only what the
-// `[:>]` crossing RENDERS is pinned.
+// The fault modelled is a bridge that caches a head BY NAME. React's
+// remount rule is that a `def` the save re-evaluates is a new object and
+// the subtree at that position is rebuilt; a runtime that went on
+// rendering the head it had before the save would preserve identity
+// across a reload and quietly contradict that. So the sabotage is exactly
+// that runtime, holding the head it had before the save and rendering it
+// afterwards. Everything else is untouched: the module still
+// re-evaluates, `react/lazy` still mints a fresh head, and the `defhost`
+// crossing beside it still takes the new one. Only what the `[:>]`
+// crossing RENDERS is pinned.
 //
 // Unlike the lost-cleanup sabotage this one is RECOVERABLE, so all four
 // phases assert: arm, confirm red, disarm, confirm green.
@@ -697,7 +670,7 @@ async function pinnedLazyHeadSabotage(page, w, ctx) {
 
   w.eq(red.heads.rendered['same?'], true,
     'RED — but the head the app RENDERS survived the save: a bridge that '
-    + 'cached by name, which is the conduct `n/component` forbids in prose');
+    + 'cached by name, which is the conduct React\'s remount rule forbids');
   w.eq(await islandLoads(page), loadsBefore + 1,
     'RED — and the chunk was fetched ONCE, not twice: a resolved payload is '
     + 'never re-read, so the pinned crossing silently skipped its re-load. '

--- a/implementation/scripts/serve-and-run-hicasso-hmr-testbed.cjs
+++ b/implementation/scripts/serve-and-run-hicasso-hmr-testbed.cjs
@@ -329,7 +329,7 @@ const REQUIRED_SECTIONS = {
   'child-hook-state-in-a-host': 6,
   'active-imperative-host': 7,
   'frame-routing-across-a-save': 13,
-  'native-lazy-island-across-a-save': 40,
+  'native-lazy-island-across-a-save': 31,
   'pinned-lazy-head-sabotage': 8,
   'zero-stale-registrations': 28,
   'lost-cleanup-sabotage': 30,

--- a/tools/xray/spec/028-Hicasso-Advisor.md
+++ b/tools/xray/spec/028-Hicasso-Advisor.md
@@ -315,7 +315,7 @@ subtree.
 Two consequences follow, and both are asserted rather than described:
 
 1. **Links 5-7 are constants.** `link-host` reads no argument `slice` was given,
-   so an interpreted-only boundary, one rendering an `n/defcomponent` island and
+   so an interpreted-only boundary, one rendering a raw-React island through `h/defhost` and
    one rendering a `[:>]` foreign escape produce three identical rows.
    `:host-opaque` means *React owns commit and paint for any boundary*; it does
    **not** mean *a foreign subtree was crossed*, and a consumer must not read it
@@ -430,7 +430,7 @@ bead: no new sentinel, no new evidence machinery, and no code under
 | `…panels.hicasso-advisor-cljs-test` | node + JVM | the timing fold (untimed ≠ zero; a memo hit is not work; an unnamed run is `:uncorrelated`, never dropped; the per-frame scope); the top-3 against a HAND profile whose frequency order deliberately inverts its time order; the fallback axis says `NOT by time`; the five classifications, each driven from a real window; `:cap` and `:host-opaque` are two remedies in two sentences; **the native refusal as a property over the classifier's whole output**, with the ladder's non-vacuity control beside it; the refusal names a non-Xray authority per candidate |
 | `…panels.hicasso-causal-cljs-test` | node (reactive substrate) | the seven links on a REAL interaction through the real commit seam and the real router; links 1–4 evidenced and 5–7 host-opaque with three distinct authorities; the 2→3 join `:uncorrelated` while the 1→2 join is `:evidenced`; **four mutation rows, each with its positive control**; the loss chips reach the page under distinct testids and change between two genuinely different window states; the advisor answers on the running app and still refuses the ladder; advice and slice come from ONE turn |
 | `…panels.hicasso-skip-semantics-cljs-test` | node + JVM | **both public results, off ONE window** — a skip-only window is `:memo-hits-only` / `:host-opaque` with `:runs` 0, routed to measure-first and never to the retention knob, while the same window's slice holds `[]` recomputes and one `:skipped`; a bundle carrying all four `:rf.sub` operations gives the advisor's recompute COUNT and the slice's recompute ROSTER the same reading; the three unattributed states are pairwise distinct and exactly one names `:rf.trace/events-retained`; an untagged RUN beside a tagged skip still degrades to `:unknown` with a `:dropped` of 1; **and the four-operation matrix** — every `:rf.sub` operation with an `:rf.sub/id` and without one, each cell asserted against what the operation IS *and* against link 2's reading of the same event |
-| `…panels.hicasso-causal-native-island-dom-cljs-test` | browser (real React DOM) | the slice over a subject PAST THE FENCE (rf2-t2d3) — a real `n/defcomponent` island reading `n/use-sub`, and a foreign React component reached through `[:>]`, under one boundary. An island's read is a first-class subject: links 1–4 evidenced, its own census row, and the advisor NAMES and TIMES it. Neither subtree's markup reaches any of the four reads, and the foreign component claims no census row and no reverse edge — against a control proving it really rendered and re-rendered. **And the refusal**: links 5–7 are identical over the crossing subject and over an interpreted-only one, with a non-vacuity control showing the two slices otherwise differ, so `:host-opaque` demonstrably does not encode a crossing |
+| `…panels.hicasso-causal-native-island-dom-cljs-test` | browser (real React DOM) | the slice over a subject PAST THE FENCE (rf2-t2d3) — a real raw-React island (a function component mounted through `h/defhost`) reading `n/use-sub`, and a foreign React component reached through `[:>]`, under one boundary. An island's read is a first-class subject: links 1–4 evidenced, its own census row, and the advisor NAMES and TIMES it. Neither subtree's markup reaches any of the four reads, and the foreign component claims no census row and no reverse edge — against a control proving it really rendered and re-rendered. **And the refusal**: links 5–7 are identical over the crossing subject and over an interpreted-only one, with a non-vacuity control showing the two slices otherwise differ, so `:host-opaque` demonstrably does not encode a crossing |
 
 The pair-in-one-row shape of the third suite is the point: an advisor-only row
 would go green against a causal slice that had drifted back, and a causal-only
@@ -457,8 +457,8 @@ finding restated as a measurement.
 The native-island suite is the one that needs a fiber, and it is the only one
 here that does. `n/use-sub` is a real React hook, and per
 `docs/design/hicasso/product/lanes/testing-xray.md` foreign regions are
-mounted-test territory with no fake hook dispatcher, ever — so a native-tier
-subject cannot be simulated at the node tier and the namespace takes the
+mounted-test territory with no fake hook dispatcher, ever — so an island
+reading through the hook cannot be simulated at the node tier and the namespace takes the
 `-dom-cljs-test` suffix that selects `:browser-test`. `:node-test` compiles it
 too (`cljs-test$` matches both suffixes), where each row degrades to a stated
 skip rather than to a false green.

--- a/tools/xray/test/day8/re_frame2_xray/panels/hicasso_causal_native_island_dom_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/hicasso_causal_native_island_dom_cljs_test.cljs
@@ -34,7 +34,7 @@
 
   That makes the honest reading of row 7's phrase the narrow one. Xray
   names and times the boundary and observes the island's reads — those
-  are witnessed below, over a genuine `n/defcomponent`. What it does NOT
+  are witnessed below, over a genuine raw-React island. What it does NOT
   do is report an opacity that is ABOUT a foreign subtree, and the third
   row asserts that in the only form the claim can take: identical output
   over two subjects that differ precisely in whether a foreign subtree
@@ -43,8 +43,9 @@
 
   ## The subjects are real, and one of them is not ours at all
 
-  The island is `n/defcomponent` + `n/use-sub` + `n/$`, so its read is a
-  real React hook against the collector's own entry cache. The foreign
+  The island is a raw React function component — `react/createElement`
+  and `n/use-sub`, mounted through `h/defhost` — so its read is a real
+  React hook against the collector's own entry cache. The foreign
   subtree is a plain React function component with its own `useState`,
   reached through the `[:>]` raw escape — *`defhost` with the declaration
   erased* (`impl/codec` §HD-011). Nothing in it is Hicasso's, which is
@@ -101,9 +102,9 @@
 (defonce ^:private !foreign-runs (atom 0))
 
 (defn- Foreign
-  "A FOREIGN React component. Not a `defview`, not an `n/defcomponent`,
-  no `h/sub`, no `n/use-sub` — it reads nothing of the application's, and
-  Hicasso knows only that React was handed a function.
+  "A FOREIGN React component. Not a `defview`, not an island reading
+  through `n/use-sub`, no `h/sub` — it reads nothing of the
+  application's, and Hicasso knows only that React was handed a function.
 
   It holds its own `useState` so a row can prove it really rendered and
   really re-rendered, which is what turns its absence from every roster
@@ -122,23 +123,31 @@
                                 "onClick"   (fn [_] (set-local inc))}
                            "nudge"))))
 
-(n/defcomponent island
-  "PAST THE FENCE. A real React function component reading a real
-  subscription through a real hook, with its own nested native markup —
-  the `n/$` tree below is what the tool tier must not be able to see."
+(defn- island
+  "PAST THE FENCE. A raw React function component reading a real
+  subscription through a real hook, with its own nested React markup —
+  the `react/createElement` tree below is what the tool tier must not be
+  able to see."
   [^js _props]
   (let [v (n/use-sub [::island])]
-    (n/$ :div {:class "island" :data-testid "island-root"}
-         (n/$ :span {:class "island-depth-1"}
-              (n/$ :b {:class "island-depth-2"} (str v))))))
+    (react/createElement
+      "div" #js {"className" "island" "data-testid" "island-root"}
+      (react/createElement
+        "span" #js {"className" "island-depth-1"}
+        (react/createElement "b" #js {"className" "island-depth-2"} (str v))))))
+
+(h/defhost island-host
+  "The declared crossing to the island — `defhost` names it, and the
+  island is React on the far side."
+  island)
 
 (h/defview crossing-boundary
   "One interpreted boundary whose subtree crosses the fence TWICE: a
-  native island below it, and a foreign React component beside that."
+  raw-React island below it, and a foreign React component beside that."
   [_]
   [:div.crossing
    [:u.shell (str (h/sub [::shell]))]
-   (n/$ island)
+   [island-host {}]
    [:> Foreign]])
 
 (h/defview interpreted-boundary


### PR DESCRIPTION
## Summary

Wave 1b of the rf2-6c12m.3 ruling (option A: `re-frame.hicasso.native` shrinks to `n/use-sub` and `n/use-frame`; everything else in it is deleted by the wave-2 source bead, which cannot go until every wave-1 PR has merged). Closes rf2-6c12m.28.

**HMR testbed** (`implementation/hicasso/testbed/**`): the island is now a plain `defn` over `react/createElement` behind `react/memo` and two raw `react/lazy` heads; the `defhost` crossing declares `:server :client-only` (written out, though it is the default). The loader resolves to the `#js {:default island}` module record `React.lazy` reads. The marker read in `core.cljs` and the nine marker assertions in `hmr_spec.cjs` (name / server policy / displayName before and after the save) are gone; the identity assertions on the memo record and the island function stay as React's own remount rule, and the React.lazy bridge row stands unchanged (a save re-evaluates the top-level `def`, a fresh `react/lazy` record is Uninitialized, React calls the loader again — `+ 2`). The island still holds no subscription. Neither testbed namespace requires `re-frame.hicasso.native` any more.

**Xray** (`tools/xray/test/**`): the native-island causal test's island is a raw React function component mounted through `h/defhost`, still reading `n/use-sub`. The three rows stand — what they prove is the hook's roster visibility.

**Out-of-tree edit, one line, flagged**: `implementation/scripts/serve-and-run-hicasso-hmr-testbed.cjs` pins a per-section check floor by name (`REQUIRED_SECTIONS`, `sections[name] < min` reds), so removing nine marker rows from the island section needs the floor to drop `40 -> 31` in the same commit or the gate reds on a section that still runs. The section NAME is unchanged (it is cited from `docs/design/hicasso/product/**`, `implementation/hicasso/spec/dispositions.md` and `lazy_boundary_dom_cljs_test`). No build-id, CI job, `shadow-cljs.edn`, `package.json`, `spec/009` or `native.cljc` change.

**`tools/xray/spec/*`**: `028-Hicasso-Advisor.md` updated — the two sentences describing the island test's subject (§"Why the third row is the one that matters" consequence 1, and the test-coverage row for `…hicasso-causal-native-island-dom-cljs-test`) and the browser-lane paragraph now say "raw-React island through `h/defhost`" instead of `n/defcomponent`. Two `n/$` mentions REMAIN in that file, deliberately: they are the advisor's own performance-ladder rung 3 label, which mirrors the advisor source string at `tools/xray/src/day8/re_frame2_xray/panels/hicasso_advisor.cljc` (the `:lowering` route label) — `tools/xray/src` is outside this bead's tree and a spec-only reword would drift from the source it pins. Noted on rf2-6c12m.31 for the wave-2 source pass. Prose only; no link targets or anchors were added or moved (the edited table row keeps its 3 columns — checked by hand).

## Native-name census (both trees + `tools/xray/spec`)

Word-bounded grep over `implementation/hicasso/testbed`, `tools/xray/test`, `tools/xray/spec`; positive control `n/use-sub` = 8 both before and after, and the same grep finds 9 `n/defcomponent` in `native.cljc`.

| name | before | after |
|---|---|---|
| `n/$` | 11 | 2 (advisor ladder, see above) |
| `n/defcomponent` | 12 | 0 |
| `n/memo` | 7 | 0 |
| `n/lazy` | 8 | 0 |
| `n/component` | 5 | 0 |
| `n/marker` | 1 | 0 |
| `n/props`, `n/props*`, `n/prop-slots`, `n/el`, `n/declared-server`, `n/tier-sentinel` | 0 | 0 |
| `[re-frame.hicasso.native :as n]` requires | 3 | 1 (the Xray test, for `n/use-sub`) |

## Quality gates

All run foreground to completion from the worker worktree (guard exit 0), one browser run at a time; exit codes are the ones captured by `echo $?` into a per-attempt file, not harness-reported. Every browser gate printed a served root or compile path inside the worker worktree.

| gate | result | captured exit |
|---|---|---|
| `npm run test:hicasso-compile` | 160 namespaces, 0 warnings | 0 |
| `npm run test:hicasso-hmr` (full matrix) | `HICASSO HMR PASS (chromium + firefox + webkit)` — 144 checks across 10 sections per engine, 45 real shadow reloads; cross-engine comparison performed | 0 |
| `HICASSO_HMR_ENGINES=chromium npm run test:hicasso-hmr` (control run before the full matrix) | PARTIAL PASS, 144 checks / 10 sections | 0 |
| `:browser-test` compiled with `--config-merge '{:ns-regexp "hicasso-causal-native-island-dom-cljs-test$"}'` + `scripts/serve-and-run-browser-tests.cjs --port 8129` | `Ran 3 tests containing 61 assertions. 0 failures, 0 errors.` | compile 0, run 0 |
| `npm run test:xray-feature-gate` (nightly-full) | `Ran 16 Xray feature scenarios. 0 failures. Covered 13 matrix rows.` | 0 |

**Planted faults (the controls), each restored by blob hash — `git hash-object` of the working file equal to `git rev-parse HEAD:<path>` after `git checkout HEAD -- <path>`, tree clean before and after:**

- HMR bridge: `views.cljs`'s `(def island (react/memo island-body))` replaced by a cache-by-name — the memo record fetched from `globalThis` and allocated only once — so the record survives the save. Anchor matched once; blob `d1a0620c…` → `c7aa4f39…` planted → `d1a0620c…` restored. `HICASSO_HMR_ENGINES=chromium npm run test:hicasso-hmr`: **exit 1**, `FAIL … [chromium] and the `react/memo` record — … it must NOT survive a hot reload …: expected false, got true`. (A first attempt that swapped `def` for `defonce` failed to COMPILE — `defonce` takes no docstring — which is a red about the wrong thing and is recorded here as such; the cache-by-name plant is the one that discriminates.)
- Xray island: `(n/use-sub [::island])` → `(n/use-sub [::shell])`, so the island's read collapses onto the shell's cell. Anchor matched once; blob `4623084e…` → `ea806357…` planted → `4623084e…` restored. Narrowed `:browser-test` run: **exit 1**, all three rows `FAIL … expected three cells; have ([… /shell] [… /plain])`.

Not run here, CI's: the docs link gates (no link targets changed) and `test:cljs` (the `:node-test` build compiles the Xray test namespace too, where each row is a stated skip).
