### PR TITLE
fix(examples/websocket): settle in-flight requests on clean disconnect (rf2-b2jpr)

### DIFF
--- a/examples/patterns/websocket/connection.cljs
+++ b/examples/patterns/websocket/connection.cljs
@@ -97,6 +97,31 @@
   [data]
   (get-in data [:rf/spawned socket-invoke-id]))
 
+(defn- fail-in-flight
+  "The in-flight half of losing the wire, shared by every door out of
+   `:active` that destroys the socket: clear every `:in-flight` slot and
+   fire each waiting `:reply-event` with the documented
+   `{:ok false :error :ws/connection-lost}` failure body. Each of those
+   requests was already on the wire that is going away, so its reply can
+   never arrive on this connection; left in `:in-flight` the slot would
+   leak forever — its timeout is stamped with the dead socket id, so
+   `:current-socket?` drops that timeout after teardown and the slot never
+   clears. Termination semantics are FAIL, not replay: the server may
+   already have processed the request, so a blind re-send risks double
+   execution. Failing is the safe, explicit default, and the caller learns
+   the outcome instead of hanging. Returns an action result (`:data` +
+   `:fx`) for the calling action to build on."
+  [data]
+  {:data (assoc data :in-flight {})
+   :fx   (into []
+               (keep (fn [[rid {:keys [reply-event]}]]
+                       (when reply-event
+                         [:dispatch (conj reply-event
+                                          {:request-id rid
+                                           :ok         false
+                                           :error      :ws/connection-lost})])))
+               (:in-flight data))})
+
 (rf/defmachine connection-machine
   "The `:ws/connection` machine spec, kept in its own `defmachine` so we can
    hand it to `reg-machine` below with per-element source captured."
@@ -189,29 +214,27 @@
       ;; `:current-socket?`). Two things happen as we head to `:reconnecting`:
       ;;   1. Bump the retry counter — it drives the `:after` backoff and the
       ;;      `:max-retries-exceeded?` guard.
-      ;;   2. FAIL every in-flight request. Each was already put on the wire
-      ;;      that just died, so its reply can never arrive on this
-      ;;      connection; left in `:in-flight` it would leak forever — its
-      ;;      timeout is stamped with the now-dead socket id, so the
-      ;;      `:current-socket?` guard drops that timeout after we reconnect
-      ;;      and the slot never clears. Loss semantics are FAIL, not replay:
-      ;;      the server may already have processed the request before the
-      ;;      drop, so a blind re-send risks double execution — failing is the
-      ;;      safe, explicit default. Each waiting `:reply-event` is fired
-      ;;      with a `{:ok false :error :ws/connection-lost}` body so the
-      ;;      caller learns the outcome instead of hanging forever.
+      ;;   2. FAIL every in-flight request (`fail-in-flight`, the helper the
+      ;;      clean-disconnect door shares) — each was already put on the
+      ;;      wire that just died, so its reply can never arrive on this
+      ;;      connection. See the helper for the full leak/replay story.
       (fn action-on-socket-lost [{data :data}]
-        {:data (-> data
-                   (update :retries inc)
-                   (assoc :in-flight {}))
-         :fx   (into []
-                     (keep (fn [[rid {:keys [reply-event]}]]
-                             (when reply-event
-                               [:dispatch (conj reply-event
-                                                {:request-id rid
-                                                 :ok         false
-                                                 :error      :ws/connection-lost})])))
-                     (:in-flight data))})
+        (-> (fail-in-flight data)
+            (update :data update :retries inc)))
+
+      :fail-in-flight
+      ;; A clean `:ws/disconnect` out of `:active` destroys the socket just
+      ;; as surely as a drop does, so the SAME invariant applies: every
+      ;; request accepted into `:in-flight` settles exactly once. Without
+      ;; this, the slot and its waiting `:reply-event` survive teardown
+      ;; forever — the scheduled timeout carries the destroyed socket's id,
+      ;; so `:current-socket?` rejects it and the only cleanup path is
+      ;; gone, including across a later reconnect. Unlike `:on-socket-lost`
+      ;; there's no retry bump: the user asked for this disconnect, so it
+      ;; isn't a connection failure — only the requests still riding the
+      ;; wire fail, with the same documented `:ws/connection-lost` body.
+      (fn action-fail-in-flight [{data :data}]
+        (fail-in-flight data))
 
       :reset-retries
       (fn action-reset-retries [{data :data}]
@@ -379,7 +402,13 @@
                :ws/send     {:action :enqueue-message}
                :ws/request  {:action :enqueue-message}
                :ws/rotate-cred {:action :rotate-cred}
-               :ws/disconnect {:target :disconnected}
+               ;; Leaving :active by the clean door still kills the wire, so
+               ;; it settles the in-flight set on the way out (see the
+               ;; :fail-in-flight action). The :reconnecting / :failed
+               ;; :ws/disconnect transitions carry no such action — their
+               ;; in-flight was already settled when :active was left.
+               :ws/disconnect {:target :disconnected
+                               :action :fail-in-flight}
                ;; Subscribe before we're fully connected? Just note the
                ;; topic down; the next :connected entry will actually send
                ;; the subscribe.

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -717,6 +717,105 @@
               (is (= rid (:request-id reply))
                   "the failure names the timed-out request"))))))))
 
