### PR TITLE
hicasso(examples): retire the deleted fence suites from the example docstrings (rf2-6c12m.10)

### DIFF
--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/app.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/app.cljs
@@ -15,11 +15,10 @@
   and broke twelve RealWorld assertions with nothing warning.
 
   A four-field editor needs no routing to be evidence about controlled
-  fields, so it registers none — and `examples.witness-surface-cljs-test`
-  makes that mechanical rather than remembered: `re-frame.routing` is
-  absent from this application's dependency roster, read off the
-  ClojureScript analyzer, so a route registered here in future reds that
-  suite before it can reach the global registry.
+  fields, so it registers none. Nothing enforces that absence — the
+  `ns` form below is the only record of it — so a route added here in
+  future reaches the global registry, and must take a path no other
+  application in the tree claims.
 
   Every other id this application mints IS namespaced and therefore safe
   by construction — the frame keyword below, every event id, every

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/flow_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/flow_dom_cljs_test.cljs
@@ -33,8 +33,8 @@
 
   **That door is the kit's, and the budget is stated through it.**
   `test.runtime/body-runs` is the internal behind it, and a test is
-  ALLOWED that reach — the fence in `examples.witness-surface-cljs-test`
-  is over APPLICATION namespaces — but an application's own witness
+  ALLOWED that reach — the fence in `examples.fence-cljs-test` is over
+  APPLICATION namespaces — but an application's own witness
   states its budget in the vocabulary of the facade that mounted it.
   Nothing else answers *how many boundary bodies ran*: `hm/census` counts
   cells, edges and boundaries — residue, not work — and Spec 009's render

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/l0_cljs_test.cljs
@@ -5,9 +5,10 @@
   deliberately does not touch: an event handler is a function of `db` and
   an event vector, a subscription is a function of its inputs, and a
   state transition is the pair. So this file requires neither
-  `re-frame.hicasso` nor either half of the kit, and
-  `examples.witness-surface-cljs-test` proves the same of the namespaces
-  it tests.
+  `re-frame.hicasso` nor either half of the kit, and neither do the
+  namespaces it tests: `examples.fence-cljs-test` holds the kit half of
+  that for every application namespace in the tree, and the
+  `re-frame.hicasso` half is read off their `ns` forms.
 
   Frame scope is the programmer's ordinary bracket — `rf/with-new-frame`.
 

--- a/implementation/hicasso/test/re_frame/hicasso/examples/editor/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/editor/views.cljs
@@ -29,8 +29,7 @@
   markers `::h/value`, `::h/checked` and `::h/revision`. It needed no
   `h/event` — every intent said what it meant as a vector — and no `use-subs`,
   `boundary`, `portal`, `as-element`, `as-component`, `defhost`, `hframe`,
-  `route-link` or `reg-state`. **Six names and three keywords**, and
-  `examples.witness-surface-cljs-test` pins the namespace roster mechanically.
+  `route-link` or `reg-state`. **Six names and three keywords.**
 
   ## The one place the public door reads awkwardly
 

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/scaling_dom_cljs_test.cljs
@@ -21,8 +21,8 @@
   the comparator. It is the kit's door onto the runtime's own always-on
   counter; this file read that counter directly until the door
   existed, which was allowed — the fence in
-  `examples.witness-surface-cljs-test` is over APPLICATION namespaces —
-  but left the application's own witness naming an internal to state a
+  `examples.fence-cljs-test` is over APPLICATION namespaces — but left
+  the application's own witness naming an internal to state a
   budget the specification states.
 
   **It cannot see a props compare.** That matters for reading the table

--- a/implementation/hicasso/test/re_frame/hicasso/examples/grid/views.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/grid/views.cljs
@@ -37,7 +37,7 @@
   hundred controlled fields required — no `::h/revision` (the grid has no
   reset), no `h/event` (every intent is a vector, including the
   three-argument one), and nothing at all from the optional modules or
-  the native tier. `examples.witness-surface-cljs-test` pins it."
+  the native tier — the `:require` below is the whole of it."
   (:require [re-frame.hicasso :as h]
             [re-frame.hicasso.examples.grid.events :as events]
             [re-frame.hicasso.examples.grid.subs :as subs]))

--- a/implementation/hicasso/test/re_frame/hicasso/examples/ledger/app.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/ledger/app.cljs
@@ -7,8 +7,8 @@
   at a hundred records and at ten thousand and asserts that the numbers
   it measures did not move.
 
