### PR TITLE
fix(reagent-slim): forward React prevState through Form-3 paired update lifecycles (rf2-08hx1)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -338,16 +338,18 @@
 ;;
 ;;   :component-did-mount         -> componentDidMount(this)
 ;;   :component-will-unmount      -> componentWillUnmount(this)
-;;   :component-did-update        -> componentDidUpdate(this, prev-argv, snapshot)
+;;   :component-did-update        -> componentDidUpdate(this, prev-argv, prev-state, snapshot)
 ;;   :reagent-render              -> render(this) — wrapped via wrap-render
 ;;   :display-name                -> displayName (static class field)
-;;   :get-snapshot-before-update  -> getSnapshotBeforeUpdate(this, prev-argv)
+;;   :get-snapshot-before-update  -> getSnapshotBeforeUpdate(this, prev-argv, prev-state)
 ;;   :component-did-catch         -> componentDidCatch(this, error, info)
 ;;
 ;; The user fns are called with `this` as the first arg to mirror
 ;; stock Reagent's convention (`(fn [this] ...)`). `componentDidUpdate`
-;; receives the previous argv (not React's prevProps) plus the snapshot
-;; from `getSnapshotBeforeUpdate`. Per IMPL-SPEC §6.6.
+;; receives the previous argv (not React's prevProps), React's prevState
+;; verbatim, and the snapshot from `getSnapshotBeforeUpdate`. Per
+;; IMPL-SPEC §6.6 and stock-Reagent 2.0.1 parity (its custom-wrapper
+;; forwards oldstate untranslated in both paired update lifecycles).
 ;;
 ;; All user-fn calls are wrapped in a `binding [*current-component* this]`
 ;; so re-frame's render-trace + `current-component` reads work.
@@ -443,21 +445,26 @@
 
     (when-let [f (:component-did-update spec)]
       ;; React calls componentDidUpdate(prevProps, prevState, snapshot).
-      ;; User fn signature: (this prev-argv snapshot) per IMPL-SPEC §6.6.
+      ;; User fn signature: (this prev-argv prev-state snapshot) per
+      ;; IMPL-SPEC §6.6. prevProps is translated to prev-argv; prevState
+      ;; and snapshot pass through verbatim (stock-Reagent parity: the
+      ;; 2.0.1 custom-wrapper calls f with c, props-argv, oldstate,
+      ;; snapshot).
       (set! (.-componentDidUpdate proto)
-            (fn [prev-props _prev-state snapshot]
+            (fn [prev-props prev-state snapshot]
               (this-as this
                 (bind-and-call this
-                  #(f this (prev-argv-from prev-props) snapshot))))))
+                  #(f this (prev-argv-from prev-props) prev-state snapshot))))))
 
     (when-let [f (:get-snapshot-before-update spec)]
-      ;; User fn: (this prev-argv) → snapshot; React then threads
-      ;; snapshot as the third arg to componentDidUpdate.
+      ;; User fn: (this prev-argv prev-state) → snapshot; React then
+      ;; threads snapshot as componentDidUpdate's third argument (the
+      ;; user fn's fourth). prevState passes through verbatim, as stock.
       (set! (.-getSnapshotBeforeUpdate proto)
-            (fn [prev-props _prev-state]
+            (fn [prev-props prev-state]
               (this-as this
                 (bind-and-call this
-                  #(f this (prev-argv-from prev-props)))))))
+                  #(f this (prev-argv-from prev-props) prev-state))))))
 
     (when-let [f (:component-did-catch spec)]
       ;; Error-boundary logging half — user fn: (this error info).

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_scu_argv_gate_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_scu_argv_gate_dom_cljs_test.cljs
@@ -78,7 +78,7 @@
                        (swap! render-count inc)
                        [:span "child-v=" v])
                      :component-did-update
-                     (fn [_this _prev-argv _snapshot]
+                     (fn [_this _prev-argv _prev-state _snapshot]
                        (swap! update-count inc))})]
         (rf/make-frame {:id frame-kw :doc "sCU argv-gate probe frame"})
         (rf/reg-event ::seed       (fn [_ _] {:db {:tick 0 :child-v 1}}))

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/lifecycle_prev_state_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/lifecycle_prev_state_dom_cljs_test.cljs
@@ -1,0 +1,123 @@
+(ns reagent2.dom.lifecycle-prev-state-dom-cljs-test
+  "rf2-08hx1 — the mounted React update proof for the Form-3 paired
+  update lifecycles, under a React 19 `createRoot`.
+
+  WHAT IT PROVES. `reagent2.core/create-class`'s two paired update
+  lifecycles receive the documented stock-Reagent argument shape on the
+  REAL React lifecycle path (not just via direct prototype invocation):
+
+    :get-snapshot-before-update  (fn [this prev-argv prev-state] ...) → snapshot
+    :component-did-update        (fn [this prev-argv prev-state snapshot] ...)
+
+  A changed-argv re-render commits; BOTH callbacks fire exactly once;
+  the gSBU return value reaches :component-did-update's snapshot slot;
+  React's prevState is forwarded verbatim (a cDM `setState` seeds a
+  real non-nil state — the framework argv-equality sCU swallows that
+  re-render, but React still commits the state, so the later
+  changed-argv update observes it as prevState); and the update is
+  asserted to have actually occurred (committed DOM advanced), so a
+  skipped lifecycle cannot read green. The callbacks are FIXED-arity —
+  the documented copy-pasteable shape — so a bridge that drops or
+  shifts an argument fails on sentinel identity rather than being
+  tolerated by a variadic probe.
+
+  WHY A DOM FILE. The sibling unit tests in
+  `reagent2.impl.component-cljs-test` invoke the prototype methods
+  directly with sentinel React args — full control, but no reconciler.
+  Only a real `react-dom/client` root proves React itself feeds the
+  bridge (prevProps, prevState, snapshot) in the documented order
+  across a genuine commit.
+
+  TEST-ONLY. ns ends in `-dom-cljs-test` so shadow-cljs's
+  `:browser-test` discovers it for the real-DOM assertion; the
+  `:node-test` runner also loads it (matches `cljs-test$`), where the
+  body gates on `(browser?)` and no-ops cleanly (no DOM)."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [reagent2.core :as r]
+            [reagent2.dom.client :as rdc]
+            ["react-dom" :as react-dom]))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (when (browser?)
+    (.createElement js/document "div")))
+
+(deftest mounted-update-forwards-prev-argv-prev-state-and-snapshot
+  (testing "reagent-slim — a real createRoot update feeds fixed-arity gSBU/cDU the documented (this prev-argv prev-state snapshot) shape (rf2-08hx1)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (let [gsbu-calls (atom [])
+            cdu-calls  (atom [])
+            klass (r/create-class
+                    {:display-name "prev-state-probe"
+                     :reagent-render
+                     (fn [v] [:div "v=" v])
+                     ;; Seed a REAL React state before the argv-change
+                     ;; update. The framework argv-equality sCU returns
+                     ;; false for this setState re-render (argv is
+                     ;; unchanged), so no render/gSBU/cDU fires for it —
+                     ;; but React still commits the state, so the later
+                     ;; changed-argv update sees it as prevState.
+                     :component-did-mount
+                     (fn [this]
+                       (.setState ^js this #js {:probe "seeded-prev-state"}))
+                     ;; The documented FIXED three-arg callback.
+                     :get-snapshot-before-update
+                     (fn [_this prev-argv prev-state]
+                       (swap! gsbu-calls conj {:prev-argv  prev-argv
+                                               :prev-state prev-state})
+                       :snapshot-sentinel-42)
+                     ;; The documented FIXED four-arg callback.
+                     :component-did-update
+                     (fn [_this prev-argv prev-state snapshot]
+                       (swap! cdu-calls conj {:prev-argv  prev-argv
+                                              :prev-state prev-state
+                                              :snapshot   snapshot}))})
+            mount-node (make-mount-node!)
+            root       (rdc/create-root mount-node)]
+        (try
+          ;; Initial mount, committed synchronously. cDM seeds the state;
+          ;; the sCU-swallowed setState pass must NOT fire the paired
+          ;; update lifecycles.
+          (react-dom/flushSync
+            (fn [] (rdc/render root [klass "a"])))
+          (is (= "v=a" (.-textContent mount-node))
+              "initial mount committed v=a")
+          (is (zero? (count @gsbu-calls))
+              "no :get-snapshot-before-update on mount (or on the sCU-swallowed setState pass)")
+          (is (zero? (count @cdu-calls))
+              "no :component-did-update on mount (or on the sCU-swallowed setState pass)")
+
+          ;; Changed argv → real reconciliation update: gSBU just before
+          ;; commit, cDU just after, snapshot threaded between them.
+          (react-dom/flushSync
+            (fn [] (rdc/render root [klass "b"])))
+          (is (= "v=b" (.-textContent mount-node))
+              "the update actually occurred: committed DOM advanced to v=b")
+          (is (= 1 (count @gsbu-calls)) ":get-snapshot-before-update fired exactly once")
+          (is (= 1 (count @cdu-calls))  ":component-did-update fired exactly once")
+
+          (let [{gsbu-prev-argv :prev-argv gsbu-prev-state :prev-state} (first @gsbu-calls)
+                {cdu-prev-argv :prev-argv cdu-prev-state :prev-state
+                 cdu-snapshot :snapshot} (first @cdu-calls)]
+            ;; prev-argv: the PREVIOUS argv, translated from prevProps.
+            (is (= "a" (second gsbu-prev-argv))
+                "gSBU received the previous argv (arg still \"a\")")
+            (is (= "a" (second cdu-prev-argv))
+                "cDU received the previous argv (arg still \"a\")")
+            ;; prev-state: React's own prevState object, forwarded
+            ;; verbatim — carries the cDM-seeded marker.
+            (is (and (some? gsbu-prev-state)
+                     (= "seeded-prev-state" (.-probe ^js gsbu-prev-state)))
+                "gSBU received React's real prevState verbatim (cDM-seeded marker present)")
+            (is (and (some? cdu-prev-state)
+                     (= "seeded-prev-state" (.-probe ^js cdu-prev-state)))
+                "cDU received React's real prevState verbatim (cDM-seeded marker present)")
+            ;; snapshot: gSBU's return value lands in cDU's 4th slot.
+            (is (= :snapshot-sentinel-42 cdu-snapshot)
+                "gSBU's return value reached cDU's snapshot slot through React"))
+          (finally
+            (try (rdc/unmount root) (catch :default _ nil))))))))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
@@ -13,7 +13,8 @@
         * error during a child's commit (componentDidMount) is caught.
         * nested boundaries: inner catches, outer does not fire.
     - :get-snapshot-before-update pairs with :component-did-update's
-      third arg.
+      snapshot arg, and both paired update lifecycles forward React's
+      prevState (rf2-08hx1).
     - Source-coord stamping integration (the renderer-side stamp lives
       in re-frame.views/reg-view*; the runtime here exercises the
       meta-tag fast path that the macro fold introduces).
@@ -116,8 +117,8 @@
                   {:reagent-render             (fn [_this] [:div])
                    :component-did-mount        (fn [_this])
                    :component-will-unmount     (fn [_this])
-                   :component-did-update       (fn [_this _prev-argv _snap])
-                   :get-snapshot-before-update (fn [_this _prev-argv] nil)
+                   :component-did-update       (fn [_this _prev-argv _prev-state _snap])
+                   :get-snapshot-before-update (fn [_this _prev-argv _prev-state] nil)
                    :component-did-catch        (fn [_this _err _info])
                    :display-name               "Full"})]
       (is (some? klass) "all-cap-keys spec produced a class")
@@ -360,55 +361,80 @@
       (is (zero? @fu-calls)
           "unmounted component was NOT forceUpdate'd on the drain"))))
 
-(deftest lifecycle-component-did-update-receives-prev-argv-and-snapshot
-  (testing "componentDidUpdate forwards (this, prev-argv, snapshot)"
+(deftest lifecycle-component-did-update-receives-prev-argv-prev-state-and-snapshot
+  (testing "componentDidUpdate forwards (this, prev-argv, prev-state, snapshot) — rf2-08hx1"
+    ;; The documented FIXED four-argument callback (README.md / FORM-3.md /
+    ;; IMPL-SPEC §6.6, stock-Reagent 2.0.1 parity). Distinct sentinels in
+    ;; every slot so a dropped or shifted argument cannot read green: a
+    ;; bridge that omits prev-state would land the snapshot sentinel in the
+    ;; prev-state slot and nil in the snapshot slot.
     (let [seen  (atom nil)
+          calls (atom 0)
+          prev-state-sentinel #js {:probe "prev-state-sentinel"}
           ^js klass (component/create-class*
                   {:reagent-render       (fn [_] [:div])
-                   :component-did-update (fn [this prev-argv snapshot]
+                   :component-did-update (fn [this prev-argv prev-state snapshot]
+                                           (swap! calls inc)
                                            (reset! seen
                                              {:this this
                                               :prev-argv prev-argv
+                                              :prev-state prev-state
                                               :snapshot snapshot}))})
           inst  (new klass #js {:__rfArgv [:render :a 1]})
           prev-props #js {:__rfArgv [:render :a 0]}]
       (.call (.. klass -prototype -componentDidUpdate)
-             inst prev-props nil :the-snapshot)
+             inst prev-props prev-state-sentinel :the-snapshot)
+      (is (= 1 @calls) "user callback fired exactly once")
       (is (= [:render :a 0] (:prev-argv @seen))
           "prev-argv reconstructed from prevProps.__rfArgv")
+      (is (identical? prev-state-sentinel (:prev-state @seen))
+          "React's prevState forwarded verbatim as the 3rd user-fn arg")
       (is (= :the-snapshot (:snapshot @seen))
-          "snapshot from React forwarded as the 3rd user-fn arg")
+          "snapshot from React forwarded as the 4th user-fn arg")
       (is (identical? inst (:this @seen))))))
 
 (deftest lifecycle-get-snapshot-before-update-pairs-with-component-did-update
-  (testing "getSnapshotBeforeUpdate's return value flows to componentDidUpdate's 3rd arg"
+  (testing "getSnapshotBeforeUpdate's return value flows to componentDidUpdate's snapshot arg"
     ;; Per IMPL-SPEC §6.6: React captures the gSBU return value and
-    ;; passes it as cDU's 3rd arg. The plumbing here mirrors that —
-    ;; we don't run React, so we exercise the user-fn dispatch shape:
-    ;; gSBU receives (this prev-argv) and returns an arbitrary value;
-    ;; cDU receives (this prev-argv snapshot).
-    (let [snapshot-captured (atom nil)
-          cdu-snapshot      (atom nil)
+    ;; passes it as componentDidUpdate's 3rd React arg. The plumbing
+    ;; here mirrors that — we don't run React, so we exercise the
+    ;; user-fn dispatch shape with the documented FIXED arities
+    ;; (rf2-08hx1): gSBU receives (this prev-argv prev-state) and
+    ;; returns an arbitrary value; cDU receives (this prev-argv
+    ;; prev-state snapshot). Distinct prev-state sentinels prove the
+    ;; bridge forwards React's prevState rather than dropping it.
+    (let [gsbu-seen  (atom nil)
+          cdu-seen   (atom nil)
+          prev-state-sentinel #js {:probe "gsbu-prev-state"}
           ^js klass (component/create-class*
                   {:reagent-render             (fn [_] [:div])
-                   :get-snapshot-before-update (fn [_this prev-argv]
-                                                 (reset! snapshot-captured prev-argv)
+                   :get-snapshot-before-update (fn [_this prev-argv prev-state]
+                                                 (reset! gsbu-seen
+                                                   {:prev-argv prev-argv
+                                                    :prev-state prev-state})
                                                  :scroll-position-42)
-                   :component-did-update       (fn [_this _prev-argv snapshot]
-                                                 (reset! cdu-snapshot snapshot))})
+                   :component-did-update       (fn [_this _prev-argv prev-state snapshot]
+                                                 (reset! cdu-seen
+                                                   {:prev-state prev-state
+                                                    :snapshot snapshot}))})
           inst  (new klass #js {:__rfArgv [:r 1]})
           prev-props #js {:__rfArgv [:r 0]}]
       (let [snap (.call (.. klass -prototype -getSnapshotBeforeUpdate)
-                        inst prev-props nil)]
+                        inst prev-props prev-state-sentinel)]
         (is (= :scroll-position-42 snap)
             "gSBU returned the snapshot value")
-        (is (= [:r 0] @snapshot-captured)
-            "gSBU received prev-argv reconstructed from prevProps"))
-      ;; React would now pass the snapshot to cDU as its 3rd arg.
+        (is (= [:r 0] (:prev-argv @gsbu-seen))
+            "gSBU received prev-argv reconstructed from prevProps")
+        (is (identical? prev-state-sentinel (:prev-state @gsbu-seen))
+            "gSBU received React's prevState verbatim as its 3rd user arg"))
+      ;; React would now pass the snapshot to cDU as its 3rd React arg
+      ;; (the user fn's 4th, after this/prev-argv/prev-state).
       (.call (.. klass -prototype -componentDidUpdate)
-             inst prev-props nil :scroll-position-42)
-      (is (= :scroll-position-42 @cdu-snapshot)
-          "cDU received gSBU's return value as 3rd arg"))))
+             inst prev-props prev-state-sentinel :scroll-position-42)
+      (is (identical? prev-state-sentinel (:prev-state @cdu-seen))
+          "cDU received React's prevState verbatim in the prev-state slot")
+      (is (= :scroll-position-42 (:snapshot @cdu-seen))
+          "cDU received gSBU's return value in the snapshot slot"))))
 
 (deftest lifecycle-display-name-statically-set
   (testing ":display-name lands on the class as displayName (static field)"


### PR DESCRIPTION
## Summary

reagent-slim's Form-3 lifecycle bridge (`install-lifecycle!`) received React's `prevState` in both paired update lifecycles and dropped it from the user callback calls — invoking `:get-snapshot-before-update` as `(f this prev-argv)` and `:component-did-update` as `(f this prev-argv snapshot)`, while the published contract (IMPL-SPEC §6.6, FORM-3.md, README.md) and pinned stock Reagent 2.0.1 invoke `(f this prev-argv prev-state)` and `(f this prev-argv prev-state snapshot)`. The documented fixed-arity callbacks failed at runtime; variadic ones observed the snapshot shifted into the prev-state slot with the true prevState unrecoverable.

## Fix

- `reagent2.impl.component/install-lifecycle!`: thread `prev-state` through both wrappers **verbatim** — parity target verified against the pinned stock Reagent 2.0.1 jar, whose custom-wrapper calls `f` with `(c, props-argv, oldstate)` / `(c, props-argv, oldstate, snapshot)`, i.e. React's raw `oldstate` untranslated. The prevProps→prev-argv translation, `*current-component*` binding, snapshot threading, 7-key cap, and method installation are unchanged.
- Corrected the two contradictory source comment blocks (the §6.4 mapping table and the wrapper comments that mis-cited IMPL-SPEC §6.6 for the reduced shape).

## Tests

- `component_cljs_test`: the two pinning tests now use the **documented fixed arities** (3-arg gSBU, 4-arg cDU) with distinct prev-state sentinels in every slot, plus call counts — a bridge that drops or shifts an argument fails on sentinel identity instead of being tolerated by a variadic probe. Reduced-arity callbacks in the cap-key acceptance test corrected too.
- `reagent_slim_scu_argv_gate_dom_cljs_test`: its fixed 3-arg `:component-did-update` probe corrected to the documented 4-arg shape (it is invoked through real reconciliation in the browser lane).
- **New mounted proof** `reagent2/dom/lifecycle_prev_state_dom_cljs_test.cljs` (`:browser-test` lane; no-ops on node): a real `createRoot` mount + changed-argv `flushSync` update through `reagent2.core/create-class` — both paired callbacks fire exactly once, gSBU's return value reaches cDU's snapshot slot, a cDM-seeded real React state arrives as prevState verbatim (the argv-equality sCU swallows the seeding re-render but React still commits the state), and the committed DOM is asserted to have advanced so a skipped lifecycle cannot read green.

Docs need no edit: README.md, FORM-3.md and IMPL-SPEC.md already teach the correct shape — the contradiction was confined to the source comments and the pinning tests. No doc-link-gate surface touched.

## Quality gates

Both nominated lanes ran locally in the worker worktree, foreground to completion, exit codes captured by redirect+echo in one shell:

| Gate | Result | Captured exit |
|---|---|---|
| `npm run test:cljs` (node lane, 1860 files compiled, 0 warnings) | Ran 11096 tests containing 54395 assertions. 0 failures, 0 errors. | 0 |
| `npm run test:browser` (browser lane, 1011 files compiled, 0 warnings) | Ran 752 tests containing 4109 assertions. 0 failures, 0 errors. | 0 |

**Control (non-vacuity), run before the greens above were trusted:** with the prev-state forwarding reverted at the two wrapper call lines (working tree only, fix already committed):

- `test:cljs` → captured exit **1**, 5 failures / 0 errors, all in the corrected unit tests, each naming the dropped prev-state: cDU's prev-state slot received the snapshot sentinel and its snapshot slot `nil`; gSBU's prev-state slot `nil`.
- `test:browser` → captured exit **1**, 3 failures / 0 errors, all in the new mounted proof: prevState marker absent in both callbacks, snapshot slot `nil`.

Restore verified by **blob hash**: the working-copy blob equals the committed object `372c4fd5b92a6737710ff89e8dee2fdf4660dca6` — the green runs executed against exactly these bytes. The controls also prove both gates read this worktree (the planted fault existed only here) and that both lanes discover the changed/new test namespaces.

rf2-08hx1