### PR TITLE
feat(xray): one-click Copy Mermaid for the selected registered machine (rf2-sxw06)

### DIFF
--- a/tools/machines-viz/README.md
+++ b/tools/machines-viz/README.md
@@ -43,7 +43,12 @@ Surfaces that ship today:
   structurally — no session data crosses a share link.
 - Mermaid `stateDiagram-v2` emitter — a pure `definition → string`
   function kept in this tool jar so the runtime machines artefact stays
-  focused on execution.
+  focused on execution. The normal end-user workflow for it is Xray's
+  **Static → Machines → Copy Mermaid** header button (rf2-sxw06): one
+  click copies the selected registered machine's fenced ```` ```mermaid ````
+  block for paste into a README, a PR description, Notion, or an
+  AI-pair chat. The library API below is for hosts building their own
+  surface.
 - SCXML import / export — pure-data round-trip over the
   supported W3C SCXML subset.
 - AI-generate-a-machine — a pluggable LLM-resolver seam; the

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -2102,6 +2102,16 @@ and emits a string suitable for paste. It is substrate-independent
 and DOM-independent — callable from JVM tests, from the JS bundle,
 and from the read-only viewer.
 
+The shipped end-user workflow over this emitter is **Xray's Static →
+Machines → Copy Mermaid** header button (rf2-sxw06): the Xray host
+passes the selected registered machine's definition to `mermaid/emit`
+and copies the fenced block in one accessible gesture — see Xray
+`spec/003-Machine-Inspector.md` §Static Machines surface. The fns in
+this section are the library seam beneath that workflow (and beneath
+any host-built surface); `chart-as-mermaid` /
+`copy-mermaid-to-clipboard!` remain chart-element conveniences for
+hosts that already hold a mounted chart.
+
 The emitter is **static-topology only**:
 
 - States render as Mermaid nodes; compound `:states` render as

