### PR TITLE
core(facade): remove implementation-only constructors from re-frame.core (rf2-93sxp)

### DIFF
--- a/.clj-kondo/hooks/re_frame/core.clj
+++ b/.clj-kondo/hooks/re_frame/core.clj
@@ -4,23 +4,26 @@
   Per spec/002-Frames.md (§What `reg-view` injects) and rf2-kkut0
   (frame-affordance redesign), `reg-view` is a defn-shape macro that auto-injects two lexical
   bindings — `dispatch` and `subscribe` — into the body, sourced from a
-  single `capture-frame` (the keystone OPERATION BUNDLE):
-  `(:dispatch (re-frame.core/make-capture-frame ...))` and
-  `(:subscribe (re-frame.core/make-capture-frame ...))`. clj-kondo doesn't
+  single `capture-frame` (the keystone OPERATION BUNDLE). clj-kondo doesn't
   macroexpand by default, so without this hook the body's `dispatch` /
   `subscribe` references all read as `Unresolved symbol`.
 
   The hook rewrites `(reg-view sym [args] body)` into
 
       (defn sym [args]
-        (let [handle    (re-frame.core/make-capture-frame
-                          (re-frame.core/current-frame-id) {})
-              dispatch  (:dispatch handle)
-              subscribe (:subscribe handle)]
+        (let [dispatch  (:dispatch  (re-frame.core/capture-frame))
+              subscribe (:subscribe (re-frame.core/capture-frame))]
           body))
 
   preserving any leading docstring + optional attr-map, so kondo's
-  built-in `defn` analysis covers arglist + arity + lexical bindings."
+  built-in `defn` analysis covers arglist + arity + lexical bindings. The
+  real expansion builds the bundle through the owned constructor
+  `re-frame.capture-frame/make-capture-frame` (off the facade, rf2-93sxp)
+  with the view's coords; the hook names the PUBLIC `capture-frame` instead
+  because the rewrite exists only to make the two bindings visible, and a
+  view namespace requires `re-frame.core`, not the implementation
+  namespace — naming the latter would make every reg-view body an
+  `Unresolved namespace` warning."
   (:require [clj-kondo.hooks-api :as api]))
 
 (defn with-frame
@@ -109,18 +112,12 @@
                              (api/list-node
                                [(api/keyword-node :dispatch)
                                 (api/list-node
-                                  [(api/token-node 're-frame.core/make-capture-frame)
-                                   (api/list-node
-                                     [(api/token-node 're-frame.core/current-frame-id)])
-                                   (api/map-node [])])])
+                                  [(api/token-node 're-frame.core/capture-frame)])])
                              (api/token-node 'subscribe)
                              (api/list-node
                                [(api/keyword-node :subscribe)
                                 (api/list-node
-                                  [(api/token-node 're-frame.core/make-capture-frame)
-                                   (api/list-node
-                                     [(api/token-node 're-frame.core/current-frame-id)])
-                                   (api/map-node [])])])])
+                                  [(api/token-node 're-frame.core/capture-frame)])])])
                           ;; Insert a leading no-op reference to
                           ;; `dispatch` / `subscribe` so kondo's
                           ;; unused-binding linter sees both bindings

--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -38,7 +38,7 @@ Every entry here registers a named handler into the frame's registrar.
     (fn [{:keys [db]} [_ item]] {:db (update db :items conj item)}))
   ```
   > **Migration note.** The bare positional interceptor middle slot — `(reg-event :id [undoable] handler)` — has been removed. Put interceptor chains in the metadata map: `(reg-event :id {:interceptors [undoable]} handler)`.
-- **Raw-context handlers**: there is no separate registrar for them. To read or rewrite the interceptor context, register a named interceptor with `(rf/reg-interceptor :my/audit {:before ... :after ...})` and reference it by id from the `:interceptors` vector (`{:interceptors [:my/audit]}`). Its `:before` / `:after` fns receive and return the context map directly. (`->interceptor` is the framework-internal lowering constructor, not the authoring form.)
+- **Raw-context handlers**: there is no separate registrar for them. To read or rewrite the interceptor context, register a named interceptor with `(rf/reg-interceptor :my/audit {:before ... :after ...})` and reference it by id from the `:interceptors` vector (`{:interceptors [:my/audit]}`). Its `:before` / `:after` fns receive and return the context map directly. (There is no public interceptor-value constructor; the framework lowers registered descriptors internally.)
 - **Example** — a pure state update and an effectful handler:
   ```clojure
   ;; State-only: the db write is an explicit :db effect.
@@ -472,16 +472,6 @@ The view layer is **substrate-agnostic**. The shared dataflow — frames, subscr
       [:div "streaming…"]))
   ```
 
-### `make-capture-frame`
-
-- **Kind**: function (internal — `:tier :implementation`, EP-0024)
-- **Signature**:
-  ```clojure
-  (make-capture-frame frame)
-  (make-capture-frame frame opts)
-  ```
-- **Description**: **Not an app-facing surface** — the internal constructor behind `capture-frame` and the `reg-view` injection sugar. It is a public Var only so the `reg-view` macro's emitted body can reference it fully-qualified. Call `capture-frame` instead.
-
 <a id="with-frame--with-new-frame"></a>
 
 ### `with-frame`
@@ -552,24 +542,6 @@ The effect map is **closed**: app handlers return `:db` + `:fx` only. (A third r
     (fn [cofx _]
       {:db (assoc (:db cofx) :cart/saving? true)}))
   ```
-
-### `->interceptor`
-
-- **Kind**: macro (internal lowering constructor, EP-0022)
-- **Signature**:
-  ```clojure
-  (->interceptor & {:keys [id before after]})
-  ```
-- **Description**: **INTERNAL — not the public authoring form.** The framework-internal lowering constructor. It turns a `{:before … :after …}` descriptor into an executable chain entry, capturing the definition-site `:source-coord` from `(meta &form)`. Application code registers interceptors with `reg-interceptor` and references them by id; `->interceptor` must not appear directly in a public `:interceptors` chain.
-
-### `->interceptor*`
-
-- **Kind**: function (internal, EP-0022)
-- **Signature**:
-  ```clojure
-  (->interceptor* & {:keys [id before after]})
-  ```
-- **Description**: **INTERNAL.** The plain, runtime-callable fn form of the `->interceptor` macro (per Conventions `*`-suffix naming). HoF / programmatic / REPL callers reach this directly; it captures no source-coord. Not an authoring surface — use `reg-interceptor`.
 
 ### `with-fx-overrides`
 

--- a/docs/tools/playground/sci/src/rf2_playground/sci.cljs
+++ b/docs/tools/playground/sci/src/rf2_playground/sci.cljs
@@ -67,6 +67,12 @@
             [re-frame.core :as rf]
             [re-frame.router :as router]
             [re-frame.subs :as subs]
+            ;; The frame api constructor behind `capture-frame` and the
+            ;; `reg-view` injection — an owned implementation seam, off the
+            ;; facade (rf2-93sxp). Bound under its own SCI namespace below so
+            ;; the `reg-view` shim can name it exactly as the real expansion
+            ;; does, without copying an internal alias into `re-frame.core`.
+            [re-frame.capture-frame :as capture-frame]
             ;; Consumed (not re-exposed to cells) for page-owned registration
             ;; ownership + clear-on-disposal — see `disposePage` (rf2-u4pqs).
             [re-frame.registrar :as registrar]
@@ -124,10 +130,12 @@
 ;; expansion lives in re-frame.core-reg-view-macro/expand-reg-view). Cells
 ;; want the same sugar, so this SCI macro mirrors that expansion — register
 ;; the render fn via the REAL `reg-view*`, inject `dispatch` / `subscribe`
-;; as locals from a render-time `make-capture-frame` (so frame resolution
-;; is genuine: the harness frame by default, or a cell-created
-;; `frame-provider`'s frame via the context tier), `def` the var to
-;; `(rf/view id)`, and return the id per Conventions §`reg-*` return-value.
+;; as locals from a render-time `re-frame.capture-frame/make-capture-frame`
+;; (the owned constructor the real expansion names, bound under its own SCI
+;; namespace below; frame resolution is genuine: the harness frame by
+;; default, or a cell-created `frame-provider`'s frame via the context
+;; tier), `def` the var to `(rf/view id)`, and return the id per
+;; Conventions §`reg-*` return-value.
 ;; Omitted vs the real expansion: source-coord capture (`*pending-coords*`,
 ;; `:rf.trace/call-site`) — a browser cell has no `*file*` to stamp, and
 ;; coord capture is an optional capability per Spec 001. The id derives
@@ -153,7 +161,7 @@
                   (if docstring {:doc docstring} {})
                   (list 'fn sym args
                         (list 'let
-                              [handle     (list 're-frame.core/make-capture-frame
+                              [handle     (list 're-frame.capture-frame/make-capture-frame
                                                 (list 're-frame.core/current-frame-id)
                                                 {:dispatch-opts {:source :ui}})
                                'dispatch  (list :dispatch handle)
@@ -199,6 +207,14 @@
     'reg-view      (sci/new-var 'reg-view sci-reg-view
                                 {:ns rf-ns :macro true :sci/macro true})}))
 
+;; The owned constructor the `reg-view` shim expands to (rf2-93sxp). ONLY that
+;; var is bound — not a `copy-ns` of the implementation namespace — and it is
+;; bound under its own namespace, never merged into the `re-frame.core` map
+;; above, so the facade a cell sees stays the real one.
+(def capture-frame-ns (sci/create-ns 're-frame.capture-frame nil))
+(def re-frame-capture-frame-namespace
+  {'make-capture-frame (sci/copy-var capture-frame/make-capture-frame capture-frame-ns)})
+
 (def r-ns (sci/create-ns 'reagent2.core nil))
 (def reagent2-core-namespace (sci/copy-ns reagent2.core r-ns))
 
@@ -215,7 +231,8 @@
 ;; a paste of stock idiom still resolves to the v2 surface.
 (def sci-ctx
   (sci/init
-   {:namespaces {'re-frame.core        re-frame-core-namespace
+   {:namespaces {'re-frame.core          re-frame-core-namespace
+                 're-frame.capture-frame re-frame-capture-frame-namespace
                  'reagent2.core        reagent2-core-namespace
                  'reagent2.ratom       reagent2-ratom-namespace
                  'reagent2.dom.client  reagent2-dom-client-namespace

--- a/implementation/core/src/re_frame/capture_frame.cljc
+++ b/implementation/core/src/re_frame/capture_frame.cljc
@@ -1,0 +1,237 @@
+(ns re-frame.capture-frame
+  "The frame api behind `re-frame.core/capture-frame` and the `reg-view`
+  injection sugar: the one constructor (`make-capture-frame`) and the
+  incarnation fence its ops run through.
+
+  An implementation namespace, not an app surface — apps call
+  `re-frame.core/capture-frame`. It sits BELOW the facade so the `reg-view`
+  macro's emitted body can name the constructor fully-qualified without a
+  compiler-only Var living on `re-frame.core` (rf2-93sxp; until then
+  `make-capture-frame` was a facade export whose manifest row read
+  `:tier :implementation` — annotation, not removal, per Conventions
+  §Removing or demoting a facade export).
+
+  The ops route through the facade's `^:no-doc` `dispatch-impl` /
+  `dispatch-sync-impl` / `subscribe-impl` seams — the same `def`-aliases the
+  call-site macros target — so a `with-redefs` on a seam is honoured by a
+  frame api captured earlier (tool tests spy on exactly that). A leaf
+  namespace cannot `:require` the facade, so `re-frame.core` publishes the
+  three through `re-frame.late-bind` (`:core/dispatch-impl` /
+  `:core/dispatch-sync-impl` / `:core/subscribe-impl`, the cycle-breaking
+  flavour) and this ns reads them at capture time, falling back to the
+  owning fns when the facade has not loaded."
+  (:require [re-frame.frame :as frame]
+            [re-frame.router :as router]
+            [re-frame.subs :as subs]
+            [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.trace :as trace
+             #?@(:cljs [:include-macros true])]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- capture-frame incarnation fence (rf2-9pyles) -------------------------
+;;
+;; A frame api is LOCKED to one frame, and moftbs (rf2-moftbs) made a frame's
+;; identity its EXACT incarnation (the record's `:drain-lock`), distinct across a
+;; `destroy-frame!` + same-id reconstruction. So a frame api captured against a
+;; LIVE frame A must stay bound to incarnation A: if A is later destroyed and a
+;; same-id successor incarnation B reseats under the id, an op fired from a stale
+;; async closure (the motivating case: a predecessor React root's DEFERRED
+;; layout/effect cleanup, firing after `destroy-adapter!` returned and a fresh
+;; generation reseated frame B) must NOT dispatch into B. The bare-id resolution
+;; `dispatch!`/`dispatch-sync!` perform at call time would otherwise silently
+;; retarget the successor.
+;;
+;; The fence PINS the incarnation live at capture and treats a superseded target
+;; as destroyed (recover-but-emit `:rf.error/frame-destroyed`, NOT a throw — these
+;; ops fire from host cleanup where a throw would break the host teardown). It
+;; applies UNIFORMLY to every op that resolves the target — `:dispatch`,
+;; `:dispatch-sync` (rf2-9pyles) AND `:subscribe` (rf2-tdjv7p, closing the same
+;; silent cross-incarnation retarget for the read op so subscribe cannot read a
+;; successor's app-db or leak a persisted reaction into its sub-cache). The pin
+;; is EXACT even over a frame VALUE: the value carries its own construction token
+;; (`:rf.frame/incarnation-token`, rf2-moftbs), preferred before the id-keyed
+;; registry lookup so `(capture-frame <value>)` pins the same incarnation
+;; `(capture-frame <id>)` does (rf2-vclh63). When the captured id was NOT live at
+;; capture (`capture-frame`'s 1-arity lock-to-id form used from outside any scope,
+;; a not-yet-mounted id, or a derived-read value carrying no token) nothing is
+;; pinned and the op stays address-directed — the documented dynamic-id
+;; semantics. This is the async-safe, RECOVER-BUT-EMIT form of the incarnation
+;; fence: where a synchronous fence throws on a superseded incarnation, this one
+;; emits `:rf.error/frame-destroyed` and drops the op.
+
+(defn- capture-target-incarnation
+  "The EXACT incarnation token (`:drain-lock`) pinning the capture TARGET's live
+  incarnation, else nil (unpinned / address-directed). `frame-target` is a
+  keyword id OR a frame VALUE.
+
+  A construction frame VALUE carries its own exact token
+  (`:rf.frame/incarnation-token`, rf2-moftbs) — PREFER it so `(capture-frame
+  <value>)` pins the SAME incarnation `(capture-frame <id>)` does. The id-keyed
+  registry lookup (`frame-incarnation-token`) returns nil for a value map (the
+  registry is keyed by id, not by the value), so without this the value path
+  silently lost its pin (rf2-vclh63). A keyword id — or a derived-read value that
+  carries no construction token — falls to the id-keyed lookup: a live id pins,
+  an absent/not-yet-mounted id (or a derived-read value, whose map is not a
+  registry key) pins nothing. Namespace-qualified `frame/…` is never shadowed by
+  a local `frame`."
+  [frame-target]
+  (or (frame/frame-value-incarnation-token frame-target)
+      (frame/frame-incarnation-token frame-target)))
+
+(defn- capture-target-superseded?
+  "True when a pinned `captured-incarnation` no longer identifies the capture
+  TARGET's live frame — the exact captured incarnation was destroyed, whether the
+  id is now unclaimed or a same-id successor incarnation reseated. `frame-target`
+  is NORMALIZED to its frame id (`frame-target->id`) before the liveness lookup so
+  a frame VALUE's carried token is compared against the current live incarnation
+  under its id — the id-keyed token lookup does not accept a value map, so without
+  this a pinned value would read nil-live and be spuriously superseded on every
+  op (rf2-vclh63). nil `captured-incarnation` (an unpinned capture) is never
+  superseded."
+  [frame-target captured-incarnation]
+  (and (some? captured-incarnation)
+       (not (frame/frame-incarnation-live?
+              (frame/frame-target->id frame-target) captured-incarnation))))
+
+(defn- capture-dispatch!
+  "Route a captured `:dispatch`/`:dispatch-sync` op through the incarnation fence:
+  when the pinned incarnation is superseded, recover-but-emit `:rf.error/frame-
+  destroyed` (never enqueue into a same-id successor); otherwise delegate to
+  `dispatch-fn` (the `dispatch-impl` / `dispatch-sync-impl` alias, preserving the
+  single `with-redefs` interception seam). `frame-target` is a keyword id OR a
+  frame VALUE; the recover-but-emit stamps the normalized frame id (identity for
+  a keyword) so the diagnostic carries an id, never a value map (rf2-vclh63).
+  `op` (rf2-7xlvt) is the ALREADY-KNOWN operation realm — `:dispatch` or
+  `:dispatch-sync` — carried through the recover-but-emit so the frame-destroyed
+  source-coord resolves under `[:event id]` exactly, never the realm-ambiguous
+  fallback that could steal a same-keyword subscription's coord."
+  [dispatch-fn op frame-target captured-incarnation event opts]
+  (if (capture-target-superseded? frame-target captured-incarnation)
+    (router/emit-captured-frame-superseded!
+      event (frame/frame-target->id frame-target) op opts)
+    ;; rf2-dlld6: the `capture-target-superseded?` pre-check above and the
+    ;; ordinary address-directed dispatch below are SEPARATE operations. On the
+    ;; concurrent JVM host frame A can be destroyed AND a same-id successor B
+    ;; installed in the window between them, so a capture that just validated A
+    ;; would enqueue into B — a bare-id resolve, violating the exact-incarnation
+    ;; promise. Carry the EXACT captured incarnation through as
+    ;; `:rf.frame/expected-incarnation` so `dispatch!` / `dispatch-sync!`
+    ;; validate it against the SAME record they resolve for enqueue (one
+    ;; exact-incarnation operation) and recover-but-emit rather than leak into B.
+    ;; nil `captured-incarnation` (an unpinned capture made while its target was
+    ;; ABSENT) carries nothing and stays deliberately address-directed.
+    (dispatch-fn event (cond-> opts
+                         (some? captured-incarnation)
+                         (assoc :rf.frame/expected-incarnation captured-incarnation)))))
+
+(defn- capture-subscribe!
+  "Route a captured `:subscribe` op through the SAME incarnation fence as
+  `capture-dispatch!` (rf2-tdjv7p): when the pinned incarnation is superseded,
+  recover-but-emit `:rf.error/frame-destroyed` and return nil — never resolve a
+  reaction against a same-id successor (which would read the successor's app-db
+  and cache a reaction in its sub-cache). Otherwise delegate to `subscribe-thunk`
+  (the live read, which itself applies the dev-only `:rf.trace/call-site`
+  wrapper). The subscribe half of the async-safe, recover-but-emit incarnation
+  fence — the dispatch half is above; reuses the dispatch fence's emit seam,
+  passing `subscribe-call-site` as the `:rf.trace/call-site` so the drop is
+  attributed to the subscribe coord, and the `:subscribe` operation realm
+  (rf2-7xlvt) so the frame-destroyed source-coord resolves under `[:sub id]`
+  exactly — never a same-keyword event's coord."
+  [subscribe-thunk frame-target captured-incarnation query-v subscribe-call-site]
+  (if (capture-target-superseded? frame-target captured-incarnation)
+    (router/emit-captured-frame-superseded!
+      query-v (frame/frame-target->id frame-target) :subscribe
+      {:rf.trace/call-site subscribe-call-site})
+    (subscribe-thunk)))
+
+(defn- seam
+  "The facade seam published under `hook-key`, else `default` (the owning fn
+  the seam aliases — identical unless a tool has redefined the seam).
+  Resolved once per capture: the published fn reads the facade var at call
+  time, so a `with-redefs` on `re-frame.core/dispatch-impl` reaches an op
+  captured before it."
+  [hook-key default]
+  (or (late-bind/get-fn-cached hook-key) default))
+
+(defn make-capture-frame
+  "Build a frame api locked to `frame` — the constructor behind
+  `re-frame.core/capture-frame` (both arities) and the `reg-view` injection
+  sugar, whose emitted body names it fully-qualified. Not an app surface:
+  call `capture-frame`.
+
+    {:frame         frame
+     :dispatch      (fn ([event] [event opts]))
+     :dispatch-sync (fn ([event] [event opts]))
+     :subscribe     (fn [query-v])}
+
+  The captured `frame` is closed over by every op — no dynamic-var read
+  at op-call time — so the frame api dispatches / subscribes into `frame`
+  even when an op fires after the surrounding `with-frame` /
+  `frame-provider` / `frame-root` scope has unwound (the async-boundary
+  case).
+
+  Per the frame-affordance redesign (rf2-kkut0) the captured frame is
+  AUTHORITATIVE: `:frame` is assoc'd LAST in the dispatch opts, so a
+  per-call `:frame` in `opts` CANNOT override it — the frame api is
+  locked to one frame.
+
+  `opts` (the second arg) supports the `reg-view` source-coord sugar:
+    :dispatch-opts        base dispatch opts merged BELOW the captured
+                          `:frame` (and below any per-call `opts`). The
+                          `reg-view` macro injects
+                          `{:source :ui :rf.trace/call-site <view-coord>}`
+                          here so a view's on-click `#((:dispatch h) [...])`
+                          classifies as `:source :ui` + carries the view's
+                          call-site for Xray's dispatch 'go to code'.
+    :subscribe-call-site  a source-coord stamped (under
+                          `interop/debug-enabled?`) onto any error emitted
+                          inside the synchronous subscribe miss path
+                          (`:rf.error/no-such-sub`, `:rf.error/frame-
+                          destroyed`). Mirrors the `subscribe` macro's
+                          `trace/with-call-site` wrapper; subscriptions
+                          carry no `:source` axis. DCEs in production."
+  [frame {:keys [dispatch-opts subscribe-call-site]}]
+  ;; rf2-9pyles: pin the EXACT incarnation live at capture so a later op cannot
+  ;; leak into a same-id successor. nil (id not live at capture) ⇒ address-directed.
+  (let [captured-incarnation (capture-target-incarnation frame)
+        dispatch-impl        (seam :core/dispatch-impl      router/dispatch!)
+        dispatch-sync-impl   (seam :core/dispatch-sync-impl router/dispatch-sync!)
+        subscribe-impl       (seam :core/subscribe-impl     subs/subscribe)]
+    {:frame frame
+     :dispatch
+     (fn dispatch-fn
+       ([event]      (capture-dispatch! dispatch-impl :dispatch frame captured-incarnation
+                                        event (merge dispatch-opts {:frame frame})))
+       ([event opts] (capture-dispatch! dispatch-impl :dispatch frame captured-incarnation
+                                        event (merge dispatch-opts opts {:frame frame}))))
+     :dispatch-sync
+     (fn dispatch-sync-fn
+       ([event]      (capture-dispatch! dispatch-sync-impl :dispatch-sync frame captured-incarnation
+                                        event (merge dispatch-opts {:frame frame})))
+       ([event opts] (capture-dispatch! dispatch-sync-impl :dispatch-sync frame captured-incarnation
+                                        event (merge dispatch-opts opts {:frame frame}))))
+     :subscribe
+     ;; rf2-tdjv7p: fence subscribe on the SAME incarnation pin as dispatch — a
+     ;; capture pinned to incarnation A whose frame was destroyed and reseated as
+     ;; a same-id successor B must NOT subscribe into B (reading B's app-db,
+     ;; caching a reaction in B's sub-cache); it recover-but-emits and returns nil.
+     (fn subscribe-fn
+       [query-v]
+       ;; rf2-dlld6: carry the EXACT captured incarnation into the read so
+       ;; `subscribe-in-frame` validates it against the SAME record it resolves
+       ;; from the sub-cache (one exact-incarnation operation) — closing the
+       ;; identical check-then-use window the dispatch arm has: a same-id
+       ;; successor B installed between the `capture-subscribe!` pre-check and
+       ;; the resolve cannot be read (nor a reaction cached in B's sub-cache).
+       (let [sub-opts (cond-> {:frame frame}
+                        (some? captured-incarnation)
+                        (assoc :rf.frame/expected-incarnation captured-incarnation))]
+         (capture-subscribe!
+           (fn []
+             (if (and subscribe-call-site interop/debug-enabled?)
+               (trace/with-call-site subscribe-call-site
+                 (subscribe-impl query-v sub-opts))
+               (subscribe-impl query-v sub-opts)))
+           frame captured-incarnation query-v subscribe-call-site)))}))

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -29,6 +29,11 @@
   which would wipe a previously-loaded `re-frame.core.X`."
   (:require [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
+            ;; The frame api constructor behind `capture-frame` and the
+            ;; `reg-view` injection — an implementation namespace below this
+            ;; facade (rf2-93sxp), so the expansion can name it fully-qualified
+            ;; without a compiler-only Var living here.
+            [re-frame.capture-frame :as frame-api]
             [re-frame.router :as router]
             [re-frame.events :as events]
             [re-frame.fx :as fx]
@@ -178,7 +183,6 @@
                                     reg-view reg-machine defmachine
                                     image
                                     dispatch dispatch-sync subscribe
-                                    ->interceptor
                                     with-frame with-new-frame
                                     with-fx-overrides
                                     with-managed-request-stubs]])))
@@ -191,8 +195,9 @@
 ;; alias below resolve the SAME var. `^:no-doc` strips them from the API
 ;; manifest / generated docs (the same mechanism `reg-event-db` etc. use) —
 ;; they are NOT a public facade surface, just the shared internal seam the
-;; `dispatch` / `dispatch-sync` / `subscribe` macro's expansion AND
-;; `make-capture-frame`'s injected ops both call through, so a SINGLE
+;; `dispatch` / `dispatch-sync` / `subscribe` macro's expansion AND a frame
+;; api's ops (`re-frame.capture-frame/make-capture-frame`, published to it
+;; below) both call through, so a SINGLE
 ;; `with-redefs` on one of these (or the CLJS value-alias, which aliases the
 ;; SAME var) intercepts every real dispatch, macro-driven or reg-view-
 ;; injected alike (rf2-m90brg — API-shrink #2 retired the PUBLIC `dispatch*` /
@@ -212,6 +217,18 @@
 (def ^:no-doc dispatch-impl      router/dispatch!)
 (def ^:no-doc dispatch-sync-impl router/dispatch-sync!)
 (def ^:no-doc subscribe-impl     subs/subscribe)
+
+;; Publish the three seams to `re-frame.capture-frame` (rf2-93sxp). It sits
+;; BELOW this facade and cannot `:require` it, so the frame api's ops reach
+;; the seams through the late-bind registry (the cycle-breaking flavour, per
+;; `re-frame.late-bind.directory`). Each published fn reads the var at CALL
+;; time — `(dispatch-impl event opts)`, not the var's current value — so a
+;; `with-redefs` on `rf/dispatch-impl` reaches an op captured before it,
+;; exactly as it reaches the macro expansions.
+(late-bind/set-fns!
+  {:core/dispatch-impl      (fn [event opts]   (dispatch-impl event opts))
+   :core/dispatch-sync-impl (fn [event opts]   (dispatch-sync-impl event opts))
+   :core/subscribe-impl     (fn [query-v opts] (subscribe-impl query-v opts))})
 
 (defn ^:no-doc stamp-opts
   "Merge macro-stamped `extra` into a call's user-supplied `opts`, TOLERANTLY:
@@ -408,8 +425,7 @@
   `reg-event-ctx` raises `:rf.error/reg-event-ctx-removed`, naming
   `reg-interceptor` as the public replacement for application full-context
   work (register the interceptor by id, then reference it from a `reg-event`
-  registration's `:interceptors` chain; `->interceptor` is internal-only
-  post-EP-0022). See `re-frame.events/reg-event-ctx` and
+  registration's `:interceptors` chain). See `re-frame.events/reg-event-ctx` and
   spec/001-Registration.md §The retired event-registration names."}
   reg-event-ctx events/reg-event-ctx)
 
@@ -433,8 +449,8 @@
        runtime-extension authority. Coeffects are declared uniformly via
        `:rf.cofx/requires`. Full-context work is expressed with an
        interceptor authored via `reg-interceptor` and referenced by id from
-       this registration's `:interceptors` chain (`->interceptor` is the
-       internal lowering constructor post-EP-0022, not the authoring form).
+       this registration's `:interceptors` chain (there is no public
+       interceptor-value constructor post-EP-0022).
        Captures source-coords (Spec 001) at this call site. Additionally
        captures the whole `(reg-event :id ...)`
        form as a string under the handler's `:rf.handler/source` meta
@@ -1250,206 +1266,6 @@
   (frame/require-current-frame! :current-frame-id
                                 {:where 're-frame.core/current-frame-id}))
 
-;; ---- capture-frame incarnation fence (rf2-9pyles) -------------------------
-;;
-;; A frame api is LOCKED to one frame, and moftbs (rf2-moftbs) made a frame's
-;; identity its EXACT incarnation (the record's `:drain-lock`), distinct across a
-;; `destroy-frame!` + same-id reconstruction. So a frame api captured against a
-;; LIVE frame A must stay bound to incarnation A: if A is later destroyed and a
-;; same-id successor incarnation B reseats under the id, an op fired from a stale
-;; async closure (the motivating case: a predecessor React root's DEFERRED
-;; layout/effect cleanup, firing after `destroy-adapter!` returned and a fresh
-;; generation reseated frame B) must NOT dispatch into B. The bare-id resolution
-;; `dispatch!`/`dispatch-sync!` perform at call time would otherwise silently
-;; retarget the successor.
-;;
-;; The fence PINS the incarnation live at capture and treats a superseded target
-;; as destroyed (recover-but-emit `:rf.error/frame-destroyed`, NOT a throw — these
-;; ops fire from host cleanup where a throw would break the host teardown). It
-;; applies UNIFORMLY to every op that resolves the target — `:dispatch`,
-;; `:dispatch-sync` (rf2-9pyles) AND `:subscribe` (rf2-tdjv7p, closing the same
-;; silent cross-incarnation retarget for the read op so subscribe cannot read a
-;; successor's app-db or leak a persisted reaction into its sub-cache). The pin
-;; is EXACT even over a frame VALUE: the value carries its own construction token
-;; (`:rf.frame/incarnation-token`, rf2-moftbs), preferred before the id-keyed
-;; registry lookup so `(capture-frame <value>)` pins the same incarnation
-;; `(capture-frame <id>)` does (rf2-vclh63). When the captured id was NOT live at
-;; capture (`capture-frame`'s 1-arity lock-to-id form used from outside any scope,
-;; a not-yet-mounted id, or a derived-read value carrying no token) nothing is
-;; pinned and the op stays address-directed — the documented dynamic-id
-;; semantics. This is the async-safe, RECOVER-BUT-EMIT form of the incarnation
-;; fence: where a synchronous fence throws on a superseded incarnation, this one
-;; emits `:rf.error/frame-destroyed` and drops the op.
-
-(defn- capture-target-incarnation
-  "The EXACT incarnation token (`:drain-lock`) pinning the capture TARGET's live
-  incarnation, else nil (unpinned / address-directed). `frame-target` is a
-  keyword id OR a frame VALUE.
-
-  A construction frame VALUE carries its own exact token
-  (`:rf.frame/incarnation-token`, rf2-moftbs) — PREFER it so `(capture-frame
-  <value>)` pins the SAME incarnation `(capture-frame <id>)` does. The id-keyed
-  registry lookup (`frame-incarnation-token`) returns nil for a value map (the
-  registry is keyed by id, not by the value), so without this the value path
-  silently lost its pin (rf2-vclh63). A keyword id — or a derived-read value that
-  carries no construction token — falls to the id-keyed lookup: a live id pins,
-  an absent/not-yet-mounted id (or a derived-read value, whose map is not a
-  registry key) pins nothing. Namespace-qualified `frame/…` is never shadowed by
-  a local `frame`."
-  [frame-target]
-  (or (frame/frame-value-incarnation-token frame-target)
-      (frame/frame-incarnation-token frame-target)))
-
-(defn- capture-target-superseded?
-  "True when a pinned `captured-incarnation` no longer identifies the capture
-  TARGET's live frame — the exact captured incarnation was destroyed, whether the
-  id is now unclaimed or a same-id successor incarnation reseated. `frame-target`
-  is NORMALIZED to its frame id (`frame-target->id`) before the liveness lookup so
-  a frame VALUE's carried token is compared against the current live incarnation
-  under its id — the id-keyed token lookup does not accept a value map, so without
-  this a pinned value would read nil-live and be spuriously superseded on every
-  op (rf2-vclh63). nil `captured-incarnation` (an unpinned capture) is never
-  superseded."
-  [frame-target captured-incarnation]
-  (and (some? captured-incarnation)
-       (not (frame/frame-incarnation-live?
-              (frame/frame-target->id frame-target) captured-incarnation))))
-
-(defn- capture-dispatch!
-  "Route a captured `:dispatch`/`:dispatch-sync` op through the incarnation fence:
-  when the pinned incarnation is superseded, recover-but-emit `:rf.error/frame-
-  destroyed` (never enqueue into a same-id successor); otherwise delegate to
-  `dispatch-fn` (the `dispatch-impl` / `dispatch-sync-impl` alias, preserving the
-  single `with-redefs` interception seam). `frame-target` is a keyword id OR a
-  frame VALUE; the recover-but-emit stamps the normalized frame id (identity for
-  a keyword) so the diagnostic carries an id, never a value map (rf2-vclh63).
-  `op` (rf2-7xlvt) is the ALREADY-KNOWN operation realm — `:dispatch` or
-  `:dispatch-sync` — carried through the recover-but-emit so the frame-destroyed
-  source-coord resolves under `[:event id]` exactly, never the realm-ambiguous
-  fallback that could steal a same-keyword subscription's coord."
-  [dispatch-fn op frame-target captured-incarnation event opts]
-  (if (capture-target-superseded? frame-target captured-incarnation)
-    (router/emit-captured-frame-superseded!
-      event (frame/frame-target->id frame-target) op opts)
-    ;; rf2-dlld6: the `capture-target-superseded?` pre-check above and the
-    ;; ordinary address-directed dispatch below are SEPARATE operations. On the
-    ;; concurrent JVM host frame A can be destroyed AND a same-id successor B
-    ;; installed in the window between them, so a capture that just validated A
-    ;; would enqueue into B — a bare-id resolve, violating the exact-incarnation
-    ;; promise. Carry the EXACT captured incarnation through as
-    ;; `:rf.frame/expected-incarnation` so `dispatch!` / `dispatch-sync!`
-    ;; validate it against the SAME record they resolve for enqueue (one
-    ;; exact-incarnation operation) and recover-but-emit rather than leak into B.
-    ;; nil `captured-incarnation` (an unpinned capture made while its target was
-    ;; ABSENT) carries nothing and stays deliberately address-directed.
-    (dispatch-fn event (cond-> opts
-                         (some? captured-incarnation)
-                         (assoc :rf.frame/expected-incarnation captured-incarnation)))))
-
-(defn- capture-subscribe!
-  "Route a captured `:subscribe` op through the SAME incarnation fence as
-  `capture-dispatch!` (rf2-tdjv7p): when the pinned incarnation is superseded,
-  recover-but-emit `:rf.error/frame-destroyed` and return nil — never resolve a
-  reaction against a same-id successor (which would read the successor's app-db
-  and cache a reaction in its sub-cache). Otherwise delegate to `subscribe-thunk`
-  (the live read, which itself applies the dev-only `:rf.trace/call-site`
-  wrapper). The subscribe half of the async-safe, recover-but-emit incarnation
-  fence — the dispatch half is above; reuses the dispatch fence's emit seam,
-  passing `subscribe-call-site` as the `:rf.trace/call-site` so the drop is
-  attributed to the subscribe coord, and the `:subscribe` operation realm
-  (rf2-7xlvt) so the frame-destroyed source-coord resolves under `[:sub id]`
-  exactly — never a same-keyword event's coord."
-  [subscribe-thunk frame-target captured-incarnation query-v subscribe-call-site]
-  (if (capture-target-superseded? frame-target captured-incarnation)
-    (router/emit-captured-frame-superseded!
-      query-v (frame/frame-target->id frame-target) :subscribe
-      {:rf.trace/call-site subscribe-call-site})
-    (subscribe-thunk)))
-
-(defn make-capture-frame
-  "INTERNAL constructor for `capture-frame` (and the `reg-view` injection
-  sugar) — `:tier :implementation` (EP-0024 Open Issue #8, rf2-5vla7c).
-  Not an app-facing surface — call `capture-frame` instead. It is a plain
-  (technically public) Var rather
-  than `defn-` ONLY so the `reg-view` macro's emitted body can reference
-  it fully-qualified (a `defn-` private would fail the CLJ analyzer when
-  the expansion compiles on the JVM); the precedent is `reg-view*` /
-  `view`, which are likewise public plumbing.
-
-  Build a frame api locked to `frame`:
-
-    {:frame         frame
-     :dispatch      (fn ([event] [event opts]))
-     :dispatch-sync (fn ([event] [event opts]))
-     :subscribe     (fn [query-v])}
-
-  The captured `frame` is closed over by every op — no dynamic-var read
-  at op-call time — so the frame api dispatches / subscribes into `frame`
-  even when an op fires after the surrounding `with-frame` /
-  `frame-provider` / `frame-root` scope has unwound (the async-boundary
-  case).
-
-  Per the frame-affordance redesign (rf2-kkut0) the captured frame is
-  AUTHORITATIVE: `:frame` is assoc'd LAST in the dispatch opts, so a
-  per-call `:frame` in `opts` CANNOT override it — the frame api is
-  locked to one frame.
-
-  `opts` (the second arg) supports the `reg-view` source-coord sugar:
-    :dispatch-opts        base dispatch opts merged BELOW the captured
-                          `:frame` (and below any per-call `opts`). The
-                          `reg-view` macro injects
-                          `{:source :ui :rf.trace/call-site <view-coord>}`
-                          here so a view's on-click `#((:dispatch h) [...])`
-                          classifies as `:source :ui` + carries the view's
-                          call-site for Xray's dispatch 'go to code'.
-    :subscribe-call-site  a source-coord stamped (under
-                          `interop/debug-enabled?`) onto any error emitted
-                          inside the synchronous subscribe miss path
-                          (`:rf.error/no-such-sub`, `:rf.error/frame-
-                          destroyed`). Mirrors the `subscribe` macro's
-                          `trace/with-call-site` wrapper; subscriptions
-                          carry no `:source` axis. DCEs in production."
-  [frame {:keys [dispatch-opts subscribe-call-site]}]
-  ;; rf2-9pyles: pin the EXACT incarnation live at capture so a later op cannot
-  ;; leak into a same-id successor. nil (id not live at capture) ⇒ address-directed.
-  (let [captured-incarnation (capture-target-incarnation frame)]
-    {:frame frame
-     :dispatch
-     (fn dispatch-fn
-       ([event]      (capture-dispatch! dispatch-impl :dispatch frame captured-incarnation
-                                        event (merge dispatch-opts {:frame frame})))
-       ([event opts] (capture-dispatch! dispatch-impl :dispatch frame captured-incarnation
-                                        event (merge dispatch-opts opts {:frame frame}))))
-     :dispatch-sync
-     (fn dispatch-sync-fn
-       ([event]      (capture-dispatch! dispatch-sync-impl :dispatch-sync frame captured-incarnation
-                                        event (merge dispatch-opts {:frame frame})))
-       ([event opts] (capture-dispatch! dispatch-sync-impl :dispatch-sync frame captured-incarnation
-                                        event (merge dispatch-opts opts {:frame frame}))))
-     :subscribe
-     ;; rf2-tdjv7p: fence subscribe on the SAME incarnation pin as dispatch — a
-     ;; capture pinned to incarnation A whose frame was destroyed and reseated as
-     ;; a same-id successor B must NOT subscribe into B (reading B's app-db,
-     ;; caching a reaction in B's sub-cache); it recover-but-emits and returns nil.
-     (fn subscribe-fn
-       [query-v]
-       ;; rf2-dlld6: carry the EXACT captured incarnation into the read so
-       ;; `subscribe-in-frame` validates it against the SAME record it resolves
-       ;; from the sub-cache (one exact-incarnation operation) — closing the
-       ;; identical check-then-use window the dispatch arm has: a same-id
-       ;; successor B installed between the `capture-subscribe!` pre-check and
-       ;; the resolve cannot be read (nor a reaction cached in B's sub-cache).
-       (let [sub-opts (cond-> {:frame frame}
-                        (some? captured-incarnation)
-                        (assoc :rf.frame/expected-incarnation captured-incarnation))]
-         (capture-subscribe!
-           (fn []
-             (if (and subscribe-call-site interop/debug-enabled?)
-               (trace/with-call-site subscribe-call-site
-                 (subscribe-impl query-v sub-opts))
-               (subscribe-impl query-v sub-opts)))
-           frame captured-incarnation query-v subscribe-call-site)))}))
-
 (defn capture-frame
   "Return a frame api — the keystone affordance for
   carrying a frame into closures and across async boundaries. Per Spec
@@ -1492,11 +1308,11 @@
   002 §Resolver surface). Use the 1-arity `(capture-frame frame-id)` to
   lock a frame api to a named frame from outside any scope (the right shape
   for async callbacks / tools / tests / SSR)."
-  ([]         (make-capture-frame
+  ([]         (frame-api/make-capture-frame
                 (frame/require-current-frame!
                   :capture-frame {:where 're-frame.core/capture-frame})
                 nil))
-  ([frame-id] (make-capture-frame frame-id nil)))
+  ([frame-id] (frame-api/make-capture-frame frame-id nil)))
 
 ;; ---- frame-scope lexical macros ------------------------------------------
 
@@ -2120,42 +1936,15 @@
 ;; same-name `def`-alias in the Convention-A block near the top of this ns
 ;; covers the HoF / programmatic case — reach the owning ns directly
 ;; (`re-frame.interceptor-registry/reg-interceptor*`) from JVM code.
-
-(def ^{:doc "INTERNAL lowering constructor (EP-0022) — NOT the public
-  application-authoring surface; author interceptors with `reg-interceptor`
-  and reference them by id from event/frame `:interceptors` chains. This
-  fn-form lowers a descriptor into an executable chain entry from kwargs:
-  `:id`, `:before`, `:after`, and an optional `:source-coord` (the
-  `->interceptor` macro supplies it from `(meta &form)`). Retained as the
-  framework-internal lowering seam (used by the registry resolver, the std
-  interceptors, and tests); it MUST NOT appear in a public event/frame
-  chain. Per spec/001 §`->interceptor` is not the application authoring
-  form, spec/002 §10, and spec/API.md §Standard interceptors."}
-  ->interceptor*  interceptor/->interceptor*)
-
-#?(:clj
-   (defmacro ->interceptor
-     "INTERNAL lowering constructor (EP-0022) — NOT the public application-
-     authoring surface. The public form is `reg-interceptor` (which names the
-     interceptor, captures source coords, and makes it addressable / queryable
-     / overridable by id). `->interceptor` survives only as the coord-capturing
-     internal lowering constructor (the macro counterpart of `->interceptor*`):
-     it builds an interceptor map from kwargs and bakes the definition-site
-     `:source-coord` from `(meta &form)` so the Xray Epoch INTERCEPTOR row can
-     jump to source when an interceptor throws. It MUST NOT appear in a public
-     event/frame chain — those carry interceptor REFERENCES (Spec 002).
-
-     Kwargs: `:id` (keyword name; default `:unnamed`), `:before`
-     (`(fn [ctx] ctx)` — runs before the handler), `:after`
-     (`(fn [ctx] ctx)` — runs after, in reverse order).
-
-     The captured coord DCEs under `:advanced` + `goog.DEBUG=false` (the
-     macro's prod branch omits the `:source-coord` kwarg entirely). Per
-     spec/001 §`->interceptor` is not the application authoring form,
-     spec/002 §10, spec/API.md §Standard interceptors, and rf2-siheh."
-     [& kwargs]
-     (csm/build-interceptor-form (meta &form) (symbol (str (ns-name *ns*))) *file*
-                                 kwargs)))
+;;
+;; The lowering constructor is NOT on this facade either (rf2-93sxp): the
+;; `->interceptor*` alias and the coord-capturing `->interceptor` macro were
+;; facade exports whose manifest rows read "internal lowering only" — an
+;; internal disposition recorded against a still-exported var, the annotation-
+;; not-removal shape Conventions §Removing or demoting a facade export names.
+;; `re-frame.interceptor/->interceptor*` is the one constructor, reached by
+;; the registry resolver, the std interceptors and tests; the macro had no
+;; library caller and is deleted. `reg-interceptor` is the authoring form.
 
 ;; Interceptor CONTEXT ACCESSORS — `get-coeffect` / `assoc-coeffect` /
 ;; `get-effect` / `assoc-effect` — are NO LONGER re-exported from the

--- a/implementation/core/src/re_frame/core_call_site_macros.cljc
+++ b/implementation/core/src/re_frame/core_call_site_macros.cljc
@@ -6,9 +6,6 @@
   the CLJS compiler from baking the owner's fixed arities into call sites, so
   tools can safely replace the seam with a differently shaped test fn.
 
-  `->interceptor` is a separate definition-site-capturing macro. It shares the
-  coordinate and debug-gate machinery but is not part of the dispatch family.
-
   Carved out of `re-frame.core` so the public namespace stays a thin
   facade focused on user-visible Var resolution rather than macro
   expansion bulk; this ns owns the cohesive responsibility of every
@@ -148,33 +145,4 @@
            plain   (if arg2
                      `(re-frame.core/subscribe-impl ~arg1 ~arg2)
                      `(re-frame.core/subscribe-impl ~arg1))]
-       (gate stamped plain))))
-
-;; ---- ->interceptor definition-site coordinate capture --------------------
-;;
-;; `->interceptor` is the only interceptor constructor with a USER
-;; definition site to jump to (the std interceptor `path` and
-;; the cofx injector are framework-built; the reg-event handler-wrappers
-;; carry the event's own coord). The macro captures `(meta &form)` and bakes
-;; the result into `->interceptor*`'s `:source-coord` kwarg. The coordinate
-;; stays on the exact interceptor instance through chain errors and
-;; `:rf.error/interceptor-exception`; it is not resolved through the registrar.
-;;
-;; The gate is OUTERMOST so the whole `:source-coord` literal DCEs under
-;; `:advanced` + `goog.DEBUG=false`: the prod branch omits the kwarg
-;; entirely, expanding to the identical fn call the bare fn-path produces.
-
-#?(:clj
-   (defn build-interceptor-form
-     "Build the expansion for the `->interceptor` macro. `kwargs` is the
-     verbatim `& {:keys [id before after]}` arg-seq the user wrote;
-     `form-meta` / `ns-sym` / `file` come from the call site. Emits a
-     gated `(if interop/debug-enabled? <with-coord> <plain>)` around
-     `re-frame.core/->interceptor*` — the dev branch splices the
-     captured `:source-coord` kwarg in, the prod branch is the bare
-     fn-call so the coord literal DCEs."
-     [form-meta ns-sym file kwargs]
-     (let [cs-form (call-site-form form-meta ns-sym file)
-           stamped `(re-frame.core/->interceptor* ~@kwargs :source-coord ~cs-form)
-           plain   `(re-frame.core/->interceptor* ~@kwargs)]
        (gate stamped plain))))

--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -168,7 +168,9 @@
              ;;
              ;; Per rf2-kkut0 (frame-affordance redesign) + rf2-cry25
              ;; (Option A, Mike-ruled): the reg-view injection is now SUGAR
-             ;; over a single `make-capture-frame` — the frame api captures the
+             ;; over a single `re-frame.capture-frame/make-capture-frame` (the
+             ;; owned constructor behind `capture-frame`, off the facade per
+             ;; rf2-93sxp) — the frame api captures the
              ;; render-time frame ONCE, and the injected `dispatch` /
              ;; `subscribe` NOUNS are its `:dispatch` / `:subscribe` ops.
              ;; They shadow the coord-capturing `dispatch` / `subscribe`
@@ -184,7 +186,7 @@
              ;; frame api's opts only. Render-time frame capture is preserved
              ;; (`make-capture-frame` captures `(current-frame-id)` once).
              fn-body  `(fn ~sym ~args
-                         (let [handle#    (re-frame.core/make-capture-frame
+                         (let [handle#    (re-frame.capture-frame/make-capture-frame
                                             (re-frame.core/current-frame-id)
                                             {:dispatch-opts       ~dispatch-opts-form
                                              :subscribe-call-site ~sub-coord-form})

--- a/implementation/core/src/re_frame/interceptor.cljc
+++ b/implementation/core/src/re_frame/interceptor.cljc
@@ -7,11 +7,12 @@
      :before (fn [context] new-context)   ;; runs before handler
      :after  (fn [context] new-context)}  ;; runs after handler
 
-  Built via the `->interceptor` macro (`re-frame.core`, captures the
-  definition-site `:source-coord` for jump-to-source per Spec 001) or
-  the `->interceptor*` fn (this ns; HoF / programmatic, no coord
-  capture). A captured `:source-coord` rides the error-record so
-  tooling can jump to the throwing interceptor's source.
+  Built via `->interceptor*` (this ns) — the framework's ONE lowering
+  constructor, reached by the registry resolver, the standard
+  interceptors and tests; it is not an application authoring surface
+  (that is `re-frame.core/reg-interceptor`, EP-0022). A `:source-coord`
+  passed to it rides the error-record so tooling can jump to the
+  throwing interceptor's source.
 
   The 'context' is a map with :coeffects (inputs) and :effects (outputs).
   The chain runs :before in order, then the handler, then :after in
@@ -21,14 +22,12 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (defn ->interceptor*
-  "Build an interceptor map from kwargs — the plain, runtime-callable
-  fn form of the `->interceptor` macro (per Conventions §`*`-suffix
-  naming). HoF / programmatic / REPL callers reach this directly; the
-  `rf/->interceptor` macro is the ergonomic surface that ALSO captures
-  the definition-site `:source-coord` from `(meta &form)` (so the Xray
-  Epoch INTERCEPTOR row can jump to source). This fn captures no
-  call-site — pass `:source-coord` explicitly if you have one (the
-  macro does exactly that).
+  "Build an interceptor map from kwargs — the framework-internal lowering
+  constructor (EP-0022). Not an application authoring surface: apps
+  author with `re-frame.core/reg-interceptor` and reference the
+  interceptor by id from a chain; the registry resolver lowers the
+  registered descriptor through this fn. This fn captures no call-site —
+  pass `:source-coord` explicitly if you have one.
 
   Kwargs:
     :id            keyword name (default `:unnamed`); appears in error
@@ -39,11 +38,10 @@
     :after         `(fn [context] new-context)` — runs after the handler,
                    in reverse declaration order.
     :source-coord  optional `{:ns :file :line :column}` source-coord map
-                   (per Spec 001 §Source-coordinate capture). Stamped by
-                   the `->interceptor` macro from `(meta &form)`; rides
-                   the error-record so tooling renders a jump-to-source
-                   chip when the interceptor throws. Absent on the plain
-                   fn path unless the caller supplies one.
+                   (per Spec 001 §Source-coordinate capture). Rides the
+                   error-record so tooling renders a jump-to-source chip
+                   when the interceptor throws. Absent unless the caller
+                   supplies one.
 
   The `context` map carries:
     `:coeffects` — input data: `:db` (current app-db value), `:event`
@@ -54,7 +52,7 @@
                    app-db value), `:fx` (the vector of `[fx-id args]`
                    pairs the runtime walks after the chain).
 
-  See also: `->interceptor` (the macro form, `re-frame.core`),
+  See also: `re-frame.core/reg-interceptor` (the authoring form),
   `get-coeffect`, `assoc-coeffect`, `get-effect`, `assoc-effect`,
   `:rf.cofx/requires` (the declared-coeffect key), `:rf.interceptor/path`
   (the standard path interceptor, a registered factory referenced as
@@ -143,8 +141,7 @@
   coeffect-supplier throw is handled there rather than on this record.
 
   The record carries the throwing interceptor's
-  `:source-coord` when one was captured (the `->interceptor` macro
-  stamps it from `(meta &form)`). The router threads it onto the
+  `:source-coord` when the interceptor value carries one. The router threads it onto the
   `:rf.error/interceptor-exception` trace so the Xray Epoch INTERCEPTOR
   row renders a jump-to-source chip (parity with EVENT HANDLER /
   SUBSCRIPTIONS / VIEWS). Absent on the fn-path / framework interceptors

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -112,6 +112,27 @@
     :design-bead "rf2-x76af2.22"
     :description "Re-kick a fresh async drain for an exact captured frame record. Called by frame/call-serialized-with-drain!'s cold-section release when that record's queue is non-empty (a dispatch! that arrived during the hold scheduled a drain-try! that CAS-lost to the cold holder and gave up). The record/token is carried across the late-bind seam so an obsolete A callback can never re-resolve and drain same-id B."}
 
+   ;; ---- re-frame.core → re-frame.capture-frame (the facade's dispatch seams) --
+   ;; `re-frame.capture-frame` (the frame api constructor behind
+   ;; `capture-frame` and the `reg-view` injection, rf2-93sxp) sits below the
+   ;; facade, but its ops must call the facade's `^:no-doc` `dispatch-impl` /
+   ;; `dispatch-sync-impl` / `subscribe-impl` `def`-aliases — the seams the
+   ;; call-site macros target and tool tests `with-redefs` — rather than the
+   ;; owning fns directly. The facade publishes the three at load; the
+   ;; constructor reads them at capture time.
+   {:key         :core/dispatch-impl
+    :producer-ns 're-frame.core
+    :design-bead "rf2-93sxp"
+    :description "The facade's `dispatch-impl` seam (a `def`-alias of re-frame.router/dispatch!), read live so a with-redefs on re-frame.core/dispatch-impl reaches a frame api's :dispatch op. Consumed by re-frame.capture-frame/make-capture-frame."}
+   {:key         :core/dispatch-sync-impl
+    :producer-ns 're-frame.core
+    :design-bead "rf2-93sxp"
+    :description "The facade's `dispatch-sync-impl` seam (a `def`-alias of re-frame.router/dispatch-sync!), read live for a frame api's :dispatch-sync op. Consumed by re-frame.capture-frame/make-capture-frame."}
+   {:key         :core/subscribe-impl
+    :producer-ns 're-frame.core
+    :design-bead "rf2-93sxp"
+    :description "The facade's `subscribe-impl` seam (a `def`-alias of re-frame.subs/subscribe), read live for a frame api's :subscribe op. Consumed by re-frame.capture-frame/make-capture-frame."}
+
    ;; ---- EP-0023 inline-registration lowering -------------------------------
    ;; `re-frame.image-assembly` lowers an image's inline `:registrations` fn
    ;; bodies (`:impl`) into the runnable descriptor shape per kind so they route

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -2246,7 +2246,7 @@
 (defn ^:no-doc emit-captured-frame-superseded!
   "rf2-9pyles — the recover-but-emit seam for a `capture-frame` op whose CAPTURED
   frame incarnation has been SUPERSEDED. A frame api built by
-  `re-frame.core/make-capture-frame` pins the EXACT incarnation live at capture
+  `re-frame.capture-frame/make-capture-frame` pins the EXACT incarnation live at capture
   (its `:drain-lock`); if that incarnation is later destroyed — whether the id is
   now unclaimed OR a same-id successor incarnation B has reseated under it — the
   captured op must NOT leak into B. It RECOVERS (the event is never enqueued into

--- a/implementation/core/test/re_frame/dispatch_family_facade_shrink_test.clj
+++ b/implementation/core/test/re_frame/dispatch_family_facade_shrink_test.clj
@@ -52,11 +52,16 @@
     (is (nil? (ns-resolve 're-frame.core 'reg-machine*))
         "re-frame.core/reg-machine* stays absent")))
 
-(deftest arrow-interceptor-star-untouched
-  (testing "->interceptor* is a SEPARATE internal-lowering pair (EP-0022) —
-            out of scope for rf2-m90brg; it must still resolve unchanged"
-    (is (some? (ns-resolve 're-frame.core '->interceptor*))
-        "re-frame.core/->interceptor* is untouched by this bead")))
+(deftest arrow-interceptor-star-gone-from-facade
+  (testing "->interceptor* was a SEPARATE internal-lowering pair (EP-0022),
+            out of scope for rf2-m90brg and left resolving then; rf2-93sxp
+            took it off the facade too — the constructor lives only on
+            re-frame.interceptor (see
+            re-frame.facade-internal-constructors-cljs-test for both platforms)"
+    (is (nil? (ns-resolve 're-frame.core '->interceptor*))
+        "re-frame.core/->interceptor* is GONE (no alias)")
+    (is (some? (ns-resolve 're-frame.interceptor '->interceptor*))
+        "re-frame.interceptor/->interceptor* is the owning constructor")))
 
 ;; ---- the retained macro forms still work -----------------------------------
 

--- a/implementation/core/test/re_frame/facade_internal_constructors_cljs_test.cljc
+++ b/implementation/core/test/re_frame/facade_internal_constructors_cljs_test.cljc
@@ -1,0 +1,67 @@
+(ns re-frame.facade-internal-constructors-cljs-test
+  "rf2-93sxp — the implementation-only lowering constructors are OFF the
+  `re-frame.core` facade, on both platforms.
+
+  `make-capture-frame`, `->interceptor` and `->interceptor*` were exported
+  from `re-frame.core` only so a macro expansion could name them
+  fully-qualified. Their manifest rows read `:tier :implementation` (or
+  \"internal lowering only\") while still carrying `:facade? true` — the
+  annotation-as-removal failure spec/Conventions.md §Removing or demoting a
+  facade export names. The lowering seams now live in their owning
+  namespaces (`re-frame.capture-frame/make-capture-frame`,
+  `re-frame.interceptor/->interceptor*`); the `->interceptor` macro is gone
+  outright (no library caller — the owning constructor suffices, and
+  `reg-interceptor` is the authoring form); the facade resolves none of the
+  three.
+
+  Every absence probe is paired with a presence probe through the SAME
+  instrument (`ns-resolve` on the JVM, `goog.getObjectByName` on CLJS), so a
+  probe that answers nil for the wrong reason cannot read as a clean
+  removal."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.core :as rf]))
+
+#?(:clj
+   (defn- facade-var
+     "The `re-frame.core` var named `sym`, or nil. `ns-resolve` follows
+     `^:no-doc` and private vars too, so nil means GONE, not hidden."
+     [sym]
+     (ns-resolve 're-frame.core sym)))
+
+#?(:cljs
+   (defn- facade-runtime-var
+     "The compiled `re-frame.core` runtime property `munged-name`, or nil.
+     A symbol reference would not compile once the var is gone, so the
+     probe reads the emitted namespace object by name instead."
+     [munged-name]
+     (js/goog.getObjectByName (str "re_frame.core." munged-name))))
+
+(deftest facade-no-longer-resolves-the-lowering-constructors
+  (testing "positive control — the probe finds the public carry primitive"
+    (is (some? #?(:clj  (facade-var 'capture-frame)
+                  :cljs (facade-runtime-var "capture_frame")))
+        "re-frame.core/capture-frame resolves (the instrument works)"))
+  (testing "make-capture-frame is off the facade"
+    (is (nil? #?(:clj  (facade-var 'make-capture-frame)
+                 :cljs (facade-runtime-var "make_capture_frame")))
+        "re-frame.core/make-capture-frame no longer resolves"))
+  (testing "->interceptor* is off the facade"
+    (is (nil? #?(:clj  (facade-var '->interceptor*)
+                 :cljs (facade-runtime-var "_GT_interceptor_STAR_")))
+        "re-frame.core/->interceptor* no longer resolves"))
+  #?(:clj
+     (testing "the ->interceptor macro is gone (JVM-only macro; CLJS never
+               carried a runtime var for it)"
+       (is (nil? (facade-var '->interceptor))
+           "re-frame.core/->interceptor no longer resolves"))))
+
+(deftest capture-frame-remains-the-supported-carry-primitive
+  (testing "the 1-arity lock-to-id form still returns the frame api bundle
+            (the behavioural contract is pinned in depth by
+            re-frame.capture-frame-test; this is the facade-side smoke)"
+    (let [handle (rf/capture-frame :rf/default)]
+      (is (= #{:frame :dispatch :dispatch-sync :subscribe} (set (keys handle))))
+      (is (= :rf/default (:frame handle)))
+      (is (fn? (:dispatch handle)))
+      (is (fn? (:dispatch-sync handle)))
+      (is (fn? (:subscribe handle))))))

--- a/implementation/core/test/re_frame/interceptor_runtime_complete_cljs_test.cljc
+++ b/implementation/core/test/re_frame/interceptor_runtime_complete_cljs_test.cljc
@@ -16,9 +16,10 @@
        NOT a sibling `[id other-arg]`; canonical-arg identity; remove + replace;
        and `:rf.error/interceptor-override-invalid` on a malformed key.
 
-    3. `->interceptor` is the internal lowering constructor — NOT public
-       authoring (the public form is `reg-interceptor`) — but the constructor
-       still produces a working executable interceptor.
+    3. `re-frame.interceptor/->interceptor*` is the internal lowering
+       constructor — NOT public authoring (the public form is
+       `reg-interceptor`), and off the `re-frame.core` facade (rf2-93sxp) —
+       but the constructor still produces a working executable interceptor.
 
   Dual-runtime (.cljc): runs on JVM (`clojure -M:test`) and CLJS
   (`npm run test:cljs`)."
@@ -317,12 +318,15 @@
            (rf/reg-interceptor :pub/authored {:doc "public form"} {:before identity})))
     (is (some? (rf/handler-meta :interceptor :pub/authored))
         "reg-interceptor produced a registered, addressable program member")
-    ;; The manifest demotes ->interceptor / ->interceptor* off the public-
-    ;; authoring (front-porch) tier to :internal-public (lowering only); this
-    ;; test pins the BEHAVIORAL contract: authoring goes through reg-interceptor,
-    ;; while ->interceptor* remains a working internal lowering seam (above).
-    (is (var? #'rf/->interceptor*)
-        "->interceptor* is retained as the internal lowering constructor")))
+    ;; The lowering constructor lives ONLY on its owning namespace
+    ;; (rf2-93sxp — the facade no longer carries `->interceptor*`; the absence
+    ;; is pinned on both platforms by
+    ;; re-frame.facade-internal-constructors-cljs-test). This test pins the
+    ;; BEHAVIORAL contract: authoring goes through reg-interceptor, while
+    ;; `re-frame.interceptor/->interceptor*` remains a working internal
+    ;; lowering seam (above).
+    (is (fn? interceptor/->interceptor*)
+        "->interceptor* is retained on re-frame.interceptor as the internal lowering constructor")))
 
 ;; ===========================================================================
 ;; PIECE 4 — interceptor-registry resolution-seam coverage gaps

--- a/implementation/core/test/re_frame/interceptor_test.clj
+++ b/implementation/core/test/re_frame/interceptor_test.clj
@@ -902,91 +902,63 @@
           (is (empty? (filterv #(= :rf.error/handler-exception (:operation %)) errs))
               "an interceptor :after throw does NOT report as handler-exception"))))))
 
-;; ---- macro-path source-coord capture (rf2-siheh) --------------------------
+;; ---- explicit source-coord on the lowering constructor (rf2-siheh) --------
 ;;
-;; The `->interceptor` MACRO captures the definition-site coord from
-;; `(meta &form)` (riding the rf2-wvsxg absolutise path, exactly like the
-;; reg-* macros) and bakes `:source-coord` into the interceptor map. When
-;; that interceptor throws, the coord rides the error-record (interceptor/
-;; error-record) → the router threads it onto the
-;; `:rf.error/interceptor-exception` trace's `:source-coord` tag, so the
-;; Xray Epoch INTERCEPTOR row can render a jump-to-source chip (parity with
-;; EVENT HANDLER / SUBSCRIPTIONS / VIEWS). The `->interceptor*` FN path
-;; captures no coord — there is no syntactic call site to attribute.
+;; `->interceptor*` (`re-frame.interceptor`, the ONE lowering constructor)
+;; captures no coord of its own — there is no syntactic call site to
+;; attribute — but a `:source-coord` passed to it stays on the interceptor
+;; map. When that interceptor throws, the coord rides the error-record
+;; (interceptor/error-record) → the router threads it onto the
+;; `:rf.error/interceptor-exception` trace's `:source-coord` tag, so the Xray
+;; Epoch INTERCEPTOR row can render a jump-to-source chip (parity with EVENT
+;; HANDLER / SUBSCRIPTIONS / VIEWS). The facade's coord-capturing
+;; `->interceptor` macro, which used to bake that coord from `(meta &form)`,
+;; is gone (rf2-93sxp — no library caller; `reg-interceptor` is the authoring
+;; form), so the threading contract is pinned with an explicit coord.
 
-(deftest macro-interceptor-carries-absolutised-source-coord
-  (testing "a macro-defined interceptor map carries an absolutised
-            :source-coord (:ns / :file / :line); :file is an absolute
-            on-disk path per the rf2-wvsxg absolutise path"
-    (let [icpt (rf/->interceptor
-                 :id     :siheh/probe
-                 :before identity)
-          {:keys [ns file line] :as coord} (:source-coord icpt)]
-      ;; SEMANTIC, posture-independent (rf2-d2841): whichever branch the macro
-      ;; expands to, it must still BUILD a usable interceptor. A production
-      ;; branch that dropped more than the coord would be an rf2-9c2jf-class
-      ;; defect, and nothing else in the suite would see it.
-      (is (= :siheh/probe (:id icpt))
-          "the macro builds an interceptor carrying the requested :id")
-      (is (fn? (:before icpt))
-          "the macro builds an interceptor carrying the :before fn")
-      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The macro's
-      ;; PRODUCTION branch omits the `:source-coord` kwarg entirely, by design.
-      (when interop/debug-enabled?
-        (is (map? coord)
-            "the macro bakes a :source-coord map into the interceptor")
-        (is (= 're-frame.interceptor-test ns)
-            ":ns is the metadata-free consumer namespace symbol")
-        (is (integer? line) ":line is the macro call-site line")
-        (is (string? file) ":file is a string")
-        ;; rf2-wvsxg — the macro feeds the picked :file through
-        ;; absolutise-file at expansion time, so the coord ships an
-        ;; absolute on-disk path (here the classpath resolved the test
-        ;; source under the core artefact's test root).
-        (is (re-find #"interceptor_test\.clj$" file)
-            ":file resolves to this test source file")
-        (is (re-find #"^(?:/|[A-Za-z]:)" file)
-            ":file is absolute (leading slash or drive letter) — absolutised"))))
+(def ^:private probe-coord
+  {:ns 're-frame.interceptor-test :file "re_frame/interceptor_test.clj" :line 921 :column 1})
 
-  (testing "the ->interceptor* fn path captures NO :source-coord (HoF /
-            programmatic — no syntactic call site to attribute)"
-    (let [icpt (interceptor/->interceptor* :id :siheh/fn-probe :before identity)]
-      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). This is the
-      ;; NEGATIVE half of the macro-vs-fn discriminator above; under the
-      ;; production gate neither path carries a coord, so asserting it there
-      ;; would pass for the wrong reason.
-      (when interop/debug-enabled?
-        (is (nil? (:source-coord icpt))
-            "fn-built interceptor carries no coord")))))
+(deftest lowering-constructor-keeps-an-explicit-source-coord
+  (testing "an interceptor built with an explicit :source-coord carries it;
+            one built without carries none"
+    (let [with-coord (interceptor/->interceptor* :id           :siheh/probe
+                                                 :before       identity
+                                                 :source-coord probe-coord)
+          bare       (interceptor/->interceptor* :id :siheh/fn-probe :before identity)]
+      (is (= :siheh/probe (:id with-coord))
+          "the constructor carries the requested :id")
+      (is (fn? (:before with-coord))
+          "the constructor carries the :before fn")
+      (is (= probe-coord (:source-coord with-coord))
+          "an explicit :source-coord stays on the interceptor map")
+      (is (nil? (:source-coord bare))
+          "no coord unless the caller supplies one"))))
 
-(deftest macro-interceptor-source-coord-rides-the-exception-trace
-  (testing "a throwing macro-defined interceptor threads its :source-coord
-            onto the :rf.error/interceptor-exception trace (the slot the
-            Xray Epoch INTERCEPTOR row's jump-to-source chip reads)"
-    ;; EP-0022 reference-only: register the MACRO-BUILT interceptor VALUE as
-    ;; the descriptor (the registration boundary accepts an interceptor value),
-    ;; so the :source-coord the macro captured from `(meta &form)` rides
-    ;; through resolution onto the trace. Then reference it by id.
+(deftest interceptor-source-coord-rides-the-exception-trace
+  (testing "a throwing interceptor threads its :source-coord onto the
+            :rf.error/interceptor-exception trace (the slot the Xray Epoch
+            INTERCEPTOR row's jump-to-source chip reads)"
+    ;; EP-0022 reference-only: register the interceptor VALUE as the
+    ;; descriptor (the registration boundary accepts an interceptor value),
+    ;; so the :source-coord it carries rides through resolution onto the
+    ;; trace. Then reference it by id.
     (rf/reg-interceptor :siheh/before-icpt
-                         (rf/->interceptor
-                           :id     :siheh/before-icpt
-                           :before (fn [_] (throw (ex-info "before blew up" {})))))
+                        (interceptor/->interceptor*
+                          :id           :siheh/before-icpt
+                          :before       (fn [_] (throw (ex-info "before blew up" {})))
+                          :source-coord probe-coord))
     (rf/reg-event :siheh/before-boom
-                     {:interceptors [:siheh/before-icpt]}
-                     (fn [{:keys [db]} _] {:db db}))
+                  {:interceptors [:siheh/before-icpt]}
+                  (fn [{:keys [db]} _] {:db db}))
     (let [errs (capture-error-traces [:siheh/before-boom])]
-      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring): a coord
-      ;; threaded onto a trace tag is dev-only twice over — the coord is not
-      ;; captured in production and the trace is not emitted there either.
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring): the trace is
+      ;; not emitted in production.
       (when interop/debug-enabled?
         (let [ix (filterv #(= :rf.error/interceptor-exception (:operation %)) errs)]
           (is (= 1 (count ix)) "exactly one interceptor-exception")
-          (let [coord (get-in (first ix) [:tags :source-coord])]
-            (is (map? coord)
-                "the trace carries the interceptor's :source-coord tag")
-            (is (re-find #"interceptor_test\.clj$" (:file coord))
-                ":file points at this test source")
-            (is (integer? (:line coord)) ":line is captured"))))))
+          (is (= probe-coord (get-in (first ix) [:tags :source-coord]))
+              "the trace carries the interceptor's :source-coord tag")))))
 
   (testing "a throwing ->interceptor*-built interceptor threads NO
             :source-coord tag (degrades to plain text in the panel)"

--- a/implementation/core/test/re_frame/on_error_cljs_test.cljc
+++ b/implementation/core/test/re_frame/on_error_cljs_test.cljc
@@ -565,13 +565,11 @@
             `:failing-id` (distinct from the event) — so an off-box shipper
             can tell WHICH interceptor failed in production, not just the
             category. `:reason` rides too."
-    (let [seen (atom [])
-          boom-after (rf/->interceptor
-                       :id :n4x74b/boom-after
-                       :after (fn [_ctx] (throw (ex-info "after boom" {}))))]
+    (let [seen (atom [])]
       (rf/register-listener! :errors :test/recorder
                              (fn [record] (swap! seen conj record)))
-      (rf/reg-interceptor :n4x74b/boom-after boom-after)
+      (rf/reg-interceptor :n4x74b/boom-after
+                          {:after (fn [_ctx] (throw (ex-info "after boom" {})))})
       (rf/reg-event :n4x74b/with-throwing-interceptor
                     {:interceptors [:n4x74b/boom-after]}
                     (fn [{:keys [db]} _] {:db (assoc db :x 1)}))
@@ -592,13 +590,11 @@
   (testing "Per rf2-n4x74b: the :before-phase variant — an interceptor whose
             :before throws is attributed to the interceptor id on the always-on
             record too (the same classification applies to both phases)."
-    (let [seen (atom [])
-          boom-before (rf/->interceptor
-                        :id :n4x74b/boom-before
-                        :before (fn [_ctx] (throw (ex-info "before boom" {}))))]
+    (let [seen (atom [])]
       (rf/register-listener! :errors :test/recorder
                              (fn [record] (swap! seen conj record)))
-      (rf/reg-interceptor :n4x74b/boom-before boom-before)
+      (rf/reg-interceptor :n4x74b/boom-before
+                          {:before (fn [_ctx] (throw (ex-info "before boom" {})))})
       (rf/reg-event :n4x74b/before-throws
                     {:interceptors [:n4x74b/boom-before]}
                     (fn [{:keys [db]} _] {:db db}))
@@ -696,14 +692,12 @@
             `:after` one through `:reason` alone. Both phases pinned here, in
             every posture."
     (rf/reg-interceptor :mlh1h/boom-before
-      (rf/->interceptor :id     :mlh1h/boom-before
-                        :before (fn [_ctx] (throw (ex-info "before boom" {})))))
+      {:before (fn [_ctx] (throw (ex-info "before boom" {})))})
     (rf/reg-event :mlh1h/before-throws
                   {:interceptors [:mlh1h/boom-before]}
                   (fn [{:keys [db]} _] {:db db}))
     (rf/reg-interceptor :mlh1h/boom-after
-      (rf/->interceptor :id    :mlh1h/boom-after
-                        :after (fn [_ctx] (throw (ex-info "after boom" {})))))
+      {:after (fn [_ctx] (throw (ex-info "after boom" {})))})
     (rf/reg-event :mlh1h/after-throws
                   {:interceptors [:mlh1h/boom-after]}
                   (fn [{:keys [db]} _] {:db db}))
@@ -1321,15 +1315,12 @@
   (testing "An interceptor :after throw aborts the event before the
             install — even though the handler produced a :db effect: app-db
             is UNCHANGED and NO :rf.event/db-changed is emitted."
-    (let [traces (atom [])
-          ;; A user interceptor whose :after throws AFTER the handler has
-          ;; produced its :db effect.
-          boom-after (rf/->interceptor
-                       :id :test/boom-after
-                       :after (fn [_ctx] (throw (ex-info "after boom" {}))))]
-      ;; EP-0022 reference-only flip: register the interceptor VALUE under its
-      ;; own id and reference it from the chain.
-      (rf/reg-interceptor :test/boom-after boom-after)
+    (let [traces (atom [])]
+      ;; A user interceptor whose :after throws AFTER the handler has
+      ;; produced its :db effect — authored with `reg-interceptor` (EP-0022)
+      ;; and referenced by id from the chain.
+      (rf/reg-interceptor :test/boom-after
+                          {:after (fn [_ctx] (throw (ex-info "after boom" {})))})
       (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:seeded 1}}))
       (rf/dispatch-sync [:seed])
       (is (= {:seeded 1} (rf/app-db-value :rf/default)) "seeded")

--- a/implementation/core/test/re_frame/reg_view_injection_test.clj
+++ b/implementation/core/test/re_frame/reg_view_injection_test.clj
@@ -260,7 +260,7 @@
 ;; ---- production-elision shape (dev coord vs slim prod coord) -------------
 ;;
 ;; Per rf2-kkut0 the injection is sugar over a single
-;; `(re-frame.core/make-capture-frame (re-frame.core/current-frame-id)
+;; `(re-frame.capture-frame/make-capture-frame (re-frame.core/current-frame-id)
 ;;   {:dispatch-opts <gated> :subscribe-call-site <gated>})`. The handle's
 ;; `:dispatch-opts` and `:subscribe-call-site` args each ride their OWN
 ;; outer `(if interop/debug-enabled? <dev> <prod>)` gate so Closure DCEs
@@ -292,10 +292,10 @@
                                   'my.ns "v.cljc" 'cv
                                   '([] [:button {:on-click #(dispatch [:x])}]))
           ;; The single injection call:
-          ;; (re-frame.core/make-capture-frame (re-frame.core/current-frame-id)
+          ;; (re-frame.capture-frame/make-capture-frame (re-frame.core/current-frame-id)
           ;;   {:dispatch-opts <gate> :subscribe-call-site <gate>}).
           mfh-call (find-form #(and (seq? %)
-                                    (= 're-frame.core/make-capture-frame (first %)))
+                                    (= 're-frame.capture-frame/make-capture-frame (first %)))
                               exp)
           frame-arg (nth mfh-call 1)            ;; the captured-frame expr
           opts-map  (nth mfh-call 2)            ;; the {:dispatch-opts ... :subscribe-call-site ...}

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -316,6 +316,27 @@
        (sort-by (comp (juxt first second) first))
        vec))
 
+(defn implementation-facade-rows
+  "Return a sorted vector of `[namespace var]` for every row that combines an
+   implementation-only disposition (`:tier :implementation`) with
+   `:facade? true` (rf2-93sxp).
+
+   A facade export tiered `:implementation` is annotation, not removal: the
+   var still resolves from `re-frame.core`, still projects into docs/api and
+   still reaches SCI's `copy-ns`, while its row claims it is internal. Per
+   Conventions §Removing or demoting a facade export the disposition must
+   fire on the SURFACE — the var leaves the facade for its owning namespace,
+   where the generator does not row it — so a row of this shape is a
+   contradiction to refuse at generation, exactly as `duplicate-rows` refuses
+   two rows for one var. `:internal-public` is deliberately NOT in scope: that
+   tier is a supported host/tool embed seam, not an internal one."
+  [rows]
+  (->> rows
+       (filter #(and (:facade? %) (= :implementation (:tier %))))
+       (map (juxt :namespace :var))
+       (sort-by (juxt first second))
+       vec))
+
 (defn build-manifest
   "Build the full manifest data structure (the value written to
    spec/api-manifest.edn). Throws on missing / stale sidecar entries with
@@ -323,7 +344,8 @@
   [sidecar]
   (let [[rows missing] (build-rows sidecar)
         stale          (stale-sidecar-entries sidecar)
-        dups           (duplicate-rows rows)]
+        dups           (duplicate-rows rows)
+        demoted        (implementation-facade-rows rows)]
     (when (seq missing)
       (throw (ex-info
               (str "Public vars with no sidecar classification (add a "
@@ -357,6 +379,21 @@
                                     (str ns-str "/" var-str " (" n " rows)"))
                                   dups)))
               {:duplicates dups})))
+    ;; Facade-vs-disposition invariant (rf2-93sxp). A `:facade? true` row at
+    ;; `:tier :implementation` says "internal" about a var that still exports
+    ;; from `re-frame.core` — annotation, not removal. Refuse it here so the
+    ;; disposition has to land on the surface (Conventions §Removing or
+    ;; demoting a facade export — delete, don't demote).
+    (when (seq demoted)
+      (throw (ex-info
+              (str "Implementation-only rows exported from the facade — these "
+                   "`[namespace var]` pairs are `:tier :implementation` AND "
+                   "`:facade? true`. A facade export cannot be internal by "
+                   "annotation: move the var off `re-frame.core` into its owning "
+                   "namespace (Conventions §Removing or demoting a facade export "
+                   "— delete, don't demote), or tier it as the surface it is:\n  "
+                   (str/join "\n  " (map #(str/join "/" %) demoted)))
+              {:implementation-facade demoted})))
     {:meta {:doc        (str "GENERATED public-API manifest — do NOT hand-edit "
                              "the :vars list. Regenerate with: clojure -M -m "
                              "re-frame.api-manifest.gen (run from "

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
@@ -112,3 +112,81 @@
       (is (pos? (count rows)) "precondition: the manifest is non-empty")
       (is (empty? (gen/duplicate-rows rows))
           "the committed manifest must not carry duplicate [namespace var] rows"))))
+
+;; ---------------------------------------------------------------------------
+;; implementation-facade-rows — the facade-vs-disposition invariant
+;; (rf2-93sxp). A `:facade? true` row at `:tier :implementation` records an
+;; internal disposition against a var that still exports from `re-frame.core`
+;; — annotation, not removal (Conventions §Removing or demoting a facade
+;; export). `build-manifest` refuses it, so the disposition must land on the
+;; surface; the planted-row shape here is exactly the one the three
+;; `make-capture-frame` / `->interceptor` / `->interceptor*` rows carried.
+;; ---------------------------------------------------------------------------
+
+(deftest implementation-facade-rows-flags-only-the-contradiction
+  (testing "a :facade? true row at :tier :implementation is flagged; an
+            :implementation row OFF the facade, an :internal-public facade
+            row and an ordinary front-porch row are not"
+    (is (= [["re-frame.core" "make-capture-frame"]]
+           (gen/implementation-facade-rows
+             [{:namespace "re-frame.core" :var "capture-frame"
+               :tier :front-porch :facade? true}
+              {:namespace "re-frame.core" :var "make-capture-frame"
+               :tier :implementation :facade? true}
+              {:namespace "re-frame.story" :var "capture-golden"
+               :tier :implementation :facade? false}
+              {:namespace "re-frame.core" :var "frame-provider"
+               :tier :internal-public :facade? true}])))))
+
+(deftest implementation-facade-rows-are-sorted
+  (testing "the report is sorted by [namespace var] for stable output"
+    (is (= [["a.ns" "b"] ["a.ns" "c"] ["z.ns" "a"]]
+           (gen/implementation-facade-rows
+             [{:namespace "z.ns" :var "a" :tier :implementation :facade? true}
+              {:namespace "a.ns" :var "c" :tier :implementation :facade? true}
+              {:namespace "a.ns" :var "b" :tier :implementation :facade? true}])))))
+
+(defn- live-sidecar-with-demoted-facade-var
+  "The REAL committed sidecar with one live facade var's classification
+   RETIERED to `:implementation` — the planted contradiction. The var itself
+   still exports from `re-frame.core`, so the generated row is
+   `:facade? true` + `:tier :implementation`: the exact shape the removed
+   rows had. Using the real sidecar keeps the missing/stale/duplicate checks
+   passing so the facade-vs-disposition check is what fires."
+  []
+  (let [sidecar (gen/read-sidecar)
+        k       ["re-frame.core" "capture-frame"]]
+    (assert (get-in sidecar [:classification k])
+            "precondition: the sidecar classifies re-frame.core/capture-frame")
+    (assoc-in sidecar [:classification k :tier] :implementation)))
+
+(deftest build-manifest-throws-on-implementation-facade-row
+  (testing "build-manifest refuses a :facade? true row at :tier :implementation
+            — the throw is what turns generation / --check red"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"Implementation-only rows exported from the facade"
+          (gen/build-manifest (live-sidecar-with-demoted-facade-var))))))
+
+(deftest build-manifest-implementation-facade-ex-data-lists-the-key
+  (testing "the thrown ex-data names the offending [namespace var] so the
+            var can be moved off the facade"
+    (try
+      (gen/build-manifest (live-sidecar-with-demoted-facade-var))
+      (is false "expected build-manifest to throw on the planted row")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= [["re-frame.core" "capture-frame"]]
+               (:implementation-facade (ex-data e))))))))
+
+(deftest live-manifest-has-no-implementation-facade-rows
+  (testing "the committed spec/api-manifest.edn carries no :facade? true row
+            at :tier :implementation, and the plant above is the only way to
+            get one (non-vacuous: the manifest still carries :implementation
+            rows OFF the facade and :facade? true rows at other tiers)"
+    (let [rows (:vars (gen/read-committed-manifest))]
+      (is (some #(and (= :implementation (:tier %)) (not (:facade? %))) rows)
+          "precondition: :implementation rows exist off the facade")
+      (is (some :facade? rows)
+          "precondition: facade rows exist")
+      (is (empty? (gen/implementation-facade-rows rows))
+          "the committed manifest must not carry an implementation-only facade row"))))

--- a/spec/API.md
+++ b/spec/API.md
@@ -815,7 +815,6 @@ Under [EP-0022](../docs/EP/EP-0022-registered-interceptors.md) the public interc
 |---|---|---|---|
 | `[:rf.interceptor/path <path-vector>]` | interceptor **reference** (the one standard interceptor; the canonical `:factory` consumer) | front-porch | Focus a handler on an `app-db` sub-slice: `:before` stages the focused slice as `:db`, `:after` widens the returned slice back into full app-db. Preserves the frame-commit `identical?` no-op — an unchanged focused slice widens back to the original app-db object, not an `assoc-in` allocation ([002 §Standard `:rf.interceptor/path`](002-Frames.md#standard-rfinterceptorpath)). A non-vector/malformed path arg is `:rf.error/path-interceptor-bad-path`. |
 | `reg-interceptor` | M (registrar) | front-porch | The public application-authoring form for any non-standard interceptor — analytics, logging, validation, ad-hoc context manipulation. The resulting interceptor is named, addressable, queryable, and referenced by id from chains. Rowed in [§Registration](#registration). |
-| `->interceptor*` | Fn (internal lowering constructor) | advanced | The framework-internal constructor that lowers a descriptor into an executable chain entry (`(->interceptor* & {:keys [id before after source-coord]})`). **NOT a public application-authoring API** and MUST NOT appear in a public event/frame chain (EP-0022). |
 
 The retired v1 public interceptor-authoring helpers and their replacements:
 
@@ -823,7 +822,7 @@ The retired v1 public interceptor-authoring helpers and their replacements:
 |---|---|
 | `path` (public value constructor) | the standard reference `[:rf.interceptor/path <path-vector>]` (EP-0022) |
 | `unwrap` | handler destructuring (the M-19 canonical map-payload form), or a project-registered interceptor for intentional chain-wide event reshaping (EP-0022 — no standard `unwrap`) |
-| `->interceptor` (public authoring macro) | `reg-interceptor` (`->interceptor` survives only as the internal lowering constructor) |
+| `->interceptor` (public authoring macro) | `reg-interceptor` (the lowering constructor is `re-frame.interceptor/->interceptor*`, framework-internal) |
 | `debug` | Trace surface ([009](009-Instrumentation.md)) + 10x / re-frame-pair |
 | `trim-v` | Canonical map-payload call shape ([M-19](../migration/from-re-frame-v1/README.md#m-19-multi-positional-dispatch--subscribe-vectors--map-payload-form-opt-in)) |
 | `on-changes` | Flows ([Spec 013](013-Flows.md)) |

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -1247,7 +1247,7 @@ The diff-time obligation above is the **add** side: it governs what goes *onto* 
 
 **Who rules.** The same diff-time bar as additions: the PR that supersedes or internalises a surface **classifies its disposition** (which fate, and why) in the same change. A mechanical "this is dead, delete it" needs no escalation; a genuine *"is this still used internally?"* judgment call escalates to the operator, exactly as a contested tier on the add side does.
 
-This rule is **enforced by the public-facade manifest-hygiene CI check** (the guardrail that joins each `:facade? true` manifest row against its disposition and fails on a faceted row that has been superseded), the symmetric enforcement partner to the api-manifest drift-check that backs the add side.
+This rule is **enforced by the api-manifest drift-check itself** (`clojure -M -m re-frame.api-manifest.gen --check`, the `api-manifest` lint job): the generator refuses any `:facade? true` row at tier `implementation`, so an internal disposition cannot be recorded against a var that still exports from the facade — the same check that backs the add side, guarding the remove side too.
 
 ## Lifecycle-verb law — a closed verb vocabulary for naming lifecycle and facade APIs
 

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -630,42 +630,24 @@
   ["re-frame.core" "with-frame"]          {:tier :front-porch :owner "002" :status "v1"}
   ["re-frame.core" "with-new-frame"]      {:tier :front-porch :owner "002" :status "v1"}
   ["re-frame.core" "capture-frame"]       {:tier :front-porch :owner "002" :status "v1"}
-  ;; EP-0024 Open Issue #8 (rf2-5vla7c): `make-capture-frame` below is
-  ;; RETIERED off the app-facing facade to `:implementation`. `capture-frame`
-  ;; (above) stays the ONE public carry primitive; it survives exported from
-  ;; `re-frame.core` ONLY for cross-namespace / test reach (NOT a supported
-  ;; app/tool surface — an app MUST NOT depend on it), the same rationale as
-  ;; `->interceptor`. No API.md var-row. Grounded by the 0-caller backbone in
-  ;; ai/findings/API-review/codex/frame-targeting-and-lifecycle.md.
-  ;;   - `make-capture-frame` — the lower-level `capture-frame` constructor;
-  ;;     `capture-frame` is the public face. Exported so the `reg-view` macro's
-  ;;     emitted body can reference `re-frame.core/make-capture-frame`.
-  ;; API-shrink #1 (rf2-csbbwu): `frame-bound-fn` (macro) / `frame-bound-fn*`
-  ;; (fn) are DELETED from `re-frame.core` entirely (not just retiered) —
-  ;; `capture-frame` (or an explicit `{:frame …}` opt) is the ONE public carry
-  ;; primitive. The frame-rebinding closure semantics survive internally as
-  ;; `re-frame.frame/bind-fn` (a different namespace, not on this facade).
-  ["re-frame.core" "make-capture-frame"]  {:tier :implementation :owner "002" :status "EP-0024 (internal capture-frame constructor)"}
+  ;; `capture-frame` is the ONE public carry primitive. Its constructor,
+  ;; `make-capture-frame`, was a facade export retiered to `:implementation`
+  ;; (EP-0024 Open Issue #8, rf2-5vla7c) — annotation, not removal. rf2-93sxp
+  ;; moved it to `re-frame.capture-frame` (an implementation namespace the
+  ;; `reg-view` expansion names fully-qualified); it has no row, exactly as
+  ;; `re-frame.frame/bind-fn` (the internal survivor of API-shrink #1,
+  ;; rf2-csbbwu, which DELETED `frame-bound-fn` / `frame-bound-fn*`) has none.
   ["re-frame.core" "view"]                {:tier :advanced    :owner "001" :status "v1"}
   ["re-frame.core" "current-frame-id"]    {:tier :advanced    :owner "002" :status "v1"}
   ;; Interceptor authoring (spec/API.md §Interceptors). EP-0022 Slice C
-  ;; (rf2-0adhqs.3): `->interceptor` is NO LONGER the public application-
-  ;; authoring surface — `reg-interceptor` is (spec/001 §`->interceptor` is not
-  ;; the application authoring form; spec/002 §10). Both `->interceptor` (the
-  ;; coord-capturing macro) and `->interceptor*` (the plain-fn constructor)
-  ;; survive only as the framework-INTERNAL lowering constructor that turns a
-  ;; descriptor into an executable chain entry; they MUST NOT appear in a public
-  ;; event/frame chain. `->interceptor` is tiered `:implementation`: exported
-  ;; only so the registry resolver, the std interceptors, and tests can reach
-  ;; the lowering seam across a namespace boundary — NOT a host/tool embedding
-  ;; point (it fails the `internal-public` boundary test "is this a surface a
-  ;; host or tool legitimately embeds against?"), so it is below the supported
-  ;; surface. (The earlier `:internal-public` row was self-contradicting: API.md
-  ;; asserts the Xray `mount-<panel>!` family is that tier's sole instance.)
-  ;; `->interceptor*` stays at the `:advanced` tier API.md §Standard
-  ;; interceptors documents it under (the "internal lowering constructor" row).
-  ["re-frame.core" "->interceptor"]       {:tier :implementation :owner "002" :status "EP-0022 (internal lowering only)"}
-  ["re-frame.core" "->interceptor*"]      {:tier :advanced        :owner "002" :status "EP-0022 (internal lowering only)"}
+  ;; (rf2-0adhqs.3): `reg-interceptor` is the public authoring surface
+  ;; (spec/001 §`->interceptor` is not the application authoring form;
+  ;; spec/002 §10). The lowering constructor `->interceptor*` lives ONLY on
+  ;; `re-frame.interceptor` (no row — not a public namespace), and the
+  ;; coord-capturing `->interceptor` macro is deleted (rf2-93sxp): neither
+  ;; is exported from `re-frame.core` any longer, so the `:implementation` +
+  ;; `:facade? true` rows they carried — the shape the generator now refuses —
+  ;; are gone rather than annotated.
   ;; EP-0017 + rf2-w9xyx1: `inject-cofx` / `inject-cofx*` — the v1 ctx→ctx
   ;; coeffect-injection interceptors — are REMOVED (EP-0017 slice A, no alias;
   ;; spec/API.md §Standard interceptors). rf2-w9xyx1 removed them from the

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 482,
+ :var-count 479,
  :tier-vocab
  [:front-porch
   :advanced
@@ -66,8 +66,6 @@
   {:namespace "re-frame.adapter.uix", :var "use-frame", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.uix", :var "use-subscribe", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.adapter.uix", :var "wrap-view", :tier :adapter, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
-  {:namespace "re-frame.core", :var "->interceptor", :tier :implementation, :kind :macro, :owner "002", :status "EP-0022 (internal lowering only)", :facade? true, :runtime-verified? true}
-  {:namespace "re-frame.core", :var "->interceptor*", :tier :advanced, :kind :fn, :owner "002", :status "EP-0022 (internal lowering only)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "active-head", :tier :advanced, :kind :fn, :owner "011", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "adapter-disposed?", :tier :advanced, :kind :fn, :owner "006", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "app-db-value", :tier :advanced, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
@@ -115,7 +113,6 @@
   {:namespace "re-frame.core", :var "init-platform", :tier :advanced, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "install-adapter!", :tier :advanced, :kind :fn, :owner "006", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "install-revalidation-listeners!", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}
-  {:namespace "re-frame.core", :var "make-capture-frame", :tier :implementation, :kind :fn, :owner "002", :status "EP-0024 (internal capture-frame constructor)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "make-frame", :tier :advanced, :kind :fn, :owner "002", :status "EP-0024", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "mutation-meta", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "mutation-state", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -1778,14 +1778,12 @@
   (testing "a phase-2 event whose USER INTERCEPTOR :before throws is
             captured as an :rf.error/exception assertion carrying the
             :rf.error/interceptor-exception operation (rf2-294yq5.2)"
-    (let [boom-icpt (rf/->interceptor
-                      :id :test/boom-icpt
-                      :before (fn [_ctx] (throw (ex-info "icpt blew up" {:why :icpt}))))]
-      ;; EP-0022 reference-only flip: register the interceptor value then
-      ;; reference it by id from the chain (the value's `:id` must match).
-      (rf/reg-interceptor :test/boom-icpt boom-icpt)
+    ;; EP-0022: author the interceptor with `reg-interceptor` (the public
+    ;; form; it returns the id) and reference it by id from the chain.
+    (let [boom-icpt (rf/reg-interceptor :test/boom-icpt
+                      {:before (fn [_ctx] (throw (ex-info "icpt blew up" {:why :icpt})))})]
       (rf/reg-event :test/uses-boom-icpt
-        {:interceptors [:test/boom-icpt]}
+        {:interceptors [boom-icpt]}
         (fn [{:keys [db]} _] {:db db}))
       (story/reg-variant :story.icpt-boom/v
         {:events [[:test/uses-boom-icpt]]})

--- a/tools/xray/testbeds/standard_epochs/core.cljs
+++ b/tools/xray/testbeds/standard_epochs/core.cljs
@@ -226,17 +226,13 @@
 ;; makes the framework's per-step exception attribution (the :before-chain
 ;; vs interceptor-:after distinction) visible live in Xray.
 
-;; Throws in :before — aborts before the handler runs (button #13).
-(def throwing-interceptor
-  (rf/->interceptor
-    :id     :standard-epochs/throwing-interceptor
-    :before (fn interceptor-before-throws [_ctx]
-              (throw (ex-info "standard-epochs / interceptor :before (intentional — exercises the interceptor :before error surface)"
-                              {:surface :interceptor-exception :phase :before})))))
-
-;; EP-0022 reference-only flip: chains carry references only, so register the
-;; interceptor value and reference it by id from the event chain (button #13).
-(rf/reg-interceptor :standard-epochs/throwing-interceptor throwing-interceptor)
+;; Throws in :before — aborts before the handler runs (button #13). Authored
+;; with `reg-interceptor` (EP-0022 — the public form; chains carry references
+;; only) and referenced by id from the event chain.
+(rf/reg-interceptor :standard-epochs/throwing-interceptor
+  {:before (fn interceptor-before-throws [_ctx]
+             (throw (ex-info "standard-epochs / interceptor :before (intentional — exercises the interceptor :before error surface)"
+                             {:surface :interceptor-exception :phase :before})))})
 
 ;; Throws in :after — the handler runs to completion first, THEN this
 ;; throws on the way back out of the chain (button #14). The foil to the
@@ -244,16 +240,10 @@
 ;; not the handler, so the per-step placement renders the exception under
 ;; the interceptor's :after step and the framework attributes it to the
 ;; interceptor rather than collapsing it into a handler exception.
-(def throwing-interceptor-after
-  (rf/->interceptor
-    :id    :standard-epochs/throwing-interceptor-after
-    :after (fn interceptor-after-throws [_ctx]
-             (throw (ex-info "standard-epochs / interceptor :after (intentional — exercises the interceptor :after error surface)"
-                             {:surface :interceptor-exception :phase :after})))))
-
-;; EP-0022 reference-only flip: register the value and reference it by id from
-;; the event chain (button #14).
-(rf/reg-interceptor :standard-epochs/throwing-interceptor-after throwing-interceptor-after)
+(rf/reg-interceptor :standard-epochs/throwing-interceptor-after
+  {:after (fn interceptor-after-throws [_ctx]
+            (throw (ex-info "standard-epochs / interceptor :after (intentional — exercises the interceptor :after error surface)"
+                            {:surface :interceptor-exception :phase :after})))})
 
 ;; ============================================================================
 ;; EFFECTS


### PR DESCRIPTION
Closes rf2-93sxp.

`make-capture-frame`, `->interceptor` and `->interceptor*` were `re-frame.core` exports whose manifest rows read "internal" (`:tier :implementation` / "internal lowering only") while still carrying `:facade? true` — the annotation-not-removal shape `spec/Conventions.md` §Removing or demoting a facade export names. This PR deletes rather than demotes.

## Removed from `re-frame.core`

| Var | Was | Now |
|---|---|---|
| `make-capture-frame` | public fn, `:tier :implementation`, `:facade? true` | moved verbatim (with its incarnation fence) to the new implementation namespace `re-frame.capture-frame`; no manifest row (the generator does not roster that namespace) |
| `->interceptor*` | `def` alias of `re-frame.interceptor/->interceptor*`, `:tier :advanced`, `:facade? true` | gone; the constructor lives only on `re-frame.interceptor` |
| `->interceptor` | coord-capturing macro, `:tier :implementation`, `:facade? true` | deleted outright with its form builder (`core-call-site-macros/build-interceptor-form`) — no library caller; `reg-interceptor` is the authoring form |

## Where each lowering seam now lives

- **capture-frame**: `re-frame.capture-frame/make-capture-frame`. The `reg-view` expansion, the SCI `reg-view` shim and the kondo hook repoint. Its ops still route through the facade's `^:no-doc` `dispatch-impl` / `dispatch-sync-impl` / `subscribe-impl` seams — the ones Xray's tests `with-redefs` — which a namespace below the facade cannot `:require`; `re-frame.core` publishes the three through `re-frame.late-bind` (`:core/dispatch-impl`, `:core/dispatch-sync-impl`, `:core/subscribe-impl`; directory-listed, drift test green; owning-fn fallback when the facade has not loaded). The published fns read the var at call time, so a `with-redefs` on `rf/dispatch-impl` reaches a frame api captured before it, exactly as it reaches the macro expansions — the consolidated `:node-test` run (which includes the Xray spy suites) is green.
- **interceptor**: `re-frame.interceptor/->interceptor*` (already existed; the registry resolver and std interceptors already used it).

The move is verbatim by construction: the fence block was extracted from `core.cljc` by line range and diffed against the new namespace — only the `seam` helper, the constructor's docstring head, and the three seam `let`-bindings differ.

## Repointed consumers

- `implementation/core/src/re_frame/core_reg_view_macro.cljc` — expansion names `re-frame.capture-frame/make-capture-frame`.
- `implementation/core/src/re_frame/core.cljc` — `capture-frame` delegates to the owned constructor; seam publication; docstring trims; `->interceptor` removed from `:require-macros`.
- `docs/tools/playground/sci/src/rf2_playground/sci.cljs` — the `reg-view` shim expands to the owned constructor, bound under its own SCI namespace `re-frame.capture-frame` (only that var; never merged into the `re-frame.core` map — `copy-ns` over `re-frame.core` no longer sees any of the three).
- `.clj-kondo/hooks/re_frame/core.clj` — the reg-view hook rewrites to the public `(re-frame.core/capture-frame)`: the rewrite exists only to make the injected bindings visible, and naming the implementation namespace made every reg-view body an `Unresolved namespace` warning.
- `implementation/core/src/re_frame/router.cljc` — one docstring reference.
- Tests: `interceptor_test.clj` (the two macro tests become explicit-`:source-coord` tests of the same trace-threading contract), `on_error_cljs_test.cljc` (four sites author with `reg-interceptor` descriptors), `reg_view_injection_test.clj` (pins the new symbol), `interceptor_runtime_complete_cljs_test.cljc` and `dispatch_family_facade_shrink_test.clj` (pin absence instead of presence), plus the new `facade_internal_constructors_cljs_test.cljc` (acceptance 1, both platforms, each absence probe paired with a presence probe through the same instrument).
- Tool sites: `tools/story/test/re_frame/story_runtime_test.clj` and `tools/xray/testbeds/standard_epochs/core.cljs` author their throwing interceptors with `reg-interceptor` descriptors (the idiomatic form). Both files are outside the brief's fence but held by no live worker; they would not compile without the repoint. Xray behaviour note: the testbed's throwing interceptors previously carried a macro-captured `:source-coord`, so the Epoch INTERCEPTOR (exception) row rendered a jump-to-source chip for them; a `reg-interceptor` descriptor carries none (registration coords land in the registry, not on the lowered value), so that row degrades to plain text there until the follow-up bead below lands. The INTERCEPTORS (registry-read) step's chip is unaffected.

## Manifest, docs, conventions

- `spec/api-manifest-metadata.edn`: the three sidecar entries removed (the sidecar is curated, not generated — a stale entry makes the generator throw; the brief's "regenerated only" premise holds for the manifest, not the sidecar). `spec/api-manifest.edn` regenerated with CI's command on the final base: 482 → 479 rows; zero `:tier :implementation` + `:facade? true` rows. rf2-v4xjh's regeneration had merged first; after rebasing, regeneration was byte-identical to the merge result and `--check` is green — verified, not assumed.
- `docs/api/re-frame.core.md`: the three sections removed; one parenthetical reworded (hand-written page; `doc-api-check` green, including page+member coverage).
- `spec/Conventions.md`: the one sentence claiming the retired "public-facade manifest-hygiene CI check" now names the check that actually enforces the rule.
- **The invariant** (bead recommendation, brief-bounded to one assertion in an existing check): `build-manifest` in `gen.clj` refuses any `:facade? true` row at `:tier :implementation` (beside its missing/stale/duplicate refusals), run by `gen --check` in the `api-manifest` lint job. `:internal-public` is deliberately out of scope (a supported embed seam). Tests in `gen_test.clj`: pure detection, sortedness, a live-sidecar plant that throws with the key in ex-data, and the committed manifest clean (non-vacuously).

## One fenced file still needs a one-row edit — spec/API.md (hot zone, not touched here)

`spec/API.md:818` rows `->interceptor*` (`Fn (internal lowering constructor)`, tier advanced). `api-md-check` validates every API.md var-row against the manifest, so with the row gone it reports `L818 MISSING`, and the two live-reconciliation unit tests in the api-manifest `clojure -M:test` red on the same fact. The Conventions rule this bead executes requires the API.md row to go too. spec/API.md is hot-zone and outside this dispatch's fence, so it is reported rather than edited. The edit: **delete line 818**, and reword line 826's replacement cell ("`->interceptor` survives only as the internal lowering constructor" → "the lowering constructor is `re-frame.interceptor/->interceptor*`, framework-internal"). Until it lands, the `api-manifest` job is red on exactly those two checks and nothing else.

## Quality gates

Captured exit codes (log + exit files named per worktree and attempt; heavy gates run one at a time). Final base: trunk 8e8475b846, head 9a8245466d.

| Gate | Exit | Result |
|---|---|---|
| Negative control: acceptance-1 test at tip before the change | 1 | 3 failures naming exactly the three Vars; positive control green |
| Focused JVM (facade, reg-view injection, interceptor, on-error, facade-shrink, interceptor-runtime-complete, late-bind drift, capture-frame) — re-run on the final base | 0 | 137 tests / 1155 assertions, 0 failures |
| Full core JVM `clojure -M:test` | 0 | 2158 tests / 11071 assertions, 0 failures |
| `bash scripts/test-core-prod-gate.sh` (`-Dre-frame.debug=false`; root line names this worktree) | 0 | 1901 tests / 8106 assertions, 178 namespaces, 0 failures |
| `npm run test:cljs` (consolidated node build; includes the new `-cljs-test` ns and the Xray spy suites — both verified present in the compiled bundle/roster) | 0 | 11079 tests / 54286 assertions, 0 failures |
| `clojure -M -m re-frame.api-manifest.gen` / `--check` (re-run on final base) | 0 / 0 | 479 vars, in sync |
| `api-md-check` | 1 | `L818 MISSING ->interceptor*` — the fenced spec/API.md row above; the only red |
| `story-spec-check` / `xray-spec-check` / `skills-check` / `doc-guide-check` / `doc-api-check` (re-run on final base) | 0×5 | in sync |
| api-manifest `clojure -M:test` | 1 | 73 tests / 139 assertions; the 2 failures are the live API.md reconciliation (L818); all new `gen_test` cases pass |
| Invariant plant on the real check: sidecar retiers `capture-frame` to `:implementation` → `gen --check` | 2 | red names `re-frame.core/capture-frame`; restore verified by git blob hash; post-restore `--check` exit 0 |
| Playground `npm run build` (both bundles) + `npm run smoke` | 0 / 0 | SCI bundle 0 warnings; smoke passed incl. the reg-view cell (rv: 0 → rv: 2 through the shim); no drift on the committed bootstrap bundles |
| `python scripts/check_doc_slugs.py` clean / planted broken anchor at the edited docs/api line / restored | 0 / 1 / 0 | plant red names `docs/api/re-frame.core.md:41 -> #rf2-93sxp-no-such-anchor`; restore verified by blob hash |
| `python -m mkdocs build --strict` | 0 | 0 warnings |
| `sh scripts/test-fast-pr.sh` | 0 | `PASS fast PR spine` (docs + JVM + node tiers all armed by this diff; core and node suites re-ran inside it) |
| Full `tools/story` `clojure -M:test` | 0 | 1877 tests / 6848 assertions, 0 failures (the earlier single-namespace run's `run-variant-twice-epoch-tape-does-not-bleed` sanity failure is a load-order isolation artifact of `-n` selection, not a regression — the full suite, which is what CI runs, is green) |
| `npx shadow-cljs compile examples/standard-epochs` (the edited testbed) | 0 | 536 files, 0 warnings |
| clj-kondo over every changed clj/cljc/cljs file | 2 (warnings only) | 0 errors; warning set diffed per file against HEAD — no new warnings from this change |

Left to CI by job: `lint` (whole-tree clj-kondo, splint, eslint), `api-manifest` (red on L818 until the spec/API.md row is removed), the browser lanes (examples/testbeds compile gate, adapter smokes, Xray feature gate, `tools-playground` — its two local halves, build + smoke, are green above), and the elision/bundle-isolation/perf gates.

## Acceptance criteria (bead rf2-93sxp)

1. **re-frame.core no longer resolves or documents the three; none has a `:facade? true` row.** ✅ `facade_internal_constructors_cljs_test.cljc` green on JVM (`ns-resolve`) and in the node run (`goog.getObjectByName`, ns verified in the compiled roster); docs/api sections removed; manifest rows gone (grep 0).
2. **reg-view expansion and internal interceptor construction use owned non-facade symbols; compilation, coord stamping/elision, advanced-build behaviour intact.** ✅ expansion pinned by `reg_view_injection_test.clj` (gated dev/prod branches unchanged, now naming the owned symbol); prod gate green; the elision-sensitive expansion shapes are untouched apart from the constructor's namespace.
3. **capture-frame remains the single carry primitive with fencing and injected ops intact; reg-interceptor remains the authoring form.** ✅ `capture_frame_test.clj`, `reg_view_injection_test.clj`, `on_error_cljs_test.cljc`, full core + node suites green; fence moved verbatim (diff shown above).
4. **Playground SCI still supports reg-view, capture-frame, registered interceptors without copying the removed aliases into re-frame.core.** ✅ smoke green; the shim reaches the owned constructor under its own SCI namespace.
5. **Focused tests assert behavioural preservation and facade absence in CLJ/CLJS; projections agree.** ✅ except the one fenced disagreement, spec/API.md:818 (reported above with the exact edit).
6. **A generic automated check fails on a planted implementation-only `:facade? true` row and passes after the plant is removed.** ✅ live plant (exit 2 → blob-hash-verified restore → exit 0) plus `gen_test.clj`.

Verified by hand (no gate covers them): the docs/api table column counts in this body's tables; the removed sections leave no dangling in-repo anchor (`check_doc_slugs` green covers `docs/` links; no tracked page links `#make-capture-frame` or `#-interceptor`).
