### PR TITLE
fix(reagent-adapter): exactly-once, re-entrant-safe Reaction disposal (rf2-rzeko)

### DIFF
--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -7,6 +7,78 @@
             [re-frame.substrate.spine :as spine]
             [re-frame.views :as views]))
 
+;; ---- exactly-once Reaction disposal (rf2-rzeko) ---------------------------
+;;
+;; Spec 006 §On-dispose hooks promises disposal that is idempotent and
+;; re-entrant safe: every on-dispose callback fires EXACTLY ONCE in
+;; registration order, a second `dispose!` is a no-op, and a `dispose!`
+;; re-entered from inside a callback cannot recurse. Stock Reagent 2.0.1's
+;; `reagent.ratom/dispose!` keeps neither half: it nils `watching`/`state`
+;; but leaves `on-dispose` / `on-dispose-arr` intact and re-invokes them on
+;; every call, and `Reaction.-remove-watch` AUTO-disposes when the last
+;; outward watch drops (with `auto-run` nil). So explicit adapter disposal
+;; followed by a host unmount — or the reverse — fires the whole callback
+;; set twice (double-releasing sub-cache input refs, repeating user
+;; teardown), and a callback that defensively re-enters `dispose!` re-enters
+;; the same callback array and can recurse to stack overflow.
+;;
+;; The guard is adapter-owned and per-Reaction (the reagent-slim Reaction
+;; bakes the same snapshot-and-clear pattern into its own `dispose!` —
+;; rf2-1bzlai — which an external stock artefact cannot).
+;; `install-dispose-guard!` registers a marker as the FIRST
+;; `add-on-dispose!` callback AT CONSTRUCTION, before any cache/user
+;; callback can register, so on the first disposal — whichever side
+;; initiates it, the adapter's disposers or a stock-internal auto-dispose —
+;; the marker runs before every later callback: it stamps the terminal
+;; disposed mark (so a re-entry through the routed `dispose!` mid-firing
+;; sees it) and nils both callback holders. Stock `dispose!` captures
+;; `on-dispose-arr` into a local before iterating, so the first firing
+;; still completes in registration order; any LATER `dispose!` — including
+;; a stock-internal auto-dispose the adapter never sees — finds empty
+;; holders and re-fires nothing. `dispose-once!` is the single disposal
+;; boundary both the claimed-generation disposer (`make-ratom-spine`'s
+;; `:dispose!`) and the routed `:adapter/dispose!` hook delegate through:
+;; it consults the same mark and no-ops outright on a marked Reaction.
+;;
+;; The mark is a string-keyed expando property: never renamed under
+;; `:advanced`, colliding with no Reagent field. The holder writes use the
+;; `^clj` field-access idiom this ns already relies on for `.-watching`.
+
+(def ^:private disposed-mark "re-frame.adapter.reagent/disposed")
+
+(defn- marked-disposed? [rx]
+  (true? (unchecked-get rx disposed-mark)))
+
+(defn- install-dispose-guard!
+  "Arm `rx` with the exactly-once disposal marker (see the section comment
+  above). MUST run at construction, before any other callback registers,
+  so the marker is first in `on-dispose-arr`. Returns `rx`."
+  [rx]
+  (ratom/add-on-dispose! rx
+    (fn mark-disposed! [r]
+      (unchecked-set r disposed-mark true)
+      (set! (.-on-dispose ^clj r) nil)
+      (set! (.-on-dispose-arr ^clj r) nil)))
+  rx)
+
+(defn- make-guarded-reaction
+  "Stock `ratom/make-reaction` plus the exactly-once disposal guard. The
+  construction path for every adapter-created Reaction: the spine's
+  `make-derived-value` (sub-cache reactions) and the routed
+  `:adapter/make-reaction` hook (`re-frame.interop/make-reaction`)."
+  [thunk]
+  (install-dispose-guard! (ratom/make-reaction thunk)))
+
+(defn- dispose-once!
+  "Dispose `a` through stock `ratom/dispose!` unless its exactly-once
+  marker shows it already disposed (explicitly, or by stock auto-disposal).
+  A Reaction without the marker — one not created through this adapter —
+  delegates unconditionally, preserving raw stock behaviour."
+  [a]
+  (when-not (marked-disposed? a)
+    (ratom/dispose! a))
+  nil)
+
 ;; ---- shared ratom-spine wiring --------------------------------------------
 ;;
 ;; Reagent and reagent-slim share the ratom spine but inject different
