### PR TITLE
skill(pair-retro): make the routing boundary local — the package ships the whole normal path (rf2-t19ve)

### DIFF
--- a/skills/re-frame2-pair-retro/README.md
+++ b/skills/re-frame2-pair-retro/README.md
@@ -30,7 +30,7 @@ It is intentionally diagnosis-first: the default outcome is a better understandi
 - `agents/openai.yaml` — UI metadata for skill lists and invocation
 - `package.json`, `LICENSE` — npm packaging metadata and the MIT licence
 
-Everything the skill loads during normal operation ships under this directory — `SKILL.md` plus the one on-demand `references/` leaf. There is no runtime dependency on any sibling directory.
+Everything the skill loads during normal operation ships under this directory — `SKILL.md`, whose routing boundary is stated locally rather than linked from the repo-level skills index, plus the one on-demand `references/` leaf. There is no runtime dependency on any sibling directory.
 
 ## Relationship to other repos
 

--- a/skills/re-frame2-pair-retro/SKILL.md
+++ b/skills/re-frame2-pair-retro/SKILL.md
@@ -29,7 +29,7 @@ allowed-tools:
 
 # re-frame2-pair-retro
 
-Turns a `re-frame2-pair` session — the one happening now (post-error), a just-finished one, or one summarised by the user as a recap — into a product retrospective for `re-frame2-pair`. One explicit request over one clear session returns the complete retrospective in that same response; when asked, the same response also carries one focused, copy-pasteable GitHub issue draft. The skill is read-only: it never files issues, never edits a repo, and never probes a runtime.
+Turns a `re-frame2-pair` session — the one happening now (post-error), a just-finished one, or one summarised by the user as a recap — into a product retrospective for `re-frame2-pair`. One explicit request over one clear session returns the complete retrospective in that same response; when asked, the same response also carries one focused, copy-pasteable GitHub issue draft. The skill is read-only and self-contained: it never files issues, never edits a repo, never probes a runtime, and every instruction it runs on ships under its own directory.
 
 ## Two entry modes
 
@@ -42,7 +42,15 @@ When you cannot tell which mode you are in, treat it as post-error: offer rather
 
 **Story recorder-session retros are out of scope.** A retro on a Story Test Codegen recording belongs in `re-frame2-pair`'s variant-refinement workflow (the recorder output is a `:play-script` snippet to refine against a frame, not a pair-session friction trace). If the user asks to "retro on my recorded play sequence" or similar, decline and route to `re-frame2-pair`.
 
