### PR TITLE
docs(reagent-slim): Form-3 table numbers the snapshot as the fourth callback arg (rf2-08hx1)

### DIFF
--- a/implementation/adapters/reagent-slim/FORM-3.md
+++ b/implementation/adapters/reagent-slim/FORM-3.md
@@ -18,9 +18,9 @@ the keys it excludes, and walks through the canonical Form-3 use case
 |---|---|
 | `:reagent-render` | The render function. Returns hiccup. Called on every render. |
 | `:component-did-mount` | Fires once, after the first commit. Use to attach DOM-dependent state (refs read, JS libraries instantiated). |
-| `:component-did-update` | Fires after every re-render commit (not the first). Receives `(this prev-props prev-state snapshot)`. The third arg is the value returned by `:get-snapshot-before-update` if set, else `nil`. |
+| `:component-did-update` | Fires after every re-render commit (not the first). Receives `(this prev-props prev-state snapshot)`. The fourth arg is the value returned by `:get-snapshot-before-update` if set, else `nil`. |
 | `:component-will-unmount` | Fires once, just before unmount. The canonical disposal seam — release timers, listeners, JS-library instances. |
-| `:get-snapshot-before-update` | Fires just before commit, with `(this prev-props prev-state)`. Returns any value; that value is passed as the 3rd arg to `:component-did-update`. Use to capture pre-commit DOM measurements (e.g. scroll position) for restoration after the commit. |
+| `:get-snapshot-before-update` | Fires just before commit, with `(this prev-props prev-state)`. Returns any value; that value is passed as the 4th arg to `:component-did-update`. Use to capture pre-commit DOM measurements (e.g. scroll position) for restoration after the commit. |
 | `:component-did-catch` | Error-boundary callback. Fires with `(this error info)` when a descendant throws during render. Logging-only — re-frame2 ships only the `componentDidCatch` half of React's error-boundary contract. Apps that want stateful fallback rendering pair this with a local `(reagent2.core/atom)` flipped from inside the callback. |
 | `:display-name` | A string used by React DevTools and error messages. Compile-time only — zero runtime cost. |
 


### PR DESCRIPTION
## What

Audit residual on rf2-08hx1 (AUDIT 2026-09-01 PR #8827 REOPEN note). PR #8827 correctly threaded `prev-state` through the Form-3 lifecycle wrappers, but the published contract still contradicted itself: the `implementation/adapters/reagent-slim/FORM-3.md` §1 table showed `:component-did-update` receiving `(this prev-props prev-state snapshot)` while calling the returned snapshot the **third** arg (lines 21 and 23). For the user callback it is the **fourth**; third is true only of React's raw `componentDidUpdate(prevProps, prevState, snapshot)`. The worked example at FORM-3.md:516-518 already said fourth.

Two-word fix: both table sentences now say fourth/4th. IMPL-SPEC.md's raw-React third-arg wording (lines 641, 663) is deliberately kept — it is correct about React. No compatibility machinery, no API change, no source-behavior edits.

## Agreement sweep (bead acceptance criterion)

Fixed-string census for `third|3rd` and `fourth|4th` across `implementation/adapters/reagent-slim/**`, exercised against known hits (the IMPL-SPEC raw-React lines, which it found). After the fix, README.md, FORM-3.md, IMPL-SPEC.md, source docstrings/comments, and both test files agree: user callbacks are `(this prev-argv prev-state)` -> snapshot and `(this prev-argv prev-state snapshot)`; every remaining "third/3rd" is either the raw-React arg position (correct, kept), prevState as the 3rd *user* arg (correct), or unrelated prose (`third driver`, `(third hiccup)`, coord-segment tests).

## Quality gates

- `python scripts/check_readme_links.py --ci` — FORM-3.md is on its beside-source roster (rf2-i4nb2). Planted-fault proof: a broken link planted at edited line 21 went red, exit **1**, the gate naming exactly that target; blob-hash-verified restore (worktree hash equals the committed object's); clean run exit **0**.
- Prose-only change — two words in two markdown table cells, no code or test lane applicable. Table structure hand-verified: no pipes added or removed, both rows still two columns; edited lines are not inside fenced blocks (the link gate reaching line 21 proves it).