@@ -24,7 +96,10 @@
      ;; Var value at load time would freeze the original impls past any
      ;; `with-redefs` rebind). Runtime behaviour is identical.
      :r-atom        (fn [v] (r/atom v))
-     :make-reaction (fn [thunk] (ratom/make-reaction thunk))
+     ;; Guarded ctor/disposer pair (rf2-rzeko): every Reaction this spine
+     ;; creates carries the exactly-once disposal marker, and this
+     ;; generation's claimed disposer consults it — see the section above.
+     :make-reaction (fn [thunk] (make-guarded-reaction thunk))
      :create-root   (fn [mount-point] (rdc/create-root mount-point))
      :render-root   (fn [root tree] (rdc/render root tree))
      :hydrate-root  (fn [mount-point tree] (rdc/hydrate-root mount-point tree))
@@ -32,7 +107,7 @@
      ;; Cleanup owns this exact substrate dispatch even after the process
      ;; lifecycle's terminal claim closes every public routed hook.
      :disposable?   (fn [a] (satisfies? ratom/IDisposable a))
-     :dispose!      (fn [a] (ratom/dispose! a))
+     :dispose!      (fn [a] (dispose-once! a))
      ;; Drain Reagent synchronously after `f`; unlike its normal next-tick path,
      ;; this works in backgrounded and headless tabs.
      :flush-render! (fn [f] (f) (r/flush))}))
@@ -74,7 +149,11 @@
      :current-component r/current-component
      :atom              r/atom
      :ratom?            (fn [x] (satisfies? ratom/IReactiveAtom x))
-     :make-reaction     ratom/make-reaction
+     ;; Guarded ctor/disposer pair (rf2-rzeko): the routed
+     ;; `:adapter/make-reaction` / `:adapter/dispose!` hooks share the
+     ;; exactly-once disposal marker with the claimed-generation disposer
+     ;; above — one coherent disposal owner per adapter generation.
+     :make-reaction     make-guarded-reaction
      ;; rf2-8cnxg — the missing `deref-capture`. A stock `Reaction` learns
      ;; its sources ONLY by being run through `deref-capture`; `ratom/run`
      ;; (its `IRunnable` op) is exactly that run, and after it the reaction
@@ -102,6 +181,6 @@
                            nil)
      :disposable?       (fn [a] (satisfies? ratom/IDisposable a))
      :add-on-dispose!   ratom/add-on-dispose!
-     :dispose!          ratom/dispose!
+     :dispose!          dispose-once!
      :reactive?         ratom/reactive?
      :after-render      r/after-render}))

