### PR TITLE
docs(method): a red on a draft is the author's; ask what each gate compares when deriving the fence

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -53,7 +53,10 @@ The order is what makes it accurate. Each step is a check the next depends on.
    its audience looks like the worker. A dispatch went out for work that had merged the
    previous day, and the worker's deliverable was refuting the premise.
 3. **Establish the fence by asking who is live, not what is open.** A listing of open
-   changes misses a worker that has not pushed yet.
+   changes misses a worker that has not pushed yet. **And ask what each nominated gate
+   COMPARES, here, not at dispatch** — a fence derived from files alone misses a gate that
+   couples two surfaces (see *Fences*), and one mayor struck an item's fence and dispatched
+   before asking, then re-fenced it five minutes later on exactly that ground.
 4. **Name the discriminator**, if the task is "find every X".
 5. **Then** assemble the standard blocks.
 

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -342,6 +342,17 @@ candidate. Once you have established the failure is the change's own and not the
 not — dispatch a fix worker onto the **existing** branch that runs the **actual** failing
 gate, not a proxy that already passed.
 
+**But a red on a change still published as a DRAFT belongs to its author, for as long as that
+author is alive.** The draft flag means the worker has not finished, and a worker briefed to push as
+it goes will publish reds by design: one here deleted a gate's witness in its first commit and the
+gate itself in its third, so the draft read three required jobs red for the twenty minutes between,
+each one a job the change was in the middle of removing. A fix worker dispatched onto that branch is
+a second worker on one branch, which is the collision every fence exists to prevent, and it arrives
+wearing the loop's own instruction. So on a draft: read the failing job against the diff so far —
+a red whose subject the change is deleting is sequencing, not a defect — and either wait for the
+ready mark or message the author. The fix-worker path opens only once the author has marked the
+change ready, or has stopped, which the stranded sweep establishes and this loop does not.
+
 **A failure BEFORE any repository code ran is the second case, and the failing step names
 itself** — an action download rate-limited, a runner setup step dying. The diff cannot have caused
 it, so no second observation is needed: re-run the failed jobs and hold the re-run to the same


### PR DESCRIPTION
Retrospective fixes to the mayor method, two paragraphs.

**1. loops.md, *When a change is not green*.** A worker briefed to push as it goes publishes reds by design: one draft here read three required jobs red for twenty minutes because its first commit deleted a gate's witness and its third deleted the gate. The merge loop's instruction — dispatch a fix worker onto a change that is not green — read literally on a draft puts a second worker on a live worker's branch. The new paragraph: a red on a draft belongs to its author while the author is alive; read the failing job against the diff so far (a red whose subject the change is deleting is sequencing); wait for the ready mark or message the author; the fix-worker path opens once the author marks ready or has stopped, which the stranded sweep establishes.

**2. dispatch-prompt-template.md, *Write the brief in this order*, step 3.** The gate-coupling question (#8769) belongs where the fence is derived, not at dispatch: one item was fenced, struck and re-fenced five minutes apart on exactly that ground. One clause added to step 3 pointing at *Fences*.

Generic; no project, platform or person named. README untouched.

## Quality gates

| Gate | Attempt | Captured exit |
|---|---|---|
| `python scripts/check_doc_slugs.py` | 1, final tree | 0 |
| `python scripts/check_readme_links.py --ci` | 1, final tree | 0 |

**Control.** The existing `#publishing-the-change` anchor in loops.md's merge criterion planted to `-PLANTED`: `check_doc_slugs.py` exit **1** naming file, line and anchor; restored by checkout; blob hash equal before and after. `mkdocs build --strict` is not the gate (no anchor validation; `docs/the-mayor-method/` is under `exclude_docs`). Prose hand-checked; no tables changed.