### PR TITLE
uix(test recipe): capture and restore the act-environment flag in mount!/unmount! (rf2-9hcyf audit residual)

### DIFF
--- a/docs/core/testing/views.md
+++ b/docs/core/testing/views.md
@@ -149,7 +149,9 @@ Everything above calls a view as a function. A UIx `defui` that reads `use-subsc
 ;; declare itself. It is on while the test drives React through
 ;; `flush-views!`, and stood down while the test waits for an update that
 ;; arrives on React's own schedule (`wait-for` below) — the discipline
-;; Testing Library's `waitFor` follows.
+;; Testing Library's `waitFor` follows. The flag is a global, so `mount!`
+;; captures the value it finds and `unmount!` puts that value back — the
+;; recipe leaves the suite's act environment exactly as it found it.
 
 (defn- act-environment! [on?]
   (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) on?))
@@ -164,21 +166,24 @@ Everything above calls a view as a function. A UIx `defui` that reads `use-subsc
 
 (defn- mount!
   "Render `element` under `:rf/default` into a fresh node on the page, inside
-   `flush-views!`, so the tree is committed when this returns."
+   `flush-views!`, so the tree is committed when this returns. Captures the
+   act-environment flag as it stood; `unmount!` restores it."
   [element]
-  (let [node (.createElement js/document "div")
-        root (uix-dom/create-root node)]
+  (let [act-prev (.-IS_REACT_ACT_ENVIRONMENT js/globalThis)
+        node     (.createElement js/document "div")
+        root     (uix-dom/create-root node)]
     (.appendChild js/document.body node)
     (act-environment! true)
     (uix-adapter/flush-views!
       #(uix-dom/render-root
          ($ uix-adapter/frame-provider {:frame :rf/default} element)
          root))
-    {:node node :root root}))
+    {:node node :root root :act-prev act-prev}))
 
-(defn- unmount! [{:keys [node root]}]
+(defn- unmount! [{:keys [node root act-prev]}]
   (uix-adapter/flush-views! #(uix-dom/unmount-root root))
-  (.remove node))
+  (.remove node)
+  (act-environment! act-prev))
 
 (defn- by-testid [node id]
   (.querySelector node (str "[data-testid=\"" id "\"]")))
@@ -217,6 +222,11 @@ Everything above calls a view as a function. A UIx `defui` that reads `use-subsc
             (.catch (fn [e] (is false (str "the +1 click never reached the DOM: " e))))
             (.finally (fn []
                         (unmount! mounted)
+                        ;; The restore is part of the recipe's contract: the
+                        ;; suite sees the act flag this test found on entry.
+                        (is (= (:act-prev mounted)
+                               (.-IS_REACT_ACT_ENVIRONMENT js/globalThis))
+                            "unmount! restores the act-environment flag mount! captured")
                         (done))))))))
 ```
 
@@ -226,7 +236,7 @@ Four things carry it.
 
 **`flush-views!` settles what you drive.** It wraps React's `act()`: the mount inside it is committed by the time it returns, and so is the re-render a `dispatch-sync` inside it causes. That is the settle for state the test pushes in — and it is per-adapter-require, as [Use UIx or reagent-slim](../how-to/use-uix-or-slim.md#what-carries-over-what-doesnt) tabulates.
 
-**A real click settles on the router's clock, not React's.** The view's `dispatch` queues the event and the router drains it on the next turn, so no `act()` can settle it. The wait is `poll-until` on the DOM — the same bounded settle as §3 — composed with `cljs.test/async`. React's `act()` asks the environment to declare itself (`IS_REACT_ACT_ENVIRONMENT`); the recipe keeps it on while `flush-views!` drives React and stands it down while the test waits for an update that lands on React's own schedule, the discipline Testing Library's `waitFor` follows. That is all the two small helpers encode.
+**A real click settles on the router's clock, not React's.** The view's `dispatch` queues the event and the router drains it on the next turn, so no `act()` can settle it. The wait is `poll-until` on the DOM — the same bounded settle as §3 — composed with `cljs.test/async`. React's `act()` asks the environment to declare itself (`IS_REACT_ACT_ENVIRONMENT`); the recipe keeps it on while `flush-views!` drives React and stands it down while the test waits for an update that lands on React's own schedule, the discipline Testing Library's `waitFor` follows. And because the flag is a global, `mount!` captures the value it finds and `unmount!` puts it back — the suite around this test sees the act environment it started with, and the async test's last assertion proves the restore. That is all the small helpers encode.
 
 **Teardown is unconditional.** `unmount!` runs in a `finally` — or the promise's `.finally` — so a red assertion never leaves a root mounted on the page; the fixture's `:after` takes care of the frame and the adapter.
 

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_component_recipe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_component_recipe_dom_cljs_test.cljs
@@ -55,7 +55,9 @@
 ;; declare itself. It is on while the test drives React through
 ;; `flush-views!`, and stood down while the test waits for an update that
 ;; arrives on React's own schedule (`wait-for` below) — the discipline
-;; Testing Library's `waitFor` follows.
+;; Testing Library's `waitFor` follows. The flag is a global, so `mount!`
+;; captures the value it finds and `unmount!` puts that value back — the
+;; recipe leaves the suite's act environment exactly as it found it.
 
 (defn- act-environment! [on?]
   (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) on?))