--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -1290,7 +1290,14 @@ The Static Machines tab is **tab 1 of 5** in the Static L3 strip (per [`007-UX-I
 
 **Left pane — browse-all list.** Scrollable list of every registered machine; search box + sort-cycle button (`Name → States → Live → Name`) at the top. Each row carries: a selection glyph (`◉` active / `○` inactive — same vocabulary as the Static tab-bar), the machine-id rendered in monospace accent-violet, a source-coord chip (jump-to-source via the existing open-in-editor affordance), a state-count chip, a live-instance pip cluster (capped at 12; beyond that → textual count), and a per-row `→ Dynamic` JUMP chip. Empty-state: "No machines registered. `rf/reg-machine` to add the first."
 
-**Right pane — definition detail.** Header carries `<machine-id> · <source-coord ↗> · <N> states · <M> live`. Below the header, the **4-mode sub-strip** drives the per-mode body.
+**Right pane — definition detail.** Header carries `<machine-id> · <source-coord ↗> · <N> states · <M> live · [Copy Mermaid]`. Below the header, the **4-mode sub-strip** drives the per-mode body.
+
+**Copy Mermaid (rf2-sxw06).** The header's trailing `Copy Mermaid` button is the one-gesture "registered topology → clipboard" workflow: activating it passes the selected machine's definition (which the host view already holds) straight to the pure `day8.re-frame2-machines-viz.mermaid/emit` and writes the returned fenced ```` ```mermaid ```` `stateDiagram-v2` markdown block to the clipboard through the Xray-owned `:rf.xray.fx/copy-to-clipboard` fx — paste into a GitHub README / PR description / Notion / an AI-pair chat and it renders inline. Contract:
+
+- **Host-owned gesture.** The Static Machines host dispatches `:rf.xray.static.machines/copy-mermaid` with the definition it already subscribes to; `MachineChart` stays presentation-only (no registry subscription, no data prop, no built-in toolbar) and no rendered chart DOM node is required.
+- **Static topology only.** The copied text is the registered definition's structure — state / event / guard / action *names*, never live-snapshot state, trace history, or runtime/definition `:data` values (`mermaid/emit` is value-free by contract, and its lossy-semantics caveat comment ships in the block by default). Like the path-copy event, this is not a value-egress site.
+- **Gated on projectability.** The button renders only when the selected definition passes the shared `grammar/valid-definition?` predicate — no selected/valid definition ⇒ no actionable control; the empty and malformed-definition header paths are unchanged.
+- **Honest, non-modal feedback.** The settled outcome renders as one inline `role="status"` / `aria-live="polite"` span beside the button — `Copied` on a resolved clipboard write, `Copy failed` on rejection/unavailability (the fx reports Promise settlement via `:on-success` / `:on-failure` callback events). An in-flight write shows nothing; a failed write is never reported as copied; selection change clears the span; there is no toast, no modal, no format chooser.
 
 ### 4-mode sub-strip
 
@@ -1826,20 +1833,17 @@ a flat, human-legible query-string and restored it on load via
 mount, so the round-trip's read half was already inert before this
 removal.
 
-### Not built — Copy machine as PNG / SVG / Mermaid
+### Copy machine as PNG / SVG / Mermaid — Mermaid built; PNG / SVG not built
 
-Right-click on the machine chart (or use the panel header's `⋯`
-overflow menu) surfaces a **Copy machine as…** sub-menu:
+Copy-as formats let a user drop a machine into a pull-request
+description, a design doc, a Slack thread, or an AI-pair chat.
+Inspired by Stately Visualizer's registry-style share.
 
-| Format | Output |
-|---|---|
-| **PNG** | Rasterised chart at 2x DPR, transparent background, current-state highlight included. Copied to clipboard as an image. |
-| **SVG** | Vector chart with embedded fonts (so it renders identically when pasted into a doc or a Figma frame), current-state highlight included. Copied to clipboard as `image/svg+xml`. |
-| **Mermaid text** | Markdown-friendly Mermaid block. Emitted by `day8.re-frame2-machines-viz.mermaid/emit` (lives in `tools/machines-viz/` per rf2-sqhqu). Copied as plain text. |
-
-Inspired by Stately Visualizer's registry-style share. Use cases:
-dropping a chart into a pull-request description, into a design doc,
-into a Slack thread, or onto a whiteboard during a design discussion.
+| Format | Output | Status |
+|---|---|---|
+| **Mermaid text** | Markdown-friendly Mermaid block. Emitted by `day8.re-frame2-machines-viz.mermaid/emit` (lives in `tools/machines-viz/` per rf2-sqhqu). Copied as plain text. | **Built (rf2-sxw06)** — the `Copy Mermaid` button in the Static Machines definition-detail header (see §Static Machines surface → Copy Mermaid above). This is the normal workflow for copying a registered topology; no right-click menu or `⋯` overflow menu was built, because one explicit header action needs neither. |
+| **PNG** | Rasterised chart at 2x DPR, transparent background, current-state highlight included. Copied to clipboard as an image. | Not built. |
+| **SVG** | Vector chart with embedded fonts (so it renders identically when pasted into a doc or a Figma frame), current-state highlight included. Copied to clipboard as `image/svg+xml`. | Not built. |
 
 ### No Stately compatibility
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_events.cljs
@@ -31,13 +31,34 @@
   ;; rendering — the panel's view layer hard-wires that posture and
   ;; this install no longer registers the sub/event/slot trio.
 
+  ;; `:on-success` / `:on-failure` (optional event vectors, rf2-sxw06) let a
+  ;; caller surface honest copy feedback: `navigator.clipboard.writeText`
+  ;; returns a Promise that REJECTS on a denied/unavailable clipboard, and
+  ;; the pre-fix fx swallowed that settlement entirely — a caller could
+  ;; never distinguish "copied" from "silently dropped". The follow-up
+  ;; dispatch is pinned to the fx-context frame (`(:frame ctx)` — the
+  ;; active frame id per the v2 reg-fx contract) because the Promise
+  ;; callback runs long after the dispatching frame's dynamic context has
+  ;; unwound. Callers that pass no callbacks keep the original
+  ;; best-effort/fire-and-forget contract unchanged.
   (rf/reg-fx :rf.xray.fx/copy-to-clipboard
-    (fn [_ctx {:keys [text]}]
-      (try
-        (when (and (exists? js/navigator)
+    (fn [ctx {:keys [text on-success on-failure]}]
+      (let [frame-id (:frame ctx)
+            notify!  (fn [ev]
+                       (when (vector? ev)
+                         (try
+                           (if (some? frame-id)
+                             (rf/with-frame frame-id (rf/dispatch ev))
+                             (rf/dispatch ev))
+                           (catch :default _ nil))))]
+        (try
+          (if (and (exists? js/navigator)
                    (.-clipboard js/navigator))
-          (.writeText (.-clipboard js/navigator) (str text)))
-        (catch :default _ nil))))
+            (-> (.writeText (.-clipboard js/navigator) (str text))
+                (.then (fn [_] (notify! on-success))
+                       (fn [_] (notify! on-failure))))
+            (notify! on-failure))
+          (catch :default _ (notify! on-failure))))))
 
   ;; ---- universal copy-to-clipboard — OFF-BOX EGRESS (rf2-uo0rc.2) ----------
   ;;

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
@@ -7,6 +7,17 @@
   The header reads:
 
       <machine-id> · <source-coord ↗> · <N> states · <M> live (→ Dynamic)
+        · [Copy Mermaid]
+
+  The trailing Copy Mermaid button (rf2-sxw06) is the one-gesture
+  \"registered topology → fenced ```mermaid block on the clipboard\"
+  action. It renders only when the selected definition passes
+  `grammar/valid-definition?` (no valid definition ⇒ no actionable
+  control), dispatches `:rf.xray.static.machines/copy-mermaid` with the
+  definition the host already holds, and surfaces the settled outcome
+  as one inline `role=\"status\"` span beside the button — cleared on
+  selection change, never a toast, and a failed/unavailable clipboard
+  write is never reported as copied.
 
   ## 4-mode sub-strip
 
@@ -34,6 +45,7 @@
   empty-state hint; the right pane mounts a matching empty surface
   to keep the visual balance."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-machines-viz.grammar :as grammar]
             [day8.re-frame2-xray.open-in-editor :as open-in-editor]
             [day8.re-frame2-xray.static.machines.cascade-dimmed
              :as cascade-dimmed]
@@ -48,10 +60,63 @@
 
 ;; ---- header -------------------------------------------------------------
 
+(defn- copy-mermaid-button
+  "The Copy Mermaid action + its inline feedback span (rf2-sxw06).
+
+  Renders nothing unless `definition` passes the shared
+  `grammar/valid-definition?` gate (nil-safe; desugars internally), whose
+  truth is exactly the condition under which `mermaid/emit` cannot
+  throw — so a rendered button is always an actionable one. The click
+  passes the definition the host view already holds; the copy itself and
+  the outcome bookkeeping live in the `:rf.xray.static.machines/copy-
+  mermaid` event (panel.cljs).
+
+  `copy-status` is the settled outcome for THIS machine (`:copied` /
+  `:failed`, nil otherwise) from the `copy-mermaid-status` sub. The span
+  is `role=status` + `aria-live=polite` so the outcome is announced
+  without stealing focus — non-modal by design."
+  [dispatch {:keys [machine-id definition copy-status]}]
+  (when (grammar/valid-definition? definition)
+    [:<>
+     [:button
+      {:data-testid "rf-xray-static-machines-copy-mermaid"
+       :type        "button"
+       :aria-label  "Copy Mermaid diagram to clipboard"
+       :title       (str "Copy this machine's topology as a fenced Mermaid "
+                         "stateDiagram-v2 markdown block")
+       :on-click    (fn [_]
+                      (dispatch [:rf.xray.static.machines/copy-mermaid
+                                 machine-id definition]))
+       :style {:background    "transparent"
+               :border        (str "1px solid " (:border-default tokens))
+               :border-radius "10px"
+               :color         (:text-secondary tokens)
+               :cursor        "pointer"
+               :font-family   sans-stack
+               :font-size     (:caption type-scale)
+               :padding       "3px 12px"
+               :white-space   "nowrap"}}
+      "Copy Mermaid"]
+     (when (some? copy-status)
+       [:span
+        {:data-testid "rf-xray-static-machines-copy-mermaid-status"
+         :role        "status"
+         :aria-live   "polite"
+         :style {:font-family mono-stack
+                 :font-size   (:caption type-scale)
+                 :white-space "nowrap"
+                 :color       (if (= :copied copy-status)
+                                (:success tokens)
+                                (:error tokens))}}
+        (if (= :copied copy-status) "Copied" "Copy failed")])]))
+
 (defn- header
   "Render the definition-detail header. Sticks at the top of the right
-  pane."
-  [{:keys [machine-id source-coord state-count live-count]}]
+  pane. `dispatch` is the frame-aware dispatcher threaded from the
+  `detail` reg-view (same convention as `sub-strip`) — the Copy Mermaid
+  button dispatches through it."
+  [dispatch {:keys [machine-id source-coord state-count live-count
+                    definition copy-status]}]
   [:header {:data-testid "rf-xray-static-machines-detail-header"
             :data-machine-id (str machine-id)
             :style {:display       "flex"
@@ -96,7 +161,10 @@
                             (:accent tokens)
                             (:text-tertiary tokens))
                    :margin-left "auto"}}
-    (str (or live-count 0) " live")]])
+    (str (or live-count 0) " live")]
+   [copy-mermaid-button dispatch {:machine-id  machine-id
+                                  :definition  definition
+                                  :copy-status copy-status}]])
 
 ;; ---- sub-strip ----------------------------------------------------------
 
