### PR TITLE
fix(story): replace stale query values for Story-owned share keys (rf2-b7je1)

### DIFF
--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -354,17 +354,40 @@
     [(subs url 0 idx) (subs url (inc idx))]
     [(or url "") nil]))
 
+(defn- ^:no-doc query-param-key
+  "Key half of an already-encoded `k=v` query fragment — the text
+  before the first `=`, or the whole fragment when it carries none.
+  Compared in encoded form: every Story-owned key is plain ASCII, so
+  its encoded spelling is its literal name."
+  [fragment]
+  (if-let [idx (str/index-of fragment "=")]
+    (subs fragment 0 idx)
+    fragment))
+
 (defn- ^:no-doc append-query-params
-  "Append already-encoded query `params` to `base-url`, inserting them
-  before any hash fragment."
+  "Merge already-encoded query `params` into `base-url`, inserting them
+  before any hash fragment.
+
+  Key-aware (rf2-b7je1): every existing occurrence of a key emitted by
+  THIS call is removed before the generated value is appended, so the
+  result carries exactly one value per Story-owned key. The browser
+  hydrator (`re-frame.story.ui.url-state/params->getter`) reads each
+  key with `URLSearchParams.get`, whose first-value semantics would
+  otherwise select a stale value already on `base-url` — opening a
+  different cell than the one shared. Unrelated existing entries
+  (e.g. `from=index`, `embed=1`) are preserved verbatim, in order,
+  ahead of the generated params."
   [base-url params]
   (let [[path fragment] (split-fragment base-url)
-        query           (str/join "&" params)
-        sep             (cond
-                          (str/blank? path)        ""
-                          (str/includes? path "?") "&"
-                          :else                    "?")
-        with-query      (str path sep query)]
+        qidx            (str/index-of path "?")
+        bare            (if qidx (subs path 0 qidx) path)
+        owned           (into #{} (map query-param-key) params)
+        kept            (when qidx
+                          (->> (str/split (subs path (inc qidx)) #"&" -1)
+                               (remove #(contains? owned (query-param-key %)))))
+        query           (str/join "&" (concat kept params))
+        sep             (if (and (nil? qidx) (str/blank? path)) "" "?")
+        with-query      (str bare sep query)]
     (if (some? fragment)
       (str with-query "#" fragment)
       with-query)))

--- a/tools/story/test/re_frame/story_share_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_share_cljs_test.cljs
@@ -41,6 +41,32 @@
       (is (str/includes? url "variant="))
       (is (str/includes? url "overrides=")))))
 
+(deftest variant-share-url-replaces-stale-owned-keys-cljs
+  (testing "rf2-b7je1 — the REAL URLSearchParams (the API the url-state
+            hydrator reads with) sees the values THIS call generated, not
+            stale ones already on the base-url. get is first-value, so an
+            append-only merge would return the old variant here."
+    (let [url    (share/variant-share-url
+                   :story.new/b
+                   "https://example.test/?variant=story.old%2Fa&modes=Mode.app%2Fstale&from=index&embed=1#/stories"
+                   {:active-modes [:Mode.app/dark]})
+          search (second (str/split (first (str/split url #"#" 2)) #"\?" 2))
+          usp    (js/URLSearchParams. search)]
+      (is (= "story.new/b" (.get usp "variant"))
+          "URLSearchParams.get returns the requested variant")
+      (is (= "Mode.app/dark" (.get usp "modes"))
+          "URLSearchParams.get returns the requested modes")
+      (is (= 1 (count (.getAll usp "variant")))
+          "exactly one variant value")
+      (is (= 1 (count (.getAll usp "modes")))
+          "exactly one modes value")
+      (is (= "index" (.get usp "from"))
+          "unrelated from= survives")
+      (is (= "1" (.get usp "embed"))
+          "unrelated embed= survives")
+      (is (str/ends-with? url "#/stories")
+          "the hash route survives, after the query"))))
+
 (deftest parse-share-url-params-cljs
   (testing "CLJS parser reconstructs the share URL tokens used by the shell hydrator"
     (is (= :story.counter/loaded

--- a/tools/story/test/re_frame/story_share_test.clj
+++ b/tools/story/test/re_frame/story_share_test.clj
@@ -89,6 +89,77 @@
                 nil)]
       (is (re-find #"\?from=index&variant=" url)))))
 
+;; ---- rf2-b7je1: owned keys REPLACE stale base-url values -----------------
+;;
+;; The browser hydrator (`re-frame.story.ui.url-state/params->getter`)
+;; reads each Story key with `URLSearchParams.get`, whose FIRST-value
+;; semantics select the oldest occurrence in the query string. An
+;; append-only merge over a base-url that already carries `variant=` /
+;; `modes=` therefore hydrates the STALE cell — violating the share
+;; invariant that a pasted URL lands on the exact same cell. The builder
+;; must emit exactly one effective value per key it owns, while leaving
+;; unrelated query entries and the hash route untouched.
+
+(defn- query-part
+  "The query-string portion of `url` — between `?` and any `#`."
+  [url]
+  (second (str/split (first (str/split url #"#" 2)) #"\?" 2)))
+
+(defn- query-key-count
+  "How many query fragments of `url` carry key `k`."
+  [url k]
+  (->> (str/split (or (query-part url) "") #"&")
+       (filter #(= k (first (str/split % #"=" 2))))
+       count))
+
+(defn- first-value-getter
+  "Standards-faithful emulation of the browser hydrator's
+  `URLSearchParams.get` reads over `url`'s query string: FIRST
+  occurrence per key wins, values form-urlencoded-decoded (`+` → space,
+  `%XX` → byte) — the same getter map
+  `re-frame.story.ui.url-state/params->getter` hands to
+  `share/parse-params`."
+  [url]
+  (let [decode #(java.net.URLDecoder/decode (str %) "UTF-8")]
+    (reduce (fn [m fragment]
+              (let [[k v] (str/split fragment #"=" 2)
+                    k     (decode k)]
+                (if (contains? m k) m (assoc m k (decode (or v ""))))))
+            {}
+            (str/split (or (query-part url) "") #"&"))))
+
+(deftest variant-share-url-replaces-stale-owned-keys
+  (testing "rf2-b7je1 — a base-url already carrying variant= and modes=
+            gets those values REPLACED, not appended after; browser
+            first-value reads and parse-params both recover the newly
+            requested cell, and unrelated params + hash route survive"
+    (let [url    (share/variant-share-url
+                   :story.new/b
+                   "https://example.test/?variant=story.old%2Fa&modes=Mode.app%2Fstale&from=index&embed=1#/stories"
+                   {:active-modes [:Mode.app/dark]})
+          getter (first-value-getter url)
+          parsed (share/parse-params getter)]
+      (is (= 1 (query-key-count url "variant"))
+          "exactly one variant= in the query string")
+      (is (= 1 (query-key-count url "modes"))
+          "exactly one modes= in the query string")
+      (is (= "story.new/b" (get getter "variant"))
+          "URLSearchParams.get-faithful read sees the requested variant")
+      (is (= "Mode.app/dark" (get getter "modes"))
+          "URLSearchParams.get-faithful read sees the requested modes")
+      (is (= :story.new/b (:variant-id parsed))
+          "parse-params reconstructs the requested variant")
+      (is (= [:Mode.app/dark] (:active-modes parsed))
+          "parse-params reconstructs the requested modes")
+      (is (= "index" (get getter "from"))
+          "unrelated from= survives with its value")
+      (is (= "1" (get getter "embed"))
+          "unrelated embed= survives with its value")
+      (is (re-find #"\?from=index&embed=1&" url)
+          "unrelated entries keep their order ahead of generated params")
+      (is (str/ends-with? url "#/stories")
+          "the hash route survives, after the query"))))
+
 (deftest variant-share-url-inserts-query-before-hash-route
   (testing "hash-routed Story links keep query params in location.search"
     (let [url (share/variant-share-url


### PR DESCRIPTION
## What

`variant-share-url` appended its generated query fragments after every existing
fragment. Against a `base-url` that already carried `variant=` / `modes=`, the
result held two values for each key, oldest first. The browser hydrator
(`re-frame.story.ui.url-state/params->getter`) reads each key with
`URLSearchParams.get`, whose first-value semantics select the **old** value — so
a URL built for one variant opened a different, stale cell. That violates the
share invariant stated in `tools/story/spec/005-SOTA-Features.md` §Share URL and
in the `re-frame.story.share` ns docstring: a pasted URL lands on the exact same
cell.

`append-query-params` now performs a key-aware merge. It splits the base query,
drops every existing fragment whose key this call also emits, then appends the
generated params once in the existing deterministic order. Unrelated entries
(`from=index`, `embed=1`) survive verbatim and in their original relative order,
ahead of the generated params; the hash route still follows the query. The codec
and the public signature are unchanged, and no compatibility layer or
first/last-value parser leniency was added — per the issue's non-goals.

Verified before assuming a test-only seam: `append-query-params` is private with
exactly one caller (`variant-share-url`), and the only other assertions over
builder output — `tools/story-mcp/test/re_frame/story_mcp/tools_test.clj:581-582`
— are order-independent.

## Spec

No spec change. `005-SOTA-Features.md` §Share URL already states the invariant
this restores and never documented the append-only behaviour, so the fix moves
the code onto the existing normative text rather than the text onto the code.

## Tests

- `tools/story/test/re_frame/story_share_test.clj` — `variant-share-url-replaces-stale-owned-keys`.
  Builds through the **real public builder** from a base carrying stale
  `variant=story.old%2Fa` and `modes=Mode.app%2Fstale`, unrelated `from=index`
  and `embed=1`, and `#/stories`, requesting a different variant and mode.
  Asserts exactly one occurrence of `variant` and of `modes`; that
  first-value-faithful reads (the hydrator's `URLSearchParams.get` semantics,
  including form-urlencoded decoding) return the newly requested values; that
  `share/parse-params` reconstructs `:story.new/b` and `[:Mode.app/dark]`; and
  that `from`, `embed` and `#/stories` survive with their values and order.
- `tools/story/test/re_frame/story_share_cljs_test.cljs` — mirror asserting the
  same through the **real** `js/URLSearchParams` (`.get` and `.getAll`).
- `variant-share-url-merges-existing-query` (the pre-existing no-collision
  existing-query case) is retained unchanged as the control, and stays green in
  both the red and green runs below — so the new fixture discriminates the
  collision property specifically rather than the merge path generally.

## Quality gates

All exits below are the runner's own captured status (`echo $?` on the same
command line as the redirect), never a harness report.

| Gate | Command | Exit |
|---|---|---|
| Focused JVM share tests, **before** the fix | `clojure -M:test -n re-frame.story-share-test` (from `tools/story`) | **1** — 7 failures, all in the new fixture |
| Focused JVM share tests, after the fix | same | **0** — 32 tests, 81 assertions |
| Full `tools/story` JVM suite, on the final rebased base | `clojure -M:test` (from `tools/story`) | **0** — 1877 tests, 6861 assertions |
| Real-`URLSearchParams` control under Node | builder output piped into `new URLSearchParams(...)` | **0** |
| Sabotage control, on the final rebased base | property removed, focused suite re-run | **1** — 7 failures |

**Non-vacuity.** Against the append-only implementation the fixture fails on
seven assertions, including the one the issue names: `parse-params` reconstructs
`:story.old/a` where `:story.new/b` was requested, and `[:Mode.app/stale]` where
`[:Mode.app/dark]` was. The Node control shows the same split through the real
browser API — the append-only URL reads `variant=story.old/a` with
`getAll().length === 2`, the fixed URL reads `story.new/b` with length 1 — so the
control discriminates in both directions rather than only where the answer is
already zero.

**Sabotage control on the final base.** After rebasing onto `origin/main`, the
key-aware merge was removed at one line (owning no keys, which reduces exactly to
the old append-only behaviour) and the focused suite re-run: exit **1**, seven
failures confined to the new fixture, with the namespace and assertion counts
unchanged from the green run (32 tests / 81 assertions), so the plant neither
crashed a namespace nor truncated the lane. The source was then restored and the
restore verified by comparing the file's **git blob hash** against the committed
object — not by reading a diff, which cannot distinguish "unchanged" from "never
applied".

**Rebase.** The branch was rebased onto `origin/main` and every gate above was
re-run on that final base; the pre-rebase greens are not being cited. The
three-dot diff against the merge base was read for reverts: three files, and the
only deletions are the eight lines of the replaced `append-query-params` body.

**CLJS lane — relying on CI.** The CLJS mirror test is covered by
`npm run test:cljs` (the `:node-test` build): `implementation/shadow-cljs.edn`
carries `../tools/story/test` on that build's `:source-paths` and selects tests
with `:ns-regexp "cljs-test$"`, which `re-frame.story-share-cljs-test` matches.
It was not run locally: that lane is a heavyweight consolidated shadow compile of
the whole node-test build, and `implementation/shadow-cljs.edn:654` explicitly
forbids narrowing `:ns-regexp` against that build id for a focused compile
(shared on-disk cache entry, rf2-6t03c). The file was reader-checked locally
under `:features #{:cljs}` (7 forms, clean), and the merge logic it exercises is
pure `clojure.string` with no reader conditionals, so the JVM and CLJS paths
compile from identical source. The Node control above independently exercises the
real `URLSearchParams` against real builder output.

**Hand checks.** No anchors or links were added. The two tables above were
checked by hand for column counts (4 and 4 header/delimiter/body columns
respectively).

Closes rf2-b7je1.
