### PR TITLE
refactor(core-machines): delete five unreachable defwrappers (rf2-0dcoa)

### DIFF
--- a/implementation/core/src/re_frame/core_machines.cljc
+++ b/implementation/core/src/re_frame/core_machines.cljc
@@ -8,9 +8,7 @@
   plain-fn surface raise with their own faithful `:where` symbol). Machine
   reads use the `[:rf.machine/has-tag? …]` and `[:rf/machine …]`
   subscription vectors."
-  (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
-                                        :cljs [:refer-macros [defwrapper]])]
-            [re-frame.interop :as interop]
+  (:require [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]))
 
@@ -20,57 +18,6 @@
   {:error-keyword :rf.error/machines-artefact-missing
    :maven         "day8/re-frame2-machines"
    :require-ns    "re-frame.machines"})
-
-(defwrapper make-machine-handler
-  "Build an event-fx handler from a machine spec. Per Spec 005
-  §Registration. Late-bound via :machines/make-machine-handler."
-  {:hook :machines/make-machine-handler :artefact machines-artefact :on-absent :throw}
-  ([machine] :delegate))
-
-(defwrapper machine-transition
-  "The pure transition: given a machine definition, the current snapshot
-  and an event vector, return one plain map — `{:status :ok :snapshot
-  <next-snapshot> :fx [...]}` on success, `{:status :error :error {:kind
-  ...}}` on an engine-reported failure. Per Spec 005 §Testing §Level 1.
-  Late-bound via :machines/machine-transition."
-  {:hook :machines/machine-transition :artefact machines-artefact :on-absent :throw}
-  ([machine snapshot event] :delegate))
-
-(defwrapper machines
-  "Return a sequence of registered machine ids. Per Spec 005
-  §Querying machines. Returns `[]` when the machines artefact is not
-  on the classpath."
-  {:hook :machines/machines :artefact machines-artefact :on-absent :empty-vec}
-  ([] :delegate))
-
-(defwrapper machine-meta
-  "Return the registered machine spec map for machine-id, or nil. Per
-  Spec 005 §Querying machines. Returns nil when the machines artefact
-  is not on the classpath."
-  {:hook :machines/machine-meta :artefact machines-artefact :on-absent :nil}
-  ([machine-id] :delegate))
-
-(defwrapper machine-by-system-id
-  "Look up the spawned-machine id currently bound to `system-id` in the
-  active frame's `[:rf.runtime/machines :system-ids]` reverse index, or nil.
-
-  EP-0002 carried invariant: the 1-arity ambient form resolves the frame
-  through the scope/hold chain (`with-frame`, a `frame-provider` (SCOPE) or
-  a `frame-root` (ENSURE) boundary, or a carried stamp) via
-  `frame/require-current-frame!` — a lookup under no established
-  scope raises `:rf.error/no-frame-context`, with NO `:rf/default` floor.
-  Pass the public opts form `(machine-by-system-id system-id {:frame
-  target})` to name a frame explicitly (async callbacks / tools /
-  cross-frame lookups); `target` is a frame-id keyword or a live frame
-  value. The 2-arity is shape-discriminated on the second arg, mirroring
-  `subscribe`'s trailing opts-map form: an opts map ⇒ the public
-  form; a bare frame target ⇒ the internal frame-last plumbing.
-
-  Per Spec 005 §Named addressing via :system-id + Spec 002 §Resolver
-  surface. Returns nil when the machines artefact is not on the classpath."
-  {:hook :machines/machine-by-system-id :artefact machines-artefact :on-absent :nil}
-  ([system-id]            :delegate)
-  ([system-id frame-or-opts] :delegate))
 
 ;; ---- machine guard/action handler-meta — DERIVED, not registered --------
 ;;

--- a/implementation/core/test/re_frame/scope_ensure_authority_test.clj
+++ b/implementation/core/test/re_frame/scope_ensure_authority_test.clj
@@ -98,11 +98,13 @@
     :required  [[#"`frame-provider`\s*\(SCOPE\) or a `frame-root`\s*\(ENSURE\)"
                  "the SCOPE/ENSURE boundary pair"]]}
 
