### PR TITLE
http: expose successful response metadata on the canonical reply's :meta slot (rf2-lddbk)

### DIFF
--- a/docs/async/http-going-further.md
+++ b/docs/async/http-going-further.md
@@ -35,9 +35,20 @@ transforms the request on the way out; `:after` transforms the reply on the way 
 The two phases:
 
 - The `:before` fn receives a ctx of `{:request :args :frame :event}` and returns a ctx whose `:request` is the modified envelope. (Above, `cond-> ctx` adds the header only when a token is present, leaving the ctx untouched otherwise.) It reads app state through `rf/app-db-value` — an accessor that hands you the frame's current [app-db](../core/glossary.md#app-db) value, never a live subscription.
-- The `:after` fn is `(fn [ctx response] response')`. It sees the *same* ctx its `:before` produced — so a `:before` that stamps a start-time lets the matching `:after` compute an elapsed delta with no app state — plus the canonical `{:status :ok …}` / `{:status :error …}` response, and it returns a possibly-transformed response that the `:on-success` / `:on-failure` dispatch then carries.
+- The `:after` fn is `(fn [ctx response] response')`. It sees the *same* ctx its `:before` produced — so a `:before` that stamps a start-time lets the matching `:after` compute an elapsed delta with no app state — plus the canonical `{:status :ok …}` / `{:status :error …}` response, and it returns a possibly-transformed response that the `:on-success` / `:on-failure` dispatch then carries. On success the response also carries the wire facts under `:meta` — the actual status, status text, and the response headers as a plain map with lower-cased names — so header-driven concerns need no side channel.
 
-That ctx-carried-forward shape is what makes per-request concerns — response-time telemetry, rate-limit header parsing, flagging a 401 for an auth refresh — single-interceptor jobs.
+That ctx-carried-forward shape, plus the `:meta` wire facts, is what makes per-request concerns — response-time telemetry, rate-limit header parsing, flagging a 401 for an auth refresh — single-interceptor jobs. Here is rate-limit parsing as a working registration — one parse per response, and every `:on-success` handler downstream reads the structured slot instead of a header string:
+
+```clojure
+(rf/reg-http-interceptor
+  :app/rate-limit
+  {:doc   "Parse X-RateLimit-* once; downstream handlers read :rate-limit."
+   :after (fn [_ctx response]
+            (let [remaining (some-> (get-in response [:meta :headers "x-ratelimit-remaining"])
+                                    parse-long)]
+              (cond-> response
+                remaining (assoc :rate-limit {:remaining remaining}))))})
+```
 
 The rules that matter:
 

--- a/docs/async/http.md
+++ b/docs/async/http.md
@@ -106,7 +106,7 @@ Every reply is the one **canonical reply envelope** — a plain map with a close
 
 | `:status` | Shape | Notes |
 |---|---|---|
-| `:ok` | `{:status :ok :value value …}` | `value` is the decoded 2xx body. If you supplied `:accept`, this is the value inside `{:ok value}`. |
+| `:ok` | `{:status :ok :value value :meta {…} …}` | `value` is the decoded 2xx body. If you supplied `:accept`, this is the value inside `{:ok value}`. `:meta` carries the response's wire facts — `{:status 200 :status-text "OK" :headers {…}}`, with headers under lower-cased names — so a handler (or [`:after` interceptor](http-going-further.md#interceptors-stamp-every-request-once)) can read a rate-limit or `Cache-Control` header without any extra plumbing. |
 | `:error` | `{:status :error :error failure-map …}` | `failure-map` is one of the [category maps below](#failures-are-a-closed-set). Branch on `(-> reply :error :kind)`. |
 | `:cancelled` | `{:status :cancelled :error {:kind :rf.http/aborted …} …}` | An aborted request — the `:rf.http/aborted` map rides under `:error`, with `:cancel/reason` alongside. |
 | `:stale` | `{:status :stale :stale? true :rf.reply/stale-reason reason …}` | The request's correlation went obsolete before delivery — a [superseded `:request-id`](#cancellation-supersession-and-abort), an epoch restore, or an actor destroy whose reply addressed the destroyed actor. **Never dispatched to your handler**; it is trace-only. Carries no `:value`. |

--- a/implementation/http/src/re_frame/http/privacy.cljc
+++ b/implementation/http/src/re_frame/http/privacy.cljc
@@ -372,6 +372,30 @@
    (when failure
      (first (redact-failure-with-flag failure sensitive? carriers)))))
 
