### PR TITLE
hicasso(compile-gate): name the control that actually reds (rf2-6c12m.1)

### DIFF
--- a/implementation/hicasso/scripts/check_modules_compile.cjs
+++ b/implementation/hicasso/scripts/check_modules_compile.cjs
@@ -57,9 +57,15 @@
 // resolved by the analyser before optimisation, and `:infer-warning` is bound
 // in both modes (mutation-proved on the overlay fault above).
 //
-// CONTROL, re-run whenever this gate is touched: drop the `^js` hint on
-// `claim-anchor!`'s `el` in `impl/overlay.cljs` -> exit 1 naming
-// `:infer-warning`; restore -> exit 0.
+// CONTROL, re-run whenever this gate is touched: read a property no extern
+// declares on an UNTAGGED parameter. In `impl/overlay.cljs`, rewrite
+// `claim-anchor!`'s `(when anchor-id` as `(when (.-anchorNameBogus anchor-id)`
+// -> exit 1, `WARNING #1 - :infer-warning`, `Cannot infer target type in
+// expression (. anchor-id -anchorNameBogus)`; restore -> exit 0. Dropping the
+// `^js` on `claim-anchor!`'s `el` is NOT a control: that `el` is bound from
+// `(.getElementById js/document ...)`, which the analyser already types `js`,
+// so the hint is redundant and the mutation reads 0 warnings (measured on
+// PR #8752 and again on the PR that replaced this instruction).
 //
 // ## Limits
 //


### PR DESCRIPTION
Bounded correction from the merged-PR audit of #8752 (the rf2-6c12m.1 residual). The header of `implementation/hicasso/scripts/check_modules_compile.cjs` told the next maintainer to prove the gate by dropping the `^js` hint on `claim-anchor!`'s `el` in `impl/overlay.cljs`. #8752 itself measured that mutation as inert: `el` is bound from `(.getElementById js/document ...)`, which the analyser already types `js`, so the hint is redundant and dropping it raises nothing. Its working control was an un-externable property read on an UNTAGGED parameter. The header now names that one, with the exact warning text, and says why the old one is not a control. One file, comment-only; the gate's code is untouched; the bench-move decision is not reopened.

## The new CONTROL text

```
// CONTROL, re-run whenever this gate is touched: read a property no extern
// declares on an UNTAGGED parameter. In `impl/overlay.cljs`, rewrite
// `claim-anchor!`'s `(when anchor-id` as `(when (.-anchorNameBogus anchor-id)`
// -> exit 1, `WARNING #1 - :infer-warning`, `Cannot infer target type in
// expression (. anchor-id -anchorNameBogus)`; restore -> exit 0. Dropping the
// `^js` on `claim-anchor!`'s `el` is NOT a control: that `el` is bound from
// `(.getElementById js/document ...)`, which the analyser already types `js`,
// so the hint is redundant and the mutation reads 0 warnings (measured on
// PR #8752 and again on the PR that replaced this instruction).
```

`anchor-id` was chosen over an `el` because it needs no hint stripped to be untagged, and because the instruction names a function and a parameter rather than a line number, so it survives #8763's `fail!`-site conversion in the same function.

## Quality gates

All from tip `7d2c7648fa` on `a9db1ced0e` (origin/main at dispatch; no rebase was needed). Every gate ran in the foreground from `implementation/` with its exit code captured on the same command line, and the header edit was committed BEFORE any plant so a checkout restore could not discard it.

- **New control, planted** (`(when anchor-id` -> `(when (.-anchorNameBogus anchor-id)`, one match, overlay.cljs:223): `npm run test:hicasso-compile` exit **1**. `[:hicasso-modules-compile] Build completed. (171 files, 170 compiled, 1 warnings, 16.97s)`; `------ WARNING #1 - :infer-warning`; `Cannot infer target type in expression (. anchor-id -anchorNameBogus)` at `overlay.cljs:223:9`; `[hicasso-compile] BUILD REFUSED — :hicasso-modules-compile compiled with 1 warning(s)`. overlay.cljs blob `1fd3aafec6f1271cfc723ecdb60c56cddce3df43` before the plant, blob `e2901acf3b972c71cfb37180881494f6d6c3c9c0` planted.
- **Restored** with `git checkout HEAD -- <path>`: blob `1fd3aafec6f1271cfc723ecdb60c56cddce3df43` after, equal to `HEAD:<path>`. `npm run test:hicasso-compile` exit **0**: `171 files, 2 compiled, 0 warnings`, `ok — 11 namespaces compiled with zero warnings`.
- **Old control at this tip** (the audit's evidence, reproduced so nobody re-derives it): `[^js el (.getElementById js/document anchor-id)]` -> `[el (.getElementById js/document anchor-id)]`, one match, blob `860551a3c7606effbc204c59041918cc95fcbe1b` planted. `npm run test:hicasso-compile` exit **0**: `171 files, 2 compiled, 0 warnings`. The `2 compiled` is the runtime observing the changed source, so this is INERT rather than unseen. Restored by blob hash: `1fd3aafec6f1271cfc723ecdb60c56cddce3df43` again, `git status` clean.
- `npm run test:script-policy` exit **0** (`changed-surfaces tests: 291 passed`; every suite in the chain passed).
- **Classifier**: `.github/scripts/report-changed-surfaces.sh implementation/hicasso/scripts/check_modules_compile.cjs` reads the `implementation/hicasso/*` arm and sets `cljs_node_test`, `cljs_browser`, `migration_hicasso_codemod`, `hicasso_controlled`, `hicasso_hmr` true — the identical five it sets for `impl/overlay.cljs` (positive control), so CI's `cljs` job, whose hicasso-compile step is this gate, runs on this PR. A comment edit in a script arms nothing beyond that. Hot zone: none.
- **Diff against the merge base** (`origin/main...HEAD`): one file, +9/-3. `impl/overlay.cljs` is not in the diff. Fences at dispatch — #8763 (touches overlay.cljs), #8762, #8764 — none touches this script.
