### PR TITLE
docs(method): an item's scope claim is a name too — derive the fence from cited files across siblings

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -232,6 +232,18 @@ working copy too, and read a change that is clean by both as *not started yet* r
 as owning nothing: what it will touch is recorded on the item it was dispatched under, not
 in version control.
 
+**And an item's own scope claim is a name too, wearing a reviewer's authority.** A review
+that files a dozen items will call them *src-only* or *parallel-safe* at the altitude it
+worked at, and every collision such a wave produces is invisible from there: four items
+editing one file in four regions; a *test-only* cut that keeps a file a sibling was told
+would be deleted; a *src-only* lane that must cross into a held tree by one line. Measured
+on one wave: ten items dispatched under that claim, three same-file collisions, every one
+caught by routing after the fact and none by the fence. So before you paste a fence, read
+each item's cited files against its siblings' — the citations are usually there, and the
+claim was made without doing that — and when two items share a file, sequence them or
+brief both with the overlap named. **A fence built from the claim is the guess the
+claim's author skipped, not a fence.**
+
 **A fence is derived, never remembered — and the worker derives it again at start-up.**
 Step 3 above settles how you establish it; a list assembled from memory of who you dispatched
 is stale inside the dispatch's own lifetime and on a busy fleet can be wrong before the brief


### PR DESCRIPTION
## What this is

One bounded addition to the mayor-method dispatch template, under *Fences*, from a measured incident rather than speculation.

A review-filed wave of items described itself as *src-only, parallel-safe*. Ten were dispatched under that claim; three same-file collisions followed — four items editing one file in four regions, a *test-only* cut that kept a file a sibling's fence said would be deleted, a *src-only* lane that had to cross into a held tree by one line. Every collision was caught by routing after the fact; none by the fence. The template already says a fence is a claim about files and must not be derived from a branch's or worker's *name* — but an item's own scope claim is a name wearing a reviewer's authority, and the section did not say so. Now it does: read each item's cited files against its siblings' before pasting a fence; when two share a file, sequence them or brief both with the overlap named.

Generic throughout — no OS, repository or operator specifics. Sibling sweep: the *Fences* section's three existing derivation paragraphs (change-listing tool, pagination, uncommitted work) each verified still correct in place; this is a fourth source of the same error, not a correction to them.

## Quality gates

- `scripts/check_doc_slugs.py` (the covering gate for this tree): captured exit 0 pre-plant, exit 1 on a planted broken anchor naming this file and the plant, exit 0 after restore; restore verified by git blob-hash equality (ecaec97053e6bf79b140a2489ca3503d97218e6d).
- Prose has no automated gate: the new paragraph was re-read in place against the surrounding register, and the three sibling paragraphs read for correctness by hand.