### PR TITLE
docs(method): a link into shared dependencies is writable through, not only deletable through

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -564,7 +564,12 @@ actually caught both observed collisions.
 
 If you create a link into shared dependencies, remove the LINK (never its target)
 before you report done: later cleanup follows it and deletes what it points at.
-And kill any poll loops you armed before you report done — each survivor fires
+And the link is WRITABLE through, not only deletable through: an installer a gate
+runs (`npm ci`, `npm install`, or any tool that reinstalls a dependency tree)
+rewrites the SHARED target, not your copy — one emptied the coordinator's real
+tree while the worker's own read as a fresh install. If a nominated gate runs an
+installer, do not link that tree: install your own from the lockfile, or STOP and
+say the gate cannot run against a link. And kill any poll loops you armed before you report done — each survivor fires
 its own completion notification after the work has landed, costing a turn apiece.
 ```
 
@@ -680,6 +685,12 @@ blocker — the five clauses are the merge criterion, and this is not among them
   hand-check what the gate already proved and to record a gap that is not there. Where a surface genuinely has
   no automated coverage, the honest brief says *no automated gate covers this surface; the worker verifies it
   by hand and says so in the change body* — and the change body then reports what was checked and the counts.
+
+- **Read what each nominated gate RUNS before telling the worker to link shared dependencies.** A link
+  into a shared dependency tree is writable through, and a gate that reinstalls dependencies as a step
+  rewrites the shared tree rather than the worker's copy — measured: a conformance runner's `npm ci`
+  emptied the coordinator's real tree through the link the brief had told the worker to make. Where a
+  gate does that, the brief says so and tells the worker to install its own tree from the lockfile.
 
 A skipped gate needs a one-line reason in the change body. A silent skip fails review.
 

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1067,7 +1067,11 @@ strength is that it has one.**
 **If your project links or junctions shared dependencies into worker worktrees, never remove a
 worktree with the plain command.** It follows the link and deletes *through* it, emptying the shared
 tree it points at — silently, exiting successfully, breaking every local build until the
-dependencies are reinstalled. It has happened more than once in this project.
+dependencies are reinstalled. It has happened more than once in this project. **And removal is not
+the only write that follows a link**: an installer a gate runs inside the worktree rewrites the shared
+target the same way, so a tree can be emptied while its worker is still alive and no cleanup has run.
+The brief-side rule is under *Quality gates — which gate* in `dispatch-prompt-template.md`; here, count
+every shared tree a worker's gates could have reinstalled, not only the ones a removal touches.
 
 Put the safe sequence in a **script**, not in prose. Prose was tried and the class recurred anyway.
 The script should: snapshot every real shared-dependency tree; unlink each *link* under the worktree


### PR DESCRIPTION
Method reread loop (rf2 mayor session, 2026-08-29), enforcement half.

**Drift, measured tonight:** the boundary block guards deletion THROUGH a link into shared dependencies (unlink before cleanup). A worker following its brief linked a tool's dependency tree at the coordinator's real one; the gate it was told to run invokes `npm ci`, which deletes and reinstalls INTO the link target. The coordinator's real tree read 0 entries while the worker's own read as a fresh install. No cleanup had run; the worker was alive. Remedy was `npm ci` from the lockfile in the coordinator checkout.

**Changes (three places, one rule, each half where its reader is):**
1. Boundary block (pasted into every editing brief): the link is writable through; if a nominated gate runs an installer, install your own tree from the lockfile or stop.
2. *Quality gates — which gate* (addressed to the mayor nominating gates): read what each gate RUNS before telling a worker to link.
3. `loops.md` *Removing*: removal is not the only write that follows a link; count every shared tree a worker's gates could have reinstalled.

**Bounded search:** `bd remember` carries the project-specific remedy; these three are the generic rule. No other copy of the link rule exists.

## Quality gates
- `python scripts/check_doc_slugs.py` from the worktree: exit 0 (captured to a per-worktree exit file).
- `mkdocs build --strict`: not nominated — this tree sits in `exclude_docs`.
- The boundary block edit sits inside the fenced block so mechanical extraction carries it; verified by reading the fence boundaries. No tables touched.