### PR TITLE
fix(http): abort during body preparation can no longer issue the JVM request (rf2-rsv2n)

### DIFF
--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -1651,6 +1651,26 @@
         ;; one-cell atom that the JVM body fills after construction; the
         ;; abort-fn reads it lazily through `@cf-holder`.
         #?@(:clj  [cf-holder (atom nil)])
+        ;; rf2-rsv2n — one-cell issuance-phase CAS closing the request-
+        ;; preparation → host-transport window. `nil` until one side commits:
+        ;; the post-prep gate below CASes it to `:issued` immediately before
+        ;; entering the host transport, and the abort closure CASes it to
+        ;; `:aborted` after winning the once-only reply guard. Exactly one
+        ;; winner. An abort that lands while `prepare-body!` is blocked inside
+        ;; a body thunk wins this cell, so the attempt NEVER calls
+        ;; `cljs-fetch` / `jvm-fetch` after the canonical cancelled reply went
+        ;; out — previously `@finalised?` was sampled only BEFORE prep, and on
+        ;; the JVM `cf-holder` was still nil during prep so the abort had no
+        ;; future to cancel: `HttpClient.sendAsync` issued a side-effecting
+        ;; request AFTER the framework told the app it was cancelled. When
+        ;; issuance wins the cell instead, the JVM abort path cancels via
+        ;; `cf-holder` — or, in the residual instant before publication, the
+        ;; issuing thread's post-publication `aborted?` re-check cancels its
+        ;; own future (see below). Per-attempt like `cf-holder`, never
+        ;; threaded through the retry handoff — each attempt owns its own
+        ;; issuance; the handoff window itself is covered by the shared-cell
+        ;; re-check further down (rf2-6nczv9).
+        issue-phase (atom nil)
         ;; Forward-reference cell for the stamped handle.
         ;; The abort-fn's registry cleanup must pass the handle to the
         ;; 2-arg `clear-in-flight!` so the actor-in-flight slot is cleared