+(defn redact-response-meta
+  "Redact the sensitive response-header carriers on a canonical reply's
+  `[:meta :headers]` before the reply rides a trace surface (rf2-lddbk).
+
+  A successful completion's reply carries the response wire facts under
+  `:meta` (`{:status :status-text :headers}` — `re-frame.http.reply/
+  success-reply`). The reply DELIVERED to the app rides raw (on-box app
+  data — the caller's own response); this redactor fires only on the
+  trace-egress path, substituting `:rf/redacted` for every header whose
+  name is in the merged denylist (the immutable built-in defaults ∪ the
+  app-declared `:carriers {:headers [..]}` extension, resolved via
+  `managed-carriers` exactly as the failure-map `:headers` redaction
+  does). A reply with no `:meta` headers passes through untouched.
+
+  Per-call `:sensitive?` wholesale redaction is NOT this fn's job — `:meta`
+  is a core wire-bearing slot, so `trace-reply`'s
+  `:rf.privacy/force-redact-wire?` translation already redacts the whole
+  slot for a sensitive request."
+  [reply]
+  (if (map? (get-in reply [:meta :headers]))
+    (update-in reply [:meta :headers]
+               headers/redact-headers (:headers (managed-carriers)))
+    reply))
+
 (defn stamp-sensitive
   "Stamp the `:sensitive?` flag onto a tags map when `sensitive?` is true.
 

--- a/implementation/http/src/re_frame/http/reply.cljc
+++ b/implementation/http/src/re_frame/http/reply.cljc
@@ -181,12 +181,29 @@
 (defn success-reply
   "Build the canonical `:status :ok` reply map for a successful HTTP
   completion. `value` is the decoded-and-`:accept`-projected payload.
-  `:rf.reply/work-status :completed`."
-  [ctx value]
-  (assoc (base-reply ctx)
-         :status      :ok
-         :rf.reply/work-status :completed
-         :value       value))
+  `:rf.reply/work-status :completed`.
+
+  `response-meta` (rf2-lddbk) is the successful response's wire facts —
+  `{:status <int> :status-text <string> :headers <normalized map>}` as the
+  transport normalized them — riding under the envelope's `:meta`
+  family-extension slot (Managed-Effects §The reply map: `:meta`
+  effect-family-data) so `:after` middleware and the app reply target can
+  read the actual response status and headers on success, exactly as the
+  failure paths already expose them on the `:error` map. `:headers` is the
+  SAME cross-host normalized shape the failure maps carry (lower-cased
+  names; string value, or vector-of-strings for a multi-valued header) —
+  never a second representation. When nil/absent (a canned stub that
+  supplied none, or a synthetic caller), `:meta` is OMITTED rather than
+  fabricated (Managed-Effects: omit optional fields when absent). `:meta`
+  is a core wire-bearing slot, so trace egress elides/redacts it through
+  the shared `re-frame.reply/trace-summary` walker like `:value`."
+  ([ctx value] (success-reply ctx value nil))
+  ([ctx value response-meta]
+   (cond-> (assoc (base-reply ctx)
+                  :status      :ok
+                  :rf.reply/work-status :completed
+                  :value       value)
+     (some? response-meta) (assoc :meta response-meta))))
 
 (defn- timed-out?
   "A `:rf.http/timeout` failure lowers to `:rf.reply/work-status :timed-out` (NOT a

--- a/implementation/http/src/re_frame/http/test_support.cljc
+++ b/implementation/http/src/re_frame/http/test_support.cljc
@@ -164,7 +164,16 @@
         ;; are deliberately OMITTED — synthesising fake ones would add noise no
         ;; handler reads. The real transport's full envelope is pinned by the
         ;; lowering conformance (`http-reply-lowering-test`).
-        reply        {:status :ok :value value}]
+        ;;
+        ;; rf2-lddbk — an optional `:meta` on the args-map rides the reply's
+        ;; `:meta` slot verbatim, so header-dependent `:after` middleware /
+        ;; reply handlers are testable without a network (supply the same
+        ;; `{:status <int> :status-text <string> :headers <normalized map>}`
+        ;; shape the live transport threads). ABSENT stays absent — the stub
+        ;; never fabricates response metadata it was not given.
+        meta*        (get args-map :meta)
+        reply        (cond-> {:status :ok :value value}
+                       (some? meta*) (assoc :meta meta*))]
     (dispatch-canned-reply!
       {:origin-event   origin-event
        ;; rf2-et4c1s — the canned stub honours the SAME reply-addressing keys
@@ -409,7 +418,12 @@
         reply          (:reply entry)]
     (cond
       (and entry (contains? reply :ok))
-      (emit-canned-success! frame-ctx (assoc args-map :value (:ok reply))
+      ;; rf2-lddbk — a route entry may supply optional response metadata
+      ;; beside its success value (`{:reply {:ok v :meta {...}}}`); it rides
+      ;; the canned reply's `:meta` slot verbatim. Absent stays absent.
+      (emit-canned-success! frame-ctx
+                            (cond-> (assoc args-map :value (:ok reply))
+                              (contains? reply :meta) (assoc :meta (:meta reply)))
                             middleware-ctx)
 
       (and entry (contains? reply :failure))

--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -240,6 +240,10 @@
 ;; attempt]`, `:rf.reply/work-kind :http`, `:rf.reply/work-status`, `:attempt`,
 ;; `:rf.frame/id`, `:completed-at`, and `:correlation {:request-id …}` (the
 ;; `:request-id` is correlation metadata, NOT a second stale-suppression key).
+;; A live-transport SUCCESS additionally carries the response wire facts under
+;; `:meta` — `{:status :status-text :headers}` as the transport normalized
+;; them (rf2-lddbk), so `:after` middleware and the app target can read the
+;; actual status/headers on success as the failure paths already do on `:error`.
 ;; The same canonical reply is delivered to the app target verbatim.
 ;; `:on-success` / `:on-failure`
 ;; are pure ROUTING sugar (both receive the canonical map) and the co-located
@@ -395,7 +399,17 @@
                           (contains? reply :value)
                           (privacy-body/schema-decode? (:decode ctx)))
                    (update reply :value privacy-body/classify-decoded (:decode ctx))
-                   reply)]
+                   reply)
+          ;; rf2-lddbk — the success reply's `:meta` carries the response
+          ;; wire facts (status / status-text / normalized headers). The
+          ;; DELIVERED reply rides raw (on-box app data — the caller's own
+          ;; response); the trace surface redacts every header whose name
+          ;; is in the merged denylist (immutable built-in defaults ∪ the
+          ;; app-declared `:carriers {:headers [..]}` extension) BEFORE the
+          ;; summary walk, matching the failure-map `:headers` posture.
+          ;; Per-call `:sensitive?` then force-redacts the whole `:meta`
+          ;; wire slot via `trace-reply` below, as for every wire slot.
+          reply' (privacy/redact-response-meta reply')]
       ;; Thread the CARRIED frame into the elider opts (EP-0002 — wire-egress
       ;; frame resolves from the carried stamp; HTTP completions fire from the
       ;; transport callback, OUTSIDE any `with-frame` scope, so without an
@@ -503,9 +517,14 @@
   `:rf.reply/work-status
   :completed` canonical reply (`http-reply/success-reply`), a completion
   trace row is emitted from those canonical facts, and the SAME canonical
-  reply is delivered to the app target verbatim."
+  reply is delivered to the app target verbatim.
+
+  rf2-lddbk — the ctx's `:response-meta` (the successful response's
+  actual `:status` / `:status-text` / normalized `:headers`, threaded from
+  `handle-response!`'s 2xx branch) rides the canonical reply under `:meta`
+  so both the `:after` chain and the app reply target can read it."
   [ctx value]
-  (let [reply (http-reply/success-reply (reply-ctx ctx) value)]
+  (let [reply (http-reply/success-reply (reply-ctx ctx) value (:response-meta ctx))]
     (emit-reply-trace! ctx reply)
     (dispatch-reply! (assoc ctx
                             :kind          :success
@@ -1421,7 +1440,21 @@
           ;; (Spec 014 §Failure categories), so we route straight to
           ;; `finalise-failure!` — never `maybe-retry!`.
           (let [decoded (:decoded decode-result)
-                ctx'    (assoc ctx :decoded decoded)
+                ;; rf2-lddbk — carry the successful response's wire facts
+                ;; (actual status, status text, and the transport's already-
+                ;; normalized header map — the SAME cross-host shape the
+                ;; 4xx/5xx failure maps ride) forward to success
+                ;; finalisation, where they land on the canonical reply's
+                ;; `:meta` family-extension slot. Before this, the 2xx tail
+                ;; passed only the accepted value, so neither `:after` nor
+                ;; the app reply target could observe status or headers for
+                ;; a SUCCESSFUL request (the facts the spec's rate-limit /
+                ;; Cache-Control `:after` use cases parse).
+                ctx'    (assoc ctx
+                               :decoded decoded
+                               :response-meta {:status      status
+                                               :status-text status-text
+                                               :headers     headers})
                 ;; rf2-ppkh3v — RESPONSE-BODY classification (EP-0015 §8,
                 ;; issue 5). The pre-`:accept` decoded body rides at
                 ;; `:decoded` on an `:rf.http/accept-failure` trace; apply

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -1646,3 +1646,65 @@
             (.then (fn [_]
                      (set! (.-fetch js/globalThis) orig)
                      (done))))))))
+
+;; ---- rf2-lddbk -- a successful CLJS request exposes response metadata -----
+;;
+;; The CLJS counterpart of the JVM real-transport-success-reply-carries-
+;; response-meta: a successful request driven through the FULL :rf.http/managed
+;; pipeline (managed handler -> Fetch transport -> decode/accept -> canonical
+;; reply) delivers the ACTUAL response status, status text, and the
+;; transport's normalized headers at [:meta ...] on the canonical reply, with
+;; :value still the decoded payload. The Fetch Response is stubbed (the node
+;; lane has no network); the transport code path is the production one.
+
+(deftest cljs-success-reply-carries-response-meta
+  (testing "rf2-lddbk -- a successful managed request delivers the actual
+            response status/status-text/normalized headers at [:meta ...]"
+    (async done
+      (rf/init! reagent-adapter/adapter)
+      (frame/ensure-default-frame!)
+      (http-managed/clear-all-in-flight!)
+      (let [replies (atom [])
+            orig    (.-fetch js/globalThis)
+            resp    #js {:ok         true
+                         :status     200
+                         :statusText "OK"
+                         ;; Fetch-`Headers`-like: `forEach (v k)` per
+                         ;; `fetch-headers->map` -- lower-cased names, as the
+                         ;; real Headers object iterates them.
+                         :headers    #js {:forEach
+                                          (fn [cb]
+                                            (cb "application/json" "content-type")
+                                            (cb "37" "x-ratelimit-remaining"))}
+                         :text       (fn [] (js/Promise.resolve "{\"title\":\"hello\"}"))}]
+        (rf/reg-event :reply/recorder (fn [_ [_ p]] (swap! replies conj p) {}))
+        (rf/reg-event :issue-meta
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url "/meta"}
+                    :decode     :json
+                    :on-success [:reply/recorder]
+                    :on-failure [:reply/recorder]}]]}))
+        (set! (.-fetch js/globalThis)
+              (fn [_url _init] (js/Promise.resolve resp)))
+        (rf/dispatch-sync [:issue-meta] {:frame :rf/default})
+        (-> (test-support/poll-until
+              #(seq @replies) {:timeout-ms 2000 :label "cljs success meta reply"})
+            (.then (fn [_]
+                     (let [reply (first @replies)]
+                       (is (= :ok (:status reply)))
+                       (is (= "hello" (get-in reply [:value :title]))
+                           ":value remains the decoded payload")
+                       (is (= 200 (get-in reply [:meta :status]))
+                           "the actual numeric wire status rides [:meta :status]")
+                       (is (= "OK" (get-in reply [:meta :status-text]))
+                           "the actual status text rides [:meta :status-text]")
+                       (is (= "37" (get-in reply [:meta :headers "x-ratelimit-remaining"]))
+                           "normalized (lower-cased) response headers ride [:meta :headers]")
+                       (is (= "application/json" (get-in reply [:meta :headers "content-type"]))))))
+            (.catch (fn [e]
+                      (is false (str "rf2-lddbk -- unexpected: " e))
+                      nil))
+            (.then (fn [_]
+                     (set! (.-fetch js/globalThis) orig)
+                     (done))))))))

--- a/implementation/http/test/re_frame/http_interceptors_test.clj
+++ b/implementation/http/test/re_frame/http_interceptors_test.clj
@@ -1210,18 +1210,22 @@
                      ;; can correlate; the real read happens in :after.
                      (assoc ctx ::rate-limit-aware true))
            :after  (fn [ctx resp]
-                     ;; The reply-payload's :value carries the decoded
-                     ;; body. Headers don't ride on the reply by default;
-                     ;; the load-bearing assertion is that :after CAN
-                     ;; reshape the reply with a structured `:rate-limit`
-                     ;; slot derived from the server-provided values + the
-                     ;; ctx-stashed `:before` mark, so downstream
-                     ;; `:on-success` handlers can throttle without
-                     ;; re-parsing the header per-call.
-                     (assoc resp :rate-limit
-                            {:remaining 37
-                             :limit     100
-                             :ctx-aware (::rate-limit-aware ctx)}))})
+                     ;; rf2-lddbk — the successful reply carries the
+                     ;; response wire facts under `:meta` (`:status` /
+                     ;; `:status-text` / normalized `:headers`), so the
+                     ;; `:after` parses the headers the server ACTUALLY
+                     ;; emitted (lower-cased names — the transport's
+                     ;; cross-host normalized shape) into a structured
+                     ;; `:rate-limit` slot. Downstream `:on-success`
+                     ;; handlers consume the structured form without
+                     ;; re-parsing per-call.
+                     (let [hs (get-in resp [:meta :headers])]
+                       (assoc resp :rate-limit
+                              {:remaining (some-> (get hs "x-ratelimit-remaining")
+                                                  Long/parseLong)
+                               :limit     (some-> (get hs "x-ratelimit-limit")
+                                                  Long/parseLong)
+                               :ctx-aware (::rate-limit-aware ctx)})))})
         (rf/reg-event :uheqq/load-rate
           (fn [{:keys [db]} [_ msg reply]]
             (if reply
@@ -1232,11 +1236,13 @@
         (rf/dispatch-sync [:uheqq/load-rate])
         (let [reply (await-reply-with-payload!)]
           (is (= 37  (get-in reply [:rate-limit :remaining]))
-              "X-RateLimit-Remaining parsed and attached to the reply by :after")
+              "X-RateLimit-Remaining parsed FROM the server-emitted header riding [:meta :headers]")
           (is (= 100 (get-in reply [:rate-limit :limit]))
-              "X-RateLimit-Limit parsed and attached")
+              "X-RateLimit-Limit parsed from the actual response header")
           (is (true? (get-in reply [:rate-limit :ctx-aware]))
-              ":after read the :before's stashed ctx flag (request-correlation works)"))
+              ":after read the :before's stashed ctx flag (request-correlation works)")
+          (is (= 200 (get-in reply [:meta :status]))
+              "the actual response status rides [:meta :status] on the delivered reply"))
         (finally (stop-server! srv))))))
 
 ;; ---- USE-CASE 2. Response-time telemetry --------------------------------
@@ -1278,11 +1284,12 @@
 ;; ---- USE-CASE 3. Cache-Control inspection -------------------------------
 
 (deftest motivating-cache-control-inspection
-  (testing "rf2-uheqq use case 3 — an :after interceptor inspects a
-            simulated Cache-Control directive and tags the reply with a
-            structured :cache slot. Downstream `:on-success` handlers
-            consume the structured form without re-parsing the header
-            string at every dispatch site."
+  (testing "rf2-uheqq use case 3 / rf2-lddbk — an :after interceptor parses
+            the server-emitted Cache-Control header off the reply's
+            [:meta :headers] and tags the reply with a structured :cache
+            slot. Downstream `:on-success` handlers consume the structured
+            form without re-parsing the header string at every dispatch
+            site."
     (let [srv (start-server!
                 (fn [^HttpExchange ex]
                   (-> ex .getResponseHeaders
@@ -1292,12 +1299,18 @@
       (try
         (rf/reg-http-interceptor :cache-control
           {:after (fn [_ctx resp]
-                    ;; The test-side server emits the header above; the
-                    ;; transport doesn't ride it on the reply, but the
-                    ;; load-bearing assertion is that :after CAN add a
-                    ;; structured :cache slot derived from a parse of
-                    ;; the canonical form.
-                    (assoc resp :cache {:max-age 600 :public? true}))})
+                    ;; rf2-lddbk — parse the Cache-Control header the
+                    ;; server ACTUALLY emitted off the reply's
+                    ;; [:meta :headers] into a structured :cache slot.
+                    ;; These assertions fail if the emitted header changes
+                    ;; without changing the expected parse.
+                    (let [cc (get-in resp [:meta :headers "cache-control"])]
+                      (assoc resp :cache
+                             {:max-age (some->> cc
+                                                (re-find #"max-age=(\d+)")
+                                                second
+                                                Long/parseLong)
+                              :public? (boolean (when cc (re-find #"\bpublic\b" cc)))})))})
         (rf/reg-event :uheqq/load-cache
           (fn [{:keys [db]} [_ msg reply]]
             (if reply
@@ -1308,9 +1321,9 @@
         (rf/dispatch-sync [:uheqq/load-cache])
         (let [reply (await-reply-with-payload!)]
           (is (= 600 (get-in reply [:cache :max-age]))
-              "Cache-Control max-age parsed and attached")
+              "Cache-Control max-age parsed FROM the server-emitted header riding [:meta :headers]")
           (is (true? (get-in reply [:cache :public?]))
-              "Cache-Control 'public' flag attached"))
+              "Cache-Control 'public' directive parsed from the actual header value"))
         (finally (stop-server! srv))))))
 
 ;; ---- USE-CASE 4. 401 auth-token refresh ---------------------------------

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -1114,6 +1114,67 @@
         (is (= :ok (get-in db [:result :status])))
         (is (= [:hello :world] (get-in db [:result :value])))))))
 
+;; ---- 11b. rf2-lddbk — stubs may supply optional response metadata ----------
+
+(deftest with-managed-request-stubs-optional-response-meta
+  (testing "rf2-lddbk — a route entry may supply optional response metadata
+            beside its success value ({:reply {:ok v :meta {...}}}); it rides
+            the canned reply's :meta slot verbatim so header-dependent :after
+            code is testable without a network. An entry WITHOUT :meta stays
+            minimal — no metadata is fabricated."
+    (rf/reg-event :meta-stub/load
+      (fn [{:keys [db]} [_ msg reply]]
+        (if reply
+          {:db (assoc db :result reply)}
+          {:fx [[:rf.http/managed
+                 {:reply-to [:meta-stub/load msg]
+                  :request  {:method :get :url (:url msg)}
+                  :decode   :json}]]})))
+    (rf/with-managed-request-stubs
+      {[:get "/with-meta"] {:reply {:ok   {:v 1}
+                                    :meta {:status  200
+                                           :headers {"x-ratelimit-remaining" "37"}}}}
+       [:get "/no-meta"]   {:reply {:ok {:v 2}}}}
+      (rf/dispatch-sync [:meta-stub/load {:url "/with-meta"}])
+      (let [db (await-reply! #(some? (:result %)) 2000)]
+        (is (= {:v 1} (get-in db [:result :value])))
+        (is (= 200 (get-in db [:result :meta :status]))
+            "the supplied stub metadata rides [:meta :status]")
+        (is (= "37" (get-in db [:result :meta :headers "x-ratelimit-remaining"]))
+            "supplied stub headers ride [:meta :headers] verbatim"))
+      (rf/dispatch-sync [:meta-stub/load {:url "/no-meta"}])
+      (let [db (await-reply! #(= {:v 2} (get-in % [:result :value])) 2000)]
+        (is (not (contains? (:result db) :meta))
+            "absence stays minimal — the stub fabricates no lifecycle facts")))))
+
+(deftest canned-success-optional-response-meta
+  (testing "rf2-lddbk — the canned-success stub honours an optional :meta on
+            its args-map (same shape the live transport threads); absent
+            stays absent"
+    (rf/reg-event :meta-canned/load
+      (fn [{:keys [db]} [_ msg reply]]
+        (if reply
+          {:db (assoc db :result reply)}
+          {:fx [[:rf.http/managed
+                 (merge {:reply-to [:meta-canned/load msg]
+                         :request  {:method :get :url "/canned"}
+                         :decode   :json}
+                        msg)]]})))
+    (rf/dispatch-sync [:meta-canned/load {:value {:v 1}
+                                          :meta  {:status  201
+                                                  :headers {"location" "/things/9"}}}]
+                      {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+    (let [db (await-reply! #(some? (:result %)))]
+      (is (= {:v 1} (get-in db [:result :value])))
+      (is (= 201 (get-in db [:result :meta :status])))
+      (is (= "/things/9" (get-in db [:result :meta :headers "location"]))
+          "a canned Location header is readable exactly as a live one would be"))
+    (rf/dispatch-sync [:meta-canned/load {:value {:v 2}}]
+                      {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+    (let [db (await-reply! #(= {:v 2} (get-in % [:result :value])))]
+      (is (not (contains? (:result db) :meta))
+          "no :meta supplied — none fabricated"))))
+
 ;; ---- 11a. rf2-rzqan — bare wrapper INTERCEPTS, never reaching the real fx ---
 ;;
 ;; The load-bearing regression for rf2-rzqan: the documented

--- a/implementation/http/test/re_frame/http_privacy_integration_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_integration_test.clj
@@ -777,3 +777,147 @@
                (fail-closed) — the off-box projector omits :decoded"))
         (finally
           (stop-server! srv))))))
+
+;; ---- rf2-lddbk — successful-response :meta headers at the trace boundary ---
+;;
+;; A successful completion's canonical reply carries the response wire facts
+;; under `:meta` (`{:status :status-text :headers}`). The reply DELIVERED to
+;; the app rides raw — the caller's own response, on-box app data. The trace
+;; surface (`:rf.http/replied`) redacts every header whose name is in the
+;; merged denylist (immutable built-in defaults ∪ the app-declared `:carriers
+;; {:headers [..]}` extension) BEFORE the shared canonical-reply elider walk,
+;; matching the failure-map `:headers` posture; ordinary headers stay useful
+;; on-box. Per-call `:sensitive?` force-redacts the WHOLE `:meta` wire slot
+;; through the shared `trace-reply` → `trace-summary` translation.
+
+(defn- await-reply-and-replied-trace!
+  "Drive the polling shared by the rf2-lddbk trace tests: wait until the
+  default frame's app-db carries `:reply` AND a `:rf.http/replied` trace row
+  landed in `captured`. Returns `[db replied-event]`."
+  [captured]
+  (let [db (wait-for!
+             (fn [] (let [d (rf/app-db-value :rf/default)]
+                      (when (some? (:reply d)) d)))
+             3000)
+        _  (wait-for!
+             (fn [] (some #(= :rf.http/replied (:operation %)) @captured))
+             3000)
+        ev (first (filter #(= :rf.http/replied (:operation %)) @captured))]
+    [db ev]))
+
+(deftest replied-trace-redacts-builtin-sensitive-response-meta-headers
+  (testing "rf2-lddbk — built-in Set-Cookie is redacted at [:tags :meta
+            :headers] on the :rf.http/replied trace while an ordinary
+            response header rides useful on-box; the DELIVERED reply keeps
+            both raw"
+    (let [srv (start-server!
+                (fn [^HttpExchange ex]
+                  (let [hs (.getResponseHeaders ex)]
+                    (.set hs "Set-Cookie" "session=SECRET-COOKIE; Path=/")
+                    (.set hs "X-RateLimit-Remaining" "37"))
+                  (write-response! ex 200 "application/json" "{\"ok\":true}")))
+          port (:port srv)
+          captured (atom [])]
+      (try
+        (trace/register-listener! :test/capture
+                                  (fn [ev] (swap! captured conj ev)))
+        (rf/reg-event :api/meta-load
+          (fn [{:keys [db]} [_ msg reply]]
+            (if reply
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request  {:method :get
+                                 :url    (str "http://127.0.0.1:" port "/x")}
+                      :decode   :json
+                      :reply-to [:api/meta-load msg]}]]})))
+
+        (rf/dispatch-sync [:api/meta-load])
+
+        (let [[db ev] (await-reply-and-replied-trace! captured)]
+          (testing "the delivered reply rides raw — on-box app data"
+            (is (= "session=SECRET-COOKIE; Path=/"
+                   (get-in db [:reply :meta :headers "set-cookie"]))
+                "Set-Cookie reaches APP code unredacted (the caller's own response)")
+            (is (= "37" (get-in db [:reply :meta :headers "x-ratelimit-remaining"]))))
+          (testing "the trace surface redacts the denylisted name, keeps ordinary headers"
+            (is (= :rf/redacted (get-in ev [:tags :meta :headers "set-cookie"]))
+                "built-in Set-Cookie is redacted on the :rf.http/replied trace")
+            (is (= "37" (get-in ev [:tags :meta :headers "x-ratelimit-remaining"]))
+                "an ordinary response header stays useful on the on-box trace")
+            (is (= 200 (get-in ev [:tags :meta :status]))
+                "the wire status rides the trace summary verbatim")))
+        (finally
+          (stop-server! srv))))))
+
+(deftest replied-trace-redacts-app-declared-carrier-in-response-meta
+  (testing "rf2-lddbk — an app-declared :carriers {:headers [..]} name is
+            redacted at [:tags :meta :headers] on the :rf.http/replied trace
+            (union onto the immutable defaults), while the delivered reply
+            keeps it raw"
+    (fx/reg-fx :rf.http/managed
+      {:carriers {:headers ["X-Honeycomb-Team"]}}
+      http-managed/managed-handler)
+    (let [srv (start-server!
+                (fn [^HttpExchange ex]
+                  (-> ex .getResponseHeaders (.set "X-Honeycomb-Team" "hc-token"))
+                  (write-response! ex 200 "application/json" "{\"ok\":true}")))
+          port (:port srv)
+          captured (atom [])]
+      (try
+        (trace/register-listener! :test/capture
+                                  (fn [ev] (swap! captured conj ev)))
+        (rf/reg-event :api/carrier-load
+          (fn [{:keys [db]} [_ msg reply]]
+            (if reply
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request  {:method :get
+                                 :url    (str "http://127.0.0.1:" port "/x")}
+                      :decode   :json
+                      :reply-to [:api/carrier-load msg]}]]})))
+
+        (rf/dispatch-sync [:api/carrier-load])
+
+        (let [[db ev] (await-reply-and-replied-trace! captured)]
+          (is (= "hc-token" (get-in db [:reply :meta :headers "x-honeycomb-team"]))
+              "the delivered reply keeps the app carrier raw (on-box app data)")
+          (is (= :rf/redacted (get-in ev [:tags :meta :headers "x-honeycomb-team"]))
+              "the app-declared sensitive response-header carrier is redacted on the trace"))
+        (finally
+          (stop-server! srv))))))
+
+(deftest sensitive-request-force-redacts-response-meta-wholesale
+  (testing "rf2-lddbk — per-call :sensitive? redacts the WHOLE :meta wire
+            slot on the :rf.http/replied trace (the shared force-redact-wire
+            translation — :meta is a core wire-bearing slot like :value)"
+    (let [srv (start-server!
+                (fn [^HttpExchange ex]
+                  (-> ex .getResponseHeaders (.set "X-RateLimit-Remaining" "37"))
+                  (write-response! ex 200 "application/json" "{\"ok\":true}")))
+          port (:port srv)
+          captured (atom [])]
+      (try
+        (trace/register-listener! :test/capture
+                                  (fn [ev] (swap! captured conj ev)))
+        (rf/reg-event :api/sensitive-load
+          (fn [{:keys [db]} [_ msg reply]]
+            (if reply
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request    {:method :get
+                                   :url    (str "http://127.0.0.1:" port "/x")}
+                      :sensitive? true
+                      :decode     :json
+                      :reply-to   [:api/sensitive-load msg]}]]})))
+
+        (rf/dispatch-sync [:api/sensitive-load])
+
+        (let [[db ev] (await-reply-and-replied-trace! captured)]
+          (is (= "37" (get-in db [:reply :meta :headers "x-ratelimit-remaining"]))
+              "the delivered reply still carries the metadata — :sensitive? governs egress, not app data")
+          (is (= :rf/redacted (get-in ev [:tags :meta]))
+              "the whole :meta wire slot is force-redacted on the trace for a sensitive request")
+          (is (= :rf/redacted (get-in ev [:tags :value]))
+              "…exactly as the :value wire slot already is"))
+        (finally
+          (stop-server! srv))))))

--- a/implementation/http/test/re_frame/http_reply_lowering_test.clj
+++ b/implementation/http/test/re_frame/http_reply_lowering_test.clj
@@ -124,6 +124,30 @@
         (is (= {:request-id :article/by-id} (:correlation r)))
         (is (not (contains? r :request-id)))))))
 
+(deftest success-reply-response-meta-is-optional-and-canonical
+  (testing "rf2-lddbk — the 3-arity threads the successful response's wire
+            facts onto the envelope's :meta family-extension slot; the reply
+            stays schema-valid and :value stays the accepted payload"
+    (let [meta* {:status      200
+                 :status-text "OK"
+                 :headers     {"content-type"          "application/json"
+                               "x-ratelimit-remaining" "37"
+                               ;; multi-valued header — the normalized
+                               ;; vector-of-verbatim-lines shape rides
+                               ;; UNCHANGED (no second representation)
+                               "set-cookie"            ["a=1; Path=/" "b=2; Path=/"]}}
+          r     (http-reply/success-reply base-ctx {:title "Welcome"} meta*)]
+      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+      (is (= :ok (:status r)) "the envelope status stays :ok — :meta adds facts, never re-levels them")
+      (is (= {:title "Welcome"} (:value r)) ":value remains the decoded-and-accepted payload")
+      (is (= meta* (:meta r)) "the response wire facts ride verbatim under :meta")
+      (is (= ["a=1; Path=/" "b=2; Path=/"] (get-in r [:meta :headers "set-cookie"]))
+          "a multi-valued header keeps the ONE normalized vector shape")))
+  (testing "rf2-lddbk — absent metadata is OMITTED, never fabricated (the
+            2-arity and a nil 3rd arg both leave :meta off the reply)"
+    (is (not (contains? (http-reply/success-reply base-ctx {:v 1}) :meta)))
+    (is (not (contains? (http-reply/success-reply base-ctx {:v 1} nil) :meta)))))
+
 (deftest failure-reply-maps-to-error
   (testing "a transport failure builds a schema-valid :status :error reply"
     (let [r (http-reply/failure-reply
@@ -266,6 +290,70 @@
           (is (= :rf.http/http-5xx (get-in db [:got :error :kind])))
           (is (= 503 (get-in db [:got :error :status])))
           (is (not (contains? (:got db) :kind)) "no retired :kind dialect"))
+        (finally (stop-server! srv))))))
+
+(deftest real-transport-success-reply-carries-response-meta
+  (testing "rf2-lddbk — a successful live request delivers the ACTUAL response
+            status, status text, and normalized headers at [:meta …] on the
+            canonical reply the app target receives; :value stays the payload"
+    (let [srv (start-server!
+                (fn [^HttpExchange ex]
+                  (let [hs (.getResponseHeaders ex)]
+                    (.set hs "X-Request-Cost" "3")
+                    ;; TWO Set-Cookie lines — the multi-valued case MUST ride
+                    ;; the one normalized vector-of-verbatim-lines shape
+                    ;; (rf2-0xvm1/rf2-wmdmou), never a second representation.
+                    (.add hs "Set-Cookie" "session=abc; Path=/")
+                    (.add hs "Set-Cookie" "csrf=xyz; Path=/"))
+                  (write-response! ex 200 "application/json" "{\"title\":\"hello\"}")))]
+      (try
+        (rf/reg-event :meta/load
+          (fn [{:keys [db]} [_ msg reply]]
+            (if reply
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request  {:url (str "http://127.0.0.1:" (:port srv) "/m")}
+                      :decode   :json
+                      :reply-to [:meta/load msg]}]]})))
+        (rf/dispatch-sync [:meta/load {}])
+        (let [db    (await-reply! #(some? (:reply %)))
+              reply (:reply db)]
+          (is (reply/valid-reply? reply) (str (reply/validate-reply reply)))
+          (is (= "hello" (get-in reply [:value :title]))
+              ":value remains the decoded-and-accepted payload")
+          (is (= 200 (get-in reply [:meta :status]))
+              "the actual numeric wire status rides [:meta :status]")
+          (is (string? (get-in reply [:meta :status-text]))
+              "the transport's status text rides [:meta :status-text]")
+          (is (= "3" (get-in reply [:meta :headers "x-request-cost"]))
+              "an ordinary response header rides the normalized (lower-cased) map RAW on the delivered reply")
+          (is (= ["session=abc; Path=/" "csrf=xyz; Path=/"]
+                 (get-in reply [:meta :headers "set-cookie"]))
+              "a multi-valued header is the normalized vector of verbatim lines — no second header representation")
+          (is (string? (get-in reply [:meta :headers "content-type"]))
+              "single-valued headers keep the string shape"))
+        (finally (stop-server! srv))))))
+
+(deftest real-transport-failure-reply-carries-no-response-meta
+  (testing "rf2-lddbk — the scope is SUCCESSFUL responses: a failure reply's
+            wire facts already ride the :error map (status/status-text/
+            headers), so no :meta is added on the failure path"
+    (let [srv (start-server!
+                (fn [^HttpExchange ex]
+                  (write-response! ex 503 "text/plain" "down")))]
+      (try
+        (rf/reg-event :meta/fail
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url (str "http://127.0.0.1:" (:port srv) "/x")}
+                    :on-failure [:meta/failed]}]]}))
+        (rf/reg-event :meta/failed (fn [{:keys [db]} [_ reply]] {:db (assoc db :reply reply)}))
+        (rf/dispatch-sync [:meta/fail])
+        (let [db (await-reply! #(some? (:reply %)))]
+          (is (not (contains? (:reply db) :meta))
+              "failure replies carry no :meta — their wire facts live on :error")
+          (is (= 503 (get-in db [:reply :error :status]))
+              "the failure map still carries the wire status as before"))
         (finally (stop-server! srv))))))
 
 ;; ===========================================================================

--- a/implementation/http/test/re_frame/http_set_cookie_parity_cljs_test.cljc
+++ b/implementation/http/test/re_frame/http_set_cookie_parity_cljs_test.cljc
@@ -27,6 +27,7 @@
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing]]
       :cljs [cljs.test :refer-macros [deftest is testing]])
+   [re-frame.http.reply :as http-reply]
    #?(:clj  [re-frame.http.transport-jvm :as transport-jvm]
       :cljs [re-frame.http.transport-cljs :as transport-cljs]))
   #?(:clj (:import [java.net.http HttpHeaders]
@@ -113,3 +114,29 @@
       (is (= "application/json" (get out "content-type")))
       (is (not (contains? out "set-cookie"))
           "no spurious set-cookie key is synthesised"))))
+
+(deftest success-reply-meta-rides-host-normalized-headers-verbatim-cross-host
+  (testing "rf2-lddbk — the host transport's normalized header map (built here
+            from the host's REAL native headers object) rides the canonical
+            success reply's [:meta :headers] VERBATIM on both hosts — the
+            multi-valued vector shape included. One header representation,
+            end to end; no reshape at the reply boundary."
+    (let [cookies ["session=abc; Path=/; Expires=Wed, 21 Oct 2026 07:28:00 GMT"
+                   "csrf=xyz; Path=/; Expires=Thu, 22 Oct 2026 07:28:00 GMT"]
+          headers (decode-headers {"Set-Cookie"             cookies
+                                   "Content-Type"           ["application/json"]
+                                   "X-RateLimit-Remaining"  ["37"]})
+          reply   (http-reply/success-reply
+                    {:request-id :parity/req :origin-event [:parity/load]
+                     :attempt 1 :frame :app/main :completed-at 1}
+                    {:ok true}
+                    {:status 200 :status-text "" :headers headers})]
+      (is (= headers (get-in reply [:meta :headers]))
+          "the normalized map threads verbatim — byte-identical shape on both hosts")
+      (is (= cookies (get-in reply [:meta :headers "set-cookie"]))
+          "the multi-valued vector-of-verbatim-lines shape survives onto the reply")
+      (is (= "37" (get-in reply [:meta :headers "x-ratelimit-remaining"]))
+          "single-valued headers stay strings under lower-cased names")
+      (is (= 200 (get-in reply [:meta :status])))
+      (is (= {:ok true} (:value reply))
+          ":value remains the accepted payload — metadata never displaces it"))))

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -542,6 +542,7 @@ There is **one** reply shape. Every managed-HTTP completion delivers the framewo
 {:status       :ok            ;; one of :ok | :error | :cancelled | :stale (:stale is a suppression outcome — never delivered to an app target; see §Actor-destroyed suppression)
  :value        <decoded-and-accepted-payload>   ;; on :ok
  :error        {:kind <one of :rf.http/*> …}     ;; on :error / :cancelled — the classified failure map, verbatim
+ :meta         {:status 200 :status-text "OK" :headers {…}} ;; on a live-transport :ok — the successful response's wire facts (§Successful-response metadata)
  :rf.reply/work-id      [:rf.work/http logical-id issuance attempt] ;; the attempt identity
  :rf.reply/work-kind    :http
  :rf.reply/work-status  :completed | :failed | :timed-out | :cancelled
@@ -569,6 +570,31 @@ Status mapping (per [Managed-Effects §Status taxonomy](Managed-Effects.md#statu
 - an **abort** → `:status :cancelled` with `:cancelled? true`, `:rf.reply/cancel-reason`, and the `:rf.http/aborted` shape under `:error`.
 
 **The priced wrinkle — `:status` at two levels on HTTP 4xx/5xx.** The reply's top-level `:status :error` and the `:error` map's own `:status` (the HTTP status code, e.g. `503`) are distinct facts at two levels — the reply-envelope status vs the wire status. This mirrors the pre-existing `:kind`-at-two-levels shape (the reply status vs the failure category `:kind`) and is accepted as the cost of one uniform envelope.
+
+#### Successful-response metadata — `:meta`
+
+A **successful live-transport completion** carries the response's wire facts on the envelope's `:meta` family-extension slot ([Managed-Effects §The reply map](Managed-Effects.md#the-reply-map): `:meta` is effect-family data):
+
+```clojure
+:meta {:status      200                     ;; the actual numeric wire status
+       :status-text "OK"                    ;; the transport's status text ("" on the JVM — HttpClient exposes no reason phrase)
+       :headers     {"content-type"          "application/json"
+                     "x-ratelimit-remaining" "37"
+                     "set-cookie"            ["a=1; Path=/" "b=2; Path=/"]}}
+```
+
+`:headers` is the transport's **already-normalized** response-header map — lower-cased names; `string → string`, or `string → vector of strings` for a multi-valued header — the **same** cross-host shape the [failure categories](#failure-categories-closed-set) carry (`:rf.http/http-4xx` / `:rf.http/http-5xx` `:headers`). There is one header representation, end to end; the reply boundary never reshapes it. `:value` remains the decoded-and-`:accept`-projected payload — metadata never displaces it. Both the [`:after` chain](#middleware) and the app reply target see the identical `:meta` (the reply threads verbatim), so response-header concerns — rate-limit parsing, `Cache-Control` inspection, an `ETag`/`Location` read — are ordinary map reads:
+
+```clojure
+;; e.g. inside an :after, or in the :on-success handler:
+(some-> (get-in reply [:meta :headers "x-ratelimit-remaining"]) parse-long)
+```
+
+Boundaries of the slot:
+
+- **Success only.** Failure and cancellation replies carry no `:meta` — their wire facts (`:status`, `:status-text`, `:headers`, raw `:body`) already ride the classified `:error` map, exactly as before.
+- **Live transports thread it; stubs may.** The [canned success / route-map stubs](#testing) accept the same shape as **optional** data; when a stub supplies none, `:meta` is **omitted**, never fabricated (Managed-Effects: omit optional fields when absent).
+- **Privacy.** The reply **delivered to the app** carries `:meta` raw — it is on-box app data, the caller's own response. On the trace surface (`:rf.http/replied`), header values whose names are in the merged denylist (the immutable built-in defaults ∪ the app-declared [`:carriers {:headers […]}`](#http-carriers-ep-0025) extension) are redacted to `:rf/redacted` before egress, matching the failure-map `:headers` posture ([§Privacy](#privacy)); ordinary headers stay useful on-box. `:meta` is a core **wire-bearing slot**, so a per-call `:sensitive?` request force-redacts it wholesale on the trace via the shared canonical-reply elider, exactly like `:value`.
 
 The HTTP `:request-id` is **correlation metadata** under `:correlation` — it is **not** a second stale-suppression key ([Managed-Effects §Work-id correlation](Managed-Effects.md#work-id-correlation); [EP-0007](../docs/EP/EP-0007-one-name-per-fact.md): one attempt, one `:work/id`). The single `:work/id` head is `[:rf.work/http logical-id issuance attempt]` (the `logical-id` is the caller's `:request-id` when supplied, else the originating event-id; `issuance` is the monotonic per-`request-id` re-issuance counter so a superseded request and the request that supersedes it carry **distinct** work ids even though both reset their retry `attempt` to 1; `attempt` discriminates transport retries within one issuance — retries of the same logical request are distinct work ids). The frame-qualified transport request-id `[:rf.req frame-id work-id]` (landed in [Spec 016](016-Resources.md#ledger-row-retention-and-identity)) is the sanctioned second identity for process-global transport correlation; intra-frame stale suppression still keys on `:work/id`.
 
@@ -802,15 +828,15 @@ Each `:after` receives `(fn [ctx response] response')`:
 | Slot | Type | Notes |
 |---|---|---|
 | `ctx` | map | The SAME ctx the `:before` chain produced for THIS request — `{:request :args :frame :event}` plus any keys `:before`s added. Carrying the request ctx forward is what makes request-correlated handling expressible: a `:before` that stamps `::started-at (System/nanoTime)` lets the same interceptor's `:after` read the start mark and compute a wall-clock delta without app-level state. Likewise per-request header parsing, correlation-id matching, and auth-refresh keyed off the originating event become single-interceptor concerns. |
-| `response` | map | The canonical reply envelope — `{:status :ok :value <decoded> …}`, `{:status :error :error <failure-map> …}`, or `{:status :cancelled :error <aborted-map> …}`. The shape matches the reply-payload `build-reply-event` appends to the user's `:on-success` / `:on-failure` event vector. |
+| `response` | map | The canonical reply envelope — `{:status :ok :value <decoded> :meta {…} …}`, `{:status :error :error <failure-map> …}`, or `{:status :cancelled :error <aborted-map> …}`. The shape matches the reply-payload `build-reply-event` appends to the user's `:on-success` / `:on-failure` event vector. On a successful live-transport completion `:meta` carries the actual response status / status text / normalized headers ([§Successful-response metadata](#successful-response-metadata--meta)), so a response-side transform reads real wire facts, not just the decoded `:value`. |
 
 Returns the (possibly-transformed) response map. The runtime threads each `:after`'s return value through the next `:after`, then substitutes the final response into the reply-payload before `:on-success` / `:on-failure` fire.
 
 #### Motivating use cases
 
-1. **Rate-limit header parsing.** Inspect `X-RateLimit-Remaining` once on the response, attach a structured `:rate-limit` slot to the reply; downstream handlers consume the structured form without re-parsing per-call.
+1. **Rate-limit header parsing.** Read `(get-in response [:meta :headers "x-ratelimit-remaining"])` once on the response ([§Successful-response metadata](#successful-response-metadata--meta)), attach a structured `:rate-limit` slot to the reply; downstream handlers consume the structured form without re-parsing per-call.
 2. **Response-time telemetry.** `:before` stamps a wall-clock mark on ctx; `:after` reads it and computes the elapsed delta. The ctx-carried-from-before contract is what makes this expressible in a single interceptor.
-3. **Cache-Control inspection.** Parse `Cache-Control` directives once; attach a structured `:cache` slot; downstream handlers consume `:max-age` / `:public?` / etc. without re-parsing the header.
+3. **Cache-Control inspection.** Parse the `(get-in response [:meta :headers "cache-control"])` directives once; attach a structured `:cache` slot; downstream handlers consume `:max-age` / `:public?` / etc. without re-parsing the header.
 4. **401 auth-token refresh.** Inspect the failure shape on a `:status :error` response whose `:error` is `:rf.http/http-4xx` with `(:status (:error response))` == 401; tag the reply with `:auth-refresh-required true` so a downstream handler can mint a refresh dispatch without every call site reimplementing the check.
 
 ### Chain order and frame scope
@@ -1091,10 +1117,10 @@ The fx vectors the helpers synthesise are exactly the same shape as the hand-wri
 
 | Stub fx-id | Behaviour |
 |---|---|
-| `:rf.http/managed-canned-success` | Synthesises a success reply. Args take `:value` (the payload under the canonical envelope's `:value`); defaults to a literal `{:stubbed true}`. Honours the same reply-addressing keys as the live fx (`:reply-to` / `:on-success`). |
+| `:rf.http/managed-canned-success` | Synthesises a success reply. Args take `:value` (the payload under the canonical envelope's `:value`); defaults to a literal `{:stubbed true}`. Optional `:meta` rides the reply's `:meta` slot verbatim (the [§Successful-response metadata](#successful-response-metadata--meta) shape — `{:status <int> :status-text <string> :headers <normalized map>}`), so header-dependent `:after` / handler code is testable without a network; absent means absent. Honours the same reply-addressing keys as the live fx (`:reply-to` / `:on-success`). |
 | `:rf.http/managed-canned-failure` | Synthesises a failure reply. Args take `:kind` (one of `:rf.http/*`; default `:rf.http/transport`) and `:tags` (the kind-specific tags map; defaults documented per row of [§Failure categories](#failure-categories-closed-set)). |
 
-The stubs deliver a **minimal canonical reply** — `{:status :ok :value v}` on success, `{:status :error :error f}` (or `{:status :cancelled :error f}` for an `:rf.http/aborted` kind) on failure — the shape a handler actually branches on (`:status`, `:value`, `:error`). A stub has no real request lifecycle, so it omits the transport's identity facts (`:rf.reply/work-id`, `:attempt`, `:rf.reply/work-status`, `:completed-at`); those are exercised against the real transport. Same pattern as the existing http-stub idiom (see `examples_test.clj` and `ssr_end_to_end_test.clj` for prior art).
+The stubs deliver a **minimal canonical reply** — `{:status :ok :value v}` on success, `{:status :error :error f}` (or `{:status :cancelled :error f}` for an `:rf.http/aborted` kind) on failure — the shape a handler actually branches on (`:status`, `:value`, `:error`). A stub has no real request lifecycle, so it omits the transport's identity facts (`:rf.reply/work-id`, `:attempt`, `:rf.reply/work-status`, `:completed-at`); those are exercised against the real transport. A success stub **may** opt into response metadata by supplying `:meta` (per the table above; the route-map form is `{:reply {:ok v :meta {…}}}`) — when omitted, no metadata is fabricated. Same pattern as the existing http-stub idiom (see `examples_test.clj` and `ssr_end_to_end_test.clj` for prior art).
 
 #### `:after-ms` — deferring a canned reply
 
@@ -1291,7 +1317,7 @@ The composers that orchestrate per-emit redaction + stamping — `request-sensit
 
 ### 1. Header denylist (always-on)
 
-A canonical set of HTTP header names is **always sensitive** — the names themselves declare the value secret regardless of the surrounding handler's `:sensitive?` flag. Implementations MUST redact (substitute the framework-reserved `:rf/redacted` sentinel per [Spec 009 §Privacy](009-Instrumentation.md#privacy--sensitive-data-in-traces)) the values of these headers in every `:rf.http/*` trace event that carries a `:headers` slot. Header-name matching is **case-insensitive**.
+A canonical set of HTTP header names is **always sensitive** — the names themselves declare the value secret regardless of the surrounding handler's `:sensitive?` flag. Implementations MUST redact (substitute the framework-reserved `:rf/redacted` sentinel per [Spec 009 §Privacy](009-Instrumentation.md#privacy--sensitive-data-in-traces)) the values of these headers in every `:rf.http/*` trace event that carries a `:headers` slot — the failure-map `:headers` on error events **and** the successful reply's `[:meta :headers]` on the `:rf.http/replied` completion row ([§Successful-response metadata](#successful-response-metadata--meta); the reply *delivered to the app* stays raw — redaction is a trace-egress concern). Header-name matching is **case-insensitive**.
 
 The v1 closed denylist:
 


### PR DESCRIPTION
## Summary

rf2-lddbk — surface-review(http): expose successful response metadata to `:after` middleware and reply handlers.

A host-normalized 2xx response entered `handle-response!` carrying `:status` / `:status-text` / `:headers`, but the success tail passed only the accepted body value to `finalise-success!`, so neither `:after` middleware nor `:reply-to` / `:on-success` could observe status or headers for a successful request — while Spec 014 §Middleware presented rate-limit-header and Cache-Control parsing as `:after` use cases, and the two motivating JVM tests hard-coded the "parsed" values.

This threads a minimal successful-response metadata value — `{:status <int> :status-text <string> :headers <normalized map>}` — from the 2xx branch of `handle-response!` through `dispatch-success!` onto the canonical reply's existing `:meta` family-extension slot (Managed-Effects §The reply map). `:value` stays the decoded-and-accepted payload; failure replies are unchanged (their wire facts already ride `:error`). The header map is the transport's existing cross-host normalized shape (lower-cased names; string, or vector-of-strings for multi-valued) — one representation end to end.

- **Privacy**: the reply delivered to the app rides raw (on-box app data). Trace egress (`:rf.http/replied`) redacts `[:meta :headers]` names in the merged denylist (immutable built-ins ∪ app-declared `:carriers {:headers [..]}`) via a new `privacy/redact-response-meta` before the shared canonical-reply elider; per-call `:sensitive?` force-redacts the whole `:meta` wire slot through the existing `trace-reply` translation (`:meta` is already a core wire-bearing slot — no core changes).
- **Stubs**: `:rf.http/managed-canned-success` takes an optional `:meta` (rides verbatim); route-map entries accept `{:reply {:ok v :meta {…}}}`. Absent stays absent — nothing fabricated.
- **Motivating tests rewritten**: the rate-limit and Cache-Control interceptor tests now parse the local server's real header values off `[:meta :headers]`; their assertions fail if the emitted headers change without changing the expected parse.
- **Cross-host pinning**: a new deftest in the set-cookie parity `.cljc` pins that each host's real native headers object flattens and rides `[:meta :headers]` verbatim (multi-valued vector included); a live JVM test pins the two-`Set-Cookie` success case; a full-pipeline CLJS test (stubbed Fetch Response, production transport path) pins status/status-text/headers on the delivered reply.
- **Spec/docs**: Spec 014 gains §Successful-response metadata — `:meta` (envelope sample, `:after` response-slot row, motivating use cases, stub table, §Privacy headers rule); `docs/async/http.md` `:ok` row and `docs/async/http-going-further.md` gain the shape plus a working rate-limit parsing registration.

No new public var — manifest/conformance data untouched (per the bead's acceptance). Per the bead's TRIAGE note (2026-08-30, premises at e159c96fbf), the "managed-HTTP skill/example material" surface does not exist and was dropped.

## Quality gates

- `clojure -M:test` (implementation/http, full artefact suite, foreground) — **captured exit 0**: `Ran 502 tests containing 3827 assertions. 0 failures, 0 errors.` Re-run on the final rebased base (same captured exit 0, same counts).
- **Control (the new tests ARE the control)**: with the metadata un-threading planted (`dispatch-success!` reverted to the 2-arity `success-reply` call), the focused run captured **exit 1** with failures naming the new tests (`motivating-rate-limit-header-parse`, `motivating-cache-control-inspection`, `real-transport-success-reply-carries-response-meta`, `replied-trace-redacts-builtin-sensitive-response-meta-headers`, `replied-trace-redacts-app-declared-carrier-in-response-meta`, `sensitive-request-force-redacts-response-meta-wholesale`). Restore verified by git blob hash (`049a352c…` working file == `HEAD:` object).
- `python scripts/check_doc_slugs.py` — **captured exit 0** (clean run and re-run on the rebased base). Planted-fault control: a broken anchor at an edited spec/014 line returned **captured exit 1** naming `spec\014-HTTPRequests.md:597 -> #privacy-nonexistent-anchor-lddbk-plant`; restore verified by git blob hash (`96bf881c…`).
- CLJS lanes NOT run locally (a peer holds the machine's heavy shadow-cljs lane): the `.cljc`/`.cljs` side (`http_set_cookie_parity_cljs_test.cljc`, `http_cljs_test.cljs`) is covered in CI by `test.yml`'s `cljs` job (“CLJS (shadow-cljs :node-test)” — the consolidated node-test build compiling core + every per-feature artefact's CLJS test tree, discovering `cljs-test$` namespaces) — plus the JVM half of each `.cljc` in the `jvm-http` job (“JVM http (clojure -M:test)”).
- Hand-verified (no gate covers these): edited table rows keep their column counts (spec/014 §`:after` response row 3 cols, stub table row 2 cols, docs/async/http.md `:ok` row 3 cols); the new spec/014 anchor `#successful-response-metadata--meta` follows the doc's existing em-dash slug convention and is validated by check_doc_slugs.

## Known pre-existing flake (not this PR)

Running `re-frame.http-privacy-integration-test` as a SOLO namespace (`clojure -M:test -n …`) fails 4 pre-existing tests (`response-body-*`, `accept-failure-emits-category-trace-with-schema-classified-decoded`) — reproduced identically on the untouched base version of the file (captured exit 1, `Ran 17 tests`). The full-suite ordering is green before and after this change. Order-dependent fixture fragility, pre-existing; not introduced or worsened here.

