### PR TITLE
ci(test.yml): rename the package-refs guard step and comment for the post-shared contract (rf2-5dauo)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -341,18 +341,21 @@ jobs:
         continue-on-error: true
         run: python scripts/check_skill_re_frame2_drift.py --verbose --ci
 
-      # Distribution-completeness guard (rf2-f14su): a published skill that
-      # loads a sibling `../shared/<leaf>` reference in normal operation can
-      # NEVER ship that leaf in its own npm tarball / plugin bundle (a `files`
-      # allow-list cannot reach a parent dir), so a non-link install silently
-      # drops the shared protocol. The gate requires every such skill's README
-      # to carry the link-only / bring-`skills/shared/`-along caveat.
+      # In-package link-resolution guard (rf2-deo2zp): every packaged skill
+      # (`package.json` + `.claude-plugin/plugin.json`) ships self-contained,
+      # so every intra-package relative link from a shipped doc (SKILL.md /
+      # README.md / references/**.md) must resolve to a file the `package.json`
+      # `files` allow-list ships — otherwise a packaged install resolves the
+      # link to a missing file at exactly the point a user is configuring the
+      # skill. Links that escape the package (`../`) are the repo-wide doc-slug
+      # gate's surface, not this one's; the former `../shared/` distribution
+      # caveat arm (rf2-f14su) was retired under rf2-fqjys.
       - name: Self-test the skill package-refs guard
         id: check_skill_package_refs_selftest
         continue-on-error: true
         run: python scripts/check_skill_package_refs.py --self-test
 
-      - name: Verify ../shared/-referencing skills carry the distribution caveat
+      - name: Verify packaged-skill doc links resolve in-package
         id: check_skill_package_refs
         continue-on-error: true
         run: python scripts/check_skill_package_refs.py --verbose --ci


### PR DESCRIPTION
Follow-up to rf2-fqjys (PR #8819), implementing rf2-5dauo.

`check_skill_package_refs.py` became the in-package link-resolution gate (rf2-deo2zp) when PR #8819 deleted the `../shared/` caveat arm, but its two `test.yml` steps still carried the retired contract's text: the step name `Verify ../shared/-referencing skills carry the distribution caveat` and a comment block describing the rf2-f14su distribution-caveat contract. This PR renames that step to `Verify packaged-skill doc links resolve in-package` and rewrites the comment block to describe the current contract (from the script's own docstring). The `Self-test the skill package-refs guard` step name was already correct and is unchanged.

**Comment/step-name-only change — no job or check-set movement.**

- The job-key discriminator over the merge-base diff returned **empty** (quoted verbatim — there was no output):

  ```
  $ git diff origin/main...HEAD -- .github/workflows/ | grep -E '^[-+]  [a-z][a-z0-9_-]*:[[:space:]]*$'
  (no output; grep exit 1)
  ```

  The pattern was exercised against a control first: a planted `+  jvm-core:` line matched (count 1), so the empty result is a real zero, not a pattern that matches nothing.
- No `run:`, `uses:`, or `if:` line changed (`git diff origin/main...HEAD | grep -E '^[-+]\s*(- )?(run:|uses:|if:)'` — empty, exit 1).
- Step **ids** (`check_skill_package_refs_selftest` / `check_skill_package_refs`) and `continue-on-error` are untouched. The job's reported check context is its job-level `name:` (`Repo invariant checks (skills, MCP, catalogues, namespaces)`), verified against a recent PR's `statusCheckRollup` — neither step name appears in the check set, and the verdict aggregator keys on step ids via `toJSON(steps)`. `check_ci_reproduce_commands.py`'s own header states the display `name:` is free to change; `check_fast_pr_gap.py`'s `SPINE_LANES` match `run:` commands, not step names.

## Quality gates

Workflow YAML has no local runner; CI's own run on this PR is the real gate. Locally, from the worker worktree:

- YAML syntax: `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/test.yml'))"` — exit 0 (log names the worktree file it parsed).
- `python scripts/check_ci_reproduce_commands.py --check --verbose` — exit 0 (the checker-step aggregation contract of the edited region holds).
- `python scripts/check_fast_pr_gap.py --check` — exit 0 ("fast-PR gap map clean"), proving no spine coverage claim was invalidated.

Closes rf2-5dauo.