### PR TITLE
fix(migration): resolve path-call heads to re-frame.core/path (rf2-8odvg)

### DIFF
--- a/migration/from-re-frame-v1/codemod/README.md
+++ b/migration/from-re-frame-v1/codemod/README.md
@@ -41,15 +41,22 @@ those in place emits output v2 **rejects at namespace load**
 mechanical and flags the rest (`rf2-8odvg`):
 
 - **The standard `path` constructor is the one mechanical lowering.**
-  `(rf/path p…)` (any alias; args flattened as v1 `path` did) becomes the
-  framework factory ref `[:rf.interceptor/path [p…]]` — recognised in
+  `(rf/path p…)` (args flattened as v1 `path` did) becomes the framework
+  factory ref `[:rf.interceptor/path [p…]]` — recognised in
   metadata-`:interceptors`, positional-vector, bare-middle, and
-  metadata-plus-vector source shapes. Positional chains are wrapped (or
-  merged) into the one metadata-map `:interceptors` form; entry declaration
-  order is preserved.
+  metadata-plus-vector source shapes. The call head must actually **resolve
+  to `re-frame.core/path`** through the file's ns form — the full namespace,
+  an `:as` alias of it, or a bare `path` it `:refer`s (`:refer :all` counts).
+  A custom function that merely shares the simple name `path` — say
+  `(app.interceptors/path :tenant)` — is *not* the standard constructor: it
+  flags like any other custom inline call below rather than being silently
+  replaced (`rf2-8odvg` reopen). Positional chains are wrapped (or merged)
+  into the one metadata-map `:interceptors` form; entry declaration order is
+  preserved.
 - **Entries that are already v2 refs are preserved verbatim.**
 - **Anything else flags the whole site** (`:flag :interceptors`, source
-  unchanged): a custom value, a var, `(rf/debug)`, a `path` call with a
+  unchanged): a custom value, a var, `(rf/debug)`, a `path` call whose head
+  does not resolve to `re-frame.core/path`, a standard `path` call with a
   non-literal arg — its registered id cannot be derived without author
   intent, so it is an unresolved **M-70 Type B** finding. Register the
   interceptor with `reg-interceptor`, reference it by id, and re-run. The

--- a/migration/from-re-frame-v1/codemod/src/re_frame/migration/reg_event_codemod.clj
+++ b/migration/from-re-frame-v1/codemod/src/re_frame/migration/reg_event_codemod.clj
@@ -43,12 +43,18 @@
       what is mechanical and flags the rest:
 
       - The standard `path` constructor is the ONE mechanical lowering:
-        `(rf/path p...)` (any alias; v1 flattens its args) becomes the
-        framework factory ref `[:rf.interceptor/path [p...]]` — recognized in
+        `(rf/path p...)` (v1 flattens its args) becomes the framework factory
+        ref `[:rf.interceptor/path [p...]]` — recognized in
         metadata-`:interceptors`, positional-vector, bare-middle, and
-        metadata-plus-vector source shapes. Positional chains are wrapped into
-        (or merged into) the ONE metadata-map `:interceptors` form; entry
-        declaration order is preserved.
+        metadata-plus-vector source shapes. The call HEAD must actually
+        resolve to `re-frame.core/path` through the file's ns form (the full
+        namespace, an `:as` alias of it, or a bare `path` it `:refer`s); a
+        custom function that merely SHARES the simple name `path` is NOT the
+        standard constructor and flags like any other custom inline call
+        (rf2-8odvg reopen; decision table at `path-head-context` below).
+        Positional chains are wrapped into (or merged into) the ONE
+        metadata-map `:interceptors` form; entry declaration order is
+        preserved.
       - Entries that are ALREADY v2 refs are preserved verbatim.
       - Any OTHER inline interceptor (a custom value, a var, `(rf/debug)`, a
         call whose registered id cannot be derived without author intent) makes
@@ -315,12 +321,137 @@
 ;; v2 chains are REFERENCE-ONLY (EP-0022): an entry is a bare keyword id or an
 ;; `[id arg]` 2-vector, and the chain lives in metadata `:interceptors`. v1
 ;; chains carried inline VALUES. The ONE mechanical (Type A) lowering is the
