### PR TITLE
skill(xray): make one debugging question land on one first Xray surface (rf2-0mw10)

### DIFF
--- a/docs/skills/re-frame2-xray.md
+++ b/docs/skills/re-frame2-xray.md
@@ -9,17 +9,17 @@ The `re-frame2-xray` skill is a tour guide for [Xray](../xray/index.md), the hum
 The skill answers three questions:
 
 1. **How do I launch Xray?** — the inline panel, the overlay fallback (`(xray/open-overlay!)`, for hosts that can't give Xray a layout column), the pop-out (`(xray/popout!)`), the programmatic `(xray/init! opts)` path, the wired hotkeys, and the Dynamic ↔ Static mode toggle.
-2. **Which tab shows X?** — a one-line purpose for each tab, across both modes.
+2. **Which tab shows X?** — a route card from the evidence sought (one dispatch, changed state, renders, raw ordering, machines/routes, server state, structure, registered definitions) to one first surface: the visible mode/tab, the reason, and the first interaction.
 3. **What's the chrome around the tabs for?** — the first-screen navigation primitives: time-travel inspect / `Reset`-rewind, the filter pills, the command palette, and the Settings popup.
 
 ## Two modes
 
 Xray runs in one of two modes, flipped by the L1 mode pill or `Cmd/Ctrl+Shift+M`:
 
-- **Dynamic** — the event-coupled spine (4-layer chrome). 10 tabs: **Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph · Frames · Hicasso** (mnemonics `e a v t m r s g u h`) — the core six spine lenses plus the cross-feature **Resources** (declarative server-state), **Graph** (Xray's UI over the EP-0014 derivation/process graph), **Frames** (its EP-0023 `image → frame` lens — which image loaded which frame, and how that frame resolves its registrations) and **Hicasso** (the evidence lens for Hicasso, re-frame2's re-frame-native view layer — six views over four evidence envelopes taken in one turn). Dynamic names the *shell*, not a uniform data scope: most tabs are lenses on the one focused event, but Graph, Frames and Hicasso are browse surfaces that do **not** rebind when you pick an epoch. There is **no Issues tab** — issues surface inline (in the Epoch cascade, the L2 event-row pink-wash, and the always-on issues-ribbon signal).
-- **Static** — event-INDEPENDENT registry browse (3-layer chrome, no spine). Every tab is a catalogue of what's *registered*. Mixed-scope: the definition catalogues are **process-global** — the registrar is shared across every frame (Spec 002 §Frame addressing) — while the L1 frame picker scopes only the per-frame *live* projections each tab adds. 5 tabs: **Machines · Routes · Schemas · Flows · Interceptors**.
+- **Dynamic** — the event-coupled spine (4-layer chrome). 10 tabs: **Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph · Frames · Hicasso**. Dynamic names the *shell*, not a uniform data scope: six tabs are lenses on the one focused event, Resources is mixed, and Graph, Frames and Hicasso browse live structure and do **not** rebind when you pick an epoch. There is **no Issues tab** — issues surface inline.
+- **Static** — event-INDEPENDENT registry browse (3-layer chrome, no spine). 5 tabs: **Machines · Routes · Schemas · Flows · Interceptors** — catalogues of what's *registered*.
 
-When the user wants to inspect a single dispatch, that's Dynamic; when they want to browse the whole registry, that's Static.
+When the user wants to inspect a single dispatch, that's Dynamic; when they want to browse the whole registry, that's Static. The canonical tab inventory and scope matrix live in the skill package, at [`skills/re-frame2-xray/references/panels.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame2-xray/references/panels.md) — this page summarizes the role and defers the anatomy to that authority.
 
 ## Wired hotkeys
 
@@ -30,7 +30,7 @@ Four hotkey families have keydown listeners installed:
 | `Ctrl+Shift+C` | global | Toggle the Xray shell. |
 | `Cmd/Ctrl+Shift+M` | global | Toggle mode — Dynamic ↔ Static. |
 | `Cmd/Ctrl+K` | global | Open the command palette. |
-| `Space` `L` `j` `k` `G` `,`/`s` `Esc` | focus-gated | Spine + chrome shortcuts (only inside the shell, off editable fields). |
+| `Space` `L` `j` `k` `G` `,`/`s` | focus-gated | Spine + chrome shortcuts (only inside the shell, off editable fields). `Esc` is modal-local, not a wired spine key. |
 
 ## When to reach for it
 
@@ -38,7 +38,7 @@ Load this skill when the user wants to *read* the Xray panel — "open Xray", "w
 
 Do **not** use this skill for:
 
-- **Driving** Xray from a live runtime (dispatch, mutate `app-db`, hot-swap, time-travel) → use [re-frame2-pair](re-frame2-pair.md). Xray owns the *seeing*; re-frame2-pair owns the *driving*.
+- **Agent runtime access** — the user asking the agent to inspect or change the running app, read-only included (read a sub, get a path, snapshot state, walk traces, dispatch, hot-swap) → use [re-frame2-pair](re-frame2-pair.md). The boundary is human panel vs agent runtime, not read vs write.
 - Writing new application code → use [re-frame2](re-frame2.md).
 - Implementing Xray itself → the spec under `tools/xray/spec/` is the source of truth (no implementor skill yet).
 
@@ -46,7 +46,7 @@ Do **not** use this skill for:
 
 - Source: [`skills/re-frame2-xray/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-xray)
 - `SKILL.md`: [`skills/re-frame2-xray/SKILL.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame2-xray/SKILL.md)
-- Reference leaves: [`skills/re-frame2-xray/references/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-xray/references) — `launch-modes.md` (launch decision tree + hotkeys) and `panels.md` (the full tab tour across both modes).
+- Reference leaves: [`skills/re-frame2-xray/references/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-xray/references) — `launch-modes.md` (launch decision tree + hotkeys), `panels.md` (the canonical tab inventory + scope matrix), the per-family depth leaves (`panels-epoch.md`, `panels-state.md`, `panels-domains.md`, `panels-resources.md`, `panels-structure.md`), and `chrome.md` (the first-screen chrome).
 - Xray source + spec: [`tools/xray/`](https://github.com/day8/re-frame2/tree/main/tools/xray).
 - Human-facing Xray guide: [Xray](../xray/index.md).
 - Live-runtime companion skill: [`re-frame2-pair`](re-frame2-pair.md).

--- a/docs/xray/02-panel-tour.md
+++ b/docs/xray/02-panel-tour.md
@@ -11,10 +11,10 @@ L1  ribbon       mode, frame, filters, settings, close
 L2  event spine  recent epochs for the selected frame
 L3  tabs         Epoch, app-db, Views, Trace, Machine, Routes,
                  Resources, Graph, Frames, Hicasso
-L4  detail       the selected tab's view of the focused epoch
+L4  detail       the selected tab's detail view
 ```
 
-The event spine is the load-bearing piece. It is not a decorative timeline; it is the focus selector for the entire tool. Click an event row and every tab reads that same epoch.
+The event spine is the load-bearing piece. It is not a decorative timeline; it is the focus selector for the event lenses. Click an event row and Epoch, app-db, Views, Trace, Machine, and Routes read that same epoch. (Graph, Frames, and Hicasso browse live structure instead — they do not follow the row you pick, and Resources follows the selected frame for its live sections.)
 
 ![The event spine and Dynamic tabs](../images/xray/xray-tutorial-epoch.png)
 

--- a/docs/xray/index.md
+++ b/docs/xray/index.md
@@ -17,7 +17,7 @@ Xray's main UI is built around that fact:
 - The tab strip chooses which lens you want.
 - The detail panel shows that lens for the focused epoch.
 
-When you click a row in the event spine, every tab rebinds to that same epoch. `Epoch`, `app-db`, `Views`, `Trace`, `Machine`, `Routes`, `Resources`, `Graph`, `Frames`, and `Hicasso` stop disagreeing because they are all projections of the same record.
+When you click a row in the event spine, the six event lenses — `Epoch`, `app-db`, `Views`, `Trace`, `Machine`, and `Routes` — rebind to that same epoch and stop disagreeing, because they are all projections of the same record. The other Dynamic tabs read live structure rather than the focused epoch: `Resources` mixes the registry with the observed frame's live state, and `Graph`, `Frames`, and `Hicasso` do not follow the row you pick.
 
 ## Two Modes
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -103,20 +103,15 @@ the situation they cover:
 
 ### Live-runtime devtools & pair programming
 
-- [`re-frame2-xray/`](re-frame2-xray) — read-only tour of
-  Xray, the re-frame2 in-app devtools panel. Answers how to launch
-  Xray (true-inline panel, pop-out, programmatic `init!`, wired hotkeys,
-  the Dynamic ↔ Static mode toggle) and which tab shows X — across the
-  10 Dynamic event-spine tabs (Epoch (hero) / app-db / Views / Trace /
-  Machine / Routes / Resources / Graph / Frames / Hicasso — Graph being
-  Xray's UI over the EP-0014 derivation/process graph, Frames its EP-0023
-  `image → frame → event stream` lens (which image loaded which frame,
-  L4-only), and Hicasso the Hicasso view substrate's evidence lens — 6
-  views over 4 evidence envelopes, L4-only)
-  and the 5 Static registry-browse
-  tabs (Machines / Routes / Schemas / Flows / Interceptors). There is no
-  Issues tab — issues surface inline. Xray owns
-  the seeing; `re-frame2-pair` owns the driving.
+- [`re-frame2-xray/`](re-frame2-xray) — question-first tour of
+  Xray, the re-frame2 in-app devtools panel. Routes a debugging
+  question to the one visible surface to open first — across the 10
+  Dynamic event-spine tabs and the 5 Static registry-browse tabs — and
+  answers how to launch Xray (true-inline panel, pop-out, programmatic
+  `init!`, wired hotkeys, the Dynamic ↔ Static mode toggle). The
+  canonical tab inventory + scope matrix live in the skill package
+  (`re-frame2-xray/references/panels.md`). Xray is the human's panel;
+  agent runtime access — read or write — is `re-frame2-pair`'s.
 
 - [`re-frame2-pair/`](re-frame2-pair) — pair-program with a live
   re-frame2 application. Attach to a running shadow-cljs build via nREPL,
@@ -156,7 +151,7 @@ migration report is signed off.
 | Write new application code on a working re-frame2 project | events, subs, fx, cofx, frames, state machines, schemas, stories, routing, canonical patterns; `reg-event`, `reg-sub`, `reg-fx`, `reg-machine`, `reg-view`, `reg-route`, `reg-story`, `reg-app-schema`, `reg-interceptor`, `dispatch`, `subscribe`, `app-db` | [`re-frame2/`](re-frame2) |
 | Migrate an existing re-frame v1.x ClojureScript codebase to re-frame2 | "migrate to re-frame2", "upgrade re-frame", "v1 to v2", "what breaks under re-frame2", or any v1 surface (`re-frame.db`, `dispatch-with`, `reg-global-interceptor`, `reg-sub-raw`, `^:flush-dom`, `re-frame.alpha`, `re-frame-test`, old top-level `:dispatch` / `:dispatch-n` effect-map keys) | [`re-frame-migration/`](re-frame-migration) |
 | Migrate Reagent **view** code to **Hicasso**, the re-frame-native view layer — the OPTIONAL, SECOND step, done only after the v1→v2 move and only if Hicasso is wanted | "migrate my Reagent views to Hicasso", "port this component to h/defview", "move off Reagent hiccup", "the re-frame-native views", deref-drop, or a Reagent view surface named in a Hicasso context (`r/atom` / `r/with-let` / `r/create-class` / `adapt-react-class` / `@(subscribe …)` in a view / `[:> …]` prop dialect) — **on an already-re-frame2 app** | [`reagent-migration/`](reagent-migration) |
-| Tour the **Xray** in-app devtools panel — how to launch it (true-inline, pop-out, programmatic `init!`, hotkeys, the Dynamic ↔ Static mode toggle) or **which tab / mode surfaces X** | "open Xray", "where is X in Xray", "which Xray panel/tab shows…", "Xray Static mode", "browse registered machines/routes/schemas in Xray", "Ctrl+Shift+C", "Xray hotkey", "Xray popout", "Xray machine inspector", "Xray epoch cascade", "where do Xray issues show up" — the user wants to *read* the panel, not drive a runtime | [`re-frame2-xray/`](re-frame2-xray) |
+| Tour the **Xray** in-app devtools panel — how to launch it (true-inline, pop-out, programmatic `init!`, hotkeys, the Dynamic ↔ Static mode toggle) or **which tab / mode surfaces X** | "open Xray", "where is X in Xray", "which Xray panel/tab shows…", "Xray Static mode", "browse registered machines/routes/schemas in Xray", "Ctrl+Shift+C", "Xray hotkey", "Xray popout", "Xray machine inspector", "Xray epoch cascade", "where do Xray issues show up" — the user asks where a *human* looks in the visible panel; the moment they ask the agent to inspect or change the running app (read-only included), that's `re-frame2-pair` | [`re-frame2-xray/`](re-frame2-xray) |
 | Pair-program against a **running** re-frame2 application — attach to a live shadow-cljs nREPL, inspect a frame's `app-db`, dispatch events, hot-swap handlers, walk traces / epochs, time-travel with `restore-epoch` | live runtime is involved; user is operating on (or wants to operate on) a running local app | [`re-frame2-pair/`](re-frame2-pair) |
 | Retrospect on a `re-frame2-pair` session and turn it into prioritised improvement ideas for the pair-tool skill, scripts, MCP surface, or upstream `re-frame2` Tool-Pair contract | concrete `re-frame2-pair` session in the conversation **or** a user-supplied recap of one; user explicitly asks for a retro ("retro on this pair session", "review my re-frame2-pair session", "draft an issue about that"), OR a post-error post-mortem trigger fires within a live re-frame2-pair session | [`re-frame2-pair-retro/`](re-frame2-pair-retro) |
 | Build a **new re-frame2 implementation** in one of the eight in-scope JS-cross-compile-to-React+VDOM host languages (TypeScript, F# / Fable, Kotlin/JS, Squint, Scala.js, PureScript, Melange / ReScript / Reason — plus ClojureScript, the reference) — porting the pattern, not building an app on the CLJS reference | "port re-frame2", "implement re-frame2 in &lt;language&gt;", "second re-frame2 implementation", "implementor checklist", "conformance corpus", or any prompt about building re-frame2 itself | [`re-frame2-implementor/`](re-frame2-implementor) |
@@ -170,7 +165,7 @@ migration report is signed off.
 - Generic debugging retrospectives, post-mortems on shell sessions, IDE workflows, or test-suite runs are out of scope for `re-frame2-pair-retro` — there is no pair-tool surface to improve.
 - Mid-session pair work stays in `re-frame2-pair`; switch to `re-frame2-pair-retro` only when the user explicitly asks for a retro, or for a post-error post-mortem within the re-frame2-pair session — not as a default mode during routine pair work.
 - "Adding re-frame2 to an existing app with other state management or non-trivial code" is an authoring task — route to `re-frame2/`, not `re-frame2-setup/`. Setup is greenfield-only and exits once the counter mounts.
-- Xray vs re-frame2-pair: read vs drive. `re-frame2-xray` is a read-only tour of the panel — how to launch it and which tab/mode shows X. The moment the user wants to operate on a running runtime (dispatch an event, mutate `app-db`, hot-swap a handler, time-travel), that is `re-frame2-pair`, even if the word "Xray" appears in the prompt.
+- Xray vs re-frame2-pair: human panel vs agent runtime — not read vs write. `re-frame2-xray` tours the visible panel: how to launch it and which tab/mode a human opens first. The moment the user asks the agent to touch a running runtime — read-only included (read a sub, get a path, snapshot state, walk traces), as much as dispatching, mutating `app-db`, hot-swapping, or time-travelling — that is `re-frame2-pair`, even if the word "Xray" appears in the prompt.
 - `re-frame2-implementor` is scoped to the 8 in-scope hosts. Per [`spec/000-Vision.md`](../spec/000-Vision.md) §scope footnote, the only in-scope implementation targets are the 8 JS-cross-compile-to-React+VDOM host languages (ClojureScript, TypeScript, F# / Fable, Kotlin/JS, Squint, Scala.js, PureScript, Melange / ReScript / Reason). A prompt asking to implement re-frame2 against a non-React substrate (Vue, Solid, Svelte, vanilla DOM, native UI, a terminal UI) or a non-cross-compile-to-JS host (Python, Ruby, native Rust, Go, server-side Kotlin / Java / Swift) is out of scope — a deliberate scope choice, not an oversight. There is no implementation track to sequence: surface the scope footnote and stop, or route the architecture question to [`SKILL-REDIRECT.md`](../SKILL-REDIRECT.md) — do not start Phase 1 / Phase 2 implementation work.
 
 ### Routing for friction found mid-pair retro
@@ -203,7 +198,7 @@ family rule — single source below:
 | `re-frame2` (authoring) | author code on an existing re-frame2 app | **split** — the skill runs the project's discovered noninteractive compile / test / lint gate; the programmer owns interactive / visual checks and anything needing a live runtime (`re-frame2-pair`) | the nearest declared gate passes on the changed path, with the exact command + result reported | trust-the-explicit-invoker baseline — the skill already discovers the gate from `deps.edn` / `shadow-cljs.edn` / `package.json` / the nearest README, so it runs it and reports rather than relaying the command to the human; it still drives no runtime of its own (that stays `re-frame2-pair`'s) |
 | `re-frame2-setup` | scaffold greenfield | the **author**, following steps | the counter mounts under `shadow-cljs watch` | greenfield bootstrap; no agent-driven runtime |
 | `re-frame2-improver` | critique existing code | nobody runs; static critique | one complete severity-ordered critique in the requesting turn, findings cross-linked to canonical idioms | read-only by default; a direct "review and apply/fix" request authorises safe in-scope `Edit`s (redesigns stay proposals); runs no suite |
-| `re-frame2-xray` | read-only tour of the devtools panel | nobody runs; read-only | n/a (read-only tour) | owns the *seeing*, not the *driving* |
+| `re-frame2-xray` | question-first tour of the devtools panel | nobody runs; read-only | n/a (read-only tour) | owns the human panel tour; agent runtime access — read or write — is `re-frame2-pair`'s |
 | `re-frame2-pair-retro` | retro on a pair session | nobody runs the app; read-only — drafts an issue the user files | a complete one-turn retrospective, with an optional copy-pasteable issue draft (tool- vs framework-shaped) | meta-skill over `re-frame2-pair`; no runtime of its own |
 
 ## Layout convention

--- a/skills/re-frame2-xray/.claude-plugin/plugin.json
+++ b/skills/re-frame2-xray/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "re-frame2-xray",
   "version": "0.1.0-alpha.1",
-  "description": "Read-only tour skill for Xray — the re-frame2 in-app devtools panel. Teaches launch modes, the Dynamic ↔ Static mode toggle, and the tab inventory (10 Dynamic event-spine tabs incl. Resources + the EP-0014 derivation/process Graph + the EP-0023 image→frame Frames tab + the Hicasso evidence tab + 5 Static registry-browse tabs); defers driving / implementing Xray to sibling skills.",
+  "description": "Question-first tour skill for Xray — the re-frame2 in-app devtools panel. Routes a debugging question to the one visible surface to open first (10 Dynamic event-spine tabs + 5 Static registry-browse tabs) and teaches launch modes and the Dynamic ↔ Static mode toggle; defers agent runtime access (read or write) and implementing Xray to sibling skills.",
   "skills": [
     "./SKILL.md"
   ],

--- a/skills/re-frame2-xray/README.md
+++ b/skills/re-frame2-xray/README.md
@@ -2,10 +2,10 @@
 
 > ↑ [`skills/`](..) — index of all re-frame2 skills.
 
-`re-frame2-xray` is a Claude Code tour skill for [Xray](https://github.com/day8/re-frame2/tree/main/tools/xray) — the re-frame2 in-app devtools panel. It answers 3 questions, and only 3:
+`re-frame2-xray` is a Claude Code tour skill for [Xray](https://github.com/day8/re-frame2/tree/main/tools/xray) — the re-frame2 in-app devtools panel. It is question-first: a concrete debugging question lands on the one visible mode/tab to open first, with the reason and the first interaction. It answers 3 questions, and only 3:
 
 1. How do I launch Xray? — the inline panel, the overlay fallback (`open-overlay!`, for hosts that can't give Xray a layout column), the pop-out, the programmatic `init!`, the wired hotkeys, and the Dynamic ↔ Static mode toggle.
-2. Which tab shows X? — a one-line purpose for each tab across both modes: the 10 Dynamic event-spine tabs (Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph · Frames · Hicasso) and the 5 Static registry-browse tabs. The Graph tab is Xray's UI over the EP-0014 derivation/process graph; the Frames tab (internal id `:module-view`) is its EP-0023 `image -> frame` lens — which image loaded which frame, and how a frame resolves its registrations; the Hicasso tab is the Hicasso view substrate's evidence lens — 6 views (Mounted · Reads · Intents · Why · Advisor · Causal) over 4 evidence envelopes taken in one turn, each stating its scope, basis, completeness and loss. Dynamic is the shell mode, not a uniform data scope: most tabs are focused-epoch lenses, but Graph and Frames read the process-global registry / observed frame and do not rebind to the selected epoch.
+2. Which tab shows X? — a route card from the evidence sought (one dispatch, changed state, renders, raw ordering, machines/routes, server state, structure, registered definitions) to one first surface, across the 10 Dynamic event-spine tabs (Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph · Frames · Hicasso) and the 5 Static registry-browse tabs. Dynamic is the shell mode, not a uniform data scope: six tabs are focused-epoch lenses, Resources is mixed, and Graph, Frames and Hicasso read live structure and do not rebind to the selected epoch. The canonical inventory + scope matrix live in `references/panels.md`.
 3. What's the chrome around the tabs for? — the first-screen navigation primitives: time-travel inspect / `Reset`-rewind, the filter-pill cluster, the command palette, and the Settings popup.
 
 Workflow procedures (find-wrong-sub, scrub-bad-epoch, click-to-source, redaction-marker semantics) are out of scope — see `SKILL.md` §Out of scope for what to do when one of those comes up.
@@ -14,27 +14,28 @@ Workflow procedures (find-wrong-sub, scrub-bad-epoch, click-to-source, redaction
 
 An in-app true-inline devtools panel for re-frame2 applications, preloaded into dev builds via shadow-cljs `:preloads`. Xray consumes re-frame2's instrumentation surface (Spec 009 trace bus, Tool-Pair epoch history, the registrar query API) — it adds nothing the framework didn't already expose. Production builds elide the entire surface through the universal `interop/debug-enabled?` gate.
 
-Xray is the human-facing panel; for an AI agent surface against the running app, see [`re-frame2-pair`](../re-frame2-pair) (the raw nREPL pair-programming companion).
+Xray is the human-facing panel; when the user asks an agent to inspect or change the running app — read-only included — that is [`re-frame2-pair`](../re-frame2-pair), the agent-facing runtime companion. The boundary is human panel vs agent runtime, not read vs write.
 
 ## Repo contents
 
-- `SKILL.md` — the compact tour/router (launch quick-reference, mode/tab chooser, chrome one-liners, and the leaf-loading guide)
+- `SKILL.md` — the question-first router: the actor fork, the route card (question → first surface), the launch quick-reference, chrome one-liners, and the leaf-loading guide
 - `references/launch-modes.md` — full launch-mode decision tree (preload vs `init!`, suppress-auto-open, `:rf.xray/layout-host-selector`, host-CSS-variable resize, the `open-overlay!` no-layout-host fallback, pop-out lifecycle, wired hotkeys)
-- `references/panels.md` — the full tab tour in depth (10 Dynamic event-spine tabs + 5 Static registry-browse tabs, deeper "open it when…" guidance, the panel → content-home mapping for surfaces that are not their own tab)
+- `references/panels.md` — the compact canonical tab inventory (10 Dynamic + 5 Static), the scope matrix, and the panel → content-home mapping for surfaces that are not their own tab
+- `references/panels-epoch.md` · `panels-state.md` · `panels-domains.md` · `panels-resources.md` · `panels-structure.md` — one leaf per panel family (the Epoch cascade + Trace + issues; app-db + Views; Machine + Routes; Resources; Graph + Frames + Hicasso) — a deep question loads only its family
 - `references/chrome.md` — the first-screen chrome inventory in depth (LIVE/RETRO, time-travel rewind, filter pills, command-palette sources, the Settings-popup tabs, the Snapshot app-db redaction contract)
 - `references/shared-components.md` — the components every L4 panel reuses (`edn-inspector/render-node`, `film_strip/header`, `focus_resolver`) + the tab-icon / L2-badge / cross-panel-arrow glyph reference
-- `evals/evals.json` — eval fixtures (trigger accuracy + answer-quality assertions for the high-drift launch / chrome / tab-routing prompts)
+- `evals/evals.json` — eval fixtures (trigger accuracy + answer-quality/route-quality assertions for the high-drift launch / chrome / tab-routing prompts)
 - `evals/README.md` — the eval harness: coverage table, schema, and how to run the answer-quality checks
 - `.claude-plugin/plugin.json` — Claude Code Plugin packaging metadata
 - `package.json` — npm packaging metadata (skill is also distributable as an Agent Skill)
 
 ## Relationship to other skills
 
-- [`re-frame2-pair`](../re-frame2-pair) — drives Xray programmatically from a live REPL. Xray owns the seeing; re-frame2-pair owns the driving.
+- [`re-frame2-pair`](../re-frame2-pair) — the agent-facing runtime companion: reads and drives the running app (read-sub, get-path, snapshots, trace/epoch reads, dispatch, hot-swap). Xray is the human's panel; Pair is the agent's runtime access, read or write.
 - [`re-frame2`](../re-frame2) — authors host application code. The host app provides the `[data-rf-xray-host]` column Xray mounts into.
 - [`re-frame2-setup`](../re-frame2-setup) — bootstraps a fresh re-frame2 project. The setup skill ensures the dev build is configured so Xray's `:preloads` entry can mount on first run.
 
-This skill does not depend on or reference `re-frame-10x` — Xray is its structural successor (re-frame2's Tool-Pair surfaces replace the v1 reliance on the 10x dev tool entirely). The surface enumeration + "supersedes re-frame-10x" claim live once in [`../shared/tool-pair-surfaces.md`](../shared/tool-pair-surfaces.md) (§Supersedes re-frame-10x); cite it rather than restating here.
+This skill does not depend on or reference `re-frame-10x` — Xray is its structural successor (re-frame2's Tool-Pair surfaces replace the v1 reliance on the 10x dev tool entirely; [`spec/Tool-Pair.md` §Implications for downstream tools](../../spec/Tool-Pair.md#implications-for-downstream-tools) owns that contract).
 
 ## Status
 

--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: re-frame2-xray
 description: >
- Read-only tour of **Xray** — the re-frame2 devtools panel. Use when the
+ Question-first tour of **Xray** — the re-frame2 devtools panel. Use when the
  user wants to know how to *launch* Xray (in-app inline panel, the
  overlay fallback for hosts with no layout column / full-screen-canvas /
  no `[data-rf-xray-host]` — `open-overlay!`, pop-out window, programmatic
@@ -21,11 +21,13 @@ description: >
  loaded this frame", "how does this frame resolve its registrations",
  "Xray Hicasso tab", "which Hicasso boundaries are mounted", "what reads
  this subscription", "why did this boundary re-render", and similar.
- **Do not use** for: driving Xray
- programmatically from a live REPL (that's `re-frame2-pair`), authoring
- the host app (`re-frame2`), bootstrapping a new project
- (`re-frame2-setup`), or implementing Xray itself (no implementor skill
- exists).
+ **Do not use** when the user asks the AGENT to inspect or change their
+ running app — read-only included (read a sub, get a path, snapshot
+ state, walk traces, dispatch): that's `re-frame2-pair`, the
+ agent-facing runtime companion. Nor for authoring the host app
+ (`re-frame2`), bootstrapping a new project (`re-frame2-setup`), or
+ implementing Xray itself (no implementor skill exists — the spec is
+ the answer).
 allowed-tools:
  - Read
  - Grep
@@ -34,407 +36,226 @@ allowed-tools:
 
 # re-frame2-xray
 
-A tour skill for **Xray** — the re-frame2 in-app devtools panel.
+One debugging question, one first surface. This skill routes a concrete
+question to the one visible Xray mode/tab to open first, says why it is
+the first stop, and names the first interaction. Xray is the human-facing
+in-app devtools panel for re-frame2 — preloaded into dev builds via
+shadow-cljs `:preloads`, auto-opening into the host's
+`[data-rf-xray-host]` column, elided entirely from production builds.
 
-## Mental model: think in Redux DevTools, map onto Xray
+## First fork — who is looking?
 
-If you know **Redux DevTools** (and **React DevTools Profiler** for the
-re-render-cause surfaces), you know 80% of Xray: same genus — a
-state-debugging devtools panel with time-travel and an inspectable log of
-state changes — applied to re-frame2's event pipeline runs. Anchor on that,
-then note the deliberate divergences.
+- **A human looking at the visible Xray panel** — "where do I look?",
+ "which tab shows X?", "how do I launch it?" — stays here.
+- **The agent inspecting or changing the running app** — "read this sub
+ for me", "what's at `[:cart :items]` right now?", "dispatch this and
+ tell me what happens" — routes to
+ [`re-frame2-pair`](../re-frame2-pair/SKILL.md), **whether or not the
+ operation mutates anything**. Pair owns agent runtime access — read-sub,
+ get-path, snapshots, trace/epoch reads, DOM/UI reads, and writes alike.
+ The boundary is human panel vs agent runtime, not read vs write.
 
-| Redux DevTools concept | Xray counterpart | Deliberate divergence |
-|---|---|---|
-| Action log (the left-rail list of dispatched actions) | The **L2 event spine** — one row per dispatched event, live-tailing | Each row is an *epoch* (a full six-domino cascade), not a single reducer call — far richer than an action entry |
-| Inspecting one action's state diff | The **Epoch** tab (hero) — the focused dispatch's numbered cascade, DISPATCH → COEFFECT(s) → EVENT HANDLER → FLOW(s) → EFFECT HANDLERS → SUBSCRIPTIONS → VIEWS | Redux shows action + state diff; the Epoch cascade shows the *whole causal chain* (cofx, interceptors, fx, flows, sub recompute, re-render), not just before/after state |
-| Time-travel / "jump to state" replay | The **inspect · `Reset`-rewind** chrome | **Passive by default** — picking an epoch rebases the panels but does NOT move the live frame; live rewind is the explicit `Reset` button (see chrome.md §Time-travel). Redux's slider *replays dispatches* into the store; Xray inverts that. |
-| State tree inspector | The **app-db** tab — sectioned, lazy-tree, inline diff annotations | Sectioned by reserved area (machines, routes, system-ids…) with downstream-subs hover, not a raw single tree |
-| React DevTools Profiler "why did this render?" | The **Views** tab — render-cause chips (`← :sub-id` vs `← props`) on every re-render leaf | Built into the same panel and tied to the epoch, not a separate profiler tab |
-| *(no Redux equivalent)* | **Static mode** — event-INDEPENDENT browse of what's *registered* (machines / routes / schemas / flows / interceptors) | Redux has no "what's registered?" surface; this is the registry-catalogue half Xray adds |
+## The route card — question → first surface
 
-Xray is also the structural successor to **re-frame-10x** (re-frame2's
-v1-internal predecessor) and references it nowhere — matters mainly to
-v1-migrating users. The lineage fact + surface-by-surface "what replaces
-what" lives once in
-[`../shared/tool-pair-surfaces.md` §Supersedes re-frame-10x](../shared/tool-pair-surfaces.md#supersedes-re-frame-10x);
-cite it, don't restate.
+Route a panel question by the evidence sought. Answer with the visible
+mode/tab, the reason, and the first interaction; name a second lens only
+when it is the natural next step. Do not enumerate the tab inventory
+unless the user asked for the inventory.
 
-This skill answers three questions, and only three:
+| The evidence sought | First surface | First interaction | Natural next step |
+|---|---|---|---|
+| What did this one dispatch do — the whole cascade, where it failed, what fx fired | **Dynamic → Epoch** (the default landing tab) | pick the frame, click the event row in the L2 list | **Trace** for raw op ordering |
+| What changed in state — is the value I expect actually there | **Dynamic → app-db** | pick the event; changed paths carry inline `← was X` diffs | hover a changed path for its downstream subs |
+| Why did this render — sub change or props, what recomputed | **Dynamic → Views** | pick the event; read the render-cause chips (`← :sub-id` vs `← props`) | **app-db** at the sub's input path |
+| Exact raw ordering / payloads the friendly views summarise | **Dynamic → Trace** | pick the event; click a row to expand it | — |
+| What this event did to a state machine — transition, guards, actions | **Dynamic → Machine** (event-driven; blank when the event touched no machine) | pick the event | **Static → Machines** to browse a full topology cold |
+| What route am I on / what did this event do to routing | **Dynamic → Routes** | pick the event | **Static → Routes** to rank a URL against the registry |
+| Server state — what owns it, is it stale, what's in flight, did my mutation's `:reply-to` fire | **Dynamic → Resources** | pick the frame — live instances follow the L1 frame picker, not the epoch | — |
+| Where does this value come from — the dependency graph across subs / flows / resources / routes / machines | **Dynamic → Graph** (does not follow the epoch) | flip its own Declared ↔ Realized projection toggle for registered-vs-observed | — |
+| Which image loaded which frame; how a frame resolves its registrations | **Dynamic → Frames** (process-global; does not follow the epoch) | open the tab | — |
+| Hicasso — which boundaries are mounted, what they read, why one re-rendered, which is hot | **Dynamic → Hicasso** (not epoch-coupled) | open the tab; pick the sub-view (Mounted · Reads · Intents · Why · Advisor · Causal) | — |
+| What's registered — machines / routes / schemas / flows / interceptors as catalogues | **Static mode** | flip the L1 mode pill or press `Cmd/Ctrl+Shift+M` | — |
+| Schema violations — what fired and when each started | **Dynamic → Epoch** (violations attach inline to the owning step) + the L2 pink-wash | pick the frame; scan the spine for washed rows | registered-schema *catalogue* → **Static → Schemas** |
+| SSR hydration mismatches | **Dynamic → Epoch** inline + the auto-open-on-error issues-ribbon signal — there is **no** Hydration tab | pick the washed event | — |
+| Anything broken in this epoch? / which epochs are broken? | **Dynamic → Epoch** (per-step ✓/✗ + inline exception cards) / the **L2 pink-wash** — there is **no** Issues tab | pick the frame; scan the spine | — |
+| A "panel" remembered from elsewhere — Subscriptions, Effects, Flows, Performance | not a tab — its content lives in the lenses above | see [`references/panels.md` §What's deliberately NOT here](references/panels.md#whats-deliberately-not-here) | — |
 
-1. **How do I launch Xray?** — inline panel, pop-out, programmatic entry
- points, wired hotkeys, the Dynamic ↔ Static mode toggle.
-2. **Which tab shows X?** — a one-line purpose per tab across both modes
- (10 Dynamic event-spine + 5 Static registry-browse). In `:order`, with
- mnemonics `e a v t m r s g u h`: **Epoch · app-db · Views · Trace ·
- Machine · Routes · Resources · Graph · Frames · Hicasso** — the last of
- which is the Hicasso view substrate's evidence lens: six views (Mounted ·
- Reads · Intents · Why · Advisor · Causal) over four evidence envelopes
- taken in one turn, each naming what it cannot know rather than showing an
- empty list.
-3. **What's the chrome around the tabs for?** — time-travel inspect /
- `Reset`-rewind, the filter pills, the command palette, the Settings popup.
+The daily path in one line: **choose the frame → choose an event (only
+when the question is event-shaped) → start at Epoch for "what happened?"
+→ branch to the exact state/render/raw/specialist lens → use Static for
+definitions.** The non-epoch surfaces (Graph · Frames · Hicasso) never
+pretend to follow the event — route them by structure, not by dispatch.
 
-Deep workflow recipes (find-wrong-sub, redaction-marker grammar,
-click-to-source / open-in-editor internals) are **out of scope** —
-see *Out of scope* below.
+## The inventory (for explicit "list every tab" requests)
 
-### Which reference leaf to load
+Dynamic mode's L3 tab bar holds **10 tabs**, left-to-right (mnemonics
+`e a v t m r s g u h`): **Epoch · app-db · Views · Trace · Machine ·
+Routes · Resources · Graph · Frames · Hicasso**. Static mode holds **5**:
+**Machines · Routes · Schemas · Flows · Interceptors** (mnemonics are
+mode-scoped — `m` opens the active mode's tab). The compact canonical
+inventory — every tab's one-liner and the scope matrix in one place — is
+[`references/panels.md`](references/panels.md); load it for an explicit
+full-inventory request, not for routine routing.
 
-This body is a **compact tour/router** (launch quick-reference, mode/tab
-chooser, chrome one-liners). Maintained detail lives in the reference
-leaves — load the matching one when the question needs more than the
-router gives:
+### Scope model — what actually follows the event
 
-| The question is about… | Load |
-|---|---|
-| Launch in depth — preload vs `init!`, the `[data-rf-xray-host]` contract, suppress-auto-open, CSS-variable / drag-handle resize, the **missing-host diagnostic + recovery** (`status()`), the `open-overlay!` fallback, pop-out lifecycle, the full wired-hotkey contract | [`references/launch-modes.md`](references/launch-modes.md) |
-| A tab in depth — per-tab layout, iconography, stripe tokens, the Epoch cascade steps, "open it when…" guidance | [`references/panels.md`](references/panels.md) |
-| First-screen chrome in depth — the **L1 frame picker**, Settings-popup tabs, command-palette sources, the rewind detail, the Snapshot redaction contract | [`references/chrome.md`](references/chrome.md) |
-| The components every L4 panel reuses + the glyph/icon reference | [`references/shared-components.md`](references/shared-components.md) |
-| The re-frame-10x lineage / surface-by-surface "what replaces what" | [`../shared/tool-pair-surfaces.md`](../shared/tool-pair-surfaces.md#supersedes-re-frame-10x) |
+"Dynamic" names the 4-layer shell (L1 ribbon · L2 event list · L3 tab bar
+· L4 detail), not a uniform data scope:
 
----
-
-## What Xray is
-
-An in-app true-inline devtools panel for re-frame2 applications, preloaded
-into dev builds via shadow-cljs `:preloads`. The host app provides a
-right-side `[data-rf-xray-host]` column in its normal layout; Xray
-auto-opens there once the substrate adapter is ready. Production builds
-elide the entire surface through the universal `interop/debug-enabled?`
-gate — zero bytes ship to consumers.
-
-Xray consumes re-frame2's instrumentation surface (Spec 009 trace bus,
-Tool-Pair epoch history, the registrar query API) — adding nothing the
-framework didn't already expose. The tabs are *presentation* of an
-already-structured runtime.
-
-### Two modes
-
-Xray runs in one of two modes at a time, flipped by the L1 mode pill or
-the `Cmd/Ctrl+Shift+M` chord:
-
-- **Dynamic** — the event-spine *shell* (4-layer chrome: L1 ribbon · L2
- event list · L3 tab bar · L4 detail). *Most* tabs are a *lens on the one
- focused event* — pick an event in the L2 list and they rebind ("what
- happened in **this** epoch?") — but Dynamic names the shell mode, **not** a
- guarantee that every panel is focused-epoch data: **Graph**, **Frames** and
- **Hicasso** are Dynamic-shell browse surfaces that read the process-global
- registry / the observed frame / the live Hicasso runtime and do **not**
- rebind when you pick an epoch (see the **scope matrix** below). 10 tabs
- (core 6 + cross-feature Resources + Graph + Frames + Hicasso).
-- **Static** — event-INDEPENDENT browse of what's *registered* (3-layer
- chrome, no L2 spine). Static is **mixed-scope**: the definition catalogues
- (events / subs / routes / interceptors / machine definitions) are
- **process-global** — the registrar is shared across every frame (Spec 001)
- — while the L1 frame picker scopes only the genuinely per-frame *live*
- projections each tab adds (machine snapshots, the flows registry, the
- app-db-schema side-table, the current-route slice). "What exists?", not
- "what just happened?". 5 tabs.
-
-Inspect a *single dispatch* → Dynamic; browse the *whole registry* →
-Static. For an AI agent surface against the running app, use
-`tools/re-frame2-pair-mcp/` — Xray is the human-facing panel;
-re-frame2-pair-mcp is the AI-facing one.
-
----
+- **Six focused-epoch lenses** — Epoch · app-db · Views · Trace ·
+ Machine · Routes — rebind when you pick an event in the L2 list.
+- **Resources is mixed** — a process-global resource registry plus the
+ observed frame's live cache/ledger (follows the L1 frame picker), with
+ per-epoch mutation evidence drawn from the trace stream.
+- **Graph, Frames and Hicasso do not follow the event.** Graph reads the
+ process-global registrar (Declared) or the observed frame (Realized) —
+ its Declared ↔ Realized projection toggle is a Graph-local control, NOT
+ the L1 Dynamic/Static mode pill (the shipped UI labels the toggle
+ static/live; Graph is always a Dynamic tab). Frames enumerates the
+ process-global live-frame registry (the `image → frame` model). Hicasso
+ re-takes its live evidence on each trace tick. "Select an epoch and
+ they update" is false — only the six lenses above rebind.
+- **Static's definition catalogues are process-global** — the registrar
+ is shared across every frame (Spec 001); the L1 frame picker moves only
+ each Static tab's per-frame *live* projections (machine snapshots, the
+ flows registry, the app-db-schema side-table, the current-route slice).
 
 ## Launching Xray — pick a mode
 
-Four launch surfaces ship today: one mount facade with three open verbs
-(inline / overlay / window) plus the programmatic `init!`. Pick the one
-that matches the user's situation.
+Four launch surfaces ship: one mount facade with three open verbs
+(inline / overlay / window) plus the programmatic `init!`.
 
 | User wants to … | Use | How |
 |---|---|---|
 | Inspect the runtime while developing locally | **Default true-inline panel** | Add the preload + a `[data-rf-xray-host]` column in the app layout. Xray auto-opens on page load. |
-| Mount where the host can't give Xray a layout column (full-screen canvas, story-only / prototype host, no `[data-rf-xray-host]`) | **Overlay (fallback)** | `(xray/open-overlay!)` from CLJS, or `window.day8.re_frame2_xray.open_overlay_BANG_()` from devtools. Floats the shell above the host under `document.body` — no layout column needed. The supported fallback for hosts that can't accommodate a right column; **not** the default path (per `spec/011-Launch-Modes.md` + `spec/API.md` §Mount facade). |
-| Put Xray on a second monitor with the app full-screen | **Pop-out window** | Click the visible **`⛶` pop-out button** in the panel top-bar's right-icons cluster (the canonical chrome path — it dispatches `:rf.xray/popout-shell`). Or, as the secondary programmatic/devtools path, `(xray/popout!)` from CLJS / `window.day8.re_frame2_xray.popout_BANG_()` (call it — note the parens) from a console. |
-| Install Xray from code (no preload, or alternative wiring) | **Programmatic `init!`** + a mount verb | Call `(xray/init! opts)` after `rf/init!` to install the foundation + apply config (it does **not** open a panel), then `(xray/open!)` / `(xray/open-overlay!)` / `(xray/popout!)` to make it visible. Idempotent. |
-| Browse what's *registered* instead of one dispatch | **Static mode** | Flip the L1 mode pill or press `Cmd/Ctrl+Shift+M`. Static drops the event spine and shows the 5 registry-browse tabs. |
-| Have an AI agent inspect the runtime | **re-frame2-pair-mcp** | Configure `tools/re-frame2-pair-mcp/` in the agent host — the raw nREPL pair-programming companion is the AI access path. Out of scope for this skill — see [`tools/re-frame2-pair-mcp/`](../../tools/re-frame2-pair-mcp). |
-| Debug a mobile browser | Not supported | Per `spec/011-Launch-Modes.md` §What this doesn't do — phones refuse to mount. |
+| Mount where the host can't give Xray a layout column (full-screen canvas, no `[data-rf-xray-host]`) | **Overlay (fallback)** | `(xray/open-overlay!)` from CLJS, or `window.day8.re_frame2_xray.open_overlay_BANG_()` from devtools. Floats the shell above the host under `document.body`. The supported fallback — **not** the default path. |
+| Put Xray on a second monitor | **Pop-out window** | Click the visible **`⛶` pop-out button** in the panel top-bar's right-icons cluster (the canonical chrome path). Secondary programmatic path: `(xray/popout!)` from CLJS / `window.day8.re_frame2_xray.popout_BANG_()` (call it — note the parens) from a console. |
+| Install Xray from code (no preload) | **Programmatic `init!`** + a mount verb | Call `(xray/init! opts)` after `rf/init!` to install the foundation (it does **not** open a panel), then `(xray/open!)` / `(xray/open-overlay!)` / `(xray/popout!)` to make it visible. Idempotent. |
+| Browse what's *registered* instead of one dispatch | **Static mode** | Flip the L1 mode pill or press `Cmd/Ctrl+Shift+M`. |
+| Have an AI agent inspect the runtime | **re-frame2-pair** | Out of scope here — see §First fork above. |
+| Debug a mobile browser | Not supported | Phones refuse to mount (`spec/011-Launch-Modes.md`). |
 
 **Most common launch failure — "the panel never appeared."** Preload in,
-page loaded, but no inline panel = a **missing layout host**: no element
-matched `[data-rf-xray-host]` when the adapter became ready. Xray fails
-loudly but safely — it logs a `console.error` and exposes the same
-diagnostic at **`window.day8.re_frame2_xray.status()`**. First response:
-check the console / call `status()`. The three recoveries (add the column ·
-point the selector · fall back to `open-overlay!`), the full `status()` map
-shape, and the distinct dev-build posture banner are in
-[`references/launch-modes.md` §Missing host](references/launch-modes.md).
-
-For the decision tree in depth (preload vs `init!`, suppress-auto-open,
-the `:rf.xray/layout-host-selector` knob, host-CSS-variable resize, the
-`open-overlay!` fallback, pop-out lifecycle), see
-[`references/launch-modes.md`](references/launch-modes.md).
+page loaded, no inline panel = a **missing layout host**: nothing matched
+`[data-rf-xray-host]` when the adapter became ready. Xray fails loudly but
+safely — a `console.error` plus the same diagnostic at
+**`window.day8.re_frame2_xray.status()`**. First response: check the
+console / call `status()`. The three recoveries (add the column · point
+the selector · fall back to `open-overlay!`) and the full decision tree
+(preload vs `init!`, suppress-auto-open, resize, pop-out lifecycle) live
+in [`references/launch-modes.md`](references/launch-modes.md).
 
 ### Wired hotkeys
 
-Four hotkey families have keydown listeners installed in `keybinding.cljs`
-today (three global, one focus-gated). Quick-reference below; full per-key
-contract + suppression knob in
+Four hotkey families are wired (three global, one focus-gated). Full
+per-key contract + suppression knob:
 [`references/launch-modes.md` §Wired hotkeys](references/launch-modes.md#wired-hotkeys).
-Spec [`007-UX-IA.md` §Keyboard](../../tools/xray/spec/007-UX-IA.md#keyboard)
-catalogues a richer map; these are what is actually wired:
 
 | Key | Scope | Action |
 |---|---|---|
 | `Ctrl+Shift+C` | global | Toggle the Xray shell (`Ctrl+Shift` avoids Safari's `Cmd+Shift+C` Inspect collision). |
-| `Cmd/Ctrl+Shift+M` | global | Toggle mode — Dynamic ↔ Static (`:rf.xray/toggle-mode`). |
-| `Cmd/Ctrl+K` | global | Open the command palette (`:rf.xray/palette-toggle`); opens the shell first if hidden. |
-| `Space` `L` `j` `k` `G` `,`/`s` | focus-gated | Spine + chrome shortcuts — fire only when the shell is visible and focused (non-editable, non-modal). Space = pause/resume LIVE · `L` = snap to LIVE · `j`/`k` = step focused event · `G` = fast-forward to head · `,`/`s` = Settings popup. |
+| `Cmd/Ctrl+Shift+M` | global | Toggle mode — Dynamic ↔ Static. |
+| `Cmd/Ctrl+K` | global | Open the command palette (**wired** — don't tell users the K-binding is unavailable); opens the shell first if hidden. |
+| `Space` `L` `j` `k` `G` `,`/`s` | focus-gated | Spine + chrome shortcuts, only while the shell is visible and focused. Space = pause/resume LIVE · `L` = snap to LIVE · `j`/`k` = step focused event · `G` = fast-forward to head · `,`/`s` = Settings popup. |
 
-`Cmd/Ctrl+K` **is** wired — don't tell users the K-binding is unavailable.
-`Esc` is modal-local,
-not a wired spine key. The **pop-out has no hotkey** — its canonical path is
-the visible **`⛶` pop-out button** (above), with `(xray/popout!)` as the
-secondary programmatic path. Source of truth:
-[`keybinding.cljs`](../../tools/xray/src/day8/re_frame2_xray/keybinding.cljs).
-
----
-
-## The tabs — what each surfaces
-
-<a id="the-tabs--what-each-surfaces"></a>
-
-Tabs split across the two modes. On "where is X?", first decide *which
-mode answers it* — Dynamic (one dispatch) or Static (the whole registry)
-— then route to the tab. For per-tab layout, iconography, stripe tokens,
-and "open it when…" depth see [`references/panels.md`](references/panels.md).
-
-### Dynamic mode — the event-spine shell (10 tabs)
-
-The L3 tab bar holds **10 tabs**, left-to-right (mnemonics `e a v t m r s g
-u h`): **Epoch · app-db · Views · Trace · Machine · Routes · Resources ·
-Graph · Frames · Hicasso** — the core 6 spine lenses (spec/018 §5 +
-spec/021 §9.1) plus the cross-feature Resources / Graph / Frames / Hicasso.
-*Most* answer "what happened in **this** epoch?"; the exceptions are
-**Graph**, **Frames** and **Hicasso**, which read the process-global
-registry / observed frame / live Hicasso runtime and do **not** rebind to
-the focused epoch (see the scope matrix below). Cross-epoch signal
-lives on the L2 timeline (badges + stripes); no Dynamic tab shows a
-cross-epoch *aggregate*. There is **no Issues tab** (see *Where issues
-surface now* below).
-
-#### Scope matrix — what each Dynamic tab actually reads
-
-"Dynamic" names the 4-layer *shell*, not a uniform data scope. Three
-authority axes:
-
-| Scope | Tabs | Picking an epoch in L2… |
-|---|---|---|
-| **Focused epoch** — the event-spine lenses | Epoch · app-db · Views · Trace · Machine · Routes | rebinds them to that epoch's captured cascade |
-| **Observed frame** — live frame state, not the epoch | **Graph** (Realized projection) · Resources (live instances) | does nothing; they follow the **L1 frame picker** |
-| **Process-global / registry-wide** | **Graph** (Declared projection) · **Frames** · **Hicasso** · Resources (static registry) | does nothing; identical for every epoch (and the global catalogues read the same in every frame) |
-
-**Graph, Frames and Hicasso are the Dynamic-shell exceptions.** Graph reads
-the process-global registrar (Declared projection) or the observed frame's
-runtime-db (Realized projection); **Frames** enumerates the process-global
-live-frame registry (the EP-0023 `image -> frame` model); **Hicasso** takes
-the live Hicasso evidence door across every frame, re-taken on each trace
-tick. None of the three composes off the focused epoch. Resources is a mix —
-a process-global resource registry plus the observed frame's live
-cache/ledger; the per-epoch mutation- and scope-resolution evidence it also
-surfaces is drawn from the trace stream. So "select an epoch and
-Graph/Frames/Hicasso update" is **false** — only the six focused-epoch
-lenses rebind.
-
-Each row below is the one-line purpose + when-to-open; **depth for every
-tab lives in [`references/panels.md`](references/panels.md)** under the
-matching § heading.
-
-| Tab | Mnem · Icon · Stripe | One-line purpose | When you'd open it |
-|---|---|---|---|
-| **Epoch** *(hero, default landing · `:order -1`)* | `e` · `⚡` · violet | The focused dispatch's full computational timeline as a **numbered vertical cascade** (rendered step labels per `epoch/badge.cljc`): DISPATCH → RECORDABLE COEFFECTS (conditional) → COEFFECT(s) → INTERCEPTORS (authored chain, conditional) → INTERCEPTOR (exception-only, phase-split around the handler) → EVENT HANDLER → FLOW(s) → EFFECT HANDLERS → SUBSCRIPTIONS → VIEWS. Only present steps render; each carries a ✓ / ✗ / ⊘ glyph; exceptions render under their step. Depth: panels.md §Epoch. | Default landing. "What did this event do?" / "What fx fired?" / "Where did the cascade fail?" / "Did the flow recompute?" |
-| **app-db** | `a` · `◐` · cyan | State sectioned by reserved area (APP STATE + per-machine + per-spawned + ROUTE + SYSTEM-IDS + …), each a collapsible lazy-tree with **inline** diff (`← was X`); hover a changed path for the downstream-subs popover. (Display label lowercase **app-db**; tab id `:app-db`.) Depth: panels.md §app-db. | "What just changed in app-db?" / "What's downstream of `[:cart :items]`?" |
-| **Views** | `v` · `◉` · cyan | The reactive cascade (SUBSCRIPTIONS + VIEWS) as a depth-first DAG with **render-cause chips** on every re-render leaf — `← :sub-id` (a deref'd sub changed) vs `← props` (the props channel); a first mount carries no cause. (Tab id `:views`.) Depth: panels.md §Views. | "Why didn't my view update?" / "Why did this re-render — sub or props?" / "Which views re-rendered this epoch?" |
-| **Trace** | `t` · `⬢` · orange | Raw Spec 009 trace events for the focused epoch — a **flat oldest-first row list**, each row carrying a **stage column** (DISPATCH·COEFFECT·EVENT HANDLER·FLOW·EFFECT HANDLERS·SUBSCRIPTIONS·VIEWS) + a colour-coded left edge reusing the Epoch badge taxonomy; the focused epoch IS the scope, click a row to expand. Depth: panels.md §Trace. | "Show me every raw op in this epoch." / "Is `:rf.fx/*` firing as expected?" |
-| **Machine** | `m` · `◆` · green | **Event-driven.** Per-machine topology + transition highlight + guards / actions / cancellation for the focused event; BLANK when the event had no machine activity. To browse a machine's **full topology cold** (picker + zoom / pan / fit), use **Static mode**'s Machines tab. (Singular **Machine**; tab id `:machines`.) Depth: panels.md §Machine. | "What did this event do to my machines?" / "What transition fired?" / "What guards passed/failed?" |
-| **Routes** | `r` · `🌐` · yellow | Focused-event lens: current matched route + params/query/fragment + a **Simulate-URL** input ranking every registered route, with `◉ TO` / `◇ FROM` overlay markers; silent when no routes registered. (Display label **Routes**; tab id `:routing`.) Depth: panels.md §Routes. | "What route am I on?" / "Did the route change this epoch?" / "What params resolved?" |
-| **Resources** | `s` · cross-feature | The declarative server-state lens (Spec 016) — static resource registry, per-frame live instances (state · owners · freshness), the in-flight work ledger, the scope-resolution timeline, and the EP-0016 mutation-completion evidence (`:reply-to` continuations · descriptor-level scoped-invalidation). **Read-only**, redaction-aware; decoupled (no `:require` on the resources artefact). Depth: panels.md §Resources. | "Where's my server state, what owns it, is it stale?" / "What's in flight?" / "Did my mutation's `:reply-to` fire and invalidate the right scopes?" |
-| **Graph** | `g` · cross-feature (violet) | Xray's UI over the **EP-0014 derivation/process graph** — every declared fact + process across all five families (subscriptions, flows, resources, routes, machines) as one node-and-edge graph over the frame fold. **Reads the process-global registrar (Declared) or the observed frame (Realized), not the focused epoch.** A per-panel **Declared ↔ Realized** projection toggle (a Graph-local control, **NOT** the L1 Dynamic/Static mode pill — Graph is always a Dynamic tab) flips registration-derived vs observed. Depth (incl. the authority-axis + internal-accessor caveats): panels.md §Graph. | "Where does this value come from / when is it evaluated / where does it live / who owns it?" — across families |
-| **Frames** *(internal id `:module-view` · `:order 9`)* | `u` · cross-feature | Xray's UI over the EP-0023 **`image -> frame`** model — each live frame as an execution context carrying its resolved image (`[kind id]` descriptors) + how it resolves `(kind id)` lookups. **Registry-wide, not epoch-coupled** — enumerates the process-global live-frame registry; picking an epoch does not rebind it. L4-only registry tab (focusable, **no** standalone `mount-*!` facade — there is no `mount-module-view!`). Depth: panels.md §Frames. | "What frames exist, and which image loaded each?" / "How does this frame resolve its registrations?" |
-| **Hicasso** *(`:order 10`)* | `h` · cross-feature | The evidence lens for **Hicasso**, re-frame2's re-frame-native view layer — a sub-strip of **six views** over one versioned, adapter-neutral schema: **Mounted** (which boundaries are mounted, over which frames) · **Reads** (which boundaries read each subscription) · **Intents** (what was dispatched, in order, in the retained window) · **Why** (which reads changed, and what that can and cannot prove) · **Advisor** (which boundary is hot and the smallest route that addresses it) · **Causal** (one dispatch walked link by link, every missing link named). The first four read the four evidence envelopes; Advisor and Causal are derivations over that **same one-turn take**. Every view states its own scope, basis, completeness and loss, and renders an absence as a **named loss state**, never an empty list — a host not running Hicasso shows the honest no-evidence state, which is distinct from *running with nothing mounted*. **Not epoch-coupled** — re-taken on each trace tick. L4-only registry tab (focusable, **no** standalone `mount-*!` facade). Depth: panels.md §Hicasso. | "Which boundaries are mounted, and what do they read?" / "Why did this boundary re-render?" / "Which boundary is hot?" |
-
-#### Where issues surface now (no Issues tab)
-
-**No Issues tab, no session-wide triage list.** Issues surface through
-three always-on inline channels: **this epoch** → Epoch-cascade per-step
-✓/✗ + the shared "Exception Thrown" card; **which epochs** → L2 event-row
-pink-wash; **cross-epoch watcher** → the `:rf.xray/issues-ribbon` signal
-(auto-open-on-error). Detail: [`references/panels.md` §Issues](references/panels.md).
-(A11y is **not** a Xray tab — it is Story's domain, `re-frame.story.ui.chrome-a11y`.)
-
-### Static mode — 5 registry-browse tabs (mixed-scope)
-
-**5 catalogue lenses** over what's *registered* (mnemonics mode-scoped —
-`m` here opens the Static Machines browse, not the Dynamic
-instance-inspector). Order per spec/007-UX-IA.md §Static mode:
-**Machines · Routes · Schemas · Flows · Interceptors**. **Mixed-scope:** the
-definition catalogues are **process-global** (the registrar is shared across
-every frame, Spec 001); the L1 frame picker scopes only the per-frame *live*
-projections each tab adds — machine snapshots, the flows registry, the
-app-db-schema side-table, the current-route slice (`static/shell.cljs`). It
-is **not** true that a picked frame owns all its registrations.
-
-> **The browse axis is `image -> frame`, full stop** — no realm / app /
-> module browse dimension; image assembly + frame isolation are the whole
-> composition story (EP-0023, `tools/xray/spec/007-UX-IA.md` §Static mode).
-
-| Tab | Mnem | One-line purpose (+ the question it answers) |
-|---|---|---|
-| **Machines** *(default)* | `m` | Registry browse of every registered machine + topology + a 4-mode sub-strip (incl. the Sim engine) — "browse my checkout machine's chart without picking an event." |
-| **Routes** | `r` | Every registered route + a Simulate-URL input (promoted from the Dynamic Routes lens) — "which route would `/orders/42` match?" |
-| **Schemas** | `c` | Every registered schema + sample data + jump-to-source — "show me the shape of `:order/schema`." |
-| **Flows** | `f` | Catalogue of every registered flow. |
-| **Interceptors** | `i` | Pure-browse lens over the registered interceptor chains — "what runs, and in what order?" |
-
-When a user asks "where do I see **all** my registered machines / routes /
-schemas / flows / interceptors?" the answer is **Static mode** — the
-focused-epoch Dynamic lenses show one event, not the registry (the Graph and
-Frames browse tabs aside).
-
-### Where familiar panels' content lives (these are not separate tabs)
-
-Subscriptions, Effects, Flows, Performance, Schemas, Hydration, and Issues
-are **not** separate Dynamic tabs. The four high-drift routes worth keeping
-in the body:
-
-- **Schemas** (violations) → **Epoch** inline + the L2 pink-wash; the
-  *registry* catalogue → **Static → Schemas**.
-- **Hydration** (SSR mismatches) → **Epoch** inline + the issues-ribbon
-  signal — there is **no** standalone Hydration tab.
-- **Flows** → **Epoch** FLOW step; the registry → **Static → Flows**.
-- **Effects** (`fx`) → **Epoch** EFFECT HANDLERS step + **Trace** raw ops.
-
-For the full panel → content-home mapping (Subscriptions,
-Performance, the rest), see
-[`references/panels.md` §What's deliberately NOT here](references/panels.md#whats-deliberately-not-here)
-(the single maintained home; + spec/021 §15). The hero on first open is
-**Epoch** (`:order -1`).
-
----
+Only these are wired: `Esc` is modal-local, not a spine key; the
+**pop-out has no hotkey** (its canonical path is the visible `⛶`
+button); no `r`/`R`/`*` time-travel keys are live — the richer keymap in
+the spec is normative-future.
 
 ## The chrome around the tabs
 
-<a id="the-chrome-around-the-tabs"></a>
+One line each; load [`references/chrome.md`](references/chrome.md) for
+the control-by-control inventory.
 
-Beyond the tabs, the first screen carries navigation primitives the user
-meets immediately — one line each below. **Load
-[`references/chrome.md`](references/chrome.md) for the control-by-control
-inventory** (Settings-popup tabs, command-palette sources, the Snapshot
-redaction contract, the rewind detail) when the question needs more than
-the one-liner.
-
-- **L1 frame picker.** The Frame control on the L1 ribbon chooses *which
- frame* Xray observes — it moves the per-frame *live* projections and the
- spine's observed frame; the process-global catalogues (Graph Declared,
- Frames, the Static definition catalogues) read the same in every frame and
- do **not** follow the picker (see the scope matrix above). It is
- mode-independent: the frame-observation axis moves in both Dynamic and
- Static. It **always
- renders**; on a single-frame app it is a working one-entry dropdown (only a
- zero-frame state disables it). The button face shows the currently-selected
- frame id live (e.g. `:rf/default ▾`). The pin is a **transient view
- scope** — not persisted across reload (resets to the head-frame default).
- Tool frames (`:rf/xray` itself, `:rf/re-frame2-pair`) are **filtered out of
- the picker unconditionally** — invariant **I1**: Xray observes ANOTHER
- frame, never itself; they cannot currently be revealed from the UI. So "I
- can't find frame X in the picker" → it's a tool frame. (chrome.md §L1 frame
- picker.)
-- **LIVE vs RETRO spine.** The L2 spine live-tails at the head (**LIVE**)
- until you pick a historical event or pause (**RETRO**); `Space`
- pauses/resumes, `L` snaps back. (chrome.md §LIVE vs RETRO spine.)
-- **Time-travel: passive inspect vs explicit rewind.** Picking an epoch is
- *passive INSPECTION* — panels rebase, the live frame does NOT move; live
- rewind is the *separate, explicit* **`Reset` button** on the L3 ribbon
- (`restore-epoch!` reinstalls the focused epoch's WHOLE frame-state — both
- app-db AND runtime-db — via `replace-frame-state!`, not the `:db-after`
- projection alone). No wired `r`/`R`/`*` keys — those are spec-future only.
- (chrome.md §Time-travel.)
-- **Filter pills.** The L1.5 events ribbon carries IN / OUT pills, a mute
- set, an `N hidden by filters` count, and `Clear Filters`; transient,
- reset on load. (chrome.md §Filter pills.)
-- **Command palette (`Cmd/Ctrl+K`).** A fuzzy-ranked surface over six
- source kinds (panel jumps · recent events · frame switch · registered
- handlers · settings · command verbs), mode-aware. (chrome.md §Command
- palette — for the full command-verb list.)
-- **Settings popup (`,` / `s`).** A 4-tab modal (General · Keybindings ·
+- **L1 frame picker** — chooses *which frame* Xray observes, in both
+ modes. It moves the per-frame live projections; the process-global
+ catalogues read the same in every frame. Always renders; the pin is
+ transient (resets on reload); tool frames (`:rf/xray`,
+ `:rf/re-frame2-pair`) are filtered out unconditionally — "I can't find
+ frame X in the picker" → it's a tool frame.
+- **LIVE vs RETRO spine** — the L2 spine live-tails at the head until you
+ pick a historical event or pause; `Space` pauses/resumes, `L` snaps back.
+- **Time-travel: passive inspect vs explicit rewind** — picking an epoch
+ is *passive inspection*: panels rebase, the live frame does NOT move.
+ Live rewind is the separate, explicit **`Reset` button** on the L3
+ ribbon — `restore-epoch!` reinstalls the focused epoch's WHOLE
+ frame-state, both app-db AND runtime-db, not the `:db-after` projection
+ alone.
+- **Filter pills** — IN / OUT pills, a mute set, an `N hidden by filters`
+ count, `Clear Filters`; transient, reset on load.
+- **Command palette (`Cmd/Ctrl+K`)** — fuzzy-ranked over six source kinds
+ (panel jumps · recent events · frame switch · registered handlers ·
+ settings · command verbs), mode-aware.
+- **Settings popup (`,` / `s`)** — a 4-tab modal (General · Keybindings ·
  Buffer · Diff). **Density and panel-width are NOT popup controls** —
  density is a boot/`configure!` concern; width is the drag handle. Merge
- order is `defaults < configure! < Settings`. (chrome.md §Settings popup —
- for the per-tab control inventory + the layered-config story.)
-- **Snapshot app-db (the on-box share helper).** The on-box share helper is
- the **Snapshot app-db**
- palette verb — and it is **redacted by default** (sensitive ⇒
- `:rf/redacted`, large ⇒ `:rf.size/large-elided`, via
- `runtime/egress-value`). There is no Share-URL or EDN-export affordance; do
- **not** present Snapshot app-db as a raw-`app-db` /
- secret-egress path. (chrome.md §Snapshot app-db — for the egress contract.)
+ order is `defaults < configure! < Settings` (the popup wins at runtime
+ for the slots it exposes).
+- **Snapshot app-db** — the on-box share helper is the palette verb, and
+ it is **redacted by default** (sensitive ⇒ `:rf/redacted`, large ⇒
+ `:rf.size/large-elided`). Do not present it as a raw-`app-db` /
+ secret-egress path.
 
----
+## Which reference leaf to load
+
+Routine selection questions are answerable from this body alone. A
+deeper question loads at most **one** focused leaf:
+
+| Deep question about… | Load |
+|---|---|
+| Launch in depth — preload vs `init!`, the `[data-rf-xray-host]` contract, missing-host recovery, `open-overlay!`, pop-out lifecycle, the full hotkey contract | [`references/launch-modes.md`](references/launch-modes.md) |
+| The full tab inventory + scope matrix + the Static catalogues (explicit "list every tab") | [`references/panels.md`](references/panels.md) |
+| The Epoch cascade, Trace rows, or where issues surface | [`references/panels-epoch.md`](references/panels-epoch.md) |
+| app-db sections + diffs, or Views render causes | [`references/panels-state.md`](references/panels-state.md) |
+| Machine or Routes activity in depth | [`references/panels-domains.md`](references/panels-domains.md) |
+| Resources (server state) in depth | [`references/panels-resources.md`](references/panels-resources.md) |
+| Graph, Frames, or Hicasso in depth | [`references/panels-structure.md`](references/panels-structure.md) |
+| First-screen chrome in depth — the L1 frame picker, Settings tabs, palette sources, Snapshot redaction, the rewind detail | [`references/chrome.md`](references/chrome.md) |
+| The components every panel reuses + the glyph reference | [`references/shared-components.md`](references/shared-components.md) |
+
+## Mental model (for Redux DevTools users)
+
+If you know Redux DevTools (and the React DevTools Profiler), you know
+80% of Xray: the L2 spine is the action log, except each row is an
+*epoch* — a full cascade (dispatch → cofx → handler → flows → fx → subs →
+views), not one reducer call; the Epoch tab is "inspect one action" with
+the whole causal chain; Views is the "why did this render?" profiler tied
+to the same epoch. Two deliberate inversions: time-travel is **passive by
+default** (picking an epoch inspects; the explicit `Reset` button
+rewinds — Redux's slider replays into the store, Xray does not), and
+**Static mode** is the "what's registered?" catalogue half Redux never
+had. Xray is the structural successor to **re-frame-10x** and references
+it nowhere; the contract behind that claim is owned by
+[`spec/Tool-Pair.md` §Implications for downstream tools](../../spec/Tool-Pair.md#implications-for-downstream-tools).
 
 ## Out of scope
 
-For the following, this skill does not have the answer — point at the spec
-doc or pair-tool surface, don't improvise.
-
-- **Deep workflow recipes** (find-wrong-sub walker, redaction-marker
- grammar, click-to-source / "open in editor" internals, pop-out lifecycle
- gotchas, branch-and-explore). Source of truth:
- [`tools/xray/spec/007-UX-IA.md`](../../tools/xray/spec/007-UX-IA.md)
- and the per-panel specs (`tools/xray/spec/00N-*.md`) — the spec is the
- answer.
- (First-screen chrome — time-travel inspect / `Reset`-rewind, filter
- pills, the command palette, Settings — is **in scope**: §The chrome
- around the tabs above is the router; load
- [`references/chrome.md`](references/chrome.md) for the detail.)
-- **Driving Xray programmatically** (hot-swap a sub via REPL, time-
- travel from CLJS, dispatch into the runtime from a tool). Route to
- the [`re-frame2-pair`](../re-frame2-pair/SKILL.md) skill — Xray
- owns the *seeing*; re-frame2-pair owns the *driving*.
-- **Implementing Xray** (panel-facade/leaf split, mount lifecycle
- internals, `frame-provider {:frame :rf/xray}` isolation, the epoch pump's contract).
- Source of truth:
- [`tools/xray/spec/011-Launch-Modes.md` §Mount lifecycle](../../tools/xray/spec/011-Launch-Modes.md)
- and the per-panel implementation specs. There is no Xray-implementor
- skill — the spec is the answer.
-- **Deep derivation-graph workflow recipes** (reading large cross-family
- graphs, the Declared↔Realized diffing workflow, the off-box egress
- grammar). The **Graph** Dynamic tab itself is **in scope** (§The tabs is
- the router); deferred here is the how-to-debug-with-it recipe layer. Cite
- [`spec/Derivations.md`](../../spec/Derivations.md) +
- [`docs/EP/EP-0014-derivation-and-process-algebra.md`](../../docs/EP/EP-0014-derivation-and-process-algebra.md)
- for the algebra contract.
----
+- **Deep workflow recipes** (find-wrong-sub walking, redaction-marker
+ grammar, click-to-source internals, branch-and-explore). Source of
+ truth: [`tools/xray/spec/007-UX-IA.md`](../../tools/xray/spec/007-UX-IA.md)
+ and the per-panel specs — the spec is the answer.
+- **Agent runtime access** — inspecting or driving the running app on the
+ user's behalf, read-only or mutating. Route to
+ [`re-frame2-pair`](../re-frame2-pair/SKILL.md) (§First fork above).
+- **Implementing Xray** (mount lifecycle internals, panel seams). The
+ spec under `tools/xray/spec/` is the answer; no implementor skill
+ exists.
 
 ## Style guidance
 
-- **Cite the spec, don't paraphrase it.** When a user asks for normative
- detail (the mount contract, the epoch pump's ordering guarantees, the
- redaction marker's grammar), link to the relevant
- `tools/xray/spec/*.md` and quote sparingly.
-- **Pre-alpha hedge.** Some surfaces are partial: the Machine tab renders
- through the shared machines-viz **MachineChart** via
- `panels/machine_canvas.cljs` (still stabilising); the inline issue surfaces
- only populate the schema / hydration rows when the host wired those
- features; the Static Machines Sim engine is still stabilising. The Static
- catalogues themselves (Machines / Routes / Schemas / Flows / Interceptors)
- are full registry browsers, not stubs. When a user asks about an
- in-progress surface, say so and point at the spec.
-- **Don't invent hotkeys.** Only the four families in §Wired hotkeys (above)
- are wired; everything else in
- [`spec/007-UX-IA.md` §Keyboard](../../tools/xray/spec/007-UX-IA.md#keyboard)
- is normative-future, not live. The full per-key contract + guardrails (no
- wired `r`/`R`/`*`, `Esc` modal-local, `Cmd/Ctrl+K` **is** wired) live in
- [`references/launch-modes.md` §Wired hotkeys](references/launch-modes.md#wired-hotkeys);
- cite `keybinding.cljs` when in doubt.
-- **Route, don't blur.** If the user wants to drive Xray, point at
- `re-frame2-pair`; if they want to implement it, point at the spec
- and note that no implementor skill exists yet. This skill is a tour.
+- **Cite the spec, don't paraphrase it.** For normative detail (the mount
+ contract, the epoch pump's ordering, the redaction grammar), link the
+ relevant `tools/xray/spec/*.md` and quote sparingly.
+- **Pre-alpha hedge.** Some surfaces are still stabilising (the Machine
+ tab's chart rendering, the Static Machines Sim engine, the schema /
+ hydration inline rows when the host wired those features). The Static
+ catalogues themselves are full registry browsers, not stubs. Say so and
+ point at the spec when asked about an in-progress surface.
+- **Don't invent controls.** Only the four hotkey families in §Wired
+ hotkeys are live; cite
+ [`keybinding.cljs`](../../tools/xray/src/day8/re_frame2_xray/keybinding.cljs)
+ when in doubt.
 
 ---
 

--- a/skills/re-frame2-xray/evals/README.md
+++ b/skills/re-frame2-xray/evals/README.md
@@ -40,10 +40,13 @@ when the eval shape changes in a way that breaks readers.
 
 ## Coverage
 
-30 evals, covering Xray's trigger surface and answer quality: 22 positives
-(skill should fire) and 8 negatives (skill should stay quiet). 14
+32 evals, covering Xray's trigger surface and answer quality: 23 positives
+(skill should fire) and 9 negatives (skill should stay quiet). 18
 positives carry the Layer-2 answer-quality `expectations[]`; they target the
-prompts whose answer drifts fastest as the Xray UI moves:
+prompts whose answer drifts fastest as the Xray UI moves, plus the
+route-quality contract (one first surface in the first paragraph, no
+full-inventory dump for a single routed question, deep follow-ups loading
+only the focused family leaf):
 
 | ID | Name | Layer 2? | What the answer-quality assertions pin |
 |---:|---|:---:|---|
@@ -52,6 +55,9 @@ prompts whose answer drifts fastest as the Xray UI moves:
 | 27 | `launch-popout-button` | yes | YES there is a visible `⛶` pop-out button — not programmatic-only, not an invented right-click path. |
 | 3 | `launch-programmatic` | yes | `init!` installs but does NOT open; a mount verb is still required; runs after `rf/init!`. |
 | 8 | `panel-route-machine-canvas` | yes | Full topology → Static Machines tab, not the event-driven Dynamic Machine tab; no standalone Machines-Canvas tab. |
+| 6 | `panel-route-state` | yes | Route quality: first paragraph → the Dynamic **app-db** tab (+ the L2 spine to find the changing epoch); first interaction (the inline `← was X` diff); no full-inventory dump. |
+| 7 | `panel-route-machine` | yes | Route quality: first surface → the Dynamic **Machine** tab (event-driven; blank without machine activity); Static Machines is the browse-cold *next* step, not the first surface; no inventory dump. |
+| 9 | `static-browse-registry` | yes | Route quality: whole-registry questions → **Static mode** (the L1 pill / `Cmd/Ctrl+Shift+M`), not the focused-epoch lenses; definition catalogues are process-global. |
 | 11 | `panel-route-schema` | yes | Schema violations → Epoch inline + L2 pink-wash; registry → Static Schemas; no Issues tab, no Dynamic Schemas tab. |
 | 12 | `panel-route-hydration` | yes | No standalone Hydration tab; mismatches → Epoch inline + issues-ribbon signal. |
 | 21 | `chrome-rewind` | yes | Passive inspect (live frame unmoved) vs explicit `Reset` button (`restore-epoch!` reinstalls the whole frame-state — both app-db and runtime-db — not just `:db-after`); `r`/`R`/`*` are NOT wired. |
@@ -61,10 +67,11 @@ prompts whose answer drifts fastest as the Xray UI moves:
 | 28 | `panel-route-frames` | yes | The which-image-loaded-which-frame / how-a-frame-resolves question → the Dynamic **Frames** tab (internal id `:module-view`, EP-0023 image→frame lens, no realm/app/module browse dimension); Frames is SHIPPED, not absent, not Static, not the same as Graph; no `mount-module-view!` (L4-only). |
 | 29 | `tab-inventory-count` | yes | The full ordered **10-tab** Dynamic list incl. Frames and Hicasso (count is 10, not 9); correct `:order`; no retired label ("Modules"); no removed tab (Issues / Event / Chrome A11y / Machines-Canvas). |
 | 30 | `graph-projection-vs-static-mode` | yes | The Graph tab's registration-derived view is its OWN per-panel projection toggle (Declared/Realized; shipped-labelled static/live), NOT the L1 Static mode pill; Graph is a Dynamic tab, so Static mode does not show it at all. |
-| 4, 5, 6, 7, 9, 10, 22, 25 | `launch-hotkey` … `config-init-boot` | no | Trigger-only positives (lower drift; covered by the body's quick-reference). |
-| 13–20 | `neg-*` | no | Negatives — adjacent surfaces (drive→pair, implement→spec, author→re-frame2, setup, migration, implementor, vocab-only). |
+| 32 | `panel-route-resources` | yes | Route quality: server-state staleness / in-flight → the Dynamic **Resources** tab; live instances follow the L1 frame picker, not the epoch; a deep follow-up loads only `references/panels-resources.md`. |
+| 4, 5, 10, 22, 25 | `launch-hotkey` … `config-init-boot` | no | Trigger-only positives (lower drift; covered by the body's quick-reference). |
+| 13–20, 31 | `neg-*` | no | Negatives — adjacent surfaces (agent runtime → pair, whether mutating (13) or read-only (31); implement→spec, author→re-frame2, setup, migration, implementor, vocab-only). |
 
-The Layer-2 set is exactly the high-drift list the bead called for:
+The Layer-2 set covers two contracts. The high-drift facts:
 launch-default, launch-overlay, launch-popout-button, launch-programmatic,
 config-init-vs-settings, chrome-rewind, chrome-palette,
 panel-route-machine-canvas, panel-route-schema, panel-route-hydration —
@@ -76,7 +83,15 @@ revert to 9 tabs, fails the
 answer-quality layer, and graph-projection-vs-static-mode that pins the
 Graph tab's per-panel projection toggle (Declared/Realized) as distinct from
 the L1 Static mode pill, so the overloaded `static`/`mode` vocabulary cannot
-re-route a user to the wrong control.
+re-route a user to the wrong control. And the route-quality contract
+(rf2-0mw10): panel-route-state, panel-route-machine, static-browse-registry
+and panel-route-resources grade one representative question per scope
+family — focused-epoch, observed-frame/live-structure, Static-definition,
+and (via panel-route-frames) process-global/registry — each requiring one
+existing first surface in the first paragraph, the first interaction, no
+full-inventory dump, and (where deep) only the focused
+`references/panels-*.md` family leaf loaded. The read-only agent boundary
+is pinned from the negative side by neg-agent-readonly-inspect.
 
 ## How to run
 
@@ -134,8 +149,8 @@ as the discipline of updating them alongside the product.
 
 The tour skill's Dynamic tab inventory (the `e a v t m r s g u h` set across
 `SKILL.md`, `README.md`, `references/panels.md`,
-`references/shared-components.md`, `package.json`, and
-`.claude-plugin/plugin.json`) is checked against the live Xray registry by
+`references/shared-components.md`, and the eval fixtures — `references/panels.md`
+is the canonical complete inventory) is checked against the live Xray registry by
 `scripts/check_skill_xray_tab_inventory_drift.py` — a structural drift gate
 that parses the shipped `reg-l4-tab!` metadata and fails if any Dynamic
 tab's `:id` / `:label` / `:mnem` / `:order` diverges from the skill + eval

--- a/skills/re-frame2-xray/evals/evals.json
+++ b/skills/re-frame2-xray/evals/evals.json
@@ -2,7 +2,7 @@
  "skill_name": "re-frame2-xray",
  "schema_version": "2",
  "convention": "anthropics/skills/skill-creator evals.json — per references/schemas.md. Two-layer fixture: every entry carries `should_trigger` so skill-creator's description-optimisation loop can score train/held-out trigger accuracy; the high-drift positives ALSO carry `expected_output` + `expectations[]` (answer-quality assertions) so a description-optimisation pass that keeps the skill firing cannot mask an answer that has drifted behind the shipped Xray UI. Negatives keep `rationale` (no answer-quality layer — there is no right answer to assert).",
- "notes": "Positives (should_trigger: true) target the launch + tab-routing + first-screen-chrome surface of SKILL.md across both modes (Dynamic event-spine + Static registry browse). The launch positives exercise the FULL public mount-verb set — the default true-inline panel (launch-default), the open-overlay! no-layout-host fallback (launch-overlay), the popout! pop-out window via both the visible chrome `⛶` top-bar button (launch-popout-button — a no-code question whose answer must name the shipped button, not a programmatic-only or future-right-click path) and the programmatic API (launch-popout), and the programmatic init! (launch-programmatic) — plus the init!/configure!-vs-Settings boot-config contract (config-init-boot, config-init-vs-settings). The tab-inventory positives PIN the current 10-tab Dynamic surface: panel-route-frames routes the which-image-loaded-which-frame / how-a-frame-resolves question to the Frames tab (:module-view, mnem u, :order 9, L4-only — no standalone mount facade), and tab-inventory-count asserts the full ordered 10-tab list (Epoch·app-db·Views·Trace·Machine·Routes·Resources·Graph·Frames·Hicasso, mnemonics e a v t m r s g u h) matching focus.cljc's valid-panels set — so a future drift that drops Hicasso or reverts to 9 tabs fails answer-quality. The high-drift entries carry expectations[] that PIN current elegant-v2 guidance (visible pop-out button canonical / open-overlay! fallback-only / init! installs-but-does-not-open / Settings override order / passive inspect vs explicit Reset / Static Machines for full topology / redacted-by-default Snapshot / 10 Dynamic tabs incl. Hicasso / no standalone Issues|Hydration|Schemas Dynamic tab) AND reject stale guidance (wired r/R/* rewind keys, density radio in Settings, raw app-db snapshot by default, a re-frame-10x compatibility path, a 9-tab inventory). Negatives target adjacent surfaces (re-frame2-pair drives Xray; re-frame2 authors host apps; spec discussion belongs to SKILL-REDIRECT) so the loop catches over-triggering. NB: density is NOT a Settings-popup control (the radio was removed 2026-05-27); config-init-vs-settings exercises the boot-default-vs-runtime-override contract through epoch-history, a slot the popup actually surfaces.",
+ "notes": "Positives (should_trigger: true) target the launch + tab-routing + first-screen-chrome surface of SKILL.md across both modes (Dynamic event-spine + Static registry browse). The launch positives exercise the FULL public mount-verb set — the default true-inline panel (launch-default), the open-overlay! no-layout-host fallback (launch-overlay), the popout! pop-out window via both the visible chrome `⛶` top-bar button (launch-popout-button — a no-code question whose answer must name the shipped button, not a programmatic-only or future-right-click path) and the programmatic API (launch-popout), and the programmatic init! (launch-programmatic) — plus the init!/configure!-vs-Settings boot-config contract (config-init-boot, config-init-vs-settings). The ROUTE-QUALITY positives (panel-route-state, panel-route-machine, panel-route-resources, static-browse-registry, plus the launch/chrome routes) grade the question-first contract: one existing first surface in the first paragraph — visible mode/tab, the reason, the first interaction — with no full-inventory dump for a single routed question, and a deep follow-up loading only the focused references/panels-*.md family leaf. The tab-inventory positives PIN the current 10-tab Dynamic surface: panel-route-frames routes the which-image-loaded-which-frame / how-a-frame-resolves question to the Frames tab (visible label Frames; L4-only — no standalone mount facade), and tab-inventory-count asserts the full ordered 10-tab list (Epoch·app-db·Views·Trace·Machine·Routes·Resources·Graph·Frames·Hicasso, mnemonics e a v t m r s g u h) matching focus.cljc's valid-panels set — so a future drift that drops Hicasso or reverts to 9 tabs fails answer-quality. The high-drift entries carry expectations[] that PIN current guidance (visible pop-out button canonical / open-overlay! fallback-only / init! installs-but-does-not-open / Settings override order / passive inspect vs explicit Reset / Static Machines for full topology / redacted-by-default Snapshot / 10 Dynamic tabs incl. Hicasso / no standalone Issues|Hydration|Schemas Dynamic tab) AND reject stale guidance (wired r/R/* rewind keys, density radio in Settings, raw app-db snapshot by default, a re-frame-10x compatibility path, a 9-tab inventory). Negatives target adjacent surfaces so the loop catches over-triggering, and pin the ACTOR boundary: agent runtime access routes to re-frame2-pair whether mutating (neg-drive-xray) or read-only (neg-agent-readonly-inspect) — the boundary is human panel vs agent runtime, not read vs write. NB: density is NOT a Settings-popup control (the radio was removed 2026-05-27); config-init-vs-settings exercises the boot-default-vs-runtime-override contract through epoch-history, a slot the popup actually surfaces.",
  "evals": [
  {
  "id": 1,
@@ -54,8 +54,30 @@
  },
  {"id": 4, "name": "launch-hotkey", "should_trigger": true, "prompt": "What's the Ctrl+Shift+C hotkey wired to?"},
  {"id": 5, "name": "hotkey-mode-toggle", "should_trigger": true, "prompt": "Is there a keyboard shortcut to switch Xray between its Dynamic and Static modes?"},
- {"id": 6, "name": "panel-route-state", "should_trigger": true, "prompt": "Which Xray panel shows me when [:cart :items] last changed in app-db?"},
- {"id": 7, "name": "panel-route-machine", "should_trigger": true, "prompt": "Where in Xray do I see the current state of my checkout state machine?"},
+ {
+ "id": 6,
+ "name": "panel-route-state",
+ "should_trigger": true,
+ "prompt": "Which Xray panel shows me when [:cart :items] last changed in app-db?",
+ "expected_output": "The agent's first paragraph routes to ONE first surface: the Dynamic app-db tab (with the L2 spine to locate the epoch that changed the path). It names the first interaction — pick the frame/event; changed paths carry the inline `← was X` diff — and may offer the downstream-subs hover as the natural next step. It does NOT enumerate the full tab inventory for this one routed question.",
+ "expectations": [
+ "The output's first paragraph names the Dynamic app-db tab as the first surface (using the L2 event spine to find the epoch that changed the path).",
+ "The output names the first interaction — pick the frame and event; changed paths carry the inline `← was X` diff annotation.",
+ "The output does NOT enumerate the full 10-tab / 15-tab inventory in answer to this single routed question."
+ ]
+ },
+ {
+ "id": 7,
+ "name": "panel-route-machine",
+ "should_trigger": true,
+ "prompt": "Where in Xray do I see the current state of my checkout state machine?",
+ "expected_output": "The agent's first paragraph routes to the Dynamic Machine tab as the first surface, with the first interaction (pick the event that touched the machine). It notes the tab is event-driven — blank when the focused event had no machine activity — and offers Static mode's Machines tab as the natural next step for browsing the full topology cold, not as the first surface. No full-inventory dump.",
+ "expectations": [
+ "The output's first paragraph routes to the Dynamic Machine tab as the first surface for a machine's current state.",
+ "The output notes the tab is event-driven (blank when the focused event carried no machine activity) and names Static mode's Machines tab as the browse-cold next step, not the first surface.",
+ "The output does NOT enumerate the full tab inventory in answer to this single routed question."
+ ]
+ },
  {
  "id": 8,
  "name": "panel-route-machine-canvas",
@@ -68,7 +90,18 @@
  "The output does NOT route this to a standalone Dynamic 'Machines Canvas' tab (it was removed)."
  ]
  },
- {"id": 9, "name": "static-browse-registry", "should_trigger": true, "prompt": "Where in Xray do I see ALL my registered machines, routes, and schemas at once — not just the focused event?"},
+ {
+ "id": 9,
+ "name": "static-browse-registry",
+ "should_trigger": true,
+ "prompt": "Where in Xray do I see ALL my registered machines, routes, and schemas at once — not just the focused event?",
+ "expected_output": "The agent routes to Static mode as the first surface — the registry catalogues — reached by flipping the L1 mode pill or pressing Cmd/Ctrl+Shift+M. It does not route a whole-registry question to the focused-epoch Dynamic lenses, and it may note the definition catalogues are process-global (the registrar is shared across frames) with the L1 frame picker moving only the per-frame live projections.",
+ "expectations": [
+ "The output routes to Static mode as the first surface, reached via the L1 mode pill or Cmd/Ctrl+Shift+M.",
+ "The output does NOT route the whole-registry question to the focused-epoch Dynamic lenses.",
+ "If the output discusses frame scoping, it says the definition catalogues are process-global — it does NOT claim a picked frame owns all its registrations."
+ ]
+ },
  {"id": 10, "name": "static-mode-name", "should_trigger": true, "prompt": "What is Xray's Static mode and how is it different from the normal event view?"},
  {
  "id": 11,
@@ -183,7 +216,21 @@
  "The output states the Graph tab is a Dynamic tab (one of the 10 Dynamic tabs) — switching to Static mode shows the 5 registry catalogues, not Graph."
  ]
  },
- {"id": 13, "name": "neg-drive-xray", "should_trigger": false, "prompt": "Use Xray to dispatch [:cart/apply-coupon \"SPRING25\"] and tell me what happens.", "rationale": "Driving Xray from a REPL is re-frame2-pair's surface, not the read-only tour."},
+ {
+ "id": 32,
+ "name": "panel-route-resources",
+ "should_trigger": true,
+ "prompt": "Where in Xray do I check whether my app's server data is stale and what requests are still in flight?",
+ "expected_output": "The agent's first paragraph routes to ONE first surface: the Dynamic Resources tab — the declarative server-state lens (registry, live instances with freshness, the in-flight work ledger). It names the first interaction — pick the observed frame, because the live instances follow the L1 frame picker, not the focused epoch — and does not dump the full tab inventory. A deep follow-up loads only the focused references/panels-resources.md leaf.",
+ "expectations": [
+ "The output's first paragraph routes to the Dynamic Resources tab as the single first surface for staleness / in-flight server-state questions.",
+ "The output names the first interaction — pick the observed frame (the live instances follow the L1 frame picker, not the focused epoch).",
+ "The output does NOT enumerate the full tab inventory in answer to this single routed question.",
+ "On a deep follow-up, the loaded reference is the focused references/panels-resources.md family leaf — not an all-panels catalogue."
+ ]
+ },
+ {"id": 13, "name": "neg-drive-xray", "should_trigger": false, "prompt": "Use Xray to dispatch [:cart/apply-coupon \"SPRING25\"] and tell me what happens.", "rationale": "A mutating agent runtime operation is re-frame2-pair's surface — the tour skill routes it there."},
+ {"id": 31, "name": "neg-agent-readonly-inspect", "should_trigger": false, "prompt": "Connect to my running re-frame2 app and tell me what the :cart/items subscription currently returns — read-only, don't change anything.", "rationale": "Agent runtime access routes to re-frame2-pair even when read-only — the boundary is human panel vs agent runtime, not read vs write."},
  {"id": 14, "name": "neg-implement-panel", "should_trigger": false, "prompt": "I want to add a new Xray panel for WebSocket connection lifecycle — walk me through the panel-facade/leaf split.", "rationale": "Implementing Xray is out of scope; route to tools/xray/spec/."},
  {"id": 15, "name": "neg-author-app", "should_trigger": false, "prompt": "Write a re-frame2 reg-event that posts a login form and dispatches :login-success / :login-failure.", "rationale": "Authoring application code is re-frame2's job."},
  {"id": 16, "name": "neg-spec-discussion", "should_trigger": false, "prompt": "Why does re-frame2 use frames at all? What's the EP rationale?", "rationale": "Spec / design rationale belongs to SKILL-REDIRECT.md."},

--- a/skills/re-frame2-xray/package.json
+++ b/skills/re-frame2-xray/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@day8/re-frame2-xray",
   "version": "0.1.0-alpha.1",
-  "description": "Read-only tour skill for Xray — the re-frame2 in-app devtools panel. Teaches how to launch Xray (true-inline, the open-overlay! fallback for no-layout-host / full-screen-canvas hosts, pop-out, programmatic, hotkeys, Dynamic ↔ Static mode toggle) and which tab — across the 10 Dynamic event-spine tabs (incl. Resources, the EP-0014 derivation/process Graph, the EP-0023 image→frame Frames tab, and the Hicasso evidence tab) and 5 Static registry-browse tabs — surfaces the data you're looking for.",
+  "description": "Question-first tour skill for Xray — the re-frame2 in-app devtools panel. Routes a debugging question to the one visible surface to open first — across the 10 Dynamic event-spine tabs and 5 Static registry-browse tabs — and teaches how to launch Xray (true-inline, the open-overlay! fallback for no-layout-host hosts, pop-out, programmatic, hotkeys, the Dynamic ↔ Static mode toggle). The canonical tab inventory lives in references/panels.md.",
   "keywords": [
     "claude-code",
     "claude-code-skill",

--- a/skills/re-frame2-xray/references/chrome.md
+++ b/skills/re-frame2-xray/references/chrome.md
@@ -81,8 +81,9 @@ alongside app-db) — disabled when no epoch is focused; on the rare framework
 failure (epoch aged out) it shows a brief inline flash, never a modal.
 
 This passive-inspect-by-default / rewind-opt-in posture is the load-bearing
-inversion from re-frame-10x v1 (the lineage fact lives once in
-[`../../shared/tool-pair-surfaces.md` §Supersedes re-frame-10x](../../shared/tool-pair-surfaces.md#supersedes-re-frame-10x)).
+inversion from re-frame-10x, Xray's structural predecessor — the contract
+behind that succession is owned by
+[`spec/Tool-Pair.md` §Implications for downstream tools](../../../spec/Tool-Pair.md#implications-for-downstream-tools).
 Spec [`002-Time-Travel.md`](../../../tools/xray/spec/002-Time-Travel.md)
 catalogues a richer keymap — `r` rewind, `R` re-dispatch, `*` pin — that is
 **normative for the future, not yet wired**; the `Reset` button is what

--- a/skills/re-frame2-xray/references/panels-domains.md
+++ b/skills/re-frame2-xray/references/panels-domains.md
@@ -1,0 +1,81 @@
+# panels-domains — machine and route activity: Machine and Routes
+
+The domain-activity family: the **Machine** tab (what this event did to
+state machines) and the **Routes** tab (what this event did to routing).
+Both focused-epoch lenses — pick the frame, click the event row, and
+they rebind. Their registry counterparts live in **Static mode**
+(Machines / Routes catalogues). Inventory + scope matrix:
+[panels.md](panels.md).
+
+## Machine — what this event did to machines
+
+Question: **What did this event do to my machines?** (Singular label
+**Machine**.)
+
+**Event-driven** — no picker, no browse modes: the panel is **blank**
+(a single calm placeholder line, no topology) when the focused event had
+no machine activity, and renders one per-machine section when it does:
+topology + transition highlight + guards + actions + cancellation
+cascade + `:after` rings. Per-machine prev/next nav walks the spine to
+the next event that touched that machine.
+
+Each machine renders as an interactive chart through the shared
+machines-viz **MachineChart** — nodes, edges, current-state highlight,
+parallel-region containers, final-state double-rings. The resolved
+current state carries a **static** highlight (accent border + soft glow
+ring); it does not pulse — no continuous animation, by ruling.
+
+**Current-state precedence** — a 4-source walk-back resolves the
+machine's current state for the focused epoch:
+
+1. **Explicit** — operator override (sticky selection)
+2. **Focused-epoch transition** — if this epoch fired one for the machine
+3. **Epoch-history walk-back** — the most recent transition in the buffer
+4. **Snapshot** — the substrate's per-frame machine state
+
+The focused-epoch **transition row** is a single prominent row: a header
+verb `<before-state → after-state>` (doubling as click-to-source) over a
+logical-state DELTA box — a before→after diff of the machine's
+`{:state :tags}` only (`:data` is carried by the per-action `↳ data Δ`).
+Guards / actions / cancellation chips list inline in the per-canvas
+footer — no modal, no popout.
+
+**Open when:** "what state is my checkout machine in?", "what transition
+fired this epoch?", "what guards passed / failed?"
+
+> **Browse-all machine canvas → Static mode.** The spine-INDEPENDENT
+> "what does this machine LOOK like overall?" canvas (picker +
+> interactive zoom / pan / fit, regardless of focused event) is **not a
+> Dynamic tab** — it lives under Static mode's Machines tab. There is no
+> standalone Dynamic "Machines Canvas" tab.
+
+Spec: [`021-Dynamic-Panel-Designs.md` §6](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md)
++ [`003-Machine-Inspector.md`](../../../tools/xray/spec/003-Machine-Inspector.md).
+
+## Routes — what this event did to routing
+
+Question: **What did this event do to my routes?** (Display label
+**Routes**.)
+
+A textual route tree with `├─ └─` box-drawing, in two blocks:
+
+- **Active route tree** (always visible) — each node with one of three
+ markers per current state and per-epoch activity:
+ - `◉` active this epoch, on the resolved match (the `:to` destination)
+ - `◇` registered, traversed (guard phases) this epoch (the `:from`
+   origin)
+ - `◀ current` on the current matched route with no activity this epoch
+- **This epoch** — a short dense block: `Phase`, `From`, `To`, `Match`,
+ `Events`. The empty state ("No route activity in this epoch.") keeps
+ the tree visible above.
+
+Reads the focused cascade's routing trace ops, correlated by dispatch
+id; silent when no routes are registered.
+
+**Open when:** "what route am I on?", "what params resolved?", "did the
+route change this epoch?" To rank an arbitrary URL against every
+registered route, use the Simulate-URL input — promoted in **Static →
+Routes**.
+
+Spec: [`021-Dynamic-Panel-Designs.md` §7](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md)
++ [`spec/012-Routing.md`](../../../spec/012-Routing.md).

--- a/skills/re-frame2-xray/references/panels-epoch.md
+++ b/skills/re-frame2-xray/references/panels-epoch.md
@@ -1,0 +1,132 @@
+# panels-epoch — one dispatch: the Epoch cascade, Trace rows, and where issues surface
+
+The "what happened?" family: the **Epoch** tab (the readable cascade),
+the **Trace** tab (the raw rows underneath it), and the three inline
+channels that carry issues. All focused-epoch surfaces — pick the frame,
+click the event row in the L2 list, and they rebind. Inventory + scope
+matrix: [panels.md](panels.md).
+
+## Epoch — the focused dispatch's cascade
+
+Question: **What happened in this epoch?** Default landing tab.
+
+A **numbered vertical cascade**, top-to-bottom — a faithful projection of
+the epoch's trace stream. Each step is **conditional**: it renders iff
+its driving trace events surfaced this epoch, and steps are numbered
+dynamically 1..N, so an absent optional step consumes no number (absence
+is conveyed by omission, not an empty-state row). The step order:
+
+1. **DISPATCH** — always present. Event vector, origin tag, call-site
+ (open-in-editor).
+2. **RECORDABLE COEFFECTS** — conditional: the dispatch envelope's
+ recordable cofx leaves (privacy-summarized), filtered to the handler's
+ *declared* recordable cofx ids. Omitted when the envelope carried none.
+3. **COEFFECT** — one numbered step per handler-declared coeffect
+ (framework defaults are filtered out, so the lens shows only declared
+ leaves). A cofx supplier that threw gets a synthesised placeholder step
+ so its exception card has a home.
+4. **INTERCEPTORS** — conditional: the *authored* interceptor chain read
+ from the registry, rendered whenever the event carries authored
+ (non-default) interceptor refs — clean or throwing. Rows carry resolved
+ metadata, per-dispatch override substitutions, and missing-ref rows.
+5. **INTERCEPTOR** — conditional, exception-only: one row per *throwing*
+ interceptor (id + phase chip + the shared Exception card),
+ **phase-split** around the handler — a `:before` throw renders BEFORE
+ the handler, an `:after` throw AFTER it.
+6. **EVENT HANDLER** — always present; the body adapts to **what the
+ handler returned** (there is one public `reg-event`, no `:db`-vs-`:fx`
+ registrar flavour): only `:db` → a `:db` diff · `:db` + `:fx` → diff +
+ per-fx · a `reg-machine` event → the time-ordered machine cascade.
+ Rendered **SKIPPED** (⊘) when an upstream `:before`-chain throw aborted
+ the cascade before the handler ran (NOT "ran, returned no :db").
+7. **FLOW** — one numbered step per flow that fired (the reshape as the
+ flow's own `:db` diff). Only when flows fired.
+8. **EFFECT HANDLERS** — the flat per-effect ledger (below). Only when a
+ side effect occurred; equally SKIPPED on an upstream abort.
+9. **SUBSCRIPTIONS** — only when subs recomputed.
+10. **VIEWS** — only when views re-rendered.
+
+**Per-step status + inline exceptions.** Every step header carries `✓`
+(ok) / `✗` (error) / `⊘` (skipped). A handler / interceptor / coeffect /
+fx / flow exception renders UNDER the step where it occurred via the
+shared **"Exception Thrown"** card; the epoch's outcome reads error
+whenever any step settled error. Schema violations attach inline the same
+way.
+
+**Open when:** "what did this event do?", "where did the cascade fail?",
+"what fx fired?", "did the flow recompute?"
+
+Spec: [`021-Dynamic-Panel-Designs.md` §9.1](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md).
+
+### The EFFECT HANDLERS step — flat per-effect ledger
+
+One row per effect, in execution order, no group headers:
+
+- Each row leads with a status glyph: `✓` ran ok · `✗` threw /
+ no-such-fx / `:db` schema-fail rollback · `↺` fx override applied · `–`
+ skipped-on-platform or dropped (neutral — never trips the badge).
+- A single AND-of-rows badge after the step label: TICK when every
+ present row succeeded, CROSS when any failed; skipped rows are neutral.
+- **The `:db` row** leads the ledger when a `:db` commit was attempted;
+ its args slot is the clickable **"→ app-db"** destination marker (the
+ diff itself lives in the app-db panel). Absent when the handler
+ returned only `:fx` / nothing / threw — no phantom `:db`.
+- fx exceptions attach to the owning row; a `:db` schema-fail rollback
+ paints the `:db` row ✗ with the reason box, and a rollback means `:fx`
+ never walked (Spec 002 atomicity) — the ledger then carries only the
+ red `:db` row.
+
+## Trace — the raw rows underneath
+
+Question: **What raw trace events fired during this epoch?**
+
+The stream the Epoch and Views tabs summarise, **focused-epoch scoped**,
+rendered as a single flat oldest-first row list. Each row carries a stage
+column (DISPATCH · COEFFECT · EVENT HANDLER · FLOW · EFFECT HANDLERS ·
+SUBSCRIPTIONS · VIEWS) + a colour-coded left edge that match the Epoch
+cascade's step model, so the two tabs tell one story. Two usage facts:
+
+- **No filtering UI** — the focused epoch IS the scope; the only
+ drill-down is per-row click, which expands the row's raw trace-event
+ map inline. (Spec 009's programmatic trace-buffer filter vocabulary is
+ real for the API but is not Trace-panel UI.)
+- **No film-strip header** — the L2 events list owns spine navigation;
+ this tab opts out of the shared `[◀ Prev] [Next ▶]` header.
+
+**Open when:** "show me every raw op in this epoch", "is `:rf.fx/*`
+firing as expected?", "what order did these emit in?"
+
+Spec: [`023-Trace-Panel.md` §3](../../../tools/xray/spec/023-Trace-Panel.md).
+
+## The L2 timeline grammar
+
+The L2 event spine above the panels carries the cross-epoch signal:
+
+- **Dispatch-origin prefix glyph** per row — `:router` (R) · `:http`
+ (🌐) · `:ssr` (💧) · `:fx-emit` (⚡) · `:timer` (⏲) · `:test` (T) ·
+ `:tool` (🔧) · `:machine-spawn` (i); app-code origins render no prefix
+ (the common case).
+- **Activity badge cluster** per row — `⚠` issue · `◆` machine
+ transition · `🌐` HTTP activity · `⚡` fx-emit child dispatch · `⏲`
+ timer-triggered. High-contrast remap is automatic (colour is never the
+ only signal).
+- **Issue pink-wash** per row — a cascade carrying an issue washes its
+ whole L2 row pink. Together with the Epoch cascade's per-step ✓/✗ this
+ is the primary "which epochs are broken?" signal.
+
+## Issues — inline, not a tab
+
+There is **no dedicated Issues tab** and no session-wide triage list.
+"What's wrong?" is answered through three always-on channels:
+
+1. **Inline in the Epoch cascade** — per-step ✓/✗, the "Exception
+ Thrown" card under the throwing step, the `:db` rollback row. Errors,
+ warnings, schema violations, and hydration mismatches each surface
+ against the step where they occurred.
+2. **The L2 pink-wash** — "which epochs are broken?" at a glance.
+3. **The always-on issues-ribbon signal** — drives the
+ auto-open-on-error watcher; the cross-epoch "something is wrong" cue.
+
+Route "anything broken in this epoch?" to the **Epoch tab**; "which
+epochs are broken?" to the **L2 pink-wash**. (A11y is not an Xray
+surface — it is Story's domain.)

--- a/skills/re-frame2-xray/references/panels-resources.md
+++ b/skills/re-frame2-xray/references/panels-resources.md
@@ -1,0 +1,58 @@
+# panels-resources — server state: the Resources tab
+
+The server-state family: the **Resources** tab, Xray's surface for
+re-frame2's declarative server state (Spec 016). **Mixed scope** — a
+process-global resource registry plus the observed frame's live
+cache/ledger (the live sections follow the **L1 frame picker**, not the
+focused epoch), with per-epoch mutation evidence drawn from the trace
+stream. Inventory + scope matrix: [panels.md](panels.md).
+
+## What it shows
+
+Question: **Where is my server state — what owns it, and is it stale?**
+
+The sections, top → bottom:
+
+- **STATIC RESOURCE REGISTRY** — every registered resource + scope,
+ stale-after, GC-after, and the routes that activate it.
+- **LIVE INSTANCES** (per frame) — each scoped cache entry with state,
+ generation, owner count, and freshness.
+- **WORK LEDGER** — live fetch attempts (running · cancellable ·
+ deadline).
+- **ROUTE / RESOURCE GRAPH** — blocking activations (the SSR wait
+ points), the lifecycle timeline, cache growth.
+- **SCOPE RESOLUTION TIMELINE** — which named scope resolver ran, its
+ inputs, the resolved scope — including fail-closed nil evidence (a
+ scope-requiring site that got nil and produced NO global fallback).
+- **MUTATION CONTINUATIONS + SCOPED INVALIDATION** — the surface that
+ makes "`:reply-to` is for workflow; populate/patch/invalidate are for
+ cache" visible: did the accepted reply continue into app workflow, and
+ which scopes a write resolved, refetched, or left stale — fail-closed,
+ never an implicit global blast.
+- **SCOPE AUDIT** — every `:rf.scope/global` use + lints.
+
+**The absence-is-evidence rule.** A continuation / refetch the runtime
+*suppresses* (a stale or superseded reply, an `ensure` that skips a fresh
+read) surfaces as its own suppression op, not as a missing row — so "my
+`:reply-to` didn't fire" / "my read didn't refetch" is answered by the
+*presence of the suppression evidence*. The op vocabulary is normative in
+[`024-Resources-Panel.md`](../../../tools/xray/spec/024-Resources-Panel.md)
++ [`spec/016-Resources.md`](../../../spec/016-Resources.md); cite those
+rather than re-deriving field-by-field detail.
+
+## Posture
+
+- **Read-only** — opening the panel pins nothing: it dispatches no
+ ensure, attaches no owner, refetches nothing, extends no GC.
+- **Privacy** — params, scopes, AND data all get the same
+ summarize-and-redact treatment: every value is a bounded,
+ redaction-aware preview, never the raw value.
+- **Decoupled** — Xray does not `:require` the optional resources
+ artefact; the panel reads the registry via the registrar query API and
+ the live cache/ledger from the runtime state the spine already
+ publishes, so it renders cleanly even when the host wired no resources.
+
+**Open when:** "where's my server state?", "what's in flight?", "is this
+resource stale?", "what owns this cache entry?", "did my mutation's
+`:reply-to` continuation fire?", "which scopes did this write
+invalidate?", "why didn't this read refetch?"

--- a/skills/re-frame2-xray/references/panels-state.md
+++ b/skills/re-frame2-xray/references/panels-state.md
@@ -1,0 +1,82 @@
+# panels-state — changed state and what rendered: app-db and Views
+
+The state-and-render family: the **app-db** tab (what does state look
+like, what just changed) and the **Views** tab (what recomputed and
+re-rendered, and why). Both focused-epoch lenses — pick the frame, click
+the event row, and they rebind. Inventory + scope matrix:
+[panels.md](panels.md).
+
+## app-db — what changed in state
+
+Question: **What does state LOOK LIKE — and what just changed?**
+(Display label lowercase **app-db**.)
+
+The complete app-db renders as **vertical sections by reserved area**,
+each headed by an uppercase caption and rendering as a collapsible
+lazy-tree inspector (depth-3-collapsed default). Diff annotations are
+carried **inline** as `← was X` on changed nodes — there is no separate
+DIFF zone; ancestor chains are force-expanded so you never dig to find a
+change. Section order, top → bottom:
+
+- **APP STATE** (always shown, even when empty — the panel's anchor) —
+ the app-db minus every reserved `:rf/*` area: the application's own
+ user-domain state.
+- **MACHINE `<id>`** — one section per machine (e.g.
+ `MACHINE :title/flow`).
+- **SPAWNED `<id>`** — one section per spawned instance.
+- **ROUTE** — the current-route slice (a singleton section).
+- **SYSTEM-IDS · PENDING-NAVIGATION · ELISION** — singleton sections for
+ the remaining reserved areas.
+
+Empty/absent reserved areas are omitted — no "no X here" placeholder
+clutter. The operator-facing section labels map onto framework state in
+the runtime-db partition; the mapping is normative in
+[`004-App-DB-Diff.md` §Reserved-keys group](../../../tools/xray/spec/004-App-DB-Diff.md).
+
+**Downstream-subs hover popover** — hover any changed path to surface
+the subs depending on it + the views they render + an inline `⤴` jump to
+the Views panel scrolled to those subs. Keyboard-dismissable.
+
+When the L2 spine is at head (no historical epoch focused), sections show
+the most-recent epoch's state with its inline diffs — current db,
+sectioned. Same render shape, no second mode.
+
+**Open when:** "what just changed in app-db?", "what's downstream of
+`[:cart :items]`?", "show me the full db at this epoch."
+
+Spec: [`021-Dynamic-Panel-Designs.md` §4](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md)
++ [`004-App-DB-Diff.md`](../../../tools/xray/spec/004-App-DB-Diff.md).
+
+## Views — what rendered, and why
+
+Question: **What RENDERED as a result?** (Display label **Views**.)
+
+The reactive cascade — the SUBSCRIPTIONS + VIEWS trailing edge — as a
+depth-first DAG with indentation showing sub-of-sub layering:
+
+- **SUBS RECOMPUTED** — each sub with its input-path → output-value
+ change inline (`:idle → :submitting`, `+1 entry`); unchanged subs
+ collapse under a `[Show N unchanged subs ▾]` footer (toggle defaults
+ OFF).
+- **VIEWS RE-RENDERED** — each view with file:line (open-in-editor) and
+ a **render-cause chip** on every re-render leaf: `← :sub-id` when a
+ subscription the view derefs changed value, or `← props` when none of
+ the view's own subs changed (the cause is the orthogonal props
+ channel — a prop changed / the parent re-rendered; the parent is never
+ named). A first **mount** carries no cause — the `(mounted)` label
+ conveys it.
+
+Flows are NOT in the reactive cascade — they are handling-side (the
+Epoch FLOW step). The cascade nodes are exactly: db-paths (seed) → subs
+(intermediate) → views (leaf).
+
+Per-cascade clicks propagate cross-panel — a sub row jumps to app-db at
+that input path. Hovering a view node toggles a pink DOM highlight on
+the live element.
+
+**Open when:** "why didn't my view update?", "why did this re-render —
+sub or props?", "which views re-rendered this epoch?", "which subs
+short-circuited?"
+
+Spec: [`021-Dynamic-Panel-Designs.md` §3](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md)
++ [`012-Views.md`](../../../tools/xray/spec/012-Views.md).

--- a/skills/re-frame2-xray/references/panels-structure.md
+++ b/skills/re-frame2-xray/references/panels-structure.md
@@ -1,0 +1,127 @@
+# panels-structure — live runtime structure: Graph, Frames, Hicasso
+
+The structure family: the three Dynamic-shell tabs that do **not** follow
+the focused event. **Graph** draws the dependency graph across families;
+**Frames** shows which image loaded each live frame; **Hicasso** is the
+evidence lens over the Hicasso view layer. Picking an epoch in L2 rebinds
+none of them — Graph follows its own projection toggle (and the L1 frame
+picker on the Realized side), Frames and Hicasso read the live runtime.
+Inventory + scope matrix: [panels.md](panels.md).
+
+## Graph — where does this value come from?
+
+Question: **Where does this value come from — when is it evaluated,
+where does it live, who owns it?** — across families, in one place.
+(Display label **Graph**.)
+
+Xray's UI over the **EP-0014 derivation/process graph**: every declared
+fact and process in the host app — across all five contributor families
+(subscriptions, flows, resources, route facts, machine processes +
+selectors) — as one node-and-edge graph over the frame fold. A family
+with no registrations contributes no nodes (the per-app no-machines /
+no-resources story, not a per-tool boundary).
+
+**The projection toggle is Graph-local.** A per-panel **Declared ↔
+Realized** toggle flips registration-derived vs observed (Declared reads
+the process-global registrar; Realized reads the observed frame). The
+shipped UI labels the toggle static/live — it is **NOT** the L1
+Dynamic/Static mode pill, and Graph is always a Dynamic tab: switching
+Xray to Static mode shows the five registry catalogues, not Graph.
+
+Two caveats this leaf owns:
+
+> **Authority is an axis, not a storage class.** Remote-backed nodes
+> (resources) carry an **authority** chip. A resource's *storage* class
+> is still local (the frame's runtime-managed state); *remote* describes
+> where the value is sourced/owned upstream. Read the chip as "locally
+> stored, locally read, upstream source of truth" — never as
+> app-db/runtime-db placement.
+
+> **The graph accessor is internal, not a public API.** The Graph tab
+> consumes an internal structured composer — not a `re-frame.core`
+> facade export, and not a public app accessor. Route users to **open
+> the Graph tab**; do not tell them to call a graph API from app code.
+
+**Read-only** — observing the graph pins nothing, dispatches nothing.
+
+**Open when:** "where does this value come from?", "show me the whole
+derivation graph", "what's the dependency graph for this page?", "is
+this ephemeral or materialized, and who owns it?"
+
+Spec: [`spec/Derivations.md` §Graph inspection — internal but structured](../../../spec/Derivations.md)
++ [`docs/EP/EP-0014-derivation-and-process-algebra.md`](../../../docs/EP/EP-0014-derivation-and-process-algebra.md).
+
+## Frames — which image loaded which frame
+
+Question: **Which images load which frames, and how do those frames
+resolve their registrations?** (Tab-bar label **Frames**; the internal id
+`:module-view` is not a user contract, and the old "Modules" label is
+retired — route users to the **Frames** tab.)
+
+Xray's UI over the EP-0023 **`image → frame`** public model — the
+structural counterpart to Graph (Graph is the per-fact view; Frames is
+the per-frame installation + image-provenance view). Each live frame
+renders as an **execution context** carrying its resolved image (the
+generation's `[kind id]` descriptor set), its capabilities, and how it
+resolves `(kind id)` lookups through that image. This is the model a
+consumer app developer reasons in: image assembly plus frame isolation
+are the whole composition story — **no realm / app / module layer to
+browse**.
+
+- **Registry-wide, not epoch-coupled** — enumerates the process-global
+ live-frame registry; picking an epoch does not rebind it.
+- **L4-only registry tab** — focusable via the tab bar / command
+ palette, but with **no** standalone mount facade: there is no
+ `mount-module-view!`, and users never need one.
+- **Read-only** — enumerating frames and images pins nothing.
+
+**Open when:** "what frames exist, and which image loaded each?", "how
+does this frame resolve its registrations?"
+
+Spec: [`026-Module-View-Panel.md` §8](../../../tools/xray/spec/026-Module-View-Panel.md).
+
+## Hicasso — the view-layer evidence lens
+
+Question: **What is Hicasso actually doing — which boundaries are
+mounted, what do they read, and why did one re-render?** The evidence
+lens for Hicasso, re-frame2's re-frame-native view layer.
+
+**Six views over four envelopes**, as a sub-strip inside the tab:
+
+| View | The question it answers |
+|---|---|
+| **Mounted** | which boundaries are mounted, over which frames |
+| **Reads** | which boundaries read each subscription |
+| **Intents** | what was dispatched, in order, inside the retained window |
+| **Why** | which reads changed, and what that can and cannot prove |
+| **Advisor** | which boundary is hot, and the smallest route that addresses it |
+| **Causal** | one dispatch walked link by link from event to paint, every missing link named |
+
+The first four each read one evidence envelope. **Advisor and Causal
+read no envelope of their own** — they are derivations over the *same*
+one-turn take, which is why they are sub-views rather than tabs: a
+second tab would take a second turn, and a mount landing between the two
+would desynchronise the census. So "four" and "six" are both right,
+about different things — **four envelopes, six views**.
+
+**Every view states its own scope, basis, completeness and loss.** An
+absence renders as a **named loss state with its own sentence**, never
+an empty list — "nothing is mounted" is a clean bill of health, while
+"the retained intent window is empty" is a cap that proves nothing about
+what was dispatched. A host **not running Hicasso** shows the honest
+no-evidence state, distinct from *running with nothing mounted*.
+
+- **No read carries application data** — a boundary's identity is its
+ read set; subscription arguments and return values never reach the
+ page.
+- **Not epoch-coupled** — the evidence is re-taken on each trace tick;
+ picking an epoch in L2 does not rebind it.
+- **L4-only registry tab** — focusable, no standalone mount facade.
+- **Read-only** — the tab observes and dispatches nothing into the host.
+
+**Open when:** "which boundaries are mounted?", "what reads
+`:cart/items`?", "why did this boundary re-render?", "which boundary is
+hot?", "walk this dispatch from event to paint".
+
+Spec: [`027-Hicasso-Evidence.md`](../../../tools/xray/spec/027-Hicasso-Evidence.md)
++ [`028-Hicasso-Advisor.md`](../../../tools/xray/spec/028-Hicasso-Advisor.md).

--- a/skills/re-frame2-xray/references/panels.md
+++ b/skills/re-frame2-xray/references/panels.md
@@ -1,853 +1,111 @@
-# panels — Dynamic lenses on one event + Static registry browse
+# panels — the canonical tab inventory
+
+The one complete tab inventory for the package. Load this for an explicit
+"list every tab" request; a deep question about one panel family loads
+that family's own leaf (linked per row below), not this catalogue.
 
 Sources of truth: the live tab inventory is the set of
 `panel-registry/reg-l4-tab!` calls under
 `tools/xray/src/day8/re_frame2_xray/panels/` (Dynamic) and `.../static/`
-(Static); the normative tab list is
-[`018-Event-Spine.md` §5](../../../tools/xray/spec/018-Event-Spine.md)
-+ [`021-Dynamic-Panel-Designs.md` §9.1](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md)
+(Static), mirrored by `focus.cljc`'s `valid-panels`; the normative tab
+list is
+[`018-Event-Spine.md` §5](../../../tools/xray/spec/018-Event-Spine.md) +
+[`021-Dynamic-Panel-Designs.md` §9.1](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md)
 (Dynamic) + [`007-UX-IA.md` §Static mode](../../../tools/xray/spec/007-UX-IA.md)
-(Static). Per-panel content design (layout, locked decisions, palette /
-iconography / animation) lives in
-[`021-Dynamic-Panel-Designs.md`](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md);
-chrome / palette tokens / density in
-[`007-UX-IA.md`](../../../tools/xray/spec/007-UX-IA.md). Tab order is set
-declaratively via `reg-l4-tab!` `:order`, rendered by `shell.cljs`
-(Dynamic) / `static/shell.cljs` (Static). Live Dynamic `:order` values:
-Epoch `-1` · app-db `1` · Views `2` · Trace `3` · Machine `4` · Routes `6`
-· Resources `7` · Graph `8` · Frames `9` · Hicasso `10` — ten in all
-(`:order 5` unallocated). The authoritative inventory (`focus.cljc`'s `valid-panels`
-def) + the build-time cross-check that guards it live in
+(Static). The executable drift gate + re-verification order live in
 [`../evals/README.md` §Keeping the tab inventory in sync](../evals/README.md).
 
-## Two modes
+## Dynamic mode — 10 tabs
 
-The two-mode model (Dynamic event-spine 4-layer chrome · Static registry
-3-layer chrome, flipped by the L1 mode pill or `Cmd/Ctrl+Shift+M`) is
-covered in [`SKILL.md` §Two modes](../SKILL.md#two-modes). This leaf is
-the per-panel tour: the 10 Dynamic tabs in §Panel-by-panel below, the 5
-Static tabs in §Static mode — registry browse. One binding constraint to
-restate: **no cross-epoch L4 panels** — no Dynamic L4 tab shows an
-*aggregate across epochs*; aggregate signal lives on L2 badges only (§021
-§1.2 — binding). That is distinct from data *scope*: most Dynamic tabs are
-focused-epoch lenses, but **Graph**, **Frames** and **Hicasso** are
-Dynamic-shell browse surfaces scoped to the process-global registry /
-observed frame / live Hicasso runtime, not the
-focused epoch (see §Scope model below). There is **no Issues tab** — issues
-surface inline (see §Issues — not a Dynamic tab below).
+Left-to-right in tab order (mnemonics `e a v t m r s g u h`):
+**Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph ·
+Frames · Hicasso.**
 
-### L2 timeline grammar
+| Tab | Mnem | Scope | One-line purpose | Depth |
+|---|---|---|---|---|
+| **Epoch** *(default landing)* | `e` | focused epoch | The focused dispatch's full cascade as a numbered vertical timeline, per-step ✓/✗/⊘, exceptions inline under their step. | [panels-epoch.md](panels-epoch.md) |
+| **app-db** | `a` | focused epoch | State sectioned by reserved area, collapsible lazy-trees, inline `← was X` diffs, downstream-subs hover. | [panels-state.md](panels-state.md) |
+| **Views** | `v` | focused epoch | The reactive cascade (subs + views) as a DAG with render-cause chips (`← :sub-id` vs `← props`). | [panels-state.md](panels-state.md) |
+| **Trace** | `t` | focused epoch | Raw trace events for the focused epoch — flat oldest-first rows, click to expand. | [panels-epoch.md](panels-epoch.md) |
+| **Machine** | `m` | focused epoch | What this event did to machines — topology + transition + guards/actions; blank on a no-machine epoch. | [panels-domains.md](panels-domains.md) |
+| **Routes** | `r` | focused epoch | Current matched route + this epoch's route activity + a Simulate-URL input. | [panels-domains.md](panels-domains.md) |
+| **Resources** | `s` | mixed | The declarative server-state lens — registry, live instances, work ledger, mutation/invalidation evidence. | [panels-resources.md](panels-resources.md) |
+| **Graph** | `g` | observed frame / process-global | The EP-0014 derivation/process graph across all five families; its own Declared ↔ Realized projection toggle. | [panels-structure.md](panels-structure.md) |
+| **Frames** | `u` | process-global | The EP-0023 `image → frame` lens — which image loaded each live frame, and how it resolves registrations. | [panels-structure.md](panels-structure.md) |
+| **Hicasso** | `h` | live runtime (not epoch-coupled) | The Hicasso evidence lens — six views (Mounted · Reads · Intents · Why · Advisor · Causal) over four envelopes taken in one turn. | [panels-structure.md](panels-structure.md) |
 
-The L2 timeline above the panels carries:
+Cross-epoch signal lives on the L2 timeline (badges + the issue
+pink-wash); **no Dynamic tab shows a cross-epoch aggregate** (binding,
+§021 §1.2). Internal tab ids are not user labels — route users by the
+visible labels above (the ninth tab is **Frames**; its internal id
+`:module-view` and the retired "Modules" label are not answers).
 
-- **Dispatch-origin prefix glyph** per row — the live classifier
- (`l2_timeline.cljc` `source->bucket`) renders a glyph for `:router` (R) ·
- `:http` (🌐) · `:ssr` (💧) · `:fx-emit` (⚡) · `:timer` (⏲) · `:test` (T) ·
- `:tool` (🔧) · `:machine-spawn` (i) · `:websocket`, and renders **no
- prefix** for app-code origins (`:ui`/`:unknown`/`:other`/`:repl`/
- `:frame-init` → silent, the common case). *(Impl note — pre-alpha drift:
- the ten-value `:user … :internal` list in §021 §1.5 is spec vocabulary the
- shipped classifier does not yet match; the live buckets above are
- authoritative.)*
-- **Activity badge cluster** per row (live impl `l2_timeline.cljc`
- `activity-badge-glyphs`, render order issue → machine → HTTP → fx-emit →
- timer): `⚠` issue (error) · `◆` machine transition · `🌐` HTTP activity ·
- `⚡` fx-emit child dispatch · `⏲` timer-triggered. HCM remap is automatic
- (colour is never alone). *(Impl note — pre-alpha drift: §021 §17.1.5's
- row-badge table documents a richer set (adds `💧` SSR-hydration, `🌊`
- flow-recomputed); the live cluster above is authoritative.)*
-- **Issue pink-wash** per row — a cascade carrying an issue
- washes its whole L2 row with the `:bg-issue-row` light-pink token. The
- wash is driven by `cascade-has-issue?`, which reuses the same
- `issue-event?` predicate as the issues-ribbon signal so the wash and the
- ribbon stay in lockstep by construction. Together with the Epoch
- cascade's per-step ✓/✗, this is the primary "which epochs are broken?"
- signal — there is no dedicated Issues tab.
+## Scope matrix — three authority axes
 
-Implementation lives at
-[`panels/l2_timeline.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/l2_timeline.cljc)
-+ [`panels/issues_ribbon_helpers.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/issues_ribbon_helpers.cljc).
-
-### Scope model — three authority axes (not a uniform epoch scope)
-
-"Dynamic" is the 4-layer *shell*, not a guarantee that every panel is
-focused-epoch data. Each Dynamic tab reads one of three scopes:
+"Dynamic" names the 4-layer shell, not a uniform data scope. Each tab
+reads one of three scopes:
 
 | Scope | Tabs | Picking an epoch in L2… |
 |---|---|---|
-| **Focused epoch** — event-spine lenses | Epoch · app-db · Views · Trace · Machine · Routes | rebinds them to that epoch's captured cascade |
+| **Focused epoch** — the event-spine lenses | Epoch · app-db · Views · Trace · Machine · Routes | rebinds them to that epoch's captured cascade |
 | **Observed frame** — live frame state | **Graph** (Realized projection) · Resources (live instances) | does nothing; they follow the **L1 frame picker** |
-| **Process-global / registry-wide** | **Graph** (Declared projection) · **Frames** · **Hicasso** · Resources (static registry) | does nothing; identical for every epoch (global catalogues read the same in every frame) |
+| **Process-global / registry-wide** | **Graph** (Declared projection) · **Frames** · **Hicasso** · Resources (static registry) | does nothing; identical for every epoch |
 
-**Graph, Frames and Hicasso are the Dynamic-shell exceptions** — they sit in
-the Dynamic chrome but do not compose off the focused epoch:
-`derivation_graph.cljs` scopes by projection mode (Declared = the
-process-global registrar over `xray-contributors`; Realized =
-`live-derivation-graph` for the observed `:rf.xray/target-frame`),
-`module_view.cljs` enumerates the process-global live-frame registry
-(`re-frame.live-frame`) directly, and `hicasso.cljs`'s
-`:rf.xray.hicasso/data` takes the live evidence door across every frame off
-a `:rf.xray/trace-buffer` tick — none of them off the focused epoch. What IS
-binding is that no Dynamic L4 tab shows a *cross-epoch aggregate*;
-cross-epoch signal lives on L2 badges.
+So "select an epoch and Graph/Frames/Hicasso update" is **false** — only
+the six focused-epoch lenses rebind.
 
-### Inspection vs Rewind
+## Static mode — 5 registry-browse tabs
 
-Clicking an L2 row is **INSPECTION** (L4 panels rebind to that epoch's
-captured snapshots; the live frame is NOT rolled back). Live rewind is the
-separate, explicit **`Reset` button** on the L3 tab-bar ribbon. The full
-mechanism — the whole frame-state (both app-db AND runtime-db) reinstalled
-via `restore-epoch!` / `replace-frame-state!`, not the `:db-after`
-projection alone — is the owning home in chrome.md §Time-travel
-(`002-Time-Travel.md`).
+Event-INDEPENDENT browse of what's *registered* (3-layer chrome, no L2
+spine). Flip in with the L1 mode pill or `Cmd/Ctrl+Shift+M`. Mnemonics
+are mode-scoped (`m` here opens the Static Machines browse, not the
+Dynamic instance-inspector). Order per
+[`007-UX-IA.md` §Static mode](../../../tools/xray/spec/007-UX-IA.md):
 
-## Panel-by-panel (Dynamic mode)
-
-Ten Dynamic tabs, left-to-right by `:order` (mnemonics
-`e a v t m r s g u h`): **Epoch · app-db · Views · Trace · Machine · Routes ·
-Resources · Graph · Frames · Hicasso.** First six are core spine lenses
-(§018 §5 + §021 §9.1); **Resources** (`:order 7`), **Graph** (`:order 8`),
-**Frames** (`:order 9`) and **Hicasso** (`:order 10`) are the cross-feature
-lenses, each self-registered through `reg-l4-tab!` (`panels/resources.cljs`,
-`panels/derivation_graph.cljs`, `panels/module_view.cljs`,
-`panels/hicasso.cljs`). **Hicasso** is the evidence lens for the Hicasso
-view substrate — six sub-views over one versioned adapter-neutral schema
-(Mounted boundaries · Reads attribution · the Intents stream · Why ·
-Advisor · Causal), each
-stating its own scope, basis, completeness and loss, and each rendering an
-absence as a named loss state rather than as an empty list. A host that is
-not running Hicasso shows the honest no-evidence state, which is distinct
-from *running with nothing mounted*. Internal tab ids (`:epoch :app-db
-:views :trace :machines :routing :resources :derivation-graph :module-view
-:hicasso`) are stable. There is no **Event** tab and no **Issues** tab — see §What's
-deliberately NOT here.
-
-Most Dynamic tabs share the same chrome: panel icon (left of stripe) ·
-panel title · focused-event id · `[◀ Prev] [Next ▶]` film-strip walking
-the L2 spine chronologically (per §021 §17.1.5; shared component at
-[`panels/shared/film_strip/header.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/shared/film_strip/header.cljc)).
-**Trace opts out of the film-strip header** — the L2 events
-list already owns spine focus navigation.
-
-### Epoch — `⚡` · stripe `:accent-violet` · mnem `e` · `:order -1`
-
-Question: **What happened in this epoch?** — the full computational
-timeline. Default landing view.
-Registered at `:order -1` so it claims the leftmost /
-default-landing slot.
-
-A **numbered vertical cascade** rendered top-to-bottom — a faithful
-projection of the epoch's trace stream. Each step is **conditional**:
-it renders iff its driving trace events surfaced this epoch, and steps
-are numbered dynamically 1..N so an absent optional step consumes no
-number (absence is conveyed by OMISSION, not an empty-state row). The
-step order, per `panels/epoch/projection.cljc`'s `project` (§021 §9.1.3):
-
-1. **DISPATCH** — always present (every epoch starts here). Event vector,
- origin tag, call-site (open-in-editor).
-2. **RECORDABLE COEFFECTS** — **conditional**: the dispatch envelope's flat
- `:rf.cofx` map (`:rf/time-ms` + owner-qualified recordable leaves,
- privacy-summarized), filtered to the handler's **declared** recordable
- cofx ids via the panel's registry resolver (EP-0010 · EP-0017 §9).
- Omitted when the envelope carried no `:rf.cofx` map.
-3. **COEFFECT** — **one numbered step per handler-declared coeffect** (the
- framework defaults `:db / :event / :frame / :source / :trace-id` are
- filtered at projection time, so the lens shows only declared leaves). A
- cofx supplier that threw while delivering its value gets a synthesised
- placeholder step so its exception card has a home.
-4. **INTERCEPTORS** — **conditional**: the **authored** interceptor chain
- read from the registry (`handler-meta :event`, threaded in by the
- composite sub as `:resolve-event-interceptors`; EP-0022 §11), rendered
- whenever the event carries authored (non-`:rf/default?`) interceptor
- refs — clean or throwing. Rows carry resolved metadata
- (`:before?`/`:after?`/factory/doc/coord), per-dispatch override
- substitutions (the `:rf.interceptor/override-summary` tag off
- `:rf.event/run-start`), and missing-ref rows. The substrate emits no
- per-interceptor "ran" trace — the chain comes from the **registry**, not
- the trace stream.
-5. **INTERCEPTOR** — **conditional, exception-only**: one row per
- **throwing** interceptor (id + phase chip + the shared Exception card),
- **phase-split** around the handler — a `:before` throw renders BEFORE the
- handler, an `:after` throw renders AFTER it. A clean chain shows nothing
- here (it renders under INTERCEPTORS above).
-6. **EVENT HANDLER** — always present; body adapts to **what the handler
- returned**, not to a registrar flavour (there is one public
- `reg-event` and the registry kind is simply `:event` — no `:db`-vs-`:fx`
- sub-discriminator): a returned map carrying only `:db` → `:db` diff · a
- map carrying `:db` + `:fx` → `:db` diff + per-fx · a `reg-machine` event
- → the time-ordered machine cascade. Rendered
- as **SKIPPED** (⊘) when an upstream `:before`-chain throw — a coeffect
- supplier that threw while delivering, or a `:before` interceptor —
- aborted the cascade before the handler ran (NOT "ran, returned no :db").
-7. **FLOW** — one numbered step per flow that fired (the t1→t2 reshape as
- the flow's own `:db` diff). Only when flows fired.
-8. **EFFECT HANDLERS** — a flat per-effect ledger (see §EFFECT HANDLERS below).
- Only when a side effect occurred; equally SKIPPED when an upstream
- throw aborted the cascade.
-9. **SUBSCRIPTIONS** — only when subs recomputed.
-10. **VIEWS** — only when views re-rendered.
-
-**Per-step status + inline exceptions.** Every step header carries a
-status glyph off the shared `step-status` primitive — `✓` (`:ok`) / `✗`
-(`:error`) / `⊘` (`:skipped`) (`panels/epoch/badge.cljc`). A
-handler / interceptor / coeffect / fx / flow **exception** renders UNDER
-the step where it occurred via the shared **"Exception Thrown"** card
-— each exception attached to its owning step per
-`exception-op->step`; the epoch's outcome reads `:error` whenever any step
-settled `:error` (trace-derived, NOT the framework epoch-record `:outcome`
-slot). Schema violations attach inline the same way.
-
-**Badge taxonomy** (the binding inventory is `badge->token-key` /
-`badge->label` in `badge.cljc` — the view never paints a badge outside this
-map): DISPATCH (`:text-tertiary`) · RECORDABLE COEFFECTS
-(`:text-secondary`) · COEFFECT (`:magenta`) · INTERCEPTORS (`:accent`) ·
-INTERCEPTOR (`:accent`) · EVENT HANDLER (`:accent`) · FLOW (`:accent`) ·
-EFFECT HANDLERS (`:orange`) · SUBSCRIPTIONS (`:magenta-pink`) · VIEWS
-(`:success`) · SCHEMA HOT-RELOAD (`:warning`). (The view's colour resolver
-bails to `:text-tertiary` on an unknown badge.)
-
-**Open when:** "what did this event do?", "where did the cascade fail?",
-"what fx fired?", "did the flow recompute?"
-
-Spec: [`021-Dynamic-Panel-Designs.md` §9.1](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md);
-implementation at
-[`panels/epoch_panel.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/epoch_panel.cljs)
-+ [`panels/epoch/`](../../../tools/xray/src/day8/re_frame2_xray/panels/epoch)
-(`view.cljs` · `projection.cljc` · `badge.cljc`).
-
-### EFFECT HANDLERS step — flat per-effect ledger
-
-The Epoch cascade's EFFECT HANDLERS step renders as **one flat ledger** —
-one row per effect, down the page, in execution order, with **no group
-headers**. Per `panels/epoch/projection.cljc`'s `side-effects-step`:
-
-- **One row per effect**, leading with a per-effect status glyph: `✓` ran
- ok · `✗` threw / no-such-fx / `:db` schema-fail rollback · `↺` fx
- override applied · `–` (muted en-dash) skipped-on-platform or a dropped
- `other` effect (NEUTRAL — never trips the badge).
-- **Single AND-of-rows badge** after the "EFFECT HANDLERS" label: TICK when
- every present row succeeded, CROSS when one or more FAILED; SKIPPED rows
- are neutral (`side-effects-badge-status`).
-- **The `:db` row** leads the ledger when a `:db` commit was attempted
- (incl. a handler that returned only `:db`); its args slot is the
- clickable **"→ app-db"** destination marker (the actual diff lives in
- the app-db panel — no duplication). Absent when the handler returned
- only `:fx` / nothing / threw (no phantom `:db`).
-- **fx exceptions** attach to the owning `:fx-id` row via the shared
- Exception card; `:db` schema-fail rollback paints the `:db` row ✗ with
- the reason box, and a rollback means `:fx` never walked (Spec 002
- atomicity) — so the ledger carries only the red `:db` row.
-
-### app-db — `◐` · stripe `:cyan` · mnem `a`
-
-Question: **What does state LOOK LIKE — and what just changed?**
-
-Sectioned-by-reserved-area layout (§021 §4.2). The complete
-app-db renders as **vertical sections**, each headed by an uppercase
-caption label and rendering its value as a collapsible cljs-devtools-
-style inspector widget (shared lazy-tree renderer, depth-3-collapsed
-default per §021 §10.4). Adjacent sections are separated by a 1px
-hairline. Diff annotations are carried **inline** as `← was X`
-on changed nodes within each section's tree — there is no separate
-DIFF zone; ancestor chains are force-expanded so the operator never
-expands to find a change. Section order, top → bottom:
-
-- **APP STATE** (always shown) — the app-db **minus** every reserved
- `:rf/*` key (the application's own user-domain state).
-- **MACHINE `<id>`** — `:rf/machines` **fans out** to one section per
- machine, headed by the machine id (e.g. `MACHINE :title/flow`).
-- **SPAWNED `<id>`** — `:rf/spawned` fans out the same way, one
- section per spawned instance.
-- **ROUTE** — `:rf/route` is a **singleton** section (the current-
- route slice; NOT fanned out).
-- **SYSTEM-IDS · PENDING-NAVIGATION · ELISION** — singleton sections
- for the remaining reserved areas (`:rf/system-ids`,
- `:rf/pending-navigation`, `:rf/elision`).
-
-Populated reserved areas render; empty / absent reserved areas are
-omitted from the model so the operator isn't shown a
-clutter of "no X here" placeholder cards. The APP STATE top section
-always renders even when the user-domain db is empty — it's the
-panel's anchor.
-
-**Underlying paths.** Framework durable state lives in the **runtime-db**
-partition (`:rf.db/runtime`, children under `:rf.runtime/*`) — a separate
-partition from the user app-db; the operator-facing labels (`:rf/machines`,
-`:rf/route`, …) map to nested runtime-db sub-paths via the `runtime-areas`
-lookup in
-[`panels/app_db_diff_helpers.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc)
-— e.g. `:rf/machines → [:rf.runtime/machines :snapshots]`,
-`:rf/route → [:rf.runtime/routing :current]`. Spec source:
-[`004-App-DB-Diff.md` §Reserved-keys group](../../../tools/xray/spec/004-App-DB-Diff.md).
-
-**Downstream-subs hover popover** (§021 §4.4) — hover any changed path
-within any section to surface the subs depending on it + the views
-rendered + an inline `⤴` to jump to the Views panel scrolled to those
-subs. Popover is Xray-owned (not a browser title), keyboard-
-dismissable. Walks subs from the registry's `:input-paths` — see
-[`panels/shared/sub_input_paths.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/shared/sub_input_paths.cljc).
-
-When the L2 spine is at head (no historical epoch focused), sections
-show the most-recent epoch's state with its inline diff annotations
-(head-cascade) — current db, sectioned. Same render shape, no second
-mode.
-
-**Open when:** "what just changed in app-db?", "what's downstream of
-`[:cart :items]`?", "show me the full db at this epoch."
-
-Spec: [`021-Dynamic-Panel-Designs.md` §4](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md)
-+ [`004-App-DB-Diff.md`](../../../tools/xray/spec/004-App-DB-Diff.md);
-implementation at
-[`panels/app_db_diff.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs)
-+ siblings (`app_db_diff_{events,format,subs,state,helpers}.{cljs,cljc}`);
-the downstream-subs walk lives in
-[`panels/app_db_diff_subs.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs)
-+ the shared
-[`panels/shared/sub_input_paths.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/shared/sub_input_paths.cljc).
-
-### Views — `◉` · stripe `:cyan` · mnem `v`
-
-Question: **What RENDERED as a result?**
-
-The display label is **Views** (set at `reactive_panel.cljs:75`). **The L3
-tab key is `:views`** — an internal id, not a user contract.
-
-The reactive cascade (the SUBSCRIPTIONS + VIEWS trailing edge) rendered as
-a depth-first DAG with explicit indentation showing sub-of-sub layering:
-
-- **SUBS RECOMPUTED** — each sub with input-path → output-value
- change inline (`:idle → :submitting`, `+1 entry`), with skipped subs
- collapsed under a footer `[Show N unchanged subs ▾]` (§021 §3.4).
-- **VIEWS RE-RENDERED** — each view with file:line (open-in-editor) +
- a **render-cause chip** on every re-render leaf
- (`panels/reactive_panel_view.cljs` `view-node` + the pure
- `panels/epoch/projection.cljc` `render-cause`): `← :sub-id` when a
- subscription the view derefs changed value (`:triggered-by`), or
- `← props` when none of the view's own subs changed (so the cause is the
- orthogonal `:rf/props` channel — a prop changed / parent re-rendered;
- the parent is never named). A first **mount** carries no
- cause (the `(mounted)` label conveys it).
-
-Flows are NOT in the reactive cascade — they're handling-side (the Epoch
-FLOW step) per §021 §3.2. The cascade nodes are exactly: db-paths (seed)
-→ subs (intermediate) → views (leaf).
-
-"Show unchanged subs" toggle defaults OFF (§021 §3.4 + §11.4).
-Per-cascade clicks propagate cross-panel: a sub row → app-db at that
-input path. Hovering a view node toggles a pink DOM highlight on the live
-element.
-
-**Open when:** "why didn't my view update?", "what re-rendered?",
-"trace the recompute chain for sub X", "which subs short-circuited?"
-
-Spec: [`021-Dynamic-Panel-Designs.md` §3](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md)
-+ [`012-Views.md`](../../../tools/xray/spec/012-Views.md);
-implementation at
-[`panels/reactive_panel.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/reactive_panel.cljs)
-+ siblings under `panels/reactive_panel_*.cljs`.
-
-### Trace — `⬢` · stripe `:orange` · mnem `t`
-
-Question: **What raw trace events fired during this epoch?**
-
-The underlying stream the Epoch + Views tabs summarise. **Focused-epoch
-scoped** (per §021 §1.2 — no aggregate-across-epochs view), rendered as a
-**single flat oldest-first row list**, click-to-expand per row. The row
-anatomy (the six columns, the per-row stage column + colour-coded left edge
-that recover the phase shape, the inline error/warning treatment) is the
-normative subject of **§023 §3 + §3a** — the one detail Xray honours by
-construction is that the stage label + edge colour resolve through the
-Epoch panel's OWN badge taxonomy, so the Trace stage column matches the
-Epoch numbered cascade (one step model). Cite §023 for the column /
-stage / severity detail rather than re-encoding it here.
-
-Two USAGE facts the operator needs to route correctly:
-
-- **No filtering UI** — the focused epoch IS the scope, so the only
- drill-down is per-row click, which opens the **edn-inspector** on the
- row's raw trace-event map inline. (Spec 009's `trace-buffer` filter
- vocabulary — `:op-type`, `:dispatch-id`, the tag axes — is real for the
- *programmatic* API but is **not** surfaced as Trace-panel UI.)
-- **No film-strip header** — the L2 events list owns spine focus
- navigation (this tab opts out, see §Panel-by-panel above).
-
-**Open when:** "show me every raw op in this epoch", "is `:rf.fx/*`
-firing as expected?", "what order did these emit in?"
-
-Spec: [`023-Trace-Panel.md` §3 + §3a](../../../tools/xray/spec/023-Trace-Panel.md)
-+ [`021-Dynamic-Panel-Designs.md` §5](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md)
-+ [`013-Trace-Consumer.md`](../../../tools/xray/spec/013-Trace-Consumer.md)
-+ [`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md);
-implementation at
-[`panels/trace.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/trace.cljs)
-+ [`panels/trace_helpers.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc).
-
-### Machine — `◆` · stripe `:green` · mnem `m`
-
-Question: **What did this event do to my machines?**
-
-**Event-driven** (no picker, no Mode A/B/C): the panel is
-BLANK when the focused event had no machine activity, and renders one
-per-machine section (topology + transition highlight + guards + actions +
-cancellation cascade + `:after` rings) when it does. Per-machine
-prev/next nav walks the spine to the next event that touched that
-machine.
-
-Topology-plus-overlay (§021 §6 + §17.4). Each machine renders as an
-xyflow canvas through the shared machines-viz **MachineChart**
-(`day8.re-frame2-machines-viz.chart`), mounted via the Xray-side
-[`panels/machine_canvas.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs)
-wrapper (per §021 §6.0) — not Stately Inspect, not native Reagent. Nodes,
-edges, current-state highlight, parallel-region containers, and final-state
-double-rings all come from that chart, which carries its own styling. The
-former Xray-local fallback projector / style catalogue
-(`panels/machines/xyflow_style.cljs` + `machines/topology.cljs`) was
-DELETED (rf2-5fm165) — it had no live-render-path consumer.
-
-**Current-state precedence** — a 4-source walk-back resolves the
-machine's current state for the focused epoch:
-
-1. **Explicit** — operator override (sticky selection)
-2. **Focused-epoch transition** — if this epoch fired a transition for the machine
-3. **Epoch-history walk-back** — scan the buffer back to the most-recent transition
-4. **Snapshot** — fall back to the substrate's per-frame machine state
-
-The resolved current state node carries a **static** highlight — a runtime
-accent border + a soft `box-shadow` glow ring + a faint header wash (§021
-§17.4.5). It does **not** pulse: Mike rejected the continuous active-state
-pulse (rf2-2sez0), so machines-viz locked "no continuous animation"; the
-old pulse keyframes were retired (rf2-wct1s8).
-
-The focused-epoch **transition row** is a single prominent row: a header
-verb `<before-state → after-state>` (larger / bolder / magenta, doubling
-as click-to-source) over a **logical-state DELTA box** — an
-`edn-inspector` before→after DIFF of the machine's `{:state :tags}` only
-(`:data` excluded — the per-action `↳ data Δ` carries it; `:rf/*` snapshot
-slots excluded), carrying `:tags` + the structured before→after object
-(§021 §6).
-
-Per-canvas footer lists guards / actions / cancellation cascade chips
-inline (no modal, no popout). When the focused event had **no machine
-activity** the panel is **truly blank** — a single calm placeholder line,
-**no per-machine topology** (no topology renders on a non-machine epoch).
-*(Impl note — pre-alpha drift: the live panel gates topology on machine
-activity; §021 §6.2 Case B's "topology always visible on a no-activity
-epoch" is not the live behaviour. Browse-all topology lives in Static mode
-— see the callout below.)*
-
-**Open when:** "what state is my checkout machine in?", "what
-transition fired this epoch?", "what guards passed / failed?"
-
-Spec: [`021-Dynamic-Panel-Designs.md` §6 + §17.4](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md)
-+ [`003-Machine-Inspector.md`](../../../tools/xray/spec/003-Machine-Inspector.md);
-implementation at
-[`panels/machine_inspector.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs)
-+ `panels/machines/`.
-
-> **Browse-all machine canvas → Static mode.** The spine-INDEPENDENT
-> "what does this machine LOOK like overall?" canvas (picker + interactive
-> zoom / pan / fit, regardless of focused event) is **not a Dynamic tab** —
-> it lives under Static mode's Machines tab (Topology sub-mode). There is no
-> standalone Dynamic "Machines Canvas" tab. Impl
-> [`static/machines/topology.cljs`](../../../tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs).
-
-### Routes — `🌐` · stripe `:yellow` · mnem `r`
-
-Question: **What did this event do to my routes?** (Display label
-**Routes**, plural-noun convention; internal tab id `:routing`.)
-
-Same topology-plus-overlay pattern as Machines, rendered as a textual
-tree with `├─ └─` box-drawing (per §021 §7.1).
-
-Two blocks:
-
-- **Active route tree** (always visible) — each node with one of three
- markers per current state and per-epoch activity:
- - `◉` active this epoch, on the resolved match (the `:to` destination)
- - `◇` registered, traversed (can-leave / can-enter guard phases) this epoch (the `:from` origin)
- - `◀ current` on the current matched route with no activity this epoch
-   (folded into the mode-accent row highlight, not a painted dot glyph)
-- **This epoch** — short dense block: `Phase`, `From`, `To`, `Match`,
- `Events`. Empty state ("No route activity in this epoch.") keeps
- the tree visible above.
-
-Reads the focused cascade's routing trace ops (correlated by
-`:rf.trace/dispatch-id`) — the live phase derivation keys off
-`:rf.route.nav-token/allocated` (a navigation landed → `:on-match`),
-`:rf.route/navigation-blocked`, and `:rf.route/fragment-changed`, and the
-active-tree traversal markers read `:rf.route/deactivated` +
-the navigate / `:rf.route/transitioned` ops (`panels/routing_helpers.cljc`).
-*(Impl note — pre-alpha drift: §021 §7's `:rf.route/can-leave` /
-`:can-enter` / `:on-match` op names are spec naming; the live panel
-correlates the ops listed above.)*
-
-**Open when:** "what route am I on?", "what params did the nav-token
-resolve?", "did the route change this epoch?"
-
-Spec: [`021-Dynamic-Panel-Designs.md` §7](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md)
-+ [`spec/012-Routing.md`](../../../spec/012-Routing.md);
-implementation at
-[`panels/routing.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/routing.cljs).
-
-### Resources — cross-feature · mnem `s` · `:order 7`
-
-Question: **Where is my server state — what owns it, and is it stale?**
-(Display label **Resources**, plural-noun convention; internal tab id
-`:resources`.) The Xray surface for re-frame2's declarative server-state
-(Spec 016 §Xray and AI tooling). The sections, top → bottom, name the
-read; the per-section anatomy + the EP-0016 trace-op vocabulary they
-project (`:rf.resource/scope-resolved`, `:rf.mutation/replied`, the
-`:invalidation` facet, `:refetch-populated?`, `:resolved-nil?`, …) is the
-normative subject of **§024** + spec/016 — cite those rather than
-re-encoding the field-by-field detail here:
-
-- **STATIC RESOURCE REGISTRY** — every registered resource + scope,
- stale-after, GC-after, and the routes that activate it.
-- **LIVE INSTANCES** (per frame) — each scoped cache entry with state,
- generation, owner count, and freshness.
-- **WORK LEDGER** — live fetch attempts (running · cancellable ·
- deadline); host handles are inaccessible.
-- **ROUTE / RESOURCE GRAPH** — blocking activations (the SSR wait
- points), the lifecycle timeline, and cache growth.
-- **SCOPE RESOLUTION TIMELINE** (EP-0016 D3) — which named
- `reg-resource-scope` resolver ran, its inputs, and the resolved scope —
- including the fail-closed nil evidence (a scope-requiring site that got
- nil and produced NO global fallback).
-- **MUTATION CONTINUATIONS + SCOPED INVALIDATION** (EP-0016 D1/D2) — the
- surface that makes the doctrine "`:reply-to` is for workflow;
- populate/patch/invalidate are for cache" visible: `:reply-to`
- continuation evidence (did the accepted reply continue into app
- workflow?) and descriptor-level invalidation evidence (which scopes a
- write resolved, refetched, or left stale — fail-closed, never an
- implicit global blast).
-- **SCOPE AUDIT** — every `:rf.scope/global` use + lints.
-
-**The absence-is-evidence rule.** A continuation / refetch that the
-runtime *suppresses* (a stale or superseded reply, an `ensure` that skips
-a fresh read) surfaces as its own suppression op (`:rf.mutation/stale-suppressed`,
-`:rf.resource/cache-hit` / `:rf.resource/stale-suppressed`), not as a
-missing row — so "my `:reply-to` didn't fire" / "my read didn't refetch"
-is answered by the *presence of the suppression op*. (The op names + the
-full settlement facet live in §024.)
-
-**Read-only** — opening this panel pins nothing: it dispatches no
-`:rf.resource/ensure`, attaches no owner, refetches nothing, extends no
-GC (Spec 016 §Active owners and causes). **Privacy**: params, scopes, AND
-data all get the same summarize-and-redact treatment — every value is a
-bounded, redaction-aware preview, never the raw value. **Decoupled**:
-Xray does **not** `:require` the optional `re-frame.resources.*` artefact;
-the panel reads the static registry via `(rf/registrations :resource)`
-and the live cache/ledger from the runtime-db slice the spine already
-publishes — so it renders cleanly even when the host wired no resources
-(identical posture to the Routes tab's route slice + the Machine tab's
-snapshots).
-
-**Open when:** "where's my server state?", "what's in flight?", "is this
-resource stale?", "what owns this cache entry?", "did my mutation's
-`:reply-to` continuation fire?", "which scopes did this write invalidate?",
-"why didn't this read refetch?"
-
-Spec: [`spec/016-Resources.md` §Xray and AI tooling](../../../spec/016-Resources.md)
-+ [`024-Resources-Panel.md`](../../../tools/xray/spec/024-Resources-Panel.md);
-implementation at
-[`panels/resources.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/resources.cljs)
-+ [`panels/resources_helpers.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc).
-
-### Graph — cross-feature · mnem `g` · `:order 8`
-
-<a id="graph"></a>
-
-Question: **Where does this value come from — when is it evaluated, where
-does it live, who owns it?** — across families, in one place. (Display
-label **Graph**; internal tab id `:derivation-graph`.) Xray's UI over the
-**EP-0014 derivation/process algebra graph** and the **named first
-consumer** of EP-0014's structured graph accessor. Every declared fact
-and process in the host app — across **all five contributor families**
-(subscriptions, flows, resources, route facts, machine processes +
-selectors) — is a node in **one** node-and-edge graph over the frame
-fold. (A family with no registrations in the host app contributes no
-nodes — the *per-app* no-machines / no-resources story, not a per-tool
-boundary.)
-
-The classification model (the two closed superkinds `:derivation` /
-`:process` read off `:kind` alone, the refined kinds as the colour axis),
-the per-panel **Declared ↔ Realized** *projection toggle* (a Graph-local
-control, NOT the L1 Dynamic/Static **mode** pill — Graph is always a Dynamic
-tab; the Declared-side **don't-execute rule**), and the off-box egress
-projection are the normative subject of **spec/Derivations.md + EP-0014 +
-§025** — cite those for the rule detail rather than re-encoding it here. (The
-internal data contract / shipped UI keeps `:mode :static | :live`; that stays
-implementation language — this skill calls the user-facing control a
-*Declared/Realized projection toggle* so it never collides with the L1
-`Static`/`Dynamic` mode words.)
-
-Two caveats this skill owns (this is their full owning home; SKILL.md
-carries the short forms):
-
-> **Authority is an axis, not a storage class.** Remote-backed nodes
-> (resources) carry an **authority** chip. A resource's *storage* class is
-> still **local** (the frame's runtime-db, like any runtime-managed value);
-> *remote* describes its **authority** — where the value is sourced/owned
-> upstream — a distinct axis from where it is stored. Read the chip as
-> "locally stored, locally read, upstream source of truth", never as
-> app-db/runtime-db placement.
-
-> **The graph accessor is internal, not a public API.** The Graph tab
-> *consumes* EP-0014's internal `re-frame.derivation.graph` composer — a
-> **structured** internal accessor, **not** a `re-frame.core` facade
-> export and **not** a public app authoring/accessor primitive, with no
-> public accessor name. Route users to **open the Graph tab**;
-> do **not** tell them to call a public graph API from app code.
-
-**Read-only** — observing the graph pins nothing, dispatches nothing,
-mutates no host state; on-box raw, off-box redacted.
-
-**Open when:** "where does this value come from?", "show me the whole
-derivation graph", "what's the dependency graph for this page?", "is this
-ephemeral or materialized, and who owns it?"
-
-Spec: [`spec/Derivations.md` §Graph inspection — internal but structured](../../../spec/Derivations.md)
-+ [`docs/EP/EP-0014-derivation-and-process-algebra.md`](../../../docs/EP/EP-0014-derivation-and-process-algebra.md);
-implementation at
-[`panels/derivation_graph.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs)
-+ [`panels/derivation_graph_helpers.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/derivation_graph_helpers.cljc).
-
-### Frames — cross-feature · mnem `u` · `:order 9`
-
-Question: **Which images load which frames, and how do those frames
-resolve their registrations?** (Tab-bar label **Frames** — the literal
-`:label` `reg-l4-tab!` registers, per `module_view.cljs` + spec/026 §5 Tab
-registration. Internal tab id `:module-view` — the id is not a user
-contract; route users to the **Frames** tab.) Xray's UI over the EP-0023
-**`image -> frame -> event stream`** public model — the structural
-counterpart to the Graph tab (Graph is the per-fact derivation/process
-view; Frames is the per-frame installation + image-provenance view).
-Registered at `:order 9`, after the Graph tab (`:order 8`), keeping the
-cross-feature runtime-structure tabs adjacent.
-
-The panel is the **FRAMES** view (§026 §8) — each live frame as an
-**execution context** carrying its **resolved image** (the generation's
-`[kind id]` descriptor set), its capabilities, and how it resolves
-`(kind id)` lookups through that image. This is the model a consumer app
-developer reasons in: image assembly plus frame isolation are the whole
-composition story, with no realm / app / module layer to browse.
-
-The projection runs through the pure
-`image-view-helpers/project-image-view` over the live-frame reads
-(`re-frame.live-frame/image-view-frames`, via the `image_view_reads` seam —
-each frame carrying its resolved image generation).
-
-> **`:module-view` is an L4-only registry tab — no standalone mount
-> facade.** Like the Graph tab, the Frames tab registers through
-> `reg-l4-tab!` but exposes **no** `mount-*!` facade (it is **not** in
-> `panel-enum`, which carries only the standalone-mountable surface) — it is
-> a shell-internal tab, focusable via `focus!` / the command palette but not
-> independently mountable the way the other seven Dynamic panels are.
-> Route users to **open the Frames tab**; do not tell them to call a
-> `mount-module-view!` — there isn't one.
-
-**Does not compose off an `:rf.xray/*` app-db slot.** Images and frames
-are process-global facts (they live in the framework's registries, not
-Xray's app-db); the sub reads them directly at recompute time, and a tab
-activation re-renders the panel which re-derefs (a browse-on-open shape
-matching the other Static-style surfaces).
-
-**Read-only** — enumerating frames and images pins nothing and dispatches
-nothing.
-
-**Open when:** "what frames exist and which image loaded each?", "how does
-this frame resolve its registrations?" — the public partitioning axis is
-`image -> frame`.
-
-Spec: [`026-Module-View-Panel.md` §8](../../../tools/xray/spec/026-Module-View-Panel.md);
-implementation at
-[`panels/module_view.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs)
-+ [`panels/image_view_helpers.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/image_view_helpers.cljc)
-+ [`panels/image_view_reads.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/image_view_reads.cljs).
-
-### Hicasso — cross-feature · mnem `h` · `:order 10`
-
-Question: **What is Hicasso actually doing — which boundaries are mounted,
-what do they read, and why did one re-render?** The evidence lens for
-**Hicasso**, re-frame2's re-frame-native view layer, consuming the
-adapter-neutral evidence surface `re-frame.hicasso.tool` publishes.
-
-**Six views over four envelopes**, as a sub-strip inside the tab:
-
-| View | Mnem | The question it answers |
+| Tab | Mnem | Question it answers |
 |---|---|---|
-| **Mounted** | `m` | which boundaries are mounted, over which frames |
-| **Reads** | `r` | which boundaries read each subscription |
-| **Intents** | `i` | what was dispatched, in order, inside the retained window |
-| **Why** | `w` | which reads changed, and what that can and cannot prove |
-| **Advisor** | `a` | which boundary is hot, what owns the pressure, and the smallest route that addresses it |
-| **Causal** | `c` | one dispatch, walked link by link from event to paint, with every missing link named |
+| **Machines** *(default)* | `m` | "What machines are registered, and what do they look like?" Registry browse + full topology (picker + zoom/pan/fit) + a 4-mode sub-strip incl. the Sim engine. |
+| **Routes** | `r` | "Which route would `/orders/42` match?" Every registered route + a Simulate-URL input. |
+| **Schemas** | `c` | "Show me the shape of `:order/schema`." Every registered schema + sample data + jump-to-source. |
+| **Flows** | `f` | "What flows are registered?" The flows catalogue. |
+| **Interceptors** | `i` | "What runs, and in what order?" Pure-browse over the registered interceptor chains. |
 
-The first four each read one envelope (`:mounted-boundaries` ·
-`:read-attribution` · `:intents` · `:explain-render`). **Advisor and Causal
-read no envelope of their own** — they are derivations over the *same*
-one-turn take, which is why they are sub-views here rather than tabs of
-their own: a second tab would take a second turn, and a mount landing
-between the two would give a ranking about a census the slice no longer
-agrees with. So "four" and "six" are both right, about different things —
-**four envelopes, six views**.
-
-**Every view states its own scope, basis, completeness and loss.**
-`:complete?` means completeness *for the stated scope* and nothing on its
-own; `:loss` is `nil` or names a reason plus a `:dropped` count that may
-itself be the explicit `:unknown`. An absence renders as a **named loss
-state with its own sentence and testid**, never as an empty list — the
-empty roster is six facts, not one, because "nothing is mounted" is a clean
-bill of health while "the retained intent window is empty" is a *cap* that
-proves nothing about what was dispatched. A host **not running Hicasso**
-shows the honest no-evidence state, which is distinct from *running with
-nothing mounted*.
-
-**No read carries application data** — a boundary's identity is its read
-set, and subscription arguments and return values never reach the page or a
-testid.
-
-**Not epoch-coupled.** `:rf.xray.hicasso/data` recomputes off a
-`:rf.xray/trace-buffer` tick, taking all four envelopes in one turn;
-picking an epoch in L2 does not rebind it.
-
-> **`:hicasso` is an L4-only registry tab — no standalone mount facade.**
-> Like Graph and Frames it registers through `reg-l4-tab!` but is **not** in
-> `panel-enum`: focusable via `focus!` / the command palette, not
-> independently mountable.
-
-**Read-only** — the tab observes and dispatches nothing into the host.
-
-**Open when:** "which boundaries are mounted?", "what reads
-`:cart/items`?", "why did this boundary re-render?", "which boundary is
-hot?", "walk this dispatch from event to paint".
-
-Spec: [`027-Hicasso-Evidence.md`](../../../tools/xray/spec/027-Hicasso-Evidence.md)
-+ [`028-Hicasso-Advisor.md`](../../../tools/xray/spec/028-Hicasso-Advisor.md);
-implementation at
-[`panels/hicasso.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/hicasso.cljs)
-+ [`panels/hicasso_helpers.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/hicasso_helpers.cljc).
-
-### Issues — not a Dynamic tab
-
-There is **no dedicated Issues tab** and no session-wide triage list.
-"What's wrong in this epoch?" is answered
-inline, through **three** always-on channels (the `.cljc` algebra lives in
-[`panels/issues_ribbon_helpers.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/issues_ribbon_helpers.cljc)):
-
-1. **Inline in the Epoch cascade** — per-step ✓ / ✗ status glyphs, the
- shared **"Exception Thrown"** card under the throwing step
- (handler / interceptor / coeffect / fx / flow exceptions), and the
- `:db` schema-fail rollback ✗ on the EFFECT HANDLERS `:db` row.
- Errors, warnings, schema violations, and hydration mismatches each
- surface against the step where they occurred.
-2. **L2 event-row pink-wash** — a cascade carrying an issue
- washes its L2 timeline row pink; the `cascade-has-issue?` predicate
- reuses `issue-event?` so the wash stays in lockstep with the ribbon.
-3. **The always-on `:rf.xray/issues-ribbon` signal** — the composite
- (registered in `registry.cljs`) drives the auto-open-on-error watcher
- (`settings/effects.cljs/install-auto-open-watcher!`) — the cross-epoch
- "something is wrong" signal.
-
-So route "anything broken in this epoch?" to the **Epoch tab**; "which
-epochs are broken?" to the **L2 pink-wash**.
-
-> **Accessibility note.** A11y dogfooding is **not** a Xray tab. A11y
-> scanning lives in Story
-> (`re-frame.story.ui.chrome-a11y` + the variant scanner
-> `re-frame.story.ui.a11y`). Route a11y questions there, not to Xray.
-
-## Static mode — registry browse
-
-Static mode answers a different question from Dynamic:
-**what is registered**, not **what just happened**. It drops the L2 event
-spine (3-layer chrome) and renders 5 catalogue tabs over the picked
-frame's registries. Flip into it with the L1 mode pill or
-`Cmd/Ctrl+Shift+M`. Source of truth:
-[`007-UX-IA.md` §Static mode](../../../tools/xray/spec/007-UX-IA.md);
-sources under
-[`tools/xray/src/day8/re_frame2_xray/static/`](../../../tools/xray/src/day8/re_frame2_xray/static).
-
-Mnemonics are **mode-scoped** — the same letter dispatches the active
-mode's tab (`m` in Dynamic opens the Machines instance-inspector; `m` in
-Static opens the Machines registry browse).
-
-| Tab | Mnem | Question it answers | Implementation |
-|---|---|---|---|
-| **Machines** *(default)* | `m` | "What machines are registered, and what do they look like?" Registry browse + topology + a 4-mode sub-strip (incl. the Sim engine). | [`static/machines/panel.cljs`](../../../tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs) |
-| **Routes** | `r` | "What routes are registered, and which would `/x/y` match?" Registered routes + Simulate-URL (promoted from the Dynamic Routes lens). | [`static/routes/panel.cljs`](../../../tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs) |
-| **Schemas** | `c` | "What schemas are registered, and what shape do they expect?" Registered schemas + sample data + jump-to-source. | [`static/schemas/panel.cljs`](../../../tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs) |
-| **Flows** | `f` | "What flows are registered?" The flows catalogue. | [`static/flows/panel.cljs`](../../../tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs) |
-| **Interceptors** | `i` | "What interceptors run, and in what order?" Pure-browse lens over the interceptor chains. | [`static/interceptors/panel.cljs`](../../../tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs) |
-
-The L1 frame picker is mode-independent, but registries are **not** blanket
-frame-scoped: the definition catalogues are process-global (the registrar is
-shared across every frame, Spec 001) and the picker scopes only the
-per-frame *live* projections each tab adds — machine snapshots, the flows
-registry, the app-db-schema side-table, the current-route slice (see
-`static/shell.cljs`). Pick the frame — whether you're in Dynamic or Static —
-to move those per-frame projections; the definition catalogues read the same
-regardless (the picker's full
-contract — single-frame collapse, tool-frames-hidden-by-default, the
-transient-not-persisted pin — lives in
-[`chrome.md` §L1 frame picker](chrome.md#l1-frame-picker)). The mode choice
-lives at `[:rf.xray/mode]` (`:dynamic | :static`, persisted to
-localStorage); the Static-scoped tab choice lives at
-`[:rf.xray.static/selected-tab]` (default `:machines`), independent of
-Dynamic's `[:rf.xray/selected-tab]` so flipping modes preserves both.
-(Note the asymmetry: mode and tab choices persist across reload, but the
-**frame pin does not** — it resets to the head-frame default each session.)
-
-**Open when:** "where do I see all my registered machines / routes /
-schemas / flows / interceptors?", "browse the whole registry", "what's
-registered in this frame?" — anything that is about the *registry* rather
-than a single dispatch.
-
-## Shared components + iconography
-
-The three components every L4 panel reuses (`edn-inspector/render-node`,
-`film_strip/header`, `focus_resolver`) and the full tab-icon / L2-badge /
-cross-panel-arrow glyph reference live in
-[`shared-components.md`](shared-components.md).
+Static is **mixed-scope**: the definition catalogues are process-global
+(the registrar is shared across every frame, Spec 001); the L1 frame
+picker scopes only the per-frame *live* projections each tab adds —
+machine snapshots, the flows registry, the app-db-schema side-table, the
+current-route slice. The mode and tab choices persist across reload; the
+**frame pin does not** (it resets to the head-frame default).
 
 ## What's deliberately NOT here
 
-Per §021 §15 (Dynamic mode) + §007 §Static mode:
+<a id="whats-deliberately-not-here"></a>
 
-- **No Issues tab** and no session-wide aggregate / triage list. The three
- inline channels that carry issues are in §Issues — not a Dynamic tab
- above.
-- **No Event tab.** The **Epoch** panel (numbered
- cascade, `:order -1`) is the canonical "what happened" surface.
-- **No peer Subscriptions L4 tab.** The reactive cascade surfaces inline
- in Views + the app-db hover popover, not as its own Dynamic tab. (The
- Dynamic set is open through the `reg-l4-tab!` seam — Resources, Graph,
- and Frames each register their own cross-feature tab — but there is
- no separate Subs lens.)
-- **No Chrome A11y tab.** A11y dogfooding is Story's domain.
-- **No standalone Dynamic "Machines Canvas" tab** — the spine-INDEPENDENT
- browse-all canvas lives under Static mode's Machines tab (see the
- §Machine Browse-all callout).
-- **No cross-epoch Dynamic L4 views.** Aggregate signals live on L2
- badges only.
-- **No pattern-view.**
-- **No master-detail coupling.** Tabs are peers, bridged by app-db.
-- **No simultaneous multi-frame display.** Single-frame focus (§021
- §1.6); switch focus via the L1 frame picker.
-- **No legacy panels.** Subscriptions, Effects, Flows, Performance,
- Schemas, Hydration are NOT separate Dynamic tabs. Their content is
- surfaced through the Dynamic tabs above — and the registry catalogues
- live in Static mode:
- - Subscriptions → Views (cascade tree) + app-db (hover popover)
- - Effects → Epoch EFFECT HANDLERS step (flat ledger) + Trace (raw `:rf.fx/*` ops)
- - Flows → Epoch FLOW step (one per flow) · Static → Flows (registry)
- - Performance → L2 row stripe colours + per-step duration in Epoch + per-row `:time` in Trace
- - Schemas → Epoch (violations attach inline to the owning step) + L2 pink-wash · Static → Schemas (registry)
- - Hydration → Epoch inline + the issues-ribbon signal
+Per §021 §15 + §007 §Static mode — these are not tabs, and their content
+has a home:
 
-The only issues-related source file is `issues_ribbon_helpers.cljc`
-(powering the ribbon signal + L2 wash); there is no `event_detail.cljs` or
-`issues_ribbon.cljs`.
+- **Issues** → no tab, no session-wide triage list. Three inline
+ channels: the Epoch cascade's per-step ✓/✗ + inline exception cards
+ ("anything broken in this epoch?"), the L2 event-row pink-wash ("which
+ epochs are broken?"), and the always-on issues-ribbon signal driving
+ auto-open-on-error. Detail: [panels-epoch.md §Issues](panels-epoch.md#issues--inline-not-a-tab).
+- **Event** → the Epoch tab is the "what happened" surface.
+- **Subscriptions** → Views (the cascade tree) + the app-db hover
+ popover; no peer Subs tab.
+- **Effects** → the Epoch EFFECT HANDLERS step + Trace raw ops.
+- **Flows** → the Epoch FLOW step; the registry → Static → Flows.
+- **Performance** → L2 row stripes + per-step durations in Epoch +
+ per-row `:time` in Trace.
+- **Schemas** (violations) → Epoch inline + the L2 pink-wash; the
+ registry catalogue → Static → Schemas.
+- **Hydration** → Epoch inline + the issues-ribbon signal; no standalone
+ tab.
+- **A11y** → not Xray at all — Story's domain
+ (`re-frame.story.ui.chrome-a11y`).
+- **A standalone Dynamic "Machines Canvas"** → the browse-all topology
+ lives under Static → Machines.
+- **Master-detail coupling / multi-frame display / pattern-view** → tabs
+ are peers bridged by app-db; single-frame focus via the L1 picker.
 
-For the user-question → tab routing tables, see
-[`SKILL.md` §The tabs — what each surfaces](../SKILL.md#the-tabs--what-each-surfaces).
+For the question → first-surface routing, see
+[`SKILL.md` §The route card](../SKILL.md#the-route-card--question--first-surface).


### PR DESCRIPTION
## What

Rebuilds the re-frame2-xray tour question-first (rf2-0mw10):

- **SKILL.md** — actor fork first (human panel vs agent runtime, not read vs write), then a route card: evidence sought → one first surface + reason + first interaction, second lens only as the natural next step. 442 lines / 33,441 B → 263 / 18,000. The compact inventory sentence, scope model, launch quick-reference, wired-hotkey table and chrome one-liners stay in the body, so routine selection questions are answerable from SKILL.md alone.
- **references/panels.md** — now the compact canonical inventory (853 lines / 49,571 B → 111 / 7,282): the ordered 10-tab + 5-tab rosters, the scope matrix, and the not-a-tab content-home mapping. Per-tab depth moved into five one-level family leaves — `panels-epoch.md` (132 lines / 6,942 B), `panels-state.md` (82 / 3,926), `panels-domains.md` (81 / 3,923), `panels-resources.md` (58 / 3,011), `panels-structure.md` (127 / 6,623) — every leaf far under the 250-line / 16-KB target. Internal ids, sparse `:order` values, source-file inventories and deleted-panel archaeology are stripped from the normal path; the visible-control caveats (inline vs overlay, the `⛶` pop-out button, passive inspect vs `Reset` rewind, Graph's local projection toggle vs top-level Static mode, no Issues tab) are all retained.
- **`../shared/` link removal this bead owns** (from rf2-fqjys's scope): SKILL.md ×2, README.md, references/chrome.md:85 now carry the structural-successor sentence citing `spec/Tool-Pair.md` §Implications for downstream tools as the contract owner. chrome.md's `runtime.cljs` link (rf2-7htk7's) untouched.
- **Evals** — repurposed toward route quality, no new runner/framework: `panel-route-state`, `panel-route-machine`, `static-browse-registry` promoted to Layer 2; `panel-route-resources` (new) covers the observed-frame scope incl. the focused-leaf-load proof; `neg-agent-readonly-inspect` (new) pins the read-only agent handoff to re-frame2-pair. 32 evals: 23 positive / 9 negative, 18 Layer-2.
- **README / package.json / plugin.json** — summarize the role + point at the canonical inventory instead of copying tab anatomy; fixes the README scope sentence that omitted Hicasso from the non-epoch exceptions.
- **Docs mirrors** — docs/xray/index.md's "every tab rebinds to the focused epoch" contradiction, 02-panel-tour.md's copy of it, docs/skills/re-frame2-xray.md's Esc-as-spine-key drift + tab-anatomy copy + read-vs-drive boundary. Nothing under docs/xray/api/ touched.
- **skills/README.md** rows :106/:158/:172/:204 — separate final commit (serial lane): question-first blurb, actor-boundary trigger row, disqualifier and family-rule row.

tools/xray spec unchanged because this PR touches only the published skill package and its doc mirrors — no Xray runtime, panel, or spec surface moves.

## Loaded-route sizes (before → after)

| Route | Before | After |
|---|---|---|
| Routine selection question (SKILL.md alone) | 4,723 words / 33,441 B | 2,714 words / 18,000 B |
| Deep one-panel question (worst case) | 11,103 words / 83,012 B (SKILL.md + the all-panels catalogue) | 3,769 words / 24,942 B (SKILL.md + panels-epoch.md) |
| Deep Resources question | 11,103 words / 83,012 B | 3,142 words / 21,011 B (SKILL.md + panels-resources.md) |

The 49,571-byte all-panels load is gone.

## Observed manual route outputs (the eval harness is manual by design)

Run by the worker against the revised SKILL.md, per the evals/README.md §How to run procedure:

- **panel-route-state (6)** — "Which panel shows when `[:cart :items]` last changed?" → first paragraph: Dynamic → app-db; pick the frame/event in the L2 spine; changed paths carry inline `← was X`; next step: hover for downstream subs. No inventory dump. PASS (3/3 expectations).
- **panel-route-machine (7)** — → Dynamic → Machine (event-driven, blank without machine activity); Static → Machines named as the browse-cold next step only. PASS (3/3).
- **static-browse-registry (9)** — → Static mode via the L1 pill / `Cmd/Ctrl+Shift+M`; definition catalogues stated process-global. PASS (3/3).
- **panel-route-resources (32)** — → Dynamic → Resources; first interaction: pick the observed frame (live instances follow the picker, not the epoch); deep follow-up loads only `references/panels-resources.md`. PASS (4/4).
- **panel-route-frames (28)** / **tab-inventory-count (29)** — Frames routed by visible label (no "Modules"); the explicit inventory request returns the ordered 10-tab list from the body's inventory section. PASS.
- **neg-agent-readonly-inspect (31)** — "connect to my running app and read `:cart/items`, read-only" → does not trigger this skill; the SKILL.md description and §First fork route it to re-frame2-pair. PASS.
- **Focused-leaf load** — the §Which reference leaf to load table names exactly one leaf per family; a deep Epoch/Trace question loads panels-epoch.md only.

## Quality gates

All run from the worktree at the final rebased base (`e998e1cebf` merge base), foreground, exit codes captured per run:

| Gate | Exit |
|---|---:|
| `check_skill_xray_tab_inventory_drift.py --self-test` | 0 |
| `check_skill_xray_tab_inventory_drift.py --verbose --ci` ("No Xray tab-inventory drift (10 Dynamic tabs verified)") | 0 |
| `check_skill_eval_docs.py` | 0 |
| `check_skill_eval_packaging.py` | 0 |
| `check_skill_package_refs.py` | 0 |
| `check_doc_slugs.py` | 0 |
| `check_readme_links.py --ci` (extra) | 0 |

**Planted-fault controls** (both at lines this PR edits, on a committed tree):

- "Frames" → "Modules" in panels.md's ordered inventory sentence → drift gate exit **1**, naming `A2 ordered-label [references/panels.md]`.
- `panels-resources.md` → `panels-resourcez.md` link target in SKILL.md → `check_doc_slugs.py` exit **1**, naming `SKILL.md:212 -> references/panels-resourcez.md`.
- Both restores verified by git blob hash against the committed objects (`8e657b6ff683…` / `b7fb140ce3d4…` match working `git hash-object` output).

Anchors and table column counts in the touched markdown verified by hand (all in-page anchors also covered by `check_doc_slugs.py`, which validates heading anchors across `skills/` and `docs/`).

Beads: rf2-0mw10.