--- a/implementation/adapters/reagent/test/re_frame/adapter_reaction_dispose_exactly_once_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_reaction_dispose_exactly_once_cljs_test.cljs
@@ -1,0 +1,227 @@
+(ns re-frame.adapter-reaction-dispose-exactly-once-cljs-test
+  "Pins the stock Reagent adapter's exactly-once Reaction disposal
+  (rf2-rzeko; Spec 006 §On-dispose hooks). The adapter promises that a
+  derived value's disposal is idempotent and re-entrant safe: every
+  on-dispose callback fires EXACTLY ONCE in registration order, a second
+  `dispose!` is a no-op, and a `dispose!` re-entered from inside a
+  callback cannot recurse. Stock Reagent 2.0.1's `reagent.ratom/dispose!`
+  keeps neither half on its own — it leaves `on-dispose`/`on-dispose-arr`
+  intact and re-invokes them on every call, and `Reaction.-remove-watch`
+  auto-disposes when the last outward watch drops — so the adapter arms
+  every Reaction it creates with a construction-time exactly-once guard.
+
+  Four proofs, all through the actual public paths (the adapter map's
+  `:make-derived-value`, the routed `re-frame.interop` surface, the
+  claimed-generation `dispose-adapter!` walk, and core `add-watch` /
+  `remove-watch` for stock auto-disposal):
+
+    1. A double `interop/dispose!` fires each callback exactly once, in
+       registration order.
+    2. A callback that (conditionally) re-enters `interop/dispose!` on
+       the same Reaction returns without recursion; it and its later
+       sibling each fire once.
+    3. Host/adapter crossover: explicit adapter disposal followed by
+       stock auto-disposal (last outward watch removed), and the
+       opposite order, both leave the callback count at one — and the
+       one-shot path still releases the source wire (no recompute after
+       disposal).
+    4. Shutdown + unmount interleaving through the claimed-generation
+       path: `dispose-adapter!` walks the sub-cache, then a lingering
+       mounted owner's watch removal auto-disposes the same cached
+       Reaction — the sub-cache teardown callbacks do not re-fire.
+
+  ns ends in -cljs-test so shadow-cljs's `:node-test` build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.core :as r]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.adapter.reagent :as reagent-adapter]))
+
+;; ---- fixture --------------------------------------------------------------
+;;
+;; Cold-start, mirroring dispose-adapter-sub-cache-walk-cljs-test: the
+;; routed interop surface and the claimed-generation dispose path are both
+;; under test, so each test installs the Reagent adapter itself and cleans
+;; up so a re-run is idempotent.
+
+(defn- cold-start-fixture [test-fn]
+  (adapter/reset-lifecycle-state-for-tests!)
+  (reset! frame/frames {})
+  (rf/init! reagent-adapter/adapter)
+  (frame/ensure-default-frame!)
+  (test-fn)
+  (when (adapter/current-adapter)
+    (adapter/dispose-adapter!))
+  (reset! frame/frames {})
+  (adapter/reset-lifecycle-state-for-tests!))
+
+(use-fixtures :each cold-start-fixture)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- make-source-and-derived
+  "Build a real source container and derived Reaction through the adapter
+  map's own contract slots. `compute-count` observes recomputes so tests
+  can assert the source wire is released by disposal."
+  [initial compute-count]
+  (let [make-container (:make-state-container reagent-adapter/adapter)
+        make-derived   (:make-derived-value reagent-adapter/adapter)
+        src            (make-container initial)
+        rx             (make-derived [src] (fn [v]
+                                             (swap! compute-count inc)
+                                             (inc v)))]
+    {:src src :rx rx}))
+
+(defn- cached-reaction
+  "The `:reaction` cached for `frame-id`'s single sub-cache entry."
+  [frame-id]
+  (let [cache (:sub-cache (frame/frame frame-id))]
+    (some (fn [[_k entry]] (:reaction entry)) @cache)))
+
+;; ---- 1. double dispose --------------------------------------------------
+
+(deftest double-dispose-fires-each-callback-exactly-once-in-order
+  (testing "a second interop/dispose! re-fires nothing; the first fired the
+  callbacks in registration order"
+    (let [compute-count (atom 0)
+          {:keys [rx]}  (make-source-and-derived 1 compute-count)
+          fired         (atom [])]
+      (is (= 2 @rx) "precondition: the derived value computes")
+      (interop/add-on-dispose! rx (fn [_] (swap! fired conj :cb-1)))
+      (interop/add-on-dispose! rx (fn [_] (swap! fired conj :cb-2)))
+      (interop/dispose! rx)
+      (is (= [:cb-1 :cb-2] @fired)
+          "first dispose! fired both callbacks, in registration order")
+      (interop/dispose! rx)
+      (is (= [:cb-1 :cb-2] @fired)
+          "second dispose! re-fired nothing (exactly-once)"))))
+
+;; ---- 2. re-entrant dispose ------------------------------------------------
+
+(deftest re-entrant-dispose-returns-without-recursion
+  (testing "a callback that re-enters interop/dispose! on the same Reaction
+  neither recurses nor re-fires the callback set"
+    (let [compute-count (atom 0)
+          {:keys [rx]}  (make-source-and-derived 1 compute-count)
+          fired         (atom [])
+          re-entered?   (atom false)]
+      (is (= 2 @rx) "precondition: the derived value computes")
+      ;; Conditional re-entry (first invocation only) so that WITHOUT the
+      ;; guard this proof goes red by count rather than by stack overflow.
+      (interop/add-on-dispose! rx
+        (fn [r]
+          (swap! fired conj :re-entrant-cb)
+          (when-not @re-entered?
+            (reset! re-entered? true)
+            (interop/dispose! r))))
+      (interop/add-on-dispose! rx (fn [_] (swap! fired conj :after-cb)))
+      (interop/dispose! rx)
+      (is (= [:re-entrant-cb :after-cb] @fired)
+          "each callback fired exactly once despite the re-entrant dispose!"))))
+
+;; ---- 3. host/adapter crossover --------------------------------------------
+;;
+;; Stock `Reaction.-remove-watch` auto-disposes when the last outward watch
+;; drops and `auto-run` is nil. Explicit disposal does NOT clear the outward
+;; `watches` map, so a mounted owner that unmounts later re-enters
+;; `dispose!` from inside stock Reagent — a path the adapter never sees.
+
+(deftest adapter-dispose-then-host-auto-dispose-fires-once
+  (testing "explicit adapter disposal, then removing the final outward watch
+  (stock auto-disposal): callbacks fire once; the source wire is released"
+    (let [compute-count (atom 0)
+          {:keys [src rx]} (make-source-and-derived 1 compute-count)
+          fired         (atom 0)]
+      (is (= 2 @rx) "precondition: the derived value computes")
+      ;; Put the Reaction on the push path so it holds a live source watch.
+      (interop/activate-derived-value! rx)
+      (interop/add-on-dispose! rx (fn [_] (swap! fired inc)))
+      (add-watch rx ::owner (fn [_ _ _ _] nil))
+      (let [computes-before-dispose @compute-count]
+        (interop/dispose! rx)
+        (is (= 1 @fired) "explicit disposal fired the callback once")
+        ;; One-shot path intact: the source wire is released, so a source
+        ;; write no longer recomputes the disposed Reaction.
+        (reset! src 41)
+        (r/flush)
+        (is (= computes-before-dispose @compute-count)
+            "post-dispose source write drove no recompute (source wire released)"))
+      ;; The lingering owner unmounts: stock -remove-watch auto-disposes.
+      (remove-watch rx ::owner)
+      (is (= 1 @fired)
+          "stock auto-disposal after explicit disposal re-fired nothing"))))
+
+(deftest host-auto-dispose-then-adapter-dispose-fires-once
+  (testing "stock auto-disposal (final outward watch removed), then explicit
+  adapter disposal: callbacks fire once"
+    (let [compute-count (atom 0)
+          {:keys [rx]}  (make-source-and-derived 1 compute-count)
+          fired         (atom 0)]
+      (is (= 2 @rx) "precondition: the derived value computes")
+      (interop/add-on-dispose! rx (fn [_] (swap! fired inc)))
+      (add-watch rx ::owner (fn [_ _ _ _] nil))
+      (remove-watch rx ::owner)
+      (is (= 1 @fired) "stock auto-disposal fired the callback once")
+      (interop/dispose! rx)
+      (is (= 1 @fired)
+          "explicit disposal after stock auto-disposal re-fired nothing"))))
+
+;; ---- 4. shutdown + unmount interleaving ------------------------------------
+;;
+;; The claimed-generation path: `dispose-adapter!` walks every live frame's
+;; sub-cache and disposes each cached Reaction through the generation's own
+;; disposer (NOT the routed hook, which terminal teardown has already
+;; closed). A mounted owner's outward watch survives that walk; its later
+;; removal auto-disposes the same Reaction inside stock Reagent.
+
+(deftest shutdown-then-unmount-does-not-refire-sub-cache-teardown
+  (testing "dispose-adapter! then a lingering owner's watch removal: the
+  cached Reaction's teardown callbacks fire once"
+    (rf/make-frame {:id :once/a})
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:seed 1] {:frame :once/a})
+    (let [handle (rf/subscribe [:n] {:frame :once/a})
+          _      (is (= 1 @handle) "precondition: the sub materialises")
+          rx     (cached-reaction :once/a)
+          fired  (atom 0)]
+      (is (some? rx) "precondition: the sub-cache holds the Reaction")
+      (interop/add-on-dispose! rx (fn [_] (swap! fired inc)))
+      ;; A mounted owner watches the cached Reaction across shutdown.
+      (add-watch rx ::owner (fn [_ _ _ _] nil))
+      (adapter/dispose-adapter!)
+      (is (= 1 @fired)
+          "claimed-generation shutdown disposed the cached Reaction once")
+      ;; The owner unmounts after shutdown: stock auto-disposal re-enters
+      ;; dispose! on the already-disposed Reaction.
+      (remove-watch rx ::owner)
+      (is (= 1 @fired)
+          "post-shutdown unmount re-fired no teardown callback"))))
+
+(deftest unmount-then-shutdown-does-not-refire-sub-cache-teardown
+  (testing "a lingering owner's watch removal (stock auto-disposal evicting
+  the cache slot), then dispose-adapter!: teardown callbacks fire once"
+    (rf/make-frame {:id :once/b})
+    (rf/reg-event :seed (fn [{:keys [db]} [_ n]] {:db {:n n}}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:seed 2] {:frame :once/b})
+    (let [handle (rf/subscribe [:n] {:frame :once/b})
+          _      (is (= 2 @handle) "precondition: the sub materialises")
+          rx     (cached-reaction :once/b)
+          fired  (atom 0)]
+      (is (some? rx) "precondition: the sub-cache holds the Reaction")
+      (interop/add-on-dispose! rx (fn [_] (swap! fired inc)))
+      (add-watch rx ::owner (fn [_ _ _ _] nil))
+      ;; The owner unmounts first: stock auto-disposal fires the teardown,
+      ;; whose sub-cache closure evicts the slot (pre-existing behaviour).
+      (remove-watch rx ::owner)
+      (is (= 1 @fired) "stock auto-disposal fired the teardown once")
+      (is (nil? (cached-reaction :once/b))
+          "auto-disposal evicted the sub-cache slot (teardown preserved)")
+      ;; Adapter shutdown then walks a cache that no longer holds it — and
+      ;; even a direct second disposal of the same Reaction is a no-op.
+      (adapter/dispose-adapter!)
+      (is (= 1 @fired)
+          "adapter shutdown after unmount re-fired no teardown callback"))))