+(defn- clean-disconnect-fails-in-flight-request-test []
+  ;; rf2-b2jpr — a clean :ws/disconnect destroys the only socket capable of
+  ;; replying, so leaving :active through the clean door must settle every
+  ;; in-flight request exactly once — the SAME invariant the drop path owns
+  ;; (:on-socket-lost), routed through the shared fail-in-flight helper.
+  ;; Before the fix, the slot and its waiting :reply-event survived teardown
+  ;; forever: the scheduled timeout carries the destroyed socket's id, so
+  ;; :current-socket? rejects it after teardown and the only cleanup path is
+  ;; gone, including across a later reconnect.
+  ;;
+  ;; The reply target is a test-local COUNTING event so at-most-once is a
+  ;; direct assertion (the example's :ws.app/request-reply only keeps the
+  ;; LAST reply — a duplicate would be invisible there). Each invocation is
+  ;; logged, then forwarded to the boundary-validated :ws.app/request-reply,
+  ;; so the machine's synthesised failure body is also proven to pass the
+  ;; closed RequestOutcome contract (dev-lane step-1 enforces the :schema —
+  ;; a rejected body would leave :last-reply untouched below).
+  (rf/reg-event :ws.test/log-reply
+    (fn handler-ws-test-log-reply [{:keys [db]} [_ body]]
+      {:db (update-in db [:messages :reply-log] (fnil conj []) body)
+       :fx [[:dispatch [:ws.app/request-reply body]]]}))
+  (with-sync-mock!
+    (fn []
+      (with-new-frame [f (new-frame)]
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock" :cred-ref :ws.demo/cred-a}]]
+                          {:frame f})
+        (is (true? (machine-has-tag? f :websocket/connected)))
+        (let [old-id (socket-id-of (snapshot (:rf.db/runtime (rf/frame-state-value f))))
+              rid    (random-uuid)
+              log    #(get-in (rf/app-db-value f) [:messages :reply-log])]
+          (is (some? old-id))
+          ;; A request whose wire :type the mock does NOT echo, so it sits
+          ;; in-flight with no reply to clear it — genuinely on the wire.
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/request {:request-id rid
+                                           :body       {:type :silent-no-echo}
+                                           :reply      [:ws.test/log-reply]
+                                           :timeout-ms 5000}]]
+                            {:frame f})
+          ;; Positive control: the request is genuinely in :in-flight and no
+          ;; reply has fired — the witness below cannot pass vacuously.
+          (is (contains? (get-in (snapshot (:rf.db/runtime (rf/frame-state-value f)))
+                                 [:data :in-flight])
+                         rid)
+              "positive control: the silent request sits in :in-flight before disconnect")
+          (is (nil? (log))
+              "positive control: no reply-event invocation before disconnect")
+          ;; Clean disconnect, mid-flight.
+          (rf/dispatch-sync [:ws/connection [:ws/disconnect]] {:frame f})
+          (let [s (snapshot (:rf.db/runtime (rf/frame-state-value f)))]
+            (is (= :disconnected (:state s)))
+            (is (nil? (socket-id-of s)) "the socket actor is torn down")
+            (is (= {} (get-in s [:data :in-flight]))
+                ":in-flight cleared on clean disconnect — no stranded slot")
+            (is (= [{:request-id rid :ok false :error :ws/connection-lost}]
+                   (log))
+                "exactly one reply-event invocation, with the documented connection-termination body")
+            (is (= {:request-id rid :ok false :error :ws/connection-lost}
+                   (get-in (rf/app-db-value f) [:messages :last-reply]))
+                "the synthesised failure body passes the closed RequestOutcome boundary"))
+          ;; At-most-once control: deliver the already-scheduled timeout,
+          ;; stamped with the DESTROYED socket's id, exactly as
+          ;; :register-request scheduled it (new-frame suppresses the real
+          ;; :dispatch-later). Nothing may fire twice or resurrect the slot.
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/request-timeout {:request-id       rid
+                                                   :source-socket-id old-id}]]
+                            {:frame f})
+          (let [s (snapshot (:rf.db/runtime (rf/frame-state-value f)))]
+            (is (= :disconnected (:state s))
+                "the stale timeout does not move the machine")
+            (is (= {} (get-in s [:data :in-flight]))
+                "the stale timeout resurrects no slot")
+            (is (= 1 (count (log)))
+                "the callback count stays exactly one after the stale timeout"))
+          ;; No leak across a reconnect: connect again (a FRESH socket), then
+          ;; deliver the old-socket-stamped timeout once more — a straggler
+          ;; landing after reconnect. :current-socket? drops it against the
+          ;; new epoch; the new connection inherits no stale bookkeeping.
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/connect {:url "ws://mock" :cred-ref :ws.demo/cred-a}]]
+                            {:frame f})
+          (is (true? (machine-has-tag? f :websocket/connected)))
+          (let [new-id (socket-id-of (snapshot (:rf.db/runtime (rf/frame-state-value f))))]
+            (is (some? new-id))
+            (is (not= old-id new-id) "reconnect spawned a fresh socket"))
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/request-timeout {:request-id       rid
+                                                   :source-socket-id old-id}]]
+                            {:frame f})
+          (let [s (snapshot (:rf.db/runtime (rf/frame-state-value f)))]
+            (is (true? (machine-has-tag? f :websocket/connected))
+                "the straggler timeout leaves the fresh connection up")
+            (is (= {} (get-in s [:data :in-flight]))
+                "no stale bookkeeping crossed the reconnect")
+            (is (= 1 (count (log)))
+                "the callback count stays exactly one across the reconnect")))))))
+
 (defn- queued-request-registers-and-replies-on-connect-test []
   ;; rf2-ryt25d — a :ws/request issued OFF-connection must be buffered as its
   ;; event and, on connect, rejoin :register-request so it registers, sends
@@ -1245,6 +1344,13 @@
             clears its in-flight slot; the waiting reply-event gets a :ws/timeout
             body, and the connection stays up"
     (timeout-fails-in-flight-request-test)))
