### PR TITLE
bench(hicasso): three prose corrections in the null-floor reader and lane.cljs (rf2-t78z, rf2-oflj7, rf2-fc7w)

### DIFF
--- a/bench/hicasso/src/re_frame/bench/hicasso/alloc_null_floor.cjs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/alloc_null_floor.cjs
@@ -114,8 +114,12 @@
 // reason.
 //
 // NO MECHANISM IS PROPOSED AND NONE IS EXCLUDED. In particular this reader
-// observes that the clean prefix is three rounds long and that `warmups` is 3,
-// says that it has not tested whether those are the same 3, and stops there.
+// observes that the clean prefix — the leading rounds carrying no mode-2 cell —
+// is TWO rounds long and that `warmups` is 3 in every run, records that those
+// are NOT the same number, and stops there. (This paragraph said `three rounds
+// long` and asked whether that and `warmups` were the same 3: a typed count the
+// table two paragraphs up contradicted on this corpus and on the 242-cell one
+// alike, so it is corrected in place rather than left as the record — rf2-t78z.)
 //
 // ## WHAT THIS MEANS FOR A BAND, WHICH IS THE LIVE CONSUMER
 //
@@ -390,6 +394,9 @@ function corpus() {
         run: `run ${i + 1}`,
         rel,
         rounds: a.rounds,
+        // Read off the record so section E's `warmups is N in every run` is a
+        // count rather than a recollection (rf2-t78z).
+        warmups: a.warmups,
         generatedAt: doc.generatedAt,
         session: recorded || `(inferred: ${w.window})`,
         sessionRecorded: Boolean(recorded),
@@ -617,8 +624,29 @@ function report() {
   L(`  rounds 0-2 : ${seg((c) => c.round <= 2)}      rounds 3+ : ${seg((c) => c.round >= 3)}`);
   L(`  rounds 1-2 alone, a near-complete sample : ${seg((c) => c.round === 1 || c.round === 2)}`);
   L(`  round 0 alone, heavily decimated by certification : ${seg((c) => c.round === 0)}`);
-  L('  The clean prefix is three rounds long and `warmups` is 3 in every run. THIS READER HAS NOT');
-  L('  TESTED WHETHER THOSE ARE THE SAME THREE, and proposes no mechanism for the structure.');
+  // THE CLEAN PREFIX, COUNTED OFF THE TABLE IT SITS UNDER — rf2-t78z. This
+  // sentence said `three rounds long` from four lines below a table reading
+  // round 2 at 12.3%, and had done since it was written: the 242-cell table read
+  // round 2 at 6.7%. It was the one typed count in E, and its only guard asked
+  // whether a DIFFERENT clause of the same sentence was present. The prefix is
+  // counted here as the leading rounds carrying no mode-2 cell, `warmups` is
+  // read off every run record rather than asserted, and the sentence states the
+  // two numbers and whether they coincide. No mechanism is proposed either way,
+  // which is the position the old wording was protecting: two counts that
+  // happen to differ are not a coincidence left unexplained.
+  let cleanPrefix = 0;
+  for (const [, cs] of [...byRound.entries()].sort((a, b) => a[0] - b[0])) {
+    if (cs.some((x) => x.c.abs >= MODE2_FLOOR_B)) break;
+    cleanPrefix++;
+  }
+  const warmupsSeen = [...new Set(rows.map((r) => r.warmups))].sort((a, b) => a - b);
+  const warmupsPhrase = warmupsSeen.length === 1
+    ? `\`warmups\` is ${warmupsSeen[0]} in every run`
+    : `\`warmups\` varies across runs (${warmupsSeen.join(', ')})`;
+  const sameNumber = warmupsSeen.length === 1 && warmupsSeen[0] === cleanPrefix;
+  L(`  The clean prefix is ${cleanPrefix} round${cleanPrefix === 1 ? '' : 's'} long and ${warmupsPhrase}. ` +
+    `THOSE ARE ${sameNumber ? 'THE SAME NUMBER' : 'NOT THE SAME NUMBER'}, and`);
+  L('  this reader proposes no mechanism for the structure either way.');
   L();
 
   L('F. THE COMMON-SUPPORT CONTROL. Phase 3 ran twelve rounds where the earlier windows ran six,');
@@ -1016,8 +1044,27 @@ function selfTest() {
   ck('the report leaves the p90 to a ruling', /THAT IS A RULING, NOT THIS READER'S CALL/.test(rep), true);
   ck('the report says the session question is not decidable here',
     /IS THE TAIL SESSION-CARRIED\? NOT DECIDABLE HERE\./.test(rep), true);
+  // THE CLEAN PREFIX, READ BACK AS A NUMBER — rf2-t78z. The check this replaces
+  // asked whether `THIS READER HAS NOT TESTED WHETHER THOSE ARE THE SAME THREE`
+  // was present, and it was, through every run the sentence spent saying
+  // `three rounds long` under a table reading round 2 at 12.3%. The prefix is
+  // re-derived here from the cells, `warmups` from the run records, both are
+  // pinned at their measured values like every other figure in this block, and
+  // the sentence's SAME / NOT THE SAME word is held to the comparison of the two.
+  const P_PREFIX = /The clean prefix is (\d+) rounds? long and `warmups` is (\d+) in every run\. THOSE ARE (THE SAME NUMBER|NOT THE SAME NUMBER), and/;
+  const roundsD = [...groupBy(all, (c) => c.round)].sort((a, b) => a[0] - b[0]);
+  let prefixD = 0;
+  while (prefixD < roundsD.length && inMode2(roundsD[prefixD][1]) === 0) prefixD++;
+  const warmupsD = [...new Set(rows.map((r) => r.warmups))];
+  ck('E\'s clean-prefix sentence is located exactly once', hits(P_PREFIX), 1);
+  ck('E\'s clean prefix is the count of leading rounds with no mode-2 cell, and it is two',
+    [grab(P_PREFIX, (m) => Number(m[1])), prefixD], [prefixD, 2]);
+  ck('and `warmups` is read off the runs, one value across all of them, and it is three',
+    [grab(P_PREFIX, (m) => Number(m[2])), warmupsD], [warmupsD[0], [3]]);
+  ck('and the sentence says the two coincide exactly when they do',
+    grab(P_PREFIX, (m) => m[3]), prefixD === warmupsD[0] ? 'THE SAME NUMBER' : 'NOT THE SAME NUMBER');
   ck('the report proposes no mechanism for the round structure',
-    /THIS READER HAS NOT\n;; {3}TESTED WHETHER THOSE ARE THE SAME THREE/.test(rep), true);
+    /THOSE ARE (?:THE SAME NUMBER|NOT THE SAME NUMBER), and\n;; {3}this reader proposes no mechanism for the structure either way\./.test(rep), true);
 
   // ---------------------------------------------------------------------------
   // THE NARRATION, HELD AGAINST THE COUNTS IT NARRATES — rf2-oflj7.

--- a/bench/hicasso/src/re_frame/bench/hicasso/alloc_null_floor.cjs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/alloc_null_floor.cjs
@@ -724,12 +724,38 @@ function report() {
   L('    magnitude on a two-population mixture. It should be RETIRED and replaced by two figures');
   L(`    that are: mode 1's own dispersion (p90 ${pooled.mode1.p90} over the corpus) and the fraction over the`);
   L('    bar. THAT IS A RULING, NOT THIS READER\'S CALL — the triple is cited by other windows\' bands.');
-  L('  IS THE TAIL SESSION-CARRIED? NOT DECIDABLE HERE. Three windows are three sessions, and the');
-  L('    session is confounded with the design, the round count and the date in all three. What is');
-  L('    ruled out is the round count (F); what is established is a within-run component (E).');
-  L('  WHAT IS MISSING: two sessions on ONE design. Every window in this corpus changed the design');
-  L('    and the session together, so re-running phase 3\'s twelve-round design in a fresh session is');
-  L('    the cheapest measurement that would separate them.');
+  // THE SESSION QUESTION, ANSWERED OFF THE SAME GROUPING THE TOTAL LINE COUNTS —
+  // rf2-oflj7 items 5 and 6. This said `NOT DECIDABLE HERE. Three windows are
+  // three sessions` under a section A that prints `4 windows over 5 sessions`,
+  // with the self-test pinning each of the two, and `WHAT IS MISSING: two
+  // sessions on ONE design` about a corpus whose fourth window IS two sessions
+  // on one design — the measurement this file's header amendment 3 already
+  // records as taken, with its 17.7% / 17.2% reading and its conclusion. Both
+  // arms are emittable and `spanning` chooses between them. The conclusion the
+  // answered arm prints is the header's own and not a new one: the per-session
+  // fractions it rests on are derived here and pinned by the self-test at the
+  // header's figures, so a corpus that moved them reds and gets read, rather
+  // than re-concluded by a threshold this reader does not have.
+  if (spanning.length === 0) {
+    L(`  IS THE TAIL SESSION-CARRIED? NOT DECIDABLE HERE. ${windowSessions.length} windows are ${windowSessions.length} sessions, and the`);
+    L(`    session is confounded with the design, the round count and the date in all ${windowSessions.length}. What is`);
+    L('    ruled out is the round count (F); what is established is a within-run component (E).');
+    L('  WHAT IS MISSING: two sessions on ONE design. Every window in this corpus changed the design');
+    L('    and the session together, so re-running phase 3\'s twelve-round design in a fresh session is');
+    L('    the cheapest measurement that would separate them.');
+  } else {
+    for (const [w, n] of spanning) {
+      const perSession = [...groupBy(rows.filter((r) => r.window === w), (r) => r.session)]
+        .map(([, rs]) => f1(ladder(cellsOf(rs)).overBarPct));
+      L(`  IS THE TAIL SESSION-CARRIED? PARTLY ANSWERED. ${w} is one design held still across ${n} sessions,`);
+      L('    where the session is not confounded with the design or the date, and its over-bar fraction');
+      L(`    reads ${perSession.join('% against ')}% over those sessions in order. ON THIS EVIDENCE THE SECOND`);
+      L('    POPULATION IS NOT SESSION-CARRIED. What is ruled out is the round count (F); what is');
+      L('    established is a within-run component (E).');
+    }
+    L(`  WHAT WAS MISSING, two sessions on ONE design, ${spanning.map(([w]) => w).join(' and ')} supplies; the other`);
+    L(`    ${windowSessions.length - spanning.length} windows changed the design and the session together and cannot separate them.`);
+  }
 
   return out.join('\n');
 }
@@ -1042,8 +1068,6 @@ function selfTest() {
   ck('the report names the basis of its cross-window comparisons',
     /Every cross-window comparison below is stated OVER THE BAR/.test(rep), true);
   ck('the report leaves the p90 to a ruling', /THAT IS A RULING, NOT THIS READER'S CALL/.test(rep), true);
-  ck('the report says the session question is not decidable here',
-    /IS THE TAIL SESSION-CARRIED\? NOT DECIDABLE HERE\./.test(rep), true);
   // THE CLEAN PREFIX, READ BACK AS A NUMBER — rf2-t78z. The check this replaces
   // asked whether `THIS READER HAS NOT TESTED WHETHER THOSE ARE THE SAME THREE`
   // was present, and it was, through every run the sentence spent saying
@@ -1114,6 +1138,38 @@ function selfTest() {
   // shape as the empty-span branch above.
   ck('and says they are the same partition exactly when no window spans two sessions',
     /WINDOW AND SESSION ARE THE SAME PARTITION HERE/.test(rep), nSpanning === 0);
+
+  // THE SESSION VERDICT, HELD TO THAT SAME GROUPING AND READ BACK AS NUMBERS —
+  // rf2-oflj7 items 5 and 6. The pin this replaces held the verdict to
+  // `NOT DECIDABLE HERE` — deliberately, and correctly for the corpus it was
+  // written on — a hundred lines under a pin holding the same run's TOTAL line
+  // to `4 windows, 5 sessions`, so one self-test enforced both halves of a
+  // contradiction. The not-decidable arm may print only when no window spans
+  // two sessions; the answered arm must name the spanning window, its session
+  // count and its per-session over-bar fractions, which are re-derived here and
+  // pinned at the figures the header's amendment 3 rests on.
+  const P_SESSION_Q = /IS THE TAIL SESSION-CARRIED\? (NOT DECIDABLE HERE|PARTLY ANSWERED)\. (.+?) (?:windows are|is one design held still across) (\d+) sessions/;
+  const P_SESSION_PCT = /its over-bar fraction\n;; {5}reads ([\d.]+(?:% against [\d.]+)*)% over those sessions in order\. ON THIS EVIDENCE THE SECOND\n;; {5}POPULATION IS NOT SESSION-CARRIED\./;
+  const P_MISSING = /WHAT (IS MISSING:|WAS MISSING,) two sessions on ONE design/;
+  ck('the session verdict and its missing-measurement clause are located exactly once each',
+    [P_SESSION_Q, P_MISSING].map(hits), [1, 1]);
+  ck('the verdict is not-decidable exactly when no window spans two sessions, and the missing-measurement clause agrees',
+    [grab(P_SESSION_Q, (m) => m[1]), grab(P_MISSING, (m) => m[1])],
+    nSpanning === 0 ? ['NOT DECIDABLE HERE', 'IS MISSING:'] : ['PARTLY ANSWERED', 'WAS MISSING,']);
+  if (nSpanning === 0) {
+    ck('and the not-decidable arm counts the windows it cannot separate',
+      grab(P_SESSION_Q, (m) => [m[2], Number(m[3])]), [String(WINDOWS.length), WINDOWS.length]);
+  } else {
+    const [spanW, spanN] = wSess.find(([, n]) => n > 1);
+    const perSessionD = [...groupBy(rows.filter((r) => r.window === spanW), (r) => r.session)]
+      .map(([, rs]) => Number(ladder(cellsOf(rs)).overBarPct.toFixed(1)));
+    ck('the answered arm names the spanning window and its session count',
+      grab(P_SESSION_Q, (m) => [m[2], Number(m[3])]), [spanW, spanN]);
+    ck('and its per-session over-bar fractions are the sessions\' own',
+      grab(P_SESSION_PCT, (m) => m[1].split('% against ').map(Number)), perSessionD);
+    ck('which are the figures the header\'s amendment 3 rests on',
+      [spanW, perSessionD], ['phase 4', [17.7, 17.2]]);
+  }
 
   // SECTION C'S HEADING is that claim again in four words, and it went stale with
   // it. Held against the same grouping, and required to NAME any window that

--- a/bench/hicasso/src/re_frame/bench/hicasso/lane.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/lane.cljs
@@ -1209,9 +1209,13 @@
   `hd8-rows/positive-control!` asks whether EVERY ROUND sits INSIDE it,
   and argues the stricter reading explicitly: a control whose worst round
   is wrong has caught something, and letting a good round vouch for a bad
-  one is how an instrument stops being one. THE STRICTER RULE IS THE
-  RIGHT ONE. This one is the lane's known defect, and a caller must not
-  read `:ok?` as though it were the strict answer — which is why the map
+  one is how an instrument stops being one. rf2-egdaq settled that
+  disagreement on 2026-08-21, and it settled as a SPLIT, one rule per
+  instrument: the HEAP arm's ten published figures were re-adjudicated
+  under the strict rule and all ten pass; the CLOCK arm REFUSED strict
+  under the 2026-07-31 quantum ruling set out below, and THAT REFUSAL
+  STANDS. So a caller must not read `:ok?` as though it were the strict
+  answer — which is why the map
   carries `:rule :overlap`, so a published record says which rule
   adjudicated it rather than leaving a reader to assume the other.
   [[control-verdict-strict]] is that other rule, spelled and callable.


### PR DESCRIPTION
Three prose corrections inside the hand-run bench project `bench/hicasso/`, one commit per bead, triaged by the mayor on 2026-08-29 under the rf2-6c12m.1 ruling's delegation. The tree is off every per-PR CI lane; its gate is its own `npm run check`, run by hand and recorded below. Two files touched: `bench/hicasso/src/re_frame/bench/hicasso/alloc_null_floor.cjs` and `bench/hicasso/src/re_frame/bench/hicasso/lane.cljs`. Nothing under `docs/design/hicasso/` (operator-held) is touched.

## Commits

1. **rf2-t78z** (`6fcd6959c0`) — section E of the null-floor reader said "the clean prefix is three rounds long … has not tested whether those are the same three" four lines under a table reading round 2 at 12.3%, and had since it was written (6.7% on the 242-cell corpus). The prefix is now COUNTED as the leading rounds carrying no mode-2 cell (2), `warmups` is READ off every run record (3 in all sixteen), and the sentence states both numbers and that they are not the same, proposing no mechanism either way. The header comment carrying the same typed count is corrected in place with a dated parenthetical. Self-test: the hollow phrase pin is replaced by checks that extract both numbers from the rendered report, re-derive them, pin them at 2 and 3, and hold the SAME / NOT THE SAME word to the comparison. 78 -> 82 checks.
2. **rf2-oflj7 items 5 and 6** (`2e8218b45f`) — the verdict printed "NOT DECIDABLE HERE. Three windows are three sessions" two hundred lines under a section A that derives "4 windows over 5 sessions", with the self-test pinning both; and "WHAT IS MISSING: two sessions on ONE design" about a corpus whose fourth window is exactly that. The verdict now derives its arm from the same window/session grouping: when a window spans two sessions it names the window, its session count and its per-session over-bar fractions (phase 4, 2, 17.7% against 17.2%) and prints the conclusion the file's OWN header amendment 3 already records — no new conclusion; a self-contradiction inside one program removed. The not-decidable arm remains emittable with derived counts. Self-test: the stale pin is replaced by checks that hold the arm to the grouping, read window / session count / fractions back out, re-derive them and pin them at the header's 17.7 / 17.2. 82 -> 86 checks. Items 1-4 and 7 were verified already repaired at tip (PR #8656 and ada4953560); nothing re-done.
3. **rf2-fc7w** (`be337c4ef5`) — the `control-verdict` docstring said "THE STRICTER RULE IS THE RIGHT ONE. This one is the lane's known defect" a few paragraphs above its own "the 2026-07-31 ruling on rf2-egdaq keeps it there on evidence". The dispatch premise was that the sentence had already gone (a fixed-string grep read 0 at tip); it had not — it wraps across a line break, which is the comment-wrap trap the bead itself records. The two sentences now carry the rf2-egdaq SPLIT in the register PR #8665 landed in the sibling instruments: heap arm re-adjudicated strict, all ten pass; clock arm refused strict under the 2026-07-31 quantum ruling, and that refusal stands. The caller guidance that follows is unchanged. No self-test reads this prose; the compile gate is the check.

Branch rebased once onto `8d4744dddd` (a beads checkpoint; no bench files) before the final gate run. Merge-base diff `origin/main...HEAD` is exactly the seven hunks above in two files; nothing landed in them since the base.

## Quality gates

All captured from the shell that ran them, on the final base `be337c4ef5`:

- `bench/hicasso`: `npm run check` — **exit 0**. Compile gate: "compiling all 155 namespaces walked from <worktree>/bench/hicasso/src … 464 files, 463 compiled, 0 warnings"; `alloc_null_floor.cjs --self-test` inside the chain reports "self-test OK (86 checks) — 569 cells, 16 runs, 4 windows, 5 sessions; the gap holds 1" (the post-edit count, so the gate read this tree); every other self-test in the chain green.
- `implementation`: `npm run test:script-policy` — **exit 0** (path-policy approved roots printed name this worktree).
- Planted-fault controls, each on a committed tree, restore verified by blob hash against the committed object:
  - commit 1: the typed "three" planted back into the derived section-E sentence -> self-test **exit 1**, "E's clean-prefix sentence is located exactly once: got 0, want 1" and "E's clean prefix … got ['NO MATCH',2], want [2,2]"; restored, 82 green.
  - commit 2: the old "NOT DECIDABLE HERE. Three windows are three sessions" literal planted back into the answered arm -> self-test **exit 1**, "the session verdict … located exactly once each: got [0,1], want [1,1]" and "the answered arm names the spanning window … got 'NO MATCH', want ['phase 4',2]"; restored, 86 green.
  - commit 3: lane.cljs has no self-test that reads prose; verified by the compile gate above (zero warnings).
- Not run and not applicable: no per-PR CI lane reads `bench/`; no doc-link gate covers these files (no markdown changed).
