### PR TITLE
epoch: replace-frame-state! is an exact-incarnation transaction end to end (rf2-gj2bo)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -429,34 +429,70 @@
 ;; the operation rather than installing state without an undo anchor.
 
 (defn- record-synthetic-replace-epoch!
-  "Record and fan out one synthetic pair-tool epoch.
+  "Record and fan out one synthetic pair-tool epoch, as an EXACT-incarnation
+  transaction keyed on `incarnation-token` — the token the replace's
+  preconditions resolved and its physical write already committed under
+  (rf2-gj2bo, following the `commit-record!` pattern above). Claiming
+  whichever same-id token happens to be CURRENT is the defect this guards
+  against: after A's write has linearized, a same-id successor B seated at
+  any callback boundary must never inherit A's synthetic record, ring entry,
+  last-settled anchor, trace, or listener delivery. So the claim, the digest
+  resolution, the record + anchor commit (`commit-frame-owner-record!`, one
+  owner-fenced transaction), and each callback-bearing tail (trace emit,
+  listener fan-out) all revalidate exact ownership; owner loss STOPS the
+  remaining bookkeeping rather than RETARGETING it onto B.
 
   The record remains raw for replay and becomes the frame's last-settled
   attribution anchor. With no application event in flight, `:committed-at`
   uses `epoch-now-ms`: a durable wall-clock value, not the elapsed-time clock."
-  [frame-id fs-before fs-after]
-  (when-let [owner-token (frame/frame-incarnation-token frame-id)]
-    (state/claim-frame-owner! frame-id owner-token))
-  (let [record (assoc (assembly/build-record frame-id fs-before fs-after []
-                                             (interop/epoch-now-ms))
-                      :event-id      :rf.epoch/db-replaced
-                      :trigger-event [:rf.epoch/db-replaced])]
-    (state/record! record)
-    (state/set-last-settled-epoch! frame-id (:epoch-id record))
-    (trace/emit! :rf.epoch :rf.epoch/db-replaced
-                 {:frame       frame-id
-                  :rf.epoch/id (:epoch-id record)})
-    (listeners/notify-listeners! record)
-    record))
+  [frame-id incarnation-token fs-before fs-after]
+  (let [continue? #(frame/event-continuation-live? frame-id incarnation-token)]
+    (when (and incarnation-token
+               (state/claim-frame-owner! frame-id incarnation-token continue?))
+      ;; Resolve the only callback-bearing assembly input before building —
+      ;; a digest hook that churns A to B fences every state write below.
+      (when (continue?)
+        (let [schema-digest (assembly/current-schema-digest frame-id continue?)]
+          (when (continue?)
+            (let [record     (assoc (assembly/build-record frame-id fs-before fs-after []
+                                                           (interop/epoch-now-ms)
+                                                           :ok nil schema-digest)
+                                    :event-id      :rf.epoch/db-replaced
+                                    :trigger-event [:rf.epoch/db-replaced])
+                  ;; Record + anchor publish as one exact-owner transaction:
+                  ;; cleanup-before-commit and B-before-commit reject,
+                  ;; commit-before-cleanup is erased by cleanup.
+                  published? (and (continue?)
+                                  (state/commit-frame-owner-record!
+                                    frame-id incarnation-token record))]
+              (when (and published? (continue?))
+                (trace/emit! :rf.epoch :rf.epoch/db-replaced
+                             {:frame       frame-id
+                              :rf.epoch/id (:epoch-id record)}))
+              (when (and published? (continue?))
+                (listeners/notify-listeners! record continue?))
+              (when (and published? (continue?)) record))))))))
 
 (defn- perform-replace!
-  "Carry out a frame-state patch after preconditions pass.
+  "Carry out a frame-state patch after preconditions pass, FENCED to the
+  exact frame incarnation the preconditions resolved against
+  (`incarnation-token`, from `check-replace-frame-state-preconditions!` —
+  rf2-gj2bo, mirroring `perform-restore!`).
 
-  Liveness is checked again at the write boundary. The write result closes the
-  remaining teardown race: nil means the frame disappeared before the write
-  landed, while any non-nil changed-key set, including empty, is a successful
-  live-frame write. Failure is reported before telemetry, listener fan-out, or
-  a synthetic epoch can claim success.
+  Liveness is checked again at the write boundary, against the EXACT token
+  rather than the bare id: a same-id successor seated between validation and
+  this write can therefore never receive the patch — the gate refuses with
+  the SAME canonical `:rf.error/no-such-handler` failure a destroyed-frame
+  race produces, and `write-fn` (core's exact-incarnation 3-arity write)
+  closes the post-liveness half of the window. The write result settles the
+  remaining teardown race: nil means the exact incarnation was lost before
+  the write landed (destroyed, or reseated), while any non-nil changed-key
+  set, including empty, is a successful live-incarnation write. Failure is
+  reported before telemetry, listener fan-out, or a synthetic epoch can claim
+  success. Once the exact-incarnation write HAS linearized, the public result
+  stays `true`; the synthetic bookkeeping that follows is itself
+  token-fenced (`record-synthetic-replace-epoch!`), so post-write owner loss
+  STOPS the tail rather than retargeting it onto a successor.
 
   The coherent read (`fs-before`), the physical write, and the synthetic-epoch
   bookkeeping run under the frame's `:drain-lock` (`serialize-tool-write!`), so
@@ -466,31 +502,40 @@
   transition, and a concurrent event's update to an omitted partition is never
   lost or silently reverted (rf2-3fc89f.4). A replace invoked reentrantly from
   the active drainer refuses with `:rf.epoch/replace-during-drain`."
-  [frame-id fs-after-fn write-fn]
+  [frame-id incarnation-token fs-after-fn write-fn]
   (tool-pair/serialize-tool-write!
     frame-id
     :rf.epoch/replace-during-drain
     {:frame frame-id}
     (fn []
-      (let [{:keys [outcome op tags]} (tool-pair/live-container-or-fail frame-id)]
-        (if (= :fail outcome)
-          (do (tool-pair/emit-precondition-failure! op tags)
-              false)
-          (let [;; Record the same coherent whole-frame value the write installs.
-                ;; Read under the drain lock so the write's own re-read (which
-                ;; preserves omitted partitions) sees this same state — fs-after
-                ;; then equals the installed value. Nil means teardown won the
-                ;; post-liveness race; an empty set is still a successful no-op
-                ;; write against a live frame.
-                fs-before (frame/frame-state-value frame-id)
-                fs-after  (fs-after-fn fs-before)
-                changed   (write-fn)]
-            (if (nil? changed)
-              (do (tool-pair/emit-precondition-failure! :rf.error/no-such-handler
-                                                        {:kind :frame :frame frame-id})
-                  false)
-              (do (record-synthetic-replace-epoch! frame-id fs-before fs-after)
-                  true))))))))
+      (if-not (frame/event-continuation-live? frame-id incarnation-token)
+        ;; The incarnation these preconditions resolved against is no longer
+        ;; live — a same-id SUCCESSOR was seated (or the frame was destroyed /
+        ;; is being torn down) between validation and this write. Refuse via
+        ;; the SAME canonical no-such-handler failure a destroyed-frame write
+        ;; race uses (rf2-gj2bo). The successor stays byte-for-byte untouched;
+        ;; no success telemetry fires.
+        (do (tool-pair/emit-precondition-failure! :rf.error/no-such-handler
+                                                  {:kind :frame :frame frame-id})
+            false)
+        (let [;; Record the same coherent whole-frame value the write installs.
+              ;; Read under the drain lock so the write's own re-read (which
+              ;; preserves omitted partitions) sees this same state — fs-after
+              ;; then equals the installed value. The write goes through the
+              ;; EXACT-INCARNATION arity: nil means the incarnation was lost
+              ;; after the gate (destroyed, or reseated — the post-liveness
+              ;; race); an empty set is still a successful no-op write against
+              ;; the live incarnation.
+              fs-before (frame/frame-state-value frame-id)
+              fs-after  (fs-after-fn fs-before)
+              changed   (write-fn)]
+          (if (nil? changed)
+            (do (tool-pair/emit-precondition-failure! :rf.error/no-such-handler
+                                                      {:kind :frame :frame frame-id})
+                false)
+            (do (record-synthetic-replace-epoch! frame-id incarnation-token
+                                                 fs-before fs-after)
+                true)))))))
 
 (defn- perform-replace-frame-state!
   "Carry out the partial frame-state patch once preconditions have passed.
@@ -499,11 +544,17 @@
   partition, an absent key is carried forward unchanged from `fs-before`.
   The recorded after-state (`merge fs-before
   new-frame-state`) mirrors that same contract so the synthetic epoch's
-  `:frame-state-after` matches exactly what the write installed."
-  [frame-id new-frame-state]
+  `:frame-state-after` matches exactly what the write installed.
+  `incarnation-token` (from the preconditions) keys the whole transaction to
+  the exact validated incarnation: the physical write goes through core's
+  EXACT-INCARNATION `replace-frame-state!` 3-arity, which returns nil unless
+  the token still names the live record — so a same-id successor can never
+  receive the patch (rf2-gj2bo)."
+  [frame-id incarnation-token new-frame-state]
   (perform-replace! frame-id
+                    incarnation-token
                     (fn [fs-before] (merge fs-before new-frame-state))
-                    #(frame/replace-frame-state! frame-id new-frame-state)))
+                    #(frame/replace-frame-state! frame-id incarnation-token new-frame-state)))
 
 (defn replace-frame-state!
   "Atomically install `new-frame-state` — a PARTIAL frame-state map (any
@@ -547,9 +598,13 @@
   [frame-id new-frame-state]
   (if-not interop/debug-enabled?
     false
-    (let [{:keys [outcome op tags]} (tool-pair/check-replace-frame-state-preconditions! frame-id new-frame-state)]
+    (let [{:keys [outcome op tags incarnation-token]}
+          (tool-pair/check-replace-frame-state-preconditions! frame-id new-frame-state)]
       (case outcome
-        :ok   (perform-replace-frame-state! frame-id new-frame-state)
+        ;; Carry the EXACT incarnation token the preconditions resolved against
+        ;; to the write boundary, so a same-id successor seated in between never
+        ;; receives this injection or its synthetic bookkeeping (rf2-gj2bo).
+        :ok   (perform-replace-frame-state! frame-id incarnation-token new-frame-state)
         :fail (do (tool-pair/emit-precondition-failure! op tags)
                   false)))))
 

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -502,37 +502,21 @@
 ;;
 ;; Precondition validation (`check-restore-preconditions!` /
 ;; `check-replace-frame-state-preconditions!`) resolves the frame, but a frame
-;; can be destroyed in the window BETWEEN the precondition pass and the
-;; actual container write (the validate-then-destroy race — most often a
-;; tool gesture interleaving with the owning component's teardown). Once
-;; destroyed, `frame/app-db-container` returns nil and the choke-point
-;; `adapter/replace-container!` no-ops the write with a
-;; `:rf.error/write-after-destroy` trace (`adapter.cljc`). Per Tool-Pair
-;; §Surface behaviour against destroyed frames the mutating surfaces must
-;; report this as the SAME structural failure a frame-miss caught at
-;; validate-time produces (`:rf.error/no-such-handler`, kind `:frame`,
-;; returns `false`) — NOT a synthetic success. This helper resolves the
-;; container at the write boundary and yields the canonical no-such-handler
-;; failure when it has disappeared, so `perform-restore!` /
-;; `perform-replace!` can bail BEFORE emitting success, recording a
-;; synthetic epoch, or fanning out to listeners.
-
-(defn live-container-or-fail
-  "Resolve `frame-id`'s app-db container at the write boundary. Returns
-  `{:outcome :ok :container <container>}` when the frame is still live, or
-  the canonical no-such-handler precondition-failure result
-  (`{:outcome :fail :op :rf.error/no-such-handler :tags {:kind :frame
-  :frame frame-id}}`) when the frame was destroyed between precondition
-  validation and now. Mirrors
-  `frame-exists-or-fail`'s failure shape so the destroyed-frame write race
-  surfaces identically to a frame-miss caught at validate-time."
-  [frame-id]
-  (if-let [container (frame/app-db-container frame-id)]
-    {:outcome :ok :container container}
-    {:outcome :fail
-     :op      :rf.error/no-such-handler
-     :tags    {:kind  :frame
-               :frame frame-id}}))
+;; can be destroyed — or destroyed and reseated under the SAME id — in the
+;; window BETWEEN the precondition pass and the actual container write (the
+;; validate-then-destroy race — most often a tool gesture interleaving with
+;; the owning component's teardown). Per Tool-Pair §Surface behaviour against
+;; destroyed frames the mutating surfaces must report this as the SAME
+;; structural failure a frame-miss caught at validate-time produces
+;; (`:rf.error/no-such-handler`, kind `:frame`, returns `false`) — NOT a
+;; synthetic success, and NEVER a write into a same-id successor. Both write
+;; paths (`perform-restore!` here, `perform-replace!` in `epoch.cljc`)
+;; therefore gate on `frame/event-continuation-live?` with the EXACT
+;; incarnation token their preconditions resolved (rf2-bjh6y, rf2-gj2bo) and
+;; install through core's exact-incarnation `frame/replace-frame-state!`
+;; 3-arity, whose nil return closes the post-liveness half of the window
+;; (rf2-s93722): a destroyed-or-reseated incarnation surfaces the canonical
+;; failure BEFORE any success telemetry, synthetic epoch, or listener fanout.
 
 ;; ---- drain serialization for tool writes ----------------------------------
 ;;
@@ -980,8 +964,15 @@
   "Validate the documented preconditions for `replace-frame-state!`, the
   frame-state write surface.
   `frame-state` is a PARTIAL frame-state map (any subset of
-  `{:rf.db/app … :rf.db/runtime …}`). Returns `{:outcome :ok}` when every
-  check passes, otherwise `{:outcome :fail :op <kw> :tags <map>}` matching
+  `{:rf.db/app … :rf.db/runtime …}`). Returns
+  `{:outcome :ok :incarnation-token <token>}` when every check passes —
+  `:incarnation-token` is the EXACT identity token of the frame incarnation
+  these checks resolved against, derived from the SAME captured record (not
+  a bare-id re-resolve), which `replace-frame-state!` carries to the write
+  boundary so the physical write and the synthetic bookkeeping can never
+  retarget onto a same-id SUCCESSOR seated after validation (rf2-gj2bo,
+  mirroring `check-restore-preconditions!`). Otherwise
+  `{:outcome :fail :op <kw> :tags <map>}` matching
   the precondition-failure shape of `check-restore-preconditions!`. Pure
   data — no trace events emitted from here; emission is the caller's job.
 
@@ -1029,7 +1020,15 @@
      :op      :rf.error/replace-frame-state-bad-keys
      :tags    {:frame frame-id :reason reason :keys keys}}
 
-    (let [frame-result (frame-exists-or-fail frame-id)]
+    (let [frame-result      (frame-exists-or-fail frame-id)
+          ;; The EXACT incarnation identity token (the record's `:drain-lock`,
+          ;; per `frame-incarnation-token`) DERIVED FROM THE SAME captured
+          ;; record — NOT an independent bare-id re-resolve — mirroring
+          ;; `check-restore-preconditions!` (rf2-gj2bo). Returned on the `:ok`
+          ;; result so the write boundary can reject a stale injection after a
+          ;; destroy + same-id reconstruction. nil when the frame is absent —
+          ;; the (1) frame-registered branch fails first in that case.
+          incarnation-token (some-> (:frame-record frame-result) :drain-lock)]
       (cond
         ;; (1) Frame registered?
         (= :fail (:outcome frame-result))
@@ -1058,12 +1057,32 @@
 
                         (contains? frame-state frame/runtime-partition-key)
                         (into (failing-runtime-paths frame-id (get frame-state frame/runtime-partition-key))))]
-          (if (seq failing)
+          (cond
+            ;; Exact-owner gate on the validation snapshot (rf2-gj2bo,
+            ;; mirroring `check-restore-preconditions!`'s history gate). The
+            ;; schema/runtime validators above resolve the frame by BARE id;
+            ;; a same-id successor seated DURING this precondition sampling
+            ;; means the captured incarnation is no longer live, so those
+            ;; walks may have validated against the successor. Refuse with
+            ;; the SAME canonical no-such-handler failure the write boundary
+            ;; uses — checked FIRST so a churned sample never surfaces as the
+            ;; successor's schema verdict. (Belt-and-braces with the
+            ;; record-derived token above: even if a race slips past here the
+            ;; ticket still carries A's token, so the exact write rejects B.)
+            (not (frame/event-continuation-live? frame-id incarnation-token))
+            {:outcome :fail
+             :op      :rf.error/no-such-handler
+             :tags    {:kind  :frame
+                       :frame frame-id}}
+
+            (seq failing)
             {:outcome :fail
              :op      :rf.epoch/replace-schema-mismatch
              :tags    {:frame         frame-id
                        :failing-paths failing}}
-            {:outcome :ok}))))))
+
+            :else
+            {:outcome :ok :incarnation-token incarnation-token}))))))
 
 ;; ---- projected egress -----------------------------------------------------
 ;;

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -44,6 +44,9 @@
             [re-frame.epoch :as epoch]
             [re-frame.epoch.listeners :as epoch.listeners]
             [re-frame.epoch.state :as state]
