### PR TITLE
hicasso(test): hooks-contract suite, two-arm parity floor, requirers re-spelt in raw React (rf2-6c12m.27)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/client_only_arms_ssr_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/client_only_arms_ssr_cljs_test.cljs
@@ -36,7 +36,7 @@
   - **HS-23, Activity.** This one splits by route, and the split is the
     point. Through `h/defhost` the Client-only refusal is real and fires
     at the declaration source, with both of the policy's arms. Through
-    `n/$` — the route
+    raw React construction — the route
     `docs/design/hicasso/product/lanes/react-compatibility-notes.md`
     tells an author to take — there is no refusal and a VISIBLE
     Activity's subtree reaches the response.
@@ -104,7 +104,6 @@
             [re-frame.hicasso.impl.codec :as codec]
             [re-frame.hicasso.impl.collector :as collector]
             [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.native :as n]
             [re-frame.hicasso.overlay :as overlay]
             [re-frame.test-support :as test-support]
             ["react" :as react]
@@ -275,13 +274,14 @@
     [island {}]]])
 
 (h/defview activity-native-page
-  "HS-23 through `n/$`, which the lane note recommends first and which
-  the client witness uses. Constructed exactly as
-  `native-hooks-dom-cljs-test`'s Activity row constructs it."
+  "HS-23 through raw React construction, which the lane note recommends
+  first and which the client witness uses: a boundary body returning the
+  `<Activity>` element itself, with the hosted subtree crossed through
+  `codec/as-element`."
   [{:keys [mode]}]
   [:div.owner
-   (n/$ Activity #js {:mode mode}
-        (codec/as-element [island {}]))])
+   (react/createElement Activity #js {:mode mode}
+                        (codec/as-element [island {}]))])
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — HS-31, the optional forms module
@@ -575,16 +575,16 @@
       (is (not (re-find #"class=\"inner\"" html))
           (str "nothing of the hidden subtree reaches the bytes: " html)))))
 