-Routing decisions (mid-session pair work, app-authoring without a live runtime, framework / spec feedback, app-bug help, vocabulary-only matches) follow the matrix at [`skills/README.md` §Skill routing — single source](../README.md#skill-routing--single-source) and §Disqualifiers. A real `re-frame2-pair` session must have occurred or be recapped. When in doubt, ask: *"Was there a `re-frame2-pair` session you want me to retrospect on? If you can paste a short recap I can work from that."* Decline rather than fabricate evidence.
+The remaining routing decisions are local and short — each of these is someone else's job, not a retro subject:
+
+- **Mid-session pair work** stays in `re-frame2-pair`; this skill enters only on an explicit retro request or the post-error offer above.
+- **App-authoring without a live runtime** (writing events, subs, views, schemas) is application work for the `re-frame2` authoring skill.
+- **Framework / spec feedback** with no pair session behind it (API-reference reading, architecture or design discussion) is not this skill's input — it turns *session evidence* into framework feedback, never free-floating opinion.
+- **App-bug help** belongs to `re-frame2-pair` (live) or ordinary debugging; the retro's subject is workflow friction, never the application bug.
+- **Vocabulary-only matches** ("retro", "what went wrong", "any improvements?") never activate this skill on their own.
+
+A real `re-frame2-pair` session must have occurred or be recapped. When in doubt, ask: *"Was there a `re-frame2-pair` session you want me to retrospect on? If you can paste a short recap I can work from that."* Decline rather than fabricate evidence.
 
 ## Guard rails
 


### PR DESCRIPTION
Discharges the merged-PR audit residual on rf2-t19ve (PR #8797 reopen): `skills/re-frame2-pair-retro/SKILL.md` still routed its five ambient routing decisions through `../README.md#skill-routing--single-source`, a file `package.json` `files[]` structurally cannot ship — so a tarball or plugin install silently lost a behavior-bearing instruction while `check_skill_package_refs.py` (which deliberately ignores non-`shared/` `../` escapes) stayed green.

## What changed

- `skills/re-frame2-pair-retro/SKILL.md` — the five already-enumerated routing decisions (mid-session pair work, app-authoring without a live runtime, framework/spec feedback, app-bug help, vocabulary-only matches) are now stated locally as short bullets; the `../README.md` link and the `§Disqualifiers` pointer are gone. The intro's contract sentence now says the skill is self-contained as well as read-only.
- `skills/re-frame2-pair-retro/README.md` — the self-containment claim in §Directory contents now says the routing boundary is stated locally, making the (previously overstated) claim true and explicit.

Per the audit ruling: no package-checker broadening, no new gate, no manifest, no fallback, no vendored copy. The local bullets state this skill's own boundary; they do not duplicate the parent trigger→skill matrix, which remains the single source for cross-skill routing inside the repo.

## Checked and left standing (other `../` escapes)

- `SKILL.md` now carries exactly one reference: `references/known-frictions.md` — local, shipped via `files[]` `references/`.
- `README.md:3` (`..` index link), `README.md:5` (`../re-frame2-pair`), `README.md:55` (`../README.md#installing-link-never-copy`) — human-facing navigation/install prose in a README that itself frames the current install path as linking from a full monorepo clone; not runtime instructions in the skill's normal path. Left standing.
- `spec/*.md` `../` links — skill-internal meta-docs, excluded from `files[]` by design and never loaded in normal operation. Left standing.
- `agents/openai.yaml`, `.claude-plugin/plugin.json` — no parent-directory references (`plugin.json` points at `./SKILL.md` only).
- `docs/skills/re-frame2-pair-retro.md:47` and `spec/design.md` §self-containment — both already claim the skill is self-contained under its own directory; this change makes those claims true rather than editing them.
- `skills/README.md` §Skill routing preamble ("per-skill SKILL.md files point here instead of duplicating") now has one deliberate exception in this published skill, owned by the audit ruling; the preamble itself is untouched (serial lane, and the audit asked for a fix inside `skills/re-frame2-pair-retro/**`).

Anchors and links in the edited region were verified by hand: the change removes one link and adds none; the one remaining `SKILL.md` link target exists and carries no heading anchor.

## Quality gates

All run locally from the worktree, exit codes captured from the runs themselves:

| Gate | Result |
|---|---|
| `scripts/check_skill_package_refs.py` | exit 0 (pass) |
| `scripts/check_skill_mcp_drift.py --self-test --ci` | exit 0 (self-test: PASS) |
| `scripts/check_skill_mcp_drift.py --verbose --ci` | exit 0 (no drift) |
| `scripts/check_skill_eval_docs.py` | exit 0 (pass) |
| `scripts/check_skill_eval_packaging.py` | exit 0 (pass) |
| `scripts/check_doc_slugs.py` | exit 0 (pass) |

Planted-fault controls (both restored, restores verified by git blob hash against the committed object):

- `check_doc_slugs.py`: a broken heading anchor planted on the `known-frictions.md` link went red (exit 1) naming exactly the planted anchor and file — proving the gate read this branch's tree.
- `check_skill_package_refs.py`: a planted `../shared/retro-protocol.md` reference in `SKILL.md` went red (exit 1) naming this skill's missing distribution caveat — the checker still bites on what it covers while correctly ignoring the (now removed) non-shared escape.

Both gates re-run green (exit 0) on the restored final tree.