+            ;; rf2-gj2bo — the CLJS same-id-successor injection pin interposes
+            ;; its churn on the real precondition check via with-redefs.
+            [re-frame.epoch.tool-pair :as tool-pair]
             ;; rf2-vxgfnd.265 — the reentrant claim-before-delivery fixture reads
             ;; the successor incarnation's token to model its pre-first-epoch claim.
             [re-frame.frame :as frame]
@@ -228,6 +231,66 @@
           "no synthetic :rf.epoch/db-replaced record was created by the refused replace")
       (is (= :done (:phase (rf/app-db-value :rf/default)))
           "the drain settled cleanly (no deadlock); app-db carries the handler's own commit"))))
+
+;; ---- 2c. rf2-gj2bo — injection fenced to the exact incarnation --------------
+;;
+;; JVM coverage in `re-frame.epoch-test` carries the full matrix (pre-write
+;; churn, post-write tail, both-partition, no-churn controls); this pins the
+;; load-bearing A-to-B PRE-WRITE invariant in the CLJS lane, deterministically,
+;; via the same precheck interposition the JVM tests use — no timing sleeps.
+;; The precheck runs REAL against live incarnation A and yields A's exact
+;; record-derived token; the interposed churn destroys A and seats + seeds a
+;; same-id successor B before the write; the token fence must then refuse.
+
+(deftest replace-frame-state-fenced-to-exact-incarnation-cljs
+  (testing "rf2-gj2bo — an injection validated against incarnation A, with a
+            same-id successor B seated + seeded BEFORE the write, is REJECTED:
+            false return, canonical :rf.error/no-such-handler, B's frame-state
+            and history byte-for-byte at their baselines, and no
+            :rf.epoch/db-replaced record or trace"
+    (rf/make-frame {:id :gj2bo/succ})
+    (rf/reg-event :gj2bo/set-owner (fn [_ [_ o]] {:db {:owner o}}))
+    (rf/dispatch-sync [:gj2bo/set-owner :A] {:frame :gj2bo/succ})
+    (let [real-check tool-pair/check-replace-frame-state-preconditions!
+          a-token    (frame/frame-incarnation-token :gj2bo/succ)
+          checked    (atom nil)
+          b-baseline (atom nil)
+          ops        (atom #{})]
+      (trace-tooling/register-listener! ::gj2bo-rec
+                                        (fn [ev] (swap! ops conj (:operation ev))))
+      (with-redefs [tool-pair/check-replace-frame-state-preconditions!
+                    (fn [frame-id new-frame-state]
+                      (let [r (real-check frame-id new-frame-state)]
+                        (reset! checked r)
+                        ;; Interpose: destroy A, seat + seed same-id successor
+                        ;; B, capture B's baselines, hand back A's ticket.
+                        (rf/destroy-frame! frame-id)
+                        (rf/make-frame {:id frame-id})
+                        (rf/dispatch-sync [:gj2bo/set-owner :B] {:frame frame-id})
+                        (reset! b-baseline
+                                {:frame-state (rf/frame-state-value frame-id)
+                                 :history     (rf/epoch-history frame-id)})
+                        r))]
+        (let [result (rf/replace-frame-state! :gj2bo/succ {:rf.db/app {:owner :STALE-A}})]
+          (trace-tooling/unregister-listener! ::gj2bo-rec)
+          (is (= :ok (:outcome @checked))
+              "the REAL precondition check passed against live incarnation A")
+          (is (identical? a-token (:incarnation-token @checked))
+              "the :ok ticket carries A's exact record-derived token")
+          (is (not (identical? a-token (frame/frame-incarnation-token :gj2bo/succ)))
+              "successor B is a fresh incarnation (A/B tokens distinct)")
+          (is (false? result) "the stale cross-incarnation injection is REJECTED")
+          (is (= {:owner :B} (rf/app-db-value :gj2bo/succ))
+              "B's app-db is byte-for-byte unchanged — :STALE-A never installed")
+          (is (= (:frame-state @b-baseline) (rf/frame-state-value :gj2bo/succ))
+              "B's whole frame-state is at its captured baseline")
+          (is (= (:history @b-baseline) (rf/epoch-history :gj2bo/succ))
+              "B's history is at its captured baseline — no stale synthetic record")
+          (is (contains? @ops :rf.error/no-such-handler)
+              "the canonical :rf.error/no-such-handler typed failure fired")
+          (is (not (contains? @ops :rf.epoch/db-replaced))
+              "no :rf.epoch/db-replaced success trace")
+          (rf/destroy-frame! :gj2bo/succ))))))
 
 ;; ---- 3. Ring depth cap -----------------------------------------------------
 

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -5007,10 +5007,13 @@
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 0}}))
     (rf/dispatch-sync [:seed] {:frame :test/short-lived})
 
