### PR TITLE
docs(method): refute the harness promise behind the strand; note-less reopens; split slices at Shape 1

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -346,7 +346,9 @@ work cannot run in parallel.
 
 **Shape 1 — Solo.** One item, one change. Item id and verbatim title; two to four paragraphs of
 context with `file:line` citations; numbered concrete steps; a dedicated worktree and branch; the
-boundary block; claim the item; gates with exact commands; push and open the change **as a draft**
+boundary block; claim the item — unless it is a slice of a split item, which nobody claims (see
+*Choosing solo or cluster*): a slice's worker appends a claim note and a result note, and the
+mayor closes the item when the last slice lands; gates with exact commands; push and open the change **as a draft**
 with a `## Quality gates` section; report the change URL, a per-step summary and test deltas.
 
 *A coverage or rigour pass must add at least one adversarial or negative case per surface.*
@@ -791,6 +793,15 @@ rule named a monitor. So name the class rather than the instances: a Monitor, a 
 subscription, a background task you expect to wake you — every one of these is the same strand,
 because you are the only thing that can read the exit file, and you can only read it while your
 turn is still running.
+
+**And refute the belief that keeps re-arming it, because the rule alone has not held.** Your own
+tooling likely documents that a backgrounded command "notifies you when it completes" or
+"re-invokes you" — a true statement about a LIVE session, and the reason a worker reads its wait
+as sanctioned rather than forbidden: it is trusting its harness's promise over this block. That
+promise does not survive the end of your turn; once you stop, the completion event goes to your
+coordinator, not to you. Measured after the class was already named here: four stranded
+turn-endings across two workers in one session, each ending on exactly that promise, each
+recovered only by the coordinator sending a status message.
 
 **A gate heavy enough that two cannot coexist WEDGES rather than fails** — no progress, no exit
 file, no error, from a run that was healthy a minute ago. This is contention for the MACHINE, so

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1323,6 +1323,16 @@ item that owned a residual. **The reflex to re-close a "reverted" item destroys 
 like tidiness.** Expect chains — a fix lands, its audit reopens for a second carrier, that fix's audit
 reopens for a third. Two or three rounds converge.
 
+**A reopen that records no finding is not yet a finding.** The rule above assumes the reopen carries its
+residual; sometimes one arrives as a bare status flip — close reason wiped, nothing appended, no new item
+filed — and then there is nothing to read and nothing to dispatch. Both reflexes are wrong: re-closing on
+the bare flip destroys a finding the reopening process may still be mid-writing, and treating the item as
+ready dispatches a worker at work nobody has named. Mark it as awaiting its finding, in the same scan-findable
+words each time, and give the writer one full pass of this loop. If nothing has landed by then, re-close,
+restoring the original close reason — the flip cleared it — and recording the reopen's emptiness alongside.
+Measured against the twelve above: two such flips in one session, distinguishable from the legitimate
+reopens around them only by the absence of any recorded residual.
+
 **Checkpoint tracker state on the heartbeat.** Many trackers auto-stage but never commit, so a long
 session's state strands locally. Commit and push it each cycle.
 


### PR DESCRIPTION
## What

Three additions from the 2026-08-31 retrospective, each a friction measured in this session with the existing rule already in force.

1. **Gate-mechanics block (template): refute the belief, not just the wait.** Four stranded turn-endings across two workers in one session, every brief carrying the block verbatim including its name-the-class sentence. Each worker ended its turn trusting its own tooling's documented promise that a backgrounded command notifies or re-invokes on completion — true for a live session, void once the turn ends. The block now says so, which is the refutation that was missing.

2. **Tracker mechanics (loops): a reopen that records no finding is not yet a finding.** Two merged-change audits reopened their items as bare status flips — close reason wiped, nothing appended, no new item. The existing rule (read the notes before re-closing) assumes notes exist. New paragraph: hold with a scan-findable marker, give the writer one full pass, then re-close restoring the original close reason.

3. **Shape 1 (template): split slices unclaimed, at the point of use.** The nobody-claims-a-split rule already existed under *Choosing solo or cluster*, but a slice is dispatched looking like a Shape 1 solo, and Shape 1 said 'claim the item' unconditionally — which is exactly how two briefs contradicted the rule hours after it landed. Cross-reference added where the brief-writer actually reads.

## Quality gates

- `python scripts/check_doc_slugs.py` — planted-anchor control: exit 1 naming `loops.md:1331 -> #a-bogus-control-anchor`; restore verified by git blob hash `bad24d9a1709…` == HEAD; clean run exit 0.
- `python -m mkdocs build --strict` — exit 0.
- Prose-only diff, 2 files, +22/−1; no fenced block, workflow, or script touched.