### PR TITLE
docs(method): long tracker text goes through a file; one-line hunks in a shared index isolate, not sequence

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -271,6 +271,13 @@ rebasing, never hand-merge, and where a job diffs the committed file against a f
 run exactly that job locally. Three concurrent changes regenerated one manifest here with no
 sequence between them.
 
+**And N changes that each touch ONE LINE of one shared index are the second exception.** A
+catalogue, a roster, a table of rows: eight items each editing a different row of it are not a
+collision worth a sequence, and one-toucher would serialise the fleet for one-line hunks. Brief
+every worker to isolate that edit as its own final commit, merge in landing order, and let each
+later change rebase — the conflict, when it comes, is one line in one commit. Write the lane rule
+on every item that shares the file, in the same words, so no worker discovers it at rebase time.
+
 **But a gate that reconciles two surfaces couples them into ONE change, and sequencing those
 deadlocks.** The one-toucher rule reasons about files, and it is right about files. Some checkers,
 though, hold one surface against another in both directions — a catalogue against the emitters it

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1333,6 +1333,13 @@ push not, and the re-run reported *nothing to checkpoint* — true, and the remo
 Verify the remote against the local head after every checkpoint; the script's message answers only
 the commit.
 
+**Long tracker text does not travel as a shell argument.** A batch of notes handed to the tracker
+CLI as quoted strings can fail to parse at the shell before a single note is written, and the
+failure names a line, not the character — and a quoted heredoc is not a cure, as one project's own
+memory had claimed. Write the text to a file with a tool that is not a shell, and drive the tracker
+from that file with a script: the transport then has no quoting to get wrong. Two batches of nine
+notes each died this way in one session; the third, through a file, wrote all nine.
+
 **If your tracker exports a whole-database file, treat it as generated.** Never resolve a conflict in it
 by taking one side wholesale — both sides are full exports, so picking one discards every item the other
 recorded. Resolve, then **regenerate**. And never let a worker commit it: a worker branch carries a


### PR DESCRIPTION
Second retrospective on `docs/the-mayor-method/` in one session (the first was #8790). Two generic gotchas the text did not carry, both measured; README untouched.

- **loops.md — Tracker mechanics.** Long tracker text does not travel as a shell argument: two batches of nine notes each failed to parse at the shell before one note was written — once as quoted arguments, once inside a quoted heredoc that a project memory had recorded as the fix. The route that works is a file written by a non-shell tool plus a script driving the tracker from it.
- **dispatch-prompt-template.md — Fences.** N changes that each touch one line of one shared index (a roster, a catalogue, a table of rows) are not a one-toucher collision; sequencing them serialises the fleet for one-line hunks. Brief each worker to isolate that edit as its own final commit, merge in landing order, rebase the rest, and write the lane rule on every sharing item in the same words. Eight items sharing one README ran in parallel under that rule.

Not carried, because the method already covered it as written: the usage-limit outage that killed six workers mid-gate (the stranded sweep's quota clause and push-as-you-go made recovery one resume message each), and two read-only reviewers stranding on their own sub-readers (the worker strand rule applied unchanged). Platform-specific findings went to the project's own instructions, not here.

## Quality gates
- `python scripts/check_doc_slugs.py` — exit 0. Control: one broken anchor planted in the new Fences paragraph → exit 1 naming it; restored; restore verified by blob hash equality against the committed object; re-run exit 0.
- `python -m mkdocs build --strict` — exit 0 (invoked via `python -m`; the bare `mkdocs` binary is not on this shell's PATH).
- No code touched; no other gate covers this surface.