### PR TITLE
docs(method): checkpoint is two operations; generated files regenerate, not sequence; Shape 4 returns brief inputs

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -263,6 +263,14 @@ Hot-zone files — anything sequential, where two concurrent editors conflict by
 not edit. **A citation is not permission**: briefs routinely cite a specification section as
 context, and a worker can read that as licence to edit it.
 
+**A GENERATED file is the one same-file overlap that sequencing does not fix.** A manifest or
+export regenerated from the tree is touched by every change that moves what it derives from, and
+serialising those changes serialises the fleet for nothing: two regenerations of the same file
+conflict textually and agree semantically. Brief every toucher instead — regenerate after
+rebasing, never hand-merge, and where a job diffs the committed file against a fresh generation,
+run exactly that job locally. Three concurrent changes regenerated one manifest here with no
+sequence between them.
+
 **But a gate that reconciles two surfaces couples them into ONE change, and sequencing those
 deadlocks.** The one-toucher rule reasons about files, and it is right about files. Some checkers,
 though, hold one surface against another in both directions — a catalogue against the emitters it
@@ -366,6 +374,16 @@ items and the ready queue. Per item decide: add to an in-flight cluster; form a 
 or more items on a shared non-hot-zone surface); solo (correctness, large, decision-resolved or
 cross-cutting); or defer. Output the net next-dispatch shape in two or three sentences. **Do not
 change tracker state.**
+
+**When items arrive faster than the mayor can read them, ask this shape for the brief inputs as
+well**, per item: the premise check at the current tip (each cited line holds, drifted to what,
+or does not hold; every asserted count re-run), the surfaces it would edit and which are hot-zone,
+same-file collisions against the live and queued sets, the gates by exact command with the
+heavyweight ones marked, and each ambiguity a worker would otherwise improvise, with a
+recommendation. That is the part of a brief the mayor cannot write without reading the tree, and
+the part that goes stale first. Measured: three such passes over twenty-six items in one evening,
+each returning premise drifts — a cited file that did not exist, an alias at another line, a flag
+the toolchain already supplied — before any worker was dispatched.
 
 **Shape 5 — Fix a failing check.** The failing check name and log lines; two or three root-cause
 hypotheses; a worktree off the **existing** branch, not a new one; the boundary block; **run the

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1326,6 +1326,13 @@ reopens for a third. Two or three rounds converge.
 **Checkpoint tracker state on the heartbeat.** Many trackers auto-stage but never commit, so a long
 session's state strands locally. Commit and push it each cycle.
 
+**A checkpoint is two operations, and the harness can kill it between them.** The export contends
+with every worker's tracker writes, so under a full fleet a checkpoint that took seconds on an empty
+board can outrun a command cap. Measured twice in one session: one kill left the commit made and the
+push not, and the re-run reported *nothing to checkpoint* — true, and the remote was still behind.
+Verify the remote against the local head after every checkpoint; the script's message answers only
+the commit.
+
 **If your tracker exports a whole-database file, treat it as generated.** Never resolve a conflict in it
 by taking one side wholesale — both sides are full exports, so picking one discards every item the other
 recorded. Resolve, then **regenerate**. And never let a worker commit it: a worker branch carries a


### PR DESCRIPTION
Retrospective on `docs/the-mayor-method/` from one session running six workers against a live review that filed twenty-six items. Three things the text did not warn about, each measured this session; nothing else changed. README untouched.

- **loops.md — Tracker mechanics.** A checkpoint is two operations (commit, push) and the harness can kill it between them: under a full fleet the export outran a command cap twice; one kill left the commit made and the push not, and the re-run said *nothing to checkpoint*. Verify the remote, not the message.
- **dispatch-prompt-template.md — Fences.** A generated file shared by parallel changes is not a one-toucher collision; sequencing serialises the fleet for nothing. Every toucher regenerates after rebasing and never hand-merges. Three concurrent changes regenerated one manifest here.
- **dispatch-prompt-template.md — Shape 4.** When items arrive faster than the mayor can read them, the cluster reviewer also returns the brief inputs (premise check at tip, surfaces, collisions, gates by command, ambiguities with a recommendation). Three passes caught three wrong premises before any dispatch.

All three are generic: no OS, repo or operator specifics.

## Quality gates
- `python scripts/check_doc_slugs.py` — exit 0. Control: one broken anchor planted in the new Fences paragraph → exit 1 naming it; restored; restore verified by blob hash equality against the committed object; re-run exit 0.
- `python -m mkdocs build --strict` — exit 0 (`docs/the-mayor-method/` is inside `docs_dir` and not in `exclude_docs`). Correction to this body's first version: the bare `mkdocs` binary is not on the authoring shell's PATH, so the first invocation returned 127 (command not found) and had verified nothing; the gate was re-run via `python -m mkdocs` and that is the exit quoted.
- No code touched; no other gate covers this surface.