### PR DESCRIPTION
## Summary

rf2-rzeko (P1 bug). Stock Reagent 2.0.1's `reagent.ratom/dispose!` has no disposed guard and does not clear `on-dispose` / `on-dispose-arr` before invoking them, and `Reaction.-remove-watch` auto-disposes when the last outward watch drops. Both stock-adapter disposal paths (the claimed-generation shutdown walk and the routed `:adapter/dispose!` hook) delegated raw — so adapter shutdown followed by a host unmount (or the reverse) re-fired every disposal callback, double-releasing sub-cache input refs and repeating user teardown, and a callback that defensively re-entered `dispose!` could recurse to stack overflow. Spec 006 §On-dispose hooks promises exactly-once, idempotent, re-entrant-safe disposal.

## Fix (adapter-owned, zero spine changes)

Every Reaction the adapter creates (spine `:make-reaction` feeding `make-derived-value`, and the routed `:adapter/make-reaction`) is armed at construction with a FIRST-registered `add-on-dispose!` marker that stamps a terminal disposed mark (string-keyed expando — never renamed under `:advanced`) and nils both callback holders. Stock `dispose!` iterates a captured local of the callback array, so the first firing still completes in registration order; any later `dispose!` — including a stock-internal auto-dispose the adapter never sees — finds empty holders and re-fires nothing. Both the claimed-generation disposer and the routed `:adapter/dispose!` hook delegate through `dispose-once!`, which consults the same mark. No fork of Reagent; native Reaction object and batching untouched; reagent-slim (already guarded in its own Reaction, rf2-1bzlai) untouched; `spine.cljs` untouched; no hot-zone file touched.