@@ -242,6 +310,12 @@
         ;; `:sim` sub-mode so the Topology/Instances/Cascade modes don't
         ;; subscribe to sim state. The subs short-circuit to nil when sim
         ;; isn't active for the selected machine, so this is cheap.
+        ;; Copy-Mermaid settled outcome for the selected machine
+        ;; (rf2-sxw06) — nil unless a copy gesture on THIS machine has
+        ;; settled; cleared by `:rf.xray.static.machines/select`.
+        copy-status @(rf/subscribe
+                       [:rf.xray.static.machines/copy-mermaid-status
+                        selected-id])
         sim-values (when (= sub-mode :sim)
                      {:sim         @(rf/subscribe
                                       [:rf.xray.static.machines/sim-state])
@@ -265,10 +339,12 @@
                        :height         "100%"
                        :background     (:bg-2 tokens)
                        :color          (:text-primary tokens)}}
-         [header {:machine-id machine-id
-                  :source-coord source-coord
-                  :state-count state-count
-                  :live-count live-count}]
+         [header dispatch {:machine-id   machine-id
+                           :source-coord source-coord
+                           :state-count  state-count
+                           :live-count   live-count
+                           :definition   definition
+                           :copy-status  copy-status}]
          [sub-strip dispatch {:machine-id machine-id
                               :sub-mode   sub-mode
                               :live-count live-count}]

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
@@ -30,6 +30,7 @@
     `:rf.xray.static.machines/sim-active?`            — sim on for selected machine?
     `:rf.xray.static.machines/sim-available-transitions` — picker source
     `:rf.xray.static.machines/sim-event-suggestions`  — datalist source
+    `:rf.xray.static.machines/copy-mermaid-status`    — copy feedback for a machine
 
   Events:
     `:rf.xray.static.machines/select`         — set selected-id
@@ -45,6 +46,8 @@
     `:rf.xray.static.machines/sim-step`       — fire one event into sim
     `:rf.xray.static.machines/sim-set-pending-event` — controlled input
     `:rf.xray.static.machines/sim-set-pending-data`  — controlled input
+    `:rf.xray.static.machines/copy-mermaid`          — emit + copy to clipboard
+    `:rf.xray.static.machines/copy-mermaid-done`     — record copy outcome
 
   Fxs:
     `:rf.xray.static.machines/persist-selection` — write selected-id to LS
