### PR TITLE
docs(claude): name remote and branch on the checkpoint pull

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,10 @@ bd close <id>         # Complete work
   ```bash
   sh scripts/beads-checkpoint.sh   # export from the database, verify, commit
   git checkout HEAD -- .beads      # now safe: HEAD carries the tracker
-  git pull --rebase
+  git pull --rebase origin main    # name both: a bare pull reads the shared fetch-head file
   ```
+
+  **Name remote and branch on that pull, and on the one in the session-completion block above** (that block is tool-generated, so read its bare form as the same command with both named). A bare `git pull --rebase` takes its target from `FETCH_HEAD`, which any fetch in this checkout rewrites — a branch fetch moments earlier leaves several refs in it, and the pull aborts with `Cannot rebase onto multiple branches` on a clean, undiverged tree where neither remedy above applies (measured 2026-08-29 22:31 AUSEST, mid-checkpoint, one line after a `git fetch origin worker/<branch>`). The abort is inert only because the push that follows still lands; the next step it silently skips is the rebase itself.
 
   `sh scripts/beads-checkpoint.sh --pre-pull` (or `-PrePull` on the `.ps1`) answers "would clearing `.beads` throw tracker state away?" — exit 0 means the checkout is safe. **Do not `git stash`**: stashes are repo-global and contaminate every other worktree in flight.
 


### PR DESCRIPTION
Method-reread fix to the project's agent-instructions file (CLAUDE.md, Beads durability block).

**Drift.** Both checkpoint sequences prescribe a bare `git pull --rebase`. loops.md's *After each merge* records that a pull takes its merge target from the shared `FETCH_HEAD` file, which any concurrent fetch rewrites, and that the failure borrows another cause's message. Measured on the mayor checkout 2026-08-29 22:31 AUSEST: one line after `git fetch origin worker/<branch>`, the bare pull aborted with `Cannot rebase onto multiple branches` on a clean, undiverged tree — neither documented abort remedy applies, and the abort is inert only because the push after it still lands.

**Fix.** The Beads-durability sequence names remote and branch (`git pull --rebase origin main`) and one paragraph says why, pointing at the session-completion block above it, which is tool-generated and so is not edited here.

## Quality gates

| Gate | Attempt | Captured exit |
|---|---|---|
| `python scripts/check_readme_links.py --ci` (CLAUDE.md is on its surface) | 1, final tree | 0 |

**Control.** One link target in CLAUDE.md planted to `docs/the-mayor-method/loops-PLANTED.md`: `check_readme_links.py --ci` exit **1** naming the broken target; restored by checkout; blob hash equal before and after. `check_doc_slugs.py` is not the gate for repo-root markdown (its roots exclude it) and `mkdocs build` never sees CLAUDE.md, so neither is nominated. Prose hand-checked; no tables changed.