### PR TITLE
docs(hicasso): the lint export README names the split replacement authority (rf2-r3r00)

### DIFF
--- a/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
+++ b/implementation/hicasso/resources/clj-kondo.exports/day8/re-frame2-hicasso/README.md
@@ -26,10 +26,15 @@ prop reads as `Unresolved symbol`.
 
 No custom `:re-frame.hicasso/*` findings ship here. An earlier version
 carried six bespoke behavioral checks — a hand-maintained scope grammar and
-Hiccup walkers policing a narrow, non-authoritative slice of what the runtime
-already refuses — and they were retired (rf2-r3r00): each mistake they could
-see is refused loudly at its execution boundary, with a named
-`:rf.error/hicasso-*` id and a documented recovery route, which is the
-authoritative version of the same assistance. A clj-kondo hook sees one form
-at a time and does not know your program; a lint layer that guesses is one
-people learn to ignore.
+Hiccup walkers policing a narrow, non-authoritative slice — and they were
+retired (rf2-r3r00). What they policed has more authoritative owners, and
+not one owner. A bad head, a read outside render, a deferral crossing a
+boundary — these the runtime refuses loudly at execution, with a named
+`:rf.error/hicasso-*` id and a documented recovery route. An unkeyed mapped
+child is React's own missing-key warning. A nameless interactive element is
+the test kit's job, whose `ht/unnamed-controls` inspects the whole tree
+rather than one form. And a read parked in a mutable reference is a
+documented judgment call — forcing it inside another body is undefined
+conduct, which nothing polices. A clj-kondo hook sees one form at a time and
+does not know your program; a lint layer that guesses is one people learn to
+ignore.


### PR DESCRIPTION
## What

Residual from the merged-PR audit of #8808 (recorded on rf2-r3r00): the reduced clj-kondo export's shipped README overstated the replacement contract, claiming every mistake the six retired checks could see is refused at execution with a named `:rf.error/hicasso-*` id. That is true only for the runtime-owned slice. This PR corrects that one paragraph to name the split authority:

- **Runtime refusals** — a bad head (`:rf.error/hicasso-bad-head`, impl/codec.cljs), a read outside render (`:rf.error/hicasso-sub-outside-render`, impl/collector.cljs), a boundary-crossing deferral (impl/codec.cljs).
- **React** — an unkeyed mapped child is React's own missing-key warning, not a named runtime refusal.
- **Test kit** — a nameless interactive element is `ht/unnamed-controls`' tree-level accessibility inspection.
- **Documented judgment** — a parked read is undefined conduct nothing polices (per the retired finding's own text and rf2-djxr).

No lint checks restored, no runtime change, no gate added, no historical records swept. One file, +12/−7.

## Quality gates

- `python scripts/check_readme_links.py --ci` — captured exit **0** (the gate for READMEs beside source). Negative control: a broken link planted in this exact file went red with captured exit **1**, naming the file, line and target — proving the gate scanned this tree and that this README is inside its roster. The plant was removed and the restore verified by git blob hash against the committed object (match).
- `npm run test:hicasso-lint` (self-test + smoke, from implementation/) — captured exit **0**: all five self-test negative controls red correctly (each macro-shape rewrite unavailable reds; a behavioral linter riding back in reds) and the unmutated shipped export passes with its sentinel.
- Prose accuracy hand-verified (no automated gate covers README prose): both cited `:rf.error/hicasso-*` ids exist at their named refusal sites; `ht/unnamed-controls` is the test kit's tree-level inspection per docs/core/hicasso/api-reference.md; the parked-read undefined-conduct wording matches the retired finding's own documentation.

Not a matrix-moving PR: no workflow, script, or scheduling edits.