@@ -70,21 +72,24 @@
 
 (defn- mount!
   "Render `element` under `:rf/default` into a fresh node on the page, inside
-   `flush-views!`, so the tree is committed when this returns."
+   `flush-views!`, so the tree is committed when this returns. Captures the
+   act-environment flag as it stood; `unmount!` restores it."
   [element]
-  (let [node (.createElement js/document "div")
-        root (uix-dom/create-root node)]
+  (let [act-prev (.-IS_REACT_ACT_ENVIRONMENT js/globalThis)
+        node     (.createElement js/document "div")
+        root     (uix-dom/create-root node)]
     (.appendChild js/document.body node)
     (act-environment! true)
     (uix-adapter/flush-views!
       #(uix-dom/render-root
          ($ uix-adapter/frame-provider {:frame :rf/default} element)
          root))
-    {:node node :root root}))
+    {:node node :root root :act-prev act-prev}))
 
-(defn- unmount! [{:keys [node root]}]
+(defn- unmount! [{:keys [node root act-prev]}]
   (uix-adapter/flush-views! #(uix-dom/unmount-root root))
-  (.remove node))
+  (.remove node)
+  (act-environment! act-prev))
 
 (defn- by-testid [node id]
   (.querySelector node (str "[data-testid=\"" id "\"]")))
@@ -123,4 +128,9 @@
             (.catch (fn [e] (is false (str "the +1 click never reached the DOM: " e))))
             (.finally (fn []
                         (unmount! mounted)
+                        ;; The restore is part of the recipe's contract: the
+                        ;; suite sees the act flag this test found on entry.
+                        (is (= (:act-prev mounted)
+                               (.-IS_REACT_ACT_ENVIRONMENT js/globalThis))
+                            "unmount! restores the act-environment flag mount! captured")
                         (done))))))))


### PR DESCRIPTION
Closes the merged-PR audit residual on rf2-9hcyf (PR #8789): the copy-complete UIx component-test recipe set `globalThis.IS_REACT_ACT_ENVIRONMENT` in `mount!` / `wait-for` but never captured or restored the pre-existing value, so both successful paths ended with the flag forced `true` — in a copied suite, changing React act-warning behaviour for later tests by execution order, against the page's copy-complete, unconditional-teardown promise.

The fix applies the shared React suite's discipline (`react_shared_suite.cljs:3280-3351`) locally, no new abstraction: `mount!` captures the flag as it stood and returns it as `:act-prev`; `unmount!` — already unconditional in `finally` / `.finally` — restores it as its last act; the `wait-for` false polling window is preserved (and its stand-back-up to `true` keeps the unmount's `flush-views!` under act before the restore). The async test's teardown now asserts the restore in-file — the durable regression tripwire the audit asked for. The pinned docs block in `docs/core/testing/views.md` §4 moves in the same commit (the pin holds them byte-equal), and the one prose sentence describing the flag behaviour is updated to stay truthful.

## Quality gates

All run from the worker worktree; exit codes captured to log+exit files, quoted from those.

- Negative-control probe (before fix): `npm run test:browser` with a temporary probe forcing a known pre-test value (`false`) and asserting the flag equals it after the recipe's tests — **exit 1**, `Ran 750 tests containing 4097 assertions. 1 failures, 0 errors.`, the single failure being the probe (`FAIL in (the-plus-one-button-is-wired)`), i.e. the flag ended `true` ≠ pre-test `false`.
- Same probe (after fix): **exit 0**, `Ran 750 tests containing 4098 assertions. 0 failures, 0 errors.` — restored.
- Pin negative control (test file edited, docs not yet): `clojure -M:test` in `implementation/adapters/uix` — **exit 1**, `Ran 1 tests containing 3 assertions. 1 failures, 0 errors.` (drift named).
- Pin after the paired docs edit: **exit 0**, `Ran 1 tests containing 3 assertions. 0 failures, 0 errors.`
- Official browser lane on final content: `npm run test:browser` — **exit 0**, `Ran 750 tests containing 4097 assertions. 0 failures, 0 errors.`
- Replays against the compiled bundle (`node scripts/serve-and-run-browser-tests.cjs` × 10): **10/10 exit 0, 0 failures total** (`Ran 750 tests containing 4097 assertions` each).
- `python scripts/check_doc_slugs.py` — **exit 0**.
- `python -m mkdocs build --strict` — **exit 0**.
- `sh scripts/test-fast-pr.sh` — **exit 0**, `PASS fast PR spine`, 0 FAIL lines (JVM core + JVM uix + docs tier + node tier all armed and green). A first attempt failed environmentally on this shared box — `fork: Resource temporarily unavailable` / `0xC0000142` killed `report-changed-surfaces.sh` and `git ls-files` inside the rf2-skvce harness checks, a surface this diff cannot touch; the clean re-run and CI's green `JS harness self-tests` job both confirm.

CI checks that gate this diff by name: `CLJS (shadow-cljs :browser-test, headless Chromium)` (cljs-browser — the lane the recipe runs in), the uix `clojure -M:test` job (jvm-uix — carries the docs pin), `CLJS (shadow-cljs :node-test)` (cljs — the recipe file's no-DOM fallback body), `Verify markdown link slugs — READMEs + the docs/spec/skills/migration corpus` (verify-readme-links), and the docs build.

Hand-verified (no gate covers these): the edited §4 prose sentence's links are unchanged; no tables touched.