-(deftest through-n-dollar-a-visible-activity-subtree-reaches-the-response
+(deftest through-raw-react-a-visible-activity-subtree-reaches-the-response
   (testing "**The finding on this row.**
             `lanes/react-compatibility-notes.md` closes its Activity
             section by telling an author to reach Activity through native
             React construction, and `rf2-9ywe`'s client witness takes that
-            route through `n/$`. On that route there is no declaration and
-            therefore no policy to consult: a VISIBLE Activity's hosted
-            subtree is server-rendered, read and all. So HS-23's
-            Client-only disposition is honest for the `defhost` route and
-            false for the one the product recommends first"
+            route through `react/createElement`. On that route there is no
+            declaration and therefore no policy to consult: a VISIBLE
+            Activity's hosted subtree is server-rendered, read and all. So
+            HS-23's Client-only disposition is honest for the `defhost`
+            route and false for the one the product recommends first"
     (fresh! true)
     (let [html (server-html [activity-native-page {:mode "visible"}])]
       (is (re-find #"class=\"inner\"" html)

--- a/implementation/hicasso/test/re_frame/hicasso/direct_return_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/direct_return_cljs_test.cljs
@@ -9,22 +9,27 @@
   ## The accept path is not new, and this file does not re-establish it
 
   `codec/as-element` carries a total `:react-element` arm, asked after
-  `vector?`, so a returned element passes through untouched;
-  `native-fence-cljs-test/the-two-languages-compose-without-either-rewriting-the-other`
-  is the row that says so, and `native-hooks-dom-cljs-test/host` writes
-  the spelling as ordinary source. What was never established is the
-  half a reader actually has to trust before moving a hot boundary onto
-  it: that **nothing else runs**. An escape whose cost is unpriced is a
-  guess, and an escape that quietly still lowers is worse than no escape
-  at all.
+  `vector?`, so a returned element passes through untouched, and
+  `retaining_host_callbacks_dom_cljs_test`'s `stable-parent` writes the
+  spelling as ordinary source.
+  What was never established is the half a reader actually has to trust
+  before moving a hot boundary onto it: that **nothing else runs**. An
+  escape whose cost is unpriced is a guess, and an escape that quietly
+  still lowers is worse than no escape at all.
 
-  ## The pair
+  This is the ONE generic direct-return witness the rf2-6c12m.3 ruling
+  keeps: a `defview` returning a raw React or UIx element skips
+  interpretation and keeps its frame, its reads and its identity.
+
+  ## The pair — and the UIx third
 
   [[hiccup-body]] and [[direct-body]] are the same view written twice —
   the same props, the same two ambient reads, the same data, and DOM
   that is **byte-equal** under React's own server renderer. One writes
-  hiccup; one writes `n/$`. Every row below is a difference between
-  them, so a row can only be about the lowering.
+  hiccup; one writes `react/createElement`. [[uix-body]] is the same
+  page a third time in `uix/$`, because a UIx element is a React
+  element and the escape must not know the difference. Every row below
+  is a difference between them, so a row can only be about the lowering.
 
   Byte equality is the fairness gate and it is checked before anything
   else is claimed, because two arms that render different pages can be
@@ -96,18 +101,11 @@
 
   ## Where the fence itself is established, and why not again here
 
-  *Native semantics begin inside the returned element* is the fence, and
-  the fence's own rows are `native-fence-cljs-test`'s: an intent vector
-  at a native callback slot refuses, hiccup in a native child position
-  refuses, and the two languages compose without either rewriting the
-  other. They are cited rather than restated — a second copy of a
-  refusal is a second thing to drift, and the literal-child half of it
-  refuses at MACROEXPANSION, so a second copy could not even be written
-  in the same shape.
-
-  What this file adds past that fence is the direction the fence cannot
-  see: the fence stops hiccup getting IN, and the rows below establish
-  that the codec does not get OUT.
+  *React semantics begin inside the returned element* is the fence: past
+  it a callback slot holds an ordinary function and a child is a React
+  node, because nothing of Hicasso's runs there. The rows below
+  establish the direction a reader has to trust: the codec does not get
+  OUT.
 
   ## What a direct return still costs — I9
 
@@ -127,8 +125,9 @@
   docstring), so detecting a hook call inside one needs a compiler that
   analyses the body — which
   `lanes/hot-path-architecture.md#explicit-refusals` forbids outright.
-  React's rules of hooks are the enforcement, `n/defcomponent` is the
-  place they are legal, and the law is stated where an author reads it.
+  React's rules of hooks are the enforcement, a React component mounted
+  through `h/defhost` is the place they are legal, and the law is stated
+  where an author reads it.
 
   ## What is NOT here, and must not be read off it
 
@@ -158,9 +157,10 @@
             [re-frame.hicasso.impl.intent :as intent]
             [re-frame.hicasso.impl.mount :as mount]
             [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.native :as n]
             [re-frame.hicasso.test :as ht]
             [re-frame.test-support :as test-support]
+            [uix.core :as uix]
+            ["react" :as react]
             ["react-dom/server" :as react-dom-server]))
 
 (def ^:private frame-id ::direct-return)
@@ -207,19 +207,30 @@
 
 (defn direct-body
   "The Rung 3 spelling of the same page. The reads are the boundary's,
-  unchanged — that is the whole of the escape: native semantics begin
-  at the element, not at the frame.
+  unchanged — that is the whole of the escape: React semantics begin at
+  the element, not at the frame.
 
-  Past `n/$` there is no intent lowering, so the callback slot holds an
-  ordinary function; and no controlled repair, so the field's echo is
-  the author's to write. Both are the escape's price and both are
-  visible in this source."
+  Past `react/createElement` there is no intent lowering, so the
+  callback slot holds an ordinary function; and no controlled repair, so
+  the field's echo is the author's to write. Both are the escape's price
+  and both are visible in this source."
   [{:keys [id]}]
   (let [label (h/sub [:dr/label id])
         n     (count (h/sub [:dr/tags id]))]
-    (n/$ :div {:class "row" :on-click (fn [_] nil)}
-         (n/$ :span {:class "label"} (str label " " n))
-         (n/$ :input {:class "field" :value label :on-change (fn [_] nil)}))))
+    (react/createElement "div" #js {:className "row" :onClick (fn [_] nil)}
+      (react/createElement "span" #js {:className "label"} (str label " " n))
+      (react/createElement "input" #js {:className "field" :value label :onChange (fn [_] nil)}))))
+
+(defn uix-body
+  "The same page a third time, in `uix/$`. A UIx element IS a React
+  element, so the escape sees it exactly as it sees [[direct-body]]'s —
+  which the probes below read rather than assume."
+  [{:keys [id]}]
+  (let [label (h/sub [:dr/label id])
+        n     (count (h/sub [:dr/tags id]))]
+    (uix/$ :div {:class "row" :on-click (fn [_] nil)}
+           (uix/$ :span {:class "label"} (str label " " n))
+           (uix/$ :input {:class "field" :value label :on-change (fn [_] nil)}))))
 
 (defn floor-body
   "The crossing carrying nothing. Every probe below reads its floor here
@@ -230,6 +241,7 @@
 
 (h/defview hiccup-arm [props] (hiccup-body props))
 (h/defview direct-arm [props] (direct-body props))
+(h/defview uix-arm    [props] (uix-body props))
 (h/defview floor-arm  [props] (floor-body props))
 
 ;; ---------------------------------------------------------------------------
@@ -242,19 +254,16 @@
 ;; the missing key on a plain tag, a host or a `[:>]` child, which it
 ;; declines on a costed ~150 ns/member argument. So a seq of `[:span …]`
 ;; would draw nothing from EITHER arm and the row below would be green
-;; without meaning anything. The members are boundaries, and their Rung 4
-;; counterpart is an `n/defcomponent` rendering the same span.
+;; without meaning anything. The members are boundaries, and their React
+;; counterpart is an ordinary function component rendering the same span.
 
 (h/defview tag-row  [{:keys [label]}] [:span {:class "tag"} label])
 
-(n/defcomponent native-tag-row
-  "`{:server :render}` because [[render!]] is the server renderer and the
-  native tier's policy is now READ: a Client-only island's
-  body does not run there, so the instrument needs the declaration. The
-  arms compare a key DIAGNOSTIC, not a server policy."
-  {:server :render}
+(defn- react-tag-row
+  "The same span as a raw React component. The arms compare a key
+  DIAGNOSTIC, not a server policy."
   [^js props]
-  (n/$ :span {:class "tag"} (.-label props)))
+  (react/createElement "span" #js {:className "tag"} (.-label props)))
 
 (h/defview key-hiccup-arm
   [{:keys [id]}]
@@ -263,8 +272,9 @@
 
 (h/defview key-direct-arm
   [{:keys [id]}]
-  (n/$ :div {:class "tags"}
-       (map (fn [t] (n/$ native-tag-row {:label t})) (h/sub [:dr/tags id]))))
+  (react/createElement "div" #js {:className "tags"}
+    (into-array (map (fn [t] (react/createElement react-tag-row #js {:label t}))
+                     (h/sub [:dr/tags id])))))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -297,24 +307,29 @@
     @n))
 
 (defn- probes
-  "The floor, the hiccup arm and the direct arm through one probe."
+  "The floor, the hiccup arm, the direct arm and the UIx arm through one
+  probe."
   [install! restore!]
   {:floor  (probe install! restore! floor-arm)
    :hiccup (probe install! restore! hiccup-arm)
-   :direct (probe install! restore! direct-arm)})
+   :direct (probe install! restore! direct-arm)
+   :uix    (probe install! restore! uix-arm)})
 
 (defn- walks-past
   "The one assertion shape every surface row makes: the hiccup arm
-  reaches the surface past the crossing's floor, and the direct arm
-  reaches exactly the floor and no more."
-  [surface {:keys [floor hiccup direct]}]
+  reaches the surface past the crossing's floor, and the two direct arms
+  reach exactly the floor and no more."
+  [surface {:keys [floor hiccup direct uix]}]
   (is (> hiccup floor)
       (str "CONTROL — the hiccup arm must reach " surface " past the "
            "crossing's floor (" floor "), or the row below is read off a "
            "probe that was never live; got " hiccup))
   (is (= floor direct)
       (str "a direct return must not reach " surface ". The crossing's "
-           "floor is " floor " and the direct arm read " direct)))
+           "floor is " floor " and the direct arm read " direct))
+  (is (= floor uix)
+      (str "a returned UIx element must not reach " surface " either. The "
+           "crossing's floor is " floor " and the UIx arm read " uix)))
 
 (defn- warnings-of
   "Hicasso's warning channel while `view` renders. React's own key
@@ -339,6 +354,11 @@
               DOM, so every row below is about the lowering and nothing
               else"
       (is (= hiccup direct)))
+
+    (testing "and the UIx spelling is the same bytes again, so the UIx arm
+              of every probe below is a third reading of one page rather
+              than a reading of a different one"
+      (is (= hiccup (render! uix-arm))))
 
     (testing "and the page is the page, not an empty string two arms agree
               on: both reads landed and both populations rendered"
@@ -411,7 +431,7 @@
       (is (re-find #"direct-return-cljs-test/key-hiccup-arm" (first hiccup-warned)))
       (is (re-find #"direct-return-cljs-test/tag-row" (first hiccup-warned))))
 
-    (testing "the same members built with `n/$` draw none. React's own key
+    (testing "the same members built with `react/createElement` draw none. React's own key
               warning fires for BOTH arms on its own channel — a
               `console.error` — and that is the point: whether React wants
               a key here is React's affair, and Hicasso has not looked"
@@ -485,5 +505,5 @@
   (testing "and it refuses at the DIRECT-RETURN position specifically —
             the body answered the element itself, with no tree around it
             for the refusal to have come from"
-    (let [{:keys [refused]} (outcome #(ht/tree [(fn [_] (n/$ :b nil "x"))] {}))]
+    (let [{:keys [refused]} (outcome #(ht/tree [(fn [_] (react/createElement "b" nil "x"))] {}))]
       (is (= :rf.error/hicasso-test-react-is-opaque (:rf.error/id refused))))))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/ledger/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/ledger/views.cljs
@@ -84,8 +84,8 @@
 
   ## What was NOT needed
 
-  No `n/defcomponent`, no ref, no effect, no imperative handle, no memo
-  hint and no second root. The application's whole native-tier surface is
+  No island component, no ref, no effect, no imperative handle, no memo
+  hint and no second root. The application's whole interop surface is
   `h/defhost` and `h/event`; the island the imperative-SDK row needs
   is not needed here, because a virtualizer is an ordinary
   React component and the door for an ordinary React component is the

--- a/implementation/hicasso/test/re_frame/hicasso/foreign_root_bridge_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/foreign_root_bridge_dom_cljs_test.cljs
@@ -97,8 +97,8 @@
 (def ^:private memo-bridged (react/memo bridged))
 
 (defui uix-parent
-  "The third parent the bridge's docstring names — *`n/defcomponent`, UIx,
-  or plain JavaScript* — rendering the same minted bridge, so a
+  "The third kind of parent the bridge serves — a raw React component,
+  UIx, or plain JavaScript — rendering the same minted bridge, so a
   difference between rows is a difference between PARENTS rather than
   between three bridges that happened to agree."
   [{:keys [label]}]

--- a/implementation/hicasso/test/re_frame/hicasso/hmr_remount_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hmr_remount_cljs_test.cljs
@@ -261,8 +261,8 @@
   ;; The model's own guard. `load-namespace!` claims to be what re-evaluating
   ;; the `defview` form does; that claim is only true while the macro expands
   ;; to this call under this name. If `mint-view!` ever gains an HMR-stable
-  ;; proxy keyed on the view name — `n/defcomponent` promises
-  ;; "source/HMR metadata", so it is a live possibility — this test goes red
+  ;; proxy keyed on the view name — a live possibility, since the ledger
+  ;; already carries source coordinates per name — this test goes red
   ;; and the recorded contract must be rewritten before the suite can pass.
   ;; That is the intended behaviour: the freeze is falsifiable.
   (let [reloaded (load-namespace! panel-body)]

--- a/implementation/hicasso/test/re_frame/hicasso/hooks_island_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hooks_island_cljs_test.cljs
@@ -1,0 +1,280 @@
+(ns re-frame.hicasso.hooks-island-cljs-test
+  "THE TWO HOOKS, WHERE NO DOM IS NEEDED.
+
+  `re-frame.hicasso.native` is two React hooks — `n/use-sub` and
+  `n/use-frame` — and nothing else, by the rf2-6c12m.3 ruling. An
+  island is an ordinary React component, raw or UIx, and it reaches
+  Hicasso state through these two. Most of what is true about them is
+  true only once React is driving a real fiber — identity across
+  re-renders, StrictMode's double mount, teardown, the crossing through
+  `h/defhost` — and that is `hooks_island_dom_cljs_test`'s subject.
+
+  Four claims do NOT need a fiber, and they are the ones here, because
+  the server renderer runs a component body for real:
+
+  | row | what it establishes |
+  |---|---|
+  | [[a-read-under-a-live-frame-answers-without-committing-anything]] | the COLD tier. A body runs, the value is right, and the runtime retained nothing — because nothing committed. Both arms. |
+  | [[both-hooks-refuse-outside-every-frame-and-each-names-itself]] | the refusal, and that the two hooks are distinguishable in it. |
+  | [[use-frame-answers-the-runtimes-own-row-rather-than-capturing-its-own]] | the hook is not a second `capture-frame`. This is the row the incarnation rule rests on, and it is an IDENTITY test because an equality test passes for the wrong implementation. |
+  | [[the-namespace-is-the-two-hooks]] | the membership pin: `use-sub` and `use-frame` are present, and the exact census is armed for the wave-2 bead. |
+
+  ## Why the server renderer is the harness
+
+  `renderToStaticMarkup` invokes bodies, resolves context and runs
+  hooks, in a Node process with no `document`. What it does NOT do is
+  commit — React never calls `subscribe` on the server — so it is also
+  the only harness in which *what a render retains* can be read as a
+  flat zero. A DOM lane would have to distinguish \"retained nothing\"
+  from \"retained and then released\", and those are different claims.
+
+  ## The island is rendered as itself, under the runtime's own provider
+
+  No `h/defhost` here. The rows are about the HOOKS' contract — what a
+  body sees, what it retains, what it refuses — and a crossing above
+  the island would add a root boundary whose own entry and shell would
+  sit in every count below. So each island element is handed to React
+  directly, under `mount/provider` (the same context `h/mount!`
+  installs) or under nothing, and the crossing is measured where it
+  costs something: the DOM lane."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.native :as n]
+            [re-frame.hicasso.test.runtime :as runtime]
+            [re-frame.test-support :as test-support]
+            [uix.core :as uix :refer-macros [defui]]
+            ["react" :as react]
+            ["react-dom/server" :as react-dom-server])
+  (:require-macros [re-frame.hicasso.expansion-probe :as probe]))
+
+(def ^:private frame-id ::hooks-island)
+
+;; Registered ABOVE `use-fixtures`, as every suite in this package does:
+;; the reset fixture captures its source-store baseline when the
+;; `use-fixtures` form is EVALUATED, so a registration written below it is
+;; erased before the first row runs.
+(rf/reg-sub ::price (fn [db [_ sym]] (get-in db [:prices sym])))
+(rf/reg-event ::seed (fn [_ [_ prices]] {:db {:prices prices}}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The islands
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !observed-ops
+  ;; What `use-frame` handed the body on its last run. A module atom rather
+  ;; than a returned value because the thing under test is what a COMPONENT
+  ;; saw, and a component's return value is markup.
+  (atom nil))
+
+(defn- reader
+  "Reads one subscription, and nothing else. Raw React."
+  [^js props]
+  (react/createElement "span" nil (str (n/use-sub [::price (.-sym props)]))))
+
+(defn- framed
+  "Takes the frame-locked ops and reports the frame it was locked to."
+  [^js _props]
+  (let [ops (n/use-frame)]
+    (reset! !observed-ops ops)
+    (react/createElement "span" nil (str (:frame ops)))))
+
+(defui uix-reader
+  "The same read in a UIx `defui`: the hook does not know which dialect
+  called it."
+  [{:keys [sym]}]
+  (uix/$ :span (str (n/use-sub [::price sym]))))
+
+(defn- uix-arm
+  "The plain React shim every crossing into UIx needs — UIx's ABI is a
+  carrier object its own `uix/$` builds."
+  [^js props]
+  (uix/$ uix-reader {:sym (.-sym props)}))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- seat!
+  "Create the frame and seed it."
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [::seed {"AAPL" 191}]))
+  nil)
+
+(defn- render-under-frame!
+  "Render `element` with the frame context installed — the same provider
+  `h/mount!` installs, reached through the runtime's own door rather than
+  through a hand-built context wrapper this suite would then be pinning
+  instead of the product."
+  [element]
+  (react-dom-server/renderToStaticMarkup (mount/provider frame-id element)))
+
+(defn- render-frameless!
+  "Render `element` with NO provider above it. The island in a portal
+  outside the app, in a second root, or in a test without the harness."
+  [element]
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  (react-dom-server/renderToStaticMarkup element))
+
+(defn- refusal
+  "Run `f` and answer the refusal's ex-data — or a marker saying what
+  happened instead, so a failing row reports WHICH of the two ways it
+  failed rather than throwing out of the assertion."
+  [f]
+  (try
+    (f)
+    {::outcome :returned-without-refusing}
+    (catch :default e
+      (or (ex-data e) {::outcome :threw-without-ex-data ::message (ex-message e)}))))
+
+(defn- cold-residue
+  "The census with the entry cache projected out — the four counts a
+  cold read must leave at zero."
+  []
+  (dissoc (runtime/residue) :entries))
+
+;; ---------------------------------------------------------------------------
+;; 1. The cold tier — a read before any commit
+;; ---------------------------------------------------------------------------
+
+(deftest a-read-under-a-live-frame-answers-without-committing-anything
+  (seat!)
+  (testing "the island reads the frame it is mounted in, on a render that
+            never commits — which is every island's FIRST render, since
+            React calls `subscribe` in a passive effect after the commit.
+            Narrowing caught: a hook whose only read path is the warm cell
+            deref. It would answer nil here and on the first render of
+            every island ever mounted, and the DOM lane would not see it
+            because React repaints the moment the subscription lands"
+    (is (= "<span>191</span>"
+           (render-under-frame! (react/createElement reader #js {:sym "AAPL"})))))
+
+  (testing "and it RETAINED nothing. A cold read is a pure probe:
+            no cell, no reader membership, no boundary, no edge, no
+            disposal obligation. Narrowing caught: acquiring during the
+            render rather than at commit — the ownership state machine's
+            one prohibition — which would leave a cell and a membership
+            behind on a render React discarded, and which is invisible
+            from the markup because the markup is right either way"
+    (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0} (cold-residue))))
+
+  (testing "`:entries` is deliberately outside that reading, and being
+            exact about it is the difference between a census and a
+            slogan. A read-set entry is minted during the RENDER — it is
+            the cached `subscribe`/`getSnapshot` pair React is about to be
+            handed — and claimed at the COMMIT that never came here; an
+            unclaimed one belongs to `collector/entry-reap-horizon-ms`'s
+            reaper. That is not a property of hooks: a boundary body whose
+            render React discards leaves exactly the same one, and the
+            hook seam mints through the same door precisely so there is
+            one story"
+    (is (= 1 (:entries (runtime/residue)))))
+
+  (testing "the UIx arm is the same hook and the same reading: the value
+            is right, and nothing was committed"
+    (is (= "<span>191</span>"
+           (render-under-frame! (react/createElement uix-arm #js {:sym "AAPL"}))))
+    (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0} (cold-residue)))))
+
+;; ---------------------------------------------------------------------------
+;; 2. The refusal, and that the two hooks are distinguishable in it
+;; ---------------------------------------------------------------------------
+
+(deftest both-hooks-refuse-outside-every-frame-and-each-names-itself
+  (testing "`n/use-sub` outside every frame refuses with
+            `:rf.error/no-frame-context`. Narrowing caught: resolving
+            through the dynamic-var tier or falling back to `:rf/default`
+            — either would answer SOMETHING here, and an island silently
+            reading a frame its own subtree is not under is the isolation
+            failure the hooks must not have"
+    (let [data (refusal #(render-frameless! (react/createElement reader #js {:sym "AAPL"})))]
+      (is (= :rf.error/no-frame-context (:rf.error/id data)))
+      (is (= :mount-under-a-frame (:recovery data)))
+      (is (= 're-frame.hicasso.native/use-sub (:where data)))))
+
+  (testing "`n/use-frame` refuses identically, and names ITSELF. The two
+            `:where` values are the reason the shell's resolution takes
+            one: a single hardcoded `:where` would send a reader of either
+            refusal to the boundary shell, which is not what refused"
+    (let [data (refusal #(render-frameless! (react/createElement framed nil)))]
+      (is (= :rf.error/no-frame-context (:rf.error/id data)))
+      (is (= 're-frame.hicasso.native/use-frame (:where data)))))
+
+  (testing "and a UIx island refuses the same way: the dialect the body is
+            written in does not change where the frame comes from"
+    (let [data (refusal #(render-frameless! (react/createElement uix-arm #js {:sym "AAPL"})))]
+      (is (= :rf.error/no-frame-context (:rf.error/id data)))
+      (is (= 're-frame.hicasso.native/use-sub (:where data))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. `use-frame` is the runtime's row, not a second capture
+;; ---------------------------------------------------------------------------
+
+(deftest use-frame-answers-the-runtimes-own-row-rather-than-capturing-its-own
+  (seat!)
+  (reset! !observed-ops nil)
+  (let [markup (render-under-frame! (react/createElement framed nil))
+        ops    @!observed-ops]
+
+    (testing "the shape is `capture-frame`'s, locked to the ambient frame"
+      (is (= (str "<span>" frame-id "</span>") markup))
+      (is (= frame-id (:frame ops)))
+      (is (every? #(fn? (get ops %)) [:dispatch :dispatch-sync :subscribe])))
+
+    (testing "and it is IDENTICAL to the runtime's own memo row for this
+              frame — the bundle a lowered intent's ambient dispatch was
+              minted over, not a second `rf/capture-frame` the hook took
+              for itself.
+
+              This is the row the incarnation rule rests on, and equality
+              would not have caught it: `rf/capture-frame` called twice on
+              one live frame answers two maps that are `=` and are not the
+              same object. The UIx adapter's `use-frame` is exactly that
+              implementation, memoised on the frame KEYWORD — which is `=`
+              across a same-id reincarnation, so it would hand a destroyed
+              incarnation's bundle out forever. `hooks_island_dom_cljs_test`
+              drives the reincarnation itself; this row is where the
+              structural reason lives"
+      (is (identical? (:ops (collector/frame-row frame-id)) ops)))))
+
+;; ---------------------------------------------------------------------------
+;; 4. The membership pin
+;; ---------------------------------------------------------------------------
+
+(def ^:private publics
+  "Every public var name in `re-frame.hicasso.native`, read from the
+  compiler at expansion — the analyser's public defs for the runtime
+  half, the JVM namespace's public vars for the macro half."
+  (set (probe/public-vars re-frame.hicasso.native)))
+
+(deftest the-namespace-is-the-two-hooks
+  (testing "the census is not vacuous: the probe really read a namespace.
+            Narrowing caught: an analyser lookup answering an empty map on
+            a miss, which would make the row below pass by describing
+            nothing"
+    (is (seq publics)))
+
+  (testing "the two hooks are there, and they resolve"
+    (is (contains? publics "use-sub"))
+    (is (contains? publics "use-frame"))
+    (is (fn? n/use-sub))
+    (is (fn? n/use-frame)))
+
+  ;; The exact census. Armed by the wave-2 source bead, rf2-6c12m.31, which
+  ;; deletes everything else in the namespace — until it lands this line
+  ;; would red on the names it removes, so it is stated here and not
+  ;; asserted:
+  ;;
+  ;;   (is (= #{"use-sub" "use-frame"} publics)
+  ;;       "the namespace's public census is exactly the two hooks")
+  )

--- a/implementation/hicasso/test/re_frame/hicasso/hooks_island_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/hooks_island_dom_cljs_test.cljs
@@ -1,0 +1,855 @@
+(ns re-frame.hicasso.hooks-island-dom-cljs-test
+  "THE TWO HOOKS UNDER A REAL REACT, THROUGH THE CROSSING.
+
+  `n/use-sub` and `n/use-frame` are React hooks, so they inherit React's
+  rules whole, and the characteristic way a hook is wrong is not that it
+  reads the wrong value — it is that it reads the RIGHT value while
+  quietly rebuilding its subscription on every render, or leaking one
+  under StrictMode's double mount, or holding a destroyed frame's ops
+  forever. Every one of those is invisible on screen. So no row below
+  reads only the DOM.
+
+  The island is an ORDINARY React function component — and, on two rows,
+  a UIx `defui` behind the plain-function shim every crossing into UIx
+  needs — mounted through `h/defhost` under `{:server :render}`, which
+  is the spelling the rf2-6c12m.3 ruling leaves an author: a programmer
+  who crosses into React writes React, and reaches Hicasso state through
+  these two hooks.
+
+  ## What each row is for, and the narrowing it is written against
+
+  | row | what it establishes | the one-line narrowing it catches |
+  |---|---|---|
+  | [[an-islands-read-is-the-runtimes-own-and-xray-sees-it]] | the read builds a real cell under the mounted frame, and the tool tier's projection names it | reading through `subscribe-once` per render — right value, no cell, invisible to Xray |
+  | [[a-write-wakes-the-island-that-reads-it-and-nothing-else]] | notification is edge-driven, not store-wide | subscribing to the generation, which repaints every island on every write |
+  | [[a-re-render-that-changed-no-read-performs-no-re-subscribe]] | `subscribe` identity is stable, so React never re-subscribes — both arms | any per-render `subscribe` closure — the screen stays correct throughout |
+  | [[strict-modes-double-mount-acquires-once-and-unmount-releases-exactly]] | acquire is commit-owned and teardown is its exact inverse | acquiring during render, or a cleanup that releases a successor's cells |
+  | [[two-frames-are-two-cells-and-an-island-cannot-see-across]] | frames are isolated contexts on the far side of the crossing — both arms | resolving the frame anywhere but the island's own context |
+  | [[two-reads-in-one-island-are-two-cells]] | `n` calls are `n` subscriptions, React's own arithmetic | a hook that folded a component's reads into one cell and lost one of them |
+  | [[use-frame-is-stable-across-renders-and-retargets-across-a-reincarnation]] | the hic-013 incarnation rule, both halves | memoising on the frame KEYWORD, which is `=` across a reincarnation |
+  | [[a-transition-around-a-write-stays-tear-free-and-is-still-blocking]] | React's external-store ceiling, measured rather than advertised | a docstring that claimed transition-awareness |
+  | [[the-declared-population-was-actually-exercised]] | the roster, asserted rather than described | a row that started returning early |
+
+  ## Why the readings are counts and identities, not text
+
+  React will make a broken subscription look correct in the final DOM:
+  it re-renders from the model it already has, so a torn-down-and-rebuilt
+  subscription and a stable one paint the same pixels. The observables
+  here are therefore the ones React cannot forge — the cell table's keys
+  and reader lists, the REGISTRATION OBJECT's identity across a
+  re-render, and a body-run count — which is `roots_frames_support`'s
+  argument applied through the same helpers.
+
+  ## What is NOT here
+
+  `<Activity>`, a post-commit `<Suspense>` and an abandoned attempt are
+  React's own schedule, and `activity_suspense_dom_cljs_test` and
+  `kernel_commit_owns_dom_cljs_test` make those statements about the
+  boundary shell. `n/use-sub` mints from the very entry cache a boundary
+  body uses, so an island inherits them by construction; the ruling
+  keeps the focused proof — isolation, lifecycle, teardown, Xray — and
+  not a second copy of the React-feature rows.
+
+  ## Browser lane
+
+  Every row needs a real document and a real React DOM. `:node-test`
+  compiles this namespace too (`cljs-test$` matches `-dom-cljs-test`), and
+  each row degrades there to a STATED skip rather than to a false green.
+  What can be said without a fiber is said in `hooks_island_cljs_test`."
+  (:require [clojure.set :as set]
+            [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.frame :as frame]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.test.runtime :as runtime]
+            [re-frame.hicasso.native :as n]
+            [re-frame.hicasso.roots-frames-support :as support]
+            [re-frame.hicasso.tool :as tool]
+            [re-frame.test-support :as test-support]
+            [uix.core :as uix :refer-macros [defui]]
+            ["react" :as react]))
+
+(def ^:private alpha ::alpha)
+(def ^:private beta  ::beta)
+
+;; Registered ABOVE `use-fixtures` — the reset fixture captures its
+;; source-store baseline when the `use-fixtures` form is EVALUATED, so a
+;; registration written below it is erased before the first row runs.
+
+(rf/reg-sub ::price     (fn [db [_ sym]] (get-in db [:prices sym])))
+(rf/reg-sub ::elsewhere (fn [db _] (:elsewhere db)))
+
+(rf/reg-event ::seed (fn [_ [_ prices]] {:db {:prices prices :elsewhere 0}}))
+(rf/reg-event ::set-price
+              (fn [{:keys [db]} [_ sym v]] {:db (assoc-in db [:prices sym] v)}))
+(rf/reg-event ::touch-elsewhere
+              (fn [{:keys [db]} _] {:db (update db :elsewhere inc)}))
+
+;; ---------------------------------------------------------------------------
+;; The roster this file undertakes to reach
+;; ---------------------------------------------------------------------------
+
+(def ^:private declared-population
+  "A row that starts returning early, or a mechanism that stops being
+  driven, fails the last deftest instead of quietly shrinking the
+  evidence."
+  #{:hooks/mounted-read
+    :hooks/selective-wake
+    :hooks/no-resubscribe
+    :hooks/no-resubscribe-uix
+    :hooks/strict-mode
+    :hooks/frame-isolation
+    :hooks/frame-isolation-uix
+    :hooks/two-cells
+    :hooks/incarnation
+    :hooks/transition})
+
+(defonce ^:private !exercised (atom #{}))
+
+(defn- exercised! [mechanism] (swap! !exercised conj mechanism) nil)
+
+;; ---------------------------------------------------------------------------
+;; The island, and the two things it reports about itself
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !island-runs
+  ;; Body invocations, counted where the body actually runs. The island
+  ;; counterpart of `runtime/body-runs`, which counts BOUNDARY bodies and
+  ;; therefore says nothing about an island.
+  (atom 0))
+
+(defonce ^:private !last-ops
+  ;; What `use-frame` handed the body on its last run, held by identity.
+  (atom nil))
+
+(defn- ticker
+  "One island: one subscription read, the frame-locked ops, and a piece
+  of purely local React state. Raw React, the whole way down.
+
+  The local state is not decoration — it is how a row re-renders the
+  island for a reason the runtime knows nothing about, which is the only
+  way to ask whether an unchanged read costs a re-subscribe."
+  [^js props]
+  (swap! !island-runs inc)
+  (let [sym               (.-sym props)
+        price             (n/use-sub [::price sym])
+        ops               (n/use-frame)
+        [local set-local] (react/useState 0)]
+    (reset! !last-ops ops)
+    ;; The class on the ROOT node is what the rows read; the `.price`,
+    ;; `.local`, `.nudge` and `.commit` names are shared with the UIx arm.
+    (react/createElement "div" #js {:className "island"}
+      (react/createElement "b" #js {:className "price"} (str price))
+      (react/createElement "i" #js {:className "local"} (str local))
+      (react/createElement "button" #js {:className "nudge"
+                                         :onClick   (fn [_] (set-local inc))}
+        "nudge")
+      (react/createElement "button" #js {:className "commit"
+                                         :onClick   (fn [_]
+                                                      ((:dispatch-sync ops)
+                                                       [::set-price sym "from-the-island"]))}
+        "commit"))))
+
+(defui uix-ticker
+  "The same island as a UIx `defui`: the same read, the same ops, the
+  same local state, the same DOM."
+  [{:keys [sym]}]
+  (swap! !island-runs inc)
+  (let [price             (n/use-sub [::price sym])
+        ops               (n/use-frame)
+        [local set-local] (uix/use-state 0)]
+    (reset! !last-ops ops)
+    (uix/$ :div {:class "island"}
+           (uix/$ :b {:class "price"} (str price))
+           (uix/$ :i {:class "local"} (str local))
+           (uix/$ :button {:class "nudge" :on-click (fn [_] (set-local inc))} "nudge")
+           (uix/$ :button {:class    "commit"
+                           :on-click (fn [_] ((:dispatch-sync ops)
+                                              [::set-price sym "from-the-island"]))}
+                  "commit"))))
+
+(defn- uix-arm
+  "The plain React shim every crossing into UIx needs: UIx's ABI is a
+  carrier object its own `uix/$` builds, so a `defui` reached through any
+  other door receives props it cannot read."
+  [^js props]
+  (uix/$ uix-ticker {:sym (.-sym props)}))
+
+(defn- two-reads
+  "An island reading TWO keys — the shape `n/use-sub`'s docstring prices
+  at two cells, and the row below measures."
+  [^js props]
+  (let [price (n/use-sub [::price (.-sym props)])
+        other (n/use-sub [::elsewhere])]
+    (react/createElement "div" #js {:className "two"}
+      (react/createElement "b" #js {:className "price"} (str price))
+      (react/createElement "i" #js {:className "other"} (str other)))))
+
+;; The crossings. `{:server :render}` so the element type React reconciles
+;; on is the author's own function with nothing in between — the declared
+;; arm the parity floor is stated over — and so the same tree is one tree
+;; on every lane.
+(h/defhost ticker-host    ticker    {:server :render})
+(h/defhost uix-host-arm   uix-arm   {:server :render})
+(h/defhost two-reads-host two-reads {:server :render})
+(h/defhost strict-mode    react/StrictMode {:server :render})
+
+(h/defview host
+  "Rung 3's neighbour: an ordinary boundary body crossing into a raw
+  React island through the named door. The island reaches the frame
+  through the context this boundary's root installed, and through
+  nothing else."
+  [{:keys [sym]}]
+  [ticker-host {:sym sym}])
+
+(h/defview uix-host
+  "The same page with the UIx arm in the island's place."
+  [{:keys [sym]}]
+  [uix-host-arm {:sym sym}])
+
+(h/defview strict-host
+  "The raw island under React's own StrictMode, which double-invokes
+  the body and runs mount/unmount/mount over every effect. StrictMode
+  is a foreign component too, so it crosses through the same door."
+  [{:keys [sym]}]
+  [strict-mode [ticker-host {:sym sym}]])
+
+(h/defview two-reads-page
+  [{:keys [sym]}]
+  [two-reads-host {:sym sym}])
+
+(h/defview boundary-reader
+  "A BOUNDARY reading the identical key the island reads — the control
+  for the shared-entry claim."
+  [{:keys [sym]}]
+  [:u.boundary (str (h/sub [::price sym]))])
+
+(h/defview shared-host
+  "One boundary and one island, reading one key."
+  [{:keys [sym]}]
+  [:div [boundary-reader {:sym sym}] [ticker-host {:sym sym}]])
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     ;; `nil` and not the default: a dynamic-var frame left in ambient scope
+     ;; would let a hook that failed to resolve its own frame answer that one
+     ;; instead, and the isolation row would read a rendering difference where
+     ;; the failure is a frame miss.
+     :ambient-frame nil
+     ;; The MAP shape, because every row here is `async`.
+     :async?        true
+     :init-fn       (fn []
+                      (support/leave-act-environment!)
+                      (reset! !island-runs 0)
+                      (reset! !last-ops nil)
+                      (error-emit/clear-error-listeners!)
+                      (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- price-key [frame-kw sym] [frame-kw [::price sym]])
+
+(defn- seat!
+  "Create `frame-kw` and seed it. Answers the incarnation token, so a row
+  that claims a reincarnation can prove one happened."
+  [frame-kw prices]
+  (rf/make-frame {:id frame-kw})
+  (rf/with-frame frame-kw (rf/dispatch-sync [::seed prices]))
+  (frame/frame-incarnation-token frame-kw))
+
+(defn- at [handle sel] (.querySelector ^js (:container handle) sel))
+(defn- text-at [handle sel] (some-> (at handle sel) .-textContent))
+(defn- click! [handle sel] (.click ^js (at handle sel)) (mount/settle!) nil)
+
+(defn- readers-of [sub-key] (runtime/cell-readers sub-key))
+
+(defonce ^:private !minted
+  ;; Every root a row has minted through `mount-live!`, oldest first.
+  ;; Emptied by `release-minted!` on the row's single trailing step.
+  (atom []))
+
+(defn- release-minted!
+  "Release every root this row minted, and forget them. Rides the single
+  trailing step, which BOTH arms reach, so the teardown is written once
+  and runs once per path; `mount/release!` is idempotent, so a row whose
+  success path already tore its root down pays nothing here — and the
+  `teardown!` assertions below stay exactly where they are, because they
+  are the act under test rather than a cleanup.
+
+  The rejection arm cannot do this itself: [[mount-live!]] mints its root
+  SYNCHRONOUSLY and hands it over only once the wait succeeds, so a
+  rejection reaches the arm with a live root the arm has no name for."
+  []
+  (run! mount/release! @!minted)
+  (reset! !minted [])
+  nil)
+
+(defn- mount-live!
+  "Mount `hiccup` under `frame-kw` and return only once `sub-key` has
+  exactly `readers` readers — which is to say, once every holder in the
+  tree is provably SUBSCRIBED.
+
+  `useSyncExternalStore` calls `subscribe` from a passive effect React
+  flushes after the commit, and an island that has not reached it cannot
+  be notified by anything — so a row that started before it would be
+  measuring an unsubscribed component and would stay green through a hook
+  that never subscribed at all. The wait is on the CELL's reader list,
+  which only the commit can populate.
+
+  Enrols the root in [[!minted]] the instant it exists, because from that
+  instant until [[release-minted!]] runs there is a live root on the page
+  and this promise is the only thing that could ever name it."
+  [frame-kw hiccup sub-key readers]
+  (let [container (mount/fresh-container!)
+        handle    (mount/root! container frame-kw hiccup)]
+    (swap! !minted conj handle)
+    (-> (support/wait-until! #(= readers (count (readers-of sub-key))))
+        (.then (fn [subscribed?]
+                 (when-not subscribed?
+                   (throw (ex-info (str "expected " readers
+                                        " subscribed reader(s) on " (pr-str sub-key))
+                                   {:residue (runtime/residue)})))
+                 handle)))))
+
+(defn- skip! [why] (is true (str "a hook claim needs a real React DOM — " why)))
+
+(defn- report-failure!
+  "Reports a rejection against `label`; it does NOT finish the row, and it
+  does not tear anything down — [[release-minted!]] on the trailing step
+  owns that, for both arms and for roots this one could never name.
+
+  `done` hands `cljs.test/run-block` a continuation that runs the WHOLE
+  remainder of the run synchronously, so a `.catch` sitting downstream of
+  the step that finished the row claims whatever a LATER namespace throws
+  and calls `done` a SECOND time. Every chain below therefore reports here
+  and finishes on a single trailing step, with nothing after it."
+  [label]
+  (fn [e]
+    (is false (str label " — " (.-message e)
+                   " | residue " (pr-str (runtime/residue))))
+    nil))
+
+(defn- teardown!
+  "Unmount, read the census while it is still exact, then finish the
+  release. The order is the load-bearing part: `mount/release!` calls
+  `collector/reset-runtime!`, which empties every table BY FIAT, so a
+  census taken after it reads zeros whether the teardown released
+  anything or not."
+  [handle]
+  (support/teardown-census! handle))
+
+;; ---------------------------------------------------------------------------
+;; W1. The read is the runtime's own, and the tool tier can see it
+;; ---------------------------------------------------------------------------
+
+(deftest an-islands-read-is-the-runtimes-own-and-xray-sees-it
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (let [k (price-key alpha "AAPL")]
+        (seat! alpha {"AAPL" 191})
+        (-> (mount-live! alpha [shared-host {:sym "AAPL"}] k 2)
+            (.then
+              (fn [handle]
+                (testing "the island painted the value, and so did the boundary
+                          beside it — the same key, read through the two
+                          different doors"
+                  (is (= "191" (text-at handle ".price")))
+                  (is (= "191" (text-at handle ".boundary"))))
+
+                (testing "and there is exactly ONE cell, under the frame the
+                          root installed, with TWO readers. Narrowing caught: a
+                          hook that read through `subscribe-once` per render —
+                          the paint above is identical under it and there would
+                          be one reader here, or none"
+                  (is (= #{k} (support/cell-keys)))
+                  (is (= 2 (count (readers-of k)))))
+
+                (testing "and TWO read-set entries exist, which is the honest
+                          count: the one-key entry the boundary and the island
+                          SHARE, and the empty one `shared-host` claimed — a
+                          body that reads nothing still mints and claims an
+                          entry, and that is what makes the tool tier's census
+                          complete"
+                  (is (= 2 (:entries (runtime/residue)))))
+
+                (testing "and `re-frame.hicasso.tool`'s mounted-boundary
+                          projection — hic-023's, the one Xray consumes — NAMES
+                          the read, without knowing that hooks exist. That is
+                          the whole return on routing the hook through the
+                          runtime's tables instead of beside them.
+
+                          `:read-orders 1` is the discriminating field.
+                          Narrowing caught: a private entry cache for hooks —
+                          the cell, the two readers and `:instances` are all
+                          unchanged under it, because two entries with equal
+                          key sets group into one row; what doubles is the
+                          number of entries folded into that row"
+                  (let [projection (tool/read-mounted-boundaries)
+                        row        (first (filter (fn [r]
+                                                    (some #(= ::price (:sub-id %))
+                                                          (:reads r)))
+                                                  (:boundaries projection)))]
+                    (is (= :mounted-boundaries (:scope projection)))
+                    (is (some? row) "the projection names no read of ::price")
+                    (is (= alpha (:frame row)))
+                    (is (= alpha (:frame-id (first (:reads row)))))
+                    (is (= 2 (:instances row))
+                        "one edge set, two holders — the runtime keys a
+                         boundary by what it reads, and an island reading what
+                         a boundary reads is indistinguishable to it")
+                    (is (= 1 (:read-orders row)))))
+
+                (exercised! :hooks/mounted-read)
+                (testing "teardown releases every membership the mount took"
+                  (is (= support/released (teardown! handle))))
+                nil))
+            (.catch (report-failure! "W1 mounted read"))
+            (.then (fn [_] (release-minted!) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; W2. A write wakes its readers and nobody else
+;; ---------------------------------------------------------------------------
+
+(deftest a-write-wakes-the-island-that-reads-it-and-nothing-else
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (let [k (price-key alpha "AAPL")]
+        (seat! alpha {"AAPL" 191})
+        (-> (mount-live! alpha [host {:sym "AAPL"}] k 1)
+            (.then
+              (fn [handle]
+                (testing "a write to the key the island reads repaints it"
+                  (mount/dispatch! handle [::set-price "AAPL" 204])
+                  (is (= "204" (text-at handle ".price"))))
+
+                (let [runs (deref !island-runs)]
+                  (testing "a write to a key NOTHING in the tree reads runs no
+                            island body at all. Narrowing caught: a hook
+                            subscribed to the generation, or to the store as a
+                            whole — it repaints correctly on the row above and
+                            wakes on every write in the application here, which
+                            is the cost the whole cell table exists to avoid"
+                    (mount/dispatch! handle [::touch-elsewhere])
+                    (is (= runs (deref !island-runs)))
+                    (is (= "204" (text-at handle ".price")))))
+
+                (testing "and the island's own dispatch — `:dispatch-sync` off
+                          the ops map, fired from a real click through React's
+                          event system — moves the same app-db the rest of the
+                          page reads"
+                  (click! handle ".commit")
+                  (is (= "from-the-island" (text-at handle ".price")))
+                  (is (= "from-the-island"
+                         (rf/with-frame alpha @(rf/subscribe [::price "AAPL"])))))
+
+                (exercised! :hooks/selective-wake)
+                (is (= support/released (teardown! handle)))
+                nil))
+            (.catch (report-failure! "W2 selective wake"))
+            (.then (fn [_] (release-minted!) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; W3. THE characteristic failure: a re-render that changed no read
+;; ---------------------------------------------------------------------------
+
+(defn- no-resubscribe-row!
+  "Mount `view` under `alpha`, drive three re-renders from the island's
+  OWN React state and one from a write, and answer a promise resolved
+  once the registration and the residue have been read on both.
+
+  This is the row the design is FOR. A hook that mints its `subscribe`
+  closure per render is correct on screen forever: React tears the
+  subscription down and rebuilds it after every single re-render,
+  releasing and re-acquiring the cell, and the value is right the whole
+  time. Only the registration's IDENTITY says so."
+  [view mechanism]
+  (let [k (price-key alpha "AAPL")]
+    (seat! alpha {"AAPL" 191})
+    (-> (mount-live! alpha [view {:sym "AAPL"}] k 1)
+        (.then
+          (fn [handle]
+            (let [reg-at-mount (first (readers-of k))
+                  runs         (deref !island-runs)
+                  residue      (runtime/residue)]
+
+              (testing "three re-renders driven by the island's OWN React
+                        state — a state bump behind a real click, which the
+                        runtime knows nothing about and cannot have moved a
+                        read"
+                (click! handle ".nudge")
+                (click! handle ".nudge")
+                (click! handle ".nudge")
+                (is (= "3" (text-at handle ".local")))
+                (is (= 3 (- (deref !island-runs) runs))
+                    "the body really did run three more times, which is
+                     what makes the readings below a test of anything"))
+
+              (testing "and the registration React holds is the IDENTICAL
+                        object. Narrowing caught: an inline `subscribe`
+                        closure, or a `useCallback` keyed on a CLJS vector
+                        (which is never `Object.is`-stable, so its deps
+                        array rebuilds every render) — either makes this a
+                        different object three times over, and nothing on
+                        screen changes"
+                (is (true? (identical? reg-at-mount (first (readers-of k))))
+                    "React holds a DIFFERENT registration, so the
+                     subscription was torn down and rebuilt"))
+
+              (testing "so nothing was released and re-acquired: one cell,
+                        one membership, one boundary, one edge, one entry —
+                        the numbers the mount established, unmoved"
+                (is (= residue (runtime/residue))))
+
+              (testing "the same holds across a re-render the RUNTIME
+                        caused. A write moves the value, React re-renders
+                        the island, and the read set is what it was — so
+                        React is never handed a new `subscribe` and the
+                        commit does no work"
+                (mount/dispatch! handle [::set-price "AAPL" 204])
+                (is (= "204" (text-at handle ".price")))
+                (is (true? (identical? reg-at-mount (first (readers-of k))))
+                    "React holds a DIFFERENT registration, so the
+                     subscription was torn down and rebuilt")
+                (is (= residue (runtime/residue))))
+
+              (exercised! mechanism)
+              (is (= support/released (teardown! handle)))
+              nil))))))
+
+(deftest a-re-render-that-changed-no-read-performs-no-re-subscribe
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (-> (no-resubscribe-row! host :hooks/no-resubscribe)
+          (.catch (report-failure! "W3 no re-subscribe"))
+          (.then (fn [_] (release-minted!) (done)))))))
+
+(deftest a-uix-island-re-rendered-for-its-own-reasons-performs-no-re-subscribe
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (-> (no-resubscribe-row! uix-host :hooks/no-resubscribe-uix)
+          (.catch (report-failure! "W3 no re-subscribe, UIx arm"))
+          (.then (fn [_] (release-minted!) (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; W4. StrictMode's double mount, and exact teardown
+;; ---------------------------------------------------------------------------
+
+(deftest strict-modes-double-mount-acquires-once-and-unmount-releases-exactly
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (let [k (price-key alpha "AAPL")]
+        (seat! alpha {"AAPL" 191})
+        (-> (mount-live! alpha [strict-host {:sym "AAPL"}] k 1)
+            (.then
+              (fn [handle]
+                (testing "StrictMode really is engaged — the body ran more than
+                          once for one mount, which is the premise the rest of
+                          this row rests on and which a production React build
+                          would silently remove"
+                  (is (< 1 (deref !island-runs))
+                      (str "the island body ran " (deref !island-runs)
+                           " time(s); StrictMode double-invokes render")))
+
+                (testing "and after mount → unmount → mount over every effect,
+                          there is exactly ONE reader on ONE cell. Narrowing
+                          caught: acquiring during the render — the ownership
+                          state machine's one prohibition — which under a
+                          double-invoked render acquires twice and reads 2 here
+                          while painting perfectly"
+                  (is (= #{k} (support/cell-keys)))
+                  (is (= 1 (count (readers-of k))))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
+                         (dissoc (runtime/residue) :entries))))
+
+                (testing "the island is live, not merely tidy — a subscription
+                          torn down by StrictMode's first cleanup and never
+                          rebuilt would satisfy every count above and repaint
+                          nothing"
+                  (mount/dispatch! handle [::set-price "AAPL" 204])
+                  (is (= "204" (text-at handle ".price"))))
+
+                (testing "and unmount releases EXACTLY what mount acquired,
+                          read between the unmount and the reset. Narrowing
+                          caught: a cleanup that released by key rather than by
+                          the cells it acquired — after a reap and rebuild it
+                          would release a successor's and leave its own"
+                  (is (= support/released (teardown! handle))))
+
+                (exercised! :hooks/strict-mode)
+                (-> (support/quiesced!)
+                    (.then (fn [_]
+                             (testing "past the reapers the tables are empty"
+                               (is (= {:cells 0 :cell-refs 0 :boundaries 0
+                                       :edges 0 :entries 0}
+                                      (runtime/residue))))
+                             nil)))))
+            (.catch (report-failure! "W4 StrictMode"))
+            (.then (fn [_] (release-minted!) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; W5. Frames are isolated contexts — on the far side of the crossing too
+;; ---------------------------------------------------------------------------
+
+(defn- isolation-row!
+  "One island source, two frames, one query — and a promise resolved once
+  both pages have been read."
+  [view mechanism]
+  (let [ka (price-key alpha "AAPL")
+        kb (price-key beta "AAPL")]
+    (seat! alpha {"AAPL" "alpha-price"})
+    (seat! beta  {"AAPL" "beta-price"})
+    (-> (mount-live! alpha [view {:sym "AAPL"}] ka 1)
+        (.then (fn [a] (.then (mount-live! beta [view {:sym "AAPL"}] kb 1)
+                              (fn [b] #js [a b]))))
+        (.then
+          (fn [^js pair]
+            (let [a (aget pair 0)
+                  b (aget pair 1)]
+              (testing "one island source, two frames, one query — TWO
+                        cells, differing only in their frame, one reader
+                        each. Narrowing caught: any frame resolution that
+                        is not the island's own React context — a module
+                        global, a dynamic var, a `:rf/default` floor —
+                        every one of which produces ONE key here and two
+                        visually plausible subtrees"
+                (is (= #{ka kb} (support/cell-keys)))
+                (is (= 1 (count (readers-of ka))))
+                (is (= 1 (count (readers-of kb)))))
+
+              (testing "and each island painted its own frame's value"
+                (is (= "alpha-price" (text-at a ".price")))
+                (is (= "beta-price"  (text-at b ".price"))))
+
+              (testing "a write in one frame moves that frame's island and
+                        leaves the other exactly where it was — the
+                        isolation claim as a REPAINT rather than as a count"
+                (mount/dispatch! a [::set-price "AAPL" "alpha-moved"])
+                (is (= "alpha-moved" (text-at a ".price")))
+                (is (= "beta-price"  (text-at b ".price"))))
+
+              (exercised! mechanism)
+              (mount/unmount! a)
+              (is (= support/released (teardown! b)))
+              (mount/release! (assoc a :root nil))
+              nil))))))
+
+(deftest two-frames-are-two-cells-and-an-island-cannot-see-across
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (-> (isolation-row! host :hooks/frame-isolation)
+          (.catch (report-failure! "W5 frame isolation"))
+          (.then (fn [_] (release-minted!) (done)))))))
+
+(deftest a-uix-island-cannot-see-across-frames-either
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (-> (isolation-row! uix-host :hooks/frame-isolation-uix)
+          (.catch (report-failure! "W5 frame isolation, UIx arm"))
+          (.then (fn [_] (release-minted!) (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; W5b. Two calls are two cells
+;; ---------------------------------------------------------------------------
+
+(deftest two-reads-in-one-island-are-two-cells
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (let [ka (price-key alpha "AAPL")
+            ke [alpha [::elsewhere]]]
+        (seat! alpha {"AAPL" 191})
+        (-> (mount-live! alpha [two-reads-page {:sym "AAPL"}] ka 1)
+            (.then
+              (fn [handle]
+                (testing "two `n/use-sub` calls in one component are two
+                          subscriptions: two cells, one reader slot on each,
+                          where a `defview` body's several `h/sub` reads are
+                          ONE. That is React's arithmetic — a store
+                          subscription is a hook, so `n` reads cost `n` of
+                          them. Narrowing caught: a hook that folded a
+                          component's reads into one entry and dropped one"
+                  (is (= #{ka ke} (support/cell-keys)))
+                  (is (= 1 (count (readers-of ka))))
+                  (is (= 1 (count (readers-of ke))))
+                  (is (= "191" (text-at handle ".price")))
+                  (is (= "0" (text-at handle ".other"))))
+
+                (testing "and both are live: a write to either key repaints
+                          the island through its own cell"
+                  (mount/dispatch! handle [::touch-elsewhere])
+                  (is (= "1" (text-at handle ".other")))
+                  (is (= "191" (text-at handle ".price")))
+                  (mount/dispatch! handle [::set-price "AAPL" 204])
+                  (is (= "204" (text-at handle ".price")))
+                  (is (= 1 (count (readers-of ka))))
+                  (is (= 1 (count (readers-of ke)))))
+
+                (exercised! :hooks/two-cells)
+                (is (= support/released (teardown! handle)))
+                nil))
+            (.catch (report-failure! "W5b two cells"))
+            (.then (fn [_] (release-minted!) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; W6. `use-frame`, both halves of the incarnation rule
+;; ---------------------------------------------------------------------------
+
+(defn- destroyed-frame-complaints
+  "Collect the always-on `:rf.error/frame-destroyed` corpus records raised
+  while `thunk` runs. Axis 1 (`error-emit`) rather than the dev trace,
+  because the refusal this row is about is always on."
+  [thunk]
+  (let [seen (atom [])
+        k    ::destroyed-listener]
+    (error-emit/register-error-listener!
+      k (fn [r] (when (= :rf.error/frame-destroyed (:error r)) (swap! seen conj r))))
+    (try (thunk) @seen
+         (finally (error-emit/unregister-error-listener! k)))))
+
+(deftest use-frame-is-stable-across-renders-and-retargets-across-a-reincarnation
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (let [k (price-key alpha "AAPL")]
+        (seat! alpha {"AAPL" "predecessor"})
+        (-> (mount-live! alpha [host {:sym "AAPL"}] k 1)
+            (.then
+              (fn [handle]
+                (let [ops-1   (deref !last-ops)
+                      token-1 (frame/frame-incarnation-token alpha)]
+
+                  (testing "reference stability: three re-renders that changed
+                            no frame hand back the IDENTICAL map, which is what
+                            makes it safe in `useEffect` deps and as a memoised
+                            child's prop"
+                    (click! handle ".nudge")
+                    (click! handle ".nudge")
+                    (click! handle ".nudge")
+                    (is (identical? ops-1 (deref !last-ops))))
+
+                  ;; The reincarnation. Same public id, different object — and
+                  ;; the runtime learns of it through the cell the frame's
+                  ;; teardown disposed, which is what re-renders the island.
+                  (rf/destroy-frame! alpha)
+                  (let [token-2 (seat! alpha {"AAPL" "successor"})]
+                    (testing "the premise: a different incarnation under one
+                              public id"
+                      (is (not (identical? token-1 token-2))))
+
+                    (-> (support/wait-until! #(= "successor" (text-at handle ".price")))
+                        (.then
+                          (fn [corrected?]
+                            (is (true? corrected?)
+                                (str "the island never observed the successor; "
+                                     "it reads " (pr-str (text-at handle ".price"))))
+
+                            (let [ops-2 (deref !last-ops)]
+                              (testing "the ops map RETARGETED. Narrowing
+                                        caught, and it is a shipping
+                                        implementation: a `useRef` memo keyed
+                                        on the resolved frame by `=` — the UIx
+                                        adapter's `use-frame` — passes the
+                                        stability block above and fails here,
+                                        because a frame keyword is `=` across a
+                                        reincarnation and the hook would hand
+                                        out the destroyed incarnation's bundle
+                                        for the rest of the mount"
+                                (is (not (identical? ops-1 ops-2)))
+                                (is (= alpha (:frame ops-2))))
+
+                              (testing "and the fresh bundle WRITES the
+                                        successor"
+                                ((:dispatch-sync ops-2) [::set-price "AAPL" "live"])
+                                (is (= "live" (rf/with-frame alpha
+                                                @(rf/subscribe [::price "AAPL"])))))
+
+                              (testing "while the bundle a callback captured
+                                        before the transition refuses — loudly,
+                                        once, through the always-on corpus —
+                                        rather than silently writing whoever
+                                        occupies the address now. That silent
+                                        write is the failure rf2-hic-013
+                                        repaired, and it is the reason the
+                                        memo is keyed on an incarnation"
+                                (let [seen (destroyed-frame-complaints
+                                             #((:dispatch-sync ops-1)
+                                               [::set-price "AAPL" "from-the-dead"]))]
+                                  (is (= 1 (count seen)))
+                                  (is (= "live" (rf/with-frame alpha
+                                                  @(rf/subscribe [::price "AAPL"])))))))
+
+                            (exercised! :hooks/incarnation)
+                            (is (= support/released (teardown! handle)))
+                            nil))
+                        ;; The inner chain finishes NOTHING and tears nothing
+                        ;; down — it is returned into the outer one below.
+                        (.catch (report-failure! "W6 incarnation")))))))
+            (.catch (report-failure! "W6 incarnation"))
+            (.then (fn [_] (release-minted!) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; W7. The external-store ceiling, measured
+;; ---------------------------------------------------------------------------
+
+(deftest a-transition-around-a-write-stays-tear-free-and-is-still-blocking
+  ;; React's `useSyncExternalStore` documentation is explicit that an
+  ;; external store's mutations cannot be non-blocking Transition updates
+  ;; and that React may restart such a transition as blocking. The lane
+  ;; note (`lanes/react-compatibility-notes.md`) rules that Hicasso TEST
+  ;; tear-freedom under `startTransition` and DOCUMENT the blocking
+  ;; fallback honestly rather than advertise transition-awareness. This is
+  ;; the test half; `n/use-sub`'s docstring is the documented half.
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no React DOM") (done))
+      (let [k (price-key alpha "AAPL")]
+        (seat! alpha {"AAPL" 191})
+        (-> (mount-live! alpha [host {:sym "AAPL"}] k 1)
+            (.then
+              (fn [handle]
+                (react/startTransition
+                  (fn [] (collector/dispatch! alpha [::set-price "AAPL" 204])))
+                (mount/settle!)
+                (testing "the paint agrees with app-db — no tear. A hook that
+                          returned a value captured independently of the epoch
+                          `getSnapshot` reports could disagree here, and React
+                          would have no way to know"
+                  (is (= "204" (text-at handle ".price")))
+                  (is (= 204 (rf/with-frame alpha @(rf/subscribe [::price "AAPL"])))))
+
+                (testing "and the subscription was not rebuilt by the
+                          transition"
+                  (is (= 1 (count (readers-of k))))
+                  (is (= {:cells 1 :cell-refs 1 :boundaries 1 :edges 1}
+                         (dissoc (runtime/residue) :entries))))
+
+                (exercised! :hooks/transition)
+                (is (= support/released (teardown! handle)))
+                nil))
+            (.catch (report-failure! "W7 transition"))
+            (.then (fn [_] (release-minted!) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; The roster
+;; ---------------------------------------------------------------------------
+
+(deftest the-declared-population-was-actually-exercised
+  (if-not (mount/browser?)
+    (skip! ":node-test reaches none of the mechanisms")
+    (is (= declared-population (deref !exercised))
+        (str "declared but never reached: "
+             (pr-str (set/difference declared-population (deref !exercised)))))))

--- a/implementation/hicasso/test/re_frame/hicasso/identifier_prefix_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/identifier_prefix_ssr_dom_cljs_test.cljs
@@ -116,7 +116,6 @@
             [re-frame.hicasso.impl.collector :as collector]
             [re-frame.hicasso.impl.mount :as mount]
             [re-frame.hicasso.impl.roots :as roots]
-            [re-frame.hicasso.native :as n]
             [re-frame.hicasso.roots-frames-support :as sup]
             [re-frame.test-support :as test-support]
             ["react" :as react]
@@ -150,17 +149,17 @@
 ;; ---------------------------------------------------------------------------
 ;;
 ;; `useId` is a React hook, so it is written where React hooks are
-;; written: a native island. And it is declared `{:server :render}` under
-;; a `{:server :render}` host, because that pair is the ONLY spelling
-;; that puts a native body into a server response — the innermost
-;; Client-only wins, and a Client-only island contributes nothing to the
-;; bytes for the prefix to be read out of (`native-ssr-dom-cljs-test`).
+;; written: a raw React component. And it is mounted through a
+;; `{:server :render}` host, because that is the ONLY policy that puts a
+;; foreign body into a server response — under the Client-only default
+;; the host region contributes nothing to the bytes for the prefix to be
+;; read out of.
 ;;
 ;; The island is the vehicle and never the subject. What is under test is
 ;; the ROOT's option; the island is the smallest legal thing that makes
 ;; React's answer to it visible.
 
-(n/defcomponent id-probe
+(defn- id-probe
   "One `useId`, rendered as text, beside a prop that changes.
 
   The prop is not decoration: it is what makes the post-adoption
@@ -168,11 +167,10 @@
   host whose props are identical, React would have every right to bail
   out, and the rows that re-read the id after a dispatch would be
   re-reading a body that never ran."
-  {:server :render}
   [^js props]
-  (n/$ :span #js {"className" "island"}
-       (n/$ :b #js {"className" "probe"} (react/useId))
-       (n/$ :i #js {"className" "label"} (.-label props))))
+  (react/createElement "span" #js {:className "island"}
+    (react/createElement "b" #js {:className "probe"} (react/useId))
+    (react/createElement "i" #js {:className "label"} (.-label props))))
 
 (h/defhost id-host id-probe {:server :render})
 

--- a/implementation/hicasso/test/re_frame/hicasso/imperative_sdk_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/imperative_sdk_dom_cljs_test.cljs
@@ -45,8 +45,8 @@
 
   | Piece | Door | Shipped? |
   |---|---|---|
-  | the wrapper component | `n/defcomponent` | yes |
-  | the DOM node it owns | `n/$` with a `:ref` | yes |
+  | the wrapper component | a raw React function component | yes |
+  | the DOM node it owns | `react/createElement` with a `:ref` | yes |
   | the crossing into hiccup | `h/defhost` | yes |
   | the SDK's outward callback | `:callbacks {:on-pick :event}` + `h/event` | yes |
   | the throw/retry region | `h/error-boundary` `:fallback` / `:reset-key` | yes |
@@ -116,7 +116,6 @@
             [re-frame.hicasso.impl.collector :as collector]
             [re-frame.hicasso.impl.mount :as mount]
             [re-frame.hicasso.test.runtime :as runtime]
-            [re-frame.hicasso.native :as n]
             [re-frame.hicasso.roots-frames-support :as support]
             [re-frame.test-support :as test-support]
             ["react" :as react]
@@ -251,10 +250,10 @@
 ;; THE RECIPE — the wrapper, and the five hooks it spends
 ;; ---------------------------------------------------------------------------
 
-(n/defcomponent spark-island
+(defn- spark-island
   "**The acquire/release recipe.** An ordinary React component that owns
-  one foreign instance, written on the native tier because that is the
-  tier with fibers, refs and effects — HD-020's ≤2-hook budget is a
+  one foreign instance, written as raw React because that is where
+  fibers, refs and effects live — HD-020's ≤2-hook budget is a
   statement about Hicasso BOUNDARIES, and an island is not one.
 
   Five hooks, and the split between them IS the recipe:
@@ -303,7 +302,7 @@
         (some-> ^js (.-current sdk-ref) (.setData data))
         js/undefined)
       #js [data])
-    (n/$ :div {:ref node-ref :class "spark"})))
+    (react/createElement "div" #js {:ref node-ref :className "spark"})))
 
 ;; ---------------------------------------------------------------------------
 ;; THE CROSSINGS — one declaration each, and hiccup uses them as heads

--- a/implementation/hicasso/test/re_frame/hicasso/lazy_boundary_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/lazy_boundary_dom_cljs_test.cljs
@@ -2,12 +2,10 @@
   "CODE SPLITTING — WHAT CROSSES A `React.lazy` BOUNDARY, AND WHAT A
   REJECTED ONE NEVER DOES AGAIN.
 
-  The bridge itself is `n/lazy`, one of the ABI helpers: a `react/lazy`
-  record carrying the tier marker, its
-  `:name` filled in on arrival, its `:server` pinned to Client-only.
-  [[re-frame.hicasso.native-abi-cljs-test]] settles the marker and
-  [[re-frame.hicasso.native-abi-dom-cljs-test]] settles the arrival.
-  **This file is about the BOUNDARY** — the five states a split region
+  The bridge itself is a raw `react/lazy` record mounted through
+  `h/defhost`, whose Client-only DEFAULT is what keeps the chunk out of a
+  server response — no helper of Hicasso's stands between the author and
+  React here. **This file is about the BOUNDARY** — the five states a split region
   moves through, what survives each crossing, and one promise the
   documentation was making that React cannot keep.
 
@@ -20,7 +18,7 @@
   | [[a-lazy-suspension-retains-the-committed-subscription-and-the-arrival-leaves-exact-ownership]] | the post-commit suspension result, re-measured across a LAZY boundary specifically | a lazy retry that quietly re-subscribed — the screen is right under it |
   | [[a-rejected-lazy-head-re-throws-its-cached-error-and-only-a-fresh-head-reloads]] | rejection is TERMINAL at the payload; `:reset-key` clears the boundary and reloads nothing | the claim, made in this repo until this bead, that changing `:reset-key` retries the chunk |
   | [[a-client-only-lazy-region-writes-nothing-and-a-declared-fallback-writes-the-skeleton]] | which DECLARATION actually emits server bytes, at the `defhost` crossing | a region documented as sending a skeleton whose declaration sends nothing |
-  | [[a-bare-lazy-head-under-native-suspense-writes-nothing-and-never-calls-its-loader]] | `n/lazy`'s OWN Client-only policy, with nothing in front of it and a raw `react/lazy` control beside it | a policy that lives on the marker while the head stays an ungated lazy record — and a witness whose zero is really two `defhost` gates |
+  | [[a-client-only-host-over-a-lazy-head-writes-nothing-and-never-calls-its-loader]] | the host's OWN Client-only policy over a lazy head, with one gate and a bare `react/lazy` control beside it | a gate that renders the head anyway, so the server fetches a chunk it cannot use — and a witness whose zero is really two `defhost` gates |
   | [[the-declared-population-was-actually-exercised]] | the roster, asserted rather than described | a row that started returning early |
 
   ## The instrument is the LOADER CALL COUNT, not the paint
@@ -79,11 +77,12 @@
   They ask different questions and the second is not a widening of the
   first. Row 5 is about a DECLARATION — which `defhost` key puts bytes in
   a server response — and it renders through two Client-only hosts
-  because that is the shape it is describing. Row 7 is about `n/lazy`
-  ITSELF, so it must have nothing in front of it: under row 5's shape the
-  loader would stay uncalled even if the lazy head were server-active, so
-  row 5 alone cannot decide row 7's subject. A witness dominated by
-  unrelated gates measures the gates."
+  because that is the shape it is describing. Row 7 is about the ONE
+  gate over the lazy head itself, so it must have nothing else in front
+  of it: under row 5's shape the loader would stay uncalled even if the
+  lazy head's own host were server-active, so row 5 alone cannot decide
+  row 7's subject. A witness dominated by unrelated gates measures the
+  gates."
   (:require [clojure.set :as set]
             [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
@@ -94,7 +93,6 @@
             [re-frame.hicasso.impl.collector :as collector]
             [re-frame.hicasso.test.runtime :as runtime]
             [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.native :as n]
             [re-frame.test-support :as test-support]
             ["react" :as react]
             ["react-dom" :as react-dom]
@@ -197,21 +195,27 @@
 ;; question: the parent wrote these before the chunk existed.
 (defonce ^:private !arrived-props (atom nil))
 
-(defn- chart-body
-  "The island in the split chunk. It reads a prop the parent wrote while
-  the module was still in flight, and renders whatever child was written
-  at the crossing."
+(defn- chart-cell
+  "The island in the split chunk, and what the chunk `def`s — an ordinary
+  React function component, which is the VALUE a row resolves a loader's
+  promise with. It reads a prop the parent wrote while the module was
+  still in flight, and renders whatever child was written at the
+  crossing."
   [^js props]
   (reset! !arrived-props props)
-  (n/$ :div {:id "chart"}
-       (n/$ :span {:class "series"} (str (count (.-points props))))
-       (.-children props)))
+  (react/createElement "div" #js {:id "chart"}
+    (react/createElement "span" #js {:className "series"} (str (count (.-points props))))
+    (.-children props)))
 
-(def ^:private chart-cell
-  "What the chunk `def`s. `n/component` rather than `n/defcomponent`
-  because the row needs the mint as a VALUE to resolve a promise with,
-  which is what a module's exported var is at the moment it lands."
-  (n/component "app/heavy-chart" :client-only chart-body))
+(unchecked-set chart-cell "displayName" "app/heavy-chart")
+
+(defn- lazy-head
+  "A raw `react/lazy` over one of this file's counted loaders. React's
+  contract wants a promise of a `#js {:default component}` module record,
+  and every ClojureScript code splitter resolves to the value, so the
+  record is put on here — once, where it is React's business."
+  [loader]
+  (react/lazy (fn [] (.then ((:load loader)) (fn [c] #js {:default c})))))
 
 ;; --- the Suspense hosts ----------------------------------------------------
 
@@ -234,13 +238,13 @@
 ;; --- scenario 2: load, fallback, arrival -----------------------------------
 
 (def ^:private paint-loader (deferred-loader))
-(def ^:private paint-head (n/lazy (:load paint-loader)))
+(def ^:private paint-head (lazy-head paint-loader))
 (h/defhost paint-host paint-head)
 
 ;; --- scenario 3: the post-commit suspension --------------------------------
 
 (def ^:private own-loader (deferred-loader))
-(def ^:private own-head (n/lazy (:load own-loader)))
+(def ^:private own-head (lazy-head own-loader))
 (h/defhost own-host own-head)
 
 ;; --- scenario 4: rejection, and the head that replaces it ------------------
@@ -250,48 +254,59 @@
 ;; reload — allocates, and it reaches the SAME function.
 
 (def ^:private reject-loader (deferred-loader))
-(def ^:private reject-head (n/lazy (:load reject-loader)))
-(def ^:private replacement-head (n/lazy (:load reject-loader)))
+(def ^:private reject-head (lazy-head reject-loader))
+(def ^:private replacement-head (lazy-head reject-loader))
 (h/defhost reject-host reject-head)
 (h/defhost replacement-host replacement-head)
 
 ;; --- scenario 6: the server render -----------------------------------------
 
 (def ^:private ssr-loader (deferred-loader))
-(def ^:private ssr-head (n/lazy (:load ssr-loader)))
+(def ^:private ssr-head (lazy-head ssr-loader))
 (h/defhost ssr-host ssr-head)
 
 ;; --- scenario 7: the UNSHADOWED server render ------------------------------
 ;;
 ;; Scenario 6's row is dominated by two `defhost` declarations, each of
-;; them independently Client-only, so it cannot distinguish `n/lazy`'s own
-;; policy from two unrelated gates in front of it. These two heads sit
-;; under NOTHING but React's own Suspense.
+;; them independently Client-only, so it cannot distinguish the lazy
+;; head's own gate from an unrelated gate in front of it. Here the head's
+;; host is the ONLY declaration, under nothing but React's own Suspense.
 
 (def ^:private bare-loader (deferred-loader))
-(def ^:private bare-head (n/lazy (:load bare-loader)))
+(def ^:private bare-head (lazy-head bare-loader))
+(h/defhost bare-host bare-head)
 
 ;; THE CONTROL, and the row is worthless without it. `renderToString` is
 ;; allowed to be inert — a renderer that never reached the region would
 ;; leave the count at zero for a reason that has nothing to do with the
-;; gate. This head is `react/lazy` with no gate at all, in the same shape
-;; and through the same `n/$`, and its count says what an ungated head
-;; does here.
+;; gate. This head is the same `react/lazy` with no gate at all, in the
+;; same shape, and its count says what an ungated head does here.
 (def ^:private raw-loader (deferred-loader))
-(def ^:private raw-head (react/lazy (fn [] (.then ((:load raw-loader))
-                                                  (fn [c] #js {:default c})))))
+(def ^:private raw-head (lazy-head raw-loader))
 
 (defn- suspense-tree
-  "The shipped shape from the audit's control, written in `n/$`: a
-  Suspense host with a fallback SLOT and one lazy head under it. No
-  `defhost`, no provider, no root element — nothing between
-  `renderToString` and the head but React."
+  "The shipped shape from the audit's control, written in raw React: a
+  Suspense with a fallback and one lazy head under it. No `defhost`, no
+  provider, no root element — nothing between `renderToString` and the
+  head but React."
   [head]
-  (n/$ :div
-       (n/$ :h1 {:id "title"} "metrics")
-       (n/$ (.-Suspense react)
-            {:fallback (n/$ :div {:id "react-fallback"} "loading")}
-            (n/$ head {:points #js [1 2 3]}))))
+  (react/createElement "div" nil
+    (react/createElement "h1" #js {:id "title"} "metrics")
+    (react/createElement (.-Suspense react)
+      #js {:fallback (react/createElement "div" #js {:id "react-fallback"} "loading")}
+      (react/createElement head #js {:points #js [1 2 3]}))))
+
+(defn- gated-suspense-tree
+  "The same shape with the head's OWN host as the one declaration in it:
+  React's Suspense, and under it the crossing, lowered under the frame
+  because a host is hiccup and hiccup needs the codec. Nothing else
+  gates the region."
+  [host]
+  (react/createElement "div" nil
+    (react/createElement "h1" #js {:id "title"} "metrics")
+    (react/createElement (.-Suspense react)
+      #js {:fallback (react/createElement "div" #js {:id "react-fallback"} "loading")}
+      (mount/provider frame-id (codec/root-element frame-id [host {:points [1 2 3]}])))))
 
 ;; ---------------------------------------------------------------------------
 ;; Views
@@ -746,8 +761,8 @@
           (str "the island certainly did not render: " html))
       (is (zero? @(:calls ssr-loader))
           "and the loader was never called: the server never sends the chunk,
-           which is why `n/lazy` pins the region to Client-only whatever the
-           component inside it declared")))
+           which is what the host's Client-only default buys whatever the
+           component inside it would have done")))
 
   (testing "the repair is `defhost`'s own `:fallback` — inert markup on the
             declaration, which the Client-only gate renders on the server
@@ -768,20 +783,19 @@
   (exercised! :lazy/server-render))
 
 ;; ---------------------------------------------------------------------------
-;; 7. The UNSHADOWED server render — `n/lazy`'s own policy, alone
+;; 7. The UNSHADOWED server render — the head's own gate, alone
 ;; ---------------------------------------------------------------------------
 
-(deftest a-bare-lazy-head-under-native-suspense-writes-nothing-and-never-calls-its-loader
+(deftest a-client-only-host-over-a-lazy-head-writes-nothing-and-never-calls-its-loader
   (testing "THE CONTROL, first, because the row above it is a zero and a
             zero is what an inert renderer also produces. A raw
             `react/lazy` head — no gate, no `defhost`, the identical
             shape — has its loader called ONCE while `renderToString`
-            runs, and React abandons the boundary to the client. That is
-            what `n/lazy` looked like before this bead: React 19's
-            `lazyInitializer` runs during a server render like any other
-            render, so a chunk the server can do nothing with is fetched
-            anyway and the response carries a switched-to-client template
-            instead of the region"
+            runs, and React abandons the boundary to the client: React
+            19's `lazyInitializer` runs during a server render like any
+            other render, so a chunk the server can do nothing with is
+            fetched anyway and the response carries a switched-to-client
+            template instead of the region"
     (let [html (react-dom-server/renderToString (suspense-tree raw-head))]
       (is (= 1 @(:calls raw-loader))
           (str "an ungated lazy head IS reached by the server renderer: " html))
@@ -790,15 +804,15 @@
       (is (re-find #"Switched to client rendering" html)
           (str "having abandoned the boundary: " html))))
 
-  (testing "and `n/lazy`'s head, in that same shape, with NOTHING in front
-            of it — no `defhost`, no provider, no root element, one
-            Suspense host and the head. The loader is never called: the
-            server does not reach for a chunk it cannot use, and that is
-            the whole of the `:server client-only` the marker advertises.
-            Narrowing caught: the policy living on the marker while the
-            head stayed an ungated `react/lazy` record (audit #7969) —
-            metadata that no renderer reads"
-    (let [html (react-dom-server/renderToString (suspense-tree bare-head))]
+  (testing "and the same head behind its OWN `h/defhost`, under the ruled
+            Client-only default, with nothing else in front of it — one
+            Suspense and the one declaration. The loader is never called:
+            the server does not reach for a chunk it cannot use, and that
+            is the whole of what the default buys a lazy head. Narrowing
+            caught: a gate that rendered the head anyway, or a policy
+            recorded somewhere no renderer reads"
+    (seeded!)
+    (let [html (react-dom-server/renderToString (gated-suspense-tree bare-host))]
       (is (re-find #"metrics" html)
           (str "the premise: the render happened and reached the region's
                 sibling, so a zero below is a gate and not an inert

--- a/implementation/hicasso/test/re_frame/hicasso/retaining_host_callbacks_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/retaining_host_callbacks_dom_cljs_test.cljs
@@ -54,7 +54,7 @@
     sat beside it until rf2-6c12m.24 retired that contract: it declared
     the passthrough this row already measures.)
   - `:native-stable` — `n/use-frame` plus React's own `useCallback`
-    inside an `n/defcomponent` island: the one carrier that is BOTH
+    inside a raw React island: the one carrier that is BOTH
     identity-stable and dispatching.
 
   `:native-churn` is that last one with the `useCallback` taken off, so
@@ -240,14 +240,16 @@
 ;; superseded — so a `useCallback` keyed on it is stable exactly as long
 ;; as it is safe to be, and no longer.
 ;;
-;; Both islands render the vendor through `react/createElement` rather
-;; than through a `defhost`, because inside the native tier that IS the
-;; ordinary spelling. There is therefore no gate above the memo on these
-;; two rows, which is stated rather than hidden: it removes a component
-;; from the path and adds nothing to it, and the `:absent` row already
-;; shows the gate does not disturb a bail-out.
+;; Both islands are raw React components and render the vendor through
+;; `react/createElement` rather than through a `defhost`, because inside
+;; React that IS the ordinary spelling; each parent boundary returns the
+;; island's element directly, the Rung 3 escape. There is therefore no
+;; gate above the memo on these two rows, which is stated rather than
+;; hidden: it removes a component from the path and adds nothing to it,
+;; and the `:absent` row already shows the gate does not disturb a
+;; bail-out.
 
-(n/defcomponent stable-island
+(defn- stable-island
   "The identity-stable DISPATCHING carrier — the whole of the safe
   solution the standing rule asks about, assembled out of surface that
   already ships."
@@ -259,10 +261,10 @@
                   #js [ops])]
     (react/createElement sink #js {:label "s" :onPing on-ping})))
 
-(n/defcomponent churning-island
+(defn- churning-island
   "The same island with the `useCallback` taken off — the negative
   control for the row above. Without it a reader could credit the
-  bail-out to the tier, to the missing gate, or to `use-frame` itself
+  bail-out to the island, to the missing gate, or to `use-frame` itself
   rather than to the memoisation of the closure."
   [^js _props]
   (let [_tick (n/use-sub [::ticks])
@@ -273,8 +275,8 @@
                                         ((:dispatch-sync ops) [::ping :native-churn])
                                         nil)})))
 
-(h/defview stable-parent [_] (n/$ stable-island {}))
-(h/defview churn-parent  [_] (n/$ churning-island {}))
+(h/defview stable-parent [_] (react/createElement stable-island nil))
+(h/defview churn-parent  [_] (react/createElement churning-island nil))
 
 ;; ---------------------------------------------------------------------------
 ;; Harness

--- a/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/server_render_ssr_dom_cljs_test.cljs
@@ -79,7 +79,6 @@
             [re-frame.hicasso.impl.collector :as collector]
             [re-frame.hicasso.impl.mount :as mount]
             [re-frame.hicasso.impl.roots :as roots]
-            [re-frame.hicasso.native :as n]
             [re-frame.hicasso.roots-frames-support :as sup]
             [re-frame.hicasso.server :as server]
             [re-frame.ssr :as ssr]
@@ -111,20 +110,18 @@
 ;; ---------------------------------------------------------------------------
 ;;
 ;; `useId` is a React hook, so it is written where React hooks are
-;; written: a native island, declared `{:server :render}` under a
-;; `{:server :render}` host — the only spelling that puts a native body
-;; into a server response. The island is the vehicle and never the
-;; subject: what is under test is the TREE the entry renders, and the
-;; island is the smallest legal thing that makes React's answer to it
-;; visible.
+;; written: a raw React component, mounted through a `{:server :render}`
+;; host — the only policy that puts a foreign body into a server
+;; response. The island is the vehicle and never the subject: what is
+;; under test is the TREE the entry renders, and the island is the
+;; smallest legal thing that makes React's answer to it visible.
 
-(n/defcomponent id-probe
+(defn- id-probe
   "One `useId`, rendered as text, beside a prop that changes."
-  {:server :render}
   [^js props]
-  (n/$ :span #js {"className" "island"}
-       (n/$ :b #js {"className" "probe"} (react/useId))
-       (n/$ :i #js {"className" "label"} (.-label props))))
+  (react/createElement "span" #js {:className "island"}
+    (react/createElement "b" #js {:className "probe"} (react/useId))
+    (react/createElement "i" #js {:className "label"} (.-label props))))
 
 (h/defhost id-host id-probe {:server :render})
 

--- a/implementation/hicasso/test/re_frame/hicasso/three_way_parity_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/three_way_parity_cljs_test.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.hicasso.three-way-parity-cljs-test
-  "THREE-WAY PARITY — Hicasso-native against BOTH handwritten React and
-  UIx.
+  "TWO-ARM PARITY — handwritten React against UIx, both through
+  `h/defhost`.
 
   > A native island should be within 5% or 1 ms of the same component
   > mounted directly through its chosen React route, excluding the single
@@ -10,39 +10,42 @@
   >
   > — `docs/design/hicasso/product/specification.md` §6
 
-  The second sentence is why there are three routes and not two. A native
-  tier measured only against UIx would be measured against a floor UIx
-  itself sets: UIx is a convenience layer, it pays a per-render price for
-  that convenience, and matching it proves nothing about whether the
-  native tier costs what React costs. Handwritten `react/createElement`
+  The native authoring tier this file used to measure as a third arm was
+  retired by the rf2-6c12m.3 ruling: an island is now a raw React
+  component or a UIx `defui`, mounted through `h/defhost`, using
+  `n/use-sub` / `n/use-frame` when it needs Hicasso state. What survives
+  here is the FLOOR that ruling kept — handwritten `react/createElement`
   is the only arm with no convenience in it, so it is the arm that
-  decides.
+  decides what a crossing costs, and UIx is measured against it rather
+  than against itself.
+
+  The file keeps its name because `implementation/hicasso/spec/budgets.md`
+  rows D14 and D16 name it as their witness and `check_budget_ledger.py`
+  reds on a witness that does not exist.
 
   ## The corpus, and why the rows are thunks
 
-  Every row of [[corpus]] is ONE subject written three times. The three
+  Every row of [[corpus]] is ONE subject written twice. The two
   spellings are the whole content of a row — the rows below assert
   equalities BETWEEN them and never against a literal, because a literal
-  is a fourth spelling that can drift from all three at once.
+  is a third spelling that can drift from both at once.
 
-  They are thunks rather than values because two of the three are macro
-  forms whose expansion is the thing under test: `n/$` lowers a literal
-  props map at expansion and `uix/$` compiles its attributes at
-  expansion, so a row evaluated once at namespace load would hide which
-  arm did what and when.
+  They are thunks rather than values because `uix/$` compiles its
+  attributes at expansion, so a row evaluated once at namespace load
+  would hide which arm did what and when.
 
   ## What each row proves, and what it deliberately does not
 
   | claim | how |
   |---|---|
-  | same DOM output, same bytes | `react-dom/server` over the three arms — one string compared three ways |
+  | same DOM output, same bytes | `react-dom/server` over the two arms — one string compared both ways |
   | same element shape | `.-type`, `.-key`, and the props object read as a map |
   | keys | a keyed seq, where React's own child reconciliation reads the slot |
   | SVG and custom elements | two heads whose attribute rules are not the ordinary ones |
-  | dynamic props | the marked operand against a hand-built object |
+  | dynamic props | a hand-built object against a runtime map |
   | children shapes | React's three — none, one, many — the shapes the outward bridge carries |
-  | component identity | the element type each route hands React |
-  | same-frame reads | one key read through all three doors in one tree |
+  | component identity | the element type each route hands React, through the crossing |
+  | same-frame reads | one key read through the interpreted door and both foreign doors in one tree |
   | hook count | React's own dispatcher, through `hook-probe` |
 
   **Refs, cleanup and hydration are NOT here.** Each is a property of a
@@ -59,26 +62,23 @@
   terms: the 5% rule has no same-instrument anchor until the ladder is
   re-pinned, no package-resident clock instrument exists, and §7 forbids
   converting a distributional row into a pull-request threshold at all.
-  §9.2 also names *this* bead as one of the three that supply C7's
-  POPULATION — the landed islands the rule is stated over — which is the
-  same statement from the other side.
 
-  So this file lands the population and the DETERMINISTIC half of the
-  band, which is the half a hosted runner is allowed to decide:
-  [[a-declared-render-island-is-the-authors-own-function-and-costs-no-wrapper]]
-  and [[the-convenience-layer-pays-a-per-render-price-the-native-tier-does-not]]
+  So this file lands the DETERMINISTIC half of the band, which is the
+  half a hosted runner is allowed to decide:
+  [[a-declared-render-crossing-is-the-authors-own-function-and-costs-no-wrapper]]
+  and [[the-convenience-layer-pays-a-per-render-price-handwritten-react-does-not]]
   read the two routes' construction cost as a structural fact rather
   than as a clock. That is a stronger reading than a timing, not a weaker
-  one: a `{:server :render}` island and a handwritten React component are
-  the SAME element type with the SAME props object, so there is no
-  interposed work for a stopwatch to find.
+  one: a `{:server :render}` crossing hands React the author's own
+  function as the element type, with the author's own props object, so
+  there is no interposed work for a stopwatch to find.
 
   **The band is stated over the DECLARED arm, and the declaration is what
   makes it comparable.** The `:client-only` default mints a gate rather than
   the author's function, so it costs one fiber and one hook the declared arm
   does not — the ruled price of the conservative default, and not a figure
-  about `n/defcomponent`'s construction. Every native fixture below therefore
-  writes `{:server :render}`, exactly as the UIx crossing declares its own.
+  about the crossing's construction. Every fixture below therefore writes
+  `{:server :render}`.
 
   No number is transcribed into the ledger here; the figures are this
   file's own, and transcribing the ledger row is the ledger's, as it was
@@ -105,8 +105,6 @@
 
 (rf/reg-event ::seed (fn [_ [_ db]] {:db db}))
 
-(rf/reg-event ::typed (fn [{:keys [db]} [_ typed]] {:db (assoc db :price typed)}))
-
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
     {:adapter       uix-adapter/adapter
@@ -116,33 +114,16 @@
                       (collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
-;; The three routes, as components
+;; The two routes, as components
 ;; ---------------------------------------------------------------------------
 ;;
 ;; One subject: a cell that paints a label. Written once per route, with
-;; nothing in any of them that the other two do not have.
-
-(n/defcomponent native-cell
-  "The native route. The ABI is one raw JavaScript props object and the
-  body reads it by name.
-
-  `{:server :render}` for the reason [[uix-host]] states about its own
-  crossing, one tier down: the native tier READS its `:server`
-  declaration, and the default is Client-only — a gate that
-  contributes nothing to a server render and is not the author's own
-  function. Both halves of this file need the declared arm: the markup
-  rows below server-render this cell, and the identity rows assert that
-  the element type IS the author's function, which is true of `:render`
-  and false of the gate. Declaring it is what makes the three routes
-  comparable, exactly as declaring the UIx crossing is."
-  {:server :render}
-  [^js props]
-  (n/$ :span {:class "cell"} (.-label props)))
+;; nothing in either of them that the other does not have.
 
 (defn react-cell
-  "The handwritten route — an ordinary React function component, which is
-  what `n/defcomponent` compiles to and the arm the band is measured
-  against."
+  "The handwritten route — an ordinary React function component, and the
+  arm the band is measured against. The ABI is one raw JavaScript props
+  object and the body reads it by name."
   [^js props]
   (react/createElement "span" #js {:className "cell"} (.-label props)))
 
@@ -152,30 +133,38 @@
   [{:keys [label]}]
   (uix/$ :span {:class "cell"} label))
 
+(defn uix-cell-arm
+  "The plain React shim every crossing into UIx needs: UIx's ABI is a
+  carrier object its own `uix/$` builds, so a `defui` reached through any
+  other door receives props it cannot read. A plain React component is
+  therefore the honest shim, and it is what the crossing looks like in an
+  application too."
+  [^js props]
+  (uix/$ uix-cell {:label (.-label props)}))
+
+(h/defhost react-cell-host react-cell {:server :render})
+(h/defhost uix-cell-host uix-cell-arm {:server :render})
+
 ;; ---------------------------------------------------------------------------
 ;; The corpus
 ;; ---------------------------------------------------------------------------
 
 (def ^:private corpus
-  "Matched triples. Every row is one subject in three spellings, and
+  "Matched pairs. Every row is one subject in two spellings, and
   `:proves` names the equality the row exists to establish rather than
   describing the markup — a row whose only claim is *these render the
-  same* is a row that would survive all three arms being wrong together."
+  same* is a row that would survive both arms being wrong together."
   [{:name   "intrinsic element, literal props, one text child"
     :proves "the ordinary case: a ClojureScript props map lowers to the same
-             React slots on all three routes, so `:class` is `className`
+             React slots as a hand-built object, so `:class` is `className`
              wherever it is written"
-    :native #(n/$ :span {:class "cell" :id "c1"} "42")
     :react  #(react/createElement "span" #js {:className "cell" :id "c1"} "42")
     :uix    #(uix/$ :span {:class "cell" :id "c1"} "42")}
 
    {:name   "a keyed sequence of children"
-    :proves "the `:key` slot is React's own on every route — the one prop React
+    :proves "the `:key` slot is React's own on both routes — the one prop React
              itself reads, and the one a route that invented its own child
              identity would get wrong"
-    :native #(n/$ :ul nil
-                  (n/$ :li {:key "a"} "a")
-                  (n/$ :li {:key "b"} "b"))
     :react  #(react/createElement "ul" nil
                                   (react/createElement "li" #js {:key "a"} "a")
                                   (react/createElement "li" #js {:key "b"} "b"))
@@ -186,28 +175,23 @@
    {:name   "an SVG element with a dashed attribute"
     :proves "SVG's attribute rules are React's, not the substrate's: `stroke-width`
              becomes `strokeWidth` and the element lands in the SVG namespace on
-             all three routes"
-    :native #(n/$ :svg {:viewBox "0 0 8 8"}
-                  (n/$ :circle {:cx 4 :cy 4 :r 3 :stroke-width 2}))
+             both routes"
     :react  #(react/createElement "svg" #js {:viewBox "0 0 8 8"}
                                   (react/createElement "circle" #js {:cx 4 :cy 4 :r 3 :strokeWidth 2}))
     :uix    #(uix/$ :svg {:view-box "0 0 8 8"}
                     (uix/$ :circle {:cx 4 :cy 4 :r 3 :stroke-width 2}))}
 
    {:name   "a custom element, spelled as a string head"
-    :proves "a head with a dash is a custom element on every route and its
+    :proves "a head with a dash is a custom element on both routes and its
              attributes pass through unrenamed — the case where React's own
              rule CHANGES, so a route carrying its own attribute table would
              diverge here and nowhere else"
-    :native #(n/$ "my-widget" #js {:data-size "lg"} "w")
     :react  #(react/createElement "my-widget" #js {:data-size "lg"} "w")
     :uix    #(uix/$ :my-widget {:data-size "lg"} "w")}
 
    {:name   "a dynamic props operand"
-    :proves "a props map built at runtime reaches the same React slots as the
-             literal one — on the native route through the explicit `n/props`
-             marker, which is the whole of what the marker does"
-    :native #(let [m {:class "cell" :id "c1"}] (n/$ :span (n/props m) "42"))
+    :proves "a props map built at runtime reaches the same React slots as a
+             hand-built object"
     :react  #(let [o #js {}]
                (unchecked-set o "className" "cell")
                (unchecked-set o "id" "c1")
@@ -219,14 +203,12 @@
              bridge over exactly these three, because React's `children` slot
              is absent, a bare value and an array in turn — and a route that
              read it as one shape got the other two wrong"
-    :native #(n/$ :span {:class "cell"})
     :react  #(react/createElement "span" #js {:className "cell"})
     :uix    #(uix/$ :span {:class "cell"})}
 
    {:name   "exactly one child"
     :proves "React's second children shape — the slot holds the child itself,
              not a one-element array"
-    :native #(n/$ :span {:class "cell"} (n/$ :b nil "one"))
     :react  #(react/createElement "span" #js {:className "cell"}
                                   (react/createElement "b" nil "one"))
     :uix    #(uix/$ :span {:class "cell"} (uix/$ :b nil "one"))}
@@ -235,7 +217,6 @@
     :proves "React's third children shape, with the mixture that makes it
              interesting: text and elements interleaved, where a route that
              normalised children would show it"
-    :native #(n/$ :p nil "a" (n/$ :b nil "b") "c" (n/$ :i nil "d"))
     :react  #(react/createElement "p" nil "a"
                                   (react/createElement "b" nil "b") "c"
                                   (react/createElement "i" nil "d"))
@@ -243,9 +224,8 @@
 
    {:name   "a component head"
     :proves "the routes agree about a COMPONENT and not only about intrinsic
-             elements — three different element types, three different props
+             elements — two different element types, two different props
              ABIs, one rendering"
-    :native #(n/$ native-cell #js {:label "42"})
     :react  #(react/createElement react-cell #js {:label "42"})
     :uix    #(uix/$ uix-cell {:label "42"})}])
 
@@ -280,23 +260,16 @@
   [el]
   (into {} (remove (fn [[_ v]] (or (fn? v) (object? v)))) (props-map el)))
 
-(defn- refusal
-  "Run `f` and answer the refusal's ex-data — or a marker saying what
-  happened instead, so a failing row reports WHICH of the two ways it
-  failed rather than throwing out of the assertion. The shape
-  `native_grammar_cljs_test` uses, for the same reason."
-  [f]
-  (try
-    (f)
-    {::outcome :returned-without-refusing}
-    (catch :default e
-      (or (ex-data e) {::outcome :threw-without-ex-data ::message (ex-message e)}))))
+(defn- slots
+  "The names on the props object React carries for `el`, in order."
+  [^js el]
+  (vec (js/Object.keys (.-props el))))
 
 ;; ---------------------------------------------------------------------------
 ;; 0. The instrument can tell two markups apart
 ;; ---------------------------------------------------------------------------
 ;;
-;; Every row below is of the form *these three are equal*, and equality is
+;; Every row below is of the form *these two are equal*, and equality is
 ;; trivially satisfied by an instrument that answers the same thing to
 ;; everything. So the first row drives a deliberate MISMATCH and asserts
 ;; the instrument reports it, exactly as `hook_budget_cljs_test` counts to
@@ -321,28 +294,23 @@
                 (scalar-props (react/createElement "span" #js {:className "two"})))))))
 
 ;; ---------------------------------------------------------------------------
-;; 1. The three routes render the same bytes
+;; 1. The two routes render the same bytes
 ;; ---------------------------------------------------------------------------
 
-(deftest the-three-routes-render-the-same-server-bytes
-  (doseq [{:keys [name proves native react uix]} corpus]
+(deftest the-two-routes-render-the-same-server-bytes
+  (doseq [{:keys [name proves react uix]} corpus]
     (testing (str name " — " proves)
       (let [handwritten (markup (react))]
 
         (testing "the premise: the handwritten arm rendered something"
           (is (seq handwritten)))
 
-        (testing "Hicasso-native against handwritten React, which is the
-                  comparison that decides — no convenience layer sets this
-                  floor"
-          (is (= handwritten (markup (native)))))
-
-        (testing "and UIx against the same handwritten arm, so the three are
-                  one subject rather than two agreeing pairs"
+        (testing "UIx against handwritten React, which is the comparison that
+                  decides — no convenience layer sets this floor"
           (is (= handwritten (markup (uix)))))))))
 
 ;; ---------------------------------------------------------------------------
-;; 2. The three routes build the same element
+;; 2. The two routes build the same element
 ;; ---------------------------------------------------------------------------
 ;;
 ;; Markup is the output; this is the CONSTRUCTION. A route could reach the
@@ -350,45 +318,39 @@
 ;; normalised child array, a key moved into props — and the rows above
 ;; would not see it.
 
-(deftest the-three-routes-build-the-same-element-shape
-  (doseq [{:keys [name proves native react uix]} corpus]
+(deftest the-two-routes-build-the-same-element-shape
+  (doseq [{:keys [name proves react uix]} corpus]
     (testing (str name " — " proves)
       (let [^js r (react)
-            ^js n (native)
             ^js u (uix)]
 
         (testing "the element TYPE. For an intrinsic element it is the tag
-                  string, identically on all three routes; for a COMPONENT
-                  head the three types are three different functions — one
-                  per route — which is not a divergence but the subject:
-                  three components rendering one output is what parity means
+                  string, identically on both routes; for a COMPONENT head
+                  the two types are two different functions — one per route
+                  — which is not a divergence but the subject: two
+                  components rendering one output is what parity means
                   here, and a row asserting they were the same object would
                   be asserting the corpus had only one arm"
           (if (string? (.-type r))
-            (do (is (= (.-type r) (.-type n)))
-                (is (= (.-type r) (.-type u))))
+            (is (= (.-type r) (.-type u)))
             (do (is (fn? (.-type r)))
-                (is (fn? (.-type n)))
                 (is (fn? (.-type u)))
-                (is (= 3 (count (distinct [(.-type r) (.-type n) (.-type u)])))
-                    "three arms, not two aliases of one"))))
+                (is (not (identical? (.-type r) (.-type u)))
+                    "two arms, not two aliases of one"))))
 
         (testing "the `key` slot, which React reads itself"
-          (is (= (.-key r) (.-key n)))
           (is (= (.-key r) (.-key u))))
 
-        (testing "and the scalar props, slot by slot — the native route's
-                  lowering is `impl/slot`'s and produces React's names"
-          (is (= (scalar-props r) (scalar-props n)))
+        (testing "and the scalar props, slot by slot, for an intrinsic element,
+                  where both routes carry React's own props object. A
+                  COMPONENT head is the one place the two ABIs differ, and
+                  that difference is its own row rather than an exception
+                  hidden here"
           (when (string? (.-type r))
-            (is (= (scalar-props r) (scalar-props u))
-                "UIx too, for an intrinsic element, where all three carry
-                 React's own props object. A COMPONENT head is the one place
-                 the three ABIs differ, and that difference is its own row
-                 rather than an exception hidden here")))))))
+            (is (= (scalar-props r) (scalar-props u)))))))))
 
 ;; ---------------------------------------------------------------------------
-;; 3. Component identity — the declared `:render` arm's zero wrapper
+;; 3. Component identity — the declared `:render` crossing's zero wrapper
 ;; ---------------------------------------------------------------------------
 ;;
 ;; This is the deterministic half of the island band. See the namespace
@@ -396,43 +358,43 @@
 ;; structural fact underneath it is decidable here and is the stronger
 ;; statement — there is no interposed work for a stopwatch to find.
 ;;
-;; The subject is `{:server :render}`, which is what [[native-cell]]
+;; The subject is `{:server :render}`, which is what [[react-cell-host]]
 ;; declares. The `:client-only` default answers a gate instead, and a
-;; gate is a wrapper: one fiber and one hook between
-;; React and the author's function. Naming the arm is the whole of the
-;; qualification — the rows below are unchanged by it.
+;; gate is a wrapper: one fiber and one hook between React and the
+;; author's function. Naming the arm is the whole of the qualification —
+;; the rows below are unchanged by it.
 
-(deftest a-declared-render-island-is-the-authors-own-function-and-costs-no-wrapper
-  (testing "`n/defcomponent` answers a FUNCTION, and under `{:server :render}`
-            it is the element type React reconciles on — not a wrapper
-            holding one"
-    (is (fn? native-cell))
-    (is (identical? native-cell (.-type (n/$ native-cell #js {:label "42"})))))
+(deftest a-declared-render-crossing-is-the-authors-own-function-and-costs-no-wrapper
+  (testing "a handwritten component is a FUNCTION, and it is the element type
+            React reconciles on — not a wrapper holding one"
+    (is (fn? react-cell))
+    (is (identical? react-cell (.-type (react/createElement react-cell #js {:label "42"})))))
 
   (testing "so the props React hands the component carry the author's own
             slot and nothing else. Stated as a KEY SET rather than by
             identity, because `React.createElement` copies its config into
-            a fresh props object on every route and always has — a row
-            asserting identity would be asserting a fact about React that
-            is not true of any of the three arms"
-    (is (= ["label"] (vec (js/Object.keys (.-props (n/$ native-cell #js {:label "42"})))))))
+            a fresh props object and always has — a row asserting identity
+            would be asserting a fact about React that is not true of any
+            arm"
+    (is (= ["label"] (slots (react/createElement react-cell #js {:label "42"})))))
 
   (testing "and the body runs when the function is CALLED — no fiber, no
-            hook, no shell. This is what `a DECLARED native island costs
-            what React costs` means as a structural fact rather than a
-            timing"
-    (let [el (native-cell #js {:label "42"})]
+            hook, no shell. This is what `a DECLARED island costs what React
+            costs` means as a structural fact rather than a timing"
+    (let [el (react-cell #js {:label "42"})]
       (is (= "span" (.-type el)))
       (is (= "42" (.-children (.-props el))))))
 
-  (testing "the handwritten arm is the same three sentences, which is the
-            point: the two routes are not close, they are identical in
-            shape, and the band excludes only the one explicit crossing"
-    (is (fn? react-cell))
-    (is (identical? react-cell (.-type (react/createElement react-cell #js {:label "42"}))))
-    (is (= ["label"] (vec (js/Object.keys (.-props (react/createElement react-cell #js {:label "42"}))))))))
+  (testing "THE CROSSING, which is the arm the band is stated over: through
+            `h/defhost` under `{:server :render}`, the element the codec
+            builds has the author's own function as its type and the
+            author's own slot as its props — zero wrappers, which is
+            budgets.md row D14"
+    (let [^js el (codec/as-element [react-cell-host {:label "42"}])]
+      (is (identical? react-cell (.-type el)))
+      (is (= ["label"] (slots el))))))
 
-(deftest the-convenience-layer-pays-a-per-render-price-the-native-tier-does-not
+(deftest the-convenience-layer-pays-a-per-render-price-handwritten-react-does-not
   (testing "UIx's element carries a CARRIER object rather than the props the
             author wrote — `#js {:argv <the map>}` — so the props a UIx
             component receives are not the props at the call site"
@@ -443,47 +405,55 @@
           "and it holds the ClojureScript map the author wrote")))
 
   (testing "read as a figure, which is what makes it comparable: the props
-            object React carries has ONE slot on every route, and on two of
-            them it is the author's `label` while on UIx it is a carrier the
-            author never wrote. That is one unwrapping hop per render, per
-            component, on the UIx route and ZERO on the other two — the
-            convenience being paid for, and exactly why §6 requires the
-            native tier to be co-instrumented against handwritten React as
-            well: a floor set by UIx would have this hop inside it"
-    (let [slots (fn [^js el] (vec (js/Object.keys (.-props el))))]
-      (is (= ["label"] (slots (n/$ native-cell #js {:label "42"}))))
-      (is (= ["label"] (slots (react/createElement react-cell #js {:label "42"}))))
-      (is (= ["argv"]  (slots (uix/$ uix-cell {:label "42"})))))
+            object React carries has ONE slot on both routes, and on the
+            handwritten route it is the author's `label` while on UIx it is
+            a carrier the author never wrote. That is one unwrapping hop per
+            render, per component, on the UIx route and ZERO on the
+            handwritten one — the convenience being paid for, and exactly
+            why §6 measures against handwritten React: a floor set by UIx
+            would have this hop inside it. budgets.md row D16"
+    (is (= ["label"] (slots (react/createElement react-cell #js {:label "42"}))))
+    (is (= ["argv"]  (slots (uix/$ uix-cell {:label "42"}))))
 
-    (let [^js uix-el    (uix/$ uix-cell {:label "42"})
-          ^js native-el (n/$ native-cell #js {:label "42"})]
+    (let [^js uix-el   (uix/$ uix-cell {:label "42"})
+          ^js react-el (react/createElement react-cell #js {:label "42"})]
       (is (nil? (.-label (.-props uix-el)))
           "UIx's element does not carry the prop at its own name")
-      (is (= "42" (.-label (.-props native-el)))
-          "the native element does — the body reads `.-label` off the props
-           object React built from the very map the call site wrote")))
+      (is (= "42" (.-label (.-props react-el)))
+          "the handwritten element does — the body reads `.-label` off the
+           props object React built from the very object the call site
+           wrote")))
+
+  (testing "and through the crossing the same hop is visible: the UIx arm's
+            host hands React a plain shim as the element type, and it is the
+            shim — not the door — that opens `argv` one level down"
+    (let [^js el (codec/as-element [uix-cell-host {:label "42"}])]
+      (is (identical? uix-cell-arm (.-type el)))
+      (is (= ["label"] (slots el)))))
 
   (testing "and the two routes' element types are different KINDS of thing:
-            the native tier's is the author's own function, UIx's is a
+            handwritten React's is the author's own function, UIx's is a
             generated component around a body the author wrote separately"
-    (is (identical? native-cell (.-type (n/$ native-cell #js {:label "42"}))))
+    (is (identical? react-cell (.-type (react/createElement react-cell #js {:label "42"}))))
     (is (true? (.-uix-component? uix-cell))
         "UIx stamps its own components, which is how it recognises one — and
-         the native tier's function carries no such stamp because it is not
+         the handwritten function carries no such stamp because it is not
          wrapped")))
 
 ;; ---------------------------------------------------------------------------
-;; 4. One frame, read through all three doors
+;; 4. One frame, read through the interpreted door and both foreign doors
 ;; ---------------------------------------------------------------------------
 
-(n/defcomponent island
-  "The native route's read: `n/use-sub`, a real React hook.
-  `{:server :render}` for [[native-cell]]'s reason — the page below is
-  server-rendered and a Client-only island would leave the premise row
-  reading two arms and calling it three."
-  {:server :render}
-  [_props]
-  (n/$ :b {:class "island"} (str (n/use-sub [::price]))))
+(defn island
+  "The raw-React route's read: `n/use-sub`, a real React hook, in an
+  ordinary function component. Mounted through `{:server :render}` for
+  [[uix-reader-host]]'s reason — the page below is server-rendered and a
+  Client-only crossing would leave the premise row reading two arms and
+  calling it three."
+  [^js _props]
+  (react/createElement "b" #js {:className "island"} (str (n/use-sub [::price]))))
+
+(h/defhost island-host island {:server :render})
 
 (defui uix-reader
   "The UIx route's read, through the adapter's own hook, in the EXPLICIT
@@ -499,27 +469,22 @@
   Spec 002's own ladder names the explicit `{:frame <id>}` as the third
   of three ways to establish a scope, so this arm takes it.
 
-  What that costs the row is nothing: the claim is that all three routes
+  What that costs the row is nothing: the claim is that all three doors
   read ONE frame and agree, not that all three discover it by the same
-  mechanism — they demonstrably do not, since the Hicasso arms resolve
+  mechanism — they demonstrably do not, since the Hicasso doors resolve
   through `impl/collector`'s own context read. The ambient UIx form is
   the browser lane's to exercise, and `re-frame.adapter.uix`'s own
   `uix_use_subscribe_dom_cljs_test` is where it already is."
   [_]
   (uix/$ :u {:class "uix"} (str (uix-adapter/use-subscribe frame-id [::price]))))
 
-(defn uix-arm
-  "The crossing into the UIx tree, and it is a PLAIN React component
-  deliberately.
-
-  UIx's ABI is a carrier object its own `uix/$` builds — `#js {:argv m}`
-  — so a `defui` reached through any door but `uix/$` receives props it
-  cannot read. A plain React component is therefore the honest shim, and
-  it is what the crossing looks like in an application too."
+(defn uix-reader-arm
+  "The crossing into the UIx tree — a plain React shim, for
+  [[uix-cell-arm]]'s reason."
   [_props]
   (uix/$ uix-reader))
 
-(h/defhost uix-host
+(h/defhost uix-reader-host
   "The UIx arm's crossing into the tree, through the named door.
 
   `{:server :render}` and not the default, and the reason belongs in the
@@ -529,7 +494,7 @@
   `hook_budget_cljs_test`; here it would delete the arm this row exists
   to compare, and the first draft of this file read two arms agreeing and
   called it three. The premise row below is what caught it."
-  uix-arm
+  uix-reader-arm
   {:server :render})
 
 (h/defview boundary
@@ -538,13 +503,14 @@
   [:i.boundary (str (h/sub [::price]))])
 
 (h/defview page
-  "One tree holding all three, so the reads are of the same frame in the
-  same render rather than three separate renders that happen to agree."
+  "One tree holding all three doors, so the reads are of the same frame
+  in the same render rather than three separate renders that happen to
+  agree."
   [_]
   [:div.page
    [boundary {}]
-   (n/$ island nil)
-   [uix-host {}]])
+   [island-host {}]
+   [uix-reader-host {}]])
 
 (defn- seeded!
   []
@@ -566,7 +532,7 @@
                                              (codec/root-element frame-id hiccup))))))]
     {:html @!html :hooks hooks}))
 
-(deftest the-three-routes-read-one-frame-and-agree
+(deftest the-three-doors-read-one-frame-and-agree
   (seeded!)
   (is (true? (probe/install!))
       "React's client-internals dispatcher slot was not found — the hook
@@ -589,15 +555,15 @@
               island's `n/use-sub`. THREE readers, TWO hooks each — and the
               island's pair is indistinguishable from a boundary shell's,
               which is the parity statement in its sharpest form: crossing
-              into the native tier does not change what a read costs"
+              into raw React does not change what a read costs"
       (is (= ["useContext" "useSyncExternalStore"
               "useContext" "useSyncExternalStore"
               "useContext" "useSyncExternalStore"]
              (vec (take 6 hooks)))))
 
     (testing "I9 holds at two, read off the ledger the shell declares — the
-              three-route tree above added a native island and a foreign
-              UIx subtree and moved it by nothing"
+              tree above added a raw-React island and a foreign UIx subtree
+              and moved it by nothing"
       (is (= 2 (count runtime/shell-hook-ledger))))
 
     (testing "and neither `useRef` nor `useState` is among them: HD-020(b)'s
@@ -608,74 +574,10 @@
               own roster"
       (is (= [] (filterv #{"useRef" "useState"} (vec (take 6 hooks))))))
 
-    (testing "the crossing itself cost no hook: `{:server :render}` mints no
-              gate, so everything past the sixth is the foreign subtree's
-              own and the door contributed nothing to the count"
+    (testing "the crossings themselves cost no hook: `{:server :render}` mints
+              no gate, so everything past the sixth is the foreign subtree's
+              own and the doors contributed nothing to the count"
       (is (seq (drop 6 hooks))
           "the premise — the UIx arm really ran hooks of its own, so the
            statement above is about a populated tail rather than an empty
            one"))))
-
-;; ---------------------------------------------------------------------------
-;; 5. The leakage matrix — the mix the fence exists for
-;; ---------------------------------------------------------------------------
-;;
-;; The bead names four ambiguous mixes. Three are already witnessed and are
-;; NOT re-asserted here, because a second copy of a row is a second thing to
-;; drift: nested hiccup in a native child and an intent vector at a native
-;; callback are `native_grammar_cljs_test`'s
-;; (`a-hiccup-vector-in-child-position-refuses`,
-;; `an-event-vector-at-a-native-callback-slot-refuses`), and dynamic heads
-;; and props are its `heads-are-classified-syntactically` and
-;; `a-dynamic-element-in-props-position-is-a-child`.
-;;
-;; The fourth has no witness anywhere, and it is the one with the most to
-;; go wrong: a CONTROLLED FIELD written inside a native subtree. Every part
-;; of the interpreted controlled-field law — I15's converge-in-turn, the
-;; caret, the revision marker, the shadow component — is installed by
-;; `impl/controlled` from the CODEC, and the codec never runs past the
-;; fence. So the same source shape means one thing on each side, and the
-;; row below is that pair measured in one breath.
-
-(h/defview interpreted-field
-  "The controlled field as the interpreted tier means it: `:value` is a
-  subscription and `:on-input` is an event vector."
-  [_]
-  [:input#interpreted {:type     "text"
-                       :value    (str (h/sub [::price]))
-                       :on-input [::typed ::h/value]}])
-
-(deftest a-controlled-field-means-one-thing-in-hiccup-and-refuses-past-the-fence
-  (seeded!)
-
-  (testing "in hiccup the field is repaired: the codec routes a convergeable
-            input through `controlled/install!`, so what React receives is
-            the shadow component and not the bare tag"
-    (let [{:keys [html]} (server-render! [interpreted-field {}])]
-      (is (some? (re-find #"id=\"interpreted\"" html)))
-      (is (some? (re-find #"value=\"191\"" html)))))
-
-  (testing "past the fence the SAME source shape refuses, and it refuses on
-            the intent rather than on the value — `:on-input` is a React
-            callback slot, nothing lowers an event vector there, and React
-            would otherwise be handed the vector itself"
-    (let [data (refusal #(n/props {:type "text" :value "191" :on-input [::typed ::h/value]}))]
-      (is (= :rf.error/hicasso-native-intent-in-prop (:rf.error/id data)))
-      (is (= "onInput" (:slot data))
-          "the CONTROLLED-field slot specifically. `native_grammar_cljs_test`
-           drives `onClick`; the field family reaches the same rule by the
-           same route, and this row is what says the two are one rule")
-      (is (= 're-frame.hicasso.native/props (:where data))
-          "and it names the form that refused, which is the recovery the
-           author needs")))
-
-  (testing "so there is no silent third behaviour: the value prop alone is
-            legal past the fence and passes by identity, which is React's
-            own read-only controlled input — the author's to complete with a
-            handler, and never repaired behind their back"
-    (let [^js el (n/$ :input (n/props {:type "text" :value "191"}))]
-      (is (= "input" (.-type el)))
-      (is (= "191" (.-value (.-props el))))
-      (is (nil? (.-onChange (.-props el)))
-          "nothing was installed — past the fence there is no controlled
-           repair, which is the fence's whole content"))))

--- a/implementation/hicasso/test/re_frame/hicasso/three_way_parity_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/three_way_parity_dom_cljs_test.cljs
@@ -1,11 +1,11 @@
 (ns re-frame.hicasso.three-way-parity-dom-cljs-test
-  "THREE-WAY PARITY UNDER A REAL REACT.
+  "TWO-ARM PARITY UNDER A REAL REACT.
 
   `three_way_parity_cljs_test` settles what a server render can settle:
   bytes, element shape, props, and the construction figures underneath
-  the island band. Three of the bead's parity axes cannot be settled
-  there at all, because each is a property of a FIBER and a real
-  document, and the node lane has neither:
+  the island band. Three of the parity axes cannot be settled there at
+  all, because each is a property of a FIBER and a real document, and
+  the node lane has neither:
 
   | axis | why it needs a fiber |
   |---|---|
@@ -18,27 +18,30 @@
   a false green — `impl.mount/browser?` is the guard, and the sentence it
   prints names what was not measured.
 
+  The native authoring tier this file used to measure as a third arm was
+  retired by the rf2-6c12m.3 ruling; the two arms that remain —
+  handwritten React and UIx — are the floor that ruling kept. The file
+  keeps its name for the node-lane sibling's reason.
+
   ## Hydration is deliberately NOT here
 
   It belongs to the *per-surface SSR/hydration witnesses*, which this
-  file unblocks. Writing a three-route hydration row here would put a
+  file unblocks. Writing a two-route hydration row here would put a
   second authority on the same claim ahead of the one that owns it, and
   the two would drift on the first policy change.
   The server bytes each route produces ARE measured, in the node-lane
   sibling; what happens when React meets those bytes on a client is the
   next bead's subject.
 
-  ## One door for all three routes, and why that is the honest shape
+  ## One door for both routes, and why that is the honest shape
 
   Every arm crosses into the tree through `h/defhost` under
   `{:server :render}`. It is uniform — the same door, the same policy,
-  the same props conversion for all three — so a difference the rows find
-  is a difference between the ROUTES rather than between three ways of
-  reaching them. It is also what an application does: a native island, a
-  handwritten React component and a UIx subtree are all foreign React
-  components to the interpreted tier, and `native.cljc`'s docstring says
-  in terms that this is what keeps native-boundary clause 6 true — the
-  door never names the tier.
+  the same props conversion for both — so a difference the rows find
+  is a difference between the ROUTES rather than between two ways of
+  reaching them. It is also what an application does: a handwritten
+  React component and a UIx subtree are both foreign React components
+  to the interpreted tier, and the door never names the tier.
 
   ## One frame, and why a second would measure nothing HERE
 
@@ -47,35 +50,29 @@
   `::parity-dom`. That is deliberate, and the reason is a property of
   this file's subject rather than a budget.
 
-  A frame is a property of what a body READS. None of the three routes
-  here reads anything: [[page]] calls `h/sub` once per arm and hands
-  each route the answer as an ordinary `label` prop, because the axes
-  this file exists to settle — painted DOM, refs, cleanup, element
-  identity across a re-render — are all properties of a route's own
-  rendering, and a subscription inside each route would be three more
-  things that could differ for reasons that are not the ones under
-  test. Mount that tree under two frames and what differs between the
-  two pages is the number React carried down a props chain. That is
-  prop plumbing, and the single-frame run above already settles it for
-  all three routes in one commit.
+  A frame is a property of what a body READS. Neither route here reads
+  anything: [[page]] calls `h/sub` once per arm and hands each route the
+  answer as an ordinary `label` prop, because the axes this file exists
+  to settle — painted DOM, refs, cleanup, element identity across a
+  re-render — are all properties of a route's own rendering, and a
+  subscription inside each route would be two more things that could
+  differ for reasons that are not the ones under test. Mount that tree
+  under two frames and what differs between the two pages is the number
+  React carried down a props chain. That is prop plumbing, and the
+  single-frame run above already settles it for both routes in one
+  commit.
 
-  So the claim is real but it does not live here, and it is NOT simply
-  covered by the outward bridge's `two-frames-are-two-cells-across-the-
-  bridge` either — that row exercises the minted component's own
-  wrapper, which is the other direction and a different read. The
-  inward two-frame claim belongs where an inward route actually
-  subscribes, and that is
-  `native-abi-dom-cljs-test/two-frames-are-two-cells-through-the-inward-
-  door-as-well`: one hosting body under two roots, four islands reading
-  through `n/use-sub` on the far side of the crossing, two keys, two
-  readers each, and a write that moves one page.
+  The inward two-frame claim belongs where an inward route actually
+  subscribes, and that is `hooks_island_dom_cljs_test`'s isolation row:
+  one island source under two roots, reading through `n/use-sub` on the
+  far side of the crossing, two keys, one reader each, and a write that
+  moves one page.
 
-  The raw-React route is why the claim cannot be made three-wide at
-  all. A handwritten React component subscribes through no re-frame2
-  hook by construction — that is what makes it the control it is here —
-  so a three-route reading tree would have to hand it one, and the row
-  would then be measuring a component this file went to some trouble to
-  keep foreign."
+  The raw-React route is why the claim cannot be made here at all. A
+  handwritten React component subscribes through no re-frame2 hook by
+  construction — that is what makes it the control it is here — so a
+  reading tree would have to hand it one, and the row would then be
+  measuring a component this file went to some trouble to keep foreign."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.adapter.uix :as uix-adapter]
@@ -84,13 +81,14 @@
             [re-frame.hicasso.checkpoint-support :as support]
             [re-frame.hicasso.impl.collector :as collector]
             [re-frame.hicasso.impl.mount :as mount]
-            [re-frame.hicasso.native :as n]
             [re-frame.hicasso.roots-frames-support :as roots-support]
             [re-frame.test-support :as test-support]
             [uix.core :as uix :refer-macros [defui]]
             ["react" :as react]))
 
 (def ^:private frame-id ::parity-dom)
+
+(def ^:private routes [:react :uix])
 
 (rf/reg-sub ::price (fn [db _] (:price db)))
 
@@ -127,9 +125,8 @@
 ;; times across one update — and the re-render row below, whose whole
 ;; instrument is the call count, would read a remount that never
 ;; happened.
-(def ^:private native-ref (fn [node] (record-ref! :native node)))
-(def ^:private react-ref  (fn [node] (record-ref! :react node)))
-(def ^:private uix-ref    (fn [node] (record-ref! :uix node)))
+(def ^:private react-ref (fn [node] (record-ref! :react node)))
+(def ^:private uix-ref   (fn [node] (record-ref! :uix node)))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -142,19 +139,13 @@
                       (collector/reset-runtime!))}))
 
 ;; ---------------------------------------------------------------------------
-;; The three routes, as components
+;; The two routes, as components
 ;; ---------------------------------------------------------------------------
 ;;
 ;; One subject: a cell painting a label, holding a ref on its own span.
 ;; The ref arrives as an ORDINARY prop named `innerRef` rather than at
-;; React's `ref` slot, so all three routes are handed it the same way and
-;; the row measures the route rather than React's own ref forwarding —
-;; which `native_abi_dom_cljs_test` already covers for the native tier.
-
-(n/defcomponent native-cell
-  [^js props]
-  (ran! :native)
-  (n/$ :span {:class "cell native" :ref (.-innerRef props)} (.-label props)))
+;; React's `ref` slot, so both routes are handed it the same way and the
+;; row measures the route rather than React's own ref forwarding.
 
 (defn react-cell
   [^js props]
@@ -175,19 +166,17 @@
   [^js props]
   (uix/$ uix-cell {:label (.-label props) :inner-ref (.-innerRef props)}))
 
-(h/defhost native-host native-cell {:server :render})
-(h/defhost react-host  react-cell  {:server :render})
-(h/defhost uix-host    uix-arm     {:server :render})
+(h/defhost react-host react-cell {:server :render})
+(h/defhost uix-host   uix-arm    {:server :render})
 
 (h/defview page
-  "All three arms in one tree, under one frame, in one commit — so a row
-  comparing them is comparing one render and not three that happened to
+  "Both arms in one tree, under one frame, in one commit — so a row
+  comparing them is comparing one render and not two that happened to
   agree."
   [_]
   [:div.page
-   [native-host {:label (str (h/sub [::price])) :inner-ref native-ref}]
-   [react-host  {:label (str (h/sub [::price])) :inner-ref react-ref}]
-   [uix-host    {:label (str (h/sub [::price])) :inner-ref uix-ref}]])
+   [react-host {:label (str (h/sub [::price])) :inner-ref react-ref}]
+   [uix-host   {:label (str (h/sub [::price])) :inner-ref uix-ref}]])
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -195,7 +184,7 @@
 
 (defn- skip!
   [why]
-  (is true (str "a three-route DOM claim needs a real React DOM — " why)))
+  (is true (str "a two-route DOM claim needs a real React DOM — " why)))
 
 (defn- seeded!
   []
@@ -210,30 +199,30 @@
     handle))
 
 (defn- cells
-  "The three painted cells, by route, read out of `handle`'s container."
+  "The two painted cells, by route, read out of `handle`'s container."
   [handle]
   (into {}
         (map (fn [route]
                [route (.querySelector ^js (:container handle) (str "span.cell." (name route)))]))
-        [:native :react :uix]))
+        routes))
 
 (defn- normalised
   "`el`'s outer HTML with the route's own class removed.
 
   The class is how the row FINDS each cell and is therefore the one
-  attribute that must differ between the three. Comparing the raw markup
+  attribute that must differ between the two. Comparing the raw markup
   would compare that difference and nothing else; removing it leaves the
   part the routes are supposed to agree about, and the row below asserts
   the removal still left something."
   [^js el]
   (when el
-    (str/replace (.-outerHTML el) #"\s*(native|react|uix)\b" "")))
+    (str/replace (.-outerHTML el) #"\s*(react|uix)\b" "")))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. The painted DOM
 ;; ---------------------------------------------------------------------------
 
-(deftest the-three-routes-paint-the-same-dom
+(deftest the-two-routes-paint-the-same-dom
   (if-not (mount/browser?)
     (skip! ":node-test has no React DOM")
     (do
@@ -241,26 +230,25 @@
       (let [handle (mounted!)
             found  (cells handle)]
         (try
-          (testing "the premise: all three arms mounted. Two arms agreeing
-                    while a third rendered nothing is the failure this row is
-                    most exposed to, and it is the one the node-lane sibling
-                    was actually bitten by"
+          (testing "the premise: both arms mounted. One arm agreeing with
+                    itself while the other rendered nothing is the failure
+                    this row is most exposed to, and it is the one the
+                    node-lane sibling was actually bitten by"
             (is (every? some? (vals found)) (pr-str (keys found))))
 
-          (testing "and each painted the value it read — one frame, three
+          (testing "and each painted the value it read — one frame, two
                     routes, one commit"
-            (is (= ["191" "191" "191"]
-                   (mapv #(.-textContent ^js (get found %)) [:native :react :uix]))))
+            (is (= ["191" "191"]
+                   (mapv #(.-textContent ^js (get found %)) routes))))
 
-          (testing "the painted markup is the same on all three routes once
-                    the class that distinguishes them is removed — which is
-                    the DOM claim the server-bytes row cannot make, because
-                    a route could emit correct bytes and still hand React a
+          (testing "the painted markup is the same on both routes once the
+                    class that distinguishes them is removed — which is the
+                    DOM claim the server-bytes row cannot make, because a
+                    route could emit correct bytes and still hand React a
                     tree it reconciles differently"
             (let [handwritten (normalised (:react found))]
               (is (seq handwritten) "the premise: normalising left markup")
               (is (some? (re-find #"<span" handwritten)))
-              (is (= handwritten (normalised (:native found))))
               (is (= handwritten (normalised (:uix found))))))
           (finally (mount/release! handle)))))))
 
@@ -278,16 +266,16 @@
 
         (testing "each route's own ref function was called, and with the very
                   node that route painted — not merely with A node"
-          (doseq [route [:native :react :uix]]
+          (doseq [route routes]
             (let [calls (get @!refs route)]
               (is (= 1 (count calls)) (str route " ref called exactly once at mount"))
               (is (identical? (get found route) (first calls))
                   (str route " ref holds the node it painted")))))
 
         (testing "and every one of them is a real element with a real tag —
-                  the three routes reach React's ref slot by three different
+                  the two routes reach React's ref slot by two different
                   spellings and land in the same place"
-          (doseq [route [:native :react :uix]]
+          (doseq [route routes]
             (is (= "SPAN" (.-tagName ^js (first (get @!refs route)))))))
 
         (roots-support/teardown-census! handle)
@@ -296,7 +284,7 @@
                   React's own contract and the half a mounted-only row cannot
                   see: a route that held the node past unmount would keep a
                   detached tree alive"
-          (doseq [route [:native :react :uix]]
+          (doseq [route routes]
             (let [calls (get @!refs route)]
               (is (= 2 (count calls)) (str route " ref called at mount and at unmount"))
               (is (nil? (second calls)) (str route " ref released")))))))))
@@ -305,7 +293,7 @@
 ;; 3. Cleanup
 ;; ---------------------------------------------------------------------------
 
-(deftest teardown-releases-everything-the-three-route-tree-acquired
+(deftest teardown-releases-everything-the-two-route-tree-acquired
   (if-not (mount/browser?)
     (skip! ":node-test acquires nothing, so it can release nothing")
     (do
@@ -318,21 +306,22 @@
                   never held anything"
           ;; `.-length`, not `count`: a `NodeList` is array-LIKE and
           ;; ES6-iterable but implements no ClojureScript protocol, so
-          ;; `count` throws `ICounted` rather than answering three.
-          (is (= 3 (.-length (.querySelectorAll ^js container "span.cell")))))
+          ;; `count` throws `ICounted` rather than answering two.
+          (is (= 2 (.-length (.querySelectorAll ^js container "span.cell")))))
 
         (let [census (roots-support/teardown-census! handle)]
 
           (testing "the container is empty — React unmounted the whole tree,
-                    the two foreign subtrees included"
+                    both foreign subtrees included"
             (is (= "" (.-innerHTML ^js container))))
 
           (testing "and the runtime's own census is exact at the instant
                     unmount returned: no cell reference, no boundary, no
-                    edge survived a tree holding a native island and a
-                    foreign UIx subtree. Read BEFORE the release finishes,
-                    because `mount/release!` empties every table by fiat and
-                    a census taken after it reads zeros either way"
+                    edge survived a tree holding a handwritten React
+                    component and a foreign UIx subtree. Read BEFORE the
+                    release finishes, because `mount/release!` empties every
+                    table by fiat and a census taken after it reads zeros
+                    either way"
             (is (= {:cell-refs 0 :boundaries 0 :edges 0} census))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -341,10 +330,10 @@
 ;;
 ;; The parity axis the DOM cannot show. A route whose element type is a
 ;; fresh object per render renders perfectly and remounts every time:
-;; same pixels, new nodes, lost state, dropped refs. `n/defcomponent`'s
-;; contract is that the element type is the author's own function, so a
-;; re-render UPDATES — and the observable is the ref, which React fills
-;; once per mount and would fill again on a remount.
+;; same pixels, new nodes, lost state, dropped refs. A `{:server :render}`
+;; crossing's contract is that the element type is the author's own
+;; function, so a re-render UPDATES — and the observable is the ref, which
+;; React fills once per mount and would fill again on a remount.
 
 (deftest a-re-render-updates-every-route-rather-than-remounting-it
   (if-not (mount/browser?)
@@ -357,7 +346,7 @@
           (testing "the premise: the first commit filled every ref exactly
                     once, which is what a second fill would be measured
                     against"
-            (is (= [1 1 1] (mapv #(count (get @!refs %)) [:native :react :uix]))))
+            (is (= [1 1] (mapv #(count (get @!refs %)) routes))))
 
           (rf/with-frame frame-id (rf/dispatch-sync [::seed {:price 192}]))
           (mount/settle!)
@@ -367,21 +356,20 @@
                     The body count is the half the node identity below
                     cannot supply, since a tree that never re-rendered at
                     all also keeps its nodes"
-            (is (= {:native 2 :react 2 :uix 2} @!renders))
-            (is (= ["192" "192" "192"]
-                   (mapv #(.-textContent ^js (get (cells handle) %))
-                         [:native :react :uix]))))
+            (is (= {:react 2 :uix 2} @!renders))
+            (is (= ["192" "192"]
+                   (mapv #(.-textContent ^js (get (cells handle) %)) routes))))
 
           (testing "and every route kept its NODE across the update. React
-                    reconciled rather than replaced, on all three, which is
-                    what an unchanged element type buys and what a
-                    per-render mint would have cost"
-            (doseq [route [:native :react :uix]]
+                    reconciled rather than replaced, on both, which is what
+                    an unchanged element type buys and what a per-render
+                    mint would have cost"
+            (doseq [route routes]
               (is (identical? (get before route) (get (cells handle) route))
                   (str route " kept its node"))))
 
           (testing "so no ref was refilled: still one call each, where a
                     remount would read two — the observable the DOM cannot
                     provide, since the pixels are identical either way"
-            (is (= [1 1 1] (mapv #(count (get @!refs %)) [:native :react :uix]))))
+            (is (= [1 1] (mapv #(count (get @!refs %)) routes))))
           (finally (mount/release! handle)))))))

--- a/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
+++ b/implementation/hicasso/test_kit/src/re_frame/hicasso/test.cljs
@@ -352,11 +352,12 @@
 
 (defn host-policy
   "The `:server` policy a `defhost` crossing was declared with —
-  `:client-only` or `:render` — read back as data, the same two values
-  `n/marker` records on the sibling native door. Refuses anything that
-  is not a minted crossing rather than answering nil, because a nil here
-  would read as `:client-only`'s neighbour. A declared `:fallback` is
-  markup rather than policy and is not part of this answer."
+  `:client-only` or `:render` — read back as data. Refuses anything that
+  is not a minted crossing with `:rf.error/hicasso-test-not-a-host`
+  rather than answering nil, because a nil here would read as
+  `:client-only`'s neighbour. A declared `:fallback` is markup rather
+  than policy and is not part of this answer. The two policies and the
+  default are HD-011's, in docs/design/hicasso/decisions.md."
   [v]
   (when-not (host? v)
     (refuse! :rf.error/hicasso-test-not-a-host


### PR DESCRIPTION
Wave 1a of the rf2-6c12m.3 ruling (Option A: `re-frame.hicasso.native` shrinks to `n/use-sub` and `n/use-frame`). Scope: `implementation/hicasso/test/**` and `test_kit/**` only. The native namespace keeps every name until wave 2 (rf2-6c12m.31); after this PR nothing in the test tree except the 8 `native_*` suites and `expansion_probe.clj` names a deleted native symbol.

## What changed

1. **New hooks-contract suite** — `hooks_island_cljs_test.cljs` (node lane: cold read, refusal outside every frame, `use-frame` identity, 2-name membership pin with the exact-census clause commented out naming rf2-6c12m.31) and `hooks_island_dom_cljs_test.cljs` (mounted read + Xray roster, selective wake, no re-subscribe, StrictMode, frame isolation, two calls are two cells, incarnation pinning, transition ceiling, roster). Islands are raw React function components mounted through `h/defhost {:server :render}`; a UIx `defui` arm (through the plain-function shim, as the parity DOM test does) runs the no-re-subscribe and isolation rows. The Activity / post-commit Suspense / abandoned-attempt rows of `native_hooks_dom` are not ported: they are the boundary tier's (`activity_suspense_dom`, `kernel_commit_owns_dom`) and the ruling keeps the focused proof, not a second copy.
2. **Two-arm parity** — `three_way_parity_cljs_test` and `three_way_parity_dom_cljs_test` reshaped to handwritten React vs UIx, both through `h/defhost`. The D14/D16 floor rows survive (zero wrapper through the `:render` crossing, measured through `codec/as-element` on the host head; one `argv` hop on UIx). File names kept: budgets.md D14/D16 name them and `check_budget_ledger.py` reds on a missing witness. The `n/props` leakage-matrix row went with the grammar.
3. **Requirers re-spelt** in `react/createElement` / `react/lazy` / `h/defhost`: `direct_return` (kept as the one generic direct-return witness, now with a UIx arm on the fairness gate and all four probes), `imperative_sdk_dom`, `lazy_boundary_dom` (row 7 becomes a Client-only `h/defhost` over a raw `react/lazy` with the bare `react/lazy` control kept; loader-count instrument and rejection-is-terminal row kept), `retaining_host_callbacks_dom` (islands re-spelt, parents return the element directly — edited on the merged #8755 text, no `:handler` declaration reintroduced), `server_render_ssr_dom`, `identifier_prefix_ssr_dom`, `client_only_arms_ssr` (Activity route), `examples/ledger/views.cljs`, and prose in `foreign_root_bridge_dom` and `hmr_remount`.
4. **test_kit** `host-policy` docstring: drops the `n/marker` citation; contract + one sentence of why + `docs/design/hicasso/decisions.md` (HD-011). Path checked to exist; no wikilinks.

## Census delta

Bead list vs tip: `client_only_arms_ssr_cljs_test.cljs` DOES name `n/$` at 39/278/283/583 (the bead's original lines were right; the "stale" correction came from a regex with `\b` after `$`, which cannot match `n/$ ` since both sides are non-word). `examples/ledger/views.cljs` taken (not on the bead's list). Bench `direct_return_clock_app.cljs` left to rf2-6c12m.31 (inside rf2-6c12m.1's tree). Residual census after this PR — `n/($|props*?|defcomponent|memo|lazy|component|marker|prop-slots|el|declared-server|tier-sentinel)` followed by a non-symbol char, over `test/**` and `test_kit/**`, excluding the 8 `native_*` suites, `expansion_probe.clj` and `bench/` — is empty; positive control `n/use-sub` hits 7 files.

## Quality gates

Run from the worktree's `implementation/`, foreground to completion, exit codes captured by the invoking shell (not the harness). First pass on `a39541257c`; re-run on the rebased head `68bc9d793e` (trunk delta: one docs-only commit, `implementation/` byte-identical across the rebase — `git diff a39541257c 68bc9d793e -- implementation/` is empty).

| gate | exit | result |
|---|---|---|
| `npm run test:hicasso-compile` | 0 (both runs) | 160 namespaces, 0 warnings |
| `npm run test:cljs` | 0 (both runs) | 11747 tests, 58719 assertions, 0 failures |
| `npm run test:hicasso-invariants` | 0 (both runs) | budget ledger 49 rows, every PR-gate witness selected by a blocking build |
| `npx shadow-cljs compile browser-test` | 0 | 1082 files, 0 warnings |
| `node scripts/serve-and-run-browser-tests.cjs` (clean tree) | 0 | 1080 tests, 6136 assertions, 0 failures |

The browser lane was run once on the clean tree (the compound `test:browser` split into its two steps so each stayed in the foreground); it was not re-run after the docs-only rebase because its input under `implementation/` is byte-identical.

**Control (planted fault):** the isolation row of `hooks_island_dom_cljs_test` was changed to expect the leaked value in the sibling frame (`(is (= "alpha-moved" (text-at b ".price")))`). Working blob hash moved `156a582f9d…` -> `72534fdfc6…`; shadow-cljs recompiled 2 files; the browser run exited **1** with `2 failures, 0 errors` naming `two-frames-are-two-cells-and-an-island-cannot-see-across` and `a-uix-island-cannot-see-across-frames-either` (`hooks_island_dom_cljs_test.cljs:640`), `actual: (not (= "alpha-moved" "beta-price"))`, same 1080-test count as the clean run. Restored with `git checkout HEAD -- <file>`; `git hash-object` on the working file is again blob `156a582f9d2afd941e981d861ef208d2d3d877ac`, equal to `HEAD:<path>`.

Docstring anchors are `[[...]]` deftest references inside test namespaces (the package's existing convention); table column counts in the new namespace docstrings were checked by hand.