### PR TITLE
bench(hicasso): two merged-PR audit residuals — the raw-record retention guidance and the four rf2-egdaq carriers (rf2-6c12m.6, rf2-fc7w)

### DIFF
--- a/bench/hicasso/src/re_frame/bench/hicasso/clock_run.cjs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/clock_run.cjs
@@ -380,10 +380,12 @@ function band(xs) {
  * instrument, and it is worth being precise about why, because the reasoning
  * that put it here was sound and is not what failed.
  *
- * The rule was chosen against `lane/control-verdict`'s overlap defect
- * (rf2-egdaq): a control whose worst block is wrong HAS caught something, and
- * letting a good block vouch for a bad one is how an instrument stops being
- * one. True, and it says nothing about how many blocks a run has. THE
+ * The rule was chosen against `lane/control-verdict`'s overlap rule — the
+ * disagreement rf2-egdaq was filed over, since settled as a SPLIT: heap arm
+ * strict, clock arm keeping overlap for clamp-limited legs — because a control
+ * whose worst block is wrong HAS caught something, and letting a good block
+ * vouch for a bad one is how an instrument stops being one. True, and it says
+ * nothing about how many blocks a run has. THE
  * ARITHMETIC IS `p^n`. A control that fully MEETS its premise — the same
  * three-point statistic on `LayoutDuration`, whose centre is right, whose
  * conditioning is healthy and whose sign gate never fired in 756 blocks — puts
@@ -862,9 +864,11 @@ function ctl3SelfTest() {
     ok: !dead.premiseMet && !Number.isFinite(dead.measured.mean),
   });
   // 6b. THE STRICT RULE IS PER BLOCK. Eight clean blocks must not vouch for
