### PR TITLE
ssr-ring: ssr-handler and stream-handler accept a declared :url-strategy on the per-request frame (rf2-089dy)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -142,6 +142,19 @@
     :ssr            — per-frame `:ssr` config map (e.g.
                       `{:dev-error-detail? true
                         :public-error-id   :myapp/projector}`).
+    :url-strategy   — per-request frame `:url-strategy` (Spec 012 §URL
+                      strategies), e.g.
+                      `(with-base-path history-url-strategy \"/realworld\")`,
+                      threaded verbatim into `(rf/make-frame ...)` so
+                      `route-link` hrefs in the server shell encode
+                      exactly as the hydrated client re-encodes them.
+                      Validated at frame construction exactly as on the
+                      client: a malformed value — an explicit nil
+                      included — fails the request with
+                      `:rf.error/invalid-url-strategy` through
+                      `:on-error`. Omit the key to keep the default
+                      path-form history strategy. Declared by the
+                      programmer; never inferred from the request.
     :emit-hash?     — emit hydration hash markers (default true). Gates the
                       WIRE markers only; the payload's hash keys are driven
                       by whether a hash exists at all (see `:root-view`).

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -263,6 +263,15 @@
   `make-frame` explicitly (`:id frame-id`) — the same lifecycle order,
   through the ONE public constructor.
 
+  A handler-declared `:url-strategy` (rf2-089dy) is threaded into the
+  make-frame config BY PRESENCE, not truthiness — make-frame's preflight
+  treats a present key (an explicit nil included) as a declaration and
+  validates it at the one frame-config commit chokepoint exactly as on the
+  client (`:rf.error/invalid-url-strategy`, Spec 012 §URL strategies) —
+  so `route-link` hrefs rendered under this frame encode through the
+  declared strategy. The programmer declares it; nothing here infers it
+  from the request.
+
   On failure mid-drain, the request slot is cleared so it does not leak
   across requests. The failed incarnation itself is NOT reaped here:
   core construction is its exact-token owner — `make-frame` tears the
