### PR TITLE
hicasso(generation): trim docstrings to the contract against the collector section (rf2-9kqn4)

### DIFF
--- a/implementation/hicasso/src/re_frame/hicasso/impl/generation.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/impl/generation.cljs
@@ -1,25 +1,13 @@
 (ns re-frame.hicasso.impl.generation
-  "THE COMMIT BASIS — the three monotone numbers invariant 5 is judged
-  against, and the only doors that advance them.
-
-  Everything here is a counter and a read of a counter. That is the
-  ownership boundary: the collector *consults* the basis on four hot
-  paths and *advances* it on two, and a number whose increment can be
-  written from anywhere is a number nobody can reason about. Both
-  volatiles are private and both bumps are named, so
-  `git grep bump-generation!` is the complete list of writers.
-
-  The basis is deliberately arithmetic over three independent terms
-  rather than one counter, because each term sees a movement the other
-  two are structurally blind to. [[commit-basis]] says which, and why the
-  fourth axis — a same-id frame reincarnation — is not carryable here at
-  all.
-
-  **The HMR contract lands on this file.** A reload
-  re-registers `:sub` handlers, which is exactly what [[registry-epoch]]
-  counts and exactly what the collector's cell-invalidation repair rides;
-  a reload that must promise identity, focus and state across a save has
-  to say what it does to these three numbers."
+  "The commit basis: the three monotone counters Spec 006 invariant 5 is
+  judged against, and the only doors that advance the two this runtime
+  owns (the third, the frame's install epoch, is the substrate's and is
+  read here, never written). The collector consults the basis on four
+  paths and advances it on two; both volatiles are private and both bumps
+  are named, so a grep for the two `bump-` doors is the complete list of
+  writers, because a counter anything can increment is a counter nothing
+  can reason about. Why the basis has three terms and what each one sees
+  is docs/design/hicasso/architecture.md, section The collector."
   (:require [re-frame.frame :as frame]))
 
 (defonce ^:private !generation (volatile! 0))