## Tests

New focused suite `re-frame.adapter-reaction-dispose-exactly-once-cljs-test` (6 deftests / 21 assertions), all through the actual public paths (adapter map `:make-derived-value`/`:make-state-container`, routed `re-frame.interop` surface, `adapter/dispose-adapter!`, core `add-watch`/`remove-watch` for stock auto-disposal):

1. double `interop/dispose!` — each callback exactly once, in registration order
2. conditional re-entrant `interop/dispose!` from inside a callback — no recursion, no double-fire
3. host/adapter crossover both orders (explicit dispose then last-watch removal; last-watch removal then explicit dispose) — callback count stays 1; one-shot path still releases the source wire (no recompute after disposal)
4. shutdown+unmount interleaving through the claimed-generation `dispose-adapter!` walk, both orders — sub-cache teardown fires once; auto-disposal's cache-slot eviction preserved

## Quality gates

All run from the worker worktree; exit codes captured via redirect + `echo $?` on the same command line (no pipes).

| Gate | Result | Captured exit |
|---|---|---|
| `node scripts/compile-node-test.cjs node-test out/node-test.js` (post-rebase) | Build completed, 0 warnings | 0 |
| Focused new suite (`--test=re-frame.adapter-reaction-dispose-exactly-once-cljs-test`) | 6 tests / 21 assertions, 0 failures, 0 errors | 0 |
| Existing disposal lifecycle suites (`dispose-adapter-sub-cache-walk`, `sub-dispose-view`, `standard-epochs-views-subs-lifecycle`) | 14 tests / 111 assertions, 0 failures, 0 errors | 0 |
| Full `test:cljs` equivalent (`compile && node out/node-test.js`), post-rebase onto ead1d8529c | 11111 tests / 54506 assertions, 0 failures, 0 errors | 0 |

(The same full suite also ran green pre-rebase: 11101 tests / 54411 assertions, exit 0.)

## Control (non-vacuity)

Guard removed at ONE line — `#_` on the marker registration in `install-dispose-guard!`, routing the same proofs to raw `ratom/dispose!` under the pinned Reagent 2.0.1 — then recompiled and re-run: focused suite exit **1**, **5 failures / 6 tests** (double-dispose, re-entrant, both crossovers, shutdown-then-unmount all red with re-fired callbacks, e.g. `(not (= 1 2))`). The one green, `unmount-then-shutdown`, is expected: pre-existing cache eviction means that ordering never re-touches the Reaction, so it pins preserved behaviour rather than the guard. Restore verified by blob hash: `git hash-object` of the restored file = committed object `4d4e6db6132daa901b911eda2e58d9a2cfff10e6`; recompile + focused re-run exit 0.

No docs/spec pages changed, so no link/anchor gates apply; spec/006 needed no edit (the fixed behaviour matches its promise verbatim).