@@ -56,6 +59,7 @@
   `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs` scopes
   subscribes / dispatches to Xray's frame."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-machines-viz.mermaid :as mermaid]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.static.machines.browse-list :as browse-list]
             [day8.re-frame2-xray.static.machines.definition-detail
@@ -135,6 +139,22 @@
       (h/normalise-sub-mode
         (get by-id machine-id h/default-sub-mode))))
 
+  ;; Copy-Mermaid feedback for ONE machine (rf2-sxw06). The db slot is a
+  ;; single `{:machine-id <mid> :status :pending|:copied|:failed}` map —
+  ;; keyed answers for any OTHER machine read nil, so a stale outcome can
+  ;; never masquerade as feedback about the machine on screen. `:pending`
+  ;; is deliberately surfaced as nil too: the header span only ever
+  ;; renders a SETTLED outcome, so an in-flight write can't be mistaken
+  ;; for a completed copy.
+  (rf/reg-sub :rf.xray.static.machines/copy-mermaid-status
+    (fn [db [_ machine-id]]
+      (let [{mid :machine-id status :status}
+            (get db :rf.xray.static.machines/copy-mermaid-status)]
+        (when (and (some? machine-id)
+                   (= mid machine-id)
+                   (contains? #{:copied :failed} status))
+          status))))
+
   ;; Composite — feeds the browse-list + detail header. Reads the
   ;; existing :rf.xray/registered-machines + machine-definitions +
   ;; machine-snapshots subs registered by panels.machine-inspector
@@ -166,7 +186,12 @@
 (defn- install-events! []
   (rf/reg-event :rf.xray.static.machines/select
     (fn [{:keys [db]} [_ machine-id]]
-      (let [next-db (assoc db :rf.xray.static.machines/selected-id machine-id)]
+      ;; Selection change also clears the Copy-Mermaid feedback span
+      ;; (rf2-sxw06) — feedback is about ONE machine's copy gesture and
+      ;; must not survive onto another machine's header.
+      (let [next-db (-> db
+                        (assoc :rf.xray.static.machines/selected-id machine-id)
+                        (dissoc :rf.xray.static.machines/copy-mermaid-status))]
         {:db next-db
          :fx [[:rf.xray.static.machines/persist-selection machine-id]]})))
 
@@ -218,6 +243,57 @@
   ;; orchestration rides the second-window UX bead.
   (rf/reg-event :rf.xray.static.machines/open-chart-popout
     (fn [{:keys [db]} [_ _machine-id]] {:db db}))
+
+  ;; ---- Copy Mermaid (rf2-sxw06) -----------------------------------------
+  ;;
+  ;; The definition-detail header's one-gesture "copy this registered
+  ;; topology as Mermaid" action. The HOST owns the gesture: the view
+  ;; passes the selected machine's definition (which it already holds)
+  ;; straight to the pure `mermaid/emit`, and the fenced markdown block
+  ;; crosses the clipboard through the existing Xray-owned
+  ;; `:rf.xray.fx/copy-to-clipboard` fx — MachineChart stays
+  ;; presentation-only and gains no registry subscription.
+  ;;
+  ;; Egress posture: the copied text is STATIC TOPOLOGY ONLY — state /
+  ;; event / guard / action NAMES from the registered definition, never
+  ;; runtime or definition `:data` values (`mermaid/emit` is value-free
+  ;; by contract; its invalid-definition diagnostic is value-free too,
+  ;; rf2-8nzxib). Like `:rf.xray/copy-path-to-clipboard`, this is NOT a
+  ;; value-egress site, so the text rides the fx directly rather than
+  ;; through `runtime/egress-value` — routing it there would `pr-str` the
+  ;; block (breaking the exact-emit contract) without ever finding a
+  ;; value to elide.
+  ;;
+  ;; `emit` throws on a definition it cannot project. The header already
+  ;; gates the control on `grammar/valid-definition?` (whose truth means
+  ;; emit cannot throw), but the handler still catches — a race between
+  ;; render and a registry mutation must land as honest `:failed`
+  ;; feedback, never as an unhandled event error.
+  (rf/reg-event :rf.xray.static.machines/copy-mermaid
+    (fn [{:keys [db]} [_ machine-id definition]]
+      (let [md (try (mermaid/emit definition) (catch :default _ nil))]
+        (if (some? md)
+          {:db (assoc db :rf.xray.static.machines/copy-mermaid-status
+                      {:machine-id machine-id :status :pending})
+           :fx [[:rf.xray.fx/copy-to-clipboard
+                 {:text       md
+                  :on-success [:rf.xray.static.machines/copy-mermaid-done
+                               machine-id :copied]
+                  :on-failure [:rf.xray.static.machines/copy-mermaid-done
+                               machine-id :failed]}]]}
+          {:db (assoc db :rf.xray.static.machines/copy-mermaid-status
+                      {:machine-id machine-id :status :failed})}))))
+
+  ;; Records the SETTLED clipboard outcome. The write is guarded on the
+  ;; machine still being selected: the async settlement can land after
+  ;; the user has moved on, and feedback about a machine no longer on
+  ;; screen must not repopulate the slot `select` just cleared.
+  (rf/reg-event :rf.xray.static.machines/copy-mermaid-done
+    (fn [{:keys [db]} [_ machine-id status]]
+      (if (= machine-id (get db :rf.xray.static.machines/selected-id))
+        {:db (assoc db :rf.xray.static.machines/copy-mermaid-status
+                    {:machine-id machine-id :status status})}
+        {:db db})))
   nil)
 
 ;; ---- public install -----------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -383,6 +383,9 @@
    ;; rf2-o5f5f.2 — Static Machines sub-tab subs (browse-all + per-
    ;; machine sub-mode). Composite + raw slots feeding the L4 master-
    ;; detail surface.
+   ;; rf2-sxw06 — Copy Mermaid settled-outcome feedback for one machine
+   ;; (nil for every other machine, and for an unsettled/pending copy).
+   :rf.xray.static.machines/copy-mermaid-status
    :rf.xray.static.machines/data
    :rf.xray.static.machines/rows
    :rf.xray.static.machines/search
@@ -699,6 +702,12 @@
    ;; click affordances land on a known handler rather than emitting
    ;; `:rf.warning/no-handler`.
    :rf.xray.static.machines/clear-search
+   ;; rf2-sxw06 — Copy Mermaid: the definition-detail header's one-
+   ;; gesture "registered topology → fenced ```mermaid block on the
+   ;; clipboard" action (emit + copy), and the settled-outcome recorder
+   ;; the clipboard fx's on-success/on-failure callbacks dispatch.
+   :rf.xray.static.machines/copy-mermaid
+   :rf.xray.static.machines/copy-mermaid-done
    :rf.xray.static.machines/cycle-sort
    :rf.xray.static.machines/hydrate
    :rf.xray.static.machines/open-chart-popout

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/copy_mermaid_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/copy_mermaid_cljs_test.cljs
@@ -1,0 +1,336 @@
+(ns day8.re-frame2-xray.static.machines.copy-mermaid-cljs-test
+  "Integration tests for the Static Machines definition-detail header's
+  Copy Mermaid action (rf2-sxw06).
+
+  ## What's under test
+
+  The one host-owned gesture that makes a registered topology reachable
+  as Mermaid: click `Copy Mermaid` in the selected machine's detail
+  header and exactly `(mermaid/emit definition)` — the fenced
+  ```mermaid markdown block — lands on the clipboard through the
+  Xray-owned `:rf.xray.fx/copy-to-clipboard` fx.
+
+    1. The control renders in the header with an accessible name, and
+       ONLY when the selected definition passes
+       `grammar/valid-definition?` — no definition / malformed
+       definition ⇒ no actionable control, header otherwise stable.
+
+    2. Activating the REAL control (the rendered button's `:on-click`)
+       produces exactly ONE clipboard write whose text equals
+       `(mermaid/emit definition)` verbatim — the emitter's corpus
+       stays the authority for diagram semantics; this suite owns only
+       the host-to-clipboard gesture.
+
+    3. Outcome feedback is honest and non-modal: the settled result
+       renders as one inline `role=status` span (`Copied` /
+       `Copy failed`); an unsettled (pending) write renders NOTHING, a
+       rejected/unavailable clipboard reports `Copy failed`, and a
+       failed write is never reported as copied.
+
+    4. Feedback hygiene: selection change clears the span, and a copy
+       that settles AFTER the user has moved to another machine does
+       not repopulate it.
+
+  ## Clipboard boundary
+
+  Mocked at the established seam: the `:rf/xray` frame's
+  `:fx-overrides` captures `:rf.xray.fx/copy-to-clipboard` args
+  (rf2-h1vqa4 — same pattern as `registry_cljs_test` /
+  `app_db_diff_cljs_test`). Settlement is then driven by dispatching
+  the captured `:on-success` / `:on-failure` event vectors — the exact
+  vectors the real fx dispatches when the `writeText` Promise settles.
+  One async test additionally exercises the REAL registered fx on this
+  node target (no `js/navigator`) to prove the unavailable-clipboard
+  branch lands `:failed` through the fx's own frame-pinned dispatch."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.test-helpers :as th]
+            [day8.re-frame2-machines-viz.mermaid :as mermaid]
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.static.machines.panel :as panel]
+            [day8.re-frame2-xray.static.machines.persistence :as ls]
+            [day8.re-frame2-xray.static.persistence :as static-persistence]
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(use-fixtures :each
+  (xray-test-support/make-xray-runtime-fixture
+    {:async?     true
+     :post-reset (fn []
+                   (config/reset-suppressed-count!)
+                   (static-persistence/clear!)
+                   (ls/clear!))}))
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- xray-setup! []
+  (registry/register-xray-handlers!)
+  (xray-test-support/install-test-overrides!)
+  (rf/make-frame {:id :rf/xray}))
+
+(defn- frame-sub [q]
+  (rf/with-frame :rf/xray
+    @(rf/subscribe q)))
+
+(defn- frame-dispatch [ev]
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync ev)))
+
+(defn- seed-machines! [ids]
+  (frame-dispatch [:rf.xray/set-registered-machines-override-for-test
+                   (vec ids)]))
+
+(defn- seed-definitions! [defs]
+  (frame-dispatch [:rf.xray/set-machine-definitions-override-for-test defs]))
+
+(defn- capture-copy!
+  "Capture `:rf.xray.fx/copy-to-clipboard` args via the `:rf/xray`
+  frame's `:fx-overrides` seam (rf2-h1vqa4 — fn-value form; the
+  re-`make-frame` is a surgical config update on the live frame). Call
+  AFTER `xray-setup!`."
+  []
+  (let [captured (atom [])]
+    (rf/make-frame {:id :rf/xray
+                    :fx-overrides {:rf.xray.fx/copy-to-clipboard
+                                   (fn [_ctx args] (swap! captured conj args))}})
+    captured))
+
+(def ^:private fixture-definition
+  "A small but representative compound topology — enough grammar for a
+  non-trivial emit, valid per `grammar/valid-definition?`."
+  {:initial :idle
+   :states  {:idle    {:on {:start :running}}
+             :running {:on {:pause :paused
+                            :stop  :idle}}
+             :paused  {:on {:resume :running}}}})
+
+(defn- find-copy-button [tree]
+  (th/find-by-testid tree "rf-xray-static-machines-copy-mermaid"))
+
+(defn- find-status-span [tree]
+  (th/find-by-testid tree "rf-xray-static-machines-copy-mermaid-status"))
+
+;; -------------------------------------------------------------------------
+;; (1) Rendering + accessibility + the no-valid-definition gate
+;; -------------------------------------------------------------------------
+
+(deftest copy-button-renders-with-accessible-name
+  (testing "A valid selected definition renders ONE labelled, focusable
+            Copy Mermaid button in the detail header"
+    (xray-setup!)
+    (seed-machines! [:m/a])
+    (seed-definitions! {:m/a fixture-definition})
+    (frame-dispatch [:rf.xray.static.machines/select :m/a])
+    (rf/with-frame :rf/xray
+      (let [tree  (panel/panel)
+            btn   (find-copy-button tree)
+            attrs (th/attrs btn)]
+        (is (some? btn) "the Copy Mermaid control renders")
+        (is (= :button (first btn))
+            "a real <button> — keyboard-reachable by default")
+        (is (= "button" (:type attrs))
+            ":type button (no accidental form-submit semantics)")
+        (is (seq (:aria-label attrs)) "carries an accessible name")
+        (is (fn? (:on-click attrs)) "wired to a click handler")
+        (is (nil? (find-status-span tree))
+            "no feedback span before any copy gesture")))))
+
+(deftest copy-button-omitted-when-no-definition
+  (testing "A machine with NO registered definition renders a stable
+            header with no copy control"
+    (xray-setup!)
+    (seed-machines! [:m/a])
+    (seed-definitions! {})
+    (frame-dispatch [:rf.xray.static.machines/select :m/a])
+    (rf/with-frame :rf/xray
+      (let [tree (panel/panel)]
+        (is (some? (th/find-by-testid
+                     tree "rf-xray-static-machines-detail-header"))
+            "header still renders")
+        (is (nil? (find-copy-button tree))
+            "no actionable copy control without a definition")))))
+
+(deftest copy-button-omitted-when-definition-invalid
+  (testing "A malformed definition (fails grammar/valid-definition?)
+            renders a stable header with no copy control"
+    (xray-setup!)
+    (seed-machines! [:m/a])
+    ;; No :initial — fails the shared grammar predicate; the same shape
+    ;; `mermaid/emit` would reject with :mermaid/invalid-definition.
+    (seed-definitions! {:m/a {:states {:idle {}}}})
+    (frame-dispatch [:rf.xray.static.machines/select :m/a])
+    (rf/with-frame :rf/xray
+      (let [tree (panel/panel)]
+        (is (some? (th/find-by-testid
+                     tree "rf-xray-static-machines-detail-header"))
+            "header still renders")
+        (is (nil? (find-copy-button tree))
+            "no actionable copy control for an unprojectable definition")))))
+
+;; -------------------------------------------------------------------------
+;; (2) The real control writes exactly (mermaid/emit definition) — once
+;; -------------------------------------------------------------------------
+
+(deftest click-writes-exact-emitter-output-once
+  (async done
+    (xray-setup!)
+    (seed-machines! [:m/a])
+    (seed-definitions! {:m/a fixture-definition})
+    (frame-dispatch [:rf.xray.static.machines/select :m/a])
+    (let [captured (capture-copy!)
+          on-click (rf/with-frame :rf/xray
+                     (:on-click (th/attrs (find-copy-button (panel/panel)))))]
+      (is (fn? on-click) "sanity: the rendered control is wired")
+      ;; Activate the REAL control. The reg-view-injected dispatcher is
+      ;; the queued (async) frame dispatch, so the event lands on the
+      ;; next router drain — hence the async test.
+      (on-click nil)
+      (js/setTimeout
+        (fn []
+          (is (= 1 (count @captured))
+              "exactly ONE clipboard write per gesture")
+          (let [{:keys [text on-success on-failure]} (first @captured)]
+            (is (= (mermaid/emit fixture-definition) text)
+                "the payload is EXACTLY (mermaid/emit definition)")
+            (is (re-find #"^```mermaid\n" (or text ""))
+                "fenced markdown block — opening fence intact")
+            (is (vector? on-success) "success callback event supplied")
+            (is (vector? on-failure) "failure callback event supplied")
+            ;; Unsettled write ⇒ NO feedback yet (pending is never
+            ;; surfaced — a write that hasn't settled must not read as
+            ;; copied).
+            (is (nil? (frame-sub [:rf.xray.static.machines/copy-mermaid-status
+                                  :m/a]))
+                "no settled status while the write is in flight")
+            (rf/with-frame :rf/xray
+              (is (nil? (find-status-span (panel/panel)))
+                  "no feedback span while the write is in flight"))
+            ;; Settle success — the exact vector the real fx dispatches
+            ;; when the writeText Promise resolves.
+            (frame-dispatch on-success)
+            (is (= :copied
+                   (frame-sub [:rf.xray.static.machines/copy-mermaid-status
+                               :m/a])))
+            (rf/with-frame :rf/xray
+              (let [span (find-status-span (panel/panel))]
+                (is (some? span) "feedback span renders on success")
+                (is (= "status" (:role (th/attrs span)))
+                    "non-modal accessible status feedback")
+                (is (= "Copied" (th/text-content span))))))
+          (done))
+        50))))
+
+;; -------------------------------------------------------------------------
+;; (3) Failure paths — never reported as copied
+;; -------------------------------------------------------------------------
+
+(deftest rejected-clipboard-reports-failure
+  (testing "A rejected clipboard write settles as Copy failed — never
+            as Copied"
+    (xray-setup!)
+    (seed-machines! [:m/a])
+    (seed-definitions! {:m/a fixture-definition})
+    (frame-dispatch [:rf.xray.static.machines/select :m/a])
+    (let [captured (capture-copy!)]
+      ;; Drive the event seam sync (mirrors the click-path proven above;
+      ;; same event vector the control dispatches).
+      (frame-dispatch [:rf.xray.static.machines/copy-mermaid
+                       :m/a fixture-definition])
+      (is (= 1 (count @captured)))
+      ;; Settle rejection — the exact vector the real fx dispatches when
+      ;; the writeText Promise rejects (denied permission etc.).
+      (frame-dispatch (:on-failure (first @captured)))
+      (is (= :failed
+             (frame-sub [:rf.xray.static.machines/copy-mermaid-status :m/a]))
+          "rejection lands as :failed")
+      (rf/with-frame :rf/xray
+        (let [span (find-status-span (panel/panel))]
+          (is (= "Copy failed" (th/text-content span)))
+          (is (not= "Copied" (th/text-content span))
+              "a failed write is never reported as copied"))))))
+
+(deftest unavailable-clipboard-real-fx-lands-failure
+  (async done
+    ;; No fx-override here: the REAL registered fx runs. On this node
+    ;; target `js/navigator` doesn't exist, so the fx takes the
+    ;; unavailable branch and dispatches `:on-failure` — queued onto the
+    ;; fx-context frame (`:rf/xray`), hence the drain wait.
+    (xray-setup!)
+    (seed-machines! [:m/a])
+    (seed-definitions! {:m/a fixture-definition})
+    (frame-dispatch [:rf.xray.static.machines/select :m/a])
+    (frame-dispatch [:rf.xray.static.machines/copy-mermaid
+                     :m/a fixture-definition])
+    (js/setTimeout
+      (fn []
+        (is (= :failed
+               (frame-sub [:rf.xray.static.machines/copy-mermaid-status
+                           :m/a]))
+            "unavailable clipboard settles as :failed via the real fx")
+        (done))
+      50)))
+
+(deftest unprojectable-definition-at-event-time-fails-without-write
+  (testing "A definition that fails emit at event time (render/registry
+            race) lands honest :failed feedback and writes NOTHING"
+    (xray-setup!)
+    (seed-machines! [:m/a])
+    (seed-definitions! {:m/a fixture-definition})
+    (frame-dispatch [:rf.xray.static.machines/select :m/a])
+    (let [captured (capture-copy!)]
+      (frame-dispatch [:rf.xray.static.machines/copy-mermaid
+                       :m/a {:states {}}])
+      (is (zero? (count @captured)) "no clipboard write is attempted")
+      (is (= :failed
+             (frame-sub [:rf.xray.static.machines/copy-mermaid-status
+                         :m/a]))))))
+
+;; -------------------------------------------------------------------------
+;; (4) Feedback hygiene — cleared on selection change; no stale settle
+;; -------------------------------------------------------------------------
+
+(deftest status-cleared-on-selection-change
+  (testing "Selecting another machine clears the feedback span"
+    (xray-setup!)
+    (seed-machines! [:m/a :m/b])
+    (seed-definitions! {:m/a fixture-definition
+                        :m/b fixture-definition})
+    (frame-dispatch [:rf.xray.static.machines/select :m/a])
+    (let [captured (capture-copy!)]
+      (frame-dispatch [:rf.xray.static.machines/copy-mermaid
+                       :m/a fixture-definition])
+      (frame-dispatch (:on-success (first @captured)))
+      (is (= :copied
+             (frame-sub [:rf.xray.static.machines/copy-mermaid-status :m/a]))
+          "sanity: feedback set before the selection change")
+      (frame-dispatch [:rf.xray.static.machines/select :m/b])
+      (is (nil? (frame-sub [:rf.xray.static.machines/copy-mermaid-status
+                            :m/a])))
+      (is (nil? (frame-sub [:rf.xray.static.machines/copy-mermaid-status
+                            :m/b])))
+      (rf/with-frame :rf/xray
+        (is (nil? (find-status-span (panel/panel)))
+            "no feedback span survives onto another machine's header")))))
+
+(deftest late-settlement-after-reselect-does-not-repopulate
+  (testing "A copy that settles AFTER the user moved to another machine
+            does not repopulate the cleared feedback slot"
+    (xray-setup!)
+    (seed-machines! [:m/a :m/b])
+    (seed-definitions! {:m/a fixture-definition
+                        :m/b fixture-definition})
+    (frame-dispatch [:rf.xray.static.machines/select :m/a])
+    (let [captured (capture-copy!)]
+      (frame-dispatch [:rf.xray.static.machines/copy-mermaid
+                       :m/a fixture-definition])
+      ;; User moves on before the async write settles…
+      (frame-dispatch [:rf.xray.static.machines/select :m/b])
+      ;; …then the stale settlement arrives.
+      (frame-dispatch (:on-success (first @captured)))
+      (is (nil? (frame-sub [:rf.xray.static.machines/copy-mermaid-status
+                            :m/a]))
+          "stale settlement is dropped, not recorded")
+      (rf/with-frame :rf/xray
+        (is (nil? (find-status-span (panel/panel))))))))