@@ -33,124 +21,60 @@
 (defn bump-generation!
   "Advance the flush generation. The collector's `flush!` is the only
   caller, and it calls it exactly once per flush that found a dirty cell
-  — which is what makes [[generation]] a count of *commits that moved
+  — which is what makes `generation` a count of *commits that moved
   something* rather than of flush attempts."
   []
   (vswap! !generation inc)
   nil)
 
 (defn registry-epoch
-  "**The runtime's own count of `:sub` registrations** — first-time and
-  replacement alike — and the third term of [[commit-basis]].
-
-  It is the runtime's rather than the substrate's on purpose: the
-  runtime already installs a registration hook for
-  [[re-frame.hicasso.impl.collector/first-registration!]], so the counter
-  is a `vswap!` on a hook that runs anyway rather than a new public
-  reader on a production namespace. Monotone, like both other terms."
+  "The runtime's own count of `:sub` registrations, first-time and
+  replacement alike, and the third term of `commit-basis`. Monotone.
+  Counted here rather than exposed by the substrate because the collector
+  already installs a registration hook, so the counter is a `vswap!` on a
+  hook that runs anyway rather than a new public reader on a production
+  namespace. A hot reload re-registers `:sub` handlers, which is exactly
+  what this counts (`hmr_registry_cljs_test`)."
   []
   @!registry-epoch)
 
 (defn bump-registry-epoch!
   "Advance the registry epoch. Called from the collector's single
-  registration hook, BEFORE that hook scans the cells — a render racing
-  the scan must not see an epoch from before the registration it is about
-  to read against. See
-  [[re-frame.hicasso.impl.collector/sub-registered!]], which is where the
-  ordering is stated and enforced."
+  registration hook (`sub-registered!`), BEFORE that hook scans the cells:
+  the scan drops reaction references, and a render racing it must not see
+  an epoch from before the registration it is about to read against."
   []
   (vswap! !registry-epoch inc)
   nil)
 
 (defn commit-basis
-  "**The number both invariant-5 windows are judged against** — this
-  runtime's flush [[generation]], plus `frame`'s own physical-install
-  epoch (`re-frame.frame/frame-commit-epoch`, the substrate's read-evidence
-  counter, bumped once per frame-state install
-  at both write chokepoints), plus the runtime's [[registry-epoch]].
+  "The number a staged read is judged against: this runtime's flush
+  generation + the frame's install epoch (`re-frame.frame/frame-commit-epoch`)
+  + the registry epoch. Monotone within a frame incarnation, so any sum of
+  bases and cell stamps is too; install-counting rather than `=`-counting,
+  so a value-equal install still advances it (one redundant re-render at
+  worst, never a missed one). Pure read; allocates nothing.
 
-  The generation alone cannot carry it, and the reason is structural
-  rather than a matter of degree: the generation moves only through
-  `mark-dirty!`, whose only caller is the value-change watch
-  [[re-frame.hicasso.impl.collector/acquire-cell!]] installs **at
-  commit**, so a key nothing holds yet can move without moving it. The
-  frame's install epoch has no such dependency — it is a counter read,
-  not a watch — which is exactly why it is the thing to ask whether durable
-  state moved in the render→commit gap. And
-  neither of them is a registry write, so the third term is what carries
-  a `reg-sub` landing in that gap.
-
-  All three terms are monotone within a frame incarnation, so the basis
-  is, and so is any sum of bases and cell epochs. Deliberately
-  install-counting rather than `=`-counting: a value-equal install still
-  advances it, which costs at most one redundant re-render and cannot
-  cost a missed one. Pure read; allocates nothing.
-
-  ## Why the registry term costs the mounted case nothing
-
-  **The term belongs in the basis and nowhere else.** The basis is read
-  live by exactly one branch of
-  [[re-frame.hicasso.impl.collector/make-snapshot]]'s sum: **a key no
-  cell holds yet**. A held key contributes its cell's *frozen* stamp,
-  which no registration touches. Putting a registry term in every key's
-  live contribution instead would move every mounted boundary's number on
-  every `reg-sub` in the application, and buy a re-render that read
-  straight back through a dead cell.
-
-  So the reach of the term is precisely the set of keys inside a
-  render→commit gap, which is the set of keys that have the defect. A
-  mounted boundary holds a reference to every key it reads, so it has no
-  staged term at all and an unrelated `reg-sub` moves its snapshot by
-  zero — `a-first-registration-of-an-id-no-cell-holds-disturbs-nothing`
-  asserts exactly that, and it is what keeps the two placements
-  distinguishable.
-
-  Conservative in the safe direction and only there, exactly as the
-  install term is: a boundary mounting as an *unrelated* module registers
-  its subs re-renders once for nothing. A MISSED move would be the P0,
-  and adding a monotone term to a monotone sum cannot cause one.
-
-  Silent on one axis, and permanently so: a same-id frame reincarnation
-  RESTARTS `frame-commit-epoch` at 0, so the basis TIES across the
-  reincarnation, which is the case Spec 006 invariant 5's `:node-key` axis
-  exists for. That axis is not this number's to carry. The
-  transition leaves the cell holding a reaction that can no longer answer
-  for its key, so a moved number would only buy a re-render that read
-  back through the same dead reference.
-  [[re-frame.hicasso.impl.collector/invalidate-cell!]] carries the
-  *held*-cell half of all three axes; this term carries the *staged* half
-  of the registry one, where there is no dead reference to read back
-  through because the commit acquires against the live registration.
-
-  ## Why the generation term stays (rf2-6c12m.19)
-
-  On every path that reaches `flush!` the frame's install epoch has
-  already moved, so the generation looks like a term the frame epoch
-  covers. It is not, and the counter-example is the reincarnation above
-  read from the STAGED side: a boundary renders a key no cell holds
-  (snapshot = the live basis), the frame is destroyed and remade under
-  the same id before that boundary commits, and the successor's install
-  count happens to equal the predecessor's at render — the frame term
-  ties, and the staged key moved no watch, so nothing it read bumps the
-  generation. What does is the side effect on any OTHER cell the frame
-  holds: its reaction dies with the frame, the microtask rewire marks it
-  dirty, and that flush bumps the generation, which the staged boundary
-  reads through the basis at commit. Measured
-  (`staged_reincarnation_basis_cljs_test`): with the term, `basis@commit`
-  differs from `basis@render` and React's post-subscribe re-read
-  corrects the boundary; with `@!generation` removed from the sum both
-  read 4, React sees no tear, and the boundary keeps the predecessor's
-  value on screen until the next write to its key. A partial cover — a
-  frame holding no other cell has nothing to rewire and ties either
-  way — but the half it covers is the P0 class, so the term is kept."
+  Three terms because each sees a movement the other two cannot: the
+  generation moves only through a committed cell's watch, the install
+  epoch is a plain counter, and only the registry term carries a
+  `reg-sub` landing in the render→commit gap — and it belongs in the
+  basis, which only a staged key reads live, so an unrelated registration
+  moves no mounted boundary (`hmr_registry_cljs_test`). The generation
+  term is load-bearing across a same-id reincarnation, where the frame
+  term restarts and can tie: any other cell the frame holds is rewired by
+  microtask and that flush bumps the generation
+  (`staged_reincarnation_basis_cljs_test`, rf2-6c12m.19); a frame holding
+  no other cell ties either way, which is Spec 006 invariant 5's
+  `:node-key` axis, not this number's. Full argument:
+  docs/design/hicasso/architecture.md, section The collector."
   [frame-kw]
   (+ @!generation (frame/frame-commit-epoch frame-kw) @!registry-epoch))
 
 (defn reset-basis!
-  "Zero both terms this namespace owns. The teardown half, called by
-  [[re-frame.hicasso.impl.collector/reset-runtime!]] and by nothing else
-  — the frame's install epoch is the substrate's and is not this door's
-  to touch."
+  "Zero both terms this namespace owns: the teardown half of the
+  collector's `reset-runtime!`, its only caller. The frame's install
+  epoch is the substrate's and is not this door's to touch."
   []
   (vreset! !generation 0)
   (vreset! !registry-epoch 0)


### PR DESCRIPTION
Docstring-only pass over `implementation/hicasso/src/re_frame/hicasso/impl/generation.cljs` executing ruling rf2-6c12m.4 (Option A) — the follow-on rf2-9kqn4 to rf2-76hbj, whose collector slice (#8781) moved the commit-basis argument into `docs/design/hicasso/architecture.md` and reported that this file still carried it. Each docstring now carries what the var is or returns, the contract, one sentence of why, and a repo-relative path into the design tree; the file has no `;` comments before or after. **No behaviour change**: the code lines are byte-identical to trunk with strings and comments stripped (33 before and after), and `test:cljs` reads the 11,075 tests #8779's tip had. One commit; no docs page changes; no hot-zone file.

**The premise held at tip, with one correction on the deftest.** At the branch base f20806f1c1 the file was 157 lines with 12 `[[wikilinks]]` and 0 comments, and `commit-basis`'s 80-line docstring restated what `architecture.md` §The collector — cells, entries, the commit basis and its repairs now carries (the three terms and what each sees, the two windows of invariant 5, the floored stamp and the generation term's counter-example, the held/staged split and the rejected registry-term placement). Those essays are deleted and the section cited. The deftest the docstring named, `a-first-registration-of-an-id-no-cell-holds-disturbs-nothing`, is **not retired**: it exists once at tip as a live `(deftest` in the frozen bench tree (`bench/hicasso/src/re_frame/bench/hicasso/arm1/first_registration_cljs_test.cljs:263`), which runs on no per-PR lane by ruling and which `prototype-suite-triage.md` classes as a re-authored row rather than a port. It is replaced by the package witness for the same claim — `hmr_registry_cljs_test` (`an-unrelated-namespaces-save-disturbs-no-mounted-boundary`), the row the architecture section already names for the two-placement distinction. Nothing in the section is contradicted by the file, so no amendment is appended to it.

Fence: `collector.cljs` and `architecture.md` untouched. No sibling PR touches either path; origin/main moved by one beads checkpoint (7552aa40fc) while this was in flight and the branch is rebased onto it (clean), with compile and lint re-run on the rebased tree.

## Quality gates

Every gate ran foreground from this worktree's `implementation/`, with its exit code captured to a per-attempt file in one shell; the number quoted is the captured one. The shadow-cljs runs print the config path, which named this worktree on every run.

| Gate | Attempt | Captured exit | Counts |
|---|---|---|---|
| `npm run test:hicasso-compile` | 1 (working tree at the commit's content, pre-rebase) | 0 | 11 namespaces, 171 files, 0 warnings |
| `npm run test:hicasso-compile` | 2 (rebased tree, 2d2ed417ff) | 0 | same |
| `npm run test:hicasso-lint` | 1 (pre-rebase) | 0 | self-test PASS; 6 checks fire on fixtures, correct code silent, testbeds quiet |
| `npm run test:hicasso-lint` | 2 (rebased tree) | 0 | same |
| `npm run test:cljs` | 1 (pre-rebase working tree) | 0 | 1,854 files, 0 warnings; **11,075 tests, 54,263 assertions, 0 failures, 0 errors** — the count at #8779's tip, unchanged |

`test:cljs` ran once, before the rebase; the rebase moved only `.beads/issues.jsonl`, which no CLJS build reads, and the file's blob at the rebased head is the one the run compiled (same `git rev-parse <rev>:path` on both sides). Not run: `scripts/check_doc_slugs.py` and `scripts/check_provenance_pins.py` — no page under `docs/` changes, so neither has a surface here and no anchor was planted; `mkdocs build` never sees `docs/design` and is not nominated; no browser gate — nothing here reaches the DOM and no headless Chromium was started.

## Controls

**The no-behaviour-change control** strips every string literal and `;` comment from both versions of the file, normalises whitespace and compares the remaining lines: `origin/main` against this branch reads **33 code lines before, 33 after, identical**. The comparator was exercised first against a copy of the file with one code line (`(vreset! !generation 0)`) removed: it read 33 vs 32, named the line, and exited 1.

**The scan is calibrated.** The same scanner run on `collector.cljs` at this base reproduces #8781's published after-figures exactly (1,105 lines = 383 docstring + 162 comment + 485 code).

**Which tree the gates read.** Compile and `test:cljs` print `shadow-cljs - config: …\dw-docstrings-generation\implementation\shadow-cljs.edn`. Lint prints no root and a docstring edit gives it nothing to fire on, so its evidence is the bounded one it affords: it is invoked through `npm run` from this worktree's `implementation/`, where `package.json` resolves the script by a path relative to that directory.

**The src docstrings have no automated content gate beyond compile and lint.** Hand-checked at this tip by a script with a planted control each time (a missing page reported MISSING; a missing `defn` read 0 while every real one read 1): the one repo-relative path the file cites, `docs/design/hicasso/architecture.md`, exists and carries the heading `## The collector — cells, entries, the commit basis and its repairs` (fixed-string match count 1); the two test namespaces named, `hmr_registry_cljs_test` and `staged_reincarnation_basis_cljs_test`, exist under `implementation/hicasso/test/re_frame/hicasso/` and carry the rows the prose leans on (`an-unrelated-namespaces-save-disturbs-no-mounted-boundary`, `a-staged-key-committed-across-a-same-id-reincarnation-sees-the-store-move`); `re-frame.frame/frame-commit-epoch` is at `implementation/core/src/re_frame/frame.cljc:1741`; the collector doors named — `sub-registered!`, `flush!`, `reset-runtime!` — resolve, and the "only caller" clauses hold at tip (`generation/bump-generation!` is called once, from `flush!`; `bump-registry-epoch!` once, from `sub-registered!`; `reset-basis!` once, from `reset-runtime!`; `commit-basis` is read on four collector paths — the acquire stamp, the flush re-stamp, `make-snapshot` and `render-body`'s fence). Spec 006's invariant 5 is the `:node-key` one (`spec/006-ReactiveSubstrate.md` §The six frozen invariants). rf2-6c12m.19 is the closed bead the counter-example cites. No `[[wikilink]]` remains (raw `[[` count 0).

## Essays

Per essay: **moved to** a path, **deleted — duplicated at** a path, or **deleted — superseded**. "Kept" means it survived as a contract clause or the one-sentence why at its var. Nothing moved: every argument the file carried is already on `architecture.md` §The collector.

| Essay | Disposition |
|---|---|
| ns §the three monotone numbers; the ownership boundary (consults on four, advances on two; private volatiles, named bumps, `git grep` is the writer list) | kept, compressed to the contract and one sentence of why; the section cited |
| ns §arithmetic over three independent terms, and the fourth axis a same-id reincarnation is not carryable here | deleted — duplicated at `architecture.md` §The collector (*The commit basis, and the two windows of invariant 5*; *The other two axes*); the axis clause survives at `commit-basis` |
| ns §The HMR contract lands on this file | kept as one sentence at `registry-epoch` with `hmr_registry_cljs_test` named; "a reload that must promise identity, focus and state across a save has to say what it does to these three numbers" deleted — narrative |
| `generation` | untouched — already at the rule |
| `bump-generation!` | kept; the wikilink made a plain name |
| `registry-epoch` §counted here rather than by the substrate | kept, compressed; the hook named without the wikilink |
| `bump-registry-epoch!` §bump before scan | kept, compressed; the "where the ordering is stated and enforced" cross-reference made a plain name |
| `commit-basis` ¶1–3: the three terms, why the generation alone cannot carry it, monotone and install-counting | the contract and one sentence per term kept (the ruling's worked example B); the derivation deleted — duplicated at §The collector *The commit basis* |
| `commit-basis` §Why the registry term costs the mounted case nothing (18 lines: the one live branch, the rejected placement, conservative in the safe direction) | deleted — duplicated at §The collector *The other two axes* (the rejected placement); the bench-only deftest replaced by `hmr_registry_cljs_test` |
| `commit-basis` §Silent on one axis (the reincarnation tie, the `:node-key` axis, `invalidate-cell!` carries the held half) | the tie and the axis kept as one clause; the held/staged split deleted — duplicated at §The collector *A cell's stamp is a basis reading, floored* and *The other two axes* |
| `commit-basis` §Why the generation term stays (rf2-6c12m.19, 21 lines) | kept as the one-sentence why with `staged_reincarnation_basis_cljs_test` named, as the ruling's example B prescribes; the measured trace ("both read 4") deleted — duplicated at §The collector and pinned by the test itself |
| `reset-basis!` | kept; the wikilink made a plain name |

## Measured

Same scan method as the rf2-6c12m.4 measurement and PRs #8774/#8777/#8778/#8781 (a prose line is inside a string literal following `(ns` / `(def…` / `:doc`, or starts with `;`; "code" is every other non-blank line; blanks in the total only). The scanner reproduces the brief's tip figures for this file (157 lines, 12 `[[`, 0 comments). `[[` is a raw occurrence count.

| File | Lines before → after | Docstring lines | Comment lines | Code lines | Blank | `[[` | Docstrings (over 30 / over 100) | Longest after |
|---|---|---|---|---|---|---|---|---|
| `impl/generation.cljs` | **157 → 81** | **124 → 48** | 0 → 0 | 26 → 26 | 8 → 8 | **12 → 0** | 7 → 7 (1 / 0 → 0 / 0) | `commit-basis` 20; ns 9; `registry-epoch` 7 |

Prose share 79% → 59% of all lines (83% → 65% of non-blank lines). Docs: no page changes.
