### PR TITLE
docs(method): an item split across workers by file is claimed by nobody

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -307,6 +307,13 @@ one-worker-per-item, and do not reflexively bundle everything.
   out routinely where single-item workers succeed.
 * **A measurement window → SOLO, Shape 6**, picked by kind rather than size and never folded
   into a cluster.
+* **One item too large for one worker → SPLIT by disjoint file, one worker each, and NOBODY
+  CLAIMS IT.** The reverse of a cluster, for an item whose slices are each a full session.
+  A claim marks the item one worker's, and the ready list, the stranded sweep and every
+  other slice's worker then read it that way; so each worker appends a claim note and a
+  result note instead, and the mayor closes the item when the last slice has landed, citing
+  every change. Measured: four slices of one item in one session, each its own change,
+  none colliding, closed once with four cross-references.
 
 **One agent owns a surface; surfaces run in parallel.** That is how you avoid serial handling:
 same-surface items ride one agent, which never collides with itself, while genuinely separable


### PR DESCRIPTION
Retrospective addition to the mayor method: one bullet under *Choosing solo or cluster* in dispatch-prompt-template.md.

**Friction.** One item this session was too large for one worker and split by disjoint file into four workers. The shape worked — four changes, no collisions, one close with four cross-references — but only because each brief told the worker NOT to claim the item: a claim marks it one worker's, and the ready list, the stranded sweep and the other slices' workers then read it that way. The method has Solo, Cluster and the measurement window; it had no shape for the reverse of a cluster, and nothing named the claim trap.

**Fix.** One bullet: split by disjoint file, one worker each, nobody claims; each worker appends a claim note and a result note; the mayor closes when the last slice lands, citing every change. Generic; no project, platform or person named. README untouched.

## Quality gates

| Gate | Attempt | Captured exit |
|---|---|---|
| `python scripts/check_doc_slugs.py` | 1, final tree | 0 |
| `python scripts/check_readme_links.py --ci` | 1, final tree | 0 |

**Control.** A `#fences-PLANTED` anchor planted on the step-3 cross-reference: `check_doc_slugs.py` exit **1** naming file, line and anchor; restored by checkout; blob hash equal before and after. `mkdocs build --strict` is not the gate (no anchor validation; the tree is under `exclude_docs`). Prose hand-checked; no tables changed.