### PR DESCRIPTION
## What

Completes the Mermaid workflow from `tools/machines-viz`'s mature pure emitter (`mermaid/emit`) to a reachable end-user gesture: a **Copy Mermaid** button in Xray's Static Machines definition-detail header. One accessible click copies exactly `(mermaid/emit definition)` — the fenced ```mermaid `stateDiagram-v2` markdown block — for the currently selected registered machine. Completion of an existing capability; no new export subsystem, no PNG/SVG (out of scope per the bead).

## How

- **Host-owned gesture** (`static/machines/definition_detail.cljs`): the header renders one labelled `<button>` (`aria-label`, `:type button`) gated on the shared `grammar/valid-definition?` predicate — no selected/valid definition means no actionable control; empty/malformed header paths unchanged. `MachineChart` stays presentation-only (no registry subscription, no new prop, no toolbar); no rendered chart DOM node is needed — the exporter's chart-element convenience is deliberately not used.
- **Event seam** (`static/machines/panel.cljs`): `:rf.xray.static.machines/copy-mermaid` try/catches `mermaid/emit` (a render/registry race lands honest `:failed`, never an unhandled error) and routes the text through the existing Xray-owned `:rf.xray.fx/copy-to-clipboard` fx. Egress posture per triage: the payload is static topology only — names, never runtime/definition `:data` values — so like `:rf.xray/copy-path-to-clipboard` this is not a value-egress site; routing through `runtime/egress-value` would `pr-str`-mangle the block without finding a value to elide (documented at the handler).
- **Honest feedback** (`panels/app_db_diff_events.cljs`): the clipboard fx gains optional `:on-success` / `:on-failure` callback events dispatched on `writeText` Promise settlement, pinned to the fx-context frame (`(:frame ctx)`) because the Promise callback outlives the dispatching frame's dynamic context. Existing callers pass no callbacks and keep the fire-and-forget contract byte-for-byte. Outcome renders as one inline `role=status` / `aria-live=polite` span — `Copied` / `Copy failed`; pending renders nothing; a failed write is never reported as copied; selection change clears it; a stale settlement after reselect is dropped (guarded in `copy-mermaid-done`). No toast, no modal, no format chooser.
- **Tests** (`static/machines/copy_mermaid_cljs_test.cljs`, 8 deftests): clipboard mocked at the established `:fx-overrides` seam; the async click test activates the REAL rendered control and asserts exactly one write whose text equals `(mermaid/emit definition)` verbatim; rejection path, real-fx unavailable-clipboard path (node target, frame-pinned async dispatch-back), no/invalid-definition gates, selection-change clearing, stale-settlement drop. Registry inventory test updated (2 events + 1 sub).
- **Spec/docs**: Xray `spec/003-Machine-Inspector.md` — the Static Machines section documents the action normatively, and the stale **"Not built — Copy machine as PNG / SVG / Mermaid"** section becomes a per-format status table with **Mermaid: Built (rf2-sxw06)**, PNG/SVG still Not built. `tools/machines-viz/README.md` + `spec/API.md` name the Xray action as the normal workflow over the emitter. (`spec/014-Registry-Catalogue.md` unchanged because its sub/event tables are deliberately selective — the exhaustive pin is `registry_cljs_test`.)
- **Manual inspection**: the existing panel-gallery fixtures seed registered machines + definitions through the same override events the Static surface composes over, so the action is reachable there with no new testbed application or launch mode.

## Quality gates

Hand-verified (link gates don't read prose/tables): new 003 table rows are 3-cell against the 3-cell header; no markdown links or anchors added by this diff (cross-references are backtick prose).

| Gate | Result | Captured exit |
|---|---|---|
| `npm run test:cljs` compile (node-test build, final base) | 0 warnings | `COMPILE_EXIT=0` |
| `npm run test:cljs` run (final base) | 11121 tests / 54556 assertions, 0 failures, 0 errors | `RUN_EXIT=0` |
| **Control (planted fault)**: button's dispatch neutralised at one line → recompile + run | RED: 9 failures, all in `click-writes-exact-emitter-output-once` (zero captured writes / nil payload) — proves the gate reads this branch's tree and the integration test guards the wiring | `RUN_EXIT=1` |
| Restore verified by git blob hash (worktree == `HEAD` object), recompile + rerun | 11121 tests / 54556 assertions, 0 failures, 0 errors | `COMPILE_EXIT=0`, `RUN_EXIT=0` |
| `npm run test:tools-machines-viz` compile | 0 warnings | `COMPILE_EXIT=0` |
| `npm run test:tools-machines-viz` run | 844 tests / 3745 assertions, 0 failures, 0 errors | `RUN_EXIT=0` |
| `python scripts/check_doc_slugs.py` | green | `DOCSLUGS_EXIT=0` |
| `python scripts/check_readme_links.py --ci` | green | `READMELINKS_EXIT=0` |

CI reliance declared for the browser/compile sink lanes (Story/Xray browser feature gate, adapter smokes) — no local browser lane in this worker per the standing split.

Beads: rf2-sxw06