@@ -270,7 +279,7 @@
   (frame.cljc, PR #6072). A bare-id reap in the catch would be address-
   directed and could destroy a same-id successor B seated in the window
   after A's exact rollback released the per-id transaction (rf2-c6lp3)."
-  [{:keys [initial-events fx-overrides ssr on-error]} request]
+  [{:keys [initial-events fx-overrides ssr on-error] :as opts} request]
   ;; The alphabetic prefix keeps the payload frame id valid for strict EDN
   ;; readers; keyword construction itself does not validate local names.
   (let [frame-id (keyword "rf.frame" (str (gensym "f")))]
@@ -288,7 +297,14 @@
                         ;; for ambient reads.
                        :initial-events (lifecycle/resolve-initial-events! initial-events request)}
                 fx-overrides (assoc :fx-overrides fx-overrides)
-                ssr          (assoc :ssr           ssr)))]
+                ssr          (assoc :ssr           ssr)
+                ;; BY PRESENCE, not truthiness: make-frame's preflight reads a
+                ;; PRESENT :url-strategy — an explicit nil included — as a
+                ;; declaration and fails loud on a malformed one
+                ;; (:rf.error/invalid-url-strategy), exactly as on the client
+                ;; (rf2-089dy). Omission keeps the default history strategy.
+                (contains? opts :url-strategy)
+                (assoc :url-strategy (:url-strategy opts))))]
         {:frame-id frame-id :frame frame-value})
       (catch Throwable t
         ;; Clear only the request side channel. Core construction is the

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -585,9 +585,13 @@
   Opts mirror `re-frame.ssr.ring/ssr-handler` — same `:initial-events` /
   `:root-view` / `:payload` / `:on-error` /
   `:error-view` / `:emit-hash?` / `:version` / `:schema-digest` /
-  `:content-type` / `:fx-overrides` / `:ssr` (the last two are threaded
+  `:content-type` / `:fx-overrides` / `:ssr` / `:url-strategy` (the last
+  three are threaded
   through the shared `pipeline/setup-request-frame!` into the per-request
-  `(rf/make-frame …)`, exactly as `ssr-handler` does) plus the four trusted
+  `(rf/make-frame …)`, exactly as `ssr-handler` does — a declared
+  `:url-strategy` encodes `route-link` hrefs in the streamed shell and is
+  validated at frame construction exactly as on the client, rf2-089dy)
+  plus the four trusted
   shell-hook opts (`:head` / `:body-end` / `:script-src` /
   `:app-element-id`, honoured by `default-streaming-prefix` /
   `default-streaming-suffix`). `:initial-events`

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/url_strategy_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/url_strategy_test.clj
@@ -1,0 +1,177 @@
+(ns re-frame.ssr.ring.url-strategy-test
+  "rf2-089dy — the stock handlers accept a DECLARED `:url-strategy` on the
+  per-request frame.
+
+  Since rf2-skr1c the JVM route-link doors encode the href through the
+  rendering frame's `:url-strategy`, so a frame CONSTRUCTED with the
+  strategy renders `/realworld/active` server-side — but the stock
+  `ssr-handler` / `stream-handler` built their per-request `make-frame`
+  config with no opt through which to seat one, so an app served through
+  them still rendered the path form and the hydrated client re-encoded on
+  hydration: the very mismatch rf2-skr1c closed, surviving through this
+  one door.
+
+  These tests pin the closure of that door:
+
+  - POSITIVE — a handler-declared `with-base-path` strategy reaches the
+    per-request frame: the wire body carries the based href, through BOTH
+    handlers, and the non-streaming body's href is byte-equal to a
+    `render-to-string` of the same root under a frame constructed with
+    the same strategy directly (the client-identical door rf2-skr1c
+    already pinned in `route_link_test.clj`).
+  - NEGATIVE — an invalid `:url-strategy` fails frame construction with
+    the SAME failure signal as on the client (`make-frame`'s preflight,
+    Spec 012 §URL strategies): the canonical
+    `:rf.error/invalid-url-strategy` ex-info, surfaced through the
+    handler's `:on-error` short-circuit. Presence semantics hold — an
+    explicit nil is a declaration and fails identically, while OMITTING
+    the key keeps the default path-form history strategy.
+
+  The strategy is DECLARED by the programmer; the handlers never infer it
+  from the request or its headers (the bead's stated non-goal)."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.routing :as routing]
+            [re-frame.ssr.ring :as ssr-ring]
+            [re-frame.ssr.ring.test-support :as ts]))
+
+(use-fixtures :each ts/reset-runtime)
+
+(defn- register-linked-app!
+  "One route, one no-op server init event, one root view whose only
+  content is a `route-link` to that route — the smallest app whose wire
+  body betrays which URL strategy the rendering frame carries."
+  []
+  (rf/reg-route :route/active {} "/active")
+  (rf/reg-event :init/url-strategy {:platforms #{:server}} (fn [_ _] {}))
+  (rf/reg-view* :pages/linked
+    (fn []
+      [:div.page [rf/route-link {:to :route/active} "Active"]])))
+
+(defn- based-strategy []
+  (routing/with-base-path routing/history-url-strategy "/realworld"))
+
+(defn- handler-opts [& {:as extra}]
+  (merge {:initial-events [[:init/url-strategy]]
+          :root-view      [(rf/view :pages/linked)]
+          :payload        :rf.ssr.payload/whole-app-db}
+         extra))
+
+(defn- first-href
+  "The first anchor href in `html` — the route-link's (the default shell
+  emits no other `href=`)."
+  [html]
+  (second (re-find #"href=\"([^\"]+)\"" html)))
+
+;; ===========================================================================
+;; Positive — the declared strategy reaches the per-request frame
+;; ===========================================================================
+
+(deftest ssr-handler-declared-url-strategy-reaches-the-request-frame
+  (register-linked-app!)
+  (let [strategy (based-strategy)
+        handler  (ssr-ring/ssr-handler (handler-opts :url-strategy strategy))
+        response (handler {:uri "/" :request-method :get})]
+    (testing "the wire body carries the based href"
+      (is (= 200 (:status response)))
+      (is (str/includes? (:body response) "href=\"/realworld/active\"")
+          (str "the server shell encodes through the declared strategy, got: "
+               (first-href (:body response))))
+      (is (not (str/includes? (:body response) "href=\"/active\""))
+          "the path-form href no longer reaches the server shell"))
+    (testing "parity with the client-identical door: the handler's href equals
+              a render-to-string under a frame CONSTRUCTED with the strategy"
+      (rf/make-frame {:id           :parity/client-identical
+                      :platform     :server
+                      :url-strategy strategy})
+      (let [direct (rf/with-frame :parity/client-identical
+                     (rf/render-to-string [(rf/view :pages/linked)]))]
+        (is (= "/realworld/active" (first-href direct))
+            "sanity: the direct-construction door renders the based href")
+        (is (= (first-href direct) (first-href (:body response)))
+            "the stock handler and the direct make-frame door agree")))))
+
+(deftest stream-handler-declared-url-strategy-reaches-the-request-frame
+  (register-linked-app!)
+  (let [handler  (ssr-ring/stream-handler
+                   (handler-opts :url-strategy (based-strategy)))
+        response (handler {:uri "/" :request-method :get})
+        body     (with-open [in ^java.io.InputStream (:body response)]
+                   (slurp in))]
+    (is (= 200 (:status response)))
+    (is (str/includes? body "href=\"/realworld/active\"")
+        "the streamed shell encodes through the declared strategy too")
+    (is (not (str/includes? body "href=\"/active\""))
+        "the path-form href does not reach the streamed shell")))
+
+(deftest omitted-url-strategy-keeps-the-default-path-form
+  (register-linked-app!)
+  (let [handler  (ssr-ring/ssr-handler (handler-opts))
+        response (handler {:uri "/" :request-method :get})]
+    (is (= 200 (:status response)))
+    (is (str/includes? (:body response) "href=\"/active\"")
+        "no declaration ⇒ the default history strategy's path-form href")))
+
+;; ===========================================================================
+;; Negative — an invalid strategy fails with the CLIENT's failure signal
+;; ===========================================================================
+
+(defn- capturing-on-error
+  "An `:on-error` hook that captures the setup throwable into `slot` and
+  returns a sentinel response, so the test can read both the wire outcome
+  and the underlying failure signal."
+  [slot]
+  (fn [_request t]
+    (reset! slot t)
+    {:status 599 :headers {} :body "setup failed"}))
+
+(defn- client-door-ex
+  "The ExceptionInfo the CLIENT-identical door throws for `strategy` —
+  `make-frame`'s preflight at the frame-config commit chokepoint."
+  [strategy]
+  (try
+    (rf/make-frame {:id           :parity/bad-strategy
+                    :platform     :server
+                    :url-strategy strategy})
+    nil
+    (catch clojure.lang.ExceptionInfo e e)))
+
+(deftest invalid-url-strategy-fails-with-the-clients-signal
+  (register-linked-app!)
+  (let [bad       {:encode "not-callable"}
+        client-ex (client-door-ex bad)
+        captured  (atom nil)
+        handler   (ssr-ring/ssr-handler
+                    (handler-opts :url-strategy bad
+                                  :on-error     (capturing-on-error captured)))
+        response  (handler {:uri "/" :request-method :get})]
+    (is (some? client-ex)
+        "sanity: the client-identical make-frame door rejects this value")
+    (is (= :rf.error/invalid-url-strategy (:rf.error/id (ex-data client-ex)))
+        "sanity: the client signal is the canonical invalid-url-strategy")
+    (testing "the handler short-circuits setup through :on-error"
+      (is (= 599 (:status response))
+          "the sentinel response proves setup-request-frame! short-circuited"))
+    (testing "the contained throwable IS the client's failure signal"
+      (is (instance? clojure.lang.ExceptionInfo @captured))
+      (is (= (:rf.error/id (ex-data client-ex))
+             (:rf.error/id (ex-data @captured)))
+          "same canonical :rf.error/id as the client door")
+      (is (= (:where (ex-data client-ex))
+             (:where (ex-data @captured)))
+          "same :where — the strategy is validated by make-frame itself"))))
+
+(deftest explicit-nil-url-strategy-is-a-declaration-and-fails
+  (register-linked-app!)
+  (let [captured (atom nil)
+        handler  (ssr-ring/ssr-handler
+                   (handler-opts :url-strategy nil
+                                 :on-error     (capturing-on-error captured)))
+        response (handler {:uri "/" :request-method :get})]
+    ;; Presence semantics (Spec 012 §URL strategies): a PRESENT key —
+    ;; explicit nil included — is a declaration and must be a valid
+    ;; strategy map; only OMISSION selects the default.
+    (is (= 599 (:status response))
+        "{:url-strategy nil} is threaded and fails loud, exactly as on the client")
+    (is (= :rf.error/invalid-url-strategy (:rf.error/id (ex-data @captured))))))


### PR DESCRIPTION
Closes rf2-089dy — the gap PR #8787 left by fence (its body filed this follow-up).

## The defect

Since rf2-skr1c the JVM route-link doors encode the href through the rendering frame's `:url-strategy`, so a frame CONSTRUCTED with a strategy renders `/realworld/article/x` server-side — but `pipeline/setup-request-frame!` built its per-request `make-frame` config from `:id` / `:doc` / `:platform` / `:initial-events` (+ `:fx-overrides`, `:ssr`) only. An app served through the stock `ssr-handler` or `stream-handler` had no opt through which to seat one, so its server shell still rendered path-form and the hydrated client re-encoded on hydration — the very mismatch rf2-skr1c closed, surviving through this one door.

## The fix

The narrow `:url-strategy` key, threaded BY PRESENCE (not truthiness) through the shared `pipeline/setup-request-frame!` into `(rf/make-frame ...)` — one edit covers BOTH handlers, since they share that setup. `make-frame`'s preflight (`preflight-frame-config!` at the one frame-config commit chokepoint, Spec 012 §URL strategies) validates it exactly as on the client: a malformed value — an explicit nil included — fails with the canonical `:rf.error/invalid-url-strategy`, surfaced through the handler's `:on-error` short-circuit; omitting the key keeps the default path-form history strategy. The programmer declares the strategy; it is never inferred from the request or headers (the bead's non-goal).

A general `:frame-config` passthrough was considered and rejected per the triage lean — the narrow key is the whole need, and the passthrough is the over-engineering the project stance excludes.

- `pipeline.clj` — `setup-request-frame!` threads the key by presence; docstring states the presence semantics.
- `ring.clj` — `ssr-handler` docstring roster (the normative opt roster; spec/011 has no opt table and is untouched) gains the `:url-strategy` entry.
- `streaming.clj` — `stream-handler` docstring mirror sentence now names `:url-strategy` among the opts threaded through the shared setup.
- `url_strategy_test.clj` (new) — 5 tests / 18 assertions:
  - positive: a `with-base-path` strategy declared on `ssr-handler` puts `href="/realworld/active"` on the wire, byte-equal (via `render-to-string`) to the client-identical direct `make-frame` door rf2-skr1c pinned; the same declaration on `stream-handler` encodes the streamed shell.
  - negative: an invalid strategy and an explicit-nil strategy short-circuit through `:on-error` carrying the client's exact failure signal (`:rf.error/id` and `:where` compared against the ex-info the direct `make-frame` door throws for the same value).
  - omission keeps the default path form.

## The control

The negative/positive suite is the control. With the threading clause disabled in `setup-request-frame!` (the plant verified applied by git blob hash change), the new namespace ran RED — exit 1, 11 of 18 assertions failing, each naming the removed property (status 200 where the `:on-error` sentinel 599 was expected, nil ex-data, path-form hrefs). Restore verified by git blob hash: the working file's hash matches the committed blob exactly. Re-run green (exit 0).

## Quality gates

- `clojure -M:test` (implementation/ssr-ring, full JVM suite, foreground) on the pre-rebase base: exit 0 — 220 tests, 1052 assertions, 0 failures, 0 errors.
- `clojure -M:test` re-run on the FINAL base after rebasing onto origin/main (3e8d7a6c4b): exit 0 — 220 tests, 1052 assertions, 0 failures, 0 errors.
- Targeted namespace `-n re-frame.ssr.ring.url-strategy-test`: exit 0 — 5 tests, 18 assertions, 0 failures (and exit 1 with 11 failures under the sabotage plant, above).
- Diff touches no markdown, so the doc-slug / readme-link gates do not apply (docstrings live in .clj files, outside both gates' rosters).
- Diff vs merge base read for reverts: only the four files above; nothing a sibling landed is touched.