### PR TITLE
hicasso(intent): trim docstrings and comments to the contract (rf2-76hbj, intent slice)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -2008,6 +2008,23 @@ below, with the full window in
 
 ## HD-024 — One callback form; the position selects the contract
 
+> **Addendum, 2026-08-30 — the render-position gate is deleted; a dispatch
+> from inside a render callback is not policed (`rf2-6c12m.20`, PR #8746).**
+> The 2026-08-03 addendum's mechanism — a gate minted per invocation of
+> every render prop, poisoning the ambient dispatch while the call ran and
+> raising `:rf.error/hicasso-dispatch-in-render-position` — is gone, and the
+> id is retired (Spec 009's row is struck in place). It spent a volatile, a
+> closure and a three-var binding per invocation of every render prop to
+> refuse a case a programmer does not plausibly write and one React's own
+> render-phase warnings already report. What stays is the half that was
+> doing the work: `render-callback` captures the supplying boundary's frame
+> and dispatch at lowering time and rebinds both per invocation, so a row
+> built inside a foreign render prop belongs to the boundary that supplied
+> it; a callback lowered with no owner rebinds nil, and a handler lowered
+> inside it raises the ordinary `:rf.error/hicasso-intent-outside-boundary`.
+> Row 3's purity law below is now a statement of the contract rather than a
+> refusal the runtime enforces.
+
 > **Addendum, 2026-08-29 — row 2 is struck: a `defhost` position takes row 1 or
 > row 3 by its spelling, and `:callbacks` is an override rather than a roster
 > (`rf2-6c12m.2`, executed by `rf2-6c12m.24`).** The position table below reads

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -2013,7 +2013,8 @@ below, with the full window in
 > The 2026-08-03 addendum's mechanism — a gate minted per invocation of
 > every render prop, poisoning the ambient dispatch while the call ran and
 > raising `:rf.error/hicasso-dispatch-in-render-position` — is gone, and the
-> id is retired (Spec 009's row is struck in place). It spent a volatile, a
+> id is retired ([Spec 009's row](../../../spec/009-Instrumentation.md#error-event-catalogue)
+> is struck in place). It spent a volatile, a
 > closure and a three-var binding per invocation of every render prop to
 > refuse a case a programmer does not plausibly write and one React's own
 > render-phase warnings already report. What stays is the half that was

--- a/implementation/hicasso/src/re_frame/hicasso/impl/intent.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/intent.cljs
@@ -56,38 +56,25 @@
 
 (def ^:dynamic *frame*
   "The frame KEYWORD for the boundary currently rendering, bound for the
-  render's dynamic extent alongside [[*dispatch*]]. `nil` outside a
-  render. [[re-frame.hicasso.impl.route-link/route-link]] reads it
-  to capture the render frame into its navigate vector — a browser click
-  fires long after the render's dynamic extent has unwound, so the frame
-  must travel as data."
+  render's dynamic extent beside `*dispatch*`; `nil` outside a render.
+  `hframe` and `re-frame.hicasso.impl.route-link/route-link` read it at
+  render time, because a browser click fires after the extent has unwound
+  and the frame must travel as data."
   nil)
 
 (def ^:private ambient-frame-refusal
-  "The detail this package hands core's refusal tier. One
-  module-level constant, so the prose — which is nearly all of it — is
-  built once at load and never per body. [[with-frame]] stamps the
-  rendering boundary's own frame onto a copy of it; that
-  `assoc` is the whole per-extent cost, and it buys the one property a
-  shared constant cannot express: which frame THIS body has.
+  "The detail this substrate hands core's refusal tier
+  (`re-frame.frame/*ambient-frame-refusal*`). One module-level constant,
+  built once at load; `with-frame` stamps the rendering boundary's frame
+  onto a copy as `:extent-frame`, and that `assoc` is the whole
+  per-extent cost.
 
-  The sentence has to be the one an author can act on, because the whole
-  point of the tier is that the generic `:rf.error/no-frame-context` advice
-  — establish a scope — is WRONG here: a body always sits under a frame
-  boundary, so following it would change nothing and the boundary would go
-  on quietly not re-rendering.
-
-  IT HAS TO ADDRESS THREE DOORS, NOT TWO. The ambient scope is
-  one door with three consumers — a read, a dispatch, and a CARRY — and
-  the reason's opening advice speaks to the first two. An author who
-  trips the refusal through `rf/capture-frame` is doing neither:
-  `capture-frame` is Spec
-  002's *one public carry primitive*, and the reason its 0-arity resolves
-  ambiently is to CAPTURE, not to read and not to dispatch. Advice that
-  says \"read through the collector, dispatch through an intent\" names
-  nothing they can write. So the carry gets its own sentence, and it is a
-  different sentence — not the collector and not an intent, but the
-  1-arity, which never consults the resolver at all."
+  The reason names THREE recoveries, and the third must stay: a read goes
+  through the collector and a dispatch through an intent, but an author
+  who trips the refusal through zero-arity `rf/capture-frame` is
+  CARRYING, and the only advice they can act on is the 1-arity, which
+  never consults the resolver (docs/design/hicasso/studio/hframe-design.md
+  §9(4))."
   {:substrate :hicasso
    :extent    'hicasso/boundary-render
    :recovery  :read-through-the-boundary-collector
@@ -111,48 +98,27 @@
                    "composition is refusal-immune by construction.")})
 
 (defn with-frame
-  "Run `body-fn` with the boundary's render context bound ambiently. Two
-  doors: the RUNTIME binds both the frame keyword and its frame-locked
-  `dispatch` (the 3-arity — the one [[route-link]] and the navigate head
-  need); a lowering test that only drives closures may bind the dispatch
-  alone (the 2-arity), and anything frame-keyword-dependent it lowers
-  stays a loud error rather than a silent guess.
+  "Run `body-fn` with the boundary's render context bound ambiently. The
+  3-arity binds the frame keyword and its frame-locked `dispatch` — the
+  runtime's door; the 2-arity binds the dispatch alone, for a lowering
+  test that only drives closures, and anything frame-dependent it lowers
+  stays a loud error rather than a silent guess. Both bind core's refusal
+  tier as well, so ambient `rf/subscribe`, `rf/dispatch` and zero-arity
+  `rf/capture-frame` refuse for the extent (HD-002 clause (a)), while an
+  explicitly carried frame — `{:frame <id>}`, an `rf/with-frame` naming
+  THIS frame — still answers: the refusal deletes the ambient FIND, not
+  the carrying. The 3-arity also declares its frame as `:extent-frame`,
+  so a carried stamp naming a DIFFERENT frame is refused too, because one
+  body would otherwise read against `:b` while its lowered intents target
+  `:a`; the 2-arity declares none and refuses no carry.
 
-  THE THIRD VAR IS CORE'S REFUSAL TIER. This extent is
-  exactly the render extent HD-002 clause (a) governs, so it is exactly
-  where ambient `rf/subscribe` / `rf/dispatch` must stop resolving. It is
-  bound HERE, fused into the binding this function already performs, rather
-  than through `frame/call-with-ambient-frame-refused` around the call:
-  `binding` pushes and pops its whole set once, so the fence costs the runtime
-  no additional frame — the general seam exists for substrates that are not
-  already binding something.
-
-  It covers all three doors deliberately. A body is the obvious one, but
-  the error boundary's fallback and the presence tray's retained children
-  are author-written render-phase code walked under this same binding, and
-  an ambient read is exactly as invisible to the collector there.
-
-  An explicitly carried frame is untouched, in this extent as everywhere:
-  `{:frame <id>}` never consults the ambient resolver, and `rf/with-frame`
-  naming THIS boundary's frame still answers inside a body. The refusal
-  deletes the ambient FIND, not the carrying.
-
-  A BODY HAS ONE FRAME, BY CONSTRUCTION. The one case the
-  sentence above does not cover: an `rf/with-frame :b` ENCLOSING a
-  boundary that renders `:a`. Left to carrying alone, core behaves
-  exactly as EP-0002 says — `:b` is carried, so `:b` answers — but the
-  boundary is rendering `:a`,
-  and the collector's reads, the lowered intents and the presence tray all
-  target `:a`. One body, two frames, chosen by which spelling the author
-  reached for, and silent. It is reachable from any host that renders a
-  Hicasso tree inside a scope: a `flushSync` mount under a `with-frame`, an
-  SSR host wrapping `renderToString`, a test fixture that root-binds an
-  ambient frame. So this extent tells core WHICH frame it is rendering
-  (`:extent-frame`) and core refuses a carried stamp that names another —
-  the only carry that stops working is the one that was already wrong.
-  The 2-arity names no frame, so it declares none and nothing is refused
-  there: an extent with no frame of its own has nothing to be mismatched
-  against."
+  The tier is fused into this `binding` rather than wrapped around the
+  call because `binding` pushes its whole set once, so the fence costs no
+  extra frame. Every author-written render-phase walk comes through here
+  — a body, the error boundary's fallback, the presence tray's retained
+  children — since an ambient read is exactly as invisible to the
+  collector in each. Contract: spec/002-Frames.md §The refusal tier;
+  docs/design/hicasso/decisions.md HD-020(a)."
   ([dispatch body-fn] (with-frame nil dispatch body-fn))
   ([frame-kw dispatch body-fn]
    (binding [*frame*                       frame-kw
@@ -165,27 +131,16 @@
 ;; package, and the ambient view and source coordinate come with it.
 
 (defn- require-dispatch
-  "The frame-locked dispatch this lowering needs, or the loud refusal.
-
-  **The message offers TWO readings, because the runtime cannot tell
-  them apart**. `*dispatch*` being `nil` says only that
-  no render window is binding one; it does not say why, and the two
-  whys want opposite repairs:
-
-  1. The form really was lowered outside any boundary — a declaration,
-     a `defhost` fallback, a module-level `def`. Lower it in a body.
-  2. The form was lowered inside a function some foreign component
-     invokes LATER, after the render window that bound the dispatch has
-     unwound. **A function prop on a `[:>]` crossing is exactly this**:
-     the escape carries no declaration, so no position claims the slot
-     and nothing installs the render wrapper that captures the owner's
-     dispatch and forwards to it. From where the author sits they ARE
-     inside a boundary's render — they wrote the crossing in a body — so
-     a message offering only reading 1 reads as a framework bug.
-
-  Naming `defhost`'s `:callbacks {… :render}` is what makes reading 2
-  actionable: a declared `:render` slot is the position that owns the
-  frame, and declaring it is the whole of the repair."
+  "The frame-locked dispatch this lowering needs, or
+  `:rf.error/hicasso-intent-outside-boundary`. The message offers TWO
+  readings because a nil `*dispatch*` cannot tell them apart and they
+  want opposite repairs: the form was lowered outside any boundary (lower
+  it in a body), or inside a function a foreign component invokes after
+  the render unwound — a function prop on a `[:>]` crossing is exactly
+  this, and the repair is to declare it (`defhost` `:callbacks {<prop>
+  :render}`) so the position owns the frame. Drop the second reading and
+  that author, who did write the crossing in a body, reads the error as a
+  framework bug."
   [intent]
   (or *dispatch*
       (fail! :rf.error/hicasso-intent-outside-boundary
@@ -252,22 +207,13 @@
 (def ^:private callback-marker "hicassoFn")
 
 (defn callback
-  "**The one callback form.** Marks `f` so the position it is written at
-  can impose a contract on it — and returns `f` ITSELF, an ordinary
-  function, which is the whole of the deletion.
-
-  A roster design's carriers are marker OBJECTS, so handing one to
-  a position the library does not walk produces the engine's own
-  `TypeError` naming nothing the author wrote. There is nothing here that
-  can fail to be callable: outside every walked position this value is a
-  plain function whose return is ignored, which is a defensible contract
-  rather than a crash.
-
-  `h/event` in the authoring surface; see
-  [[re-frame.hicasso/event]]. Marking mutates the function
-  object, which is safe because a callback written in a body is minted
-  fresh per render — and it is one own-property read to test, with no
-  registry and no map."
+  "The one callback form, `h/event`: marks `f` so the position it is
+  written at can impose a contract, and returns `f` ITSELF — an ordinary
+  function, so outside every walked position it simply runs and nothing
+  can fail to be callable, which is HD-024's deletion of the roster.
+  Marking mutates the function object, which is safe because a callback
+  written in a body is minted fresh per render, and costs one own-property
+  read to test. Design record: docs/design/hicasso/decisions.md HD-024."
   [f]
   (unchecked-set f callback-marker true)
   f)
@@ -279,35 +225,17 @@
   (and (fn? v) (true? (unchecked-get v callback-marker))))
 
 (defn- event-callback
-  "**Event position.** A returned VECTOR is dispatched; anything else is
-  ignored, so the same form serves the live-event case (files, geometry,
-  filters) and the imperative one without the author choosing between two
-  spellings.
-
-  The ambient dispatch is captured at LOWERING time, as everywhere else
-  in this namespace — the browser invokes the callback long after the
-  render's dynamic extent has unwound. It is captured rather than
-  *required*, so a callback that never returns an intent is legal with no
-  frame in scope; returning one there is the loud error, and it names the
-  position.
-
-  **The census-weighted policy defaults do NOT apply here, deliberately.**
-  `:on-submit`'s auto-prevent is a property of the *data* spelling: an
-  intent vector never sees the event, so the runtime must decide for it.
-  A callback is handed the event, so the event is the callback's — it
-  calls `.preventDefault` itself, and the runtime does not reach in after
-  the body has run to second-guess it. One rule: whoever holds the event
-  owns it.
-
-  **Every argument the invoker passes reaches the body**, the same way
-  [[render-callback]] forwards them. A native DOM event position calls
-  with one argument and that is the overwhelming case, but this is also
-  the wrapper a `defhost` `:callbacks` entry declared `:event` gets, and
-  a foreign component's live invoker calls with whatever its own contract
-  says — `(on-change value event)`, `(on-select item index)`. Accepting
-  exactly `[e]` would silently drop everything after the first, or raise
-  an arity error naming nothing the author wrote, against a form whose
-  parameter vector is arbitrary by construction."
+  "Event position: a returned VECTOR is dispatched, anything else is
+  ignored, and every argument the invoker passes reaches the body — a
+  `defhost` `:event` entry or a foreign live invoker may pass several,
+  and a wrapper fixed at `[e]` would drop them or raise an arity error
+  naming nothing the author wrote. The dispatch is captured at lowering
+  time, and captured rather than required: a callback that never returns
+  an intent is legal with no frame in scope, and returning one there is
+  the loud error naming the position. The data spelling's policy defaults
+  do not apply, because a callback holds the event and so owns
+  `.preventDefault` (HD-026, Scope). Design record:
+  docs/design/hicasso/decisions.md HD-024."
   [k f]
   (let [dispatch *dispatch*]
     (fn hicasso-event-callback [& args]
@@ -325,35 +253,24 @@
         nil))))
 
 (defn- render-callback
-  "**Render position.** The callback is invoked by whatever holds it —
-  a slot, a foreign component's render prop — DURING a render, so its
-  return is the render output and is not an intent: it crosses back
-  UNCONVERTED, and a row written as hiccup is turned into an element by
-  the author, with [[re-frame.hicasso.impl.codec/as-element]] (exported
-  as `h/as-element`):
+  "Render position: invoked by whatever holds it DURING a render, so the
+  return is render output, is not dispatched, and crosses back
+  UNCONVERTED — the author makes the element with
+  `re-frame.hicasso.impl.codec/as-element` (`h/as-element`):
 
       (h/event [i]
         (h/as-element
           [:li {:on-click [:row/pick (nth ids i)]} (str (nth ids i))]))
 
-  The wrapper captures the ambient frame AND dispatch at LOWERING time —
-  the supplying boundary's, because it is minted during that boundary's
-  eager `with-frame` + `as-element` walk — and rebinds both for each
-  invocation. That is what makes the row above belong to the boundary
-  that SUPPLIED the callback: its `:on-click` lowers under the owner's
-  frame-locked dispatch and a
-  [[re-frame.hicasso.impl.route-link/route-link]] in it pins its
-  navigation to the owner's frame. Nothing else could own it — the
-  foreign component has no frame of its own, and frames are isolated
-  contexts.
-
-  Dispatching from INSIDE the call is not policed. It is a render, and a
-  programmer does not plausibly write a render prop that dispatches
-  while it runs; where one does, React's own render-phase warnings are
-  the report. A callback lowered with no owner in scope at all rebinds
-  `nil`, so a handler lowered inside it raises the ordinary
-  `:rf.error/hicasso-intent-outside-boundary` — loud, never a silently
-  inert handler. `.preventDefault`-style side effects are untouched."
+  The wrapper captures `*frame*` and `*dispatch*` at lowering time — the
+  SUPPLYING boundary's, the only frame that can own the row — and rebinds
+  both per invocation, so an intent lowered inside fires into that frame.
+  Lowered with no owner in scope it rebinds nil, and a handler lowered
+  inside raises the ordinary `:rf.error/hicasso-intent-outside-boundary`.
+  A dispatch from INSIDE the call is not policed; React's render-phase
+  warnings are the report (rf2-6c12m.20). Design record:
+  docs/design/hicasso/decisions.md HD-024, its 2026-08-03 and 2026-08-30
+  addenda."
   [_k f]
   (let [owner-dispatch *dispatch*
         owner-frame    *frame*]
@@ -366,18 +283,13 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- event-arg!
-  "Answer `e` when it is the DOM event this closure needs, and raise a
-  diagnostic naming the POSITION when it is not. `slot` is the one
-  property the closure is about to read off it — `preventDefault`,
-  `target`, `key` — so the check is the read that was going to happen
-  anyway, and the message can say which capability was missing rather
-  than asserting a type.
-
-  See the namespace docstring §The argument law. The whole point is that
-  a value-first foreign invoker produces THIS error, naming the position
-  and pointing at `h/event`, instead of the engine's
-  `value.preventDefault is not a function` — which names nothing the
-  author wrote and is the failure class HD-024 exists to delete."
+  "Answer `e` when it carries `slot` — the one property the closure is
+  about to read (`preventDefault`, `target`, `key`) — and raise
+  `:rf.error/hicasso-intent-needs-the-event`, naming the position, the
+  intent and what arrived, when it does not. The check is the read that
+  was going to happen anyway; what it buys is that a value-first invoker
+  produces THIS error, pointing at `h/event`, instead of the engine's
+  `value.preventDefault is not a function` (HD-024, the argument law)."
   [k form e slot]
   (if (and (some? e) (some? (unchecked-get e slot)))
     e
@@ -408,9 +320,9 @@
 
 (def prevent-head
   "`::h/prevent` — the FIRST reserved intent HEAD. `[::h/prevent [:app/go]]`
-  at an event position dispatches `[:app/go]` and calls `.preventDefault`
-  first. See [[unwrap-prevent]] for the closed grammar, and the policy
-  defaults above for why it is a head rather than metadata."
+  at an event position calls `.preventDefault` and dispatches `[:app/go]`;
+  `unwrap-prevent` holds the closed grammar. A head rather than metadata
+  because metadata does not participate in `=` (HD-026)."
   :re-frame.hicasso/prevent)
 
 (def navigate-head
@@ -482,9 +394,11 @@
   (boolean (some marker-readers intent)))
 
 (defn materialize
-  "THE ONE PURE MATERIALIZER. Substitute the markers in `intent` with
-  values pulled from the DOM event's target. Top level only — see the
-  namespace docstring."
+  "Substitute the markers in `intent` with values read off the DOM event's
+  target. Pure, and top level only: the corpus writes
+  `[:todo.ui/edit id ::h/value]`, and a deep walk per event to serve a
+  shape nobody writes would be paid on every keystroke of every controlled
+  field."
   [intent e]
   (let [target (.-target e)]
     (mapv (fn [x] (if-some [read-value (marker-readers x)] (read-value target) x))
@@ -496,23 +410,12 @@
 
 (defn composing?
   "Is this key event part of an in-flight IME composition? `isComposing`
-  where the browser sets it, and the legacy keyCode-229 signal where it
-  is all the browser sends.
-
-  **Both signals are read off the NATIVE event**, and that is not
-  defensive tidiness — it is the difference between a live fence and a
-  dead one. React does not hand a handler the browser's event: it hands
-  it a synthetic one built by copying an enumerated interface, and
-  `KeyboardEventInterface` lists key, code, location, the modifier flags,
-  repeat, locale, `charCode`, `keyCode` and `which`. **`isComposing` is
-  not on that list**, so on React it reads `undefined` however plainly the
-  browser set it, and the modern half of this gate would never fire —
-  leaving only the legacy signal, on browsers that happen to send it.
-  Measured at
-  `re-frame.bench.hicasso.arm1.controlled-grid-dom-cljs-test/reacts-synthetic-keyboard-event-drops-is-composing`.
-
-  A raw DOM event has no `nativeEvent`, so it falls back to itself and
-  the node-side unit tests read exactly as they did."
+  where the browser sets it, and the legacy keyCode-229 signal where that
+  is all it sends. Both are read off the NATIVE event: React's synthetic
+  keyboard event copies an enumerated interface that omits `isComposing`,
+  so a gate reading the synthetic event is dead on its modern half
+  (docs/design/hicasso/studio/the-dogfood-preference-case.md). A raw DOM
+  event has no `nativeEvent` and falls back to itself."
   [e]
   (let [native (or (.-nativeEvent e) e)]
     (or (true? (.-isComposing native))
@@ -558,23 +461,14 @@
   (or (prevent-head? v) (navigate-head? v)))
 
 (defn- unwrap-prevent
-  "CLASSIFY AND UNWRAP. `v` is the decorator; answer the intent inside it,
-  refusing anything that is not exactly one inner intent vector.
-
-  **The grammar is closed, and this is the whole of it.** `[::h/prevent
-  INTENT]` — two forms, the second a non-empty vector that is not itself a
-  decorator. Everything else is
-  `:rf.error/hicasso-malformed-prevent`, named at the position it was
-  written at. There is no options map, no second decorator, no modifier
-  language: one reserved head in the same tiny roster as `::h/value`, so
-  the thing that keeps it closed is that the roster is a list rather than
-  a convention.
-
-  It is deliberately NOT a walker. The decorator is recognised at ONE
-  known position — a vector at an event position, which lowering already
-  had in its hand — and the answer is a classification taken once per
-  render. Nothing descends into the intent, and the inner vector stays
-  ordinary data all the way to `dispatch`."
+  "Answer the intent inside the `::h/prevent` decorator `v`, refusing
+  anything that is not exactly `[::h/prevent INTENT]` with a non-empty
+  inner vector that is not itself a decorator
+  (`:rf.error/hicasso-malformed-prevent`, naming the position). The
+  grammar is closed and this is all of it. Not a walker: the
+  classification is taken once per render at the one position lowering
+  already holds, and the inner vector stays ordinary data all the way to
+  `dispatch`. Design record: docs/design/hicasso/decisions.md HD-026."
   [k v]
   (let [inner (nth v 1 nil)]
     (when-not (and (= 2 (count v))
@@ -626,18 +520,15 @@
 
 (defn- navigate-handler
   "Lower one navigate vector into the closure the browser will call. The
-  veto is lowered HERE, at lowering time — a prevent veto needs the
-  ambient dispatch, which is gone by click time — and the click decision
-  itself stays routing's: the closure hands the event to the
-  `:routing/activate-link!` late-bound seam (caller veto first, modifier
-  and native deferral, `preventDefault` + dispatch to the captured frame).
-  When the hook is unbound at click time — the routing artefact
-  hot-reloaded away between render and click — the closure runs the veto
-  and otherwise stands aside, so the browser follows the anchor's real
-  `href`: native navigation, never a throw at a detached click.
-  ([[re-frame.hicasso.impl.route-link/route-link]] already proved
-  routing present at RENDER, so absence here is transient by
-  construction.)"
+  veto is lowered HERE, at lowering time, because a prevent veto needs the
+  ambient dispatch, which is gone by click time; the click decision stays
+  routing's — the closure hands the event to the `:routing/activate-link!`
+  late-bound seam. When that hook is unbound at click time (the routing
+  artefact hot-reloaded away between render and click) the closure runs
+  the veto and otherwise stands aside, so the browser follows the anchor's
+  real `href` rather than throwing at a detached click; `route-link`
+  proved routing present at RENDER, so absence here is transient. Design
+  record: docs/design/hicasso/decisions.md HD-027."
   [k v]
   (let [{:keys [frame payload native? veto]} (unwrap-navigate k v)
         veto-fn (lower-veto k veto)]
@@ -649,21 +540,13 @@
 
 (defn- intent-handler
   "Lower one intent vector into the closure the browser will call. The
-  three axes — prevent, markers, dispatch — are all resolved here, so the
-  event path is the shortest one this intent can have.
-
-  Classification comes FIRST, so the markers compose inside a prevented
-  intent: `[::h/prevent [:filter/set ::h/value]]` is unwrapped before
-  [[markers?]] is ever asked, and the materializer then sees the ordinary
-  intent it has always seen. The navigate head is classified here too —
-  the same one-compare, once per render — and its whole lowering lives in
-  [[navigate-handler]].
-
-  **Only the branches that read the event carry the argument law**
-  ([[event-arg!]], and the namespace docstring's §The argument law): each
-  checks the one property its own first read needs, and the `:else`
-  branch — an intent with no marker and no prevent, which is the
-  overwhelming case — never touches its argument at all, so it costs
+  navigate head is classified first and `navigate-handler` owns it;
+  otherwise prevent, markers and dispatch are all resolved HERE, once per
+  render, so the event path is the shortest this intent can have.
+  Classification precedes marker analysis so the markers compose inside a
+  prevented intent (HD-026). Only the branches that read the event carry
+  the argument law (`event-arg!`); the `:else` branch — no marker, no
+  prevent, the overwhelming case — never touches its argument, so it costs
   nothing and is correct under any invoker contract."
   [k v]
   (if (navigate-head? v)
@@ -686,14 +569,10 @@
 
 (defn- key-map-handler
   "Lower a data key-map into one closure over a plain map of key-string →
-  handler. The map is built once per render; an event costs one
-  composition test and one lookup.
-
-  The argument law applies here too, and the property it needs is `key`:
-  without the check a key-map handed a value-first invoker's first
-  argument would find no `.key`, look nothing up, and do NOTHING — the
-  silently dead handler every loud error in this namespace exists to
-  delete."
+  handler, built once per render; an event costs one composition test and
+  one lookup. The argument law applies through `key`: without it a
+  value-first invoker's first argument would find no `.key`, and the
+  handler would silently do nothing."
   [k key-map]
   (let [lowered (reduce-kv (fn [m key-name v]
                              (assoc m key-name (cond
@@ -709,13 +588,12 @@
           (h e))))))
 
 (defn ref-position?
-  "`:ref` is the one prop position whose contract is neither Hicasso's to
-  select nor the same for both phases: React invokes it in the COMMIT
-  phase with the node, and whatever it returns is the detach cleanup. So
-  it is excluded from callback lowering entirely and keeps its own
-  declared contract (HD-016 callback refs, HD-022's reserved vector) —
-  wrapping it would forbid a dispatch that is legitimate there and would
-  change the identity React uses to decide whether to re-attach."
+  "`:ref` is the one prop position whose contract is not Hicasso's to
+  select: React invokes it in the COMMIT phase with the node, and its
+  return is the detach cleanup. Excluded from callback lowering entirely
+  (HD-016 callback refs, HD-022's reserved vector) — wrapping it would
+  forbid a dispatch that is legitimate there and change the identity React
+  uses to decide whether to re-attach."
   [k]
   (or (= :ref k) (= "ref" k)))
 
@@ -724,7 +602,7 @@
   event position is the only one the attribute grammar can name by
   itself; everything else Hicasso walks is a render position, and a
   `defhost` declaration overrides this by saying so
-  ([[lower-declared-prop]])."
+  (`lower-declared-prop`)."
   [k]
   (cond
     (ref-position? k) :ref
@@ -751,7 +629,7 @@
 
 (defn lower-declared-prop
   "Lower one prop whose contract a `defhost` `:callbacks` entry OVERRIDES:
-  `:event` or `:render`, the two wrappers [[lower-prop]] selects by
+  `:event` or `:render`, the two wrappers `lower-prop` selects by
   spelling, applied where a vendor's spelling is wrong. At `:event` the
   marked form takes the event wrapper and an intent vector or key-map
   lowers as at a native event position; at `:render` the marked form

--- a/implementation/hicasso/src/re_frame/hicasso/impl/intent.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/intent.cljs
@@ -127,9 +127,6 @@
                                              frame-kw (assoc :extent-frame frame-kw))]
      (body-fn))))
 
-;; `fail!` is `re-frame.hicasso.impl.error`'s — one constructor for the whole
-;; package, and the ambient view and source coordinate come with it.
-
 (defn- require-dispatch
   "The frame-locked dispatch this lowering needs, or
   `:rf.error/hicasso-intent-outside-boundary`. The message offers TWO
@@ -158,7 +155,7 @@
              {:intent intent})))
 
 ;; ---------------------------------------------------------------------------
-;; The author-facing frame read — `h/frame`
+;; The author-facing frame read — `hframe`
 ;; ---------------------------------------------------------------------------
 
 (defn hframe

--- a/implementation/hicasso/src/re_frame/hicasso/impl/intent.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/intent.cljs
@@ -1,245 +1,45 @@
 (ns re-frame.hicasso.impl.intent
-  "INTENT LOWERING — the shared front half's ergonomics-as-data.
-  The author writes what should
-  happen, and the front half, not the author, turns it into the closure
-  the browser calls.
+  "Intent lowering: the front half turns what an author writes at an
+  `on-*` prop into the closure the browser calls. It dispatches on the
+  SHAPE of the value, so there is no roster of DOM event names to keep in
+  step with the platform:
 
       [:button {:on-click [:todo/toggle id]} \"done\"]
       [:input  {:on-input [:todo.ui/edit id ::h/value]}]
       [:form   {:on-submit [:todo/create]}]
-      [:input  {:on-key-down {\"Enter\"  [:todo/commit id]
-                              \"Escape\" [:todo.ui/cancel id]}}]
+      [:input  {:on-key-down {\"Enter\" [:todo/commit id] \"Escape\" [:todo.ui/cancel id]}}]
       [:a      {:href \"#\" :on-click [::h/prevent [:todo/show-done]]}]
 
-  authoring.md's whole event surface, and nothing beyond it. Four
-  behaviours, dispatched on the *shape* of the value at an `on-*` prop
-  so that there is no roster of blessed prop names to keep in step with
-  the DOM:
-
-  | value      | lowered to |
-  |------------|------------|
-  | vector     | a closure dispatching that intent |
-  | map        | a composition-gated key-map |
-  | [[callback]] | one form; the POSITION selects its contract — see below |
-  | fn         | passed through untouched — ordinary functions stay legal |
+  | value at an event position | lowered to |
+  |---|---|
+  | vector | a closure dispatching that intent (`intent-handler`) |
+  | map | a composition-gated key-map (`key-map-handler`) |
+  | the one callback form, `h/event` (`callback`) | a wrapper whose contract the POSITION selects — event, render, or `:ref`'s own |
   | anything else | passed through untouched |
 
-  ## ONE callback form, and the position selects the contract (HD-024)
+  Owns the ambient render context (`*frame*`, `*dispatch*`, `with-frame`,
+  `hframe`); the one callback form and its two wrappers; the marker roster
+  (`::h/value`, `::h/checked`) and its one pure materializer; the two
+  reserved heads (`::h/prevent`, and the navigate head `route-link` mints);
+  the composition gate; and the lowering doors `lower-prop`,
+  `lower-declared-prop` and `lower-props`. It does not implement the
+  `defhost` / `[:>]` crossing (`re-frame.hicasso.impl.codec`, HD-011) or
+  the controlled-value restore (`re-frame.hicasso.impl.controlled`, HD-019),
+  which wraps the handler produced here after it has been produced.
 
-  When a vector is not enough, a roster design (the one this ruling
-  rejects) asks the author to pick from FOUR forms, each with a
-  different contract — one
-  returning an event vector, one whose return is ignored, one that is
-  pure and runs during a foreign render, one that passes a function
-  through by identity — and then adds a FIFTH rule about *where the
-  roster reaches*. Outside that reach the failure is not even the
-  library's: a roster carrier handed to a raw `#js` prop is a marker
-  object rather than a function, so the author gets the engine's own
-  `TypeError`, \"naming nothing you wrote\".
+  Three laws every var below assumes. The frame is read ONCE, at lowering
+  time, and the closure closes over it, because a browser event fires
+  long after the render's dynamic extent has unwound (HD-020(a)). The
+  vector spelling is EVENT-FIRST: whatever reads the event takes it from
+  argument one, and a value-first invoker is refused by name rather than
+  left to the engine's `TypeError` (HD-024). And behaviour lives in the
+  vector where `=` can see it — a reserved head, never metadata (HD-026,
+  HD-027).
 
-  Hicasso ships **one** form, [[callback]] (`h/event`), and it is an
-  ORDINARY FUNCTION. The contract comes from the position, because the
-  runtime already knows every position it walks:
-
-  | Position | How it is recognised | Contract |
-  |---|---|---|
-  | an `on*`-spelled prop — on a native tag, a `defhost` or a `[:>]` crossing alike | [[event-prop?]] — the same two-shape rule as an intent vector | **event**: a returned VECTOR is dispatched; any other return is ignored |
-  | any other walked prop (a foreign render prop) | not an event position | **render**: pure. The return is the render output and is NOT dispatched; the wrapper rebinds the frame that supplied it, so an intent inside the returned markup fires into that frame |
-  | `:ref` | [[ref-position?]] | React's own: commit phase, the node as the argument, the return as the detach cleanup. Excluded from lowering entirely |
-  | anywhere Hicasso does not walk — a raw `#js` prop, a value handed to a foreign API | it is not a position | it is a plain function and it simply runs; the return is ignored |
-
-  That last row is the deletion. There is no carrier object, so there is
-  nothing that can fail to be callable, so the fifth rule has nothing to
-  govern.
-
-  **A `defhost` declaration may override the spelling for one prop**,
-  `{:callbacks {:on-render-item :render}}`, for the on*-named render
-  props some vendors ship (Fluent's `onRenderItem`, Ant's `onRow`), where
-  the event wrapper's nil return would blank the UI. The override takes
-  `:event` or `:render` and nothing else, and [[lower-declared-prop]]
-  applies it with the same two wrappers. A declared `:slots` position is
-  markup rather than a callback position and refuses the marked form
-  ([[re-frame.hicasso.impl.codec/host-entry]]). Inference by position at a
-  host is HD-024's own law applied to the crossing; the argument is in
-  docs/design/hicasso/decisions.md, HD-024's 2026-08-29 addendum.
-
-  **A Hicasso view's own props map is not a position — it is data in
-  transit.** An intent vector handed to a view is not lowered there
-  either; the view puts it on an element and *that* position lowers it.
-  A callback travels the same way, and a callback a view simply *calls*
-  is ordinary Clojure with no foreign ABI in between, so there is nothing
-  to protect. Which is also why the render row is not free-floating
-  policy: it bites exactly where something other than Hicasso invokes the
-  callback.
-
-  **`raw-fn`'s identity passthrough is not v0, and costs nothing to
-  omit**: [[re-frame.hicasso.impl.codec/convert-prop-value]]
-  already passes functions to React by identity, deliberately, so that
-  `React.memo` and every downstream bail-out that compares handler
-  identity keep working. The behaviour a roster design spells as a fourth
-  roster form is the default here. The census agrees with the omission —
-  zero foreign components across 85 idiomatic files.
-
-  ## The argument law: the vector spelling is EVENT-FIRST
-
-  One law, and it covers every feature of the vector spelling that reads
-  the event — `::h/prevent`, `::h/value`, `::h/checked`, `:on-submit`'s
-  auto-prevent and the key-map's `.key` lookup alike: **a vector or a
-  key-map takes the DOM event from argument ONE.** That is what every
-  native position hands it, and what an event-first foreign contract
-  (`(on-draft event)`) hands it too.
-
-  A value-first foreign invoker — `(on-pick value event)`, the date
-  picker's `(on-change date)` — has no event at argument one, and there is
-  nothing to guess: the vector cannot know which of the library's
-  arguments is the event, and a runtime that went looking for one would be
-  guessing at a foreign ABI's argument order. **`h/event` is
-  that spelling**, and it needs no rule of its own, because the one form
-  receives every argument the invoker passed, in order.
-
-  What the law buys is that the violation is LOUD.
-  [[event-arg!]] checks the one property the closure is about to read and
-  raises `:rf.error/hicasso-intent-needs-the-event` naming the position,
-  the intent, and the argument that actually arrived. Without it the
-  author gets `value.preventDefault is not a function` — the engine's own
-  `TypeError`, naming nothing they wrote, which is the failure class the
-  whole ruling exists to delete.
-
-  It is paid only by the closures that read the event. An intent carrying
-  no marker and no prevent never touches its argument, so it costs
-  nothing, and it is correct under ANY invoker contract — which is why the
-  overwhelmingly common `[:todo/toggle id]` at a declared position needs
-  no law at all.
-
-  ## The frame, and why the closure closes over it
-
-  HD-020(a): a boundary resolves its frame **once**, from the substrate's
-  single internal context, and binds it ambiently for the render's
-  dynamic extent so inlined helpers and generated callbacks resolve it
-  without hooks of their own. [[*dispatch*]] is that ambient binding —
-  the frame-locked `dispatch` the substrate hands back for this
-  boundary's frame.
-
-  Lowering reads it **at lowering time**, during the render, and the
-  generated closure closes over the value. That is the load-bearing part:
-  the browser invokes these callbacks long after the render's dynamic
-  extent has unwound, and a closure that read an ambient binding *when
-  the click happened* would find nothing there. Reading it eagerly is
-  also the cheaper of the two — one read per lowered props map instead of
-  one per event.
-
-  A vector at an event position with no ambient frame is a loud error,
-  never a silently inert handler.
-
-  [[hframe]] (`h/frame` in the authoring surface) is the AUTHOR-facing
-  half of the same binding — the one door an author has to the frame
-  identity the lowering reads implicitly. See its docstring; the design
-  record is `docs/design/hicasso/studio/hframe-design.md`.
-
-  A RENDER callback ([[render-callback]]) re-establishes that ambient
-  context for its own invocation, out of what it captured when it was
-  lowered, so a row built inside a foreign `renderRow` belongs to the
-  boundary that SUPPLIED the callback — the only frame that can own it.
-
-  ## The marker roster and its one pure materializer
-
-  Two markers, both of which the ruled surface names:
-  `:re-frame.hicasso/value` (authoring.md's `::h/value`) and
-  `:re-frame.hicasso/checked` — the controlled pair HD-010's owned-literal
-  merge law and HD-019's controlled door both speak of. They are ordinary
-  qualified keywords; the namespace segment names the product namespace
-  HD-017 forbids *creating* before P2, which costs a keyword nothing.
-
-  [[materialize]] is the one pure materializer: it substitutes markers at
-  the intent vector's top level, which is the shape the corpus writes
-  (`[:todo.ui/edit id ::h/value]`), and does not walk nested structure —
-  a per-event deep walk to serve a shape nobody writes would be paid on
-  every keystroke of every controlled field.
-
-  **The static/dynamic split is decided once, at lowering time.** An
-  intent carrying no marker lowers to a closure that dispatches a vector
-  it already holds; only a marker-carrying intent pays a materialization
-  per event. Deciding this per render rather than per event is why the
-  controlled path costs one allocation per keystroke and the ordinary
-  button path costs none.
-
-  ## The policy defaults
-
-  - **`:on-submit` auto-prevents** (authoring.md, census-weighted), and
-    the opt-out for the rare form that wants a real submission is the
-    existing `h/event` escape — a callback is handed the event, so the event
-    is the callback's.
-  - **Anywhere else, prevention is opted IN by one reserved head**:
-    `[::h/prevent [:conduit/show-your-feed]]`. It is a head rather than
-    metadata because **metadata does not participate in `=`**, and
-    HD-021's headless door sells itself on intent vectors assertable by
-    equality: `(= [:app/go] ^{::h/prevent? true} [:app/go])` is `true`,
-    so the one axis the annotation carried was the one axis a structural
-    test — or a log, or a snapshot — could not see. `preventDefault`
-    changes the event's `canceled` flag; it is behaviour, and behaviour a
-    spelling hides from the product's own testing story is a defect
-    rather than a taste. A click cannot simply auto-prevent the way
-    submit does: a modifier-click on a real link must still open a tab,
-    so the anchor-acting-as-a-button needs an explicit opt-in and this is
-    its spelling (HD-026).
-  - **The key-map is composition-gated, centrally.** A key event arriving
-    mid-composition commits nothing: `isComposing`, or the legacy
-    keyCode-229 signal that is all some IMEs on some browsers ever send.
-    authoring.md pins the case that must not fire — a composing Enter —
-    and the gate is written over the whole map rather than that one key,
-    because during composition every keystroke belongs to the IME and a
-    per-key exception list is a second place for the law to rot.
-  - Each key-map branch is lowered **once per render** into a plain map
-    of key-string → handler, so an event is one `.-key` lookup and no
-    allocation.
-
-  ## The navigate head
-
-  The SECOND reserved head, and the router-owned counterpart of
-  `::h/prevent`: `[navigate-head {…}]` at an event position is the click
-  half of `re-frame.hicasso.impl.route-link/route-link`. The head is this
-  namespace's own keyword rather than a public marker — `route-link`
-  mints it and no author writes it — and the route-link view puts it on
-  the anchor it builds, carrying the whole click decision AS DATA: the
-  render-captured frame, the routing-owned dispatch payload, the
-  native-attrs verdict, and the caller's veto:
-
-      [:a {:href \"/profile/jane\"
-           :on-click [navigate-head {:frame    :app/frame
-                                     :payload  [:rf.route/url-requested {…}]
-                                     :native?  false
-                                     :veto     nil}]}]
-
-  Same school as the prevent head (HD-026): behaviour in the vector where
-  `=` can see it, classified once at lowering. `route-link` mints the
-  form and nothing else writes it, so the lowering reads the map
-  (`unwrap-navigate`) rather than re-validating it. The click LAW is
-  not restated here: the lowered closure hands the event to
-  routing's own `:routing/activate-link!` late-bound seam — the same one
-  decision `rf/route-link` runs — so caller-veto-first, modifier-click deferral, native-anchor
-  deferral and `preventDefault`-then-dispatch stay routing's law, stated
-  once. A hook that vanished between render and click (dev hot-reload of
-  the routing artefact) degrades to native navigation — the browser
-  follows the real `href` — after running the veto.
-
-  The `:veto` slot is where the two heads compose, and the composition is
-  the existing grammar: `[::h/prevent [:app/event]]` there lowers to the
-  ordinary prevent closure, `activate-link!` runs it FIRST, sees
-  `defaultPrevented`, and stands down — the navigation is cancelled and
-  the app intent dispatched instead. That is the cancelable-navigation
-  case the prevent head was built for, reached with no new machinery. A
-  BARE intent vector at the veto slot is refused loudly: a route click
-  already produces the one routing intent, and a second un-prevented
-  intent site on the same click would be one user action yielding two
-  semantic events (Freehand's route-link law, kept).
-
-  This namespace deliberately does not implement `defhost`/`[:>]`
-  interop (HD-011, its own surface), or any controlled-value restore.
-  HD-019's door belongs to whatever owns the DOM element, which is the
-  emitter rather than the lowering:
-  [[re-frame.hicasso.impl.controlled]] wraps the handler this
-  namespace produced, after it has produced it, and nothing about the
-  lowering changes because of it."
+  Design record: docs/design/hicasso/decisions.md HD-020, HD-024, HD-026
+  and HD-027; the authoring surface in docs/design/hicasso/authoring.md
+  §Event intent as data; the frame read in
+  docs/design/hicasso/studio/hframe-design.md."
   (:require [re-frame.frame :as frame]
             [re-frame.hicasso.impl.error :refer [fail!]]
             [re-frame.late-bind :as late-bind]))

--- a/implementation/hicasso/src/re_frame/hicasso/impl/intent.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/intent.cljs
@@ -207,86 +207,26 @@
 ;; ---------------------------------------------------------------------------
 
 (defn hframe
-  "**`h/frame` in the authoring surface.** The frame id KEYWORD of the
-  boundary currently rendering. A plain function call, legal anywhere in
-  a body, and a loud error outside a render extent.
+  "The frame id KEYWORD of the boundary currently rendering — exported as
+  `re-frame.hicasso/hframe`. A plain function call, legal anywhere in a
+  body and inside a render callback that body supplied, where it answers
+  the SUPPLYING boundary's frame; `:rf.error/hicasso-frame-outside-boundary`
+  anywhere else. Not a tracked read: one dynamic-var read, no collector
+  edge, no hook. The value is process-local identity carried in closures
+  and must never be placed in markup — two same-process SSR renders take
+  two gensyms, and the render-twice determinism witness would go red.
 
-  Spelled `hframe` here for exactly the reason
-  [[re-frame.hicasso/event]] is spelled `event`: the product
-  name is qualified (`h/frame`), and a bare `frame` would shadow the
-  `re-frame.frame` alias that this namespace — and every other namespace
-  in the package — already carries.
-
-  ## What it is FOR, and the honest layering (design §6)
-
-  It serves ONE author: someone at a foreign edge who must hand a
-  dispatching closure to a caller they do not control — an SDK attach
-  ref, a value-first callback on a foreign component, a `defhost`
-  callback slot. What that author captures is not time; it is **frame
-  identity at the one moment it is knowable**.
-
-  Hand-written async *work* is a different problem and this is not its
-  answer. An fx handler already receives the frame id in its ctx and
-  `:dispatch-later` already expresses delay as data; a `setTimeout` in a
-  view that dispatches is mis-layered, and no primitive here is designed
-  for it. `h/frame` does make that spelling *work* — that softening is
-  stated on the design record rather than argued away, and the
-  compensation is that every guide row putting `h/frame` on the page puts
-  `:fx` first.
-
-  ## The carry spelling is COMPOSITION, not a second primitive
-
-      (rf/capture-frame (h/frame))
-
-  Hicasso contributes the deterministic frame READ; core keeps
-  `capture-frame` as what Spec 002 calls *the ONE public carry
-  primitive*. The two-step spelling, against the adapters' one-step
-  `(rf/capture-frame)`, is the taught asymmetry, and it has a one-
-  sentence reason: **ambient frame lookup is what Hicasso's stricter body
-  discipline withdraws** (see [[ambient-frame-refusal]]).
-
-  THE LOAD-BEARING FACT is narrower than it looks. The refusal deletes
-  the ambient FIND, never the carrying, so `rf/with-frame` and
-  `{:frame <id>}` both still answer inside a body — but neither is the
-  author-facing answer, because both *presuppose knowing the frame id*,
-  which is exactly what a reusable view mounted under N frames cannot
-  know. What makes the composition work is that **`capture-frame`'s
-  1-arity never consults the resolver at all**, so
-  `(rf/capture-frame (h/frame))` is refusal-immune by construction, and
-  `h/frame` supplies the id the carrying spellings presuppose.
-
-  ## Why it reads [[*frame*]] and not the runtime's render slot
-
-  Load-bearing, and the difference is visible in one position.
-  [[*frame*]] is rebound to the
-  **supplying** boundary while a foreign component invokes a render
-  callback ([[render-callback]]), where the runtime's own `rstate.frame`
-  is nil — the foreign render runs outside Hicasso's render pass. So
-  reading the binding answers the OWNER's frame inside a render callback
-  for free, and answers it immune to tree position, adapter, renderer and
-  timing. [[re-frame.hicasso.impl.route-link/route-link]] is the
-  internal consumer already doing exactly this.
-
-  ## NOT a tracked read, and it must not become one
-
-  Reads become collector edges because they are sub-KEYS. The frame is
-  not one: it is render-constant per boundary, resolved once by the shell
-  and bound ambiently. This is one dynamic-var read. It appends nothing
-  to the collector scratch, registers no edge and takes no React hook —
-  so the ≤2-hook shell ledger is untouched. Reactivity needs no edge: a
-  frame change is a context change or a
-  remount, and React propagates context to consumers ahead of the memo
-  comparator.
-
-  ## SSR
-
-  Server frames are per-request gensyms destroyed in the render's
-  `finally`, and the body runs on Node through this same path — so this
-  answers the per-request frame id and per-request isolation holds by
-  construction. **The value is process-local identity, carried in
-  closures, and must never be placed in markup**: two same-process
-  renders take two gensyms, so rendering it would break the render-twice
-  determinism the SSR witnesses assert."
+  It exists so a body can compose the one carry primitive without the
+  ambient find this substrate's render discipline withdraws:
+  `(rf/capture-frame (hframe))` is refusal-immune because `capture-frame`'s
+  1-arity never consults the resolver, and `hframe` supplies the id the
+  carrying spellings presuppose. It reads `*frame*` rather than the
+  runtime's render slot because only the binding is rebound to the
+  supplying boundary during a render callback. Spelled `hframe` because a
+  bare `frame` would shadow the `re-frame.frame` alias this namespace
+  carries. Design record, rejections and witnesses:
+  docs/design/hicasso/studio/hframe-design.md; its retirement is the open
+  question at docs/design/hicasso/product/naming-ledger.md row 18."
   []
   (or *frame*
       (fail! :rf.error/hicasso-frame-outside-boundary
@@ -484,79 +424,29 @@
   ::navigate)
 
 (defn- target-value
-  "The event target's current value — `.value`, except on the two controls
-  where `.value` is not it. One is corrected, one is refused, and the
-  difference between those two answers is the whole of this docstring.
+  "The event target's current value: `.value`, except on the two controls
+  where `.value` is not it. A `<select multiple>` answers its SELECTION as
+  a vector of option values, `[]` when nothing is picked — `.value` there
+  is only the first selected option, and `::h/value` already means the
+  control's current value, so this is a correction; fed back as `:value`
+  it round-trips, because the codec hands React an array. An
+  `<input type=\"file\">` is refused
+  (`:rf.error/hicasso-file-input-value-marker`): `.value` there is the
+  `C:\\fakepath\\` fiction naming one file of many, and the guide keeps
+  file inputs off the marker's surface on purpose, so answering with a
+  `FileList` would widen the marker onto a control the design excludes.
+  The asymmetry is argued at spec/009-Instrumentation.md, the row for that
+  id, and docs/design/hicasso/product/dispositions.md (Select (multiple),
+  File input).
 
-  ## The file input, refused
-
-  On an `<input type=\"file\">`, `HTMLInputElement.value` is in FILENAME
-  MODE: it answers the literal fiction `C:\\fakepath\\` followed by the
-  FIRST selected file's name. So `[:app/upload ::h/value]` on a file input
-  is a correct-looking expression that quietly means something else — it
-  names one file out of however many were chosen, over a path the spec
-  mandates as a deliberate privacy fiction, which nothing downstream can
-  open or turn back into a `File`. Same silence as the multi-select below,
-  same plausible-but-wrong string.
-
-  **It is refused rather than corrected, and the guide is what decides
-  that.** The multi-select was a correction because `::h/value` already
-  meant *the control's current value* and a multi-select's current value
-  IS its selection — the marker was answering its own question badly. A
-  file input is not that case: chapter 04's supported-controls table rules
-  it OUT of the marker's surface on purpose (`no controlled value`, with
-  `:on-change` and an `h/event` reading `.files` as the whole of its event
-  form, *because the platform owns their value*), and answering with a
-  `FileList` here would WIDEN the marker onto a control the design
-  deliberately excludes. The same chapter states the posture that settles
-  it: unsupported controlled shapes are rejected rather than approximated.
-  Handing back the fakepath string is an approximation; so is quietly
-  substituting `.files` for what the author asked for.
-
-  `.files` is the test because it is the discriminator the platform
-  already provides: it is a `FileList` on this control, `null` on every
-  other `<input>`, and absent entirely off an input. It is asked FIRST
-  because this is the one control that must not reach `.value` at all —
-  the cost is one property read on the marker path, and no allocation.
-
-  ## The multi-select, corrected
-
-  HTML defines `HTMLSelectElement.value` as *the value of the first
-  option in tree order whose selectedness is set*, and that definition
-  does not change for a `multiple` select. So on a multi-select `.value`
-  answers a plausible non-empty string that is **not** the selection: the
-  user picks two options, `[:tb/pick ::h/value]` lowers to one, the
-  controlled echo writes that one back, and the second choice is
-  discarded inside the turn. Nothing throws, nothing warns, and the shape
-  is indistinguishable from a single select's honest answer — which is
-  what makes it the worst kind of wrong, and why this is a correction
-  rather than a refusal or a second marker. `::h/value` already means
-  *the control's current value*; a multi-select's current value is its
-  selection, and it always was.
-
-  A selection is a LIST, and `[]` when nothing is picked. That is not
-  invented here: `spec/004B-UI-Tree-and-Conversion.md` rules it for the
-  same DOM control in its conversion contract — \"a `<select multiple>`'s
-  value is not a scalar — what is selected is the *list* of chosen option
-  values\", with the empty selection the empty collection rather than
-  `\"\"`. Fed straight back as `:value` it round-trips, because
-  [[re-frame.hicasso.impl.codec/convert-prop-value]] hands a CLJS vector
-  to React as an array and React's `updateOptions` takes an array on a
-  multiple select.
-
-  ## Why the test is `.multiple` AND `.selectedOptions`
-
-  `.multiple` alone is the wrong test and would break a working control:
-  `<input type=\"email\" multiple>` carries it too and has no selection to
-  read. (`<input type=\"file\" multiple>` carries it as well, and never
-  reaches this branch — it is refused above.) Only a `<select>` has
-  `.selectedOptions`, so asking for it is what confines this branch to
-  the control it is about.
-
-  `.multiple` is asked FIRST of the two select tests because it is
-  `undefined` on every element that is not one of those three, so the
-  overwhelming case — a text field — reaches `.value` on one extra
-  property read and no allocation."
+  `.files` is asked FIRST because it is the platform's own discriminator —
+  a `FileList` on a file input, `null` on every other input — and this is
+  the one control that must not reach `.value` at all. The select test is
+  `.multiple` AND `.selectedOptions`, because `<input type=\"email\"
+  multiple>` carries `.multiple` and has no selection to read, while only a
+  `<select>` has `.selectedOptions`; `.multiple` is asked first because it
+  is `undefined` off those controls, so a text field reaches `.value` on
+  one extra property read and no allocation."
   [target]
   (when (.-files target)
     (fail! :rf.error/hicasso-file-input-value-marker


### PR DESCRIPTION
Docstring-and-comment pass executing ruling rf2-6c12m.4 (Option A) over `implementation/hicasso/src/re_frame/hicasso/impl/intent.cljs` — the intent slice of rf2-76hbj (one worker per file; mount #8778 and codec #8777 are merged, `impl/collector.cljs` is a sibling worker's). Each docstring now carries what the var is or returns, the contract, one sentence of why, and a repo-relative path into the design tree; a comment survives only as a local correctness proof. **No behaviour change**: a code-only comparator (docstrings and comments stripped, whitespace normalised) reads the 288 code lines identical before and after, and `test:cljs` on the final tree reads 11,075 tests, the count at #8779's tip. The shape copies #8777: one commit per chunk (namespace docstring; the two long essays; the rest; the comment), a per-essay disposition table, and a planted-anchor control on `check_doc_slugs.py`.

Two things the trim found rather than carried. **rf2-6c12m.20 was never recorded on HD-024**: its 2026-08-03 addendum still describes the render-position poison gate and `:rf.error/hicasso-dispatch-in-render-position`, both deleted by PR #8746, and Spec 009 struck the row without `decisions.md` saying so — so `render-callback`'s "a dispatch from inside the call is not policed" was a ruling with no home, and it is **moved** to a dated 2026-08-30 addendum on HD-024 rather than deleted. And `composing?` cited its witness at `re-frame.bench.hicasso.arm1.controlled-grid-dom-cljs-test/reacts-synthetic-keyboard-event-drops-is-composing`, a namespace that no longer exists at tip; the finding is recorded at `studio/the-dogfood-preference-case.md`, which is what the docstring now cites.

**The `hframe` decision (rf2-6c12m.13 is operator-held on rf2-t32wg).** Its docstring is trimmed to the contract as it stands — the frame id keyword, legal in a body and in a render callback the body supplied, loud outside, not a tracked read, never in markup — with the one-sentence why (the composed carry `(rf/capture-frame (hframe))` is refusal-immune because `capture-frame`'s 1-arity never consults the resolver) and `studio/hframe-design.md` cited for the verdict, rejections, layering and witnesses. The "spelled `hframe` here for exactly the reason" proof is **kept**, as a local correctness proof under rule 4: the plausible-but-wrong edit is renaming the var `frame` to match the taught name, which would shadow the `re-frame.frame` alias this namespace reads two forms above (`frame/*ambient-frame-refusal*`). Nothing pre-empts the ruling in either direction: the docstring names neither a retirement nor a keep, and points at naming-ledger row 18 as where the open question lives.

Fence: `codec.cljs`, `mount.cljs`, `route_link.cljs` and `collector.cljs` untouched — where an intent docstring explained their mechanism it now cites the owner. The one docs edit is an addendum inserted at the top of HD-024's addenda; the sibling collector worker may also append to `decisions.md`, and on rebase both intents are kept. No hot-zone file touched. `origin/main` has moved by beads checkpoints only since the branch was cut at 587031bc00, so no rebase was needed.

## Quality gates

Every gate ran foreground from this worktree with its exit code captured to a per-attempt file; the number quoted is the captured one. The shadow-cljs runs print the config path, which named this worktree on every run. The final `intent.cljs` content is that of the fourth commit; the fifth touches `decisions.md` only, so compile, lint and `test:cljs` stand for the head tree.

| Gate | Attempt | Captured exit | Counts |
|---|---|---|---|
| `npm run test:hicasso-compile` | 1 (ns docstring) | 0 | 11 namespaces, 0 warnings |
| `npm run test:hicasso-compile` | 2 (hframe, target-value) | **1** | a `\\` in the new `target-value` docstring had collapsed to `\` (`Unsupported escape character: \``, line 435) — a real defect in the edit, fixed by hand |
| `npm run test:hicasso-compile` | 3 (hframe, target-value, fixed) | 0 | 11 namespaces, 0 warnings |
| `npm run test:hicasso-compile` | 4 (remaining docstrings) | 0 | 11 namespaces, 0 warnings |
| `npm run test:hicasso-compile` | 5 (comments; final `intent.cljs`) | 0 | 11 namespaces, 0 warnings |
| `npm run test:hicasso-lint` | 1 (final `intent.cljs`) | 0 | self-test PASS; 6 checks fire on fixtures, correct code silent, testbeds quiet |
| `npm run test:cljs` | 1 (final `intent.cljs`) | 0 | 1,854 files, 0 warnings; **11,075 tests, 54,263 assertions, 0 failures, 0 errors** |
| `python scripts/check_doc_slugs.py` | 1 (addendum, no link) | 0 | — |
| `python scripts/check_doc_slugs.py` | 2 (addendum with the Spec 009 link) | 0 | — |
| `python scripts/check_doc_slugs.py` | 3 (planted anchor — the control) | **1** | `BROKEN ANCHOR: docs\design\hicasso\decisions.md:2016 -> ../../../spec/009-Instrumentation.md#error-event-catalogue-no-such-anchor` |
| `python scripts/check_doc_slugs.py` | 4 (restored) | 0 | — |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | 1 (committed addendum) | 0 | 1 page inspected, 5 cited pins — 4 landed, 1 stranded accompanied in scope, 0 findings (the pins are the page's existing ones; the addendum cites no commit hash) |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | 2 (head tree) | 0 | same |

Not run: no browser gate — nothing here reaches the DOM and no headless Chromium was started. `mkdocs build` never sees `docs/design` and is not nominated.

## Controls

**The plantable gate is `scripts/check_doc_slugs.py`**, since `docs/design/hicasso/decisions.md` changed. Planted on a line this PR added — the addendum's link to Spec 009's error catalogue — by appending `-no-such-anchor` to the anchor (fixed-string replace, match count 1, from a clean committed tree). The gate went red naming file, line and anchor (table above). Restored with `git checkout HEAD -- docs/design/hicasso/decisions.md`; the file's blob hash read `3d0c1930d39429b0201b678418294a75136e0e55` before the plant, `d1ffb8b723ce659ada842bb17098d7ca7b52dfca` while planted, and `3d0c1930d39429b0201b678418294a75136e0e55` after the restore and at `HEAD:` — the restore is verified by content, and the fault existed only in this worktree, so the red proves the gate read this tree.

**The no-behaviour-change control** is a comparator that strips docstrings and comments with the same scanner as the measurement below and diffs the remaining lines whitespace-normalised: `origin/main`'s `intent.cljs` against this branch's reads **288 code lines before, 288 after, identical** (exit 0). Its own control: the same comparator against a copy with one code token changed (`(nth v 1 nil)` → `(nth v 2 nil)`) reads not-identical and exits 1, naming the line.

**The src docstrings have no automated content gate beyond compile and lint.** Hand-checked at this tip (a script listed every repo-relative `.md` path cited in the file and tested existence, with a planted `docs/design/hicasso/no-such-page.md` correctly reported missing as its control) — all 8 present: `docs/design/hicasso/authoring.md`, `docs/design/hicasso/decisions.md`, `docs/design/hicasso/product/dispositions.md`, `docs/design/hicasso/product/naming-ledger.md`, `docs/design/hicasso/studio/hframe-design.md`, `docs/design/hicasso/studio/the-dogfood-preference-case.md`, `spec/002-Frames.md`, `spec/009-Instrumentation.md`. The sections and rows named beside them exist: `authoring.md` §Event intent as data; HD-002, HD-011, HD-016, HD-019, HD-020, HD-022, HD-024 (with its 2026-08-03 and 2026-08-30 addenda), HD-026, HD-027; `dispositions.md` rows Select (multiple) and File input; naming-ledger row 18; `hframe-design.md` §3, §8a and §9(4); `the-dogfood-preference-case.md`'s `KeyboardEventInterface` finding; `spec/002-Frames.md` §The refusal tier — a substrate may withdraw the ambient find; Spec 009's `:rf.error/hicasso-file-input-value-marker` row. Symbols named in prose resolve at source: `re-frame.hicasso.impl.route-link/route-link`, `re-frame.hicasso.impl.codec/as-element`, `re-frame.frame/*ambient-frame-refusal*` (`implementation/core/src/re_frame/frame.cljc`), `re-frame.hicasso/hframe`. No `[[wikilink]]` remains in any docstring or comment; the one `[[` a raw grep still finds is `(fn [[k v]] …)` destructuring in `lower-props`. The ns docstring's value-shape table was hand-counted (2 columns × 4 rows).

## Essays

Per essay: **moved to** a path, **deleted — duplicated at** a path, or **deleted — superseded**. "Kept" means it survived as a contract clause or a local proof at its var.

### The namespace docstring (241 lines → 41)
| Essay | Disposition |
|---|---|
| Opening and the value-shape table | kept, compressed; the table now names the lowering var per row |
| §ONE callback form, and the position selects the contract — the four-form roster critique, the position table, the `defhost` override, "a view's props map is not a position", `raw-fn`'s identity passthrough and the 85-file census | deleted — duplicated at `decisions.md` HD-024 (the ruling table, Rationale, and the 2026-08-29 addendum) and `authoring.md` §When a vector is not enough; the contract kept as one table row |
| §The argument law: the vector spelling is EVENT-FIRST | deleted — duplicated at HD-024 "The vector spelling is EVENT-FIRST" and `authoring.md`; kept as the second of the three laws and at `event-arg!` |
| §The frame, and why the closure closes over it (HD-020(a), lowering-time read, the render-callback owner) | deleted — duplicated at HD-020(a) and `hframe-design.md` §3; kept as the first law; the owner rule lives at `render-callback` |
| §The marker roster and its one pure materializer (the HD-017 namespace-segment remark; top level only; the static/dynamic split) | the HD-017 remark deleted — an HD derivation; the top-level why kept at `materialize`; the once-per-render split kept as a clause at `markers?` and `intent-handler`; the author-facing rule is `docs/core/hicasso/03-events-as-data.md`'s |
| §The policy defaults (`:on-submit` auto-prevent; head not metadata with the `=` probe; the modifier-click argument; the composition gate; once-per-render key-map) | deleted — duplicated at `authoring.md` §Event intent as data and `decisions.md` HD-026 (Ruling, Scope, Rationale); the "head, never metadata" why kept as the third law and at `prevent-head` |
| §The navigate head (the example, the `:veto` composition with `::h/prevent`, hot-reload degradation, the bare-vector refusal) | deleted — duplicated at `decisions.md` HD-027 (Ruling, Composition, the 2026-08-29 and 2026-08-30 amendments); the contract kept at `navigate-head`, `lower-veto` and `navigate-handler` |
| Closing paragraph (does not implement `defhost`/`[:>]` or the controlled restore) | kept as one sentence naming the owners |

### Function docstrings and comments
| Essay | Disposition |
|---|---|
| `*dispatch*` | untouched |
| `*frame*` | kept, compressed; wikilinks replaced by paths |
| `ambient-frame-refusal` (24): why the generic `no-frame-context` advice is wrong here | deleted — duplicated at `hframe-design.md` §5(d) and `spec/002-Frames.md` §The refusal tier; the three-recoveries proof kept (a local correctness proof for the reason text), §9(4) cited |
| `with-frame` (42): the fused binding's cost; the three doors it covers; "A BODY HAS ONE FRAME, BY CONSTRUCTION" | the cost and the coverage kept as one sentence each; the `:extent-frame` derivation deleted — duplicated at `spec/002-Frames.md` §The refusal tier ("One exception, opt-in and substrate-declared") and `hframe-design.md` §8a; the contract kept as two clauses |
| `require-dispatch` (21): the two readings of a nil dispatch | kept, compressed (a local proof for the message's second reading) |
| `hframe` (80): §What it is FOR and the layering (design §6); §The carry spelling is COMPOSITION and THE LOAD-BEARING FACT; §Why it reads `*frame*`; §NOT a tracked read; §SSR | deleted — duplicated at `hframe-design.md` §1, §6, §2(3), §3, §4 and §7 respectively (cited); each kept as one sentence or clause of contract; the spelling proof kept (local; also at §8a); naming-ledger row 18 cited for the held retirement — see the hframe decision above |
| `callback` (16): the marker-object critique of a roster design | deleted — duplicated at HD-024 Rationale; contract and the mutation-safety proof kept |
| `callback?` | untouched |
| `event-callback` (29): the policy defaults do not apply; every argument reaches the body | the defaults paragraph deleted — duplicated at HD-026 Scope (cited); the forwarding contract kept (HD-024 carries the argument); captured-not-required kept |
| `render-callback` (29): "nothing else could own it"; "dispatching from inside is not policed" | the ownership derivation deleted — duplicated at HD-024's 2026-08-03 addendum; the not-policed ruling **moved to** `docs/design/hicasso/decisions.md` HD-024, 2026-08-30 addendum; the `h/as-element` example kept (it removes the unconverted-return ambiguity) |
| `event-arg!` (12) | kept, compressed; the failure-class sentence deleted — duplicated at HD-024 |
| `value-marker`, `checked-marker`, `navigate-head` | untouched |
| `prevent-head` | kept; wikilink replaced by the var name; HD-026 cited |
| `target-value` (73): §The file input, refused (the fakepath fiction; refused rather than corrected, via chapter 04) | deleted — duplicated at `spec/009-Instrumentation.md`'s `:rf.error/hicasso-file-input-value-marker` row (cited); the refusal kept as contract with its one-sentence why |
| `target-value` §The multi-select, corrected (HTML's `.value` definition, the discarded second choice, the `spec/004B` list ruling, React's `updateOptions`) | deleted — duplicated at `docs/design/hicasso/product/dispositions.md` Select (multiple) row (cited); the correction kept as contract |
| `target-value` §Why the test is `.multiple` AND `.selectedOptions`; the ask-order | kept, compressed (local correctness proofs) |
| `marker-readers` (`identical?` is the wrong test) | untouched (local proof) |
| `markers?` | untouched |
| `materialize` | kept; the top-level-only why moved into the var from the ns docstring |
| `composing?` (18): the `KeyboardEventInterface` enumeration; the bench witness citation | the enumeration deleted — duplicated at `studio/the-dogfood-preference-case.md` (cited); the native-event proof kept as one sentence; the citation of a namespace absent at tip deleted — superseded |
| `re-event-prop`, `event-prop?`, `prevent-head?`, `navigate-head?`, `reserved-head?` | untouched |
| `unwrap-prevent` (17): "no options map, no second decorator, no modifier language" | deleted — duplicated at HD-026 Scope (cited); contract and the not-a-walker proof kept |
| `lower-veto`, `unwrap-navigate` | untouched (already at the rule; HD-027 cited) |
| `navigate-handler` (13): the click law in parenthesis | deleted — routing's law, HD-027 (cited); contract and the hot-reload degradation kept |
| `intent-handler` (17), `key-map-handler` (9), `ref-position?` (7) | kept, compressed; wikilinks replaced by var names |
| `position-contract`, `lower-prop`, `lower-declared-prop`, `lower-props` | untouched except wikilinks replaced by var names |
| The `fail!` comment | deleted — explains `impl.error`'s constructor |
| Section banners | kept, as #8777 kept them; the frame-read banner now names `hframe` rather than `h/frame` |

## Measured

Same scan method as the rf2-6c12m.4 measurement and #8777/#8778 (a prose line is inside a string literal following `(ns` / `(def…` / `:doc`, or starts with `;`; blanks in the total only). The scanner reproduces the filing worker's figures for this file at d9e5685e9c exactly (1,087 = 730 + 23 + 287, `hframe` 80, `target-value` 73), which is its calibration; the +6 docstring lines at 587031bc00 are #8779's. `[[` is a raw occurrence count.

| File | Lines before → after | Docstring lines | Comment lines | Code lines | `[[` | Docstrings over 30 / over 100 | Longest after |
|---|---|---|---|---|---|---|---|
| `impl/intent.cljs` | **1,093 → 658** | **736 → 304** | **23 → 21** | 287 → 287 | **36 → 1** (code) | 4 / 1 → 1 / 0 | ns, 41; then `target-value` 23, `with-frame` 21, `hframe` 20 |

Prose share 72% → 53%. Docs: `+18` on `docs/design/hicasso/decisions.md` (one dated HD-024 addendum). No studio page: the file carries no measurement table — its one figure, the 85-file census, is HD-024's already.
