### PR TITLE
reagent-slim: reagent2.core/reaction is a stock-compatible macro (rf2-b9l8o)

### DIFF
--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -38,8 +38,9 @@ implementation/adapters/reagent-slim/
 │   │       └── reagent_slim.cljs      ; adapter Var at re-frame.adapter.reagent-slim
 │   └── reagent2/
 │       ├── core.cljs                  ; user-facing compat surface
+│       ├── core.clj                   ; the core-spelled reaction macro (CLJS-only consumer)
 │       ├── ratom.cljs                 ; reactive primitives
-│       ├── ratom.clj                  ; the reaction macro (CLJS-only consumer)
+│       ├── ratom.clj                  ; the ratom-spelled reaction macro (CLJS-only consumer)
 │       ├── dom/
 │       │   ├── client.cljs            ; create-root / render / unmount / hydrate-root / flush-views!
 │       │   └── server.cljs            ; pure-CLJS render-to-static-markup
@@ -202,9 +203,11 @@ The `:adapter/current-frame` late-bind hook (currently set to `views/current-fra
 
 ### §2.2 `reagent2.core` — user-facing compat surface
 
-File: `src/reagent2/core.cljs`.
+Files:
+- `src/reagent2/core.cljs` — the Vars.
+- `src/reagent2/core.clj` — the `reaction` macro (see §14.2).
 
-Public Vars (the audit-binding fourteen surfaces, per Stage 2 §2.7):
+Public symbols (the audit-binding fourteen surfaces, per Stage 2 §2.7 — thirteen Vars in `core.cljs` plus the `reaction` macro in `core.clj`):
 
 | Symbol | Signature | Notes |
 |---|---|---|
@@ -221,7 +224,7 @@ Public Vars (the audit-binding fourteen surfaces, per Stage 2 §2.7):
 | `set-state` | `[this m]` | Form-3 state mutator. |
 | `replace-state` | `[this m]` | Form-3 state mutator. |
 | `force-update` | `[this]`, `[this true]` | Force re-render of `this` component. |
-| `reaction` | function `[f]` | Sugar over `make-reaction`; the **function** form (Dash8 uses 25 sites of `r/reaction` per rf2-kfpf §2). The macro form lives in `reagent2.ratom`. |
+| `reaction` | macro `[& body]` | Stock-shaped macro in `src/reagent2/core.clj`: `(reaction body...)` expands to `(reagent2.ratom/make-reaction (fn [] body...))`, exactly as stock `reagent.core/reaction` does — so the 25 Dash8 `r/reaction` sites (rf2-kfpf §2) compile unchanged after the §13.1 ns-rename. `reagent2.ratom/reaction` is the same expansion under the ratom spelling; a caller that already holds a thunk uses `reagent2.ratom/make-reaction`. |
 
 Internal helpers (private but load-bearing): none unique — this ns is mostly re-exports.
 
@@ -231,7 +234,7 @@ Symbols **not shipped** (per Stage 1 §2.4 + DECISION-7 + Stage 2 §2.7 audit-co
 
 Files:
 - `src/reagent2/ratom.cljs` — type definitions + public Vars.
-- `src/reagent2/ratom.clj` — the `reaction` macro only (Stage 1 §1.6 marked both `reaction` and `run!` SHOULD; Stage 2 §2.6 ships `reaction` as a 5-line indirection over `make-reaction`). `run!` is not shipped — see the "Symbols not shipped" list below.
+- `src/reagent2/ratom.clj` — the `reaction` macro only (Stage 1 §1.6 marked both `reaction` and `run!` SHOULD; Stage 2 §2.6 ships `reaction` as a 5-line indirection over `make-reaction`). `src/reagent2/core.clj` carries the same macro under the `reagent2.core` spelling (§2.2). `run!` is not shipped — see the "Symbols not shipped" list below.
 
 Public Vars:
 
@@ -1043,7 +1046,7 @@ Per the bead description and Stage 2 §5 risk register R-001..R-007.
 
 | Namespace | Test file | Coverage |
 |---|---|---|
-| `reagent2.core` | `core_test.cljs` | All 14 public Vars (re-export integrity). |
+| `reagent2.core` | `core_cljs_test.cljs` | All 14 public surfaces (re-export integrity); the `reaction` macro from the consumer side — body deferred until the first deref, reagent2-atom dependency capture and recompute, and the expansion shape `(make-reaction (fn [] body...))`. |
 | `reagent2.ratom` | `ratom_test.cljs` | RAtom + Reaction lifecycle; protocol satisfaction; equality memoisation; `IDisposable` reify; cross-substrate cache-wiring contract. |
 | `reagent2.dom.client` | `dom_client_test.cljs` | create-root / render / unmount / hydrate-root happy-paths; flush-views! determinism contract per §4.6; React-19 `act` cooperation. |
 | `reagent2.dom.server` | `dom_server_test.cljs` + `parity_test.cljs` | render-to-static-markup output for representative corpus; parity against `react-dom/server` per §8.7. |
@@ -1126,7 +1129,7 @@ App author currently using `day8/re-frame2-reagent` (the thin bridge) wants to m
           [reagent2.ratom      :as ratom])
 ```
 
-A simple `s/reagent\./reagent2./g` ns-rename at the import site is sufficient for apps inside the bounded surface.
+A simple `s/reagent\./reagent2./g` ns-rename at the import site is sufficient for apps inside the bounded surface. That includes `r/reaction`: `reagent2.core/reaction` is a macro with stock's body syntax (§2.2, §14.2), so `(r/reaction (* @a @a))` means the same lazy Reaction on both sides of the rename.
 
 ### §13.2 Apps that used keys outside the 7-key Form-3 cap
 
@@ -1184,11 +1187,11 @@ Stage 4 ships `reagent2.impl.component/defview` as an optional Form-detection ma
 
 **Disposition (as shipped)**: resolved per the rf2-yfbx decision — `defview` is **not** shipped. The runtime Form-detection path is the canonical implementation; no separate `defview` macro exists (see `reagent2/impl/component.cljs:31` and `component.clj:10`: "No separate `defview` macro is shipped"). This matches the original recommendation (ship runtime detection, skip `defview`).
 
-### §14.2 The `reagent2.core/reaction` function vs `reagent2.ratom/reaction` macro
+### §14.2 `reagent2.core/reaction` and `reagent2.ratom/reaction` — both macros
 
-Dash8 uses 25 sites of `reagent.core/reaction` (the **function** form). rf8 uses both `reagent.core/reaction` (1 site) and the `reagent.ratom/reaction` **macro** (2 sites). The two surfaces co-exist in stock Reagent under different names but produce equivalent Reactions.
+Dash8 uses 25 sites of `reagent.core/reaction`; rf8 uses `reagent.core/reaction` (1 site) and `reagent.ratom/reaction` (2 sites). In stock Reagent 2.0.1 both spellings are macros with the same expansion: `reagent/core.clj` and `reagent/ratom.clj` each define `(defmacro reaction [& body] ...)` over `(reagent.ratom/make-reaction (fn [] ~@body))`, and `reagent/core.cljs` defines no `reaction` function at all.
 
-The rewrite ships `reagent2.core/reaction` (function) AND `reagent2.ratom/reaction` (macro). No filing needed; this is straightforward.
+Earlier revisions of this document read the core spelling as a "function form", and the rewrite shipped it as `(defn reaction [f] ...)` with no `core.clj` macro namespace. That turned every `(r/reaction (* @a @a))` into an eager call: the body ran at the call site, its value was passed as `f`, and the first deref tried to call that value — a silent semantic change on the audited path the §13.1 rename promises to preserve. Corrected under rf2-b9l8o: `reagent2.core/reaction` is a macro in `src/reagent2/core.clj` with stock's body syntax and expansion, `reagent2.ratom/reaction` is the same macro under its own spelling, and an explicit thunk goes through `reagent2.ratom/make-reaction`. No thunk-taking `reaction` function exists in stock Reagent, and none ships here.
 
 ### §14.3 Boolean-attribute set + void-tag set duplication
 

--- a/implementation/adapters/reagent-slim/src/reagent2/core.clj
+++ b/implementation/adapters/reagent-slim/src/reagent2/core.clj
@@ -1,0 +1,28 @@
+(ns reagent2.core
+  "CLJS-side macros for reagent2.core.
+
+  Stock Reagent defines `reagent.core/reaction` as a macro in
+  `reagent/core.clj` (Reagent 2.0.1); its `core.cljs` carries no
+  `reaction` function at all. This file is the same arrangement under
+  the `reagent2.core` spelling, so the mechanical `s/reagent\\./reagent2./g`
+  import rename (IMPL-SPEC §13.1) leaves every `(r/reaction body...)`
+  call site meaning what it meant.
+
+  No CLJ-side runtime code lives here; only the macro consumed by CLJS
+  build sites via `:require-macros`.")
+
+(defmacro reaction
+  "Creates a Reaction from `body` and returns it: a derefable holding the
+  body's result. Every reagent2 atom or Reaction deref'd inside `body`
+  registers as a dependency, and the Reaction recomputes when any of
+  them change. The body does not run until the first deref.
+
+  Expands to `(reagent2.ratom/make-reaction (fn [] body...))` — the same
+  expansion as stock `reagent.core/reaction` and as the sibling
+  `reagent2.ratom/reaction`. A caller that already holds a thunk uses
+  `reagent2.ratom/make-reaction` directly.
+
+  A new Reaction is created on every call, so build it once (a Form-2
+  closure, Form-3 state) rather than inside a render body."
+  [& body]
+  `(reagent2.ratom/make-reaction (fn [] ~@body)))

--- a/implementation/adapters/reagent-slim/src/reagent2/core.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/core.cljs
@@ -22,7 +22,8 @@
     set-state         — Form-3 state mutator
     replace-state     — Form-3 state mutator
     force-update      — force re-render of `this` component
-    reaction          — function form sugar over make-reaction
+    reaction          — macro (src/reagent2/core.clj); stock body syntax,
+                        expands to make-reaction over (fn [] body...)
 
   Symbols **not shipped** (per Stage 1 §2.4 + DECISION-7 + Stage 2 §2.7
   audit-confirmed zero usage): `track`, `track!`, `cursor`, `wrap`,
@@ -45,6 +46,7 @@
   adapter day8/re-frame2-reagent; the rewrite's commitment is
   to ship only the surfaces the audited codebases actually exercise."
   (:refer-clojure :exclude [atom])
+  (:require-macros [reagent2.core])
   (:require [reagent2.ratom :as ratom]
             [reagent2.impl.batching :as batching]
             [reagent2.impl.component :as component]
@@ -62,14 +64,12 @@
   to changes."
   ratom/atom)
 
-(defn reaction
-  "Construct a Reaction wrapping fn `f` (function form; the macro form
-  lives in `reagent2.ratom`). Sugar over `reagent2.ratom/make-reaction`.
-
-  Per IMPL-SPEC §14.2: ships the function form because Dash8 uses 25
-  sites of `r/reaction` and the rewrite preserves that surface."
-  [f]
-  (ratom/make-reaction f))
+;; `reaction` is a macro, defined in src/reagent2/core.clj and loaded
+;; through the `:require-macros` above: `(reaction body...)` expands to
+;; `(reagent2.ratom/make-reaction (fn [] body...))`, as stock
+;; `reagent.core/reaction` does. There is deliberately no thunk-taking
+;; function under this name — an explicit thunk goes straight to
+;; `reagent2.ratom/make-reaction` (rf2-b9l8o).
 
 ;; ---------------------------------------------------------------------------
 ;; Component-shape surface

--- a/implementation/adapters/reagent-slim/src/reagent2/ratom.clj
+++ b/implementation/adapters/reagent-slim/src/reagent2/ratom.clj
@@ -5,8 +5,9 @@
 
     - `reaction` ships as a 5-line indirection over `make-reaction`.
       Required for rf8 wizard/reports_util.cljs:158, 166 (rf2-kfpf §3).
-      Dash8 also uses the function form `reagent.core/reaction` (25
-      sites); that surface lives in `reagent2.core` (Stage 4-D).
+      `reagent2.core/reaction` (src/reagent2/core.clj) is the same macro
+      under the stock `reagent.core` spelling — the one Dash8's 25
+      `r/reaction` sites use.
 
     - `run!` is NOT shipped — audit-confirmed zero usage across re-com /
       10x / Dash8 / rf8 (per §2.3 \"Symbols not shipped\" list).
@@ -28,8 +29,8 @@
     (reset! first-name \"Bob\")
     @full-name  ;=> \"Bob Tan\"
 
-  Per IMPL-SPEC §2.3: 5-line indirection. The function form
-  `reagent2.core/reaction` (Stage 4-D) is equivalent but takes a
-  thunk argument explicitly."
+  Per IMPL-SPEC §2.3: 5-line indirection. `reagent2.core/reaction` has
+  the same expansion; a caller that already holds a thunk uses
+  `make-reaction` directly."
   [& body]
   `(reagent2.ratom/make-reaction (fn [] ~@body)))

--- a/implementation/adapters/reagent-slim/test/reagent2/core_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/core_cljs_test.cljs
@@ -19,14 +19,25 @@
       cell, `set-state` MERGES while `replace-state` RESETS (a real,
       distinguishable invariant a key-swap bug would otherwise slip),
       and that the accessor wrappers route to the right impl fn. The
-      `reagent2.core` re-export `atom`, the `reaction` function form,
-      `create-class`, `current-component`, `after-render`, and
-      `as-element` keep their dedicated per-impl coverage
-      (ratom / component / template / batching).
+      `reagent2.core` re-export `atom`, `create-class`,
+      `current-component`, `after-render`, and `as-element` keep their
+      dedicated per-impl coverage (ratom / component / template /
+      batching).
+
+    - The `reaction` macro (rf2-b9l8o): stock Reagent's
+      `reagent.core/reaction` is a macro over the body, and so is this
+      one. Pinned here, from the consumer side, with only
+      `reagent2.core` required at the call site: the body is deferred
+      until the first deref, a reagent2 atom deref'd inside it is
+      captured and drives recomputation, and the expansion is
+      `(reagent2.ratom/make-reaction (fn [] body...))` — the shape a
+      thunk-taking function cannot have. `reagent2.ratom` is required
+      below only so the type assertion can name `Reaction`.
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [reagent2.core :as r]))
+            [reagent2.core :as r]
+            [reagent2.ratom :as ratom]))
 
 ;; ---------------------------------------------------------------------------
 ;; force-update — 1-arity routes .forceUpdate on `this`
