### PR TITLE
docs(story-mcp): pin the project-root cwd in the MCP-host entries (rf2-cfq8a)

### DIFF
--- a/tools/mcp-conformance/test/end-to-end-project-stories.cjs
+++ b/tools/mcp-conformance/test/end-to-end-project-stories.cjs
@@ -117,6 +117,10 @@ runWithWatchdog(
       // alias carries the require + server main; nothing here re-states
       // the namespace. Deliberately NO --allow-writes.
       args: ['-M:story-mcp'],
+      // `cwd` pins the fixture project root — the explicit
+      // working-directory property the README's host entries establish
+      // (a `cwd` field, or a command-established directory): the alias
+      // and the fixture's `:paths` resolve from the deps.edn HERE.
       cwd: FIXTURE_PROJECT,
       env: { ...process.env },
     },

--- a/tools/story-mcp/README.md
+++ b/tools/story-mcp/README.md
@@ -70,12 +70,40 @@ over to the server:
                 "-m" "re-frame.story-mcp.server"]}}} ; then the server takes stdio
 ```
 
-and an MCP-host entry that launches it from the project root:
+and an MCP-host entry. The property the entry must establish: **the
+server starts with your project root as its working directory** — that
+is where `clojure -M:story-mcp` finds the deps.edn carrying the alias
+and your `:paths`. Agent hosts frequently launch MCP subprocesses from
+somewhere else, even when the config file itself lives in the project
+root, so pin the directory explicitly (the SDK witness below pins it
+the same way, through its transport's `cwd`). Where the host entry has
+a working-directory field, use it — VS Code's project-scoped
+`.vscode/mcp.json` documents `cwd` and the `${workspaceFolder}`
+variable:
+
+```json
+{"servers":
+ {"story": {"type": "stdio", "command": "clojure",
+            "args": ["-M:story-mcp"], "cwd": "${workspaceFolder}"}}}
+```
+
+Claude Code's project-scoped `.mcp.json` and Cursor's
+`.cursor/mcp.json` document no `cwd` field, so there the command itself
+must establish the directory (swap `sh -c` for your shell on Windows).
+Claude Code sets `CLAUDE_PROJECT_DIR` (the project root) in the
+server's environment and expands `${VAR}` in `command`/`args`:
 
 ```json
 {"mcpServers":
- {"story": {"command": "clojure", "args": ["-M:story-mcp"]}}}
+ {"story": {"command": "sh",
+            "args": ["-c", "cd \"${CLAUDE_PROJECT_DIR}\" && exec clojure -M:story-mcp"]}}}
 ```
+
+Cursor documents no equivalent project-root variable (entries carry
+only `command`/`args`/`env`/`envFile`), so write the absolute project
+path into that `cd` yourself. From any other working directory
+`clojure` cannot see your project's deps.edn — neither the alias nor
+your stories are reachable.
 
 Repeat the `-e` form (or require several namespaces in one) as needed;
 init-opts run in command order. Add `--allow-writes` to the host's


### PR DESCRIPTION
## What

Audit residual on rf2-cfq8a (AUDIT PR #8810 reopen): the copyable MCP-host entry claimed to launch `clojure -M:story-mcp` "from the project root" but carried no working-directory setting, and agent hosts frequently launch MCP subprocesses from somewhere else — so a real host's first launch never found the project alias. The SDK witness passes only because its transport sets an explicit `cwd`.

`tools/story-mcp/README.md` now states the property the entry must establish — the server starts with the project root as its working directory, because that is where `clojure -M:story-mcp` finds the deps.edn carrying the alias and `:paths` — and makes the host configuration concrete, sourced from each host's documented config surface:

- **VS Code** `.vscode/mcp.json`: documented `cwd` field with `${workspaceFolder}` (MCP configuration reference) — the direct analogue of the witness's transport `cwd`.
- **Claude Code** `.mcp.json`: no documented `cwd` field; the documented `${VAR}` expansion in `command`/`args` plus the documented `CLAUDE_PROJECT_DIR` env var (set to the project root in the spawned server's environment) give a command-established directory.
- **Cursor** `.cursor/mcp.json`: documented fields are `command`/`args`/`env`/`envFile` only — no cwd field and no project-root variable; stated honestly (absolute project path written by hand).

The SDK witness `tools/mcp-conformance/test/end-to-end-project-stories.cjs` gains a comment (no behavior change) naming its `cwd: FIXTURE_PROJECT` as the same working-directory property the README's entries establish.

No new server flag, root-discovery protocol, wrapper namespace, transport, or test framework.

## Quality gates

- `python scripts/check_readme_links.py --ci` — captured exit **0** on the final rebased base. Control exercised: a broken link target planted at an edited README line turned the gate red (captured exit **1**, naming `tools/story-mcp/README.md:76 -> ./no-such-file-plant.md`), proving the run read this checkout; the restore was verified by git blob hash equal to the committed object; the re-run captured exit **0**.
- Neither link gate reads inside fenced code blocks, so the two copyable JSON blocks were verified by hand: both parse as valid JSON via `json.loads`.
- `node --check` on the witness `.cjs` passes (comment-only change); the witness itself rides CI's `test:story` lane.
- Host-config claims verified by hand against each host's own documented config surface: VS Code's MCP configuration reference (`cwd`, `${workspaceFolder}`, default-to-workspace-folder), Claude Code's MCP docs (stdio server fields, `${VAR}`/`${VAR:-default}` expansion in `command`/`args`/`env`, `CLAUDE_PROJECT_DIR` set to the project root), Cursor's MCP docs (stdio field table: `type`/`command`/`args`/`env`/`envFile`, launch cwd undocumented). No automated gate covers this prose.
- `tools/story-mcp/spec/**` untouched (grep found no repetition of the project-root claim there), so `check_doc_slugs.py` is not this change's gate.