-  One root, one frame, no route — see `examples.witness-surface-cljs-test`
-  on why an application in this tree registers no route."
+  One root, one frame, no route — `examples.editor.app` says why an
+  application in this tree registers none."
   (:require [re-frame.adapter.uix :as uix-adapter]
             [re-frame.core :as rf]
             [re-frame.hicasso :as h]

--- a/implementation/hicasso/test/re_frame/hicasso/examples/ledger/events.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/ledger/events.cljs
@@ -8,10 +8,10 @@
   component deciding which few.
 
   Nothing in this namespace knows that. It is `re-frame.core` and pure
-  functions — `ledger.surface-cljs-test` holds the absence of a view
-  substrate here mechanically — and that is the first claim the screen
-  makes: **virtualization is a rendering strategy, and it does not reach
-  the model.** The same handlers, the same addresses and the same `l0`
+  functions — the `ns` form names no view substrate — and that is the
+  first claim the screen makes: **virtualization is a rendering strategy,
+  and it does not reach the model.** The same handlers, the same
+  addresses and the same `l0`
   suite would serve a screen that mounted all ten thousand rows.
 
   ## One address per record, for the same reason the grid has one per cell

--- a/implementation/hicasso/test/re_frame/hicasso/examples/ledger/l0_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/ledger/l0_cljs_test.cljs
@@ -6,7 +6,7 @@
   **The model**, which knows nothing about windowing. Ten thousand
   records, four handlers and five reads, and every one of them behaves
   exactly as it would behind a screen that mounted all ten thousand rows.
-  That is the claim `ledger.surface-cljs-test` makes structurally and
+  That is the claim `ledger.events`' `ns` form makes structurally and
   this file makes behaviourally: virtualization is a rendering strategy
   and it does not reach the model.
 

--- a/implementation/hicasso/test/re_frame/hicasso/examples/ledger/vendor.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/ledger/vendor.cljs
@@ -6,14 +6,13 @@
   foreign to be a recipe ABOUT. This namespace is that something: a real
   windowing component, written in **raw React and nothing else**.
 
-  ## It is FOREIGN, and that is mechanical rather than claimed
+  ## It is FOREIGN, and the `ns` form is the evidence
 
   Its only dependency is `[\"react\" :as react]`. It knows nothing of
-  `re-frame.hicasso`, `re-frame.core`, the native tier or the test kit,
-  and `ledger.surface-cljs-test` reads that off the analyzer's own
-  dependency graph rather than off this sentence. So everything the
-  ledger does with it, it does through the declared door — which is the
-  whole point of the screen.
+  `re-frame.hicasso`, `re-frame.core`, the native tier or the test kit —
+  read that off the `:require` below rather than off this sentence. So
+  everything the ledger does with it, it does through the declared door
+  — which is the whole point of the screen.
 
   It is a **stand-in for the npm package** for the reason
   `imperative-sdk-dom-cljs-test` states about its own vendor: the

--- a/implementation/hicasso/test/re_frame/hicasso/examples/ledger/virtualized_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/ledger/virtualized_dom_cljs_test.cljs
@@ -542,8 +542,7 @@
   ;; kit can hold: one root, one frame, and a residue reading against this
   ;; mount's own baseline. The vendor's scroll offset is React state and
   ;; dies with the fiber; the application holds no reactive cell of its
-  ;; own anywhere, which `ledger.surface-cljs-test`'s roster is the
-  ;; structural half of.
+  ;; own anywhere.
   (if-not (browser?)
     (skip! "the teardown claim")
     (async done

--- a/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/app.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/examples/typeahead/app.cljs
@@ -17,12 +17,13 @@
 
   Nothing under `re-frame.hicasso.impl.*`, nothing under
   `re-frame.bench.*`, nothing under `tools/`, and no test-kit namespace.
-  `…typeahead.surface-cljs-test` asserts that off the ClojureScript
-  ANALYZER's dependency graph rather than off a reading of this list.
+  `examples.fence-cljs-test` asserts that for every application under
+  `examples/`, read off each `ns` form at run time rather than off this
+  list.
 
   ## It registers no route
 
-  Deliberately, and the surface suite asserts the absent edge. Route paths
+  Deliberately, and nothing enforces the absence. Route paths
   are plain strings in a process-global registrar and the shared node
   bundle loads every application in the tree into one process. Nothing
   about a resource witness needs a URL."


### PR DESCRIPTION
Closes rf2-6c12m.10 (audit-reopened residual).

PR #8744 replaced the eight per-package import-fence suites, `witness-surface-cljs-test`, `require_graph.clj` and `check_example_fence_coverage.py` with one directory-derived fence, `examples/fence_cljs_test.cljs`. The merged-PR audit found 12 docstrings/comments under `implementation/hicasso/test/re_frame/hicasso/examples/**` still naming the deleted machinery, several promising guarantees the new fence does not make. This PR is the bounded prose repair: no suite restored, no new gate, no new test.

## What changed, per file

Re-pointed to `examples.fence-cljs-test` only where its four-family guarantee (no `impl.*`/bench/tools/test-kit require per application namespace) is the claim being made:

- `editor/flow_dom_cljs_test.cljs`, `grid/scaling_dom_cljs_test.cljs` — "the fence is over APPLICATION namespaces" (true of the new fence: suites are excluded by the build's own `cljs-test` rule).
- `typeahead/app.cljs` — the four-family list itself, now stated as read off each `ns` form at run time rather than off the analyzer.
- `editor/l0_cljs_test.cljs` — the kit half of "the namespaces it tests require neither `re-frame.hicasso` nor the kit"; the `re-frame.hicasso` half is now stated as read off their `ns` forms, since the fence does not (and must not) forbid the public door.

Removed or rephrased, because the new fence does not make the claim:

- `editor/app.cljs` — the routing-absence guarantee ("a route registered here reds that suite"). Now: nothing enforces the absence; a future route must take a path no other application claims.
- `editor/views.cljs` — "pins the namespace roster mechanically" (exact roster). Sentence ends at "Six names and three keywords."
- `grid/views.cljs` — "pins it" over optional modules / native tier (exact roster). Now: the `:require` below is the whole of it.
- `ledger/events.cljs`, `ledger/l0_cljs_test.cljs` — "holds the absence of a view substrate mechanically" / "makes structurally". Now attributed to `ledger.events`' `ns` form.
- `ledger/vendor.cljs` — the analyzer-graph claim and its heading. Now: read off the `:require` below.
- `ledger/virtualized_dom_cljs_test.cljs` — the roster clause in the teardown comment dropped.
- `ledger/app.cljs` — cross-reference re-pointed to `examples.editor.app`, which carries the no-route reasoning.
- `typeahead/app.cljs` — "the surface suite asserts the absent edge" (routing), a stale claim the census pattern does not catch but the same file carries. Now: nothing enforces the absence.

## Census (the control for a prose edit)

Pattern: `git grep -nE 'witness-surface-cljs-test|surface-cljs-test|surface_cljs_test|check_example_fence_coverage|require_graph' -- implementation/hicasso scripts`, positive control `fence_cljs_test.cljs` (hits before and after).

- Before (tip `5d5c888e87`): 12 hits under `examples/**` (the audit's 12) plus five lines outside it that are not this PR's: `scripts/check_optional_module_reachability.py:465` and `src/re_frame/hicasso/native.cljc:154` (both in rf2-6c12m.31's PR #8762), `spec/naming-ledger.md` rows 44-45 (rf2-6c12m.8), and `native_surface_cljs_test.cljs:1`'s own ns form (deleted by #8762).
- After: 0 under `examples/**`; the same five outside it; control still hits.
- Planted control: one stale name appended to `editor/views.cljs`' docstring — census found it (exit 0, one hit); restored by `git checkout HEAD --` and the working file's blob hash matched the committed blob afterwards.
- Prose-variant sweep (`surface suite|witness surface|fence coverage|off the analyzer|analyzer's own|dependency roster`, case-insensitive) under `examples/**`: 0 after.

## Quality gates

Run from the worker worktree's `implementation/` (each log opens with the `git rev-parse --show-toplevel` of the tree it read, and it named the worker worktree), exit codes captured on the same command line as the redirect:

| gate | exit | note |
|---|---|---|
| `npm run test:hicasso-lint` | 0 | self-test PASS; 6 checks fire on fixtures, correct code silent |
| `npm run test:hicasso-compile` | 0 | 11 namespaces compiled with zero warnings (171 files, 0 warnings) |
| `npm run test:cljs` | 0 | 11182 tests, 54833 assertions, 0 failures, 0 errors; the fence suite ran and reported "8 packages read off the directory: editor, forms, grid, ledger, navigation, slice, todo, typeahead" |

Base at run time: merge-base `5d5c888e87`. `origin/main` has since moved by six `chore(beads)` commits, all confined to `.beads/`, which no gate reads; `main...HEAD` is exactly these 12 files.

No installer ran; `node_modules` was a junction to the primary checkout's tree, removed before this PR was marked ready.

## Classifier

`.github/scripts/report-changed-surfaces.sh` on this diff reads `implementation_jvm`, `cljs_node_test`, `cljs_browser`, `migration_hicasso_codemod`, `hicasso_controlled` and `hicasso_hmr` as `true`, everything else `false`. The classifier keys on paths, and `implementation/hicasso/test/**` is a browser-armed path, so the browser lanes WILL run on this PR even though every hunk is inside a docstring or a `;;` comment — the dispatch brief's premise that no browser lane would be armed does not hold at the classifier. (Instrument control: the script handed an adapter testbed spec path flips `adapter_testbed_smokes` and the rest to `true`, so it was read, not assumed.)

Link gates: no markdown touched; nothing here is on `check_doc_slugs.py`'s or `check_readme_links.py`'s surface. Per rf2-6c12m.4, the reworded sentences carry the contract and one sentence of why, no `[[wikilinks]]` were added, and no sentence names a guarantee nothing enforces.
