### PR TITLE
fix(resources): carry conflict-staled keys into :affected-keys on rollback (rf2-wcdj4 audit)

### DIFF
--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -603,10 +603,15 @@
   refetch `:cause`; `clock-ms` is the reply's causal completion time (the
   durable stale `:invalidated-at` stamp — EP-0010, off the reply token). Returns
   `{:runtime-db <rdb'> :dispositions [<disp> …] :recovery-fx
-  [<fx> …] :restored-keys [<sk> …] :conflicted-keys [<sk> …] :refetched-keys
-  [<sk> …]}` — `:refetched-keys` names ONLY the keys whose recovery refetch was
-  actually enqueued (never a stale-only / vanished key — rf2-wcdj4). PURE
-  w.r.t. trace (the caller emits `:rf.mutation/optimistic-rolled-back`)."
+  [<fx> …] :restored-keys [<sk> …] :conflicted-keys [<sk> …] :staled-keys
+  [<sk> …] :refetched-keys [<sk> …]}` — `:staled-keys` names every SURVIVING
+  `:invalidate` key actually marked durably stale (never a vanished key): the
+  caller's `:affected-keys` evidence, because a stale-marked key IS affected
+  even when owner-free with no refetch armed (Spec 016 §Mutation completion
+  continuations — rf2-wcdj4 audit); `:refetched-keys` names ONLY the keys
+  whose recovery refetch was actually enqueued (its active-owner subset —
+  never a stale-only / vanished key — rf2-wcdj4). PURE w.r.t. trace (the
+  caller emits `:rf.mutation/optimistic-rolled-back`)."
   [inverse runtime-db on-conflict cause clock-ms]
   (let [dispositions (mapv (fn [{scoped-key :resource/key :as recorded}]
                              (mstate/rollback-entry-disposition
@@ -629,15 +634,21 @@
         ;; :resource/key (`state/entry-invalidate` — the same in-place exact-key
         ;; staling the EP-0019 restore-dangle reconciler uses), never
         ;; rediscovered through the entry's tags (`:tags` is optional and must
-        ;; not gate rollback recovery — rf2-wcdj4). A vanished entry no-ops.
-        rdb'         (reduce (fn [rdb {scoped-key :resource/key :as disp}]
+        ;; not gate rollback recovery — rf2-wcdj4). A vanished entry no-ops —
+        ;; and only a key actually marked stale accumulates into `staled-ks`,
+        ;; the caller's `:affected-keys` evidence (a stale-marked key is
+        ;; materially changed and therefore affected, refetched or not —
+        ;; rf2-wcdj4 audit).
+        [rdb' staled-ks]
+                     (reduce (fn [[rdb staled] {scoped-key :resource/key :as disp}]
                                (case (:disposition disp)
-                                 :restore    (mstate/restore-before rdb disp)
+                                 :restore    [(mstate/restore-before rdb disp) staled]
                                  :invalidate (if (get-in rdb (state/entry-path scoped-key))
-                                               (update-in rdb (state/entry-path scoped-key)
-                                                          state/entry-invalidate clock-ms)
-                                               rdb)))
-                             runtime-db dispositions)
+                                               [(update-in rdb (state/entry-path scoped-key)
+                                                           state/entry-invalidate clock-ms)
+                                                (conj staled scoped-key)]
+                                               [rdb staled])))
+                             [runtime-db []] dispositions)
         rdb''        (update rdb' state/resources-key state/reindex-keys
                              old-entries changed-ids)
         ;; one ordinary EXACT refetch per :invalidate (conflicted, non-:force)
@@ -657,6 +668,7 @@
      :recovery-fx     (mapv second recoveries)
      :restored-keys   (into [] (comp (filter restored?) (map :resource/key)) dispositions)
      :conflicted-keys (into [] (comp (filter :conflict?) (map :resource/key)) dispositions)
+     :staled-keys     staled-ks
      :refetched-keys  (mapv first recoveries)}))
 
 (defn- rollback-trace-dispositions
@@ -2060,12 +2072,17 @@
             invalidated-ks (when inv-plan
                              (vec (:invalidated-keys (plan-key-evidence inv-plan #{} settle-db))))
             ;; EP-0019 — the keys the rollback refetched on conflict ride the
-            ;; instance row's reserved `:reconciliation-refetches` slot + flow
-            ;; into the reply `:affected-keys` (a conflict-invalidated key IS
-            ;; affected). The restored keys are also affected.
+            ;; instance row's reserved `:reconciliation-refetches` slot; the
+            ;; keys it marked durably STALE (every SURVIVING `:invalidate`
+            ;; disposition — the refetched keys are its active-owner subset)
+            ;; flow into the reply `:affected-keys` (a conflict-invalidated
+            ;; key IS affected, even owner-free with no refetch armed — Spec
+            ;; 016 §Mutation completion continuations, rf2-wcdj4 audit). The
+            ;; restored keys are also affected.
             refetched-ks (vec (:refetched-keys rolled))
             restored-ks  (vec (:restored-keys rolled))
-            affected (vec (distinct (concat invalidated-ks restored-ks refetched-ks)))
+            staled-ks    (vec (:staled-keys rolled))
+            affected (vec (distinct (concat invalidated-ks restored-ks staled-ks refetched-ks)))
             ;; EP-0019 — fill the reserved `:patch-summary` slots on the failed
             ;; instance row so Xray's mutation view can show that the optimistic
             ;; apply rolled back, per-key restored-vs-conflict, and which keys

--- a/implementation/resources/test/re_frame/resources_optimistic_settle_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_optimistic_settle_cljs_test.cljc
@@ -594,40 +594,59 @@
   ;; A conflicted entry with NO active owners at settle stays durably stale in
   ;; place — no liveness created, no immediate fetch — and recovers on its next
   ;; public ensure. This distinguishes STALE from REFETCHED and prevents an
-  ;; always-fetch fix.
+  ;; always-fetch fix. AND the stale-marked key is still AFFECTED (rf2-wcdj4
+  ;; audit residual): Spec 016 §Mutation completion continuations — `:affected-keys` carries
+  ;; every key populated, patched, removed, OR MARKED STALE by the accepted
+  ;; reply, so the owner-free conflict key flows into the instance row, the
+  ;; `:rf.mutation/failed` trace, and the `:reply-to` continuation even though
+  ;; no refetch was armed (before the fix, affected was derived only from
+  ;; restored + actually-refetched keys and the owner-free stale key vanished).
   (reg-profile-resource! false)
-  (own-loaded! {:resource :r/profile :scope :rf.scope/global :params {} :owner [:v :a]}
-               {:saved? false})
-  (reg-save-profile-mutation!)
-  (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save-profile :params {} :instance :s1}])
-  ;; the sole owner leaves mid-flight — state/detach-owner advances :revision
-  ;; (rf2-cxwuhl), so the settle sees a conflict on an OWNER-FREE entry.
-  (rf/dispatch-sync [:rf.resource/release-owner {:owner [:v :a]}])
-  (is (empty? (:active-owners (entry profile-key)))
-      "precondition: the entry is owner-free before the reply settles")
-  (let [muta @last-managed-args
-        _    (reset! last-managed-args nil)
-        rb   (trace-of :rf.mutation/optimistic-rolled-back
-               #(reply-failure! muta {:kind :rf.http/http-5xx :status 500}))]
-    (testing "the exact entry is made durably STALE in place — owners/work facts
-              preserved, no liveness created, no immediate fetch"
-      (let [e (entry profile-key)]
-        (is (some? e) "the entry survives")
-        (is (some? (:invalidated-at e)) "durably stale (:invalidated-at stamped)")
-        (is (empty? (:active-owners e)) "no owner was resurrected")
-        (is (nil? (:current-work e)) "no fetch was started — no owner needs it now")))
-    (testing "the public sub derives :stale? from the durable fact"
-      (is (true? (:stale? @(rf/subscribe [:rf/resource profile-q])))))
-    (testing "NO recovery request was issued for the owner-free entry"
-      (is (nil? @last-managed-args)))
-    (testing "the trace + :reconciliation-refetches do NOT report a refetch that
-              never happened (the key is conflicted, not refetched)"
-      (is (= [profile-key] (:conflicted rb)))
-      (is (= [] (:refetched rb)))
-      (is (= [] (:restored rb)))
-      (is (= [] (:reconciliation-refetches (patch-summary :s1)))))
-    (testing "a LATER public ensure starts recovery (the stale entry refetches)"
-      (rf/dispatch-sync [:rf.resource/ensure {:resource :r/profile :scope :rf.scope/global
-                                              :params {} :owner [:v :c]}])
-      (is (= {:method :get :url "/profile"} (:request @last-managed-args))
-          "the next live-owner ensure issued the recovery request"))))
+  (let [replied (atom nil)]
+    (rf/reg-event :t/save-settled (fn [_ event] (reset! replied (last event)) {}))
+    (own-loaded! {:resource :r/profile :scope :rf.scope/global :params {} :owner [:v :a]}
+                 {:saved? false})
+    (reg-save-profile-mutation!)
+    (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save-profile :params {} :instance :s1
+                                             :reply-to [:t/save-settled]}])
+    ;; the sole owner leaves mid-flight — state/detach-owner advances :revision
+    ;; (rf2-cxwuhl), so the settle sees a conflict on an OWNER-FREE entry.
+    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:v :a]}])
+    (is (empty? (:active-owners (entry profile-key)))
+        "precondition: the entry is owner-free before the reply settles")
+    (let [muta @last-managed-args
+          _    (reset! last-managed-args nil)
+          trs  (traces-of [:rf.mutation/optimistic-rolled-back :rf.mutation/failed]
+                 #(reply-failure! muta {:kind :rf.http/http-5xx :status 500}))
+          rb   (:rf.mutation/optimistic-rolled-back trs)]
+      (testing "the exact entry is made durably STALE in place — owners/work facts
+                preserved, no liveness created, no immediate fetch"
+        (let [e (entry profile-key)]
+          (is (some? e) "the entry survives")
+          (is (some? (:invalidated-at e)) "durably stale (:invalidated-at stamped)")
+          (is (empty? (:active-owners e)) "no owner was resurrected")
+          (is (nil? (:current-work e)) "no fetch was started — no owner needs it now")))
+      (testing "the public sub derives :stale? from the durable fact"
+        (is (true? (:stale? @(rf/subscribe [:rf/resource profile-q])))))
+      (testing "NO recovery request was issued for the owner-free entry"
+        (is (nil? @last-managed-args)))
+      (testing "the trace + :reconciliation-refetches do NOT report a refetch that
+                never happened (the key is conflicted, not refetched)"
+        (is (= [profile-key] (:conflicted rb)))
+        (is (= [] (:refetched rb)))
+        (is (= [] (:restored rb)))
+        (is (= [] (:reconciliation-refetches (patch-summary :s1)))))
+      (testing "the stale-marked key IS in :affected-keys on every public surface
+                — materially changed (:invalidated-at + :revision advanced) is
+                affected, refetched or not (Spec 016 §Mutation completion continuations)"
+        (is (= [profile-key] (:affected-keys (instance :s1)))
+            "the failed instance row records the stale-marked key")
+        (is (= [profile-key] (:affected-keys (:rf.mutation/failed trs)))
+            "the :rf.mutation/failed trace carries the stale-marked key")
+        (is (= #{profile-key} (:affected-keys @replied))
+            "the :reply-to continuation reply carries the stale-marked key"))
+      (testing "a LATER public ensure starts recovery (the stale entry refetches)"
+        (rf/dispatch-sync [:rf.resource/ensure {:resource :r/profile :scope :rf.scope/global
+                                                :params {} :owner [:v :c]}])
+        (is (= {:method :get :url "/profile"} (:request @last-managed-args))
+            "the next live-owner ensure issued the recovery request")))))


### PR DESCRIPTION
## What

The rf2-wcdj4 audit residual (AUDIT PR #8825, 2026-09-01). The exact-key conflict rollback recovery from PR #8825 durably stales every surviving `:invalidate` disposition, but the failure settlement computed `:affected-keys` solely from failure-plan invalidated keys, restored keys, and actually-refetched keys. An owner-free conflicted key was therefore materially changed (`:invalidated-at` stamped, `:revision` advanced) yet absent from the failed instance row, the `:rf.mutation/failed` trace, and the `:reply-to` continuation — violating Spec 016 §Mutation completion continuations (`:affected-keys` carries every key populated, patched, removed, or marked stale by the accepted reply). The spec is already right; only the code moved.

## How

- `settle-optimistic-rollback` now also returns `:staled-keys` — every SURVIVING `:invalidate` key actually marked durably stale (a vanished entry no-ops and is never listed). The stale-mark reduce threads the accumulator, so the evidence and the write cannot disagree.
- The failure settlement folds `:staled-keys` into `affected` (deduped). `:refetched-keys` and `:reconciliation-refetches` stay limited to recovery requests actually enqueued — the active-owner subset — exactly as before.
- The owner-free test now asserts `:affected-keys` on all three public surfaces: the instance row, the `:rf.mutation/failed` trace, and the `:reply-to` continuation reply.
- Active-owner, no-conflict, `:on-conflict :force`, and vanished-entry behavior unchanged (the active-owner key was already affected via `:refetched-keys`; dedupe keeps its `affected` identical). No spec edit — spec/016 already states the contract.

## Quality gates

- `clojure -M:test` from `implementation/resources/` (full JVM suite), on the rebased base `d401ef8d9d`: **exit 0 — 821 tests / 7321 assertions, 0 failures, 0 errors**.
- Red-before: with only the test additions applied (source unfixed), the focused namespace run exited 1 with exactly the 3 new `:affected-keys` assertions failing (`[[:rf.scope/global :r/profile {}]]` expected, `[]` actual on the instance row and failed trace; `#{…}` vs `#{}` on the reply-to) — proving the owner-free key is genuinely absent at tip and the regression was green before.
- Negative control: reinstating the narrowing (`affected` without `staled-ks`, one line) re-reds the same 3 assertions (focused run exit 1, 10 tests / 97 assertions, 3 failures); the file was restored and the restore verified by git blob hash (working blob == HEAD blob, `b5af550739ec76c940b1810b34d8f4dd6c1e7762`).
- CLJS lanes (`npm run test:cljs`, browser) are CI's: both changed files are `.cljc` and the changed logic is platform-neutral; the JVM suite runs the same test namespace.
- No files outside `implementation/resources/src` + `test` are touched (verified via `git diff origin/main...HEAD --stat`).

Closes rf2-wcdj4.