### PR TITLE
fix(interceptors): reg-interceptor registration coords reach the interceptor-exception trace (rf2-tq26u)

### DIFF
--- a/implementation/core/src/re_frame/interceptor_registry.cljc
+++ b/implementation/core/src/re_frame/interceptor_registry.cljc
@@ -268,20 +268,46 @@
       (and (some? authored) (ref= override-key authored))
       :else false)))
 
+(defn- registration-coords
+  "The registration-site source coords the `reg-interceptor` MACRO captured
+  into the registry slot's metadata (`reg-interceptor*` →
+  `source-coords/merge-coords` stores them FLAT on the meta map per Spec 001
+  §Source-coordinate capture), re-nested as the `{:ns :file :line :column}`
+  `:source-coord` map shape the interceptor error-record carries
+  (`interceptor/->interceptor*` §`:source-coord`). Returns nil when the slot
+  carries no coords — a programmatic `reg-interceptor*` call, a framework
+  standard (`:rf.interceptor/path`), or a production build whose
+  `merge-coords` elided the public coords (rf2-3un2g)."
+  [meta]
+  (not-empty (select-keys meta [:ns :file :line :column])))
+
 (defn- descriptor->interceptor
   "Lower a registered static descriptor (`{:before}` / `{:after}` /
   `{:before :after}`, or an interceptor value carrying `:before` / `:after`)
   into an executable interceptor value, stamping `id` so chain tooling +
   override-by-id matching see the registered id. An interceptor value that
   already carries its own `:id` keeps it (the migration boundary guarantees it
-  equals `id`)."
-  [id descriptor]
+  equals `id`).
+
+  `coords` is the registration-site `:source-coord` map ([[registration-coords]]
+  off the registry slot's meta; nil when none were captured). It is stamped
+  onto the built value — the value's OWN `:source-coord` (a migration-boundary
+  interceptor value carrying one) wins over it — so a throwing interceptor
+  authored the supported way (`reg-interceptor` + a descriptor, EP-0022)
+  threads its registration coord onto the error-record → the
+  `:rf.error/interceptor-exception` trace's `:source-coord` tag, and the Xray
+  Epoch INTERCEPTOR row renders its jump-to-source chip (rf2-tq26u; the coord
+  used to stop at the registry meta and the chip degraded to plain text)."
+  [id descriptor coords]
   (if (contains? descriptor :id)
-    descriptor
+    (cond-> descriptor
+      (and coords (nil? (:source-coord descriptor)))
+      (assoc :source-coord coords))
     (interceptor/->interceptor*
-      :id     id
-      :before (:before descriptor)
-      :after  (:after descriptor))))
+      :id           id
+      :before       (:before descriptor)
+      :after        (:after descriptor)
+      :source-coord (or (:source-coord descriptor) coords))))
 
 (defn- throw-unregistered-interceptor!
   [ref id]
@@ -348,8 +374,14 @@
   "Resolve a parameterized `[id arg]` ref against its registered `:factory`
   descriptor. The factory receives the single `arg` and returns a static
   descriptor or an executable interceptor value, which we lower to an
-  executable interceptor (stamped with `id`)."
-  [ref id arg descriptor]
+  executable interceptor (stamped with `id`). `coords` is the factory
+  registration's [[registration-coords]] (nil when none) — stamped as the
+  built value's `:source-coord` fallback so a throwing factory-built
+  interceptor's exception-trace chip jumps to the factory's `reg-interceptor`
+  site (a built value carrying its OWN `:source-coord` keeps it; the
+  framework `:rf.interceptor/path` registers programmatically, so it stays
+  coord-free)."
+  [ref id arg descriptor coords]
   (when-not (factory-descriptor? descriptor)
     (throw-factory-arity!
       ref id
@@ -380,10 +412,14 @@
       ;; :before / :after / :id) — STAMP the registry id over it so the
       ;; resolved chain entry carries the registered factory id (e.g.
       ;; `:rf.interceptor/path`) for override-by-id matching + tooling, even
-      ;; when the built interceptor stamped its own internal id.
-      (interceptor-value? built) (assoc built :id id)
+      ;; when the built interceptor stamped its own internal id. The factory
+      ;; registration's coords ride as the `:source-coord` fallback
+      ;; (rf2-tq26u; the built value's own coord wins).
+      (interceptor-value? built) (cond-> (assoc built :id id)
+                                   (and coords (nil? (:source-coord built)))
+                                   (assoc :source-coord coords))
       ;; Factory returned a static descriptor — lower it.
-      (static-descriptor? built) (descriptor->interceptor id built)
+      (static-descriptor? built) (descriptor->interceptor id built coords)
       :else
       (throw-factory-arity!
         ref id
@@ -401,7 +437,15 @@
 
   Per Spec 002 §Validation and resolution timing: resolution happens at
   chain assembly, so a hot-reloaded interceptor descriptor is picked up on the
-  next dispatch without re-registering the event."
+  next dispatch without re-registering the event.
+
+  The resolved value carries the registration-site `:source-coord`
+  ([[registration-coords]] off the registry slot's meta — captured by the
+  `reg-interceptor` MACRO; absent for programmatic `reg-interceptor*` /
+  framework / production-elided registrations) unless the registered value
+  carries its own, so a throwing interceptor's error-record →
+  `:rf.error/interceptor-exception` trace names the registration site
+  (rf2-tq26u — the Xray Epoch INTERCEPTOR row's jump-to-source chip)."
   [ref]
   (cond
     (keyword? ref)
@@ -415,14 +459,15 @@
             (str "interceptor reference `" ref "` is a bare keyword, but id `" ref
                  "` is registered as a `:factory` interceptor — a factory MUST be "
                  "referenced as `[" ref " arg]`.")))
-        (descriptor->interceptor ref descriptor)))
+        (descriptor->interceptor ref descriptor (registration-coords meta))))
 
     (and (vector? ref) (= 2 (count ref)) (keyword? (first ref)))
     (let [[id arg] ref
           meta     (registrar/lookup interceptor-kind id)]
       (when (nil? meta)
         (throw-unregistered-interceptor! ref id))
-      (resolve-factory ref id arg (:rf/interceptor-descriptor meta)))
+      (resolve-factory ref id arg (:rf/interceptor-descriptor meta)
+                       (registration-coords meta)))
 
     :else
     (throw-invalid-ref! ref)))