-;; standard `path` constructor — `(path p...)` (any alias; v1 flattens its
-;; args) becomes the framework factory ref `[:rf.interceptor/path [p...]]`.
-;; Any other inline entry has no derivable registered id (author intent), so
-;; it is surfaced as an unresolved M-70 Type-B finding (`:flag :interceptors`)
-;; and the site is left unchanged — the codemod must never certify output the
+;; standard `path` constructor — `(path p...)` (v1 flattens its args) becomes
+;; the framework factory ref `[:rf.interceptor/path [p...]]`. Any other
+;; inline entry has no derivable registered id (author intent), so it is
+;; surfaced as an unresolved M-70 Type-B finding (`:flag :interceptors`) and
+;; the site is left unchanged — the codemod must never certify output the
 ;; target rejects (rf2-8odvg).
+;;
+;; "Standard" is a RESOLUTION fact, not a naming fact (rf2-8odvg reopen):
+;; `(app.interceptors/path :tenant)` shares the simple name `path` with the
+;; standard constructor while carrying entirely different author semantics,
+;; and recognizing path calls by simple name alone silently replaced such
+;; custom interceptors with `[:rf.interceptor/path ...]`. The head must
+;; denote `re-frame.core/path`:
+;;
+;;   * `re-frame.core/path`          — always standard.
+;;   * `A/path`, ns form present     — standard iff the ns form `:require`s
+;;                                     re-frame.core `:as A`.
+;;   * bare `path`, ns form present  — standard iff the ns form refers `path`
+;;                                     from re-frame.core (`:refer [... path
+;;                                     ...]` / `:refer :all` / `:use`).
+;;   * anything else, ns form present — NOT the standard constructor (a
+;;                                     custom namespace or alias, an alias the
+;;                                     ns form does not resolve, a local
+;;                                     `path` fn): the entry takes the
+;;                                     unresolved M-70 flag route above —
+;;                                     conservative by construction, never a
+;;                                     silent rewrite.
+;;   * NO ns form (a REPL/test FRAGMENT — every real v1 file carries one):
+;;     bare `path` and a DOTLESS qualifier (an alias with nothing to resolve
+;;     it against, e.g. `rf/path`) keep the historical convention-based
+;;     reading; a DOTTED qualifier is a concrete namespace reference and must
+;;     BE re-frame.core.
+;;
+;; A require clause the parser cannot read (e.g. one inside a reader
+;; conditional) contributes nothing, so aliases it declares degrade to the
+;; FLAG route — never to a silent rewrite.
+
+(def ^:private standard-path-ns
+  "The one v1 namespace whose `path` is the standard interceptor constructor."
+  "re-frame.core")
+
+(defn- libspec-entries
+  "Flatten ONE `:require`/`:use` clause argument into entry maps
+  `{:ns \"...\" :alias \"...\"|nil :refers :all|#{\"name\" ...}|nil}`.
+  Handles a bare symbol, a `[ns & opts]` libspec (`:as`, `:refer`, `:only`),
+  and a prefix form `(prefix libspec+)`. Anything unreadable yields NO entry —
+  the conservative direction: an alias we fail to record makes its `path`
+  calls flag, never rewrite."
+  [spec]
+  (try
+    (cond
+      (symbol? spec)
+      [{:ns (str spec)}]
+
+      (and (sequential? spec) (symbol? (first spec)))
+      (let [[head & more] spec]
+        (if (or (empty? more) (keyword? (first more)))
+          ;; libspec: [ns :as A :refer [..]|:refer :all|:only [..]]
+          (let [opts    (apply hash-map more)
+                refers* (or (:refer opts) (:only opts))]
+            [{:ns     (str head)
+              :alias  (some-> (:as opts) str)
+              :refers (cond
+                        (= :all refers*)      :all
+                        (sequential? refers*) (into #{} (map str) refers*)
+                        :else                 nil)}])
+          ;; prefix form: (prefix libspec+) — the prefix prepends to each child ns
+          (into []
+                (comp (mapcat libspec-entries)
+                      (map #(update % :ns (fn [n] (str head "." n)))))
+                more)))
+
+      :else [])
+    (catch Exception _ [])))
+
+(defn- path-head-context
+  "Derive the path-head resolution context for ONE source (decision table in
+  the section comment above) from `zroot`, the zipper positioned at its first
+  top-level form. Returns
+    {:ns? bool           ;; did the source carry a top-level ns form?
+     :rf-aliases #{\"a\"} ;; aliases the ns form resolves to re-frame.core
+     :bare-path? bool}    ;; is bare `path` referred from re-frame.core?
+  An ns form whose sexpr cannot be read yields `{:ns? true}` with nothing
+  resolved — every path head then takes the conservative flag route."
+  [zroot]
+  (let [ns-sexpr (loop [zloc zroot]
+                   (when zloc
+                     (or (when (= :list (z/tag zloc))
+                           (let [head (try (some-> (z/down zloc) z/sexpr)
+                                           (catch Exception _ nil))]
+                             (when (= 'ns head)
+                               (or (try (z/sexpr zloc) (catch Exception _ nil))
+                                   ::unreadable))))
+                         (recur (z/right zloc)))))]
+    (if (nil? ns-sexpr)
+      {:ns? false}
+      (let [entries (when (not= ::unreadable ns-sexpr)
+                      (mapcat (fn [clause]
+                                (when (and (sequential? clause)
+                                           (#{:require :use} (first clause)))
+                                  ;; a bare/optless :use spec refers EVERYTHING
+                                  (let [use? (= :use (first clause))]
+                                    (map (fn [e]
+                                           (cond-> e
+                                             (and use? (nil? (:refers e)))
+                                             (assoc :refers :all)))
+                                         (mapcat libspec-entries (rest clause))))))
+                              (rest ns-sexpr)))
+            rf      (filter #(= standard-path-ns (:ns %)) entries)]
+        {:ns?        true
+         :rf-aliases (into #{} (keep :alias) rf)
+         :bare-path? (boolean (some #(let [r (:refers %)]
+                                       (or (= :all r)
+                                           (and (set? r) (contains? r "path"))))
+                                    rf))}))))
+
+(defn- standard-path-head?
+  "Does the call-head symbol `hv` — already known to carry the simple name
+  `path` — actually denote the STANDARD `re-frame.core/path` constructor
+  under `path-ctx` (per `path-head-context`)? Decision table in the section
+  comment above."
+  [hv {:keys [ns? rf-aliases bare-path?]}]
+  (if-let [q (namespace hv)]
+    (or (= q standard-path-ns)
+        (if ns?
+          (contains? rf-aliases q)
+          ;; fragment mode: a dotless qualifier is an unresolvable alias —
+          ;; keep the conventional reading; a dotted one is a concrete
+          ;; namespace and must BE re-frame.core (the branch above).
+          (not (str/includes? q "."))))
+    (or (not ns?) (boolean bare-path?))))
 
 (defn- path-literal?
   "A value usable as a literal path segment: keyword / string / number /
@@ -329,20 +460,23 @@
   (or (keyword? v) (string? v) (number? v) (boolean? v)))
 
 (defn- path-call-info
-  "If `node` is a call of the v1 standard `path` interceptor constructor —
-  `(rf/path :counter)`, `(re-frame.core/path :a :b)`, bare `(path [:a :b])` —
-  return `{:path-vec [...]}` when the path vector derives mechanically (every
-  arg a literal segment, or a vector of literal segments — spliced, matching
-  v1 `path`'s arg flatten); `:unresolved-args` when it IS a path call whose
-  args cannot be derived (a symbol / call / nested shape); nil when the node
-  is not a path call at all."
-  [node]
+  "If `node` is a call of the v1 STANDARD `path` interceptor constructor —
+  a head that resolves to `re-frame.core/path` under `path-ctx` (per
+  `standard-path-head?`) — return `{:path-vec [...]}` when the path vector
+  derives mechanically (every arg a literal segment, or a vector of literal
+  segments — spliced, matching v1 `path`'s arg flatten); `:unresolved-args`
+  when it IS a standard path call whose args cannot be derived (a symbol /
+  call / nested shape); nil when the node is not a standard path call at all.
+  A custom function that merely shares the simple name `path` returns nil
+  here and so takes the unresolved M-70 flag route (rf2-8odvg reopen)."
+  [node path-ctx]
   (when (and node (= :list (n/tag node)))
     (let [kids (sig-children node)
           hd   (first kids)]
       (when (and hd (= :token (n/tag hd)))
         (let [hv (try (n/sexpr hd) (catch Exception _ nil))]
-          (when (and (symbol? hv) (= "path" (name hv)))
+          (when (and (symbol? hv) (= "path" (name hv))
+                     (standard-path-head? hv path-ctx))
             (loop [args (rest kids)
                    acc  []]
               (if-let [a (first args)]
@@ -381,10 +515,10 @@
      {:kind :keep}                       — already a v2 ref; preserved verbatim
      {:kind :convert :node <ref-node>}   — standard path call, lowered
      {:kind :unresolved :offending node} — no derivable stable id (M-70 Type B)"
-  [node]
+  [node path-ctx]
   (if (ref-entry-node? node)
     {:kind :keep}
-    (let [pc (path-call-info node)]
+    (let [pc (path-call-info node path-ctx)]
       (if (map? pc)
         {:kind :convert :node (path-ref-node (:path-vec pc))}
         {:kind :unresolved :offending node}))))
@@ -396,12 +530,12 @@
      {:kind :ok}                          — every entry already a v2 ref
      {:kind :convert :node <new-vector>}  — >=1 path call lowered
      {:kind :unresolved :offending node}  — >=1 underivable entry"
-  [vec-node]
+  [vec-node path-ctx]
   (let [res (reduce
               (fn [acc kid]
                 (if (n/whitespace-or-comment? kid)
                   (update acc :kids conj kid)
-                  (let [{:keys [kind node offending]} (convert-entry kid)]
+                  (let [{:keys [kind node offending]} (convert-entry kid path-ctx)]
                     (case kind
                       :keep       (update acc :kids conj kid)
                       :convert    (-> acc
@@ -432,12 +566,12 @@
      {:kind :ok}   — no `:interceptors` key, or all entries already refs
      {:kind :convert :node <new-map-node>}
      {:kind :unresolved :offending node}"
-  [map-node]
+  [map-node path-ctx]
   (if-let [v (meta-map-interceptors-value map-node)]
     (if (not= :vector (n/tag v))
       ;; a non-vector `:interceptors` value cannot be certified (v2 rejects it)
       {:kind :unresolved :offending v}
-      (let [res (convert-chain-vector v)]
+      (let [res (convert-chain-vector v path-ctx)]
         (if (= :convert (:kind res))
           {:kind :convert
            :node (n/replace-children
@@ -459,15 +593,15 @@
   both sides. The map's own `:interceptors` entries come first, the positional
   entries are appended — declaration order preserved. Returns
      {:kind :convert :node <new-map-node>} | {:kind :unresolved :offending _}."
-  [map-node vec-node]
-  (let [vec-res (convert-chain-vector vec-node)]
+  [map-node vec-node path-ctx]
+  (let [vec-res (convert-chain-vector vec-node path-ctx)]
     (if (= :unresolved (:kind vec-res))
       vec-res
       (let [conv-vec (if (= :convert (:kind vec-res)) (:node vec-res) vec-node)]
         (if-let [existing (meta-map-interceptors-value map-node)]
           (if (not= :vector (n/tag existing))
             {:kind :unresolved :offending existing}
-            (let [ex-res (convert-chain-vector existing)]
+            (let [ex-res (convert-chain-vector existing path-ctx)]
               (if (= :unresolved (:kind ex-res))
                 ex-res
                 (let [conv-existing (if (= :convert (:kind ex-res))
@@ -502,18 +636,18 @@
      {:kind :ok}         — already valid v2 (metadata map; chain refs-only)
      {:kind :convert :replace {<old-node> <new-node>} :remove #{<node>}}
      {:kind :unresolved :offending <node>}   — M-70 Type B"
-  [middles]
+  [middles path-ctx]
   (case (count middles)
     0 {:kind :none}
     1 (let [m (first middles)]
         (case (n/tag m)
-          :map    (let [res (analyse-meta-map m)]
+          :map    (let [res (analyse-meta-map m path-ctx)]
                     (if (= :convert (:kind res))
                       {:kind :convert :replace {m (:node res)}}
                       res))
           ;; a positional chain is invalid v2 even when every entry is already
           ;; a ref — always wrap the (converted) vector into the metadata form
-          :vector (let [res (convert-chain-vector m)]
+          :vector (let [res (convert-chain-vector m path-ctx)]
                     (if (= :unresolved (:kind res))
                       res
                       {:kind :convert
@@ -523,7 +657,7 @@
                                        m))}}))
           ;; bare middle: v1 flattened chains, so a single bare interceptor
           ;; value was legal — mechanical only for the standard path call
-          (let [pc (path-call-info m)]
+          (let [pc (path-call-info m path-ctx)]
             (if (map? pc)
               {:kind :convert
                :replace {m (wrap-chain-in-meta-node
@@ -532,7 +666,7 @@
               {:kind :unresolved :offending m}))))
     2 (let [[a b] middles]
         (if (and (= :map (n/tag a)) (= :vector (n/tag b)))
-          (let [res (merge-vector-into-meta a b)]
+          (let [res (merge-vector-into-meta a b path-ctx)]
             (if (= :convert (:kind res))
               {:kind :convert :replace {a (:node res)} :remove #{b}}
               res))
@@ -590,7 +724,7 @@
      :simple-fn m|nil                                     — db-handler rewrite
      :middle analyse-middle-result|nil}                   — middle-slot conversion
   or nil — a `reg-event` site whose middle slot is already valid (no finding)."
-  [zloc form-kw {:keys [file force-db-wrap?]}]
+  [zloc form-kw {:keys [file force-db-wrap? path-ctx]}]
   (let [{:keys [line col]} (pos-of zloc)
         base    {:file file :line line :col col :form form-kw}
         kids    (sig-children (z/node zloc))
@@ -603,7 +737,7 @@
        :kind :flag}
 
       :reg-event-fx
-      (let [mid (analyse-middle middles)]
+      (let [mid (analyse-middle middles path-ctx)]
         (case (:kind mid)
           :unresolved {:finding (interceptors-flag-finding base form-kw (:offending mid))
                        :kind :flag}
@@ -619,7 +753,7 @@
       ;; (no middle, or a metadata map whose chain is refs-only) yields NO
       ;; finding — the rescan exists to recover partially migrated trees.
       :reg-event
-      (let [mid (analyse-middle middles)]
+      (let [mid (analyse-middle middles path-ctx)]
         (case (:kind mid)
           :unresolved {:finding (interceptors-flag-finding base form-kw (:offending mid))
                        :kind :flag}
@@ -629,7 +763,7 @@
           nil))
 
       :reg-event-db
-      (let [mid (analyse-middle middles)]
+      (let [mid (analyse-middle middles path-ctx)]
         (if (= :unresolved (:kind mid))
           {:finding (interceptors-flag-finding base form-kw (:offending mid))
            :kind :flag}
@@ -1076,7 +1210,9 @@
   ([s] (scan-string s {}))
   ([s opts]
    (let [zroot (z/of-string s {:track-position? true})]
-     (:findings (walk zroot (assoc opts :rewrite? false))))))
+     (:findings (walk zroot (assoc opts
+                                   :rewrite? false
+                                   :path-ctx (path-head-context zroot)))))))
 
 (defn rewrite-string
   "Apply the conservative codemod to a source string. Returns
@@ -1085,7 +1221,9 @@
   ([s] (rewrite-string s {}))
   ([s opts]
    (let [zroot  (z/of-string s {:track-position? true})
-         {:keys [zip findings]} (walk zroot (assoc opts :rewrite? true))]
+         {:keys [zip findings]} (walk zroot (assoc opts
+                                                   :rewrite? true
+                                                   :path-ctx (path-head-context zroot)))]
      {:source   (z/root-string (or zip zroot))
       :findings findings})))
 

--- a/migration/from-re-frame-v1/codemod/test/re_frame/migration/reg_event_codemod_test.clj
+++ b/migration/from-re-frame-v1/codemod/test/re_frame/migration/reg_event_codemod_test.clj
@@ -21,7 +21,9 @@
     |   destructured db param)         |                   |                       |
 
   Plus: shape-non-corruption (round-trips of untouched code), alias-agnostic
-  detection, scan-file/scan-paths over the filesystem, and idempotence. The
+  registrar detection, path-head RESOLUTION (only a head resolving to
+  re-frame.core/path lowers; custom `*/path` fns flag — rf2-8odvg reopen),
+  scan-file/scan-paths over the filesystem, and idempotence. The
   RUNTIME proof that the emitted chain shapes register against the real v2
   reg-event contract lives in the `:integration` alias
   (test-integration/, rf2-8odvg) so this default suite stays self-contained."
@@ -245,6 +247,121 @@
       (is (= :flag (:action (first findings))))
       (is (= :nil-capable (:flag (first findings))))
       (is (= src source)))))
+
+;; ---------------------------------------------------------------------------
+;; path-head resolution — only the STANDARD constructor is mechanical
+;; (rf2-8odvg reopen)
+;; ---------------------------------------------------------------------------
+;; `(app.interceptors/path :tenant)` shares the simple name `path` with the
+;; standard constructor while carrying entirely different author semantics.
+;; The head must RESOLVE to `re-frame.core/path` — through the file's ns form
+;; (the full namespace, an `:as` alias of it, or a bare `path` it `:refer`s),
+;; or, in an ns-less fragment, by the conventional bare/dotless-alias reading.
+;; Any other function named `path` is a custom inline interceptor: unresolved
+;; M-70 Type B, source unchanged — never a silent rewrite.
+
+(deftest custom-qualified-path-flagged-not-rewritten
+  (testing "the reopen probe: a custom qualified fn named `path` is NOT lowered"
+    (let [src (str "(ns app.events\n"
+                   "  (:require [re-frame.core :as rf]\n"
+                   "            [app.interceptors]))\n"
+                   "\n"
+                   "(rf/reg-event-db :tenant/load\n"
+                   "  {:interceptors [(app.interceptors/path :tenant)]}\n"
+                   "  (fn [db _] (assoc db :loaded true)))\n")
+          {:keys [source findings]} (cm/rewrite-string src)]
+      (is (= 1 (count findings)))
+      (is (= :flag (:action (first findings))))
+      (is (= :interceptors (:flag (first findings))))
+      (is (not (str/includes? source ":rf.interceptor/path"))
+          "custom path semantics must never be replaced by the standard factory ref")
+      (is (= src source) "flagged site left byte-for-byte unchanged"))))
+
+(deftest custom-aliased-path-flagged
+  (testing "an ALIAS of a custom namespace whose fn is named `path` flags too"
+    (let [src (str "(ns app.events\n"
+                   "  (:require [re-frame.core :as rf]\n"
+                   "            [app.interceptors :as icpt]))\n"
+                   "(rf/reg-event-db :x {:interceptors [(icpt/path :tenant)]}\n"
+                   "  (fn [db _] (assoc db :k 1)))\n")
+          {:keys [source findings]} (cm/rewrite-string src)]
+      (is (= :flag (:action (first findings))))
+      (is (= :interceptors (:flag (first findings))))
+      (is (= src source)))))
+
+(deftest custom-dotted-path-flagged-in-ns-less-fragment
+  (testing "even with no ns form, a DOTTED head namespace that is not re-frame.core flags"
+    (let [src "(rf/reg-event-db :x {:interceptors [(app.interceptors/path :tenant)]} (fn [db _] (assoc db :k 1)))"
+          {:keys [source findings]} (cm/rewrite-string src)]
+      (is (= :flag (:action (first findings))))
+      (is (= :interceptors (:flag (first findings))))
+      (is (= src source)))))
+
+(deftest unknown-alias-path-flagged-when-ns-form-present
+  (testing "an alias the ns form does not resolve is ambiguous -> conservative flag"
+    (let [src (str "(ns app.events (:require [re-frame.core :as rf]))\n"
+                   "(rf/reg-event-db :x {:interceptors [(xyz/path :a)]} (fn [db _] (assoc db :k 1)))\n")
+          {:keys [source findings]} (cm/rewrite-string src)]
+      (is (= :flag (:action (first findings))))
+      (is (= :interceptors (:flag (first findings))))
+      (is (= src source)))))
+
+(deftest local-bare-path-flagged-when-not-referred
+  (testing "a bare `path` under an ns form that does NOT refer it is a local fn -> flag"
+    (let [src (str "(ns app.events (:require [re-frame.core :as rf]))\n"
+                   "(rf/reg-event-db :x {:interceptors [(path :a)]} (fn [db _] (assoc db :k 1)))\n")
+          {:keys [source findings]} (cm/rewrite-string src)]
+      (is (= :flag (:action (first findings))))
+      (is (= :interceptors (:flag (first findings))))
+      (is (= src source)))))
+
+(deftest standard-alias-resolved-through-ns-form
+  (testing "the canonical rf alias resolves through the ns form and still lowers"
+    (let [src (str "(ns app.events (:require [re-frame.core :as rf]))\n"
+                   "(rf/reg-event-db :counter/inc\n"
+                   "  {:interceptors [(rf/path :counter)]}\n"
+                   "  (fn [db _] (update db :value inc)))\n")
+          {:keys [source findings]} (cm/rewrite-string src)]
+      (is (= :rewrite (:action (first findings))))
+      (is (str/includes? source "{:interceptors [[:rf.interceptor/path [:counter]]]}"))
+      (is (not (str/includes? source "(rf/path"))))))
+
+(deftest standard-referred-bare-path-resolved
+  (testing "a bare `path` the ns form refers from re-frame.core lowers; :refer :all too"
+    (doseq [req ["[re-frame.core :refer [reg-event-db path]]"
+                 "[re-frame.core :refer :all]"]]
+      (let [src (str "(ns app.events (:require " req "))\n"
+                     "(reg-event-db :counter/inc\n"
+                     "  {:interceptors [(path :counter)]}\n"
+                     "  (fn [db _] (update db :value inc)))\n")
+            {:keys [source findings]} (cm/rewrite-string src)]
+        (is (= :rewrite (:action (first findings))) (str "require " req))
+        (is (str/includes? source "{:interceptors [[:rf.interceptor/path [:counter]]]}"))))))
+
+(deftest standard-fully-qualified-path-resolved-everywhere
+  (testing "a fully qualified re-frame.core/path head is standard with or without an ns form"
+    (doseq [src [(str "(ns app.events (:require [re-frame.core]))\n"
+                      "(re-frame.core/reg-event-db :x {:interceptors [(re-frame.core/path :a)]} (fn [db _] (assoc db :k 1)))\n")
+                 "(re-frame.core/reg-event-db :x {:interceptors [(re-frame.core/path :a)]} (fn [db _] (assoc db :k 1)))"]]
+      (let [{:keys [source findings]} (cm/rewrite-string src)]
+        (is (= :rewrite (:action (first findings))))
+        (is (str/includes? source "[:rf.interceptor/path [:a]]"))))))
+
+(deftest path-head-resolution-idempotent
+  (testing "flagged custom sites and resolved standard rewrites are both idempotent"
+    (let [custom   (str "(ns app.events\n"
+                        "  (:require [re-frame.core :as rf]\n"
+                        "            [app.interceptors :as icpt]))\n"
+                        "(rf/reg-event-db :x {:interceptors [(icpt/path :tenant)]}\n"
+                        "  (fn [db _] (assoc db :k 1)))\n")
+          standard (str "(ns app.events (:require [re-frame.core :as rf]))\n"
+                        "(rf/reg-event-db :counter/inc {:interceptors [(rf/path :counter)]}\n"
+                        "  (fn [db _] (update db :value inc)))\n")]
+      (is (= custom (:source (cm/rewrite-string custom))) "custom site untouched")
+      (let [once  (rewrite standard)
+            twice (rewrite once)]
+        (is (= once twice))
+        (is (empty? (cm/scan-string once)) "normalized ns-ful output rescans clean")))))
 
 ;; ---------------------------------------------------------------------------
 ;; reg-event rescan — recovering a partially migrated tree


### PR DESCRIPTION
## What

Audit PR #8828 reopened rf2-8odvg: `path-call-info` recognized the standard `path` interceptor constructor by simple name alone (`(= "path" (name hv))`), so EVERY qualified custom function named `path` was treated as `rf/path`. The reopen probe — `(app.interceptors/path :tenant)` inside a real `rf/reg-event-db` — returned `:action :rewrite` and emitted `[:rf.interceptor/path [:tenant]]`, silently replacing custom interceptor semantics instead of the promised unresolved M-70 `:flag :interceptors`. Reproduced verbatim at tip `97a306e671` before the fix, in both ns-ful and ns-less shapes.

## The repair

Recognition is now a RESOLUTION fact, not a naming fact. A per-source `path-head-context` is derived once from the file's ns form and threaded through the chain analysis:

- `re-frame.core/path` (full namespace) — always standard.
- `A/path` with an ns form — standard iff the ns form `:require`s re-frame.core `:as A`.
- bare `path` with an ns form — standard iff the ns form refers `path` from re-frame.core (`:refer [... path ...]` / `:refer :all` / `:use`).
- anything else under an ns form (custom namespace, unresolvable alias, local `path` fn) — NOT the standard constructor: the entry takes the conservative unresolved M-70 flag route, never a silent rewrite.
- NO ns form (a REPL/test fragment — every real v1 file has one): bare `path` and dotless aliases (`rf/path`) keep the historical convention reading, so the standard qualified/alias/bare fixtures are retained; a DOTTED head namespace is a concrete reference and must BE re-frame.core — the ns-less probe also flags.

A require clause the parser cannot read (e.g. inside a reader conditional) contributes nothing, so its aliases degrade to the flag route — the failure direction is always flag, never rewrite. Holds for any v1 repo: resolution uses only the file's own ns form.

Nine new tests cover the probe (negative), the custom alias / dotted-fragment / unknown-alias / unreferred-bare negatives, the ns-ful standard alias / referred-bare / fully-qualified positives, and idempotence on both routes. The codemod README's "any alias" claim is corrected to state the resolution boundary.

## Reopen note coverage

- **Correctness half**: fixed here, as above.
- **Implementation-quality half** (wire `clojure -M:integration` into the changed-surface codemod CI job): that job is `jvm-migration-v1-codemod` in `.github/workflows/test.yml`, which this dispatch is fenced out of (live workers own `.github/workflows/**`). Filed as a follow-up bead (referenced on rf2-8odvg) rather than half-landing it here.
- The skills/re-frame-migration reference prose already states the boundary correctly ("the standard `(rf/path …)` constructor is the *one* inline value the codemod lowers mechanically"), so it is untouched; `migration/from-re-frame-v1/README.md` (hot-zone) is untouched — nothing in it is falsified by the fix.

## Quality gates

- `clojure -M:test` (migration/from-re-frame-v1/codemod): **exit 0** — 72 tests / 245 assertions, 0 failures (was 63/214 prior; +9 resolution tests).
- `clojure -M:integration`: **exit 0** — 6 tests / 10 assertions, 0 failures (unchanged from prior green).
- **Control**: with the head-resolution repair reverted at one line (dropping the `standard-path-head?` term from `path-call-info`), the suite goes RED — exit 1, 17 failures, including all four assertions of `custom-qualified-path-flagged-not-rewritten` reproducing the silent rewrite. Restore verified by blob hash (`6b509c6614` == committed object).
- Anchors/links: no doc-gate surface touched beyond `migration/from-re-frame-v1/codemod/README.md`, whose edits add no links or headings; table column counts unchanged (verified by hand).

Refs rf2-8odvg.