@@ -194,3 +205,46 @@
       (is (= [:a :b]
              (vec (r/children (fake-instance [render-fn :a :b]))))
           "no props map → children start right after the head"))))
+
+;; ---------------------------------------------------------------------------
+;; reaction macro (rf2-b9l8o)
+;;
+;; `reagent2.core/reaction` is a macro with stock Reagent's body syntax:
+;; `(r/reaction body...)` expands to
+;; `(reagent2.ratom/make-reaction (fn [] body...))`. Against the earlier
+;; thunk-taking function `(defn reaction [f] ...)` every test below is red:
+;; the body ran eagerly at the call site, its VALUE was handed to
+;; make-reaction as `f`, and the first deref tried to call that value.
+;; ---------------------------------------------------------------------------
+
+(deftest reaction-body-is-deferred-until-deref
+  (testing "(r/reaction body) does not run body at construction; the
+            first deref runs it once"
+    (let [runs (atom 0)
+          rx   (r/reaction (do (swap! runs inc) :computed))]
+      (is (zero? @runs) "body did not run at construction")
+      (is (= :computed @rx) "deref yields the body's value")
+      (is (= 1 @runs) "the first deref ran the body exactly once"))))
+
+(deftest reaction-captures-reagent2-atom-and-recomputes
+  (testing "a reagent2 atom deref'd inside the body is a dependency:
+            the Reaction recomputes after that atom changes"
+    (let [a  (r/atom 3)
+          rx (r/reaction (* @a @a))]
+      (is (instance? ratom/Reaction rx) "produces a reagent2.ratom/Reaction")
+      (is (= 9 @rx))
+      (reset! a 4)
+      (is (= 16 @rx) "recomputed against the new dependency value"))))
+
+(deftest reaction-expands-to-make-reaction-over-a-zero-arity-fn
+  (testing "(r/reaction body...) expands to
+            (reagent2.ratom/make-reaction (fn [] body...)) — the whole
+            body, verbatim, inside a zero-argument fn"
+    (let [[head thunk & more]          (macroexpand-1 '(r/reaction (+ 1 2) (* @a @a)))
+          [fn-sym params & fn-body]    thunk]
+      (is (= 'reagent2.ratom/make-reaction head))
+      (is (nil? more) "make-reaction receives the thunk and nothing else")
+      (is (= "fn" (name fn-sym)) "the thunk is a fn form")
+      (is (= [] params) "the fn takes zero arguments")
+      (is (= '((+ 1 2) (* @a @a)) fn-body)
+          "every body form is the fn body, in order"))))


### PR DESCRIPTION
Closes rf2-b9l8o.

Stock Reagent 2.0.1 defines `reagent.core/reaction` as a macro in `reagent/core.clj` — `(defmacro reaction [& body] ...)` expanding to `(reagent.ratom/make-reaction (fn [] ~@body))` — and its `core.cljs` has no `reaction` function (read from the pinned jar). reagent-slim shipped `(defn reaction [f] ...)` under that spelling with no `core.clj`, so the documented `s/reagent\./reagent2./g` rename turned `(r/reaction (* @a @a))` into an eager call: the body ran at the call site, its value went to `make-reaction` as `f`, and the first deref called that value (`TypeError: self__.f.call is not a function` in the control below).

## What changed (all under `implementation/adapters/reagent-slim/`)

- `src/reagent2/core.clj` (new): `(defmacro reaction [& body] ...)` expanding to `(reagent2.ratom/make-reaction (fn [] ~@body))`, mirroring `ratom.clj`.
- `src/reagent2/core.cljs`: `(:require-macros [reagent2.core])`; the thunk-taking `defn reaction` is deleted — no shim, no alias. Explicit thunks use `reagent2.ratom/make-reaction`.
- `test/reagent2/core_cljs_test.cljs`: three new deftests (below); the header no longer claims coverage the file did not have.
- `IMPL-SPEC.md` §2.2 (files, symbol table row), §2.3, §12.1, §13.1, §14.2 (rewritten: both spellings are macros; the "function form" reading recorded as the corrected error) and the `ratom.clj` docstring.

## Acceptance criteria (from the bead)

- [x] With only `(:require [reagent2.core :as r])`, `(r/reaction <body...>)` compiles with stock body syntax and produces a `reagent2.ratom/Reaction` — `reaction-captures-reagent2-atom-and-recomputes` (the test ns requires `reagent2.ratom` only to name `Reaction` in the type assertion; the macro's expansion resolves `reagent2.ratom/make-reaction` through `reagent2.core`'s own require, as stock does).
- [x] Focused regression: body deferred until deref, captures a reagent2 atom dependency, recomputes after it changes — `reaction-body-is-deferred-until-deref`, `reaction-captures-reagent2-atom-and-recomputes`.
- [x] Structural assertion that the body is wrapped in a zero-argument fn passed to `reagent2.ratom/make-reaction` — `reaction-expands-to-make-reaction-over-a-zero-arity-fn` (cljs `macroexpand-1` over a two-form body: head symbol, `[]` params, body verbatim, nothing else passed).
- [x] No thunk-taking `reagent2.core/reaction` remains; `reagent2.ratom/make-reaction` stays — `git grep -n "defn reaction" -- implementation/adapters/reagent-slim/src` returns nothing (the two remaining hits in the artefact are prose: §14.2's account of the corrected error and the test file's comment).
- [x] Core ns docs, IMPL-SPEC tables/§14.2, migration guidance (§13.1) describe the macro; no claim that the function form exists in stock.
- [x] Package/test gates include and exercise the new `.clj` from the published src path — `deps.edn` `:paths ["src"]` and `:clein/build :src-dirs ["src"]` package the whole `src` tree (no preflight change needed: `preflight-reagent-slim-package.sh` asserts the adapter ns entries, not a `reagent2/*` roster); `shadow-cljs.edn` `:source-paths` carries `adapters/reagent-slim/src`, and the `:node-test` build compiles `core_cljs_test.cljs` through the macro. The JVM alias `clojure -M:test` puts the `.clj` on its classpath but no JVM test loads it (its one test ns is `reagent2.impl.component-test`) — said rather than padded with a duplicate.

## Negative control

The three new tests run against the OLD function form (`npm run test:cljs` before the macro landed, base `fd4b71ab4f`): captured exit `1`, `Ran 11078 tests containing 54274 assertions. 6 failures, 3 errors.` — every failure and error in the three new deftests, nothing else red:

```
FAIL  in (reaction-body-is-deferred-until-deref)                 expected: (zero? @runs)   actual: (not (zero? 1))
ERROR in (reaction-captures-reagent2-atom-and-recomputes)        actual: #object[TypeError TypeError: self__.f.call is not a function]
FAIL  in (reaction-expands-to-make-reaction-over-a-zero-arity-fn) actual: (not (= reagent2.ratom/make-reaction r/reaction))
```

## Quality gates

Branch rebased onto `556b8fabbc` (the trunk after #8784 merged) before the final runs; every gate below was re-run there unless marked. Exit codes are the captured `.exit` files, not the harness's.

| Gate | Exit | Result |
|---|---|---|
| `npm run test:cljs` — control, old form, base `fd4b71ab4f` | `1` | 11078 tests / 54274 assertions, 6 failures, 3 errors (all three new deftests) |
| `npm run test:cljs` — with the macro, base `fd4b71ab4f` | `0` | 11078 tests / 54274 assertions, 0 failures, 0 errors; build 0 warnings |
| `clojure -M:test` (implementation/adapters/reagent-slim) | `0` | 11 tests / 12 assertions (does not load `reagent2.core`; see above) |
| `npm run test:reagent-slim:smoke` (rebased base) | `0` | `Ran 1 reagent-slim client-runtime smoke. 0 failures.`; build 0 warnings |
| `npm run test:reagent-slim:bundle-isolation` (rebased base) | `0` | `PASS reagent-slim-bundle-isolation: 6 contracts passed; 25 sentinel checks` |
| `python scripts/check_readme_links.py --ci` (rebased base) | `0` | clean |
| — planted control: one broken link in IMPL-SPEC.md §13.1 | `1` | `BROKEN TARGET: implementation\adapters\reagent-slim\IMPL-SPEC.md:1132 -> NO-SUCH-FILE-b9l8o.md`; restored, working-file blob hash `c2f2bbcb…` equals the HEAD blob |
| `sh scripts/test-fast-pr.sh` (rebased base) | `0` | `PASS fast PR spine` — docs tier (all checkers + `mkdocs --strict`), clj-kondo `errors: 0`, JVM core 2156 tests / 11059 assertions, JVM reagent-slim 11 / 12, node `:node-test` 11080 tests / 54289 assertions 0 failures (build 0 warnings), per-ns isolation 16/16, hicasso gates |

Left to CI (not in any local lane run here): `cljs-reagent-slim-bundle-isolation` job (covered locally above but CI is the record), `jvm-reagent-slim`, `verify-readme-links`, `check_doc_slugs` (not this PR's surface: nothing under `docs/`, `spec/`, `skills/`, `migration/` changed), the playground SCI-bundle job (`implementation/adapters/reagent-slim/*` is an input), and the adapter smokes matrix.

Verified by hand: IMPL-SPEC §2.2 table keeps three columns in the edited row; §12.1 row keeps three; no in-page anchor was added or renamed.