--- a/implementation/core/test/re_frame/interceptor_test.clj
+++ b/implementation/core/test/re_frame/interceptor_test.clj
@@ -41,10 +41,11 @@
       the gate. NOTE that this makes the NEGATIVE controls (`(empty? (filterv
       …))`) vacuous there, which is why they sit inside the arm too rather than
       standing outside it looking load-bearing.
-    * `:source-coord`. The `->interceptor` MACRO's production branch omits the
-      `:source-coord` kwarg entirely (core.cljc §`->interceptor`), so the coord
-      is absent under the gate — and so is the fn-path's, which is what makes
-      the macro-vs-fn discriminator dev-only as a pair.
+    * `:source-coord`. The trace tag rides the dev-only trace surface, and
+      the REGISTRATION coord is production-elided too: under the gate
+      `source-coords/merge-coords` strips the coords from the public registry
+      meta (rf2-3un2g), so the resolver has nothing to stamp on the built
+      value (rf2-tq26u) — the coord discriminators are dev-only as a pair.
 
   The rf2-mszrz ATTRIBUTION contract (`:failing-id` = the true failing
   component) is production-real on the always-on error-emit axis, which lifts
@@ -58,6 +59,7 @@
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.interceptor :as interceptor]
+            [re-frame.interceptor-registry :as icpt-reg]
             [re-frame.interop :as interop]
             [re-frame.std-interceptors :as std-interceptors]
             [re-frame.trace :as trace]
@@ -960,12 +962,16 @@
           (is (= probe-coord (get-in (first ix) [:tags :source-coord]))
               "the trace carries the interceptor's :source-coord tag")))))
 
