### PR TITLE
docs(method): probe a quota hold once; a search control must share the target's shape

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -786,7 +786,12 @@ whether you re-ran the whole gate or one step.
 **A search that returns ZERO is not a check that passed.** A wrong pattern answers "no matches" in
 the same voice as "nothing is wrong"; the recurring instance is a backslash-bearing literal quoted
 so the shell strips them. Match fixed strings as fixed strings, and when a search underwrites a
-claim, run it once against something it should find.
+claim, run it once against something it should find. **And make that control share the SHAPE of
+the target**, because a pattern fails on a feature, and a control that lacks the feature passes
+without exercising it. Measured: a word-boundary anchor placed after a `$` matched a letter-final
+control and missed every punctuation-final hit, so the census read zero on four real sites while
+its control read green. If the target ends in punctuation, carries a backslash, or spans a line,
+the control must too.
 
 **This is not a fact about searching, and reading it as one is how it gets past you.** ANY
 instrument that can answer "nothing here" gives the same answer when misused, and a misused one

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -893,6 +893,14 @@ and both readings went wrong in a single day here, in opposite directions.
    chooses the remedy** — a quota death, a crash, a timeout and step 2's detached-gate strand look
    identical from outside.
 
+   **But the stated reset is a floor, not the only release.** An allowance can be restored by an
+   operator act — re-authenticating, changing plan — well before the clock the harness quoted, and
+   nothing tells the mayor it happened. So before holding the fleet for the whole interval, spend ONE
+   resume message on the worker with the most context to lose: a refusal confirms the hold at no
+   cost beyond what the hold was already costing, and an answer means the interval was over. Measured
+   here: three workers died on a stated reset an hour away; the operator re-authenticated within
+   minutes; one probe resumed all three. Hold on the clock only once the probe has refused.
+
 **Never build a commit from someone else's uncommitted work.** Only that worker knows whether it forms
 a coherent change.
 


### PR DESCRIPTION
Method reread loop (rf2 mayor session, 2026-08-29), second half: rules enforced against what the tree did.

**Two drifts, both measured this session, both generic:**

1. `loops.md` stranded sweep step 3 said a quota death means hold until the stated reset. The reset arrived by an operator re-authentication within minutes, and one resume message recovered all three dead workers. Added: the stated reset is a floor; spend one resume as a probe before holding on the clock.

2. The gate-mechanics block said to run a search once against something it should find. A word-boundary anchor after `$` passed a letter-final control and missed every punctuation-final hit, so a census read zero on four real sites with a green control. Added: the control must share the shape of the target.

**Bounded search:** the instrument rule under *Tracker mechanics* covers the neighbouring case (right answer, different question) and is left alone; no other copy of either rule exists in the tree.

## Quality gates
- `python scripts/check_doc_slugs.py` from the worktree: exit 0 (captured to a per-worktree exit file).
- `mkdocs build --strict`: not nominated — this tree sits in `exclude_docs`.
- Anchors and prose verified by hand; no tables touched.