### PR TITLE
docs(method): name the strand class, not its instances

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -721,7 +721,14 @@ turn waiting for a completion notification* — it fails open on the first wait 
 worker that ARMED A MONITOR on its exit file and ended its turn presented as compliant and
 stranded identically, because a watcher owned by an agent stops when its agent does. Measured
 twice in one session, both briefs carrying this block verbatim; the second worker read the
-enumerated wording as licence for the un-enumerated variant.
+enumerated wording as licence for the un-enumerated variant. **And the terminal condition alone
+did not close it either**: with that sentence in the block, three more workers in one session
+ended their turns on a *watch*, a *notification subscription* and a *background task expected to
+wake them* — each a fresh name for the same wait, and each read as outside the rule because the
+rule named a monitor. So name the class rather than the instances: a Monitor, a watch, a
+subscription, a background task you expect to wake you — every one of these is the same strand,
+because you are the only thing that can read the exit file, and you can only read it while your
+turn is still running.
 
 **A gate heavy enough that two cannot coexist WEDGES rather than fails** — no progress, no exit
 file, no error, from a run that was healthy a minute ago. This is contention for the MACHINE, so


### PR DESCRIPTION
Method reread loop (rf2 mayor session, 2026-08-29).

**Drift found by enforcing the block against what workers did:** with the terminal-condition sentence already in the gate-mechanics block (PR #8742), three more workers in one session ended their turns on a *watch*, a *notification subscription* and a *background task expected to wake them* respectively — each read as outside the rule because the rule named a monitor. All three recovered on a status message, as the method predicts.

**Change:** one paragraph in `## Quality gates — how a gate is run` names the CLASS (a Monitor, a watch, a subscription, a background task you expect to wake you) and the reason it is one class: only the worker can read the exit file, and only while its turn runs. Additive to the pasted block, never weakening.

**Bounded search:** the same rule in `loops.md` stranded-sweep step 2 already speaks of the harness agent-stopped event generically and needs no sibling edit.

## Quality gates
- `python scripts/check_doc_slugs.py` from the worktree: exit 0 (docs/the-mayor-method is inside its roots).
- `mkdocs build --strict`: not nominated — this tree sits in `exclude_docs`.
- Heading anchors and prose verified by hand; no tables touched.