-  (testing "a throwing ->interceptor*-built interceptor threads NO
+  (testing "a throwing interceptor with NO captured coord threads NO
             :source-coord tag (degrades to plain text in the panel)"
-    ;; The fn-built (`->interceptor*`) value carries NO :source-coord;
-    ;; register it verbatim + reference it so the "no coord" intent rides
-    ;; through resolution.
-    (rf/reg-interceptor :siheh/fn-before-icpt
+    ;; The fn-built (`->interceptor*`) value carries NO :source-coord, and
+    ;; registering it via the PROGRAMMATIC `reg-interceptor*` fn (no macro,
+    ;; no `*pending-coords*`) captures no registration coord either — so
+    ;; nothing rides through resolution onto the trace. (A `reg-interceptor`
+    ;; MACRO registration now stamps its registration-site coord onto the
+    ;; resolved value — rf2-tq26u — so the no-coord degradation is pinned on
+    ;; the programmatic path, the one Xray spec 021 documents as plain-text.)
+    (icpt-reg/reg-interceptor* :siheh/fn-before-icpt
                          (interceptor/->interceptor*
                            :id     :siheh/fn-before-icpt
                            :before (fn [_] (throw (ex-info "fn before blew up" {})))))

--- a/implementation/core/test/re_frame/reg_interceptor_cljs_test.cljc
+++ b/implementation/core/test/re_frame/reg_interceptor_cljs_test.cljc
@@ -20,6 +20,7 @@
             [re-frame.core :as rf]
             [re-frame.interceptor :as interceptor]
             [re-frame.interceptor-registry :as icpt-reg]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
@@ -313,3 +314,108 @@
       (is (nil? (registrar/lookup :event :rint/run)))
       (is (some? (get-in @realm-reg [:event :rint/run]))
           "the event + interceptor are seated in the realm registrar"))))
