### PR TITLE
hicasso: trim impl/mount.cljs docstrings to the contract (rf2-76hbj, mount slice)

### DIFF
--- a/docs/design/hicasso/architecture.md
+++ b/docs/design/hicasso/architecture.md
@@ -228,6 +228,133 @@ node as `defaultValue`, which React maintains there itself. The matrix, the
 two implementations UIx chooses between, and the price are on
 [the studio page](studio/controlled-input-two-implementations.md).
 
+## The root (HD-021(b)) — mount, hydration and teardown
+
+The mechanism record for `impl/mount.cljs`, written 2026-08-30 when that
+file's docstrings were trimmed to the contract (rf2-76hbj, executing the
+rf2-6c12m.4 rule). The ruling is
+[HD-021](decisions.md#hd-021--the-v0-execution-contract-root-hmr-headless);
+the door names and the `(node config view)` shape are naming-ledger rows 13
+and 20 (`implementation/hicasso/spec/naming-ledger.md`); what teardown may
+and may not touch is [globals.md](product/globals.md).
+
+**Every door commits before it returns, except the hydrating one.** React 19
+renders a root concurrently and a `useSyncExternalStore` notification
+schedules at the sync lane rather than committing inline, so `render!` renders
+inside `flushSync` and `settle!` is the empty `flushSync` that lets an
+already-scheduled notification land — which is what lets a witness read the
+DOM on the line after a dispatch. Neither is `act`: `act` diverts work to a
+queue that is not the browser's, the right tool for an effect-ordering test
+and the wrong one for a witness that reads the page. `hydrate-root!` calls
+`hydrateRoot` plain. Adoption is React's own concurrent business and nothing
+in the tree forces it synchronously, so a `flushSync` there would manufacture
+a schedule no shipped caller has and every row taken through it would be a
+row about the manufactured one; the door returns before the tree is adopted,
+the DOM on the next line is still the server's, and the completion signal is
+the adoption window closing
+([the mutation finding](studio/ssr-spike-witness.md#a-finding-the-mutation-proof-produced)).
+
+**The hydrated root's shape, and why it rides on every render.** `tree` is the
+one place the root tree's shape is decided. An ordinary root is the bare frame
+provider around the app subtree — no extra fiber, passive effect or context
+provider, so the tree the bench lane measures carries none of them. A
+hydrated root is a Fragment whose first child is `adoption-window-closer` and
+whose second is the app under the window's provider, and the handle's
+`:adoption` key selects that branch: the window's presence is the one fact
+that says a root is hydrated, and there is no second flag to disagree with
+it. The wrapper must be reproduced on every subsequent `render!`, because
+React reconciles a root by its top element — a bare provider handed to a root
+that adopted under the Fragment is not a cheaper render but a different tree,
+and React unmounts the adopted subtree and mounts a fresh one, discarding
+every node, cell and subscription the adoption established. That was observed
+when the shape landed as the first `render!` after a hydration re-running all
+four boundary bodies and replacing all four DOM nodes; the standing witness is
+`re-frame.hicasso.roots-frames-hydration-dom-cljs-test`, whose
+`tearing-down-one-hydrated-root-leaves-the-other-adopted-and-live` row asserts
+that a props-equal `render!` after adoption bails at the memo with zero body
+runs and every node still the server's. `tree` is public because
+`re-frame.hicasso.server/render` builds its element from the same function:
+React derives a `useId` from tree position as well as from the prefix, so the
+server's bytes and the adopted tree agree by construction rather than by two
+implementations agreeing (`implementation/hicasso/spec/dispositions.md`,
+HS-11 obstruction 2).
+
+**The adoption window is per-root, closed by a component, and minted in
+production.** `hydrate-root!` mints the window and carries it on the handle as
+`:adoption`; nothing else can reach it, and the closer, the reporter and the
+presence reads all take that one object, so *this root is adopting* is one
+fact with one owner rather than a page-wide slot several callers race for.
+It is closed by `adoption-window-closer` — a nil-rendering component running
+a passive `useEffect` with empty deps, placed outside the frame provider
+because it reads no subscription — rather than by the function, because a
+passive effect is the earliest thing unambiguously after the hydration
+commit; closing before `hydrateRoot` returned would close it before a single
+body had run inside it. The window reaches the closer as a prop, which is
+what confines a closer to its own root. Per-root rather than page-wide
+because the two failure directions are both real: React holds
+`onRecoverableError` for the root's whole lifetime and fires it for
+post-hydration recoveries too, so a page-wide window (or a reference count)
+would label a completed root's later recovery a hydration mismatch whenever
+any sibling was still adopting, while a page-wide boolean lets one root's
+closer silence another root's genuine mismatch — the
+`a-completed-roots-later-recovery-is-not-a-mismatch-while-a-sibling-adopts`
+and `two-overlapping-hydrating-roots-recover-and-complain-independently` rows
+in the same namespace. The window is minted unconditionally, where the spine
+(`re-frame.substrate.spine`) mints only when it is going to install a
+reporter, because this one has a production reader: presence starts an
+adopted child `:present` rather than `:mounting`
+(`a-page-global-adoption-window-steals-an-ordinary-roots-enter-transition`),
+so the window and its provider ride in a release build and only the reporter
+is debug-gated.
+
+**The reporter, and why the two root options are gated differently.** With no
+root options React's default handler is the only channel, so a divergence
+React recovers from — a text mismatch, a missing or extra or wrong-type
+element — would be an uncaught window error and nothing else, and Spec 011's
+`:rf.ssr/hydration-mismatch` would never fire. `hydration-reporter` closes
+over one root's window, emits the diagnostic while that window is open, and
+always delegates to React's default afterwards, because installing any
+`onRecoverableError` takes the default off and a reporter that only emitted
+would swallow the error the fail-open rule requires to stay uncaught
+(`rf2-2rtt6.97`, on [the SSR spike page](studio/ssr-spike-witness.md)).
+Attribute-only divergences are outside React's own contract and stay outside
+this channel ([production-server-arm.md](production-server-arm.md)). The
+reporter is a diagnostic: its emit compiles away behind
+`interop/debug-enabled?`, and what would remain is a replica of the default
+React runs anyway, so a release build installs none. `:identifier-prefix` is
+behaviour — it decides what `useId` answers, and a release build that dropped
+it would hydrate every server `useId` into a mismatch — so it is never gated.
+Both doors hand React the bare arity when there is nothing to say, which is
+why `root-options` answers nil rather than an empty object.
+
+**`ensure-frame!` seeds before the first render and guards on the
+incarnation.** `root!` ensures its frame before `createRoot`: created through
+`rf/make-frame` with `:initial-events` when absent, joined untouched when
+live. The guard asks `frame/frame-incarnation-token` rather than trusting
+`make-frame`, because re-`make-frame`-ing a live id is idempotent
+replacement — config and generation refresh, durable state preserved — so an
+unguarded call would not fail a joining root, it would silently refresh the
+config of the frame the first root created, and the guide promises the
+opposite (`docs/core/hicasso/00-installation.md`). `make-frame` drains the
+seed to a fixed point before it returns, so the seeded app-db is on the frame
+before React renders anything and the first paint is the seeded one — an
+ordering the substrate's `frame-root` component cannot have, since its ensure
+runs in a `useLayoutEffect` after the first commit, and a root door, being a
+function call, simply does first. `hydrate-root!` does not ensure: an
+adopting root takes its state from the payload through `re-frame.ssr/hydrate!`,
+and a seed there would overwrite it.
+
+**Teardown is root-scoped.** `unmount!` shuts the root's own window first — a
+root torn down before its passive effects ran never gets its closer, and an
+open window that outlives its root is one nothing can shut — then unmounts
+inside `flushSync`. It empties none of the runtime's tables: they are
+one-per-page and keyed by frame, so a reset would tear down every sibling
+root's state, and what survives an unmount is exactly what a residue gate
+reads — a teardown that emptied the tables first would answer zero whether it
+released anything or not. It does not remove the container, which is the
+caller's node. `release!` does both and empties the runtime; it is the fixture
+door, and it is off the facade for that reason (naming-ledger row 13).
+
 ## Memoization (HD-028, amending HD-006)
 
 A value-equality bail-out is the boundary **default**: every minted head carries

--- a/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
@@ -1,59 +1,22 @@
 (ns re-frame.hicasso.impl.mount
-  "THE PACKAGE'S ROOT — one operation, an idempotent teardown
-  (HD-021(b)).
+  "The package's root: one operation that associates a DOM node, a frame
+  and a hiccup tree, and an idempotent teardown (HD-021(b),
+  docs/design/hicasso/decisions.md). `re-frame.hicasso`'s root lifecycle
+  is spelled here — `root!` and `hydrate-root!` are published as
+  `h/mount!` and `h/hydrate!` over the guide's `(node config view)` shape,
+  `render!` and `unmount!` under their own names
+  (implementation/hicasso/spec/naming-ledger.md rows 13 and 20). Every
+  door is root-scoped: it takes a handle, or makes one, and reaches
+  nothing another root owns. `release!` is the fixture door and is not on
+  the facade.
 
-  `root!` ENSURES a frame, associates it with a DOM node and a hiccup
-  tree, and returns the handle every other door here takes. That is the
-  whole execution contract the package needs; the names stay unfrozen
-  (HD-021 pins the semantics, not the spelling).
-
-  ## Three of these vars ARE the public door
-
-  `re-frame.hicasso` re-exports [[root!]], [[render!]] and [[unmount!]],
-  so a consumer's whole root lifecycle — mount, re-render after a hot
-  reload, tear down — is spelled here. Each of the three is root-scoped:
-  it takes a handle (or makes one) and reaches nothing another root owns.
-
-  **Two of the three keep their spelling on the door and [[root!]] does
-  not** (naming-ledger row 13): it is published as `h/mount!`,
-  over the `(node config view)` contract row 20 settles, and the config
-  map is what carries [[ensure-frame!]]'s `:initial-events` alongside
-  `:identifier-prefix` without a second arity. [[hydrate-root!]] is
-  published as `h/hydrate!` over the same shape and for the same reason,
-  so the asymmetry here is one rule rather than two exceptions: the impl
-  door keeps ONE positional caller shape for its own witnesses to drive,
-  and the facade adapts.
-
-  [[release!]] is NOT among them. It is [[unmount!]] plus a detached
-  container plus a page-wide `collector/reset-runtime!` — the fixture
-  door, correct where one app owns the page and wrong on a public
-  facade, where tearing down one of two roots would empty the runtime
-  under the other.
-
-  The frame reaches the tree through the substrate's single internal
-  React context — the same object every React-shaped adapter reads
-  (`re-frame.adapter.context/frame-context`), so a Hicasso subtree and a
-  UIx subtree under one provider resolve the same frame. That is what
-  lets the dogfood screen's three renderings sit side by side in one page
-  and be compared on authoring rather than on plumbing.
-
-  ## Why the flushes are explicit
-
-  React 19 renders a root concurrently, and a `useSyncExternalStore`
-  notification schedules at the SYNC lane rather than committing inline.
-  Witnesses assert the DOM, so every door here commits before it returns:
-  `render!` renders inside `flushSync`, and [[settle!]] is the empty
-  `flushSync` that lets an already-scheduled sync-lane notification land.
-  Neither is `act` — `act` diverts work to a queue that is not the
-  browser's, which is the right tool for an effect-ordering test and the
-  wrong one for a witness that reads the page.
-
-  **[[hydrate-root!]] is the exception, and deliberately.**
-  Adoption is React's own concurrent business and nothing in this tree
-  forces it synchronously; wrapping `hydrateRoot` in a `flushSync` would
-  be inventing a schedule to make a witness easier to write. So that one
-  door returns before the tree is adopted, and a witness for it waits for
-  the closer instead of for a flush."
+  Every door commits before it returns — `render!` inside `flushSync`,
+  `settle!` as the empty `flushSync` — because React 19 renders a root
+  concurrently and a witness reads the DOM on the next line.
+  `hydrate-root!` is the one exception: adoption is React's own concurrent
+  business, so it returns before the tree is adopted and a witness waits
+  for the adoption window to close. The mechanism record is
+  docs/design/hicasso/architecture.md, section The root."
   (:require [re-frame.adapter.context :as adapter-context]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -67,17 +30,21 @@
             ["react-dom/client" :as react-dom-client]))
 
 (defn provider
-  "Scope `frame-kw` for a subtree. Renders no DOM of its own, so it cannot
-  move a canonical-DOM parity comparison."
+  "Scope `frame-kw` for a subtree through the substrate's one internal
+  React context (`re-frame.adapter.context/frame-context`), so a Hicasso
+  subtree and a UIx subtree under one provider resolve the same frame.
+  Renders no DOM of its own, so it cannot move a canonical-DOM parity
+  comparison."
   [frame-kw child]
   (react/createElement (.-Provider adapter-context/frame-context)
                        #js {:value frame-kw}
                        child))
 
 (defn settle!
-  "Let an already-scheduled sync-lane notification commit. The empty
-  `flushSync` — no work of its own, and the reason a witness may read the
-  DOM on the line after a dispatch."
+  "Let an already-scheduled sync-lane notification commit: the empty
+  `flushSync`, and the reason a witness may read the DOM on the line after
+  a dispatch. Not `act`, which diverts work to a queue that is not the
+  browser's."
   []
   (react-dom/flushSync (fn [] nil))
   nil)
@@ -85,39 +52,25 @@
 (declare adoption-window-closer)
 
 (defn tree
-  "The root element for `handle`'s next render — **the one place the root
-  tree's SHAPE is decided**, and the reason it is a function of the
-  handle rather than of its two callers.
+  "The root element for `handle`'s next render, and the one place the root
+  tree's shape is decided. A hydrated root — one whose handle carries an
+  `:adoption` window — is a Fragment of `adoption-window-closer` and the
+  app subtree under the window's provider; an ordinary root is the bare
+  frame provider, so the tree the bench lane measures carries no extra
+  fiber, effect or context.
 
-  **Public because the SERVER half calls it too.**
-  `re-frame.hicasso.server/render` builds its element from this exact
-  function, with a handle carrying a per-request `:adoption` window, so
-  the bytes it emits and the tree [[hydrate-root!]] adopts are the same
-  shape by CONSTRUCTION rather than by two implementations agreeing.
-  That is what makes the server a matching entry rather than a second
-  renderer: were the server to build its own element, the fork this
-  function decides would have to be mirrored in a place nothing forces to
-  follow it, which is the shape of the bug rather than of the fix.
-
-  A hydrated root carries [[adoption-window-closer]] and its own
-  adoption-window provider as a Fragment around the app subtree, and it
-  has to carry them on EVERY subsequent render: React reconciles a root
-  by its top element, so handing a hydrated root a bare provider where a
-  Fragment stood would not be a cheaper render, it would be a different
-  tree — React unmounts the adopted subtree and mounts a fresh one,
-  discarding every node, cell and subscription the adoption just
-  established. Measured: the first `render!` after a hydration re-ran all
-  four boundary bodies and replaced all four DOM nodes.
-
-  **The window is what says a root is hydrated.** The presence of
-  `:adoption` drives this branch, and it is the thing the wrapper is FOR,
-  so there is one fact here rather than a separate `:hydrated?` flag that
-  could disagree with it.
-
-  An ordinary root gets no wrapper at all, which keeps the tree the whole
-  bench lane measures free of it — no extra fiber, no extra
-  passive effect, no context provider, and nothing new retained per
-  boundary."
+  A hydrated root must be handed this wrapper on EVERY render, not only
+  the adopting one: React reconciles a root by its top element, so a bare
+  provider where the Fragment stood is a different tree, and React
+  unmounts the adopted subtree and mounts a fresh one — every node, cell
+  and subscription the adoption established discarded. The window's
+  presence is the one fact that says a root is hydrated; there is no
+  second flag to disagree with it. Public because
+  `re-frame.hicasso.server/render` builds its element here too, so the
+  bytes it emits and the tree `hydrate-root!` adopts agree on `useId`'s
+  tree position by construction
+  (implementation/hicasso/spec/dispositions.md HS-11, obstruction 2;
+  witnesses in docs/design/hicasso/architecture.md, section The root)."
   [handle hiccup]
   (let [app (provider (:frame handle)
                       (codec/root-element (:frame handle) hiccup))]
@@ -129,83 +82,27 @@
       app)))
 
 (defn render!
-  "Render `hiccup` into an existing root, synchronously. Answers the
-  handle.
-
-  **The public door's re-render, and the whole of a consumer's hot-reload
-  hook**:
-
-      (defonce ^:private !root (atom nil))
-
-      (defn ^:export init []
-        (reset! !root (h/mount! node {:frame ::frame} [app {}])))
-
-      (defn ^:dev/after-load reload! []
-        (h/render! @!root [app {}]))
-
-  It re-renders the root React already has, so React reconciles against
-  the tree on the page and the reloaded view code meets its own DOM.
-  Calling [[root!]] again instead would `createRoot` a second time and
-  REPLACE the tree — every node discarded, every subscription re-made,
-  every scrap of component state and scroll position lost, which is
-  exactly what a hot reload must not do.
-
-  The root hiccup is interpreted through
-  [[re-frame.hicasso.impl.codec/root-element]] rather than
-  `as-element`, because the root is the one creator with no ancestor body
-  to inherit the frame from — the case the frame-as-a-prop variant needs
-  named. The context provider is installed regardless: it
-  is what the substrate's other React-shaped adapters read, and what the
-  error boundary and the presence tray resolve their frame from.
-
-  Takes a hydrated handle unchanged — [[tree]] is what makes that true."
+  "Render `hiccup` into an existing root, synchronously, and answer the
+  handle: the public re-render (`h/render!`) and the whole of a consumer's
+  hot-reload hook (docs/core/hicasso/00-installation.md). React reconciles
+  against the tree on the page, so component state and scroll position
+  survive; calling `root!` again would `createRoot` a second time and
+  replace the tree. The root hiccup goes through `codec/root-element`
+  rather than `as-element` because the root is the one creator with no
+  ancestor body to inherit the frame from. Takes a hydrated handle
+  unchanged — `tree` is what makes that true."
   [handle hiccup]
   (react-dom/flushSync (fn [] (.render (:root handle) (tree handle hiccup))))
   handle)
 
-;; ---------------------------------------------------------------------------
-;; The one root option a CALLER may name
-;; ---------------------------------------------------------------------------
-;;
-;; `identifierPrefix` is React's own, and `:identifier-prefix` is a
-;; PASS-THROUGH to it: no default, no coercion, no schema, no second
-;; spelling. Two facts make it necessary and React owns both of them.
-;; `useId` numbers each root from the same start, so two roots on one page
-;; mint the same ids unless their prefixes differ; and a HYDRATING root
-;; must be given the prefix its server render used, or every `useId` in
-;; the tree resolves to a different string on the client and React
-;; recovers by throwing the server's nodes away. Neither is a fact about
-;; this package. These doors are what let a caller say the word.
-;;
-;; **The PREFIX's server half is React's too, and it needs no door
-;; here.** It is spelled on whichever server caller bakes the bytes:
-;; `re-frame.hicasso.server/render` carries `:identifier-prefix`, a
-;; pass-through of exactly this shape, and a hand-rolled
-;; `renderToString(element, #js {"identifierPrefix" "a-"})` names
-;; React's option directly. Either way the two sides meet in React's
-;; own vocabulary and what matters is that the caller hands BOTH of
-;; them the same string.
-;; Agreement is the contract; presence on one side proves nothing.
-;;
-;; **That settles the prefix and not the pair**, and the difference is
-;; the whole of why no hydrating door is public. `useId` derives from
-;; tree POSITION as well as from the prefix, and a hydrating root's tree
-;; is not the app subtree. [[hydrate-root!]] carries the measurement and
-;; the consequence.
-
 (defn- root-options
   "React's `react-dom/client` root options object, or nil when there is
-  nothing to say.
-
-  Nil rather than an empty object, because both root doors branch on it
-  to call React's BARE arity — the arrangement [[hydrate-root!]] relies
-  on for production, where the reporter compiles away and the shipped
-  call is the bare two-argument one.
-
-  String keys through `unchecked-set`, for the reason the `displayName`
-  stamps in this file use it: the string key is what keeps the property
-  off Closure's renamer under `:advanced`, and an `identifierPrefix`
-  renamed is a prefix React never sees."
+  nothing to say. Nil rather than an empty object, because both root doors
+  branch on it to call React's bare arity — the shipped production call
+  once the reporter compiles away. String keys through `unchecked-set`:
+  the string is what keeps the property off Closure's renamer under
+  `:advanced`, and an `identifierPrefix` renamed is a prefix React never
+  sees."
   [identifier-prefix on-recoverable-error]
   (when (or (some? identifier-prefix) (some? on-recoverable-error))
     (let [o #js {}]
@@ -240,21 +137,18 @@
   frame-kw)
 
 (defn root!
-  "Associate `container`, `frame-kw` and `hiccup`. Returns the handle.
+  "Associate `container`, `frame-kw` and `hiccup`: ensure the frame,
+  create the React root, render once inside `flushSync`. Returns the
+  handle `{:root :frame :container}` every other door takes. Published as
+  `h/mount!` over the guide's config map.
 
-  `opts` is optional and carries two keys, both of them the CALLER's:
-
-  `:initial-events` seeds the frame this root names, through
-  [[ensure-frame!]] and before React renders anything — ordinary events,
-  in the order given, run once when this mount CREATES the frame and
-  never when it joins one. It is core's `:initial-events`
-  reaching `rf/make-frame` untouched, not a spelling this package owns.
-
-  `:identifier-prefix` is handed straight to `createRoot` as React's
-  `identifierPrefix`. A page mounting two roots gives them
-  distinct prefixes so their `useId` values cannot collide; a page with
-  one root names none, and passing no `opts` is how it says so — the call
-  React receives is then the bare one it always was."
+  `opts` is optional and carries two keys, both the caller's:
+  `:initial-events`, ordinary events dispatched in order when this mount
+  CREATES the frame and never when it joins one (`ensure-frame!`); and
+  `:identifier-prefix`, handed to `createRoot` as React's
+  `identifierPrefix` untouched — no default, no coercion — so a page
+  mounting two roots can keep their `useId` values apart. Name neither and
+  the call React receives is the bare one."
   ([container frame-kw hiccup] (root! container frame-kw hiccup nil))
   ([container frame-kw hiccup opts]
    (ensure-frame! frame-kw (:initial-events opts))
@@ -268,24 +162,17 @@
      handle)))
 
 (defn adoption-window-closer
-  "The component that CLOSES **its own root's** adoption window, on that
-  root's hydration commit and not before.
-
-  Lifted in shape from the spine's own
-  `re-frame.substrate.spine/adoption-window-closer`, down to taking the
-  window off a prop: a passive `useEffect` with empty deps, so it runs
-  exactly once and strictly AFTER the commit that adopted the server DOM.
-  Renders nil — no DOM, so it adds nothing for `hydrateRoot` to match and
-  cannot itself mismatch.
-
-  The window arrives as `rfWindow` rather than being read from a module
-  slot, and that prop IS the repair: a closer can only shut the window
-  its own root minted, so a sibling root still adopting stays adopting.
-
-  Public because that is what makes adoption OBSERVABLE without a probe:
-  `(roots/adopting? (:adoption handle))` answering false is this effect
-  having run, which is the completion signal a witness waits on in place
-  of the `flushSync` [[hydrate-root!]] refuses to perform."
+  "The component that closes its own root's adoption window, from a
+  passive `useEffect` with empty deps — once, and strictly after the
+  commit that adopted the server DOM. Renders nil, so it adds nothing for
+  `hydrateRoot` to match. The window arrives as the `rfWindow` prop rather
+  than from a module slot, so a closer can only shut the window its own
+  root minted and a sibling still adopting stays adopting. Public because
+  `(roots/adopting? (:adoption handle))` turning false is this effect
+  having run — the completion signal a witness waits on in place of the
+  `flushSync` `hydrate-root!` refuses. The shape is
+  `re-frame.substrate.spine/adoption-window-closer`'s
+  (docs/design/hicasso/architecture.md, section The root)."
   [^js props]
   (react/useEffect (fn close-window []
                      (roots/close-adoption-window! (.-rfWindow props))
@@ -293,57 +180,28 @@
                    #js [])
   nil)
 
-;; `unchecked-set`, not `aset`: `aset` is cljs.core's ARRAY writer and a
-;; component is a function, so the write was a type error the compiler
-;; happens not to enforce. Both emit the same `(x["displayName"] = ...)`,
-;; and it is the STRING key that keeps the property off Closure's renamer
-;; under `:advanced` — the reason the package's other stamps
-;; (`collector/mint-view!`, `codec/memoize-boundary!`) are spelled this way.
+;; `unchecked-set`, not `aset`: `aset` is the ARRAY writer and a component
+;; is a function. The STRING key is what keeps `displayName` off Closure's
+;; renamer under `:advanced`.
 (unchecked-set adoption-window-closer "displayName" "hicasso/adoption-window-closer")
 
-;; ---------------------------------------------------------------------------
-;; The recoverable-error reporter
-;; ---------------------------------------------------------------------------
-;;
-;; React reports the adoption divergences it RECOVERS FROM — a text
-;; mismatch, or a missing / extra / wrong-type element — through the root's
-;; `onRecoverableError`. With no root options that channel is React's
-;; DEFAULT handler, so a mismatch would be an uncaught window error and
-;; NOTHING ELSE: Spec 011's `:rf.ssr/hydration-mismatch` would never fire,
-;; and a mismatch would be invisible to every tool that reads the
-;; instrumentation stream. The reporter below is what closes that gap.
-;;
-;; The shape is the spine's (`re-frame.substrate.spine`,
-;; `native-hydration-reporter` / `hydrate-root-options`), because this
-;; package's root is a React-element root exactly as a native UIx root is:
-;; no hashable client render-tree, so adoption IS the verification channel.
-;; Attribute-only divergences are outside it by React's own contract and
-;; stay outside it here (Spec 011 §Hydration-mismatch detection).
-
 (defn- report-recoverable-default!
-  "React's own default reporting, replicated.
-
-  Installing ANY `onRecoverableError` takes React's default OFF, so a
-  reporter that only emitted would SWALLOW the error, which the
-  fail-open rule forbids. This door composes over React's default
-  and never clobbers it: the uncaught error a runner treats as fatal is
-  still uncaught, and the diagnostic is added beside it."
+  "React's own default reporting, replicated. Installing any
+  `onRecoverableError` takes React's default off, so a reporter that only
+  emitted would swallow the error, which the fail-open rule forbids
+  (docs/design/hicasso/studio/ssr-spike-witness.md, rf2-2rtt6.97)."
   [error]
   (if (fn? (.-reportError js/globalThis))
     (js/reportError error)
     (when (exists? js/console) (.error js/console error))))
 
 (defn- emit-hydration-mismatch!
-  "Spec 011's `:rf.ssr/hydration-mismatch`, tier-discriminated by
-  `:where` — this door's own site, the way the spine tags
-  `re-frame.substrate.spine/make-render`. No hash and no `:root-id`: a
-  React-element root has
-  neither. `:recovery` is `:warned-and-replaced` because React has
-  already patched the DOM by the time this runs — there is no
-  `:hard-error` escalation to make.
-
-  Not an event and it mints no epoch: it fires from a React root-error
-  callback, outside any dispatch scope."
+  "Spec 011's `:rf.ssr/hydration-mismatch`, `:where` naming this door the
+  way the spine's `make-render` tags its own. No hash and no `:root-id` —
+  a React-element root has neither — and `:recovery` is
+  `:warned-and-replaced` because React has already patched the DOM. Not
+  an event and mints no epoch: it fires from a root-error callback,
+  outside any dispatch scope."
   [error]
   (trace/emit! :warning :rf.ssr/hydration-mismatch
                {:error    (some-> error .-message)
@@ -351,34 +209,24 @@
                 :recovery :warned-and-replaced}))
 
 (defn hydration-reporter
-  "BUILD the `onRecoverableError` for the root that owns `window`.
-  A builder, exactly as the spine's
-  `re-frame.substrate.spine/native-hydration-reporter` is a builder, and
-  for the spine's reason: the window it consults belongs to ONE root, so
-  the callback has to close over it.
+  "Build the `onRecoverableError` for the root that owns `window`: emit
+  the framework diagnostic while THAT root's window is open, then always
+  delegate to React's default reporting. Without it a mismatch is an
+  uncaught window error and nothing else — Spec 011's
+  `:rf.ssr/hydration-mismatch` never fires. A builder, as the spine's
+  `native-hydration-reporter` is, because the window belongs to one root
+  and the callback has to close over it.
 
-  Emits the framework diagnostic ONLY while THAT root's window is open,
-  then ALWAYS reports. Both halves matter and they fail in opposite
-  directions:
-
-    - React holds this callback for the root's whole lifetime and fires
-      it for post-hydration recoverable errors too — a concurrent render
-      it retried and recovered. Emitting outside the window would label
-      one of those a hydration mismatch. **Reading a page-wide window
-      here would mislabel a completed root's later recovery whenever any
-      sibling was still adopting** — which is what a page-global
-      reference count would have bought.
-    - Never emitting is the other failure: a page-wide BOOLEAN lets
-      root A's closer silence root B's genuine mismatch, which is why
-      the window is per-root rather than a page-wide flag.
-
-  The delegation is unconditional in both cases — installing ANY
-  `onRecoverableError` takes React's default off, so the fail-open rule
-  is preserved by reporting whether or not the framework emitted.
-
-  Public because that is what lets a witness drive the REAL callback
-  across the window boundary rather than a copy of it — the spine's own
-  reason for publishing `native-hydration-reporter`."
+  Per-root rather than page-wide because both failure directions are
+  real: React fires this callback for post-hydration recoveries too, so a
+  page-wide window would label a completed root's later recovery a
+  hydration mismatch whenever a sibling was still adopting, and a
+  page-wide boolean lets one root's closer silence another's genuine
+  mismatch (docs/design/hicasso/architecture.md, section The root).
+  Attribute-only divergences are outside React's contract and stay
+  outside this channel (docs/design/hicasso/production-server-arm.md).
+  Public so a witness can drive the real callback across the window
+  boundary."
   [^js window]
   (fn on-recoverable [error _error-info]
     (when (roots/adopting? window)
@@ -386,23 +234,12 @@
     (report-recoverable-default! error)))
 
 (defn- hydrate-root-options
-  "The `react-dom/client` root options for the root owning `window` and
-  named by `opts`, or nil.
-
-  The reporter is debug-only: in production the emit DCEs behind
-  `interop/debug-enabled?` and the only thing left to install would be a
-  replica of the default React would have run anyway. The spine gates the
-  same way, one clause wider: it also installs for a host-authored
-  `:on-recoverable-error`, and this package has no host-authored callback
-  to compose with.
-
-  **`:identifier-prefix` is NOT gated, and that asymmetry is the point.**
-  The reporter is a diagnostic and a release build is
-  entitled to lose it; the prefix is BEHAVIOUR — it decides what `useId`
-  answers, and a release build that dropped it would hydrate every server
-  `useId` into a mismatch. So a caller who names one gets it in every
-  build, and a caller who names none still gets nil here in production
-  and React's bare two-argument call downstream."
+  "The root options for the root owning `window`, or nil. The reporter is
+  debug-only — in production the emit compiles away behind
+  `interop/debug-enabled?` and what would remain is a replica of React's
+  default — while `:identifier-prefix` is never gated: it is behaviour,
+  deciding what `useId` answers, and a release build that dropped it would
+  hydrate every server `useId` into a mismatch."
   [window opts]
   (root-options (:identifier-prefix opts)
                 (when interop/debug-enabled? (hydration-reporter window))))
@@ -449,39 +286,21 @@
                            (react-dom-client/hydrateRoot container element))))))
 
 (defn unmount!
-  "Take THIS root down, and touch nothing else. `re-frame.hicasso`'s
-  public teardown door and [[root!]]'s exact inverse.
+  "Take THIS root down and touch nothing else: `h/unmount!`, `root!`'s
+  inverse. Shuts the root's own adoption window first — a root torn down
+  before its passive effects ran never gets its closer — then unmounts
+  inside `flushSync`. Idempotent and nil-tolerant: an ordinary handle
+  carries no window, and a second call is a no-op.
 
-  Two things it deliberately does not do, and each would be a fault on a
-  public teardown door:
-
-  **It touches nothing the runtime holds.** Whatever edges, cells and
-  cached closures survive are the ones React's own cleanup failed to
-  release, which is what makes this the half a residue gate can read: a
-  teardown that emptied the tables first answers `0` whether it released
-  anything or not, and that is a gate that cannot go red.
-  It is also what makes teardown ROOT-scoped in a multi-root page —
-  every table the package holds is one-per-page and keyed by frame, so a
-  door that reset them would tear down every sibling root's state along
-  with its own.
-
-  **It does not remove the container from the document.** The container
-  is the CALLER's node, handed to [[root!]], and a teardown door may not
-  delete a node it did not create — React's own `root.unmount()` empties
-  a container and leaves it where it is, which is the contract every
-  consumer already knows. Detaching is [[release!]]'s, where the
-  container is one [[fresh-container!]] minted for the occasion.
-
-  **Shuts this root's adoption window first.** A root torn
-  down before its passive effects ever ran never gets its closer, and an
-  open window that outlives its root is a window nothing can ever shut.
-  Root teardown owns root state, so it is this door's job and not a
-  page-wide reset's — closing a sibling's window from a reset is exactly
-  the cross-root reach this door must not have.
-
-  Idempotent: `roots/close-adoption-window!` is idempotent and
-  nil-tolerant, so an ordinary handle (which carries no window) and a
-  second call are both no-ops."
+  Two things it deliberately does not do. It empties none of the
+  runtime's tables — they are one-per-page and keyed by frame, so a reset
+  here would tear down every sibling root's state, and what survives an
+  unmount is exactly what a residue gate reads, which a teardown that
+  emptied the tables first could never turn red. And it does not remove
+  the container: that is the caller's node, and React's own
+  `root.unmount()` empties it and leaves it where it is. Both are
+  `release!`'s (docs/design/hicasso/product/globals.md, the
+  `reset-runtime!` paragraph)."
   [handle]
   (roots/close-adoption-window! (:adoption handle))
   (when-some [r (:root handle)]
@@ -489,22 +308,13 @@
   nil)
 
 (defn release!
-  "Unmount the root, drop its container, and empty the runtime. **The
-  fixture door, and it is not on the public facade.** It ends
-  with a page that holds nothing, whatever this test left behind, which
-  is right when one app owns the page and wrong for a consumer who has
-  two roots and meant to tear down one.
-
-  The two acts [[unmount!]] refuses are both here, and each is legitimate
-  for a fixture: the container it detaches is a [[fresh-container!]] this
-  same fixture appended, and the runtime it empties is a page the fixture
-  owns end to end.
-
-  Idempotent: releasing twice is not an error, because a teardown door
-  that throws on the second call is a teardown door test fixtures route
-  around.
-
-  **Not the door a residue assertion takes** — see [[unmount!]]."
+  "Unmount the root, detach its container and empty the runtime: the
+  fixture door, and not on the facade, because it ends with a page that
+  holds nothing — right where one test owns the page, wrong for a consumer
+  tearing down one of two roots
+  (implementation/hicasso/spec/naming-ledger.md row 13). Idempotent, so a
+  fixture can route through it twice. Not the door a residue assertion
+  takes — see `unmount!`."
   [handle]
   (unmount! handle)
   (when-some [c (:container handle)]

--- a/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs
@@ -216,53 +216,23 @@
       o)))
 
 (defn ensure-frame!
-  "ENSURE `frame-kw` before its root's first render: create the frame if
-  it is absent, seeding it with `initial-events`; JOIN it untouched if it
-  is already live. Answers `frame-kw`.
+  "Ensure `frame-kw` before its root's first render: create it through
+  `rf/make-frame` seeded with `initial-events` when absent; join it
+  untouched — no re-seed, no config refresh — when live. Answers
+  `frame-kw`. This is core's `frame-root` vocabulary
+  (docs/EP/EP-0027-frame-initial-events.md): `:initial-events` reaches
+  `make-frame` untouched, and EP-0027's preflight owns its shape and
+  errors.
 
-  ## This is core's `frame-root` vocabulary, not a second one
-
-  `rf/frame-root` (Reagent) and `re-frame.adapter.uix/frame-root` are the
-  substrate's ENSURE boundaries and they already read exactly this way —
-  *creates the frame if absent, REUSES it if present without re-seeding*,
-  taking `rf/make-frame`'s own opts, `:initial-events` among them
-  (EP-0027). This door reads the same way, so a consumer's boot line
-  names the frame id once — to the root door — rather than to
-  `rf/make-frame` and then again to `root!`. `:initial-events` reaches
-  `make-frame` UNTOUCHED — no default, no coercion, no second spelling
-  and no re-validation, the pass-through discipline
-  [[root-options]] already applies to `:identifier-prefix`. EP-0027's
-  preflight owns the shape and its errors name `rf/make-frame`, which is
-  the constructor a consumer would otherwise have called by hand.
-
-  ## Why the guard is on the INCARNATION and not on `make-frame`
-
-  Re-`make-frame`-ing a live id is IDEMPOTENT REPLACEMENT — config and
-  generation refresh, durable state preserved — so an unguarded call
-  would not crash a joining root, it would silently refresh the config of
-  the frame the first root created. The guide teaches the opposite in as
-  many words (*\"a later root that names the same frame joins its current
-  state and does not replay `:initial-events`\"*), so absence is asked
-  first. `frame/frame-incarnation-token` is the liveness question the
-  package asks — nil for absent, destroyed, or another actor's
-  provisional record — and it is what
-  [[re-frame.hicasso.impl.frames/frame-row]] already asks one layer down.
-
-  ## Synchronous, and that is what buys \"before first paint\"
-
-  `make-frame` dispatches `:initial-events` synchronously, in order,
-  draining each to a fixed point before it returns. So calling this
-  BEFORE `createRoot` means the seeded app-db is on the frame by the time
-  React renders anything, and the first paint is the seeded one rather
-  than an empty frame filled in a moment later. That is the ordering the
-  substrate's `frame-root` cannot have — it is a component, so its ENSURE
-  runs in a `useLayoutEffect` after the first commit — and a ROOT door,
-  being an ordinary function call, can simply do it first.
-
-  Not [[hydrate-root!]]'s: an adopting root takes its state from the
-  server payload through `re-frame.ssr/hydrate!`, so a seed here would
-  overwrite it. That door's chapter tells a consumer to `rf/make-frame`
-  first and means it."
+  The guard asks `frame/frame-incarnation-token` rather than trusting
+  `make-frame`, because re-`make-frame`-ing a live id is idempotent
+  REPLACEMENT — config and generation refresh, durable state preserved —
+  so an unguarded call would not fail a joining root, it would silently
+  refresh the first root's config, and the guide promises the opposite
+  (docs/core/hicasso/00-installation.md). Synchronous, and called before
+  `createRoot`: `make-frame` drains the seed to a fixed point before it
+  returns, so the first paint is the seeded one
+  (docs/design/hicasso/architecture.md, section The root)."
   [frame-kw initial-events]
   (when (nil? (frame/frame-incarnation-token frame-kw))
     (rf/make-frame (cond-> {:id frame-kw}
@@ -438,110 +408,36 @@
                 (when interop/debug-enabled? (hydration-reporter window))))
 
 (defn hydrate-root!
-  "Associate `container`'s **existing server-rendered DOM** with
-  `frame-kw` and `hiccup`, by adoption. [[root!]]'s hydrating twin, and
-  the client half every SSR route shares.
+  "Associate `container`'s existing server-rendered DOM with `frame-kw`
+  and `hiccup` by adoption: `root!`'s hydrating twin, published as
+  `h/hydrate!`. Returns `root!`'s handle shape plus `:adoption`, this
+  root's own window, and every other door takes a hydrated handle
+  unchanged. Does not ensure the frame — an adopting root's state arrives
+  through `re-frame.ssr/hydrate!` first, and a seed here would overwrite
+  it.
 
-  Returns the same handle shape [[root!]] does — `{:root :frame
-  :container}` — so [[render!]], [[dispatch!]], [[unmount!]] and
-  [[release!]] all take a hydrated handle unchanged.
+  Returns BEFORE the tree is adopted: `hydrateRoot` is called plain,
+  because a `flushSync` would manufacture a schedule no shipped caller
+  has, so the DOM on the next line is still the server's and the window
+  is closed by `adoption-window-closer` from a passive effect, the
+  earliest point unambiguously after the hydration commit. In debug
+  builds the root carries `hydration-reporter` as its `onRecoverableError`,
+  so a divergence React recovers from surfaces as Spec 011's
+  `:rf.ssr/hydration-mismatch` beside the uncaught error, never instead
+  of it. The window is minted in every build because presence reads it in
+  production.
 
-  ## `hydrateRoot` is not wrapped in `flushSync`
-
-  No `flushSync`, and that is a finding rather than an omission: nothing
-  in this tree forces hydration synchronously, so a flush here would
-  manufacture a schedule no shipped caller has and every row taken
-  through it would be a row about the manufactured one. The consequence
-  is that **this returns before the tree is adopted** — React adopts
-  concurrently, and the DOM on the line after this call is still the
-  server's.
-
-  ## So the window is closed by a COMPONENT, not by this function
-
-  [[adoption-window-closer]] rides as a Fragment sibling of the app
-  subtree and clears the window from its passive effect. That is the
-  spine's pattern (`spine.cljs`, `adoption-window-closer` /
-  `make-render`), and the reason is the same in both places: a passive
-  effect is the earliest thing that is unambiguously after the hydration
-  commit. Closing the window here, before `hydrateRoot` returns, would
-  close it before a single body had run inside it.
-
-  The closer sits OUTSIDE the frame provider on purpose — it reads no
-  subscription and needs no frame, and a nil-rendering component with no
-  frame dependency is the smallest thing that can carry the effect.
-
-  ## It carries two root options — one the package's, one the CALLER's
-
-  [[hydration-reporter]] rides as the root's `onRecoverableError`, so a
-  divergence React recovers from surfaces as Spec 011's
-  `:rf.ssr/hydration-mismatch` instead of only as an uncaught window
-  error. It is the SPINE's arrangement, and it does not soften the
-  fail-open rule: the reporter always reports, so the uncaught error is
-  still uncaught and the diagnostic is added beside it.
-
-  `opts` is the caller's half and carries ONE key,
-  `:identifier-prefix` — React's `identifierPrefix`, passed through
-  untouched. **Hand it the same string the server render
-  used.** `useId` is numbered per root and prefixed by this option, so a
-  hydrating root given a different prefix (or none, where the server had
-  one) resolves every id in the tree differently from the bytes it is
-  adopting; React sees the divergence as a mismatch and recovers by
-  replacing the subtree, which is a correct repair of a page that should
-  never have shipped.
-
-  Name neither and [[hydrate-root-options]] answers nil in production, so
-  this call is the bare two-argument one it always was.
-
-  ## Matching the prefix is NECESSARY and it is not SUFFICIENT
-
-  The prefix half of the pair does meet in React's own vocabulary, and
-  needs nothing from this package: a consumer names `identifierPrefix` on
-  `react-dom/server`'s own render and the same string here — the
-  [[root-options]] section comment is where that is set out.
-
-  **Matching root STRUCTURE is the other half** (`dispositions.md`
-  HS-11 obstruction 2). React derives a `useId` from tree POSITION as
-  well as from the prefix, and a hydrating root's tree is NOT the app
-  subtree: [[tree]] wraps it in a Fragment whose first child is
-  [[adoption-window-closer]], with the adoption-window provider around
-  the app. A server path emitting no counterpart to that fork bakes
-  bytes that hydrate into a text mismatch whose two ids agree on the
-  prefix and differ after it.
-
-  `re-frame.hicasso.server/render` is the matching server-render entry,
-  and it matches by calling [[tree]], the same function this door calls,
-  with a handle carrying its own per-request window. So the fork is
-  decided once for both halves, the closer occupies the same tree
-  position on both sides, and the adoption provider presence reads to
-  start an adopted child `:present` rather than `:mounting` has its
-  server counterpart. `re-frame.hicasso.server-render-ssr-dom-cljs-test`
-  is the witness — its rows pin the hydrating shape and that the entry's
-  bytes hydrate through `h/hydrate!` without a mismatch.
-
-  **This door is on the `re-frame.hicasso` facade as `h/hydrate!`** —
-  the spelling naming-ledger row 13 rules, over row 20's `(node config
-  view)` contract shape.
-
-  ## The handle carries `:adoption` — this root's OWN window
-
-  [[root!]]'s three keys are all here and every door takes this handle
-  unchanged. The fourth key is not decoration and it is not a flag: it is
-  the window itself, minted here and reachable from nowhere else. Three
-  things need it and each gets the same object — the closer, the
-  reporter, and the provider presence reads — so \"this root is adopting\"
-  is one fact with one owner rather than a page-wide slot four callers
-  race for.
-
-  It is also what [[tree]] branches on, because the wrapper is part of the
-  ROOT's shape and [[render!]] has to reproduce it or React tears the
-  adopted tree down and rebuilds it.
-
-  **Minted unconditionally, unlike the spine's** — which mints only when
-  it is going to install a reporter, because its window has no other
-  reader. This window has a PRODUCTION reader: presence starts an
-  adopted child `:present` rather than `:mounting`, which is behaviour a
-  release build must keep. So the window and its provider ride in
-  production and only the reporter is debug-gated."
+  `opts` carries one key, `:identifier-prefix` — React's `identifierPrefix`,
+  passed through untouched, and it must be the string the server render
+  used or every `useId` in the tree resolves differently from the bytes
+  and React recovers by replacing the subtree. Matching the prefix is
+  necessary and not sufficient: `useId` also derives from tree position,
+  and this root's tree is `tree`'s Fragment rather than the bare app, so
+  the server half must be `re-frame.hicasso.server/render`, which builds
+  its element from the same function
+  (implementation/hicasso/spec/dispositions.md HS-11, obstruction 2;
+  `re-frame.hicasso.server-render-ssr-dom-cljs-test`). Mechanism and
+  witnesses: docs/design/hicasso/architecture.md, section The root."
   ([container frame-kw hiccup] (hydrate-root! container frame-kw hiccup nil))
   ([container frame-kw hiccup opts]
    (let [window  (roots/open-adoption-window!)


### PR DESCRIPTION
Docstring-and-comment cleanup of `implementation/hicasso/src/re_frame/hicasso/impl/mount.cljs` executing ruling rf2-6c12m.4 (Option A) — the mount slice of rf2-76hbj, one of four files that bead trims one worker each. Each docstring now carries what the var is or returns, the contract, one sentence of why, and a repo-relative path into the design tree; comments survive only as local correctness proofs. **No behaviour change**: the code lines are byte-identical to trunk (128 before and after, with strings and comments stripped), and the `test:cljs` count is unchanged at 11,079. Two commits: the two long essays (`hydrate-root!`, `ensure-frame!`) with the moved material first, then the rest of the file.

The essays' mechanism reasoning had no home in `docs/design/hicasso` — neither `architecture.md` nor `decisions.md` said why the doors flush, how a hydrated root is shaped, why the adoption window is per-root and closed by a component, why the two root options are gated differently, or why `ensure-frame!` guards on the incarnation — so it moves to a new `architecture.md` section, **The root (HD-021(b)) — mount, hydration and teardown**, which names the standing witness rows in `roots_frames_hydration_dom_cljs_test` rather than restating them. What a design page already carried is deleted and cited: the prefix and tree-position argument at `dispositions.md` HS-11, the composing reporter at `studio/ssr-spike-witness.md` (rf2-2rtt6.97), the fixture-door split at `product/globals.md`, the door names at naming-ledger rows 13 and 20.

Fence: rf2-6c12m.8 owns `implementation/hicasso/spec/**` and is demoting it into `docs/design/hicasso/product/`. Two retained paths point there — `implementation/hicasso/spec/naming-ledger.md` (rows 13, 20) and `implementation/hicasso/spec/dispositions.md` (HS-11) — cited as they stand at this PR's tip; .8 may move them. The sibling docstring worker on `impl/codec.cljs` may also add to `architecture.md`; this PR inserts one section immediately before *Memoization* and touches nothing else on the page. `collector.cljs` and `intent.cljs` are untouched (fenced behind rf2-6c12m.15); where a mount docstring explained their mechanism it now cites the owner instead.

## Quality gates

Every gate ran foreground from this worktree with its exit code captured to a per-attempt file; the number quoted is the captured one. The compile and `test:cljs` runs print the shadow-cljs config path, which named this worktree on both runs. Compile and lint ran on the working tree once it held the final content of the head commit; `test:cljs` likewise.

| Gate | Attempt | Captured exit | Counts |
|---|---|---|---|
| `npm run test:hicasso-compile` | 1 (final tree) | 0 | 11 namespaces, 171 files, 0 warnings |
| `npm run test:hicasso-lint` | 1 (final tree) | 0 | self-test PASS; 6 checks fire on fixtures, correct code silent, testbeds quiet |
| `npm run test:cljs` | 1 (final tree) | 0 | 1,853 files, 0 warnings; **11,079 tests, 54,286 assertions, 0 failures, 0 errors** |
| `python scripts/check_doc_slugs.py` | 1 (clean) | 0 | — |
| `python scripts/check_doc_slugs.py` | 2 (planted anchor — the control) | **1** | `BROKEN ANCHOR: docs\design\hicasso\architecture.md:255 -> studio/ssr-spike-witness.md#a-finding-the-mutation-proof-produced-no-such-anchor` |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | 1 (committed final tree) | 0 | 1 page inspected, 0 cited pins, 0 findings (the new section cites no commit hashes) |

Not run: no browser gate — nothing here reaches the DOM, and the `*-dom-cljs-test` rows the new section names are CI's browser lane. `mkdocs build` never sees `docs/design` and is not nominated. The branch is based on 03b2b5134a; trunk has since moved three commits (two beads checkpoints and one `docs/the-mayor-method` edit), none touching either file in this diff, so it was not rebased.

## Controls

**The plantable gate** is `scripts/check_doc_slugs.py`, since a page under `docs/design/hicasso/` changed. Planted on a line this PR added — the new section's link to the SSR spike page — by appending `-no-such-anchor` to its anchor (fixed-string replace, match count 1, planted from a clean committed file). The gate went red naming file, line and anchor (table above). Restored with `git checkout HEAD -- docs/design/hicasso/architecture.md`; the file's blob hash read `95beca8e03b0ea8e038b077f5362303c97f50d84` before the plant, `93b8a3cc164017adb226bbfc80f811337c1c99a8` while planted, and `95beca8e03b0ea8e038b077f5362303c97f50d84` after the restore and at `HEAD:` — so the restore is verified by content, and the fault existed only in this worktree.

**No behaviour change, checked mechanically.** A scan that strips every string literal and `;` comment from both versions of `mount.cljs` and compares the remaining lines reads 128 lines on each side, identical in order.

**The src docstrings have no automated content gate beyond compile and lint.** Hand-checked at this tip, every retained repo-relative path exists (a script listed each path grep'd from the file and tested existence, with a planted `docs/design/hicasso/no-such-page.md` correctly reported missing as its control): `docs/EP/EP-0027-frame-initial-events.md`, `docs/core/hicasso/00-installation.md`, `docs/design/hicasso/architecture.md`, `docs/design/hicasso/decisions.md`, `docs/design/hicasso/product/globals.md`, `docs/design/hicasso/production-server-arm.md`, `docs/design/hicasso/studio/ssr-spike-witness.md`, `implementation/hicasso/spec/dispositions.md`, `implementation/hicasso/spec/naming-ledger.md`. The sections and rows cited beside them exist: `architecture.md` §The root (this PR), `decisions.md` HD-021, naming-ledger rows 13 and 20, `dispositions.md` HS-11, `globals.md`'s `reset-runtime!` fixture-door paragraph, `ssr-spike-witness.md` §A finding the mutation proof produced (rf2-2rtt6.97), `production-server-arm.md`'s attribute-only clause, the guide's `^:dev/after-load` example and its "joins its current state" sentence. Every `deftest` the new section names was grep'd as `(deftest <name>` and found once in `roots_frames_hydration_dom_cljs_test.cljs`; both test namespaces cited (`re-frame.hicasso.server-render-ssr-dom-cljs-test`, `re-frame.hicasso.roots-frames-hydration-dom-cljs-test`) exist. Symbols named in prose resolve at source: `re-frame.substrate.spine/adoption-window-closer`, `native-hydration-reporter` and `make-render` (spine.cljs), `re-frame.adapter.context/frame-context`, `re-frame.frame/frame-incarnation-token`, `re-frame.ssr/hydrate!`, `re-frame.interop/debug-enabled?`. No `[[wikilink]]` remains anywhere in the file (raw `[[` count 0).

## Essays

Per essay: **moved to** a path, **deleted — duplicated at** a path, or **deleted — superseded**. "Kept" means it survived as a contract clause or a local proof at its var.

| Essay | Disposition |
|---|---|
| ns opening (HD-021(b), names unfrozen) | kept as one sentence; HD-021 cited |
| ns §Three of these vars ARE the public door (the row 13/20 argument; why `root!` is published as `mount!` over the config map and the impl keeps one positional shape) | deleted — duplicated at `implementation/hicasso/spec/naming-ledger.md` rows 13 and 20 and at `h/mount!` / `h/hydrate!`'s own docstrings in `hicasso.cljc`; the roster kept as one sentence with the rows cited |
| ns §`release!` is NOT among them | kept as one sentence at ns and at `release!`; the argument duplicated at naming-ledger row 13 and `docs/design/hicasso/product/globals.md` (cited) |
| ns §the frame reaches the tree through the substrate's single context / the dogfood screen's three renderings | the shared-context fact kept at `provider`; the dogfood-screen sentence deleted — narrative |
| ns §Why the flushes are explicit (React 19 sync lane; `flushSync` versus `act`) | the ordering contract kept at ns and `settle!`; the derivation **moved to** `docs/design/hicasso/architecture.md` §The root |
| ns §`hydrate-root!` is the exception, and deliberately | kept as one sentence at ns and at `hydrate-root!` |
| `tree` §Public because the SERVER half calls it too ("the shape of the bug rather than of the fix") | kept as one sentence; the argument deleted — duplicated at `implementation/hicasso/spec/dispositions.md` HS-11 obstruction 2 (cited) |
| `tree` §the wrapper must ride on EVERY render, and the measured four-body / four-node remount | the invariant kept as a local proof at the var; the observation and its standing witness row (`tearing-down-one-hydrated-root-leaves-the-other-adopted-and-live`) **moved to** `architecture.md` §The root |
| `tree` §The window is what says a root is hydrated / an ordinary root gets no wrapper | kept, compressed |
| `render!` hot-reload example (10 lines) | deleted — duplicated at `docs/core/hicasso/00-installation.md` (the `^:dev/after-load` hook, cited) and at `h/render!`'s facade docstring; the contract and the "calling `root!` again replaces the tree" clause kept |
| `render!` §root hiccup through `root-element`; the provider installed regardless | the `root-element` sentence kept; the provider sentence deleted — `provider`'s own docstring |
| §The one root option a CALLER may name (29-line section comment: `useId` per root, the hydrating root must match the server's prefix, the server half needs no door, necessary-not-sufficient) | deleted — duplicated at `dispositions.md` HS-11 (obstructions 1 and 2), `docs/design/hicasso/product/lanes/react-compatibility-notes.md` (matching `identifierPrefix`) and the facade docstrings; the pass-through contract kept at `root!` and `hydrate-root!` |
| `root-options` nil-not-empty-object / string keys off Closure's renamer | kept, compressed (local proof) |
| `ensure-frame!` §This is core's `frame-root` vocabulary (EP-0027) | kept as one sentence with `docs/EP/EP-0027-frame-initial-events.md` cited; the `frame-root` / boot-line comparison deleted — duplicated at naming-ledger row 20 and `h/mount!`'s docstring |
| `ensure-frame!` §Why the guard is on the INCARNATION (idempotent replacement) | kept, compressed (local proof; the guide's join sentence cited) |
| `ensure-frame!` §Synchronous buys "before first paint" (the `frame-root` `useLayoutEffect` contrast) | kept as one sentence; the `frame-root` contrast **moved to** `architecture.md` §The root |
| `ensure-frame!` §Not `hydrate-root!`'s | kept at `hydrate-root!` (does not ensure; state through `re-frame.ssr/hydrate!`) |
| `root!` opts contract | kept, compressed |
| `adoption-window-closer` (lifted from the spine; the prop IS the repair; public because observable) | kept, compressed; the spine's builder named, the derivation on `architecture.md` §The root |
| `displayName` stamp comment (`unchecked-set` not `aset`, the other stamps) | kept as three lines (local proof); the cross-reference to `collector` / `codec`'s stamps deleted |
| §The recoverable-error reporter (17-line section comment: React's default handler is invisible to Spec 011; the spine's shape; attribute-only outside) | deleted — the invisible-mismatch sentence kept at `hydration-reporter`; attribute-only duplicated at `docs/design/hicasso/production-server-arm.md` (cited); the spine's shape is the spine's |
| `report-recoverable-default!` (installing any handler takes the default off; never clobbers) | kept, compressed; duplicated at `docs/design/hicasso/studio/ssr-spike-witness.md` rf2-2rtt6.97 (cited) |
| `emit-hydration-mismatch!` | kept, compressed |
| `hydration-reporter` §both halves matter and fail in opposite directions (page-wide window mislabels; page-wide boolean silences) | kept as two sentences of why; the derivation and its two witness rows **moved to** `architecture.md` §The root |
| `hydration-reporter` §delegation unconditional / public so a witness drives the real callback | kept, compressed |
| `hydrate-root-options` (reporter debug-only; the spine one clause wider; `:identifier-prefix` NOT gated) | the gating asymmetry kept as contract; the spine comparison deleted — another namespace's mechanism; the reasoning **moved to** `architecture.md` §The root |
| `hydrate-root!` §`hydrateRoot` is not wrapped in `flushSync` ("a finding rather than an omission") | the ordering contract kept; the narrative **moved to** `architecture.md` §The root, which cites `ssr-spike-witness.md` §A finding the mutation proof produced |
| `hydrate-root!` §So the window is closed by a COMPONENT | kept as one sentence; derivation on `architecture.md` §The root |
| `hydrate-root!` §It carries two root options | the reporter kept as one sentence; the prefix contract kept |
| `hydrate-root!` §Matching the prefix is NECESSARY and it is not SUFFICIENT (tree position; `server/render` matches by calling `tree`; the witness) | kept, compressed to one paragraph with HS-11 and `re-frame.hicasso.server-render-ssr-dom-cljs-test` cited; the rest deleted — duplicated at HS-11 obstruction 2, which carries the server-entry amendment |
| `hydrate-root!` §This door is on the facade as `h/hydrate!` (row 13 over row 20) | deleted — duplicated at naming-ledger row 13; "published as `h/hydrate!`" kept |
| `hydrate-root!` §The handle carries `:adoption` — this root's OWN window (three readers, one owner; `tree` branches on it; minted unconditionally unlike the spine's) | kept as two clauses; the derivation **moved to** `architecture.md` §The root |
| `unmount!` §touches nothing the runtime holds (the residue-gate argument) / §does not remove the container / §shuts the window first | kept, compressed to three contract clauses with the local proof; the `reset-runtime!` versus root-teardown split duplicated at `docs/design/hicasso/product/globals.md` (cited) |
| `release!` | kept, compressed; naming-ledger row 13 cited |
| `dispatch!`, `fresh-container!`, `browser?` | untouched — already at the rule |

## Measured

Same scan method as the rf2-6c12m.4 measurement and PR #8774 (a prose line is inside a string literal following `(ns` / `(def…` / `:doc`, or starts with `;`; blank lines in the total only). The scanner reproduces the bead's tip figures for this file exactly (639 = 436 + 53 + 128, `hydrate-root!` 104, `ensure-frame!` 47) and #8774's published figures for `controlled.cljs` and `server.cljs`, which is its calibration. `[[` is a raw occurrence count.

| File | Lines before → after | Docstring lines | Comment lines | `[[` | Longest docstring after |
|---|---|---|---|---|---|
| `impl/mount.cljs` | 639 → 345 | 436 → 194 | 53 → 3 | 45 → 0 (on 40 lines → 0) | `hydrate-root!`, 30 |

Docs: `+127` on `docs/design/hicasso/architecture.md` (one new section). No studio page: the file's only measured claim (the four-node remount on the first `render!` after adoption) carries no producing commit or reproduction command, so it cannot meet the studio index's page obligations; it is recorded on the architecture page as an observation with the witness row that now stands for it.