-    ;; (1) Validate against the LIVE frame — passes.
-    (let [{:keys [outcome]} (tool-pair/check-replace-frame-state-preconditions!
-                              :test/short-lived {:rf.db/app {:n 999}})]
+    ;; (1) Validate against the LIVE frame — passes, yields the exact
+    ;; incarnation token the checks resolved against (rf2-gj2bo).
+    (let [{:keys [outcome incarnation-token]}
+          (tool-pair/check-replace-frame-state-preconditions!
+            :test/short-lived {:rf.db/app {:n 999}})]
       (is (= :ok outcome) "precondition validation passed against the live frame")
+      (is (some? incarnation-token) "the :ok ticket carries the incarnation token")
 
       ;; A listener that records every fanned record — it must NOT see a
       ;; record for the destroyed frame.
@@ -5024,9 +5027,10 @@
         ;; (2) The race: destroy in the validate→write window.
         (rf/destroy-frame! :test/short-lived)
 
-        ;; (3) Perform the reset at the boundary — container is now nil.
+        ;; (3) Perform the reset at the boundary — the resolved incarnation is gone.
         (let [recorded (record-trace!)
-              result   (#'epoch/perform-replace-frame-state! :test/short-lived {:rf.db/app {:n 999}})]
+              result   (#'epoch/perform-replace-frame-state!
+                         :test/short-lived incarnation-token {:rf.db/app {:n 999}})]
           (is (false? result)
               "perform-replace-frame-state! reports HONEST failure (false) — NOT a
                synthetic success — for the validate-then-destroy race")
@@ -5410,6 +5414,223 @@
           (is (some #(= :rf.epoch/restored (:operation %)) @recorded)
               ":rf.epoch/restored success trace fired"))
         (finally (late-bind/set-fn! rk r0))))))
+
+;; ---- rf2-gj2bo — state INJECTION is the same exact-incarnation transaction -
+;;
+;; rf2-bjh6y/rf2-qfrh4 fenced RESTORE end to end, but the sibling Tool-Pair
+;; write — replace-frame-state!, the dev-only state injection Xray / Pair-MCP
+;; drive — still validated a bare frame id, returned no incarnation token, and
+;; wrote through the non-exact two-arity core write. If validated incarnation A
+;; was destroyed and a same-id successor B seated before the write, the stale
+;; gesture overwrote B and recorded the transition in B's history while
+;; returning true. The fix mirrors the shipped restore transaction exactly: the
+;; preconditions derive the EXACT token from the same captured record and
+;; return it on :ok; the public fn threads it to the write boundary; the
+;; serialized region gates on `event-continuation-live?` and installs through
+;; core's exact-incarnation 3-arity write; and the synthetic bookkeeping
+;; claims/commits only under that exact token (`commit-frame-owner-record!`),
+;; with liveness re-checks around the callback-bearing trace/listener tails.
+;;
+;; The churn is interposed exactly as the public fn sequences the phases: a
+;; with-redefs precheck wrapper runs the REAL (live-A) validation, then
+;; destroys A, seats + seeds same-id B, and hands back A's ticket — the
+;; deterministic validate→write window, no timing sleeps.
+
+(deftest replace-frame-state-fenced-to-exact-incarnation-leaves-same-id-successor-untouched
+  (testing "rf2-gj2bo — an app-only injection (the Xray/Pair-MCP shape) whose
+            preconditions resolve against incarnation A, then A is destroyed
+            and a same-id SUCCESSOR B is seated + seeded BEFORE the write,
+            REJECTS the stale install through the PUBLIC surface: returns
+            false, emits the canonical :rf.error/no-such-handler (kind
+            :frame), emits no :rf.epoch/db-replaced, fans nothing to epoch
+            listeners, and leaves B's full frame-state AND history exactly at
+            their captured baselines."
+    (rf/make-frame {:id :test/inj})
+    (rf/reg-event :set-owner-inj (fn [_ [_ o]] {:db {:owner o}}))
+    (rf/dispatch-sync [:set-owner-inj :A] {:frame :test/inj})
+
+    (let [real-check   tool-pair/check-replace-frame-state-preconditions!
+          a-token      (frame/frame-incarnation-token :test/inj)
+          check-result (atom nil)
+          b-baseline   (atom nil)
+          fanned       (atom [])
+          recorded     (record-trace!)]
+      (rf/register-listener! :epoch ::inj-fan (fn [r] (swap! fanned conj r)))
+      (with-redefs [tool-pair/check-replace-frame-state-preconditions!
+                    (fn [frame-id new-frame-state]
+                      (let [r (real-check frame-id new-frame-state)]
+                        (reset! check-result r)
+                        ;; Interpose: destroy A, seat + seed same-id successor
+                        ;; B, capture B's baselines, then hand back A's ticket.
+                        (rf/destroy-frame! frame-id)
+                        (rf/make-frame {:id frame-id})
+                        (rf/dispatch-sync [:set-owner-inj :B] {:frame frame-id})
+                        (reset! b-baseline
+                                {:frame-state (rf/frame-state-value frame-id)
+                                 :history     (rf/epoch-history frame-id)})
+                        ;; Drop B's own seed fan-out; only post-churn deliveries
+                        ;; are under test.
+                        (reset! fanned [])
+                        r))]
+        (let [result (rf/replace-frame-state! :test/inj {:rf.db/app {:owner :STALE-A}})]
+          (is (= :ok (:outcome @check-result))
+              "the REAL precondition check passed against live incarnation A")
+          (is (identical? a-token (:incarnation-token @check-result))
+              "the :ok ticket carries A's exact record-derived token")
+          (is (not (identical? a-token (frame/frame-incarnation-token :test/inj)))
+              "successor B is a fresh incarnation (A/B tokens distinct)")
+          (is (false? result)
+              (str "the stale cross-incarnation injection must be REJECTED; got "
+                   (pr-str result)))
+          (is (= {:owner :B} (rf/app-db-value :test/inj))
+              "successor B's app-db is byte-for-byte unchanged — :STALE-A never installed")
+          (is (= (:frame-state @b-baseline) (rf/frame-state-value :test/inj))
+              "B's WHOLE frame-state is exactly at its captured baseline")
+          (is (= (:history @b-baseline) (rf/epoch-history :test/inj))
+              "B's history is exactly at its captured baseline — no stale synthetic record spliced in")
+          (is (has-error-op? @recorded :rf.error/no-such-handler)
+              ":rf.error/no-such-handler fired for the lost incarnation")
+          (let [ev (some #(when (= :rf.error/no-such-handler (:operation %)) %) @recorded)]
+            (is (= :frame (:kind (:tags ev))) "the typed failure carries :kind :frame")
+            (is (= :test/inj (:frame (:tags ev))) "the typed failure carries :frame"))
+          (is (not-any? #(= :rf.epoch/db-replaced (:operation %)) @recorded)
+              "no :rf.epoch/db-replaced success trace for the rejected stale injection")
+          (is (empty? @fanned)
+              "no synthetic epoch fanned out to listeners after the churn"))))))
+
+(deftest replace-frame-state-both-partition-fenced-to-exact-incarnation
+  (testing "rf2-gj2bo — the same validate→churn→write window with a
+            BOTH-partition patch: the stale injection is rejected, B's two
+            partitions and history stay exactly at their captured baselines."
+    (rf/make-frame {:id :test/inj2})
+    (rf/reg-event :seed-inj2
+      (fn [{rt :rf.db/runtime} [_ o]]
+        {:db {:owner o}
+         :rf.db/runtime (assoc (or rt {}) :rf.runtime/routing {:current {:route-id :start}})}))
+    (rf/dispatch-sync [:seed-inj2 :A] {:frame :test/inj2})
+
+    (let [real-check tool-pair/check-replace-frame-state-preconditions!
+          b-baseline (atom nil)
+          recorded   (record-trace!)]
+      (with-redefs [tool-pair/check-replace-frame-state-preconditions!
+                    (fn [frame-id new-frame-state]
+                      (let [r (real-check frame-id new-frame-state)]
+                        (rf/destroy-frame! frame-id)
+                        (rf/make-frame {:id frame-id})
+                        (rf/dispatch-sync [:seed-inj2 :B] {:frame frame-id})
+                        (reset! b-baseline
+                                {:frame-state (rf/frame-state-value frame-id)
+                                 :history     (rf/epoch-history frame-id)})
+                        r))]
+        (let [result (rf/replace-frame-state!
+                       :test/inj2
+                       {:rf.db/app     {:owner :STALE-A}
+                        :rf.db/runtime {:rf.runtime/routing {:current {:route-id :stale}}}})]
+          (is (false? result) "the stale both-partition injection must be REJECTED")
+          (is (= (:frame-state @b-baseline) (rf/frame-state-value :test/inj2))
+              "B's whole frame-state (both partitions) is exactly at its baseline")
+          (is (= (:history @b-baseline) (rf/epoch-history :test/inj2))
+              "B's history is exactly at its baseline")
+          (is (has-error-op? @recorded :rf.error/no-such-handler)
+              ":rf.error/no-such-handler fired for the lost incarnation")
+          (is (not-any? #(= :rf.epoch/db-replaced (:operation %)) @recorded)
+              "no :rf.epoch/db-replaced success trace"))))))
+
+(deftest replace-frame-state-post-write-tail-fenced-to-exact-incarnation
+  (testing "rf2-gj2bo — A-to-B churn interposed AFTER the exact A physical
+            write but BEFORE the synthetic bookkeeping: the write demonstrably
+            ran against A (the arm cannot pass by skipping it), the public
+            result stays TRUE (the exact-incarnation install committed on A —
+            the restore-tail precedent), and NO A synthetic record, ring
+            entry, last-settled anchor, :rf.epoch/db-replaced trace, or
+            listener delivery appears in B; B remains unchanged."
+    (rf/make-frame {:id :test/inj3})
+    (rf/reg-event :set-owner-inj3 (fn [_ [_ o]] {:db {:owner o}}))
+    (rf/dispatch-sync [:set-owner-inj3 :A] {:frame :test/inj3})
+
+    (let [real-write frame/replace-frame-state!
+          a-changed  (atom ::unset)
+          fanned     (atom [])
+          recorded   (record-trace!)]
+      (rf/register-listener! :epoch ::inj3-fan (fn [r] (swap! fanned conj r)))
+      (let [result (with-redefs [frame/replace-frame-state!
+                                 (fn [frame-id token fs]
+                                   ;; The exact A write runs FIRST and its
+                                   ;; changed-key-set is captured — then the
+                                   ;; churn lands before the tail bookkeeping.
+                                   (let [changed (real-write frame-id token fs)]
+                                     (reset! a-changed changed)
+                                     (rf/destroy-frame! frame-id)
+                                     (rf/make-frame {:id frame-id})
+                                     (rf/dispatch-sync [:set-owner-inj3 :B] {:frame frame-id})
+                                     changed))]
+                     (rf/replace-frame-state! :test/inj3 {:rf.db/app {:owner :INJECTED-A}}))
+            b-history (rf/epoch-history :test/inj3)
+            b-seed    (some #(when (= :set-owner-inj3 (:event-id %)) %) b-history)]
+        (is (= #{:rf.db/app} @a-changed)
+            "the exact A physical write actually ran and landed (non-vacuity)")
+        (is (true? result)
+            "the install committed on the exact incarnation A, so the public result stays TRUE")
+        (is (= {:owner :B} (rf/app-db-value :test/inj3))
+            "successor B's live app-db remains B's own — untouched by A's tail")
+        (is (not-any? #(= :rf.epoch/db-replaced (:event-id %)) b-history)
+            "A's synthetic :rf.epoch/db-replaced record was NOT spliced into B's ring")
+        (is (some? b-seed) "B's own seed epoch is in B's ring")
+        (is (= (:epoch-id b-seed) (state/last-settled-epoch-id :test/inj3))
+            "B's last-settled anchor is B's own epoch — NOT retargeted to A's synthetic id")
+        (is (not-any? #(= :rf.epoch/db-replaced (:operation %)) @recorded)
+            "no :rf.epoch/db-replaced trace fired after the churn")
+        (is (not-any? #(= :rf.epoch/db-replaced (:event-id %)) @fanned)
+            "no synthetic record was delivered to epoch listeners")))))
+
+(deftest replace-frame-state-within-incarnation-through-fence-still-succeeds
+  (testing "rf2-gj2bo control — the identical app-only patch with NO churn
+            still succeeds through every fence: true return, the intended
+            frame changes, the omitted runtime partition is PRESERVED, exactly
+            one matching synthetic record is appended, and the success
+            notification fans out. The fences reject only a lost incarnation,
+            never an ordinary live one."
+    (rf/make-frame {:id :test/inj-ctl})
+    (rf/reg-event :seed-ctl
+      (fn [{rt :rf.db/runtime} [_ o]]
+        {:db {:owner o}
+         :rf.db/runtime (assoc (or rt {}) :rf.runtime/routing {:current {:route-id :kept}})}))
+    (rf/dispatch-sync [:seed-ctl :A] {:frame :test/inj-ctl})
+
+    ;; The :ok ticket pairs the live incarnation's own record-derived token.
+    (let [{:keys [outcome incarnation-token]}
+          (tool-pair/check-replace-frame-state-preconditions!
+            :test/inj-ctl {:rf.db/app {:owner :INJECTED}})]
+      (is (= :ok outcome) "preconditions pass against the live frame")
+      (is (identical? incarnation-token (frame/frame-incarnation-token :test/inj-ctl))
+          "the :ok ticket's token is the live incarnation's own drain-lock"))
+
+    (let [fanned   (atom [])
+          recorded (record-trace!)]
+      (rf/register-listener! :epoch ::inj-ctl-fan (fn [r] (swap! fanned conj r)))
+      (let [result     (rf/replace-frame-state! :test/inj-ctl {:rf.db/app {:owner :INJECTED}})
+            history    (rf/epoch-history :test/inj-ctl)
+            synthetics (filter #(= :rf.epoch/db-replaced (:event-id %)) history)
+            synthetic  (first synthetics)]
+        (is (true? result) "an ordinary within-incarnation injection still succeeds")
+        (is (= {:owner :INJECTED} (rf/app-db-value :test/inj-ctl))
+            "the intended frame's app-db holds the patch")
+        (is (= {:current {:route-id :kept}}
+               (get-in (rf/frame-state-value :test/inj-ctl)
+                       [:rf.db/runtime :rf.runtime/routing]))
+            "the OMITTED runtime partition is preserved by the no-churn control")
+        (is (= 1 (count synthetics))
+            "exactly one synthetic :rf.epoch/db-replaced record was appended")
+        (is (= {:owner :A} (get-in synthetic [:frame-state-before :rf.db/app]))
+            "the synthetic record's before-state matches the pre-injection app-db")
+        (is (= {:owner :INJECTED} (get-in synthetic [:frame-state-after :rf.db/app]))
+            "the synthetic record's after-state matches the installed app-db")
+        (is (= (:epoch-id synthetic) (state/last-settled-epoch-id :test/inj-ctl))
+            "the synthetic epoch anchors last-settled")
+        (is (some #(= :rf.epoch/db-replaced (:operation %)) @recorded)
+            ":rf.epoch/db-replaced success trace fired")
+        (is (= 1 (count (filter #(= :rf.epoch/db-replaced (:event-id %)) @fanned)))
+            "the success notification fanned exactly one synthetic record to listeners")))))
 
 ;; ---- rf2-sdeae — the fenced tail ops are themselves FAN-OUTS ---------------
 ;;
@@ -5800,12 +6021,14 @@
       (reset! fanned [])
 
       (let [real-write frame/replace-frame-state!
+            a-token    (frame/frame-incarnation-token :test/short-lived)
             recorded   (record-trace!)
             result     (with-redefs [frame/replace-frame-state!
-                                     (fn [frame-id fs]
+                                     (fn [frame-id token fs]
                                        (rf/destroy-frame! frame-id)
-                                       (real-write frame-id fs))]
-                         (#'epoch/perform-replace-frame-state! :test/short-lived {:rf.db/app {:n 999}}))]
+                                       (real-write frame-id token fs))]
+                         (#'epoch/perform-replace-frame-state!
+                           :test/short-lived a-token {:rf.db/app {:n 999}}))]
         (is (false? result)
             "perform-replace-frame-state! reports HONEST failure (false) for the
              nil-return post-liveness teardown")
@@ -5838,13 +6061,15 @@
       (reset! fanned [])
 
       (let [real-write frame/replace-frame-state!
+            a-token    (frame/frame-incarnation-token :test/short-lived)
             recorded   (record-trace!)
             result     (with-redefs [frame/replace-frame-state!
-                                     (fn [frame-id fs]
+                                     (fn [frame-id token fs]
                                        (rf/destroy-frame! frame-id)
-                                       (real-write frame-id fs))]
+                                       (real-write frame-id token fs))]
                          (#'epoch/perform-replace-frame-state!
-                           :test/short-lived {:rf.db/runtime {:rf.runtime/routing {:current {:route-id :home}}}}))]
+                           :test/short-lived a-token
+                           {:rf.db/runtime {:rf.runtime/routing {:current {:route-id :home}}}}))]
         (is (false? result)
             "perform-replace-frame-state! reports HONEST failure (false) for the
              nil-return post-liveness teardown")
@@ -5876,13 +6101,15 @@
       (reset! fanned [])
 
       (let [real-write frame/replace-frame-state!
+            a-token    (frame/frame-incarnation-token :test/short-lived)
             recorded   (record-trace!)
             new-fs     {:rf.db/app {:n 999} :rf.db/runtime {:rf.runtime/routing {:current {:route-id :home}}}}
             result     (with-redefs [frame/replace-frame-state!
-                                     (fn [frame-id fs]
+                                     (fn [frame-id token fs]
                                        (rf/destroy-frame! frame-id)
-                                       (real-write frame-id fs))]
-                         (#'epoch/perform-replace-frame-state! :test/short-lived new-fs))]
+                                       (real-write frame-id token fs))]
+                         (#'epoch/perform-replace-frame-state!
+                           :test/short-lived a-token new-fs))]
         (is (false? result)
             "perform-replace-frame-state! reports HONEST failure (false) for the
              nil-return post-liveness teardown")
@@ -5916,7 +6143,9 @@
     (let [recorded (record-trace!)
           ;; Inject the IDENTICAL value — a genuine no-op write against a live
           ;; frame. commit-frame-transition! returns #{} (empty, non-nil).
-          result   (#'epoch/perform-replace-frame-state! :test/main {:rf.db/app {:n 7}})]
+          result   (#'epoch/perform-replace-frame-state!
+                     :test/main (frame/frame-incarnation-token :test/main)
+                     {:rf.db/app {:n 7}})]
       (is (true? result)
           "a live-frame no-op write stays successful (empty-set ≠ nil)")
       (is (= {:n 7} (rf/app-db-value :test/main))


### PR DESCRIPTION
Closes rf2-gj2bo (P1 bug): the dev-only Tool-Pair state injection `replace-frame-state!` validated a bare frame id, returned no incarnation token, and wrote through the non-exact two-arity core write — so if validated incarnation A was destroyed and a same-id successor B seated before the write, the stale gesture overwrote B (and recorded the transition in B's history) while returning `true`; a churn landing just after A's physical write could instead splice A's synthetic `:rf.epoch/db-replaced` record into B's ring.

## Fix

Mirrors the shipped restore transaction — no new abstraction, no public token argument (per the bead's non-goals):

- `check-replace-frame-state-preconditions!` derives the exact incarnation token from the SAME captured frame record (not a bare-id re-resolve), gates the bare-id schema/runtime sampling on exact liveness, and returns the token on `:ok`.
- Public `replace-frame-state!` threads the token through `perform-replace-frame-state!` / `perform-replace!`; the serialized region gates on `event-continuation-live?` with that exact token and installs through core's existing exact-incarnation `frame/replace-frame-state!` 3-arity (nil unless the token still names the live incarnation). Owner loss surfaces the canonical `false` + `:rf.error/no-such-handler` — the same shape as a destroyed-frame race.
- `record-synthetic-replace-epoch!` is now an exact-owner transaction on the same token: claim + record + last-settled anchor commit via `commit-frame-owner-record!`, with exact-liveness re-checks around the callback-bearing trace/listener tails. Post-write owner loss STOPS the bookkeeping instead of retargeting it onto B.
- `live-container-or-fail` is subsumed by the token gate and removed.

## Tests

JVM (`epoch_test.clj`): public pre-write churn (real precheck against A asserted `:ok` with distinct A/B tokens, destroy-A/make-B/seed-B interposed before the write; app-only Xray/Pair-MCP shape AND both-partition patch) proving `false`, canonical `:rf.error/no-such-handler`, no `:rf.epoch/db-replaced`, no listener fan-out, and B's frame-state + history byte-for-byte at captured baselines; post-write-tail churn (interposed after the exact A write, write asserted to have actually run) proving `true` result with no A synthetic record, anchor, trace, or listener delivery in B; no-churn control proving `true`, one matching synthetic record, preserved omitted partition, and the success fan-out. Existing perform-level races updated to the token-threaded arity.

CLJS (`epoch_cljs_test.cljs`): pins the load-bearing A-to-B pre-write invariant deterministically via the same precheck interposition — no timing sleeps.

## Quality gates

- Epoch JVM suite (`clojure -M:test` from `implementation/epoch`, foreground to completion, on the rebased tree): **exit 0 — 543 tests, 7176 assertions, 0 failures, 0 errors.**
- Control 1 — write-boundary exactness reverted (serialized-region gate back to a current-token check + non-exact two-arity write): focused run **exit 1, 14 failures** — the new pre-write tests go red naming the stale write ("the stale cross-incarnation injection must be REJECTED; got true", "successor B's app-db is byte-for-byte unchanged — :STALE-A never installed"), while the no-churn control test stays green.
- Control 2 — synthetic-tail token fence alone disabled (one line, `continue?` to `(constantly true)`): focused run **exit 1, 5 failures** — the tail test goes red on every splice assertion (A's record spliced into B's ring, B's seed epoch dropped, last-settled retargeted, trace + listener delivery after the churn).
- Restore verified by blob hash: the restored `epoch.cljc` hashes to the committed object (`git hash-object` == `git rev-parse HEAD:…` — `dde73810a5…`); the controls were never committed.
- CLJS lane: the new `epoch_cljs_test` pin runs in CI's `test:cljs` job — relying on CI for that lane rather than running the full shadow-cljs compile/browser sink locally.

Anchors and table columns: no docs/spec pages touched — source and tests only, all under `implementation/epoch/`.