+
+;; ---------------------------------------------------------------------------
+;; 5. registration coords ride resolution onto the exception trace (rf2-tq26u)
+;; ---------------------------------------------------------------------------
+;;
+;; The `reg-interceptor` MACRO (the ONE supported authoring form, EP-0022)
+;; captures its call-site coords into the REGISTRY meta (`reg-interceptor*` →
+;; `source-coords/merge-coords`), and the resolver threads them onto the BUILT
+;; interceptor value as `:source-coord` — so a throwing descriptor-authored
+;; interceptor's error-record → `:rf.error/interceptor-exception` trace
+;; carries the coord tag the Xray Epoch INTERCEPTOR row's jump-to-source chip
+;; reads (Xray spec 021 §INTERCEPTOR step). Before rf2-tq26u the coords
+;; stopped at the registry meta — the built value carried none, so the chip
+;; degraded to plain text for the supported authoring form and only a
+;; migration-boundary VALUE carrying its own `:source-coord` got the chip.
+;;
+;; Posture split (rf2-d2841): the trace stream is dev-only, and the PUBLIC
+;; registry coords are production-elided (`merge-coords`, rf2-3un2g) — so the
+;; coord assertions sit inside `(when interop/debug-enabled? …)` arms. The
+;; no-coord degradations (programmatic registration, framework standard) hold
+;; in both postures and stand outside the gate.
+
+(defn- capture-error-traces
+  "Dispatch `event` and return the vector of emitted `:op-type :error` trace
+  events (failure rides the trace stream per the runtime's no-abort contract;
+  `dispatch-sync` settles normally)."
+  [event]
+  (let [traces (atom [])]
+    (rf/register-listener! :trace ::tq26u
+                           (fn [ev] (when (= :error (:op-type ev))
+                                      (swap! traces conj ev))))
+    (rf/dispatch-sync event)
+    (rf/unregister-listener! :trace ::tq26u)
+    @traces))
+
+(defn- registered-coord
+  "The `{:ns :file :line :column}` coord the `reg-interceptor` macro captured
+  into `id`'s registry meta — the shape the resolver stamps as `:source-coord`."
+  [id]
+  (select-keys (rf/handler-meta :interceptor id) [:ns :file :line :column]))
+
+(deftest descriptor-authored-coord-rides-the-exception-trace
+  (testing "a throwing reg-interceptor DESCRIPTOR-authored interceptor threads its
+            registration coord onto the :rf.error/interceptor-exception trace"
+    (rf/reg-interceptor :tq26u/boom
+      {:before (fn [_] (throw (ex-info "descriptor before blew up" {})))})
+    (rf/reg-event :tq26u/run
+      {:interceptors [:tq26u/boom]}
+      (fn [{:keys [db]} _] {:db db}))
+    (let [errs (capture-error-traces [:tq26u/run])]
+      ;; Dev-instrumentation arm — see the section comment. The registry-meta
+      ;; sanity check sits inside too: production strips the public coords.
+      (when interop/debug-enabled?
+        (let [coord (registered-coord :tq26u/boom)
+              ix    (filterv #(= :rf.error/interceptor-exception (:operation %)) errs)]
+          (is (int? (:line coord))
+              "the reg-interceptor macro captured the registration line into the registry meta")
+          (is (= 1 (count ix)) "exactly one interceptor-exception")
+          (is (= coord (get-in (first ix) [:tags :source-coord]))
+              "the trace's :source-coord tag is the registration-site coord — the slot the Xray chip reads"))))))
+
+(deftest factory-authored-coord-rides-the-built-value
+  (testing "an [id arg] factory ref resolves to a value carrying the factory's
+            registration coord as :source-coord"
+    (rf/reg-interceptor :tq26u/fac
+      {:factory (fn [tag] {:before (fn [ctx] (assoc ctx :tag tag))})})
+    (when interop/debug-enabled?
+      (let [resolved (icpt-reg/resolve-ref [:tq26u/fac :x])]
+        (is (= :tq26u/fac (:id resolved)))
+        (is (= (registered-coord :tq26u/fac) (:source-coord resolved))
+            "the factory registration's coord rides the built value"))))
+
+  (testing "the framework :rf.interceptor/path factory stays coord-free
+            (programmatic registration — no captured coord, nothing to jump to)"
+    (let [resolved (icpt-reg/resolve-ref [:rf.interceptor/path [:cart]])]
+      (is (= :rf.interceptor/path (:id resolved)))
+      (is (nil? (:source-coord resolved))
+          "framework standards register via the reg-interceptor* fn — no coord is stamped"))))
+
+(deftest programmatic-registration-resolves-coord-free
+  (testing "an interceptor registered via the plain reg-interceptor* FN resolves
+            with no :source-coord (the plain-text degradation Xray spec 021 documents)"
+    (icpt-reg/reg-interceptor* :tq26u/plain {:before identity})
+    (let [resolved (icpt-reg/resolve-ref :tq26u/plain)]
+      (is (= :tq26u/plain (:id resolved)))
+      (is (nil? (:source-coord resolved))
+          "no macro path, no coords in the registry meta, nothing stamped"))))
+
+(deftest migration-value-coord-precedence
+  (let [own-coord {:ns 'tq26u.own :file "tq26u/own.cljc" :line 7 :column 3}]
+    (testing "a migration-boundary VALUE carrying its own :source-coord keeps it
+              over the registration coord (the authoring site is more specific)"
+      (rf/reg-interceptor :tq26u/own-coord
+        (interceptor/->interceptor* :id :tq26u/own-coord :before identity
+                                    :source-coord own-coord))
+      (is (= own-coord (:source-coord (icpt-reg/resolve-ref :tq26u/own-coord)))
+          "the value's own coord wins"))
+    (testing "a migration-boundary VALUE without its own coord falls back to the
+              registration coord (the best available jump target)"
+      (rf/reg-interceptor :tq26u/no-coord
+        (interceptor/->interceptor* :id :tq26u/no-coord :before identity))
+      (when interop/debug-enabled?
+        (is (= (registered-coord :tq26u/no-coord)
+               (:source-coord (icpt-reg/resolve-ref :tq26u/no-coord)))
+            "the registration site rides as the fallback")))))


### PR DESCRIPTION
## What

An interceptor authored the ONE supported way — `reg-interceptor` + a descriptor (EP-0022) — never got the Xray Epoch INTERCEPTOR exception-row jump-to-source chip. The `reg-interceptor` macro captures its call-site coords into the REGISTRY meta (`reg-interceptor*` → `source-coords/merge-coords`), but the resolver lowered `{:before/:after}` descriptors through `->interceptor*` without threading those coords onto the built value, so the error-record → `:rf.error/interceptor-exception` trace carried no `:source-coord` tag and the chip degraded to plain text. Only a migration-boundary VALUE carrying its own `:source-coord` got the chip. Since PR #8791 removed the `->interceptor` macro, the standard_epochs testbed's exception row showed exactly this degradation (rf2-tq26u).

## How

One site — the registry resolver (`interceptor_registry.cljc`):

- new private `registration-coords` re-nests the flat `:ns`/`:file`/`:line`/`:column` keys off the registry slot's meta as the `:source-coord` map shape;
- `resolve-ref` threads it through `descriptor->interceptor` (both the descriptor lowering and the `:id`-carrying migration-value branch) and `resolve-factory` (both the built-value and built-descriptor branches);
- a value's OWN `:source-coord` always wins over the registration coord (the authoring site is more specific);
- nothing is stamped where no coords exist: programmatic `reg-interceptor*` registrations, framework standards (`:rf.interceptor/path` registers programmatically), and production builds (`merge-coords` strips the public meta coords, rf2-3un2g) — so the documented plain-text degradation now lives on exactly the paths Xray spec 021 names, and framework interceptors stay coord-free as `interceptor.cljc`'s error-record contract promises.

## Tests

- `reg_interceptor_cljs_test.cljc` (dual-runtime) gains a section pinning the ACTUAL failing path: a throwing descriptor-authored interceptor's `:rf.error/interceptor-exception` trace carries the registration coord in its `:source-coord` tag (the slot the chip reads); plus the factory arm, the programmatic no-coord degradation, the framework `:rf.interceptor/path` no-coord arm, and migration-value coord precedence (own coord wins; registration coord is the fallback). Posture-split per rf2-d2841: trace/coord assertions sit in `debug-enabled?` arms; the no-coord degradations are posture-independent.
- `interceptor_test.clj`'s existing "no `:source-coord` tag" leg moves to the programmatic `reg-interceptor*` registration path — the macro path now legitimately carries a coord, and the plain-text degradation it pins lives on the fn path (the one spec 021 documents). Its ns-docstring posture note now describes the `merge-coords` elision rather than the removed `->interceptor` macro's production branch.

## Spec currency

- **tools/xray spec unchanged because** spec 021 §INTERCEPTOR step (exception-row chip) already documents the fixed behaviour — the coord "resolved from the `:rf.error/interceptor-exception` trace's `:source-coord` tag … The `reg-interceptor` macro … captures that coord at the registration site", degrading to plain text only for the `reg-interceptor*` fn path / framework interceptors / production elision. The implementation now matches that wording; no 021 line describes the old behaviour.
- No spec/009 change needed: its coord prose covers the trigger-handler and always-on error-record channels, both untouched.
- Known stale prose NOT touched here (interceptor-prose peer rf2-jui1c owns the sweep): `router.cljc`'s comment above the trace threading still credits the removed `->interceptor` macro; `tools/xray/test/.../trace_event_builders.cljc:648` and `.../view_cljs_test.cljs:3309` docstrings likewise.

## Quality gates

- `clojure -M:test` (implementation/core, JVM — covers the changed `.cljc` on the JVM side): captured exit **0** — `Ran 2162 tests containing 11082 assertions. 0 failures, 0 errors.` Re-run in full on the final rebased base (35402e4322) after the base moved.
- **Regression control (the deliverable):** with the coord-threading removed from `resolve-ref` (descriptor path handed `nil` instead of the registration coords), the focused suite ran RED — captured exit **1**, `2 failures, 0 errors` in 17 tests / 39 assertions, both failures naming the new coord assertions (`:source-coord` tag nil where the registration coord was expected). Restore verified by git blob hash: the working file's blob hash equals the committed blob `20b130d0a889f52e7f0696663268719ed77f6efc` byte-for-byte.
- CLJS side of the changed `.cljc`: not run locally (a peer holds the machine's heavy shadow-cljs lane); covered in CI by the `cljs` job (**CLJS (shadow-cljs :node-test)** — the consolidated build compiling core + adapters + feature artefacts + the tools/{story,xray} CLJS test trees), with the JVM twin in `jvm-core` and the production posture in `jvm-core-prod-gate`. The merge decision is CI's.
- No markdown touched, so no doc-slug gate applies.