-   {:file      "implementation/core/src/re_frame/core_machines.cljc"
-    :why       "machine-by-system-id's scope/hold chain"
-    :forbidden [[stale-token "a provider-only scope-chain inventory"]]
-    :required  [[#"`frame-provider`\s*\(SCOPE\) or a `frame-root`\s*\(ENSURE\)"
-                 "the SCOPE/ENSURE boundary pair"]]}
+   ;; core_machines.cljc's row ("machine-by-system-id's scope/hold chain")
+   ;; retired WITH its subject (rf2-0dcoa): the unreachable machine-by-system-id
+   ;; defwrapper whose docstring carried the boundary-pair inventory is deleted,
+   ;; and no surviving form in that file enumerates the frame scope/hold chain.
+   ;; The surviving carriers (re-frame.machines/machine-by-system-id, Spec 005
+   ;; §Named addressing) cite the chain without a member inventory, which
+   ;; cannot carry the provider-only claim this table retires.
 
    {:file      "implementation/core/src/re_frame/router.cljc"
     :why       "the dispatch envelope's frame-resolution inventory (x2)"


### PR DESCRIPTION
## What

Deletes the five dead `defwrapper`s in `re-frame.core-machines` — `make-machine-handler`, `machine-transition`, `machines`, `machine-meta`, `machine-by-system-id` — plus the now-unused `re-frame.core-artefact` (`defwrapper`) require. Per the 2026-08-31 mayor ruling on rf2-0dcoa: they are residue of the front-porch shrink (rf2-wad2fl) — `re-frame.core` re-exports none of them, a repo-wide census finds zero callers via either alias, and their default `:where` of `'rf/<name>` stamped a name that no longer resolves.

**Kept untouched** (live per the ruling): `reg-machine`, `reg-machine*`, `reg-machine-impl`, `machine-handler-meta`.

The artefact-owned implementations in `re-frame.machines` and their late-bind hook registrations are unaffected (the hook keys stay rostered in `late_bind/directory.cljc`, whose drift test checks producer parity — producers all live in `re-frame.machines`).

## One pin existed, and the suite caught it

The first post-deletion run failed exactly one assertion: the rf2-kk2uf SCOPE/ENSURE authority guard (`scope_ensure_authority_test.clj`) carried a roster row requiring the `frame-provider` (SCOPE) / `frame-root` (ENSURE) boundary-pair prose in `core_machines.cljc` — whose only carrier was the deleted `machine-by-system-id` docstring. A dynamic pattern-pin, invisible to the alias-caller census. That red also doubles as tree-discrimination evidence: the failure named this branch's file and the exact region deleted, so the gate demonstrably read this tree.

The row is retired WITH its subject (second commit): with the wrapper gone, no form in that file enumerates the frame scope/hold chain, so the row pinned the deleted wrapper's existence. The surviving carriers (`re-frame.machines/machine-by-system-id`, Spec 005 §Named addressing) cite the chain without a member inventory, which cannot carry the provider-only claim the table retires. The test's own "do NOT delete the row" instruction addresses the region-moved case, not a deliberately abolished subject; a comment in the table records the retirement per its changelog style.

## Census (verified at a9376a7eeb and re-verified at rebase base 53551982f8)

- **Before**: all five `(defwrapper <name>` forms present (non-vacuity).
- **Callers**: zero hits per wrapper via `rf-machines/<name>` and `core-machines/<name>` fixed-string greps (the two `rf-machines/make-machine-handler` hits are quoted `:where` error-trace symbols inside the machines artefact, not calls). Control: the same search shape for `machine-handler-meta` (which HAS a caller) correctly finds core.cljc:1883.
- **No re-export**: `re-frame.core`'s only `rf-machines/` call is `machine-handler-meta`.
- **api-manifest**: rows for these names all point at `re-frame.machines` with `:facade? false`; no `core-machines` rows exist — no manifest drift.
- **After**: zero `defwrapper`/`core-artefact` residue; kept four present; alias census unchanged (five at zero, control still hits).

## spec/Conventions.md judgment (per the bead)

**No edit.** The §Optional-artefact wrapper convention prose does not contradict the post-deletion state — the five wrappers were the counter-examples to it (published but unreachable), so the deletion removes the tension rather than creating one. Zero hot-zone files touched.

## Quality gates

| Gate | Result | Captured exit |
|---|---|---|
| `clojure -M:test` (implementation/core, JVM) — baseline pre-deletion at a9376a7eeb | 2162 tests, 11082 assertions, 0 failures, 0 errors | 0 |
| `clojure -M:test` — post-deletion, pre-pin-move | 2162 tests, 11082 assertions, 1 failure (the rf2-kk2uf pin, above) | 1 |
| `clojure -M:test` — final, on rebase base 53551982f8 | 2162 tests, 11079 assertions, 0 failures, 0 errors | 0 |

The assertion delta (11082 → 11079) is exactly the retired row's three assertions (one per roster deftest); test count unchanged. The diff is confined to one `.cljc` source file plus its gate-coupled test roster, so this suite plus the census is the whole gate (no docs-gate surface, no manifest surface, no adapter/tool surface touched). Trunk's subsequent `chore(beads)` checkpoint commits touch no `implementation/core` path.