-  //     a ninth that is wrong — that is `lane/control-verdict`'s recorded
-  //     overlap defect (rf2-egdaq), and it is the reason this control is
-  //     adjudicated block by block rather than on a pooled mean. Note that a
+  //     a ninth that is wrong — that is the case rf2-egdaq was filed over
+  //     against `lane/control-verdict`'s overlap rule (settled as a SPLIT:
+  //     heap arm strict, clock arm keeping overlap for clamp-limited legs),
+  //     and it is the reason this control is adjudicated block by block
+  //     rather than on a pooled mean. Note that a
   //     block-wide SCALING would not do as a fixture here: it cancels in the
   //     quotient by design, so the one bad block has to be bad in SHAPE.
   const oneBad = ctl3Verdict(

--- a/bench/hicasso/src/re_frame/bench/hicasso/topo/control_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/topo/control_app.cljs
@@ -285,7 +285,9 @@
 
   - **in band**, round-wise rather than pooled, so one bad round refuses
     instead of being averaged away (`census_clock_run/controlVerdict`'s
-    rule, and the stricter half of `lane/control-verdict`'s known defect);
+    rule, and the strict side of the rf2-egdaq split, which kept
+    `lane/control-verdict`'s overlap rule only for clamp-limited clock
+    legs);
   - **positive in sign**, which is PR #7634's fix — a band alone admits a
     control certifying that more work reads faster;
   - **verified**, which is the audit obligation on this file: `0

--- a/bench/hicasso/src/re_frame/bench/hicasso/walk_profile_app.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/walk_profile_app.cljs
@@ -802,13 +802,16 @@
   ## Why EVERY ROUND and not an overlap
 
   `lane/control-verdict` passes a control whose measured range merely
-  OVERLAPS the band, and its own docstring records that as a KNOWN DEFECT
-  against `hd8-rows/positive-control!`'s every-round-inside rule, needing
-  an operator ruling because tightening it re-adjudicates a published
-  row. This control is NEW, so it has no published row to re-adjudicate
-  and inherits none of that: it takes the stricter rule from birth, the
-  way `hd8-rows` did and for the reason `hd8-rows` gives — a control
-  whose worst round is wrong has caught something.
+  OVERLAPS the band. Its disagreement with `hd8-rows/positive-control!`'s
+  every-round-inside rule was rf2-egdaq, settled on 2026-08-21 as a
+  SPLIT: the heap arm's ten published figures were re-adjudicated strict
+  and all ten pass; the clock arm REFUSED strict for legs sitting on
+  Chrome's 100 µs quantum, under the 2026-07-31 ruling, and that refusal
+  stands there. This control inherits neither side of that: it is NEW,
+  so it had no published row to re-adjudicate, and its windows are
+  whole-page walks well clear of the quantum. It takes the stricter rule
+  from birth, the way `hd8-rows` did and for the reason `hd8-rows` gives
+  — a control whose worst round is wrong has caught something.
 
   ## Why a floor of zero or below REFUSES (rf2-1huc, merged-PR audit #8149)
 

--- a/bench/hicasso/src/re_frame/bench/p0_ladder_structural.test.cjs
+++ b/bench/hicasso/src/re_frame/bench/p0_ladder_structural.test.cjs
@@ -1501,19 +1501,22 @@ test('THE RECORD RETAINS EACH WINDOW’S RAW STREAM, so a later estimator can be
   lacks(/allocSteps\(win\.samples\)|allocSteps\(w\.samples\)/, 'the certificate is unmoved');
 });
 
-test('AN ALLOCATION WINDOW COMMITS ITS RAW RECORD — stated where the file is written', () => {
+test('AN ALLOCATION WINDOW KEEPS ITS RAW RECORD — stated where the file is written', () => {
   // rf2-erre5 part (1) is a CONVENTION, deliberately not a mechanism: nothing
-  // in this driver can tell whether an operator committed a file, and a gate
+  // in this driver can tell whether an operator kept a file, and a gate
   // that guessed would refuse every run that was not a published window. What
   // it gets instead is a line the operator actually sees, at the moment the
-  // artefact exists, plus the reason beside the code that writes it.
+  // artefact exists, plus the reason beside the code that writes it. Since
+  // rf2-6c12m.6 `data/` is git-ignored and the corpus is archived in git
+  // history, so the line says retaining the record is a deliberate act rather
+  // than telling the operator to commit into an ignored path.
   has(
-    /an allocation window COMMITS this file beside its studio page/,
+    /an allocation window KEEPS this file and its studio page cites it by SHA/,
     'the operator is told, on the run that produced the artefact'
   );
   has(
     /data\/alloc-<bead>\//,
-    'and where it goes — the path rf2-2rtt6.138 used, which is the only one that exists'
+    'and where it goes — the path rf2-2rtt6.138 used, which every reader still looks under'
   );
   // The env var that produces it is named in the usage banner. It was reachable
   // only by reading the last twenty lines of a 3,800-line driver, which is a

--- a/bench/hicasso/src/re_frame/bench/p0_run.cjs
+++ b/bench/hicasso/src/re_frame/bench/p0_run.cjs
@@ -5206,13 +5206,19 @@ if (require.main === module) (async () => {
     server.close();
   }
   // THE RAW RECORD, AND WHAT AN ALLOCATION WINDOW IS EXPECTED TO DO WITH IT
-  // (rf2-erre5). **An allocation window commits this file beside its studio
-  // page**, under
-  // `implementation/hicasso/test/re_frame/bench/hicasso/data/alloc-<bead>/`,
-  // exactly as rf2-2rtt6.138 did — and that is a CONVENTION rather than a
-  // mechanism, because nothing here can tell whether an operator committed a
-  // file, and a gate that guessed would go red on every run that was not a
-  // published window.
+  // (rf2-erre5). **An allocation window KEEPS this file, and its studio page
+  // cites it by SHA.** Its home is `data/alloc-<bead>/` beside the readers
+  // (`bench/hicasso/src/re_frame/bench/hicasso/data/`), where rf2-2rtt6.138
+  // committed its record and where every reader still looks — but since
+  // rf2-6c12m.6 that directory is git-ignored and the corpus of past windows
+  // is archived in git history (`data_archive.cjs` carries the SHA and the
+  // restore command), so a record written there lands in no commit by
+  // accident. Retaining one is a deliberate act: `git add -f` the window's
+  // directory beside its page, or commit it off main and cite that commit;
+  // either way the page's provenance block carries a SHA the record resolves
+  // at. That is a CONVENTION rather than a mechanism, because nothing here
+  // can tell whether an operator kept a file, and a gate that guessed would
+  // go red on every run that was not a published window.
   //
   // WHY IT IS WORTH THE HABIT. The 2026-08-08 window is the only allocation
   // window that ever did it, and it is the only one that has since been
@@ -5239,7 +5245,10 @@ if (require.main === module) (async () => {
     fs.mkdirSync(path.dirname(raw), { recursive: true });
     fs.writeFileSync(raw, JSON.stringify(out, null, 2));
     console.error(`[p0] raw data -> ${raw}`);
-    console.error('[p0] an allocation window COMMITS this file beside its studio page');
+    console.error(
+      '[p0] an allocation window KEEPS this file and its studio page cites it by SHA ' +
+        '(data/ is git-ignored — retaining the record is a deliberate act; see data_archive.cjs)'
+    );
   }
   // THE PAGES' OWN FAILURES, JOINING THE LIST THE EXIT ALREADY READS
   // (rf2-sib23). It joins `failures` rather than taking a code of its own

--- a/implementation/hicasso/spec/budgets.md
+++ b/implementation/hicasso/spec/budgets.md
@@ -535,10 +535,13 @@ longer what the row carries** — the change of basis set out in this section's
 `S8` note replaced it, and every figure in this paragraph is history from here
 down. Run 2's positive control
 predicted `4.000` with a ±25% band of `[3.000–5.000]` and its rounds reach
-`5.150`, so it refuses under the strict every-round-inside rule —
-`lane/control-verdict`'s own docstring names its overlap `:ok?` rule the lane's
-known defect and the strict rule the right one, and an ensemble whose control
-refuses cannot contribute to a published figure. On run 1 the arm-order guard
+`5.150`, so it refuses under the strict every-round-inside rule — the rule that
+binds these legs, twenty-plus quanta clear of the clock, under the `rf2-egdaq`
+split (settled 2026-08-21: the heap arm went strict and its ten published
+figures pass re-adjudicated; the clock arm keeps `lane/control-verdict`'s
+overlap `:ok?` rule only for clamp-limited legs, under the 2026-07-31 ruling) —
+and an ensemble whose control refuses cannot contribute to a published figure.
+On run 1 the arm-order guard
 returned `reportable`, the positive control predicted `4.500` and measured
 `4.300` `[3.950–4.950]` — every round inside `[3.375–5.625]` — and all 225 of
 its measured mounts were read back out of the document at their own far end.
@@ -1831,9 +1834,10 @@ or `C5` changes with it.
   published, none of which moves its status. The figure is **run 1 alone**,
   because run 2's positive control predicted `4.000` against a ±25% band of
   `[3.000–5.000]` and its rounds reach `5.150` — a refusal under the strict
-  every-round-inside rule that `lane/control-verdict`'s own docstring says is
-  the right one — and a pooled figure that includes a control-refused ensemble
-  is not a published figure. The interval is an **observed range across
+  every-round-inside rule, which is the rule the `rf2-egdaq` split leaves in
+  force for legs clear of the clock quantum (`lane/control-verdict`'s overlap
+  rule stands only for clamp-limited legs) — and a pooled figure that includes
+  a control-refused ensemble is not a published figure. The interval is an **observed range across
   per-round ratios, not a confidence interval**, and §4 now says so where the
   row is stated. And C8's `≥ 2 ms p95` disjunct is **UNASSESSED at this
   witness** rather than missed: the instrument computes no `p95`, so the


### PR DESCRIPTION
Two merged-PR audit residuals in the hand-run bench project, one commit each, dispatched as a cluster (worktree dw-bench-carriers, cut from `a694b8f3c0`, rebased once onto `d36753410c`). Prose consistency only: no behaviour changes, `lane/control-verdict` and every control stay as they are.

## Item 1 — rf2-6c12m.6 (`89777558b6`): the raw-record guidance names the archived `data/` path and the retention policy

**Audit finding (MERGED-PR AUDIT #8761):** `p0_run.cjs`'s rf2-erre5 block still told an allocation window to commit its raw record under `implementation/hicasso/test/re_frame/bench/hicasso/data/`, a path deleted by the .1 move, while the new `data/` is git-ignored.

**Changed:**
- `bench/hicasso/src/re_frame/bench/p0_run.cjs`, the rf2-erre5 comment block: now names the current home (`data/alloc-<bead>/` beside the readers, under `bench/hicasso/src/re_frame/bench/hicasso/data/`), says the directory is git-ignored and the corpus of past windows is archived in git history (`data_archive.cjs` carries the SHA and the restore command), and states the policy for retaining a new window's record: it is a deliberate act — `git add -f` the window's directory beside its page, or commit it off main and cite that commit — and the studio page's provenance block carries a SHA the record resolves at either way. The "convention rather than a mechanism" reasoning is kept.
- Same file, the `P0_RAW_OUT` console line 30 lines below (not on the audit's list): it printed the same instruction at runtime (`an allocation window COMMITS this file beside its studio page`), so it now carries the same guidance as the block. The discriminator was *does this line tell an operator what to do NOW* — it did.
- `bench/hicasso/src/re_frame/bench/p0_ladder_structural.test.cjs` (not on the audit's list): the test that pins that console line is re-pinned to the new wording; its `data/alloc-<bead>/` pin still holds against the block, and its comment no longer calls the old path "the only one that exists".

**Stood, because already right:** the block's "WHY IT IS WORTH THE HABIT" paragraph and the "where rf2-2rtt6.138 committed its record" clause (past-tense records); every citation of the old path under `docs/design/hicasso/` (24 pages — history per the rf2-6c12m.1 ruling, not re-pointed; `check_provenance_pins.py` checks SHA accompaniment, not paths). After the edit `git grep -F` for the old path reads 0 under `bench/`, `implementation/` and `scripts/` (1 in `p0_run.cjs` before it; an impossible token reads 0).

## Item 2 — rf2-fc7w (`70a60d9ff1`): the rf2-egdaq split carried into the four remaining carriers, and a fifth

**Audit finding (MERGED-PR AUDIT #8759):** PR #8759 rewrote `lane/control-verdict`'s docstring to state how rf2-egdaq settled — a SPLIT: the heap arm strict (ten published figures re-adjudicated, all pass), the clock arm refusing strict for clamp-limited legs under the 2026-07-31 quantum ruling — but four same-judgement carriers were left outside that dispatch. Verified at source: the ruling comment on rf2-egdaq (Option A, 2026-08-21) and the rewritten docstring in `lane.cljs`.

**Changed** (each now says what was ruled and for which lane):
- `implementation/hicasso/spec/budgets.md` §4, the S8 note (was "names its overlap `:ok?` rule the lane's known defect and the strict rule the right one"): now names the split and why strict binds these legs (twenty-plus quanta clear, as the same section already says lower down).
- `implementation/hicasso/spec/budgets.md` §9.2, the S8 row's 2026-08-13 amendment — **a fifth site the audit did not list**, found by the fixed-string sweep for `the right one`: "the strict every-round-inside rule that `lane/control-verdict`'s own docstring says is the right one" (present tense, false since #8759). Settled the same way.
- `bench/hicasso/src/re_frame/bench/hicasso/walk_profile_app.cljs` (was "KNOWN DEFECT ... needing an operator ruling"): records the split and that this control, new and quantum-clear (its windows are eight whole-page walks, per its own `walks-per-sample` docstring), inherits neither side and took the strict rule from birth.
- `bench/hicasso/src/re_frame/bench/hicasso/topo/control_app.cljs` (was "the stricter half of `lane/control-verdict`'s known defect"): now the strict side of the split, with what the split kept overlap for.
- `bench/hicasso/src/re_frame/bench/hicasso/clock_run.cjs`, both sites (was "overlap defect" / "recorded overlap defect"): now the disagreement rf2-egdaq was filed over and how it settled; the past-tense reason the strict rule was chosen is kept. The brief's own discriminator would have let the first of these stand as history; the bead lists both and the bead governs, so both are qualified with the split rather than rewritten.

**Stood, because already right or out of fence:** `lane.cljs` (PR #8759's file; not re-edited — its `## KNOWN DEFECT` heading remains above the paragraph that now carries the split); `amp_merge_clock_app.cljs`, `lane_control_strict_cljs_test.cljs`, `inpage_ladder_aggregate.cjs`, `inpage_ladder_exit_path.test.cjs`, `walk_profile_control_cljs_test.cljs`, `p0_run.cjs:105-156` and `p0_app.cljs:475` (all already state the split); every other `operator ruling` hit (`front/presence.cljs:47`, `budgets.md` at 426/1779/1849/1945, `dispositions.md`, `naming-ledger.md` — other rulings, 2026-08-04 and 2026-08-13) and every other `the right one` hit (unrelated prose).

**Sweep, controlled:** fixed strings over `bench/hicasso` + `implementation/hicasso/spec` after the edit — `known defect` 0, `overlap defect` 0, `recorded overlap` 0, `operator ruling because` 0, `stricter half` 0, `docstring says is` 0, `docstring names its overlap` 0, `KNOWN DEFECT` 1 (`lane.cljs:1205`); positive control `rf2-egdaq` reads 2/1/1/2 across the four carrier files. A wrap-tolerant sweep (comment continuations unwrapped before matching, the trap rf2-fc7w records) read the same set before the edit and found no further site.

## Quality gates

Every exit below is the number captured by the run itself (`cmd > log; echo $? > exit`), on the final base `d36753410c` (origin/main unchanged between rebase and push; the merge-base diff `origin/main...HEAD` is exactly the six files' hunks above — nothing reverted).

| Gate | Where | Attempt | Captured exit | Counts |
|---|---|---|---|---|
| `npm run check` | `bench/hicasso/` | 2 (final tree; attempt 1 on the item-1 tree also 0) | **0** | "compiling all 155 namespaces walked from" this worktree's `bench/hicasso/src`; 464 files, 463 compiled, 0 warnings; 8 skip lines (corpus absent, as at #8761); `lane_build` 11, `clock_exit_path` 375, `p0_ladder_structural` 100, `inpage_ladder_exit_path` 25, `hicasso_narrow_exit_path` 19 passed; no FAIL line |
| `npm run test:script-policy` | `implementation/` | 2 | **0** | approved roots printed name this worktree |
| `npm run test:hicasso-invariants` | `implementation/` | 2 | **0** | `check_budget_ledger`: 49 rows — 32 MET, 5 BREACH, 3 UNRESOLVED, 9 UNPINNED, identical before and after the budgets.md edits |
| `python scripts/check_readme_links.py --ci` | repo root | 1 | **0** | silent on green; coverage of budgets.md proven by the plant below |

`check_budget_ledger.py` parses the §9 reconciliation ledger table and the sections its pointers name; the two budgets.md edits sit in §4 prose and a §9.2 list item, touch no row id or table cell, and the row counts are unchanged. The comment prose in the four `.cljs`/`.cjs` carriers and `p0_run.cjs` has no automated gate reading its content: comment prose verified by hand; compile gate exit 0. `check_doc_slugs.py` is not nominated — its roots do not include `implementation/hicasso/spec`.

**Left to CI** (`.github/scripts/report-changed-surfaces.sh` over the six changed paths: `cljs_node_test`, `cljs_browser`, `migration_hicasso_codemod`, `hicasso_controlled`, `hicasso_hmr` = true, armed by `budgets.md` under `implementation/hicasso/spec/**`; control on `implementation/hicasso/src/re_frame/hicasso.cljs` flags 5): the hicasso browser lanes and the cljs node lane were not run locally (one headless-Chromium slot, CI's to run); `verify-readme-links` runs both link gates on every PR.

## Controls

Each plant into a committed tree, anchored to one line with the match count read first (1), restored with `git checkout HEAD --`, restore verified by blob hash against `HEAD:<path>`:

- **Structural pin (item 1):** the old console wording planted back into `p0_run.cjs` (blob `6debe8678d` → `69e9012969`); `node src/re_frame/bench/p0_ladder_structural.test.cjs` alone, captured exit **1**: `FAIL AN ALLOCATION WINDOW KEEPS ITS RAW RECORD — stated where the file is written / p0_run.cjs: expected /an allocation window KEEPS this file and its studio page cites it by SHA/ — the operator is told, on the run that produced the artefact / p0_ladder_structural.test.cjs: 1/100 failed`. Restored: blob `6debe8678d` = `HEAD:`.
- **Link plant (item 2):** `[plant](./no-such-page.md#nowhere)` appended to budgets.md line 543, a line this PR edits (blob `6541852f80` → `5bf8eb533f`); `check_readme_links.py --ci` captured exit **1**: `BROKEN TARGET: implementation/hicasso/spec/budgets.md:543 -> ./no-such-page.md#nowhere` (printed with Windows separators). Restored: blob `6541852f80` = `HEAD:`. So the roster includes this file.

## Fences

`docs/design/hicasso/**` untouched; `lane.cljs` untouched; no hot-zone file; `.beads/` not staged; no browser gate run. PR #8762 (budgets.md native-tier rows) was still open at push; this PR's budgets.md hunks are the §4 S8 note and the §9.2 S8 row, a different region — if it lands first, rebase keeps both intents.
