### PR TITLE
websocket pattern: safe to copy at both trust boundaries (rf2-iyjae)

### DIFF
--- a/examples/patterns/websocket/README.md
+++ b/examples/patterns/websocket/README.md
@@ -90,16 +90,23 @@ Everything below builds on those 3. The rest is ordinary machine grammar — `:a
   explicit `{:ok false :error :ws/connection-lost}` body — at-most-once
   semantics, no silent leak, and no double-execution from a blind replay.
 
-- Reconnect cascade with token refresh threaded through. Leaving `:active`
-  destroys the actor (the declarative `:spawn` desugars to a
-  `:rf.machine/destroy` on exit), and the runtime clears its id from the
-  `:rf/spawned` slot — so the connection machine needs no `:exit` action to
-  forget the id. The actor itself does carry one: an `:exit :close-socket` on
-  its `:open` state closes the host `WebSocket` on the way down, because a live
-  socket is a handle the runtime can't drop for you. After the `:after`
-  backoff, re-entering `:active` re-runs the `:spawn`'s `:data` function, which
-  re-reads the URL and token from `:data` — so a `:ws/refresh-token` arriving
-  between reconnects flows into the next socket with no extra wiring.
+- Reconnect cascade with credential rotation threaded through — and no raw
+  credential anywhere the framework can see. Machine `:data` is inspectable
+  (snapshots, traces, recorder fixtures), so it carries only an opaque
+  `:cred-ref`; the socket actor exchanges the reference for the real bearer
+  inside its private host closure at authentication time
+  (`resolve-credential` in `messages.cljs`), uses it for the one auth send,
+  and discards it. Leaving `:active` destroys the actor (the declarative
+  `:spawn` desugars to a `:rf.machine/destroy` on exit), and the runtime
+  clears its id from the `:rf/spawned` slot — so the connection machine needs
+  no `:exit` action to forget the id. The actor itself does carry one: an
+  `:exit :close-socket` on its `:open` state closes the host `WebSocket` on
+  the way down, because a live socket is a handle the runtime can't drop for
+  you. After the `:after` backoff, re-entering `:active` re-runs the
+  `:spawn`'s `:data` function, which re-reads the URL and credential
+  reference from `:data` — so a `:ws/rotate-cred` arriving between reconnects
+  flows into the next socket with no extra wiring, and the new socket
+  resolves the new reference.
 
 - An offline queue and a surviving subscription set. A `:ws/send` or
   `:ws/request` issued while off-connection buffers its whole event into

--- a/examples/patterns/websocket/connection.cljs
+++ b/examples/patterns/websocket/connection.cljs
@@ -113,8 +113,15 @@
      ;; there's no `:socket-id` here: the live socket's id lives in the
      ;; framework's `:rf/spawned` slot (read via `socket-id`), which the
      ;; runtime keeps current for us.
+     ;;
+     ;; And note `:cred-ref`, not a token. Machine `:data` is
+     ;; framework-inspectable — snapshots, traces, recorder fixtures — so a
+     ;; raw bearer must never sit here (or ride a dispatch). We carry an
+     ;; OPAQUE reference; the socket actor exchanges it for the real bearer
+     ;; inside its own host closure at authentication time
+     ;; (`websocket.messages/resolve-credential`) and discards it.
      :data    {:url            nil
-               :auth-token     nil
+               :cred-ref       nil
                :retries        0
                :max-retries    8
                :base-ms        100
@@ -149,10 +156,12 @@
 
      :actions
      {:record-connection-opts
-      (fn action-record-connection-opts [{data :data [_ {:keys [url auth-token]}] :event}]
+      ;; Caller passes the URL and an OPAQUE credential reference on
+      ;; `:ws/connect` — never the bearer itself (see `:data` above).
+      (fn action-record-connection-opts [{data :data [_ {:keys [url cred-ref]}] :event}]
         {:data (-> data
                    (assoc :url url)
-                   (assoc :auth-token auth-token)
+                   (assoc :cred-ref cred-ref)
                    (assoc :error nil))})
 
       :record-and-reset
@@ -160,16 +169,20 @@
       ;; This runs on a *manual* `:ws/connect` out of `:reconnecting` or
       ;; `:failed` — the user is asking for a clean slate, so we give them
       ;; one and forget the failed attempts.
-      (fn action-record-and-reset [{data :data [_ {:keys [url auth-token]}] :event}]
+      (fn action-record-and-reset [{data :data [_ {:keys [url cred-ref]}] :event}]
         {:data (-> data
                    (assoc :url url)
-                   (assoc :auth-token auth-token)
+                   (assoc :cred-ref cred-ref)
                    (assoc :retries 0)
                    (assoc :error nil))})
 
-      :refresh-token
-      (fn action-refresh-token [{data :data [_ token] :event}]
-        {:data (assoc data :auth-token token)})
+      :rotate-cred
+      ;; The app rotated its credential (say, the auth slice refreshed a
+      ;; session). Only the new opaque reference crosses the dispatch
+      ;; boundary; the next `:active` entry's spawn re-reads it and the new
+      ;; socket resolves it host-side.
+      (fn action-rotate-cred [{data :data [_ new-cred-ref] :event}]
+        {:data (assoc data :cred-ref new-cred-ref)})
 
       :on-socket-lost
       ;; The live socket just dropped (a `:ws/closed` that passed
@@ -209,13 +222,15 @@
         {:data (assoc data :error error)})
 
       :send-auth
-      ;; We've just entered `:authenticating`, so send the credentials:
+      ;; We've just entered `:authenticating`, so start the handshake:
       ;; route an `:auth` message into the live socket actor and wait for
-      ;; the server to bless us.
+      ;; the server to bless us. Note there's NO token in this payload —
+      ;; the actor resolved the bearer from `:cred-ref` when it opened the
+      ;; socket, holds it in its private host closure, and attaches it to
+      ;; the wire frame itself. The credential never rides a dispatch.
       (fn action-send-auth [{data :data}]
         {:fx [[:dispatch [(socket-id data)
-                          [:send {:type  :auth
-                                  :token (:auth-token data)}]]]]})
+                          [:send {:type :auth}]]]]})
 
       :flush-queue-and-resubscribe
       ;; We're connected at last. Two bits of housekeeping on entry: reset
@@ -342,13 +357,16 @@
        ;; clears its id from our :rf/spawned slot, so `socket-id` reads nil).
        ;; See docs/machines/concepts.md#when-the-machine-grows.
        :spawn {:machine-id :websocket/socket
-                ;; Hand the child the URL and token from our `:data` as it's
-                ;; born. Every fresh entry to :active re-reads whatever's
-                ;; current — so a token refreshed mid-reconnect just rides
-                ;; into the next socket, no extra plumbing.
+                ;; Hand the child the URL and the opaque `:cred-ref` from
+                ;; our `:data` as it's born. Every fresh entry to :active
+                ;; re-reads whatever's current — so a credential rotated
+                ;; mid-reconnect just rides into the next socket, no extra
+                ;; plumbing. The reference is all that moves: the child
+                ;; resolves it to the real bearer inside its own host
+                ;; closure at socket-open.
                 :data       (fn [{snap :snapshot}]
-                              {:url        (-> snap :data :url)
-                               :auth-token (-> snap :data :auth-token)})}
+                              {:url      (-> snap :data :url)
+                               :cred-ref (-> snap :data :cred-ref)})}
 
        ;; Transitions every leaf inherits. A leaf can override any of these
        ;; (deepest state wins); anything it doesn't handle falls through to
@@ -360,7 +378,7 @@
                              :action :record-error}
                :ws/send     {:action :enqueue-message}
                :ws/request  {:action :enqueue-message}
-               :ws/refresh-token {:action :refresh-token}
+               :ws/rotate-cred {:action :rotate-cred}
                :ws/disconnect {:target :disconnected}
                ;; Subscribe before we're fully connected? Just note the
                ;; topic down; the next :connected entry will actually send
@@ -430,7 +448,7 @@
                                    :action :record-and-reset}
                 :ws/send          {:action :enqueue-message}
                 :ws/request       {:action :enqueue-message}
-                :ws/refresh-token {:action :refresh-token}
+                :ws/rotate-cred   {:action :rotate-cred}
                 :ws/disconnect    {:target :disconnected
                                    :action :reset-retries}}}
 
@@ -450,7 +468,7 @@
               ;; unhandled and silently dropped — user-visible message loss.
               :ws/send          {:action :enqueue-message}
               :ws/request       {:action :enqueue-message}
-              :ws/refresh-token {:action :refresh-token}
+              :ws/rotate-cred   {:action :rotate-cred}
               :ws/disconnect    {:target :disconnected
                                  :action :reset-retries}}}}})
 

--- a/examples/patterns/websocket/messages.cljs
+++ b/examples/patterns/websocket/messages.cljs
@@ -24,10 +24,17 @@
    The two halves are kept apart on purpose. Swap the pretend server for a
    real `(js/WebSocket. url)` and the actor machine doesn't even notice.
    The shape stays put no matter the transport: the machine owns the actor,
-   the actor owns the host-side handle."
+   the actor owns the host-side handle.
+
+   Two trust boundaries also live here, because this is the host seam:
+   `resolve-credential` exchanges the machine's opaque `:cred-ref` for the
+   real bearer inside the socket closure (credentials leaving the app),
+   and `:ws/handle-message` / `:ws.app/request-reply` hold inbound frames
+   to the closed wire schemas with `:rf.schema/at-boundary` (frames
+   entering it)."
   (:require [re-frame.core :as rf]
             [re-frame.machines]
-            [websocket.schema]))
+            [websocket.schema :as schema]))
 
 ;; ============================================================================
 ;; HOST-SIDE SOCKET STORE
@@ -50,6 +57,32 @@
 
 (defn- clear-socket! [actor-id]
   (swap! sockets-by-actor dissoc actor-id))
+
+;; ============================================================================
+;; CREDENTIAL SEAM
+;; ============================================================================
+;;
+;; The connection machine carries only an OPAQUE `:cred-ref` — never the
+;; bearer. This host-side, client-only seam is where the reference becomes
+;; the real credential, at the one moment it's needed: socket
+;; authentication. `mock-socket-for-actor` calls it as the socket opens,
+;; holds the result in the socket's private closure for the one auth send,
+;; and that is the bearer's whole life — it never enters machine `:data`,
+;; a dispatch payload, app-db, or anything the framework can serialise.
+;; See skills/re-frame2/patterns/websocket.md §Credential discipline.
+
+(defn resolve-credential
+  "Exchange an opaque credential reference for the real bearer. App-owned
+   and app-prefixed — re-frame2 ships no credential surface. The demo
+   recognises two references (so credential rotation has somewhere to
+   rotate TO); swap the body for your auth slice's real lookup. Returns
+   nil for an unknown reference, which the mock server then refuses —
+   authentication genuinely depends on resolution."
+  [cred-ref]
+  (case cred-ref
+    :ws.demo/cred-a "demo-bearer-secret-a"
+    :ws.demo/cred-b "demo-bearer-secret-b"
+    nil))
 
 ;; ============================================================================
 ;; MOCK WEBSOCKET SERVER
@@ -126,10 +159,20 @@
   "Open a fresh mock socket bound to this actor's id, and return its handle.
    The handle's `:send` fn fields every outbound message the actor makes;
    the mock knows how to answer two of them — `:auth` (→ `:auth-ok`) and
-   `:request` (→ a correlated `:type :reply` echo)."
-  [actor-id _url _auth-token]
-  (let [id   (next-mock-socket-id)
-        open? (atom true)
+   `:request` (→ a correlated `:type :reply` echo).
+
+   This is also where the opaque `:cred-ref` becomes a real credential:
+   `resolve-credential` runs right here, beside socket creation, and the
+   bearer lives only in this closure — attached to the one `:auth` wire
+   frame, then gone. A real socket would do the same with
+   `(js/WebSocket. url)` in hand."
+  [actor-id _url cred-ref]
+  (let [id     (next-mock-socket-id)
+        open?  (atom true)
+        ;; The bearer's whole life is this local: resolved as the socket
+        ;; opens, read once by the `:auth` send below, never stored
+        ;; anywhere the framework can inspect.
+        bearer (resolve-credential cred-ref)
         ;; We're inside the actor's `:open-socket` action right now, which
         ;; means a frame is in scope — but the deferred deliveries below
         ;; fire from a bare `setTimeout` callback, long after it's gone.
@@ -145,11 +188,20 @@
               (when @open?
                 (case (:type msg)
                   :auth
-                  ;; Auth: reply :auth-ok or :auth-failed on the same
-                  ;; channel, a tick later (via `later`).
-                  (later
-                    #(deliver-to-actor! dispatch actor-id :received
-                                        (mock-encode-auth-reply (:token msg))))
+                  ;; Auth: the machine's `:send-auth` sends a bare
+                  ;; `{:type :auth}` — no credential in the dispatch. THIS
+                  ;; is where the bearer joins: attached to the wire frame
+                  ;; from the closure, the way a real client would write
+                  ;; `(.send socket (encode (assoc msg :token bearer)))`.
+                  ;; The mock 'server' then reads the wire frame's `:token`
+                  ;; and replies :auth-ok or :auth-failed a tick later
+                  ;; (via `later`). An unresolvable `:cred-ref` means a
+                  ;; nil `:token` on the wire — refused, so authentication
+                  ;; genuinely depends on the credential seam.
+                  (let [wire-frame (assoc msg :token bearer)]
+                    (later
+                      #(deliver-to-actor! dispatch actor-id :received
+                                          (mock-encode-auth-reply (:token wire-frame)))))
 
                   :request
                   ;; Every :request gets the same treatment: "here's your
@@ -254,8 +306,13 @@
   "The `:websocket/socket` actor spec, in its own `defmachine` so `reg-machine`
    below can point at it with per-element source captured."
     {:initial :opening
-     :data    {:url        nil
-               :auth-token nil}
+     ;; Like the parent, the actor's `:data` carries only the URL and the
+     ;; OPAQUE `:cred-ref` — the real bearer exists solely inside the
+     ;; socket closure `mock-socket-for-actor` builds. Validated on every
+     ;; transition, same as the parent's `:data`.
+     :schemas {:data schema/SocketActorData}
+     :data    {:url      nil
+               :cred-ref nil}
 
      :actions
      {:open-socket
@@ -266,7 +323,7 @@
               parent-id (:rf/parent-id data)
               socket    (mock-socket-for-actor self-id
                                                (:url data)
-                                               (:auth-token data))]
+                                               (:cred-ref data))]
           (store-socket! self-id socket)
           ;; Notice we report `:opened` as a `:dispatch` *fx*, not a bare
           ;; `(rf/dispatch ...)` in the action body. The fx inherits the
@@ -385,14 +442,29 @@
 ;; For every message that comes in — a correlated reply or a server push —
 ;; the connection machine dispatches `[:ws/handle-message body]`, and this
 ;; handler is where it lands in app-db for the views to read.
+;;
+;; This is a SYSTEM BOUNDARY: the body is the server's bytes, and on a
+;; compromised or hostile server it is whatever the sender chose. The
+;; connection machine validated the socket id, never the payload — so the
+;; payload check lives here, and `:rf.schema/at-boundary` is what keeps it
+;; in the RELEASE build (a bare `:schema` is a dev diagnostic and elides
+;; under :advanced). A frame that fails the closed `InboundMessage` union
+;; is dropped whole: the handler never runs, nothing reaches app-db, and
+;; the always-on `:rf.error/schema-validation-failure` record is the
+;; counter to alert on. See spec/Pattern-WebSocket.md §Inbound frames are
+;; untrusted.
 (rf/reg-event :ws/handle-message
-  {:doc "Fold an inbound message into app-db. It joins the
+  {:doc "Fold one inbound frame into app-db. UNTRUSTED INGRESS — the body
+         is validated against the closed `InboundMessage` wire union, in
+         every build, before this handler runs. It joins the
          [:messages :received] log, and if it's a correlated reply it also
          lands at [:messages :last-reply]. Each one gets a monotonic
          `:rx-seq` stamp on the way in — that's the inbox's stable React
          `:key`. (Server pushes carry no `:request-id`, so we can't lean
          on identity from the wire, and list position shifts as new
-         messages arrive at the top.)"}
+         messages arrive at the top.)"
+   :schema       [:cat [:= :ws/handle-message] schema/InboundMessage]
+   :interceptors [:rf.schema/at-boundary]}
   (fn handler-ws-handle-message [{:keys [db]} [_ body]]
     {:db (let [rx-seq (get-in db [:messages :rx-count] 0)]
       (-> db
@@ -450,10 +522,22 @@
                                     :timeout-ms 5000}]]]]}))
 
 (rf/reg-event :ws.app/request-reply
-  {:doc "The reply finally arrived. The connection machine fires this once
-         the correlated reply lands, handing us the app's reply body (the
-         server's echo). We just file it at [:messages :last-reply].
-         See :ws.app/request for the correlation it completes."}
+  {:doc "The request's outcome arrived. Two producers reach this event,
+         and the schema admits exactly those two shapes. (1) The
+         correlated WIRE reply: the connection machine hands on the
+         server's bytes, so this is the SECOND untrusted ingress — a reply
+         arriving under a known :request-id is still the server's bytes,
+         and it's held to the closed `ReplyMessage` contract in every
+         build. (2) A LOCALLY synthesised failure: the machine's own
+         socket-drop / timeout paths mint a tight
+         `{:request-id … :ok false :error …}` body — local truth, valid
+         here without ever being dressed as server bytes (it never
+         traverses :ws/handle-message, so it can't masquerade as a wire
+         frame in the inbox either). Either way the outcome files at
+         [:messages :last-reply]. See :ws.app/request for the correlation
+         it completes."
+   :schema       [:cat [:= :ws.app/request-reply] schema/RequestOutcome]
+   :interceptors [:rf.schema/at-boundary]}
   (fn handler-app-request-reply [{:keys [db]} [_ body]]
     {:db (assoc-in db [:messages :last-reply] body)}))
 

--- a/examples/patterns/websocket/schema.cljs
+++ b/examples/patterns/websocket/schema.cljs
@@ -1,16 +1,25 @@
 (ns websocket.schema
   "Malli schemas for the WebSocket example — the shapes we promise to hold.
 
-   Two slices get described here:
+   Three slices get described here:
 
-   - The `:ws/connection` machine's `:data` map: the URL and token, the
-     retry counters, `:subscriptions`, the offline `:queue`, and the
-     `:in-flight` map of awaited replies. The live socket actor's id isn't a
-     field here — it lives in the framework-maintained `:rf/spawned` slot
-     (see `connection.cljs`'s `socket-id`). This map hangs off the machine
-     as `[:schemas :data]`, because a machine validates its own `:data` —
-     there's no app-schema involved.
-     See docs/machines/concepts.md#validating-a-machines-data.
+   - The `:ws/connection` machine's `:data` map: the URL and the opaque
+     credential reference, the retry counters, `:subscriptions`, the
+     offline `:queue`, and the `:in-flight` map of awaited replies. The
+     live socket actor's id isn't a field here — it lives in the
+     framework-maintained `:rf/spawned` slot (see `connection.cljs`'s
+     `socket-id`). This map hangs off the machine as `[:schemas :data]`,
+     because a machine validates its own `:data` — there's no app-schema
+     involved. See docs/machines/concepts.md#validating-a-machines-data.
+     (The spawned socket actor's small `:data` map gets the same
+     treatment — `SocketActorData` below.)
+
+   - The inbound WIRE contract: a closed union of every frame the server
+     is allowed to deliver (`InboundMessage`), plus the shape of what may
+     land on the request-reply callback (`RequestOutcome`). These back the
+     `:rf.schema/at-boundary` checks on the two untrusted-ingress events
+     in `messages.cljs` — see spec/Pattern-WebSocket.md §Inbound frames
+     are untrusted.
 
    - The `:messages` slice in app-db: every message that arrives is logged
      at `[:messages :received]` for the UI to list, and the form's draft
@@ -33,10 +42,15 @@
    [:timeout-ms  :int]])
 
 (def ConnectionData
-  "The connection machine's `:data` map."
+  "The connection machine's `:data` map. Note `:cred-ref`, not a token:
+   machine `:data` is framework-inspectable (snapshots, traces, recorder
+   fixtures), so it carries only an OPAQUE credential reference — the real
+   bearer never enters `:data` or a dispatch payload. The socket actor
+   exchanges the reference for the bearer inside its own host closure at
+   authentication time (`resolve-credential` in `messages.cljs`)."
   [:map
    [:url            [:maybe :string]]
-   [:auth-token     [:maybe :string]]
+   [:cred-ref       [:maybe :keyword]]
    [:retries        :int]
    [:max-retries    :int]
    [:base-ms        :int]
@@ -59,6 +73,79 @@
    [:rf/parent-id   {:optional true} :any]
    [:rf/invoke-id  {:optional true} :any]])
 
+(def SocketActorData
+  "The spawned `:websocket/socket` actor's `:data` map — the URL and the
+   same opaque `:cred-ref` the parent carries, plus the framework keys the
+   runtime stamps into every spawned actor's `:data`. Like the parent's
+   map, it holds a credential REFERENCE only; the bearer lives in the
+   actor's private host closure and nowhere the framework can see."
+  [:map
+   [:url          [:maybe :string]]
+   [:cred-ref     [:maybe :keyword]]
+   [:rf/self-id   {:optional true} :any]
+   [:rf/parent-id {:optional true} :any]
+   [:rf/invoke-id {:optional true} :any]])
+
+;; ============================================================================
+;; INBOUND WIRE CONTRACT — the untrusted-ingress schemas
+;; ============================================================================
+;;
+;; A frame arrives from the network, so on a compromised or hostile server
+;; it carries whatever the sender chose. These schemas are the demo's
+;; closed wire contract: `:ws/handle-message` and `:ws.app/request-reply`
+;; (the two events that write server bytes into app-db) validate against
+;; them with `:rf.schema/at-boundary`, so the check survives the release
+;; build. A closed `:multi` with no default arm is what makes an
+;; unrecognised `:type` a rejection rather than a `case` fall-through.
+;; See spec/Pattern-WebSocket.md §Inbound frames are untrusted.
+
+(def ReplyMessage
+  "A correlated reply, as the server puts it on the wire: the echo the
+   mock answers every `:request` with."
+  [:map
+   [:type       [:= :reply]]
+   [:request-id :any]
+   [:ok         :boolean]
+   [:echo       {:optional true} [:map [:type :keyword]]]])
+
+(def PushMessage
+  "A server push — the subscribe ack and the manual 'Trigger server push'
+   both use this shape."
+  [:map
+   [:type  [:= :push]]
+   [:topic {:optional true} :keyword]
+   [:note  {:optional true} :string]])
+
+(def InboundMessage
+  "Every frame the server is allowed to deliver to the app: a correlated
+   `:reply` or a `:push`. Closed union — an unknown `:type` (or a missing
+   one) is a boundary rejection, never a fall-through. (The `:auth-ok` /
+   `:auth-failed` wire replies never reach this contract: the socket actor
+   routes them to the connection machine's lifecycle events, which read
+   only the socket id the actor itself stamped.)"
+  [:multi {:dispatch :type}
+   [:reply ReplyMessage]
+   [:push  PushMessage]])
+
+(def LocalRequestFailure
+  "A request outcome the connection machine itself minted — a socket drop
+   (`:ws/connection-lost`) or an elapsed deadline (`:ws/timeout`) failing a
+   still-waiting request. Closed tight: exactly these three keys, `:ok`
+   pinned false, the error a member of the two local kinds. It is local
+   truth about the connection, deliberately NOT dressed as server bytes —
+   there is no `:type`, so it can never be mistaken for a wire frame."
+  [:map {:closed true}
+   [:request-id :any]
+   [:ok         [:= false]]
+   [:error      [:enum :ws/connection-lost :ws/timeout]]])
+
+(def RequestOutcome
+  "What may land on the request-reply callback (`:ws.app/request-reply`):
+   a correlated wire reply — server bytes, held to the closed `:reply`
+   contract — or a locally synthesised failure from the machine's loss /
+   timeout paths."
+  [:or ReplyMessage LocalRequestFailure])
+
 ;; ============================================================================
 ;; APP-DB SLICES
 ;; ============================================================================
@@ -69,11 +156,11 @@
 
 (def Message
   "One message, as it sits in the log — either a server push (no
-   :request-id) or a correlated reply. The envelope is a tiny ad-hoc thing;
-   nothing here cares about the wire format. The one local addition is
-   `:rx-seq`, a monotonic counter :ws/handle-message stamps on arrival so
-   the inbox can give each row a stable React :key. It's ours, not the
-   server's."
+   :request-id) or a correlated reply. This is the STORED shape, after the
+   frame has already passed the `InboundMessage` wire contract above. The
+   one local addition is `:rx-seq`, a monotonic counter :ws/handle-message
+   stamps on arrival so the inbox can give each row a stable React :key.
+   It's ours, not the server's."
   [:map
    [:type :keyword]
    [:body {:optional true} :any]

--- a/examples/patterns/websocket/views.cljs
+++ b/examples/patterns/websocket/views.cljs
@@ -89,10 +89,14 @@
         handle        (rf/capture-frame)]
     [:div.lifecycle
      [:button {:data-testid "ws-connect"
+               ;; Note what the connect payload carries: the URL and an
+               ;; OPAQUE credential reference — never a bearer. The socket
+               ;; actor resolves the reference host-side at authentication
+               ;; time (see `websocket.messages/resolve-credential`).
                :on-click    #(dispatch [:ws/connection
                                         [:ws/connect
-                                         {:url        "ws://mock"
-                                          :auth-token "demo-token"}]])
+                                         {:url      "ws://mock"
+                                          :cred-ref :ws.demo/cred-a}]])
                :disabled    any-active?}
       "Connect"]
      [:button {:data-testid "ws-drop"

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -21,6 +21,7 @@
    the example's ns-load registrations, and the restore on the way out
    leaves them intact for any subsequent test ns."
   (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
+            [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
             [re-frame.subs :as subs]
@@ -148,7 +149,14 @@
 
   ;; --- websocket.messages -------------------------------------------------
   (rf/reg-machine :websocket/socket messages/socket-actor-machine)
+  ;; UNTRUSTED INGRESS — mirrors the example's registration exactly: the
+  ;; closed InboundMessage wire union as :schema plus the
+  ;; :rf.schema/at-boundary interceptor, so the check is release-resident
+  ;; (rf2-iyjae). The boundary-rejection tests below exercise THIS
+  ;; registration (register-all! is last-write-wins over the ns-load one).
   (rf/reg-event :ws/handle-message
+    {:schema       [:cat [:= :ws/handle-message] ws.schema/InboundMessage]
+     :interceptors [:rf.schema/at-boundary]}
     (fn handler-ws-handle-message [{:keys [db]} [_ body]]
       {:db (let [rx-seq (get-in db [:messages :rx-count] 0)]
         (-> db
@@ -182,7 +190,13 @@
                                                    :body body}
                                       :reply      [:ws.app/request-reply]
                                       :timeout-ms 5000}]]]]}))
+  ;; The SECOND untrusted ingress — a correlated reply is still the
+  ;; server's bytes. RequestOutcome admits exactly the closed wire :reply
+  ;; arm OR the machine's locally synthesised loss/timeout failure shape
+  ;; (rf2-iyjae). Mirrors the example's registration.
   (rf/reg-event :ws.app/request-reply
+    {:schema       [:cat [:= :ws.app/request-reply] ws.schema/RequestOutcome]
+     :interceptors [:rf.schema/at-boundary]}
     (fn handler-app-request-reply [{:keys [db]} [_ body]]
       {:db (assoc-in db [:messages :last-reply] body)}))
   (rf/reg-event :ws.app/subscribe-demo
@@ -268,6 +282,25 @@
     (finally
       (messages/set-mock-sync! false))))
 
+(defn- fire-after-timer!
+  "Synthesise `:reconnecting`'s `:after` timer-elapsed event so the machine
+   re-enters `:active` deterministically. The synthetic event must carry
+   the SAME delay-key the runtime armed with — for a fn-form `:after`
+   entry that is the FN itself (the `:after` table's key), because
+   `pick-after-transition` resolves the table BY that key
+   (`(get-in node [:after delay-key])`, Spec 005 §Hierarchy interaction);
+   a resolved-ms NUMBER matches nothing and silently no-ops. Read the key
+   straight off the registered spec, plus the node's current per-path
+   epoch from the runtime-maintained `:rf/after-epoch` slot."
+  [f]
+  (let [snap      (snapshot (:rf.db/runtime (rf/frame-state-value f)))
+        epoch     (get-in snap [:data :rf/after-epoch [:reconnecting]])
+        delay-key (first (keys (get-in ws.connection/connection-machine
+                                       [:states :reconnecting :after])))]
+    (rf/dispatch-sync [:ws/connection
+                       [:rf.machine.timer/after-elapsed delay-key epoch [:reconnecting]]]
+                      {:frame f})))
+
 ;; ============================================================================
 ;; CONNECTION LIFECYCLE
 ;; ============================================================================
@@ -291,7 +324,7 @@
       (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
-                                         :auth-token "demo"}]]
+                                         :cred-ref :ws.demo/cred-a}]]
                           {:frame f})
         ;; Sync-mode mock: the actor's open-then-send-auth-then-auth-ok
         ;; chain runs to completion inside the dispatch-sync stack.
@@ -303,10 +336,13 @@
           (is (false? (machine-has-tag? f :websocket/failed)))
           (is (= 0    (get-in s [:data :retries])))
           (is (some?  (socket-id-of s)))
-          ;; URL + token were recorded in :data — they survive across
-          ;; reconnects.
-          (is (= "ws://mock" (get-in s [:data :url])))
-          (is (= "demo"      (get-in s [:data :auth-token]))))))))
+          ;; URL + the OPAQUE credential reference were recorded in :data —
+          ;; they survive across reconnects. Only the reference: the machine
+          ;; never sees the bearer (rf2-iyjae).
+          (is (= "ws://mock"      (get-in s [:data :url])))
+          (is (= :ws.demo/cred-a  (get-in s [:data :cred-ref])))
+          (is (not (contains? (:data s) :auth-token))
+              "no raw-token field survives in machine :data"))))))
 
 (defn- offline-queue-test []
   (with-sync-mock!
@@ -334,7 +370,7 @@
         ;; queue-flush on :connected drains both messages.
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
-                                         :auth-token "demo"}]]
+                                         :cred-ref :ws.demo/cred-a}]]
                           {:frame f})
         (let [s (snapshot (:rf.db/runtime (rf/frame-state-value f)))]
           (is (true? (machine-has-tag? f :websocket/connected)))
@@ -348,7 +384,7 @@
         ;; Connect, then drop.
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
-                                         :auth-token "demo"}]]
+                                         :cred-ref :ws.demo/cred-a}]]
                           {:frame f})
         (is (true? (machine-has-tag? f :websocket/connected)))
         (let [pre-snap   (snapshot (:rf.db/runtime (rf/frame-state-value f)))
@@ -371,46 +407,22 @@
             ;; :on-socket-lost bumped the retry counter (and cleared the
             ;; then-empty in-flight map).
             (is (= 1 (get-in s [:data :retries]))))
-          ;; Fire the :after timer to re-enter :active. The :after key
-          ;; is the fn-form delay; the runtime stamps the matching key
-          ;; into the synthetic timer event. We need to pull the same
-          ;; descriptor — for an fn-form :after the key is the fn
-          ;; itself; but for the synthetic event the runtime passes
-          ;; the resolved-delay-ms as the second slot. Look up the
-          ;; current :after-epoch from :data and fire the after-elapsed
-          ;; event keyed by the fn-form spec.
-          (let [snap-now (snapshot (:rf.db/runtime (rf/frame-state-value f)))
-                ;; Per Spec 005 §Hierarchy interaction the epoch is
-                ;; per-decl-path; :reconnecting is the :after-bearing node.
-                epoch    (get-in snap-now [:data :rf/after-epoch [:reconnecting]])
-                ;; The :after table on :reconnecting has exactly one
-                ;; entry — the fn-form delay. Pull it out so we can
-                ;; replay the matching synthetic event.
-                base-ms        (get-in snap-now [:data :base-ms])
-                resolved-delay (long (* base-ms (Math/pow 2 (max 0 (dec (get-in snap-now [:data :retries]))))))]
-            ;; Synthesise the timer-elapsed event. The matching
-            ;; semantics: `:rf.machine.timer/after-elapsed delay epoch`
-            ;; where `delay` is either the literal ms key (when the
-            ;; :after entry is keyed by a literal) or the fn-form key
-            ;; (when keyed by an fn). Our spec is fn-keyed.
-            (rf/dispatch-sync [:ws/connection
-                               [:rf.machine.timer/after-elapsed resolved-delay epoch [:reconnecting]]]
-                              {:frame f}))
-          ;; After firing the :after timer the machine re-enters :active.
-          ;; In sync-mode the open-auth-ok cascade runs to :connected
-          ;; inside the synthetic-timer dispatch.
+          ;; Fire the :after timer to re-enter :active — `fire-after-timer!`
+          ;; carries the fn-form delay-key the runtime armed with (a
+          ;; resolved-ms number matches nothing — see the helper), so the
+          ;; re-entry is deterministic and the assertions below are
+          ;; unconditional. In sync-mode the open-auth-ok cascade runs to
+          ;; :connected inside the synthetic-timer dispatch.
+          (fire-after-timer! f)
           (let [s (snapshot (:rf.db/runtime (rf/frame-state-value f)))]
-            ;; Either :active is re-entered (and in sync-mode runs to
-            ;; :connected) OR the synthetic event was dropped as stale
-            ;; (in which case the test asserts the precondition only).
-            ;; The richer assertion is the connection-epoch one in the
-            ;; staleness test.
-            (when (= [:active :connected] (:state s))
-              (is (true? (machine-has-tag? f :websocket/connected)))
-              ;; A NEW socket id is in the :rf/spawned slot (a fresh actor,
-              ;; so a different id from pre-socket).
-              (is (not= pre-socket (socket-id-of s))
-                  "reconnect spawned a fresh socket"))))))))
+            (is (= [:active :connected] (:state s))
+                (str "the :after re-entry ran to :connected, got " (:state s)))
+            (is (true? (machine-has-tag? f :websocket/connected)))
+            ;; A NEW socket id is in the :rf/spawned slot (a fresh actor,
+            ;; so a different id from pre-socket).
+            (is (some? (socket-id-of s)))
+            (is (not= pre-socket (socket-id-of s))
+                "reconnect spawned a fresh socket")))))))
 
 (defn- max-retries-failed-test []
   ;; The `:max-retries-exceeded?` guard on `:reconnecting`'s
@@ -426,7 +438,7 @@
         ;; Connect to spawn the actor.
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
-                                         :auth-token "demo"}]]
+                                         :cred-ref :ws.demo/cred-a}]]
                           {:frame f})
         ;; Seed the snapshot's :data :retries past :max-retries via a
         ;; direct write to the machine's :data slot. This is a test
@@ -457,7 +469,7 @@
       (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
-                                         :auth-token "demo"}]]
+                                         :cred-ref :ws.demo/cred-a}]]
                           {:frame f})
         (let [live-socket-id (socket-id-of (snapshot (:rf.db/runtime (rf/frame-state-value f))))
               stale-id       (str "stale-" (random-uuid))]
@@ -474,35 +486,41 @@
               (is (= pre-msgs post-msgs)
                   "stale :ws/received was suppressed by :current-socket?")))
           ;; A :ws/received event with the LIVE source-socket-id lands
-          ;; — the :messages slice grows.
+          ;; — the :messages slice grows. (The body is a valid :push wire
+          ;; frame — the closed InboundMessage union now rejects unknown
+          ;; :type values at the boundary, which the boundary-rejection
+          ;; test pins.)
           (let [pre-msgs (count (get-in (rf/app-db-value f) [:messages :received]))]
             (rf/dispatch-sync [:ws/connection
                                [:ws/received {:source-socket-id live-socket-id
-                                              :body {:type :live-push :note "hi"}}]]
+                                              :body {:type :push :note "hi"}}]]
                               {:frame f})
             (let [post-msgs (count (get-in (rf/app-db-value f) [:messages :received]))]
               (is (= (inc pre-msgs) post-msgs)
                   "live :ws/received passed the :current-socket? guard"))))))))
 
-(defn- refresh-token-test []
-  ;; :ws/refresh-token works from every state — :disconnected,
-  ;; :active/*, :reconnecting, :failed. The next :active entry's
-  ;; :spawn :data fn reads the refreshed token.
+(defn- rotate-cred-test []
+  ;; :ws/rotate-cred works from every non-disconnected state — :active/*,
+  ;; :reconnecting, :failed. Only the OPAQUE reference crosses the dispatch
+  ;; boundary; the next :active entry's :spawn :data fn reads the rotated
+  ;; reference and the new socket resolves it host-side (rf2-iyjae).
   (with-sync-mock!
     (fn []
       (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
-                                         :auth-token "old-token"}]]
+                                         :cred-ref :ws.demo/cred-a}]]
                           {:frame f})
-        (is (= "old-token" (get-in (snapshot (:rf.db/runtime (rf/frame-state-value f)))
-                                   [:data :auth-token])))
-        ;; Refresh from :connected.
+        (is (= :ws.demo/cred-a
+               (get-in (snapshot (:rf.db/runtime (rf/frame-state-value f)))
+                       [:data :cred-ref])))
+        ;; Rotate from :connected.
         (rf/dispatch-sync [:ws/connection
-                           [:ws/refresh-token "new-token"]]
+                           [:ws/rotate-cred :ws.demo/cred-b]]
                           {:frame f})
-        (is (= "new-token" (get-in (snapshot (:rf.db/runtime (rf/frame-state-value f)))
-                                   [:data :auth-token])))))))
+        (is (= :ws.demo/cred-b
+               (get-in (snapshot (:rf.db/runtime (rf/frame-state-value f)))
+                       [:data :cred-ref])))))))
 
 (defn- disconnect-cleanly-test []
   (with-sync-mock!
@@ -510,7 +528,7 @@
       (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
-                                         :auth-token "demo"}]]
+                                         :cred-ref :ws.demo/cred-a}]]
                           {:frame f})
         (is (true? (machine-has-tag? f :websocket/connected)))
         (rf/dispatch-sync [:ws/connection [:ws/disconnect]] {:frame f})
@@ -537,7 +555,7 @@
     (fn []
       (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
-                           [:ws/connect {:url "ws://mock" :auth-token "demo"}]]
+                           [:ws/connect {:url "ws://mock" :cred-ref :ws.demo/cred-a}]]
                           {:frame f})
         (is (true? (machine-has-tag? f :websocket/connected)))
         (let [s0       (snapshot (:rf.db/runtime (rf/frame-state-value f)))
@@ -615,7 +633,7 @@
     (fn []
       (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
-                           [:ws/connect {:url "ws://mock" :auth-token "demo"}]]
+                           [:ws/connect {:url "ws://mock" :cred-ref :ws.demo/cred-a}]]
                           {:frame f})
         (is (true? (machine-has-tag? f :websocket/connected)))
         ;; A request whose wire :type the mock does NOT echo, so it sits
@@ -657,7 +675,7 @@
     (fn []
       (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
-                           [:ws/connect {:url "ws://mock" :auth-token "demo"}]]
+                           [:ws/connect {:url "ws://mock" :cred-ref :ws.demo/cred-a}]]
                           {:frame f})
         (is (true? (machine-has-tag? f :websocket/connected)))
         (let [live-id (socket-id-of (snapshot (:rf.db/runtime (rf/frame-state-value f))))
@@ -720,7 +738,7 @@
           ;; :register-request; the mock echoes and the reply correlates, all
           ;; inside this sync dispatch.
           (rf/dispatch-sync [:ws/connection
-                             [:ws/connect {:url "ws://mock" :auth-token "demo"}]]
+                             [:ws/connect {:url "ws://mock" :cred-ref :ws.demo/cred-a}]]
                             {:frame f})
           (let [s  (snapshot (:rf.db/runtime (rf/frame-state-value f)))
                 db (rf/app-db-value f)]
@@ -757,7 +775,7 @@
    `:max-retries-exceeded?` `:always` cascade."
   [f]
   (rf/dispatch-sync [:ws/connection
-                     [:ws/connect {:url "ws://mock" :auth-token "demo"}]]
+                     [:ws/connect {:url "ws://mock" :cred-ref :ws.demo/cred-a}]]
                     {:frame f})
   (re-frame.frame/swap-runtime-db! f
     (fn [rt]
@@ -810,7 +828,7 @@
           ;; :record-and-reset (the :ws/connect action out of :failed) leaves
           ;; :queue untouched, so the :connected entry's :always flush finds it.
           (rf/dispatch-sync [:ws/connection
-                             [:ws/connect {:url "ws://mock" :auth-token "demo"}]]
+                             [:ws/connect {:url "ws://mock" :cred-ref :ws.demo/cred-a}]]
                             {:frame f})
           (let [s  (snapshot (:rf.db/runtime (rf/frame-state-value f)))
                 db (rf/app-db-value f)]
@@ -874,7 +892,7 @@
       (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
-                                         :auth-token "demo"}]]
+                                         :cred-ref :ws.demo/cred-a}]]
                           {:frame f})
         ;; Issue a request. Sync-mode mock echoes immediately, so the
         ;; reply lands inside the dispatch-sync stack — :in-flight
@@ -945,7 +963,7 @@
       (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
-                                         :auth-token "demo"}]]
+                                         :cred-ref :ws.demo/cred-a}]]
                           {:frame f})
         (let [pre-count (count (get-in (rf/app-db-value f) [:messages :received]))]
           (messages/send-server-push! (rf/capture-frame f)
@@ -964,7 +982,7 @@
       (with-new-frame [f (new-frame)]
         (rf/dispatch-sync [:ws/connection
                            [:ws/connect {:url "ws://mock"
-                                         :auth-token "demo"}]]
+                                         :cred-ref :ws.demo/cred-a}]]
                           {:frame f})
         (rf/dispatch-sync [:ws.app/subscribe-demo] {:frame f})
         ;; EP-0001 (rf2-vzld77): the machine snapshot is runtime-db; `:messages`
@@ -1000,6 +1018,175 @@
       (is (= [2 1 0] (mapv :rx-seq received))
           ":rx-seq is a stable, monotonic, newest-first identity"))))
 
+;; ----------------------------------------------------------------------------
+;; TRUST BOUNDARIES (rf2-iyjae) — inbound frames + credential discipline
+;; ----------------------------------------------------------------------------
+
+(defn- inbound-boundary-structural-test []
+  ;; The RELEASE-build half of the inbound contract, pinned structurally.
+  ;; In this dev lane the router's step-1 validation enforces the :schema
+  ;; (the :rf.schema/at-boundary interceptor is a deliberate dev no-op —
+  ;; the framework pins that split in re-frame.schemas-cljs-test
+  ;; boundary-interceptor-noop-in-dev-cljs), so behavioural rejection
+  ;; alone cannot distinguish a dev-only :schema tripwire from a
+  ;; release-resident boundary: drop the interceptor and every dev-lane
+  ;; rejection test stays green while the production build loses the
+  ;; check entirely. What makes the check release-resident is the
+  ;; registration carrying BOTH the :schema and the :rf.schema/at-boundary
+  ;; reference — this is the assertion that goes red if someone removes
+  ;; the interceptor and leaves the dev tripwire.
+  (doseq [ingress [:ws/handle-message :ws.app/request-reply]]
+    (let [m (rf/handler-meta :event ingress)]
+      (is (some? (:schema m))
+          (str ingress " declares a :schema (the closed wire contract)"))
+      (is (some #{:rf.schema/at-boundary} (:interceptors m))
+          (str ingress " attaches :rf.schema/at-boundary — the release-resident half")))))
+
+(defn- inbound-boundary-rejection-test []
+  ;; Malformed and unknown frames from the LIVE socket are refused at the
+  ;; ingress: the handler never runs, [:messages :received] and
+  ;; [:messages :last-reply] don't move, and each refusal is observable as
+  ;; the :rf.error/schema-validation-failure signal attributed to the
+  ;; ingress event. Both app-db-writing ingresses are exercised — the
+  ;; push path (:ws/handle-message) and the correlated-reply path
+  ;; (:ws.app/request-reply). A valid frame still lands afterwards.
+  (with-sync-mock!
+    (fn []
+      (with-new-frame [f (new-frame)]
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock" :cred-ref :ws.demo/cred-a}]]
+                          {:frame f})
+        (is (true? (machine-has-tag? f :websocket/connected)))
+        (let [live-id (socket-id-of (snapshot (:rf.db/runtime (rf/frame-state-value f))))
+              traces  (atom [])]
+          (rf/register-listener! :trace ::boundary-traces
+                                 (fn [r] (swap! traces conj r)))
+          (try
+            (let [pre-db    (rf/app-db-value f)
+                  pre-msgs  (get-in pre-db [:messages :received])
+                  pre-reply (get-in pre-db [:messages :last-reply])
+                  rid       (random-uuid)]
+              ;; Park a request in-flight (the mock doesn't echo this
+              ;; :type), so a malformed correlated reply has a slot to
+              ;; target and reaches the SECOND ingress too.
+              (rf/dispatch-sync [:ws/connection
+                                 [:ws/request {:request-id rid
+                                               :body       {:type :silent-no-echo}
+                                               :reply      [:ws.app/request-reply]
+                                               :timeout-ms 5000}]]
+                                {:frame f})
+              ;; (1) unknown :type — the closed union has no arm for it.
+              (rf/dispatch-sync [:ws/connection
+                                 [:ws/received {:source-socket-id live-id
+                                                :body {:type :evil/exec :cmd "drop tables"}}]]
+                                {:frame f})
+              ;; (2) malformed :push — :note must be a string.
+              (rf/dispatch-sync [:ws/connection
+                                 [:ws/received {:source-socket-id live-id
+                                                :body {:type :push :note 42}}]]
+                                {:frame f})
+              ;; (3) malformed correlated :reply — right :request-id, but
+              ;; missing :ok. :receive-message routes it to BOTH ingresses;
+              ;; each must refuse it (it fails ReplyMessage, and carrying a
+              ;; :type means it can't pose as a local loss body either).
+              (rf/dispatch-sync [:ws/connection
+                                 [:ws/received {:source-socket-id live-id
+                                                :body {:type :reply :request-id rid}}]]
+                                {:frame f})
+              (let [db (rf/app-db-value f)]
+                (is (= pre-msgs (get-in db [:messages :received]))
+                    "no malformed/unknown frame reached [:messages :received]")
+                (is (= pre-reply (get-in db [:messages :last-reply]))
+                    "no malformed/unknown frame moved [:messages :last-reply]"))
+              ;; The refusals are observable — the schema-validation
+              ;; failure signal fired, attributed to EACH ingress. (In this
+              ;; dev lane the signal is step-1's :where :event emission; the
+              ;; :source :boundary spelling is the production build's, where
+              ;; the interceptor takes over — see the structural test.)
+              (let [rejections (filter #(= :rf.error/schema-validation-failure
+                                           (:operation %))
+                                       @traces)
+                    by-event   (into #{} (keep #(-> % :tags :event-id)) rejections)]
+                (is (contains? by-event :ws/handle-message)
+                    "the push-path refusal is observable and attributed")
+                (is (contains? by-event :ws.app/request-reply)
+                    "the correlated-reply-path refusal is observable and attributed"))
+              ;; Control: a VALID push still lands after all that.
+              (rf/dispatch-sync [:ws/connection
+                                 [:ws/received {:source-socket-id live-id
+                                                :body {:type :push :note "still fine"}}]]
+                                {:frame f})
+              (is (= (inc (count pre-msgs))
+                     (count (get-in (rf/app-db-value f) [:messages :received])))
+                  "a valid frame still lands — the boundary rejects, it doesn't block"))
+            (finally
+              (rf/unregister-listener! :trace ::boundary-traces))))))))
+
+(defn- credential-discipline-test []
+  ;; AC 2 (rf2-iyjae): the resolved bearer is a distinctive sentinel
+  ;; ("demo-bearer-secret-…", websocket.messages/resolve-credential). It
+  ;; must be absent from the machine snapshot, app-db, and the whole
+  ;; exercised event/trace surface across connect, drop/reconnect, and
+  ;; rotation — and resolution must genuinely GATE authentication.
+  (with-sync-mock!
+    (fn []
+      (with-new-frame [f (new-frame)]
+        (let [traces (atom [])
+              events (atom [])]
+          (rf/register-listener! :trace  ::cred-traces (fn [r] (swap! traces conj r)))
+          (rf/register-listener! :events ::cred-events (fn [r] (swap! events conj r)))
+          (try
+            ;; Initial connect authenticates via the closure-resolved bearer.
+            (rf/dispatch-sync [:ws/connection
+                               [:ws/connect {:url "ws://mock" :cred-ref :ws.demo/cred-a}]]
+                              {:frame f})
+            (is (true? (machine-has-tag? f :websocket/connected))
+                "initial connect authenticates through the resolver seam")
+            ;; Rotate to cred-b, then drop: the reconnect's fresh spawn must
+            ;; read the ROTATED reference out of :data and still authenticate.
+            (rf/dispatch-sync [:ws/connection [:ws/rotate-cred :ws.demo/cred-b]]
+                              {:frame f})
+            (messages/simulate-disconnect! (rf/capture-frame f))
+            (is (true? (machine-has-tag? f :websocket/reconnecting)))
+            (fire-after-timer! f)
+            (is (true? (machine-has-tag? f :websocket/connected))
+                "reconnect after rotation authenticates with the rotated reference")
+            (is (= :ws.demo/cred-b
+                   (get-in (snapshot (:rf.db/runtime (rf/frame-state-value f)))
+                           [:data :cred-ref])))
+            ;; The negative arm — rotate to an UNKNOWN reference and drop:
+            ;; the fresh socket resolves nil, the mock's server side refuses
+            ;; the auth frame, and the machine lands in :failed. This is
+            ;; what proves the rotated reference actually REACHED the next
+            ;; socket and that authentication depends on resolution — the
+            ;; seam is load-bearing, not decorative.
+            (rf/dispatch-sync [:ws/connection [:ws/rotate-cred :ws.demo/revoked]]
+                              {:frame f})
+            (messages/simulate-disconnect! (rf/capture-frame f))
+            (is (true? (machine-has-tag? f :websocket/reconnecting)))
+            (fire-after-timer! f)
+            (is (true? (machine-has-tag? f :websocket/failed))
+                "an unresolvable reference fails authentication — resolution gates auth")
+            ;; The sentinel sweep: nothing the framework can inspect ever
+            ;; saw a bearer. Sweep the machine snapshot, app-db, and every
+            ;; captured trace + event record in one pr-str.
+            (let [surface (pr-str {:snapshot (snapshot (:rf.db/runtime (rf/frame-state-value f)))
+                                   :app-db   (rf/app-db-value f)
+                                   :traces   @traces
+                                   :events   @events})]
+              ;; Control for the sweep itself: it must be able to SEE
+              ;; content that is genuinely on the surface — the opaque
+              ;; references are (they ride :data and dispatches by design).
+              (is (str/includes? surface ":ws.demo/cred-b")
+                  "sweep control: the sweep sees the opaque reference that IS on the surface")
+              (is (not (str/includes? surface "demo-bearer-secret"))
+                  "the raw bearer sentinel appears NOWHERE on the exercised snapshot/app-db/event/trace surface")
+              (is (not (str/includes? surface ":auth-token"))
+                  "no raw-token field anywhere on the exercised surface"))
+            (finally
+              (rf/unregister-listener! :trace  ::cred-traces)
+              (rf/unregister-listener! :events ::cred-events))))))))
+
 ;; ============================================================================
 ;; DEFTESTS — one per fixture so the :each fixture (which resets mock state
 ;; + re-registers everything) runs around each individually.
@@ -1029,9 +1216,9 @@
   (testing "connection epoch — stale :ws/received from a prior socket is dropped"
     (connection-epoch-staleness-test)))
 
-(deftest websocket-refresh-token
-  (testing ":ws/refresh-token — updates :data :auth-token"
-    (refresh-token-test)))
+(deftest websocket-rotate-cred
+  (testing ":ws/rotate-cred — updates :data :cred-ref (the opaque reference only)"
+    (rotate-cred-test)))
 
 (deftest websocket-disconnect-cleanly
   (testing "clean :ws/disconnect — :connected → :disconnected, socket-id cleared"
@@ -1097,3 +1284,22 @@
 (deftest websocket-handle-message-newest-first
   (testing ":ws/handle-message keeps the [:messages :received] log newest-first"
     (handle-message-newest-first-test)))
+
+(deftest websocket-inbound-boundary-structural
+  (testing "rf2-iyjae — both app-db-writing ingresses declare the closed wire
+            :schema AND attach :rf.schema/at-boundary, the release-resident
+            half a dev-lane rejection test cannot see"
+    (inbound-boundary-structural-test)))
+
+(deftest websocket-inbound-boundary-rejection
+  (testing "rf2-iyjae — malformed bodies and unknown :type values from the
+            live socket are refused at both ingresses, observably, without
+            touching :messages or :last-reply; a valid frame still lands"
+    (inbound-boundary-rejection-test)))
+
+(deftest websocket-credential-discipline
+  (testing "rf2-iyjae — connect/reconnect/rotation authenticate through the
+            opaque :cred-ref seam; an unresolvable reference fails auth; the
+            raw bearer sentinel is absent from the exercised snapshot,
+            app-db, event and trace surface"
+    (credential-discipline-test)))

--- a/skills/re-frame2/patterns/websocket.md
+++ b/skills/re-frame2/patterns/websocket.md
@@ -22,7 +22,7 @@ SSE (`EventSource`) and WebRTC peer connections share the same lifecycle shape �
 | `:spawn` (declarative spawn) | `:active` invokes a `:websocket/socket` child owning the JS `WebSocket`. Exiting `:active` destroys it; re-entering spawns a fresh one. |
 | `:after` (fn-form delay) | Exponential backoff timer in `:reconnecting`, computed at entry from `:retries` and `:base-ms`. |
 | `:always` | Max-retries guard on `:reconnecting` entry; queue-flush guard on `:connected` entry. |
-| Parent-level `:on` | `:ws/closed`, `:ws/fatal`, `:ws/send`, `:ws/refresh-token` declared once on `:active`, inherited by every leaf. |
+| Parent-level `:on` | `:ws/closed`, `:ws/fatal`, `:ws/send`, `:ws/rotate-cred` declared once on `:active`, inherited by every leaf. |
 | Connection-epoch staleness check | Live socket-actor's `:rf/self-id` is the epoch. Replies carry `:source-socket-id`; `:current-socket?` guard rejects events from a torn-down prior socket. |
 
 ## Credential discipline (load-bearing — read before the snippet)
@@ -31,7 +31,7 @@ Bearer tokens, cookies, refresh tokens, and similar credentials **must never liv
 
 > **The credential cofx/fx live under YOUR app's prefix, not `:rf/*`.** re-frame2 ships **no** credential surface, and the `:rf/*` root is framework-reserved (`spec/Conventions.md` §single-root reserved set). Register the credential cofx/fx under your auth slice's own feature prefix — the `:auth.cred/fetch` / `:auth.cred/store` names in this leaf are illustrative placeholders for *your* registrations, not framework-provided surfaces.
 
-For events that genuinely must carry a secret across the dispatch boundary (e.g. `:ws/refresh-token` propagating a freshly minted bearer), classify the secret's path at its owner (the three-owner model — see [`../references/cross-cutting/privacy-and-elision.md`](../references/cross-cutting/privacy-and-elision.md)). Here the bearer rides the **event payload**, so name it in the registration's `:sensitive` metadata — `(rf/reg-event :ws/refresh-token {:sensitive [[:bearer]]} handler)`; a bearer that instead lands at a durable app-db slot is classified by the writing event's `:sensitive` **commit-plane effect** — `{:db … :sensitive [[:auth :bearer]]}`.
+For events that genuinely must carry a secret across the dispatch boundary (e.g. `:ws/rotate-cred-from-bearer` propagating a freshly minted bearer — the escape hatch worked below), classify the secret's path at its owner (the three-owner model — see [`../references/cross-cutting/privacy-and-elision.md`](../references/cross-cutting/privacy-and-elision.md)). Here the bearer rides the **event payload**, so name it in the registration's `:sensitive` metadata — `(rf/reg-event :ws/rotate-cred-from-bearer {:sensitive [[:bearer]]} handler)`; a bearer that instead lands at a durable app-db slot is classified by the writing event's `:sensitive` **commit-plane effect** — `{:db … :sensitive [[:auth :bearer]]}`.
 
 The pattern below uses `:cred-ref` as the placeholder; substitute whatever opaque key your auth slice already issues (a UUID, a `(random-uuid)` index into a host-side credential vault, a session id, etc.). The crucial property: the value in `:data` is **not** the bearer itself.
 

--- a/skills/re-frame2/patterns/websocket.md
+++ b/skills/re-frame2/patterns/websocket.md
@@ -27,7 +27,7 @@ SSE (`EventSource`) and WebRTC peer connections share the same lifecycle shape �
 
 ## Credential discipline (load-bearing — read before the snippet)
 
-Bearer tokens, cookies, refresh tokens, and similar credentials **must never live in machine `:data`**. Machine state is framework-inspectable (app-db snapshots, trace emissions, recorder fixtures, pair tooling), so anything in `:data` is liable to be serialised somewhere the dev never inspects character-by-character. The canonical declaration below holds **only a credential reference** (`:cred-ref`) — an opaque key the host-side socket actor exchanges for the real bearer at spawn time via a client-only cofx (`:platforms #{:client}` so SSR never sees it). The actor uses the resolved bearer inside its own JS context and discards it; the bearer never re-enters the dispatch stream.
+Bearer tokens, cookies, refresh tokens, and similar credentials **must never live in machine `:data`**. Machine state is framework-inspectable (app-db snapshots, trace emissions, recorder fixtures, pair tooling), so anything in `:data` is liable to be serialised somewhere the dev never inspects character-by-character. The canonical declaration below holds **only a credential reference** (`:cred-ref`) — an opaque key the host-side socket actor exchanges for the real bearer at the moment it opens/authenticates the socket, via an app-owned, client-only resolver: a plain host-fn seam like the worked example's `resolve-credential` (`examples/patterns/websocket/messages.cljs`), or a client-only cofx (`:platforms #{:client}` so SSR never sees it). The actor uses the resolved bearer inside its own JS context — its private socket closure — for the auth write and discards it; the bearer never re-enters the dispatch stream.
 
 > **The credential cofx/fx live under YOUR app's prefix, not `:rf/*`.** re-frame2 ships **no** credential surface, and the `:rf/*` root is framework-reserved (`spec/Conventions.md` §single-root reserved set). Register the credential cofx/fx under your auth slice's own feature prefix — the `:auth.cred/fetch` / `:auth.cred/store` names in this leaf are illustrative placeholders for *your* registrations, not framework-provided surfaces.
 
@@ -182,7 +182,7 @@ The `:connected` `:ws/received` handler branches on `:request-id`; a `:dispatch-
 
 ## Worked example
 
-`examples/patterns/websocket/` is the canonical worked example. `connection.cljs` holds the lifecycle machine (compound `:active` parenting `:connecting` / `:authenticating` / `:connected`, a `:spawn`d socket actor, `:after` backoff, `:always` offline-queue flush, connection-epoch staleness, request/reply correlation); `messages.cljs`, `schema.cljs`, and `views.cljs` complete it. Read the source first; the declaration above is the leaf-level summary.
+`examples/patterns/websocket/` is the canonical worked example. `connection.cljs` holds the lifecycle machine (compound `:active` parenting `:connecting` / `:authenticating` / `:connected`, a `:spawn`d socket actor, `:after` backoff, `:always` offline-queue flush, connection-epoch staleness, request/reply correlation); `messages.cljs`, `schema.cljs`, and `views.cljs` complete it, and both trust boundaries are implemented there: the opaque-`:cred-ref` seam (`resolve-credential`, bearer held in the socket closure only) and the closed inbound wire union enforced with `:rf.schema/at-boundary` on both app-db-writing ingress events. Read the source first; the declaration above is the leaf-level summary.
 
 ## Pointers
 

--- a/spec/Pattern-WebSocket.md
+++ b/spec/Pattern-WebSocket.md
@@ -82,8 +82,8 @@ The connection machine composes the locked substrate:
          :authenticating → :connected} → reconnecting (with backoff) → failed."}
   (rf/make-machine-handler
     {:initial :disconnected
-     :data    {:url            nil               ;; supplied by :ws/connect; refreshed by :ws/refresh-token
-               :auth-token     nil               ;; supplied by :ws/connect (or refreshed at runtime)
+     :data    {:url            nil               ;; supplied by :ws/connect
+               :cred-ref       nil               ;; OPAQUE credential reference — never the bearer itself (see §Parameters)
                :retries        0
                :max-retries    8
                :base-ms        1000              ;; initial backoff
@@ -118,16 +118,19 @@ The connection machine composes the locked substrate:
 
      :actions
      {:record-connection-opts
-      ;; Caller passes URL + token on :ws/connect; opts land in :data and
-      ;; every subsequent reconnect re-reads them via :spawn's :data fn.
-      (fn [{:keys [data] [_ {:keys [url auth-token]}] :event}]
-        {:data (assoc data :url url :auth-token auth-token)})
+      ;; Caller passes the URL + an OPAQUE credential reference on
+      ;; :ws/connect; opts land in :data and every subsequent reconnect
+      ;; re-reads them via :spawn's :data fn. Never the bearer itself —
+      ;; see §Parameters.
+      (fn [{:keys [data] [_ {:keys [url cred-ref]}] :event}]
+        {:data (assoc data :url url :cred-ref cred-ref)})
 
-      :refresh-token
-      ;; The auth machine calls this after an out-of-band refresh; the
-      ;; next :active entry's :spawn :data fn picks up the fresh token.
-      (fn [{:keys [data] [_ token] :event}]
-        {:data (assoc data :auth-token token)})
+      :rotate-cred
+      ;; The auth machine calls this after an out-of-band credential
+      ;; rotation; only the new opaque reference crosses the dispatch
+      ;; boundary, and the next :active entry's :spawn :data fn picks it up.
+      (fn [{:keys [data] [_ new-cred-ref] :event}]
+        {:data (assoc data :cred-ref new-cred-ref)})
 
       :on-socket-lost
       ;; The live socket dropped (a :ws/closed that passed :current-socket?).
@@ -155,10 +158,12 @@ The connection machine composes the locked substrate:
                      (:in-flight data))})
 
       :send-auth
-      ;; Route an :auth message into the live socket actor.
+      ;; Route an :auth message into the live socket actor. NO token in
+      ;; the payload: the actor resolved the bearer from :cred-ref inside
+      ;; its own host closure at socket-open and attaches it to the wire
+      ;; frame itself — the credential never rides a dispatch.
       (fn [{:keys [data]}]
-        {:fx [[:dispatch [(socket-id data) [:send {:type  :auth
-                                                   :token (:auth-token data)}]]]]})
+        {:fx [[:dispatch [(socket-id data) [:send {:type :auth}]]]]})
 
       :on-connected
       ;; Compound entry action for :connected — reset the retry counter (we
@@ -222,10 +227,10 @@ The connection machine composes the locked substrate:
       :record-and-reset
       ;; Compound action — record fresh opts AND reset the retry counter.
       ;; Used on manual :ws/connect from :reconnecting / :failed (the
-      ;; running app has refreshed the token; reconnect immediately).
-      (fn [{:keys [data] [_ {:keys [url auth-token]}] :event}]
+      ;; running app has rotated its credential; reconnect immediately).
+      (fn [{:keys [data] [_ {:keys [url cred-ref]}] :event}]
         {:data (-> data
-                   (assoc :url url :auth-token auth-token)
+                   (assoc :url url :cred-ref cred-ref)
                    (assoc :retries 0))})
 
       :record-error
@@ -248,14 +253,16 @@ The connection machine composes the locked substrate:
        ;; spawns a fresh one.
        :spawn {:machine-id :websocket/socket
                 ;; Mechanism 2 from Pattern-AsyncEffect §Parameter passing
-                ;; across the boundary — the child reads URL + auth-token
-                ;; from the parent's :data at spawn time. Every re-entry to
-                ;; :active picks up whatever the parent's :data currently
-                ;; holds, so a :refresh-token between reconnects flows in
+                ;; across the boundary — the child reads URL + the opaque
+                ;; :cred-ref from the parent's :data at spawn time (the
+                ;; child resolves the reference to the real bearer inside
+                ;; its own host closure — see §Parameters). Every re-entry
+                ;; to :active picks up whatever the parent's :data currently
+                ;; holds, so a :rotate-cred between reconnects flows in
                 ;; without any extra wiring.
                 :data       (fn [{snap :snapshot}]
-                              {:url        (-> snap :data :url)
-                               :auth-token (-> snap :data :auth-token)})}
+                              {:url      (-> snap :data :url)
+                               :cred-ref (-> snap :data :cred-ref)})}
                 ;; Recording the socket-id needs no :on-spawn write and no
                 ;; :exit cleanup: on every declarative :spawn the runtime binds
                 ;; the newborn actor's id into THIS machine's :data under
@@ -279,7 +286,7 @@ The connection machine composes the locked substrate:
                :ws/fatal    {:target :failed
                              :action :record-error}
                :ws/send     {:action :enqueue-message}
-               :ws/refresh-token {:action :refresh-token}
+               :ws/rotate-cred {:action :rotate-cred}
                ;; A request issued before the connection is :connected is
                ;; queued like any other send (the whole event is buffered, so
                ;; its :request-id survives); the :connected leaf overrides
@@ -360,33 +367,35 @@ The connection machine composes the locked substrate:
                     (min (* base-ms (Math/pow 2 retries))
                          max-backoff-ms)))
                 {:target [:active]}}
-       :on     {;; Manual reconnect (e.g., after the auth machine refreshes
-                ;; the token) — short-circuit the backoff, record fresh opts,
-                ;; zero the retry counter, re-enter :active.
+       :on     {;; Manual reconnect (e.g., after the auth machine rotates
+                ;; the credential) — short-circuit the backoff, record fresh
+                ;; opts, zero the retry counter, re-enter :active.
                 :ws/connect {:target [:active]
                              :action :record-and-reset}
                 :ws/send    {:action :enqueue-message}
                 :ws/request {:action :enqueue-message}
-                :ws/refresh-token {:action :refresh-token}}}
+                :ws/rotate-cred {:action :rotate-cred}}}
 
       :failed
-      {:on {:ws/connect       {:target [:active]
-                               :action :record-and-reset}
-            :ws/refresh-token {:action :refresh-token}}}}}))
+      {:on {:ws/connect     {:target [:active]
+                             :action :record-and-reset}
+            :ws/rotate-cred {:action :rotate-cred}}}}}))
 ```
 
-The `:websocket/socket` invoked actor is itself a small machine (or fx-backed event handler) that owns the JS `WebSocket` instance and translates `:open`, `:message`, `:error`, `:close` events into dispatches back to the parent connection machine. Every outgoing dispatch carries `:source-socket-id` (the actor's `:rf/self-id`, per [005 §Runtime stamps on the spawned actor's `:data`](005-StateMachines.md#runtime-stamps-on-the-spawned-actors-data)) so the parent's `:current-socket?` guard can suppress messages from a prior socket if one happens to dispatch in flight as the cascade tears it down. The actor's lifetime is bound to `:active` — leaving `:active` (whether to `:reconnecting` on error or `:failed` fatally) destroys it; re-entering `:active` creates a fresh socket.
+The `:websocket/socket` invoked actor is itself a small machine (or fx-backed event handler) that owns the JS `WebSocket` instance and translates `:open`, `:message`, `:error`, `:close` events into dispatches back to the parent connection machine. It is also where the opaque `:cred-ref` becomes a real credential: the actor resolves the reference inside its own host closure as the socket opens, attaches the bearer to the auth wire frame, and discards it — the bearer never enters machine `:data` or a dispatch (see §Parameters). Every outgoing dispatch carries `:source-socket-id` (the actor's `:rf/self-id`, per [005 §Runtime stamps on the spawned actor's `:data`](005-StateMachines.md#runtime-stamps-on-the-spawned-actors-data)) so the parent's `:current-socket?` guard can suppress messages from a prior socket if one happens to dispatch in flight as the cascade tears it down. The actor's lifetime is bound to `:active` — leaving `:active` (whether to `:reconnecting` on error or `:failed` fatally) destroys it; re-entering `:active` creates a fresh socket.
 
 ### Parameters
 
-The connection's `:url` and `:auth-token` arrive on the `:ws/connect` event:
+The connection's `:url` and an **opaque credential reference** arrive on the `:ws/connect` event:
 
 ```clojure
-(rf/dispatch [:ws/connection [:ws/connect {:url        "wss://api.example.com/ws"
-                                           :auth-token (some-token)}]])
+(rf/dispatch [:ws/connection [:ws/connect {:url      "wss://api.example.com/ws"
+                                           :cred-ref (current-session-cred-ref)}]])
 ```
 
-`:record-connection-opts` persists them into `:data`; the `:active` state's `:spawn` `:data` fn reads them out at spawn time and threads them into the child `:websocket/socket` actor. **Every reconnect re-reads `:data` at the new `:active` entry**, so a refreshed token (via `[:ws/connection [:ws/refresh-token new-token]]`) automatically flows into the next socket without re-dispatching `:ws/connect`. A full re-target (different URL) is a fresh `:ws/connect` that records the new opts and forces an `:active` re-entry.
+`:cred-ref` is a REFERENCE — a session id, a vault index, any opaque key your auth slice issues — never the bearer itself. Machine `:data` is framework-inspectable (snapshots, trace emissions, recorder fixtures, pair tooling), so a raw bearer, cookie, or refresh token must never enter `:data` or ride a dispatch payload. The socket actor exchanges the reference for the real credential inside its own host closure at the moment it opens/authenticates the socket — the worked example's `resolve-credential` seam in `examples/patterns/websocket/messages.cljs` — writes it to the auth wire frame, and discards it.
+
+`:record-connection-opts` persists URL + reference into `:data`; the `:active` state's `:spawn` `:data` fn reads them out at spawn time and threads them into the child `:websocket/socket` actor. **Every reconnect re-reads `:data` at the new `:active` entry**, so a rotated credential (via `[:ws/connection [:ws/rotate-cred new-cred-ref]]`, carrying only the new reference) automatically flows into the next socket without re-dispatching `:ws/connect`. A full re-target (different URL) is a fresh `:ws/connect` that records the new opts and forces an `:active` re-entry.
 
 For the canonical menu of mechanisms — event payload (used here for caller-supplied URL/token), spawn-spec `:data` fn (used between this machine and the child socket actor), and boot-time host config (when the URL is fixed by build-time config and threaded in by the boot machine) — see [Pattern-AsyncEffect §Parameter passing across the boundary](Pattern-AsyncEffect.md#parameter-passing-across-the-boundary).
 
@@ -459,7 +468,7 @@ A bare `:schema` is not that check. It is an ordinary registration diagnostic �
 
 ### Re-authentication on reconnect
 
-Token expiry across reconnects has two recovery paths, both supported by the worked machine. **Proactive**: the auth machine refreshes the token and dispatches `[:ws/connection [:ws/refresh-token new-token]]`; the `:refresh-token` action updates `:data :auth-token`; the next `:active` entry's `:spawn` `:data` fn picks up the fresh value. **Reactive**: a reconnect into `:authenticating` fails with `:ws/auth-failed` and the machine transitions to `:failed`; the auth machine observes via a `[:rf/machine <id>]` subscription (per [005 §Subscribing to machines via the `:rf/machine` sub](005-StateMachines.md#subscribing-to-machines-via-the-rfmachine-sub)), runs its refresh, and dispatches `[:ws/connection [:ws/connect {:url ... :auth-token new-token}]]` to re-target. Either way, refreshed credentials land in `:data` and the next `:active` entry threads them through `:spawn` `:data`.
+Credential expiry across reconnects has two recovery paths, both supported by the worked machine. **Proactive**: the auth machine refreshes the credential host-side and dispatches `[:ws/connection [:ws/rotate-cred new-cred-ref]]` carrying only the opaque reference; the `:rotate-cred` action updates `:data :cred-ref`; the next `:active` entry's `:spawn` `:data` fn picks up the fresh reference and the new socket resolves it to the new bearer. **Reactive**: a reconnect into `:authenticating` fails with `:ws/auth-failed` and the machine transitions to `:failed`; the auth machine observes via a `[:rf/machine <id>]` subscription (per [005 §Subscribing to machines via the `:rf/machine` sub](005-StateMachines.md#subscribing-to-machines-via-the-rfmachine-sub)), runs its refresh, and dispatches `[:ws/connection [:ws/connect {:url ... :cred-ref new-cred-ref}]]` to re-target. Either way, only the opaque reference lands in `:data`; the bearer stays host-side, resolved by the spawning socket's own closure.
 
 ## SSR
 
@@ -476,7 +485,8 @@ This mirrors the rule for any client-only fx: the `:platforms` metadata gates ex
 - **Storing the `WebSocket` object in `app-db`.** The JS `WebSocket` is not a value; it cannot serialise; it cannot survive Tool-Pair epoch replay. The `:websocket/socket` actor owns it via a host-side reference; only its id appears in `:data` — under the runtime-maintained `:rf/spawned` slot.
 - **Leaking in-flight requests when the socket drops.** A request already on the wire when the connection is lost can never be answered on that socket; left in `:in-flight` it dangles forever (its timeout is stamped with the dead socket-id, so `:current-socket?` drops the timeout after reconnect and the slot never clears). Fail each on loss — fire its `:reply-event` with `{:ok false :error :ws/connection-lost}` and clear `:in-flight` (the worked example's `:on-socket-lost`) — so callers learn the outcome. FAIL, not blind replay: the server may already have processed the request, so re-sending risks double execution.
 - **Anchoring the `:spawn` on `:connecting` instead of the `:active` parent.** A socket actor scoped to `:connecting` is destroyed the moment the leaf transitions to `:authenticating` — every dispatch from `:authenticating` and `:connected` then addresses a dead actor. The actor's lifetime must outlive every leaf that dispatches through it; the hierarchical parent is the natural anchor.
-- **Forgetting to re-thread connection opts on reconnect.** Recording `:url` and `:auth-token` only in `:disconnected`'s `:ws/connect` handler — and never refreshing them on the `:reconnecting` → `:active` path — means a token expiry mid-session can never recover. Either store opts in `:data` (where the `:spawn` `:data` fn re-reads them on every `:active` entry — the worked example's approach) or provide an explicit `:ws/refresh-token` slot at the parent level.
+- **Storing a raw bearer / cookie / refresh token in machine `:data`, or dispatching one through the machine.** `:data` is framework-inspectable — app-db snapshots, trace emissions, recorder fixtures, pair tooling — so a credential held there is liable to be serialised somewhere nobody inspects character-by-character. Carry an opaque `:cred-ref` and resolve it to the real bearer inside the socket actor's host closure at authentication time (see §Parameters).
+- **Forgetting to re-thread connection opts on reconnect.** Recording `:url` and `:cred-ref` only in `:disconnected`'s `:ws/connect` handler — and never refreshing them on the `:reconnecting` → `:active` path — means a credential expiry mid-session can never recover. Either store opts in `:data` (where the `:spawn` `:data` fn re-reads them on every `:active` entry — the worked example's approach) or provide an explicit `:ws/rotate-cred` slot at the parent level.
 - **Skipping the connection-epoch check on socket-sourced events.** Without `:current-socket?` (or equivalent) on `:ws/received` **and** on the lifecycle transitions `:ws/opened`, `:ws/auth-ok`, `:ws/auth-failed`, `:ws/closed`, a slow event from a torn-down socket can land after a reconnect and act on the fresh connection: a stale `:message` processed against the new `:in-flight` map (wrong-reply dispatch, or a slot cleared by a stale correlation id), or a stale `:ws/closed` tearing the live connection back to `:reconnecting`. The guard is one key; skipping it is the websocket equivalent of [012 §Navigation tokens](012-Routing.md#navigation-tokens--stale-result-suppression)'s nav-token bug.
 - **Hardcoding the wire format in the pattern.** EDN, JSON, MessagePack, Protobuf — the connection machine doesn't care. The `:websocket/socket` actor serialises on send and deserialises on receive; the machine sees plain Clojure values.
 - **Declaring a `:schema` on the receiving handler and calling the ingress guarded.** That schema is a development diagnostic and elides, so on the build facing the real network there is no check at all. The connection machine validates the socket-id, never the payload, so nothing else covers it either. Add `:rf.schema/at-boundary` to the handler's `:interceptors` — see [§Inbound frames are untrusted](#inbound-frames-are-untrusted-and-schema-alone-will-not-check-them).

--- a/spec/Pattern-WebSocket.md
+++ b/spec/Pattern-WebSocket.md
@@ -397,7 +397,7 @@ The connection's `:url` and an **opaque credential reference** arrive on the `:w
 
 `:record-connection-opts` persists URL + reference into `:data`; the `:active` state's `:spawn` `:data` fn reads them out at spawn time and threads them into the child `:websocket/socket` actor. **Every reconnect re-reads `:data` at the new `:active` entry**, so a rotated credential (via `[:ws/connection [:ws/rotate-cred new-cred-ref]]`, carrying only the new reference) automatically flows into the next socket without re-dispatching `:ws/connect`. A full re-target (different URL) is a fresh `:ws/connect` that records the new opts and forces an `:active` re-entry.
 
-For the canonical menu of mechanisms — event payload (used here for caller-supplied URL/token), spawn-spec `:data` fn (used between this machine and the child socket actor), and boot-time host config (when the URL is fixed by build-time config and threaded in by the boot machine) — see [Pattern-AsyncEffect §Parameter passing across the boundary](Pattern-AsyncEffect.md#parameter-passing-across-the-boundary).
+For the canonical menu of mechanisms — event payload (used here for the caller-supplied URL and opaque `:cred-ref`), spawn-spec `:data` fn (used between this machine and the child socket actor), and boot-time host config (when the URL is fixed by build-time config and threaded in by the boot machine) — see [Pattern-AsyncEffect §Parameter passing across the boundary](Pattern-AsyncEffect.md#parameter-passing-across-the-boundary).
 
 ### Subscription protocol
 


### PR DESCRIPTION
Closes rf2-iyjae.

The canonical runnable WebSocket example, its external CLJS wrapper, spec/Pattern-WebSocket.md, and the WebSocket skill now agree on both trust-boundary contracts, so the code programmers and coding agents copy is the safe form.

## Credentials leaving the app

- Connection and socket-actor machine `:data` (and their schemas) carry an opaque `:cred-ref` only — never a bearer. Connect/reconnect/rotation payloads carry only the reference; `:ws/refresh-token` is renamed `:ws/rotate-cred` to match the skill's canonical vocabulary.
- The new app-owned, client-only seam `websocket.messages/resolve-credential` exchanges the reference for the real bearer at the one moment it is needed: inside `mock-socket-for-actor`'s private closure at socket authentication. The machine's `:send-auth` now sends a bare `{:type :auth}`; the closure attaches the bearer to the wire frame itself (the shape a real `(.send socket (encode (assoc msg :token bearer)))` takes). An unresolvable reference yields a nil wire token and the mock refuses it — resolution genuinely gates auth.
- spec/Pattern-WebSocket.md's worked machine, §Parameters, §Re-authentication and the anti-patterns teach the same contract (new anti-pattern bullet for raw credentials in `:data`); the README's rotation paragraph is rewritten; the skill's credential paragraph now names the example's resolver seam and the worked-example section names both boundaries.
- Follow-up alignment on the resumed run: the spec's §Parameters mechanism-menu line now says "URL and opaque `:cred-ref`" instead of "URL/token"; the skill's feature table speaks `:ws/rotate-cred` (matching its own canonical declaration), and its sensitive-path escape-hatch prose names the event `:ws/rotate-cred-from-bearer`, matching the worked snippet below it.

## Frames entering the app

- `websocket.schema` gains the demo's closed wire contract: `InboundMessage` (`:multi` on `:type`, arms `ReplyMessage` | `PushMessage`, no default arm — unknown or missing `:type` is a rejection), plus `RequestOutcome` (`ReplyMessage` OR the closed `LocalRequestFailure` shape the machine itself mints on socket-drop/timeout, deliberately `:type`-less so local truth can't pose as server bytes).
- `:ws/handle-message` validates against `InboundMessage` with `:rf.schema/at-boundary`; `:ws.app/request-reply` — the second app-db-writing ingress — gets the same release-resident treatment via `RequestOutcome`. Locally synthesised loss replies stay valid and never traverse `:ws/handle-message`.

## Wrapper proof (implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs)

- `websocket-inbound-boundary-structural`: both ingress registrations carry the `:schema` AND the `:rf.schema/at-boundary` reference — the release-resident half. In the dev node lane step-1 router validation enforces `:schema` while the boundary interceptor is a deliberate dev no-op (framework-pinned split), so removing the interceptor keeps every behavioural rejection green while the production build loses the check; this structural pin is what goes red.
- `websocket-inbound-boundary-rejection`: an unknown `:type`, a malformed push, and a malformed correlated reply (right `:request-id`, missing `:ok`) are refused at both ingresses — `[:messages :received]` and `[:messages :last-reply]` unmoved, each refusal observable as `:rf.error/schema-validation-failure` attributed to its ingress event — and a valid frame still lands afterwards.
- `websocket-credential-discipline`: connect, rotate-then-drop reconnect, all authenticate through the seam; rotating to an unknown reference makes the NEXT socket fail auth into `:failed` (rotation provably reaches the spawn; resolution gates auth); a `pr-str` sweep over the machine snapshot, app-db, and every captured `:trace`/`:events` record finds the bearer sentinel nowhere (with a positive control proving the sweep sees the cred-ref that IS there).
- The reconnect-cascade test's `:after` re-entry is now deterministic and unconditional: the synthetic timer event must carry the fn-form delay-KEY the runtime armed with (`pick-after-transition` resolves the `:after` table by key); the old resolved-ms number matched nothing, so the hedged `when` branch never ran.
- Existing lifecycle tests (backoff, stale-epoch, queue flush, replay, correlation, timeout, fail-in-flight, teardown) keep their coverage on `:cred-ref` payloads; the raw-token snapshot assertions are replaced by no-token assertions.

Examples remain test-free; regression coverage lives in the wrapper above. Verified by hand: markdown anchors and table columns in the touched spec/skill/README prose (the link gates below cover targets/anchors, not prose).

## Quality gates

Final runs on the resumed attempt, branch rebased onto origin/main at `693522886c` (the only trunk commits past that base at push time touch `.beads/issues.jsonl` alone — outside every gated surface). All exit codes captured from the runner itself (log + exit file per attempt):

- `npm run test:cljs` (from the worktree's `implementation/`): captured exit 0 — 11098 tests, 54414 assertions, 0 failures, 0 errors. The run's own config line names the worktree's `shadow-cljs.edn`, and the executed build's `cljs-runtime` contains the compiled `re_frame.websocket_cljs_test.js` with the new trust-boundary deftests, loader-required by `out/node-test.js`.
  - Control retained from the first attempt (pre-rebase base): with `:rf.schema/at-boundary` removed from the `:ws/handle-message` mirror (schema kept), exit 1 — exactly 1 failure, `websocket-inbound-boundary-structural`; restore verified by identical git blob hash; post-restore rerun exit 0.
- `npm run test:examples-compile`: captured exit 0 — "all 56 swept builds compiled with zero warnings", `[:examples/websocket] Build completed. (0 warnings)`, config line naming the worktree.
- `python scripts/check_doc_slugs.py`: captured exit 0.
  - Control (this attempt): planted broken link in skills/re-frame2/patterns/websocket.md → exit 1 naming the planted file/line/target; restored, blob hash identical to HEAD → the exit-0 verdict stands for the exact final bytes.
- `python scripts/check_readme_links.py --ci`: captured exit 0.
  - Control (this attempt): planted broken link in examples/patterns/websocket/README.md → exit 1 naming the planted file/line/target; restored, blob hash identical to HEAD.