@@ -1696,6 +1716,20 @@
                                 ;; succession against the same handle)
                                 ;; is a no-op past the first call.
                                 (when (compare-and-set! finalised? false true)
+                                  ;; rf2-rsv2n — claim the issuance phase.
+                                  ;; Winning (nil → `:aborted`) means
+                                  ;; preparation has not handed off to the
+                                  ;; host transport yet: the post-prep gate's
+                                  ;; own CAS will now fail, so no fetch is
+                                  ;; ever issued for this cancelled attempt.
+                                  ;; Losing (already `:issued`) means the
+                                  ;; transport call is in flight or done —
+                                  ;; the JVM branch below cancels via
+                                  ;; `cf-holder`, and when the future is not
+                                  ;; yet published there, the issuing
+                                  ;; thread's post-publication `aborted?`
+                                  ;; re-check cancels it on our behalf.
+                                  (compare-and-set! issue-phase nil :aborted)
                                   #?(:cljs
                                      (try
                                        (when internal-controller
@@ -1856,6 +1890,24 @@
         ;; precedence, and the `:on-failure` reply shape all stay consistent.
         (maybe-retry! ctx' prep-error)
         (let [{:keys [enc-body headers]} (:ok prep)]
+        ;; rf2-rsv2n — POST-PREPARATION cancellation gate. A body thunk may
+        ;; block inside `prepare-body!` for arbitrarily long, and the
+        ;; `@finalised?` sample above ran BEFORE prep — so an abort that won
+        ;; while preparation was in progress has already delivered the
+        ;; canonical cancelled reply and cleared the registry, and this
+        ;; attempt must not now enter the host transport (Spec 014 §Abort
+        ;; precedence: body realization is a managed phase; a cancelled
+        ;; request must not issue). The CAS makes the abort/issuance race
+        ;; have exactly one winner: losing here (the abort closure already
+        ;; CASed `:aborted`) skips the fetch entirely, with nothing left to
+        ;; do — reply and registry were the abort's. Winning commits this
+        ;; attempt to issuance BEFORE any side effect, so an abort landing
+        ;; from here on takes the cancel-the-future path instead. Shared
+        ;; CLJC, no reader conditional — the same gate covers a re-entrant
+        ;; external abort fired during CLJS body realization, so no Fetch
+        ;; call follows a delivered cancellation on either host.
+        (when (compare-and-set! issue-phase nil :issued)
+        (interleave! :issue/before-send ctx')
         #?(:cljs
            (-> (transport-cljs/cljs-fetch
                            {:method              method
@@ -1942,6 +1994,22 @@
                  ;; registering still finds cf in the holder and can cancel
                  ;; it.
                  (reset! cf-holder cf)
+                 ;; rf2-rsv2n — residual-window re-check. An abort that fired
+                 ;; after this attempt won the issuance-phase CAS but before
+                 ;; the `reset!` above found `cf-holder` still nil and had
+                 ;; nothing to cancel; it has already delivered the canonical
+                 ;; cancelled reply and cleared the registry (it won the
+                 ;; once-only guard), so the one thing left undone is stopping
+                 ;; the work. Re-read the abort-precedence cell now that the
+                 ;; future is published and cancel it on the abort's behalf.
+                 ;; `.cancel` is idempotent, so racing the abort path's own
+                 ;; cancel is harmless; the `whenComplete` below then fires
+                 ;; with a CancellationException and `finalise-failure!` bails
+                 ;; on the won `:finalised?` CAS — the abort's reply stays the
+                 ;; only one.
+                 (when (some? @aborted?)
+                   (try (.cancel cf true)
+                        (catch Throwable _ nil)))
                  ;; The whenComplete callback fires even after
                  ;; `.cancel cf true`: the cancel completes-exceptionally
                  ;; with a CancellationException, which routes through this
@@ -1957,4 +2025,4 @@
                                       (maybe-retry! ctx' (transport-jvm/classify-jvm-error throwable timeout-ms (elapsed-ms)))
                                       (handle-response! ctx' result))))))
                (catch Throwable t
-                 (maybe-retry! ctx' (transport-jvm/classify-jvm-error t timeout-ms (elapsed-ms)))))))))))))
+                 (maybe-retry! ctx' (transport-jvm/classify-jvm-error t timeout-ms (elapsed-ms))))))))))))))

--- a/implementation/http/test/re_frame/http_abort_body_prep_race_test.clj
+++ b/implementation/http/test/re_frame/http_abort_body_prep_race_test.clj
@@ -1,0 +1,280 @@
+(ns re-frame.http-abort-body-prep-race-test
+  "rf2-rsv2n (JVM) — an abort that wins while `run-attempt!` is blocked in
+  the managed request-preparation phase must never subsequently enter the
+  host transport.
+
+  Defect (closed by this test): `run-attempt!` sampled `@finalised?` only
+  BEFORE `prepare-body!`, and a `:body` thunk may block inside that call
+  for arbitrarily long. An abort landing in that window delivered the
+  canonical cancelled reply and cleared the in-flight registry — the
+  framework told the app the request was cancelled — yet the same attempt
+  then proceeded into the successful-preparation branch and called
+  `jvm-fetch`, so `HttpClient.sendAsync` issued a side-effecting request
+  AFTER cancellation. During preparation `cf-holder` is still nil, so the
+  abort closure had no future to cancel either: the request escaped
+  cancellation entirely (Spec 014 §Abort precedence — body realization is
+  a managed phase; §Aborts — a cancelled request must not issue a fresh
+  attempt).
+
+  Fix: a one-cell issuance-phase CAS (`issue-phase`, nil → `:issued` |
+  `:aborted`) shared between the abort closure and the post-preparation
+  gate, so the abort/issuance race has exactly one winner. Abort-before-
+  send wins the cell and the transport is never entered; send-before-abort
+  loses the cell to issuance, which publishes the cancellable future and
+  re-reads the abort-precedence cell after publication, cancelling its own
+  future when the abort landed in the residual publish window. The gate is
+  shared CLJC with no reader conditional, so the same guard covers a
+  re-entrantly fired abort during CLJS body realization (the third test
+  here drives that exact single-threaded re-entrant ordering through the
+  shared code path on the JVM).
+
+  All tests stub `transport-jvm/jvm-fetch` (the host-transport seam the
+  bug escapes through — the `with-managed-request-stubs` layer overrides
+  the whole `:rf.http/managed` fx and so sits ABOVE the lifecycle under
+  test) and use latches/promises, never timing sleeps."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.http.managed :as http-managed]
+            [re-frame.http.registry :as registry]
+            [re-frame.http.transport :as transport]
+            [re-frame.http.transport-jvm :as transport-jvm]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support])
+  (:import [java.util.concurrent CompletableFuture]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- await-condition!
+  ([pred] (await-condition! pred 5000))
+  ([pred timeout-ms]
+   (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
+                                  :label "http-abort-body-prep-race condition"})
+   true))
+
+(defn- register-recorder-and-issue!
+  "Register the shared `:reply/recorder` event plus an `:issue` event that
+  fires `:rf.http/managed` with `request` under `request-id`, recording
+  every reply into the `replies` atom."
+  [replies request-id request]
+  (rf/reg-event :reply/recorder
+    (fn [_ [_ payload]] (swap! replies conj payload) {}))
+  (rf/reg-event :issue
+    (fn [_ _]
+      {:fx [[:rf.http/managed
+             {:request    request
+              :decode     :text
+              :request-id request-id
+              :on-failure [:reply/recorder]
+              :on-success [:reply/recorder]}]]})))
+
+;; ---- (1) abort while the body thunk holds preparation ----------------------
+
+(deftest abort-during-body-prep-never-enters-host-transport
+  (testing "rf2-rsv2n — an abort that completes while the body thunk holds request preparation yields ZERO jvm-fetch calls, exactly one canonical :status :cancelled reply, and an empty registry"
+    (let [fetch-calls   (atom 0)
+          thunk-entered (promise)
+          release       (promise)
+          replies       (atom [])]
+      (with-redefs [transport-jvm/jvm-fetch (fn [_]
+                                              (swap! fetch-calls inc)
+                                              (CompletableFuture.))]
+        (register-recorder-and-issue!
+          replies :prep-race
+          {:url    "http://127.0.0.1:0/x"
+           :method :post
+           ;; The thunk signals entry, then blocks until the test releases
+           ;; it — holding the attempt inside `prepare-body!` while the
+           ;; abort races it (latches, not sleeps).
+           :body   (fn []
+                     (deliver thunk-entered true)
+                     @release
+                     "held-body")})
+        (let [worker (future (rf/dispatch-sync [:issue]))]
+          (try
+            (is (true? (deref thunk-entered 5000 false))
+                "the body thunk entered — preparation is in progress")
+            (is (contains? (registry/in-flight-snapshot) :prep-race)
+                "the handle was registered before preparation began")
+            ;; The abort resolves the live handle and COMPLETES (registry
+            ;; cleared synchronously by the abort closure) while the thunk
+            ;; is still held.
+            (is (true? (registry/abort-in-flight! :prep-race :user))
+                "the abort resolved the in-flight handle before release")
+            (is (empty? (registry/in-flight-snapshot))
+                "the registry is cleared before the body thunk is released")
+            (is (zero? @fetch-calls)
+                "no transport call while preparation is held")
+            ;; Release the thunk: preparation returns successfully, and the
+            ;; post-preparation gate must now SKIP the host transport.
+            (deliver release true)
+            (is (not= ::timeout (deref worker 5000 ::timeout))
+                "the attempt returned after release")
+            (is (zero? @fetch-calls)
+                "jvm-fetch was NEVER called after the cancelled reply — the cancelled attempt must not reach sendAsync")
+            (await-condition! #(seq @replies))
+            (is (= 1 (count @replies))
+                "exactly one terminal reply — the cancellation")
+            (let [reply (first @replies)]
+              (is (= :cancelled (:status reply))
+                  "the single reply is the canonical cancellation")
+              (is (= :rf.http/aborted (get-in reply [:error :kind])))
+              (is (= :user (get-in reply [:error :reason]))))
+            (is (empty? (registry/in-flight-snapshot))
+                "the request-id registry stays clean")
+            (is (empty? (registry/actor-in-flight-snapshot))
+                "the actor registry stays clean")
+            (finally
+              (deliver release true)
+              (deref worker 5000 nil))))))))
+
+;; ---- (2) non-vacuity control: same harness, no abort -----------------------
+
+(deftest no-abort-control-enters-host-transport-exactly-once
+  (testing "rf2-rsv2n (non-vacuity control) — the identical harness WITHOUT an abort invokes the host transport exactly once and completes normally"
+    (let [fetch-calls   (atom 0)
+          thunk-entered (promise)
+          release       (promise)
+          replies       (atom [])]
+      (with-redefs [transport-jvm/jvm-fetch
+                    (fn [_]
+                      (swap! fetch-calls inc)
+                      (CompletableFuture/completedFuture
+                        {:ok?         true
+                         :status      200
+                         :status-text ""
+                         :headers     {}
+                         :body-text   "ok"}))]
+        (register-recorder-and-issue!
+          replies :prep-control
+          {:url    "http://127.0.0.1:0/x"
+           :method :post
+           :body   (fn []
+                     (deliver thunk-entered true)
+                     @release
+                     "held-body")})
+        (let [worker (future (rf/dispatch-sync [:issue]))]
+          (try
+            (is (true? (deref thunk-entered 5000 false))
+                "the body thunk entered — the harness holds preparation exactly as the abort case does")
+            ;; No abort: release immediately.
+            (deliver release true)
+            (is (not= ::timeout (deref worker 5000 ::timeout)))
+            (is (= 1 @fetch-calls)
+                "the host transport was entered exactly once — the gate did not disable the send branch")
+            (await-condition! #(seq @replies))
+            (is (= 1 (count @replies)))
+            (is (= :ok (:status (first @replies)))
+                "the request completed normally through the stubbed transport")
+            (is (empty? (registry/in-flight-snapshot)))
+            (finally
+              (deliver release true)
+              (deref worker 5000 nil))))))))
+
+;; ---- (3) re-entrant abort fired BY body realization ------------------------
+
+(deftest reentrant-abort-inside-body-thunk-never-enters-host-transport
+  (testing "rf2-rsv2n — an abort fired synchronously/re-entrantly FROM INSIDE the body thunk (the single-threaded ordering the CLJS host produces) is honoured by the shared post-prep gate: no transport call follows the cancellation"
+    (let [fetch-calls  (atom 0)
+          abort-result (atom ::not-fired)
+          replies      (atom [])]
+      (with-redefs [transport-jvm/jvm-fetch (fn [_]
+                                              (swap! fetch-calls inc)
+                                              (CompletableFuture.))]
+        (register-recorder-and-issue!
+          replies :prep-reentrant
+          {:url    "http://127.0.0.1:0/x"
+           :method :post
+           ;; The thunk aborts its OWN request mid-realization, then
+           ;; returns successfully — preparation succeeds, and the gate
+           ;; alone stands between the delivered cancellation and the send.
+           :body   (fn []
+                     (reset! abort-result
+                             (registry/abort-in-flight! :prep-reentrant :user))
+                     "reentrant-body")})
+        (rf/dispatch-sync [:issue])
+        (is (true? @abort-result)
+            "the re-entrant abort resolved the live handle during realization")
+        (is (zero? @fetch-calls)
+            "the host transport was never entered after the re-entrant cancellation")
+        (await-condition! #(seq @replies))
+        (is (= 1 (count @replies)) "exactly one terminal reply")
+        (let [reply (first @replies)]
+          (is (= :cancelled (:status reply)))
+          (is (= :rf.http/aborted (get-in reply [:error :kind]))))
+        (is (empty? (registry/in-flight-snapshot)))))))
+
+;; ---- (4) handoff controls: issuance wins the phase CAS ---------------------
+
+(deftest abort-after-issuance-cancels-published-future
+  (testing "rf2-rsv2n (handoff control) — when issuance wins, the future is published and cancellable: a subsequent abort cancels it via cf-holder and produces no double reply"
+    (let [fetch-calls (atom 0)
+          returned-cf (atom nil)
+          replies     (atom [])]
+      (with-redefs [transport-jvm/jvm-fetch (fn [_]
+                                              (swap! fetch-calls inc)
+                                              (let [cf (CompletableFuture.)]
+                                                (reset! returned-cf cf)
+                                                cf))]
+        (register-recorder-and-issue!
+          replies :issued-then-abort
+          {:url "http://127.0.0.1:0/x" :method :post :body "plain"})
+        ;; Issuance completes synchronously inside dispatch-sync: the stub
+        ;; was entered, the future published, whenComplete wired.
+        (rf/dispatch-sync [:issue])
+        (is (= 1 @fetch-calls) "issuance won — the transport was entered once")
+        (is (some? @returned-cf) "the transport future exists")
+        (is (true? (registry/abort-in-flight! :issued-then-abort :user))
+            "the abort resolved the in-flight handle")
+        (is (.isCancelled ^CompletableFuture @returned-cf)
+            "the abort cancelled the PUBLISHED future — the work actually stops")
+        (await-condition! #(seq @replies))
+        (is (= 1 (count @replies))
+            "exactly one terminal reply — the CancellationException completion did not double-reply")
+        (let [reply (first @replies)]
+          (is (= :cancelled (:status reply)))
+          (is (= :rf.http/aborted (get-in reply [:error :kind]))))
+        (is (empty? (registry/in-flight-snapshot)))))))
+
+(deftest abort-in-residual-publish-window-still-cancels-future
+  (testing "rf2-rsv2n (residual window) — an abort landing AFTER issuance won the phase CAS but BEFORE the future is published (cf-holder still nil, injected deterministically at :issue/before-send) is honoured by the issuing thread's post-publication re-check: the future is cancelled on the abort's behalf, one reply, clean registry"
+    (let [fetch-calls  (atom 0)
+          returned-cf  (atom nil)
+          abort-result (atom ::not-fired)
+          replies      (atom [])]
+      (try
+        (with-redefs [transport-jvm/jvm-fetch (fn [_]
+                                                (swap! fetch-calls inc)
+                                                (let [cf (CompletableFuture.)]
+                                                  (reset! returned-cf cf)
+                                                  cf))]
+          (register-recorder-and-issue!
+            replies :residual-window
+            {:url "http://127.0.0.1:0/x" :method :post :body "plain"})
+          ;; The seam: fire the abort at the point where issuance has
+          ;; committed (phase CAS won) but nothing is published yet — the
+          ;; exact window the abort closure's cf-holder read finds nil.
+          (transport/set-test-interleave-hook!
+            (fn [point ctx]
+              (when (and (= point :issue/before-send)
+                         (= :residual-window (:request-id ctx))
+                         (= ::not-fired @abort-result))
+                (reset! abort-result
+                        (registry/abort-in-flight! :residual-window :user)))))
+          (rf/dispatch-sync [:issue])
+          (is (true? @abort-result)
+              "the injected abort resolved the handle inside the residual window")
+          (is (= 1 @fetch-calls)
+              "issuance had already committed, so the transport WAS entered in this ordering")
+          (is (some? @returned-cf))
+          (is (.isCancelled ^CompletableFuture @returned-cf)
+              "the issuing thread's post-publication re-check cancelled the future on the abort's behalf")
+          (await-condition! #(seq @replies))
+          (is (= 1 (count @replies)) "exactly one terminal reply — the abort's")
+          (let [reply (first @replies)]
+            (is (= :cancelled (:status reply)))
+            (is (= :rf.http/aborted (get-in reply [:error :kind]))))
+          (is (empty? (registry/in-flight-snapshot)))
+          (is (empty? (registry/actor-in-flight-snapshot))))
+        (finally
+          (transport/set-test-interleave-hook! nil))))))


### PR DESCRIPTION
Fixes rf2-rsv2n: an abort winning while `prepare-body!` is blocked in a body thunk could still issue the JVM `HttpClient.sendAsync` request after the cancelled reply (`@finalised?` was sampled only pre-prep and `cf-holder` was nil during prep).

Shipped: a per-attempt one-cell issuance-phase CAS (`issue-phase`, nil -> `:issued` | `:aborted`) in `run-attempt!`, shared between the abort closure and a new post-preparation gate, so a winning abort means the host transport is never entered. The residual publish window is closed too: the issuing thread re-reads `aborted?` after publishing the CompletableFuture and cancels its own future on the abort's behalf. The gate is shared CLJC with no reader conditional, covering the re-entrant CLJS body-realization abort by construction (the item's sanctioned alternative to a browser-lane test); the re-entrant ordering is driven through the shared gate by a JVM test. One test-only interleave point `:issue/before-send` added; public API unchanged; no spec edit (Spec 014 already mandates the fixed behavior).

Tests: `implementation/http/test/re_frame/http_abort_body_prep_race_test.clj` — 5 tests / 42 assertions at the jvm-fetch seam with deterministic latches/promises: abort-held-in-prep (zero fetch calls, one canonical `:status :cancelled` reply, empty registries), no-abort non-vacuity control (exactly one transport entry), re-entrant thunk abort, abort-after-issuance cancels the published future with no double reply, residual-window injection at `:issue/before-send`.

## Quality gates

- Full `clojure -M:test` from `implementation/http` on the final rebased base: 507 tests / 3869 assertions, 0 failures 0 errors, exit 0 (recent green 502/3827 plus this work's 5/42). Same result pre-rebase, exit 0. New namespace solo: 5/42, exit 0. Exit codes captured in the same shell as the run.
- Control: gate neutralized at one line -> exit 1, exactly the two abort-before-send tests red with fetch calls after the cancelled reply, other three stayed green (discriminating). Restore verified by blob hash: working file == committed object `1a5a1e272c891e4f6ac7c8472043e29f8e766522`.
- Heavy CLJS/browser lanes: CI.

(Body restored by the mayor from rf2-rsv2n's close reason — the original `--body-file` argument failed and left the body as the literal `@-`.)
