### PR TITLE
fix(schemas): declaration presence is key-presence, not value truthiness (rf2-6eh5h)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -617,7 +617,12 @@
         ;; when `schema` declares any `:sensitive?` slot.
         leak-slots (cond-> {:value value}
                      (some? explanation) (assoc :explain explanation))
-        redacted   (if (and redact-fn (some? schema))
+        ;; The schema declaration's PRESENCE was established by the caller
+        ;; (`validate-recordable-value!` delegates only a present key), so
+        ;; do NOT suppress redaction again with a truthiness / some? test
+        ;; on the opaque schema value (rf2-6eh5h): a present nil schema is
+        ;; opaque to the walker, which classes it fail-closed sensitive.
+        redacted   (if redact-fn
                      (try
                        (redact-fn schema leak-slots)
                        (catch #?(:clj Throwable :cljs :default) e
@@ -655,9 +660,12 @@
 (defn- validate-recordable-value!
   "Validate a recordable `value` for `cofx-id` against its registration's
   `:schema` (from `meta`). A no-op when the registration declares no
-  `:schema`, when no validator is registered (schemas artefact absent / set
-  to nil), or when the value conforms; otherwise emits
-  `:rf.error/cofx-value-invalid` and THROWS (a production hard error).
+  `:schema` — declaration is KEY-presence, not value truthiness
+  (rf2-6eh5h): a present nil / false `:schema` is delegated verbatim to
+  the registered validator — when no validator is registered (schemas
+  artefact absent / set to nil), or when the value conforms; otherwise
+  emits `:rf.error/cofx-value-invalid` and THROWS (a production hard
+  error).
 
   Routes through the shared `:schemas/validate-with-registered-fn` /
   `:schemas/explain-with-registered-fn` late-bind seam (the same one
@@ -669,33 +677,38 @@
   [cofx-id value meta failing-id frame-id continue?]
   (if-not (continue?)
     nil
-    (if-let [schema (:schema meta)]
-    (let [validate-fn (late-bind/get-fn-cached :schemas/validate-with-registered-fn)]
-      (if (nil? validate-fn)
-        ;; No validator registered (schemas artefact absent, or
-        ;; `set-schema-validator!` called with nil) → nil = "every value
-        ;; passes"; the check is a no-op (Spec 010 §Non-Malli validators).
-        value
-        (let [ok? (try (validate-fn schema value)
-                       (catch #?(:clj Throwable :cljs :default) e
-                         (if (continue?) false nil)))]
-          (cond
-            (not (continue?)) nil
-            ok?
-            value
-            :else
-            (let [explain-fn  (late-bind/get-fn-cached :schemas/explain-with-registered-fn)
-                  explanation (when (and (continue?) explain-fn)
-                                (try (explain-fn schema value)
-                                     (catch #?(:clj Throwable :cljs :default) e
-                                       (if (continue?) nil nil))))]
-              ;; Pass `schema` so the emit redacts the value-bearing slots
-              ;; (trace tags AND thrown ex-data) when the schema marks any
-              ;; slot `:sensitive?` — fail-closed off-box (rf2-hdi6wr).
-              (when (continue?)
-                (emit-cofx-value-invalid! cofx-id value explanation schema failing-id frame-id
-                                          continue?)))))))
-      value)))
+    ;; KEY-presence, not value truthiness (rf2-6eh5h): a present nil /
+    ;; false `:schema` is a declaration whose exact token goes to the
+    ;; registered validator (default Malli throws on the non-schema form
+    ;; → the catch below fails CLOSED). Only an ABSENT key skips.
+    (if-not (contains? meta :schema)
+      value
+      (let [schema      (:schema meta)
+            validate-fn (late-bind/get-fn-cached :schemas/validate-with-registered-fn)]
+        (if (nil? validate-fn)
+          ;; No validator registered (schemas artefact absent, or
+          ;; `set-schema-validator!` called with nil) → nil = "every value
+          ;; passes"; the check is a no-op (Spec 010 §Non-Malli validators).
+          value
+          (let [ok? (try (validate-fn schema value)
+                         (catch #?(:clj Throwable :cljs :default) e
+                           (if (continue?) false nil)))]
+            (cond
+              (not (continue?)) nil
+              ok?
+              value
+              :else
+              (let [explain-fn  (late-bind/get-fn-cached :schemas/explain-with-registered-fn)
+                    explanation (when (and (continue?) explain-fn)
+                                  (try (explain-fn schema value)
+                                       (catch #?(:clj Throwable :cljs :default) e
+                                         (if (continue?) nil nil))))]
+                ;; Pass `schema` so the emit redacts the value-bearing slots
+                ;; (trace tags AND thrown ex-data) when the schema marks any
+                ;; slot `:sensitive?` — fail-closed off-box (rf2-hdi6wr).
+                (when (continue?)
+                  (emit-cofx-value-invalid! cofx-id value explanation schema failing-id frame-id
+                                            continue?))))))))))
 
 ;; ---- structural-EDN check of GENERATED recordable values ------------------
 ;;    (EP-0017 erratum rf2-rmroo4 slice B — rf2-uqz2ir)

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -1486,9 +1486,13 @@
         ;; failure :where :fx-args` trace; this caller only honours the
         ;; boolean.
         ;; Sticky hook (rf2-f72pd) — fires per-fx invocation.
+        ;; KEY-presence, not value truthiness (rf2-6eh5h): a present nil /
+        ;; false `:schema` on the fx registration is a declaration — consult
+        ;; `validate-fx!`, which delegates the exact token to the registered
+        ;; validator. Only an ABSENT key short-circuits to pass.
         (let [validate-fx! (late-bind/get-fn-cached :schemas/validate-fx!)
               fx-ok?       (if (and validate-fx!
-                                    (:schema meta))
+                                    (contains? meta :schema))
                              (try
                                ;; rf2-9cm27 — pass the in-flight cascade's
                                ;; frame so the `:where :fx-args` failure trace

--- a/implementation/core/src/re_frame/spec.cljc
+++ b/implementation/core/src/re_frame/spec.cljc
@@ -196,12 +196,19 @@
                 (nil? handler-meta)
                 ctx
 
-                ;; Per rf2-iftj4, registration would have rejected an
-                ;; validate-at-boundary-interceptor attachment without `:schema`. A nil
-                ;; schema here can only happen if a caller mutated the
-                ;; registry metadata after registration; fall through
-                ;; as a no-op (defensive — never expected in practice).
-                (nil? schema)
+                ;; Declaration is KEY-presence, not value truthiness
+                ;; (rf2-6eh5h). Per rf2-iftj4 registration rejects a
+                ;; boundary attachment whose metadata lacks the `:schema`
+                ;; KEY — but `{:schema nil}` registers (the registrar
+                ;; checks `contains?`), so a present falsey value MUST be
+                ;; delegated verbatim below rather than treated as
+                ;; impossible: the old `(nil? schema)` no-op ran the
+                ;; handler UNGUARDED on exactly the payloads this
+                ;; interceptor exists to gate (a release-resident
+                ;; fail-open). An ABSENT key can only mean the registry
+                ;; metadata was mutated post-registration; no declaration,
+                ;; fall through as a no-op (defensive).
+                (not (contains? handler-meta :schema))
                 ctx
 
                 :else

--- a/implementation/core/src/re_frame/subs/memo.cljc
+++ b/implementation/core/src/re_frame/subs/memo.cljc
@@ -104,7 +104,10 @@
   capture buffers only frame-tagged traces). Mirrors the `:where
   :app-db` / `:where :event` traces."
   [value query-v sub-id sub-meta frame-id]
-  (if (and sub-meta (:schema sub-meta))
+  ;; KEY-presence, not value truthiness (rf2-6eh5h): a present nil / false
+  ;; `:schema` is a declaration — consult the validator seam, which
+  ;; delegates the exact token. Only an ABSENT key skips the consult.
+  (if (and sub-meta (contains? sub-meta :schema))
     ;; Sticky hook — fires per-sub recompute.
     (if-let [validate (late-bind/get-fn-cached :schemas/validate-sub!)]
       (if (try (validate sub-id query-v value sub-meta frame-id)

--- a/implementation/core/src/re_frame/subs/override_schema.cljc
+++ b/implementation/core/src/re_frame/subs/override_schema.cljc
@@ -32,7 +32,9 @@
 (defn validate-sub-override!
   "Validate a resolved Story override HIT and RECOVER to nil on a violation.
 
-  When `sub-meta` declares an output `:schema`, validate `value` against it
+  When `sub-meta` declares an output `:schema` — declaration is KEY-presence,
+  not value truthiness (rf2-6eh5h); a present nil / false token is delegated
+  verbatim — validate `value` against it
   via the registered validator (`:schemas/validate-with-registered-fn`). On
   a mismatch, emit `:rf.error/schema-validation-failure` tagged `:where
   :sub-override` (value-bearing slots routed through the shared
@@ -51,8 +53,13 @@
   generation (a multi-image frame validates against its own image's schema);
   this primitive takes the already-resolved metadata."
   [value query-v sub-meta frame-id]
-  (let [schema (:schema sub-meta)]
-    (if (and schema (some? sub-meta))
+  ;; KEY-presence, not value truthiness (rf2-6eh5h): a present nil / false
+  ;; `:schema` is a declaration whose exact token is delegated to the
+  ;; registered validator; only an ABSENT key means no declaration.
+  ;; (`contains?` on a nil sub-meta is false, covering the frameless case.)
+  (if-not (contains? sub-meta :schema)
+    value
+    (let [schema (:schema sub-meta)]
       (if-let [validate (late-bind/get-fn-cached :schemas/validate-with-registered-fn)]
         (if (try (validate schema value)
                  (catch #?(:clj Throwable :cljs :default) _ true))
@@ -80,5 +87,4 @@
                                (cond-> tags
                                  redact (->> (redact schema))))
             nil))
-        value)
-      value)))
+        value))))

--- a/implementation/core/test/re_frame/schema_presence_seams_test.clj
+++ b/implementation/core/test/re_frame/schema_presence_seams_test.clj
@@ -1,0 +1,181 @@
+(ns re-frame.schema-presence-seams-test
+  "rf2-6eh5h — declaration presence is KEY-presence at every core-side
+  Spec 010 validation seam.
+
+  The schemas artefact's own suite (`re-frame.schemas-presence-test`) pins
+  the meta-bearing hot path (`run-validation`) and the production boundary
+  interceptor. This namespace pins the census of core-owned consumer seams
+  that used to test the schema VALUE for truthiness:
+
+   - **Recordable cofx** (`re-frame.cofx/validate-recordable-value!`) —
+     used `(if-let [schema (:schema meta)] …)`, so a present nil / false
+     token silently skipped the always-on production hard error.
+   - **Sub override** (`re-frame.subs.override-schema/validate-sub-override!`)
+     — used `(and schema …)`.
+   - **Sub return outer gate** (`re-frame.subs.memo/maybe-validate-sub!`)
+     — gated the `:schemas/validate-sub!` consult on `(:schema sub-meta)`
+     truthiness, bypassing the (now presence-correct) validator seam.
+   - **Fx-args outer gate** (`re-frame.fx` walk) — gated `validate-fx!`
+     on `(:schema meta)` truthiness.
+
+  Contract pinned per AC 3: a present falsey token is delegated exactly
+  once and the surface takes its documented recovery; an omitted key
+  remains a no-op (the validator is never consulted)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.cofx :as cofx]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.event-emit :as event-emit]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.schemas.malli]
+            [re-frame.subs.memo :as memo]
+            [re-frame.subs.override-schema :as override-schema]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace])
+  (:import [clojure.lang ExceptionInfo]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (schemas/clear-schemas-by-frame!)
+  (schemas/reset-schema-validator!)
+  (trace/clear-listeners!)
+  (error-emit/clear-error-listeners!)
+  (event-emit/clear-event-listeners!)
+  (rf/init! plain-atom/adapter)
+  ;; `registrar/clear-all!` drops the framework-standard registrations;
+  ;; `init!` re-seeds them. Reloading the schemas artefact republishes the
+  ;; late-bind validation hooks these seams reach through (mirrors
+  ;; `re-frame.always-on-validation-production-test`).
+  (require 're-frame.schemas :reload)
+  (rf/make-frame {:id :rf/default})
+  (try
+    (rf/with-frame :rf/default
+      (test-fn))
+    (finally
+      (schemas/reset-schema-validator!))))
+
+(use-fixtures :each reset-runtime)
+
+(defn- spy-validator!
+  "Install a validator that records every schema token it is handed and
+  returns false. Returns the recording atom."
+  []
+  (let [seen (atom [])]
+    (schemas/set-schema-validator!
+      (fn [schema _value] (swap! seen conj schema) false))
+    seen))
+
+;; The recordable-cofx validator is deliberately private (its public
+;; surface is the EP-0017 satisfaction pipeline); reach it through its var
+;; for the focused seam pin.
+(def ^:private validate-recordable-value!
+  @#'cofx/validate-recordable-value!)
+
+;; ===========================================================================
+;; Recordable cofx — present falsey token delegated; the hard error fires
+;; ===========================================================================
+
+(deftest recordable-cofx-delegates-present-falsey-tokens
+  (doseq [token [nil false]]
+    (testing (str "a present " (pr-str token) " :schema on a recordable "
+                  "cofx registration is delegated verbatim; the false "
+                  "verdict takes the documented production hard error")
+      (let [seen (spy-validator!)]
+        (is (thrown? ExceptionInfo
+              (validate-recordable-value!
+                :cofx/x {:v 1} {:schema token} :ev/x nil (constantly true)))
+            ":rf.error/cofx-value-invalid THROWS — the always-on recovery")
+        (is (= [token] @seen)
+            "the EXACT declared token reached the validator, exactly once")))))
+
+(deftest recordable-cofx-omitted-key-is-a-no-op
+  (testing "an ABSENT :schema key on a recordable cofx registration never
+            consults the validator and returns the value"
+    (let [seen (spy-validator!)]
+      (is (= {:v 1}
+             (validate-recordable-value!
+               :cofx/x {:v 1} {:doc "no schema"} :ev/x nil (constantly true)))
+          "value returned unchanged")
+      (is (= [] @seen) "the validator was never consulted"))))
+
+;; ===========================================================================
+;; Sub override — present falsey token delegated; recover-to-nil
+;; ===========================================================================
+
+(deftest sub-override-delegates-present-falsey-tokens
+  (doseq [token [nil false]]
+    (testing (str "a present " (pr-str token) " :schema on the overridden "
+                  "sub's metadata is delegated verbatim; the false verdict "
+                  "recovers to nil (:replaced-with-default)")
+      (let [seen (spy-validator!)]
+        (is (nil? (override-schema/validate-sub-override!
+                    {:pinned :state} [:sub/x] {:schema token} nil))
+            "override value replaced with nil on the false verdict")
+        (is (= [token] @seen)
+            "the EXACT declared token reached the validator, exactly once")))))
+
+(deftest sub-override-omitted-key-is-a-no-op
+  (testing "an ABSENT :schema key passes the override value through unchecked"
+    (let [seen (spy-validator!)]
+      (is (= {:pinned :state}
+             (override-schema/validate-sub-override!
+               {:pinned :state} [:sub/x] {:doc "no schema"} nil)))
+      (is (= [] @seen) "the validator was never consulted"))))
+
+;; ===========================================================================
+;; Sub return outer gate (memo) — the consult itself is presence-gated
+;; ===========================================================================
+
+(deftest memo-gate-consults-the-validator-for-present-falsey-tokens
+  (doseq [token [nil false]]
+    (testing (str "maybe-validate-sub! consults the :schemas/validate-sub! "
+                  "seam for a present " (pr-str token) " :schema; the false "
+                  "verdict recovers to nil")
+      (let [seen (spy-validator!)]
+        (is (nil? (memo/maybe-validate-sub! 42 [:sub/x] :sub/x
+                                            {:schema token} nil))
+            "sub return replaced with nil on the false verdict")
+        (is (= [token] @seen)
+            "the EXACT declared token reached the validator, exactly once")))))
+
+(deftest memo-gate-omitted-key-is-a-no-op
+  (testing "an ABSENT :schema key returns the sub value unchecked"
+    (let [seen (spy-validator!)]
+      (is (= 42 (memo/maybe-validate-sub! 42 [:sub/x] :sub/x {:doc "x"} nil)))
+      (is (= 42 (memo/maybe-validate-sub! 42 [:sub/x] :sub/x nil nil))
+          "nil sub-meta is 'no declaration' too")
+      (is (= [] @seen) "the validator was never consulted"))))
+
+;; ===========================================================================
+;; Fx-args outer gate — through the real effect walk
+;; ===========================================================================
+
+(deftest fx-gate-delegates-a-present-false-token-through-the-real-walk
+  (testing "a reg-fx registration declaring {:schema false} is validated
+            during the :fx walk (spy sees the exact false token once) and
+            the offending fx is SKIPPED (recovery :skipped); siblings and
+            the cascade are unaffected"
+    (let [seen     (spy-validator!)
+          fx-calls (atom 0)]
+      (rf/reg-fx :fxp/guarded {:schema false}
+                 (fn [_ctx _args] (swap! fx-calls inc)))
+      (rf/reg-event :evp/emit
+        (fn [{:keys [db]} _] {:db db :fx [[:fxp/guarded {:a 1}]]}))
+      (rf/dispatch-sync [:evp/emit])
+      (is (= 0 @fx-calls) "the fx handler was skipped on the false verdict")
+      (is (= [false] @seen)
+          "the EXACT false token reached the validator, exactly once"))))
+
+(deftest fx-gate-omitted-key-is-a-no-op
+  (testing "a reg-fx registration with no :schema key runs unchecked"
+    (let [seen     (spy-validator!)
+          fx-calls (atom 0)]
+      (rf/reg-fx :fxp/plain (fn [_ctx _args] (swap! fx-calls inc)))
+      (rf/reg-event :evp/emit
+        (fn [{:keys [db]} _] {:db db :fx [[:fxp/plain {:a 1}]]}))
+      (rf/dispatch-sync [:evp/emit])
+      (is (= 1 @fx-calls) "the fx ran")
+      (is (= [] @seen) "the validator was never consulted"))))

--- a/implementation/core/test/re_frame/schema_presence_seams_test.clj
+++ b/implementation/core/test/re_frame/schema_presence_seams_test.clj
@@ -129,7 +129,12 @@
 ;; Sub return outer gate (memo) — the consult itself is presence-gated
 ;; ===========================================================================
 
-(deftest memo-gate-consults-the-validator-for-present-falsey-tokens
+;; ^:requires-debug — the consult delegates to the schemas artefact's
+;; `validate-sub!`, whose body is Spec 010 dev-only (elided under
+;; `-Dre-frame.debug=false`, where it returns true by design). The
+;; production-side presence enforcement is pinned by the boundary /
+;; recordable-cofx tests, which run under the gate untagged.
+(deftest ^:requires-debug memo-gate-consults-the-validator-for-present-falsey-tokens
   (doseq [token [nil false]]
     (testing (str "maybe-validate-sub! consults the :schemas/validate-sub! "
                   "seam for a present " (pr-str token) " :schema; the false "
@@ -153,7 +158,10 @@
 ;; Fx-args outer gate — through the real effect walk
 ;; ===========================================================================
 
-(deftest fx-gate-delegates-a-present-false-token-through-the-real-walk
+;; ^:requires-debug — the fx walk's consult delegates to the schemas
+;; artefact's `validate-fx!`, whose body is Spec 010 dev-only (elided
+;; under `-Dre-frame.debug=false`, where the fx runs unchecked by design).
+(deftest ^:requires-debug fx-gate-delegates-a-present-false-token-through-the-real-walk
   (testing "a reg-fx registration declaring {:schema false} is validated
             during the :fx walk (spy sees the exact false token once) and
             the offending fx is SKIPPED (recovery :skipped); siblings and

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -98,7 +98,11 @@
         schema (:schema flow)]
     (cond
       (not (live?)) false
-      (nil? schema) true
+      ;; KEY-presence, not value truthiness (rf2-6eh5h): a present nil /
+      ;; false `:schema` on the flow is a declaration whose exact token is
+      ;; delegated to the registered validator below; only an ABSENT key
+      ;; means no declaration.
+      (not (contains? flow :schema)) true
       :else
       (if-let [validate (late-bind/get-fn-cached
                           :schemas/validate-with-registered-fn)]

--- a/implementation/flows/test/re_frame/flows_schema_validation_test.clj
+++ b/implementation/flows/test/re_frame/flows_schema_validation_test.clj
@@ -229,3 +229,31 @@
     (let [ids (set (map #(get-in % [:tags :rf.flow/id]) (violations)))]
       (is (= #{:cart/subtotal :cart/total} ids)
           "both flows' bad outputs surface, each attributed to its own id"))))
+
+;; ---------------------------------------------------------------------------
+;; 7. rf2-6eh5h — declaration presence is KEY-presence, not value truthiness.
+;;    A flow registered with an explicit {:schema nil} DELEGATES the exact
+;;    nil token to the registered validator (the value is opaque per Spec
+;;    010); only an ABSENT key skips validation (case 3 above is the
+;;    control).
+;; ---------------------------------------------------------------------------
+
+(deftest present-nil-schema-is-delegated-not-skipped
+  (testing "an explicit {:schema nil} flow declaration reaches the validator
+            verbatim; the false verdict emits :where :flow-output"
+    (let [seen (atom [])]
+      (schemas/set-schema-fns!
+        {:validate (fn [schema _value] (swap! seen conj schema) false)})
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:w 3 :h 4}}))
+      (rf/reg-flow :area
+                   {:inputs [[:w] [:h]] :output-path [:rect :area] :schema nil}
+                   (fn [w h] (* w h)))
+      (rf/dispatch-sync [:seed])
+      (is (= [nil] @seen)
+          "the EXACT nil token reached the validator, exactly once")
+      (is (= 1 (count (violations)))
+          "the false verdict emitted exactly one flow-output violation")
+      (is (= :flow-output (get-in (first (violations)) [:tags :where]))
+          ":where :flow-output — the flow surface's own discriminator")
+      (is (= 12 (get-in (rf/app-db-value :rf/default) [:rect :area]))
+          "the value is still written — flow validation stays observational"))))

--- a/implementation/machines/src/re_frame/machines/data_validation.cljc
+++ b/implementation/machines/src/re_frame/machines/data_validation.cljc
@@ -242,8 +242,11 @@
   resolves through the registered event handler (`:machines/machine-meta`);
   a SPAWNED actor has NO per-instance handler — its TYPE rides the snapshot's
   `:rf/machine-type` reserved slot, so it resolves through
-  `:machines/spec-from-snapshot`. Returns the schema or nil
-  (no schema / unresolvable spec).
+  `:machines/spec-from-snapshot`. Returns the `[:data schema]` MAP ENTRY
+  (presence-carrying — the entry exists exactly when the spec declares the
+  key, so a present nil / false schema token is distinguishable from no
+  declaration, rf2-6eh5h; read the schema with `val`) or nil
+  (no declaration / unresolvable spec).
 
   Both resolvers are consumed through the late-bind table to keep this
   leaf namespace free of a require cycle through `re-frame.machines` /
@@ -254,22 +257,24 @@
   ([machine-id snapshot]
    (resolve-data-schema machine-id snapshot (constantly true)))
   ([machine-id snapshot continue?]
-   (let [meta-schema
+   (let [meta-entry
          (when (continue?)
            (some-> (when-let [meta-fn (late-bind/get-fn-cached :machines/machine-meta)]
                      (try
                        (meta-fn machine-id)
                        (catch #?(:clj Throwable :cljs :default) e
                          (if (continue?) (throw e) nil))))
-                   (get-in [:schemas :data])))]
-     (or meta-schema
+                   (get :schemas)
+                   (find :data)))]
+     (or meta-entry
          (when (continue?)
            (some-> (when-let [spec-fn (late-bind/get-fn-cached :machines/spec-from-snapshot)]
                      (try
                        (spec-fn snapshot)
                        (catch #?(:clj Throwable :cljs :default) e
                          (if (continue?) (throw e) nil))))
-                   (get-in [:schemas :data])))))))
+                   (get :schemas)
+                   (find :data)))))))
 
 (defn validate-machine-data!
   "Walk every snapshot under `[:rf.runtime/machines :snapshots]` in
@@ -319,10 +324,13 @@
         (nil? entries) ok?
         :else
         (let [[machine-id snapshot] (first entries)
-              schema (resolve-data-schema machine-id snapshot continue?)
-              result (if (and (continue?) schema)
+              ;; A presence-carrying [:data schema] map entry, or nil for no
+              ;; declaration (rf2-6eh5h) — so a present nil / false schema
+              ;; token is delegated to the validator rather than skipped.
+              schema-entry (resolve-data-schema machine-id snapshot continue?)
+              result (if (and (continue?) schema-entry)
                        (validate-snapshot-data!
-                         machine-id snapshot schema :macrostep continue?)
+                         machine-id snapshot (val schema-entry) :macrostep continue?)
                        true)]
           (if (or (= :rf/stale-incarnation result)
                   (not (continue?)))
@@ -359,11 +367,16 @@
    (validate-spawn-data! spawned-id spec snapshot (current-owner-continuation)))
   ([spawned-id spec snapshot continue?]
    (if interop/debug-enabled?
-     (if-let [schema (get-in spec [:schemas :data])]
+     ;; KEY-presence, not value truthiness (rf2-6eh5h): a present nil /
+     ;; false `[:schemas :data]` is a declaration whose exact token is
+     ;; delegated to the registered validator; only an ABSENT key means
+     ;; no declaration.
+     (if (contains? (get spec :schemas) :data)
        ;; Returns true (conform) / false (schema violation, A still owns) /
        ;; :rf/stale-incarnation (the validator callback lost A). The no-schema
        ;; branch runs NO callback, so A cannot be lost here — `true`.
-       (validate-snapshot-data! spawned-id snapshot schema :spawn continue?)
+       (validate-snapshot-data! spawned-id snapshot (get-in spec [:schemas :data])
+                                :spawn continue?)
        true)
      true)))
 
@@ -403,8 +416,12 @@
   [machine-id merged-snapshot]
   (if interop/debug-enabled?
     (let [continue? (current-owner-continuation)]
-      (if-let [schema (resolve-data-schema machine-id merged-snapshot continue?)]
-        (let [result (validate-snapshot-data! machine-id merged-snapshot schema
+      ;; Presence-carrying [:data schema] map entry (rf2-6eh5h): the entry
+      ;; is truthy whenever the spec DECLARES [:schemas :data], so a
+      ;; present nil / false schema token is delegated rather than skipped.
+      (if-let [schema-entry (resolve-data-schema machine-id merged-snapshot continue?)]
+        (let [result (validate-snapshot-data! machine-id merged-snapshot
+                                              (val schema-entry)
                                               :update-snapshot continue?)]
           ;; Owner-loss (:rf/stale-incarnation) is truthy — collapse it to
           ;; `false` so the caller's `(when validator (write))` skips the write.
@@ -455,51 +472,58 @@
   `goog.DEBUG=false`, parity with the `:where :machine-data` boundaries."
   [machine-id spec result]
   (if interop/debug-enabled?
-    (if-let [schema (get-in spec [:schemas :output])]
-      (if-let [validate-fn (late-bind/get-fn-cached
-                             :schemas/validate-with-registered-fn)]
-        ;; A MALFORMED `[:schemas :output]` schema (a bad Malli form) makes the
-        ;; registered validator THROW at validate-time (Malli validates forms
-        ;; lazily). The macrostep `:where :machine-data` boundary leans on the
-        ;; router's defensive catch for that, but finalize has no such
-        ;; wrapper — an escaping throw here would break the auto-destroy
-        ;; cascade and leave the actor half-torn-down. Per the best-effort
-        ;; completion posture the throw is caught: emit the standard
-        ;; `:rf.error/malformed-schema :where :machine-output` trace and
-        ;; PROCEED (return true), so a schema typo surfaces loudly yet never
-        ;; deadlocks a finishing machine.
-        (let [continue? (current-owner-continuation)]
-          (try
-            (let [conforms? (validate-fn schema result)]
-              (cond
-                ;; The validator callback destroyed A / published same-id B —
-                ;; suppress the (now-stale) diagnostic; do not attribute it to B.
-                (not (continue?)) :rf/stale-incarnation
-                conforms?         true
-                :else
-                (do (emit-failure! machine-id :machine-output :completion result
-                                   schema nil false
-                                   (str "Machine " machine-id
-                                        " completion output (the :output-key payload) "
-                                        "failed schema at boundary :where "
-                                        ":machine-output (phase :completion).")
-                                   continue?)
-                    false)))
-            (catch #?(:clj Throwable :cljs :default) e
-              ;; Owner still live → a genuine malformed-schema diagnostic.
-              ;; Owner lost (the callback threw AND destroyed A) → suppress it.
-              (if (continue?)
-                (do (trace/emit-error! :rf.error/malformed-schema
-                                       {:where    :machine-output
-                                        :reason   (str "Machine " machine-id
-                                                       "'s [:schemas :output] schema is malformed — "
-                                                       "the registered validator threw: "
-                                                       #?(:clj (.getMessage e) :cljs (ex-message e))
-                                                       ". The completion proceeds (best-effort).")
-                                        :schema   schema
-                                        :rollback? false})
-                    true)
-                :rf/stale-incarnation))))
-        true)
-      true)
+    ;; KEY-presence, not value truthiness (rf2-6eh5h): a present nil /
+    ;; false `[:schemas :output]` is a declaration whose exact token is
+    ;; delegated to the registered validator (default Malli then throws
+    ;; → the malformed-schema catch below surfaces it and proceeds,
+    ;; per the best-effort completion posture); only an ABSENT key
+    ;; means no declaration.
+    (if-not (contains? (get spec :schemas) :output)
+      true
+      (let [schema (get-in spec [:schemas :output])]
+        (if-let [validate-fn (late-bind/get-fn-cached
+                               :schemas/validate-with-registered-fn)]
+          ;; A MALFORMED `[:schemas :output]` schema (a bad Malli form) makes the
+          ;; registered validator THROW at validate-time (Malli validates forms
+          ;; lazily). The macrostep `:where :machine-data` boundary leans on the
+          ;; router's defensive catch for that, but finalize has no such
+          ;; wrapper — an escaping throw here would break the auto-destroy
+          ;; cascade and leave the actor half-torn-down. Per the best-effort
+          ;; completion posture the throw is caught: emit the standard
+          ;; `:rf.error/malformed-schema :where :machine-output` trace and
+          ;; PROCEED (return true), so a schema typo surfaces loudly yet never
+          ;; deadlocks a finishing machine.
+          (let [continue? (current-owner-continuation)]
+            (try
+              (let [conforms? (validate-fn schema result)]
+                (cond
+                  ;; The validator callback destroyed A / published same-id B —
+                  ;; suppress the (now-stale) diagnostic; do not attribute it to B.
+                  (not (continue?)) :rf/stale-incarnation
+                  conforms?         true
+                  :else
+                  (do (emit-failure! machine-id :machine-output :completion result
+                                     schema nil false
+                                     (str "Machine " machine-id
+                                          " completion output (the :output-key payload) "
+                                          "failed schema at boundary :where "
+                                          ":machine-output (phase :completion).")
+                                     continue?)
+                      false)))
+              (catch #?(:clj Throwable :cljs :default) e
+                ;; Owner still live → a genuine malformed-schema diagnostic.
+                ;; Owner lost (the callback threw AND destroyed A) → suppress it.
+                (if (continue?)
+                  (do (trace/emit-error! :rf.error/malformed-schema
+                                         {:where    :machine-output
+                                          :reason   (str "Machine " machine-id
+                                                         "'s [:schemas :output] schema is malformed — "
+                                                         "the registered validator threw: "
+                                                         #?(:clj (.getMessage e) :cljs (ex-message e))
+                                                         ". The completion proceeds (best-effort).")
+                                          :schema   schema
+                                          :rollback? false})
+                      true)
+                  :rf/stale-incarnation))))
+          true)))
     true))

--- a/implementation/machines/test/re_frame/machine_schema_test.clj
+++ b/implementation/machines/test/re_frame/machine_schema_test.clj
@@ -316,3 +316,63 @@
         ;; `:recovery` rides the trace envelope, not :tags.
         (is (contains? trace-ev :recovery) ":recovery present on trace envelope")
         (is (string? (:reason tag))       ":reason is a human-readable string")))))
+
+;; ---- (7) rf2-6eh5h — declaration presence is KEY-presence ------------------
+;;
+;; A schema value is OPAQUE to re-frame (Spec 010): an ABSENT [:schemas :data]
+;; key means "no declaration" (case 5 above), while a PRESENT key must hand
+;; its exact value — nil included — to the registered validator. Before
+;; rf2-6eh5h the machine seams tested the value for truthiness (if-let /
+;; `(and (continue?) schema)`), so `{:schemas {:data nil}}` silently
+;; validated nothing.
+
+(deftest present-nil-data-schema-is-delegated-not-skipped
+  (testing "a machine registered with {:schemas {:data nil}} delegates the
+            exact nil token to a custom validator at the bootstrap commit;
+            the false verdict emits :where :machine-data and rolls back"
+    (let [seen (atom [])]
+      (re-frame.schemas/set-schema-validator!
+        (fn [schema _value] (swap! seen conj schema) false))
+      (try
+        (let [spec {:initial :idle
+                    :data    {:n 1}
+                    :schemas {:data nil}
+                    :states  {:idle {}}}]
+          (rf/reg-machine :rf.machine-schema/nil-declared spec)
+          (let [traces (collect-traces!
+                         #(rf/dispatch-sync [:rf.machine-schema/nil-declared [:noop]]))]
+            (is (= [nil] @seen)
+                "the EXACT nil token reached the validator, exactly once")
+            (is (= 1 (count traces))
+                "the false verdict emitted the :where :machine-data boundary trace")
+            (is (= :machine-data (-> traces first :tags :where)))
+            (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                              [:rf.runtime/machines :snapshots
+                               :rf.machine-schema/nil-declared]))
+                "rolled back: the violating snapshot never installed")))
+        (finally
+          (re-frame.schemas/reset-schema-validator!))))))
+
+(deftest present-nil-data-schema-fails-closed-under-default-malli
+  (testing "with the DEFAULT Malli validator a present nil [:schemas :data]
+            fails CLOSED: Malli throws on the non-schema form, the
+            `:schemas/validate-with-registered-fn` seam isolates the throw
+            to a false verdict (its documented malformed-schema fail-closed
+            contract — the seam is a pure check surface, so the failure
+            surfaces as the boundary's own :where :machine-data trace), and
+            the bootstrap commit is rejected — never silently installed
+            unvalidated"
+    (let [spec {:initial :idle
+                :data    {:n 1}
+                :schemas {:data nil}
+                :states  {:idle {}}}]
+      (rf/reg-machine :rf.machine-schema/nil-malli spec)
+      (let [traces (collect-traces!
+                     #(rf/dispatch-sync [:rf.machine-schema/nil-malli [:noop]]))]
+        (is (= 1 (count traces))
+            "exactly one :where :machine-data boundary trace — fail closed")
+        (is (= :machine-data (-> traces first :tags :where))))
+      (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                        [:rf.runtime/machines :snapshots
+                         :rf.machine-schema/nil-malli]))
+          "rejected: the snapshot never installed (fail closed, not fail open)"))))

--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -390,7 +390,14 @@
 
   Parameters:
     - `reg-meta`     the registration metadata (handler / sub /
-                     fx) — its `:schema` slot, if any, is the schema.
+                     fx) — its `:schema` entry, when PRESENT, is the
+                     declaration. Presence is KEY-presence, never value
+                     truthiness (rf2-6eh5h): a present nil / false is a
+                     declaration whose exact token is delegated to the
+                     registered validator (the value is opaque per Spec
+                     010), mirroring `validate-app-schema!`'s
+                     unconditional pass-through. Only an ABSENT key
+                     means no declaration.
     - `value`        the value being checked (event vector, sub
                      return value, fx args).
     - `walk-schema?` boolean — when true and the validator fails,
@@ -448,9 +455,14 @@
   (if-not (continue?)
     :rf/stale-incarnation
     (if-let [vf @validator/validator-fn]
-      (if-let [schema (:schema reg-meta)]
+      ;; KEY-presence, not value truthiness (rf2-6eh5h): a present nil /
+      ;; false `:schema` is delegated verbatim — default Malli then throws
+      ;; on the non-schema form and the malformed isolation below fails
+      ;; CLOSED; a custom validator interprets its own token.
+      (if (contains? reg-meta :schema)
         ;; Isolate malformed schemas before a caller can treat a throw as pass.
-        (let [result (validate-entry-result vf schema value)]
+        (let [schema (:schema reg-meta)
+              result (validate-entry-result vf schema value)]
           ;; The registered validator is callback-bearing. A destroy+return or
           ;; destroy+throw makes its result inert before explanation, schema
           ;; walking, tag construction, or diagnostic delivery can begin.

--- a/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
@@ -278,3 +278,48 @@
         "no humanizer in a production build")
     (is (fn? (late-bind/get-fn :schemas/malli-validate))
         "the validator from the same adapter ns-load IS bound — the absence above is the gate, not a missing adapter")))
+
+;; ---- rf2-6eh5h — a present NIL :schema cannot run a boundary handler -----
+;;
+;; Declaration presence is KEY-presence, not value truthiness. The
+;; registrar accepts `{:schema nil :interceptors [:rf.schema/at-boundary]}`
+;; (it checks `contains?`), and before rf2-6eh5h the boundary interceptor's
+;; production branch treated nil as impossible and returned the context
+;; unchanged — in THIS build configuration (step-1 DCE'd, boundary as the
+;; only guard) the handler ran UNGUARDED on the untrusted payload the
+;; interceptor exists to gate. These pins are the release-resident
+;; regression: the boundary must delegate the exact nil token and reject.
+
+(deftest boundary-rejects-explicit-nil-schema-in-prod
+  (testing "rf2-6eh5h — under `:advanced` + `goog.DEBUG=false` a handler
+            registered with {:schema nil} + the boundary interceptor does
+            NOT run on dispatch: the nil delegates to default Malli, which
+            fails CLOSED through the seam's malformed-schema isolation"
+    (let [calls (atom 0)]
+      (rf/reg-event :wire/received
+        {:schema       nil
+         :interceptors [:rf.schema/at-boundary]}
+        (fn [_ _] (swap! calls inc) {}))
+      (rf/dispatch-sync [:wire/received {:untrusted "payload"}])
+      (is (= 0 @calls)
+          "handler NOT invoked — the present-nil declaration fails closed, never fail-open"))))
+
+(deftest boundary-delegates-nil-token-to-custom-validator-in-prod
+  (testing "rf2-6eh5h — the production path hands the EXACT nil token to a
+            substituted validator (the value is opaque per Spec 010); its
+            false verdict rejects the event and the handler is not invoked"
+    (let [seen  (atom [])
+          calls (atom 0)]
+      (schemas/set-schema-validator!
+        (fn [schema _value] (swap! seen conj schema) false))
+      (try
+        (rf/reg-event :wire/custom
+          {:schema       nil
+           :interceptors [:rf.schema/at-boundary]}
+          (fn [_ _] (swap! calls inc) {}))
+        (rf/dispatch-sync [:wire/custom {:untrusted 1}])
+        (is (= 0 @calls) "handler NOT invoked — rejected on the false verdict")
+        (is (= [nil] @seen)
+            "the validator RECEIVED the exact nil token in the production path")
+        (finally
+          (schemas/reset-schema-validator!))))))

--- a/implementation/schemas/test/re_frame/schemas_presence_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_presence_test.clj
@@ -1,0 +1,203 @@
+(ns re-frame.schemas-presence-test
+  "rf2-6eh5h — declaration presence is KEY-presence, not value truthiness.
+
+  The invariant under test (Spec 010 §The `:schema` value is opaque): an
+  ABSENT `:schema` key means \"no declaration\", while a PRESENT key must
+  hand its exact value — nil and false included — to the registered
+  validator. Before this bead the meta-bearing hot path (`run-validation`)
+  used `if-let`, so explicit nil / false tokens silently bypassed the
+  validator; and the PRODUCTION boundary interceptor treated a nil schema
+  as impossible and returned the context unchanged — a release-resident
+  fail-open in which `{:schema nil :interceptors [:rf.schema/at-boundary]}`
+  registered successfully (the registrar checks `contains?`) and the
+  handler then ran UNGUARDED on exactly the untrusted payloads the
+  interceptor exists to gate.
+
+  What is pinned here:
+
+   1. **Exact-token delegation** (AC 1) — a spy validator proves nil and
+      false reach `validate-event!` / `validate-fx!` / `validate-sub!`
+      verbatim, once per consult, and the false verdict returns per the
+      `run-validation` contract.
+   2. **The production boundary fail-open is closed** (AC 2, JVM half) —
+      with `re-frame.spec/dev-mode?` rebound false (the documented JVM
+      route to the interceptor's production branch), a registered
+      `{:schema nil}` boundary handler's `:before` delegates nil to the
+      validator and sets `:rf/skip-handler?`. The CLJS half rides the
+      production-compiled `re-frame.schemas-boundary-prod-test` suite.
+   3. **Default Malli fails CLOSED** (AC 5) — a present nil / false
+      schema takes the malformed-schema route (`:rf.error/malformed-schema`
+      + false), never registration-success-plus-runtime-no-op.
+   4. **The controls** (AC 4) — an omitted `:schema` key never consults
+      the validator, and `set-schema-validator!` nil still disables every
+      surface. These make the spy proof non-vacuous: restoring an
+      `if-let` / nil guard turns the present-falsey cases red while the
+      controls stay green."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.schemas.malli]
+            [re-frame.schemas.test-fixture :as tf]
+            [re-frame.spec :as spec]
+            [re-frame.test-support :refer [with-trace-recorder!]]))
+
+(use-fixtures :each tf/reset-runtime)
+
+(defn- spy-validator!
+  "Install a validator that records every schema token it is handed and
+  returns false. Returns the recording atom."
+  []
+  (let [seen (atom [])]
+    (schemas/set-schema-validator!
+      (fn [schema _value] (swap! seen conj schema) false))
+    seen))
+
+(defn- ops [traces op]
+  (filterv #(= op (:operation %)) traces))
+
+;; ===========================================================================
+;; AC 1 — the exact declared token reaches the validator on event / fx / sub
+;; ===========================================================================
+
+(deftest present-falsey-tokens-are-delegated-verbatim-on-event-fx-sub
+  (doseq [token [nil false]]
+    (testing (str "a present " (pr-str token) " :schema token is handed "
+                  "verbatim to the validator, once per consult, and the "
+                  "false verdict returns")
+      (let [seen (atom [])]
+        (schemas/set-schema-validator!
+          (fn [schema _value] (swap! seen conj schema) false))
+        (is (false? (schemas/validate-event! :ev/x [:ev/x 1] {:schema token}))
+            "event surface returns false — the caller skips the handler")
+        (is (false? (schemas/validate-fx! :fx/x :ev/x {:a 1} {:schema token}))
+            "fx surface returns false — the caller skips the fx")
+        (is (false? (schemas/validate-sub! :sub/x [:sub/x] 42 {:schema token}))
+            "sub surface returns false — the caller replaces with default")
+        (is (= [token token token] @seen)
+            "the EXACT declared token was delegated, exactly once per surface")))))
+
+(deftest explicit-nil-schema-skips-the-handler-through-the-real-dispatch-path
+  (testing "rf2-6eh5h — a reg-event handler declaring {:schema nil} is
+            validated (spy validator sees nil, returns false) and skipped
+            on dispatch; the failure emits :where :event"
+    (let [seen  (spy-validator!)
+          calls (atom 0)]
+      (rf/reg-event :ev/nil-schema
+        {:schema nil}
+        (fn [{:keys [db]} _] (swap! calls inc) {:db db}))
+      (with-trace-recorder! [traces]
+        (rf/dispatch-sync [:ev/nil-schema {:whatever 1}])
+        (is (= 0 @calls) "handler skipped — nil was validated, not ignored")
+        (is (= [nil] @seen) "the exact nil token reached the validator once")
+        (is (= 1 (count (ops @traces :rf.error/schema-validation-failure)))
+            "exactly one :rf.error/schema-validation-failure fired")
+        (is (= :event (-> (ops @traces :rf.error/schema-validation-failure)
+                          first :tags :where)))))))
+
+;; ===========================================================================
+;; AC 2 (JVM half) — the production boundary interceptor delegates nil
+;; ===========================================================================
+
+(deftest boundary-registration-with-explicit-nil-schema-succeeds
+  (testing "the fail-open's precondition, pinned: {:schema nil} + the
+            boundary interceptor REGISTERS (the registrar checks key
+            presence), and the registered metadata preserves the nil"
+    (rf/reg-event :wire/received
+      {:schema       nil
+       :interceptors [:rf.schema/at-boundary]}
+      (fn [_ _] {}))
+    (let [meta (registrar/lookup :event :wire/received)]
+      (is (some? meta) "registration succeeded")
+      (is (contains? meta :schema) "the :schema key is present")
+      (is (nil? (:schema meta)) "…and its value is the authored nil"))))
+
+(deftest boundary-interceptor-delegates-a-present-nil-schema-in-production
+  (testing "rf2-6eh5h HEADLINE — the production branch of
+            :rf.schema/at-boundary hands a present nil schema to the
+            registered validator and rejects on its false verdict; the
+            handler is NOT invoked. Before the fix the interceptor's
+            (nil? schema) arm returned the context unchanged and the
+            handler ran unguarded."
+    (let [seen (spy-validator!)]
+      (rf/reg-event :wire/received
+        {:schema       nil
+         :interceptors [:rf.schema/at-boundary]}
+        (fn [_ _] {}))
+      (with-redefs [spec/dev-mode? (constantly false)]
+        (let [before (:before rf/validate-at-boundary-interceptor)
+              ctx    (before {:coeffects {:event [:wire/received {:untrusted 1}]}})]
+          (is (= [nil] @seen)
+              "the boundary delegated the EXACT nil token to the validator")
+          (is (true? (:rf/skip-handler? ctx))
+              "the invalid event is rejected — the handler will not run"))))))
+
+(deftest boundary-interceptor-fails-closed-on-nil-schema-under-default-malli
+  (testing "AC 5 — with the DEFAULT Malli validator a present nil schema
+            cannot silently run a boundary handler: Malli throws on the
+            non-schema form, the seam isolates the throw to false, and the
+            boundary rejects (the malformed-schema fail-closed route)"
+    ;; Fixture reset restored the default Malli validator.
+    (rf/reg-event :wire/received
+      {:schema       nil
+       :interceptors [:rf.schema/at-boundary]}
+      (fn [_ _] {}))
+    (with-redefs [spec/dev-mode? (constantly false)]
+      (let [before (:before rf/validate-at-boundary-interceptor)
+            ctx    (before {:coeffects {:event [:wire/received {:untrusted 1}]}})]
+        (is (true? (:rf/skip-handler? ctx))
+            "rejected — never registration success plus runtime no-op")))))
+
+(deftest boundary-nil-validator-still-disables-validation-in-production
+  (testing "AC 4 control — set-schema-validator! nil remains the documented
+            global opt-out: even a present nil schema passes the boundary
+            unchecked when validation is disabled"
+    (schemas/set-schema-validator! nil)
+    (rf/reg-event :wire/received
+      {:schema       nil
+       :interceptors [:rf.schema/at-boundary]}
+      (fn [_ _] {}))
+    (with-redefs [spec/dev-mode? (constantly false)]
+      (let [before (:before rf/validate-at-boundary-interceptor)
+            ctx    (before {:coeffects {:event [:wire/received {:untrusted 1}]}})]
+        (is (not (:rf/skip-handler? ctx))
+            "no validator registered → no validation → handler runs")))))
+
+;; ===========================================================================
+;; AC 5 — default Malli takes the malformed-schema fail-closed route
+;; ===========================================================================
+
+(deftest default-malli-fails-closed-on-present-falsey-schemas
+  (doseq [token [nil false]]
+    (testing (str "with default Malli a present " (pr-str token)
+                  " schema fails CLOSED via :rf.error/malformed-schema")
+      (with-trace-recorder! [traces]
+        (is (false? (schemas/validate-event! :ev/x [:ev/x 1] {:schema token}))
+            "false — the caller runs its normal recovery (skip)")
+        (let [mal (ops @traces :rf.error/malformed-schema)]
+          (is (= 1 (count mal))
+              "exactly one malformed-schema trace fired — the fail-closed route")
+          (is (= :event (-> mal first :tags :where))))))))
+
+;; ===========================================================================
+;; AC 4 — the controls that make the spy proofs non-vacuous
+;; ===========================================================================
+
+(deftest omitted-schema-key-never-consults-the-validator
+  (testing "an ABSENT :schema key remains a no-op on every meta surface —
+            the validator is never invoked and every surface passes"
+    (let [seen (spy-validator!)]
+      (is (true? (schemas/validate-event! :ev/x [:ev/x 1] {:doc "no schema"})))
+      (is (true? (schemas/validate-event! :ev/x [:ev/x 1] nil))
+          "nil registration metadata is 'no declaration' too")
+      (is (true? (schemas/validate-fx! :fx/x :ev/x {:a 1} {})))
+      (is (true? (schemas/validate-sub! :sub/x [:sub/x] 42 {})))
+      (is (= [] @seen) "the validator was never consulted"))))
+
+(deftest nil-registered-validator-disables-validation-for-present-falsey-tokens
+  (testing "set-schema-validator! nil disables validation even for a
+            present nil / false declaration — the documented global opt-out"
+    (schemas/set-schema-validator! nil)
+    (is (true? (schemas/validate-event! :ev/x [:ev/x 1] {:schema nil})))
+    (is (true? (schemas/validate-fx! :fx/x :ev/x {:a 1} {:schema false})))
+    (is (true? (schemas/validate-sub! :sub/x [:sub/x] 42 {:schema nil})))))


### PR DESCRIPTION
## Summary

rf2-6eh5h (P1): an explicit nil `:schema` bypassed the production boundary guard - a release-resident fail-open. Event registration accepts `{:schema nil :interceptors [:rf.schema/at-boundary]}` (the registrar checks `contains?`), but the production interceptor treated nil as impossible and returned the context unchanged: the handler ran without the boundary check the registration explicitly requested.

The invariant (Spec 010): a schema value is OPAQUE to re-frame. An ABSENT `:schema` key means no declaration; a PRESENT key hands its exact value - nil and false included - to the registered validator. Presence tests now replace truthiness tests at every Spec 010 validation seam; with default Malli a present nil/false schema fails CLOSED through the existing malformed-schema isolation, and a custom validator receives its own token verbatim.

Seams fixed:
- `schemas/validate.cljc` `run-validation` (event/fx/sub hot path)
- `core/spec.cljc` production boundary interceptor (the headline fail-open)
- `core/cofx.cljc` `validate-recordable-value!` + its failure-trace redaction no longer suppressed by `some?` on the opaque value
- `core/subs/override_schema.cljc`, `core/subs/memo.cljc` (outer gate), `core/fx.cljc` (outer gate)
- `flows/flows.cljc` `validate-output!`
- `machines/data_validation.cljc` spawn/output/macrostep/update-snapshot seams (`resolve-data-schema` returns a presence-carrying map entry)

App-db path schemas, the registered-validator API, validation recovery and redaction policy are otherwise unchanged. `spec/010-Schemas.md` needs no edit (its opaque-value contract is what this PR implements); no hot-zone files touched.

Census notes: the item's AC 3 census also flagged `subs/memo.cljc` and `fx.cljc` outer gates (fixed here) and the machines seams (fixed here). Classified NOT in scope, as walkers/extractors rather than validation gates: `http/privacy_body.cljc:149`, `routing/navigate.cljc:72`, `routing/registry.cljc:745`, `resources/classification.cljc` (Spec 015 params-schema surface), `machines/tooling.cljc:212`, and the machines home fail-loud registration guard (`lifecycle_fx/registration.cljc:845` - a registration diagnostic, not a validation bypass).

## Tests

- `schemas/test/re_frame/schemas_presence_test.clj` (new) - exact nil/false token delegation on event/fx/sub; production boundary prod-branch delegation (spy + default-Malli fail-closed); registration precondition; omitted-key and nil-validator controls (AC 1/2/4/5).
- `core/test/re_frame/schema_presence_seams_test.clj` (new) - recordable-cofx hard error, sub-override recover-to-nil, memo outer gate, fx-args outer gate through the real `:fx` walk; per-seam omitted-key controls (AC 3).
- `flows_schema_validation_test.clj` - present-nil flow `:schema` delegates verbatim, `:where :flow-output`.
- `machine_schema_test.clj` - `{:schemas {:data nil}}` delegates the exact nil at the bootstrap boundary and rolls back; default Malli fails closed.
- `schemas_boundary_prod_test.cljs` - release-resident regression under `:advanced` + `goog.DEBUG=false`: a `{:schema nil}` boundary handler is NOT invoked, and a substituted validator receives the exact nil token (AC 2, production-compiled).

## Quality gates

All run locally from this branch's worktree, foreground, exit codes captured per run. The four JVM suites and the production browser lane were re-run on the FINAL base (after rebasing onto c39c44ec32).

| Gate | Result | Captured exit |
|---|---|---|
| schemas JVM (`clojure -M:test`) | 372 tests / 19221 assertions, 0 failures, 0 errors | 0 |
| core JVM (`clojure -M:test`) | 2170 tests / 11105 assertions, 0 failures, 0 errors | 0 |
| flows JVM (`clojure -M:test`) | 241 tests / 6041 assertions, 0 failures, 0 errors | 0 |
| machines JVM (`clojure -M:test`) | 1204 tests / 4196 assertions, 0 failures, 0 errors | 0 |
| `test:browser-schemas-boundary-prod` (shadow `release` + browser) | 11 tests / 20 assertions, 0 failures, 0 errors | 0 |
| core prod-gate (`scripts/test-core-prod-gate.sh`, `-Dre-frame.debug=false`) | 1911 tests / 8128 assertions, 0 failures, 0 errors | 0 |

The first CI round redded the core prod-gate lane: the new memo/fx outer-gate delegation deftests assert Spec 010 dev-only validation surfaces (their schemas-side bodies are elided under the gate by design). Reproduced locally (captured exit 1, exactly those two deftests), fixed by declaring `^:requires-debug` on them per the lane's documented per-var mechanism, lane re-run green locally (exit 0 above). The always-on presence pins - recordable cofx, sub-override, omitted-key controls - stay untagged and run under the gate.

Pre-rebase runs of the same five gates were also green (schemas 372/19221 exit 0; core 2170/11105 exit 0; flows 241/6041 exit 0; machines 1204/4196 exit 0; boundary-prod 11 tests/20 assertions exit 0 - the lane count was 9 tests before this PR's two additions). CLJS dev lanes (`test:cljs`, `test:browser`) are relied on in CI per the heavy-lane policy; the release-compiled boundary lane above is the production-path CLJS gate and ran locally.

## Control (the fail-open, demonstrated)

With the presence fix REVERTED at the single production-interceptor line (`(not (contains? handler-meta :schema))` back to `(nil? schema)`), the schemas suite goes RED in exactly the headline tests - 3 failing assertions, 0 elsewhere (captured exit 1):

- `boundary-interceptor-delegates-a-present-nil-schema-in-production`: the validator never receives the nil token, and `:rf/skip-handler?` stays unset - the handler runs UNGUARDED on the untrusted payload.
- `boundary-interceptor-fails-closed-on-nil-schema-under-default-malli`: the default-Malli rejection disappears.

Restore verified by blob hash: after `git checkout HEAD -- implementation/core/src/re_frame/spec.cljc`, `git hash-object` on the working file equals `git rev-parse HEAD:...spec.cljc` (`182cb4990a6cba86b1578db7ae3478968d32d0b0` both sides).

Refs rf2-6eh5h