+
+(deftest websocket-clean-disconnect-fails-in-flight-request
+  (testing "rf2-b2jpr — a clean :ws/disconnect settles every in-flight request
+            exactly once: the slot clears, the waiting reply-event fires one
+            :ws/connection-lost failure, and the destroyed socket's stale
+            timeout resurrects nothing — before or after a reconnect"
+    (clean-disconnect-fails-in-flight-request-test)))
 
 (deftest websocket-queued-request-registers-and-replies-on-connect
   (testing "rf2-ryt25d — a :ws/request buffered off-connection registers and


### PR DESCRIPTION
## Summary

A clean `:ws/disconnect` destroys the live socket actor but left every `:in-flight` request slot behind. The scheduled timeout carries the destroyed socket's id, so `:current-socket?` rejects it after teardown and the only cleanup path is gone — the slot and its waiting `:reply` callback survived forever, including across a later reconnect (rf2-b2jpr).

The fix routes the clean door through the same invariant the loss path already owns: the fail-and-clear half of `:on-socket-lost` is factored into a `fail-in-flight` helper, used by both the guarded unexpected `:ws/closed` (with the retry bump) and `:ws/disconnect` while leaving `:active` (without it). Machine topology, request/reply API, socket-epoch guard, and queue/reconnect behavior are unchanged. Follow-up rf2-ni0ko covers the remaining `:ws/fatal` door (same class, currently reachable only by consumer code).

**Reply-error decision**: clean disconnect delivers the established `{:ok false :error :ws/connection-lost}` body, not a distinct value. Grounds: the published contract documents exactly this value for connection-termination failure (spec/Pattern-WebSocket.md §5 and §Common pitfalls, example README), the `LocalRequestFailure` schema is a deliberately closed enum of `:ws/connection-lost` / `:ws/timeout` enforced at the release-resident boundary, and to the waiting caller a clean disconnect terminates the wire the same way a drop does. spec/Pattern-WebSocket.md needed no edit: its worked-example listing does not include the `:ws/disconnect` transition, and its prose nowhere contradicts clean disconnect settling requests.

## Coverage

New wrapper test `websocket-clean-disconnect-fails-in-flight-request` (external wrapper, per the test-free-examples policy):
- parks a `:silent-no-echo` request genuinely in `:in-flight` (positive control: slot present, zero replies fired),
- clean-disconnects mid-flight: asserts `:disconnected`, socket actor gone, `:in-flight` empty, exactly ONE reply invocation with the documented failure body (counting reply target that forwards to the boundary-validated `:ws.app/request-reply`, so the synthesized body is also proven to pass the closed `RequestOutcome` contract),
- at-most-once control: delivers the already-scheduled timeout stamped with the destroyed socket's id — nothing fires twice, nothing resurrects,
- reconnect control: after a fresh connect, the same stale timeout is dropped against the new epoch — no stale bookkeeping crosses the reconnect.

## Quality gates

All run locally in the worker worktree, foreground/detached-with-poll to completion, exits captured via redirect + same-shell echo:

- `npm run test:cljs` (adapters/reagent/test is on the :node-test classpath, so the wrapper suite runs here), split into its two phases:
  - compile: **exit 0** (1862 files, 0 warnings; shadow config line names the worker worktree)
  - run: **exit 0** — 11113 tests / 54529 assertions, **0 failures, 0 errors**
- Control (planted fault): with the `:action :fail-in-flight` routing line reverted at that single line, run **exit 1** — **7 failures, all in `websocket-clean-disconnect-fails-in-flight-request`**, red on BOTH the retained slot (`:in-flight` holds the request + waiting `:reply-event`) and the missing callback (reply log nil), no other test red. This also proves the gate read this branch's tree and that the new test runs in this lane (the quiet reporter names only failures). Restore verified by git blob hash: worktree object == `HEAD:examples/patterns/websocket/connection.cljs` (`d35690f1cd…`). Recompile **exit 0** + rerun **exit 0** (11113 / 54529, 0 failures, 0 errors) on the restored source.
- `npm run test:examples-compile` (sweeps every `examples/` build incl. `:examples/websocket`, zero-warning floor): **exit 0**; the `out/examples/websocket` artefact was compiled fresh during the run.

Merge-base check: `git diff origin/main...HEAD` contains exactly the two fenced files, reverts nothing; main's advance since the base touches neither file.

Anchors and table column counts in touched prose: no doc pages touched (code + docstrings/comments only).