### PR TITLE
docs(method): the fleet shares one allowance, and a probe's liveness reads sooner than its reply

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -528,6 +528,18 @@ constraint a measurement window is already fenced under, seen from the other sid
 is held for a quiet machine, and a heavyweight gate is what makes the machine loud. Keep one
 vocabulary for the two rather than inventing a second.
 
+**And the fleet shares one ALLOWANCE — the same shape a third time, and the one the ceiling
+hides best.** Surfaces are contention for files and a heavyweight gate is contention for the
+machine; the account quota every worker draws on is contention for a resource with no local
+evidence at all, since nothing in a worktree, a gate log or a run listing says how much of it
+is left. So N workers are not N independent bets — they fail TOGETHER, mid-run, on a limit none
+of them approached alone. Measured here: a saturated fleet of six died inside the same minute,
+three of them holding work that was not on the remote. **The remedy is not a smaller fleet**,
+which would trade a recoverable failure for a permanently slower one; it is that *push
+continuously* is what makes a fleet-wide kill survivable. Read a worker that has not pushed for
+a long stretch as the exposure it is, and expect the salvage under *The stranded sweep* to be
+wanted for the whole fleet at once rather than for one worker.
+
 **A queued measurement window makes an otherwise-free slot not free.** The drain clause in
 the filter list does not reach this case — it lifts only once the exclusive items are all
 that remains — so where ordinary work is still available, nothing above holds you back and
@@ -927,6 +939,20 @@ and both readings went wrong in a single day here, in opposite directions.
    cost beyond what the hold was already costing, and an answer means the interval was over. Measured
    here: three workers died on a stated reset an hour away; the operator re-authenticated within
    minutes; one probe resumed all three. Hold on the clock only once the probe has refused.
+
+   **But a probe's ANSWER is not the only reading of it, and its LIVENESS arrives far sooner.**
+   The rule above is written around a reply, and a reply is what step 2 rightly calls the read —
+   yet a resumed worker that is *working* has not replied and will not for many minutes, so a
+   mayor waiting for words waits out most of the interval the probe existed to cut short. Ask the
+   harness whether that agent is RUNNING instead. It costs one call, and it is decisive in one
+   direction: an agent under an exhausted allowance dies within seconds of being resumed, so
+   minutes of running is positive evidence the allowance came back. **Stillness is not the
+   converse** — an empty listing restores the ambiguity rather than settling it — so read this
+   exactly as the per-item fetch-head clock is read under *The stranded sweep*: movement proves
+   life and needs no corroboration, absence only sends you to another signal. Measured here: six
+   workers died together on a reset two and a half hours out, the operator re-authenticated, and
+   the probe read *running* five minutes in; all six were resumed on that reading, none
+   redispatched, and every one kept its context.
 
 **Never build a commit from someone else's uncommitted work.** Only that worker knows whether it forms
 a coherent change.


### PR DESCRIPTION
Two gaps found by the method-reread loop, both against a live incident rather than by re-reading: a session-wide usage limit killed all six workers at once, and recovering from it exercised two rules that turned out to be incomplete.

**`loops.md` §2, Shape and saturation — the fleet shares one allowance.** The section already reasons about two kinds of contention: surfaces (files) and a heavyweight gate (the machine). The account quota every worker draws on is a third, and the one the six-worker ceiling hides best, because it has no local evidence at all — nothing in a worktree, a gate log or a run listing says how much is left. N workers are therefore not N independent bets; they fail together, mid-run, on a limit none approached alone. The paragraph states the remedy is *not* a smaller fleet (that trades a recoverable failure for a permanently slower one) but push-as-you-go, and points at the stranded sweep's salvage as something to expect fleet-wide rather than per-worker.

**`loops.md` §4, the quota-death probe — liveness reads sooner than a reply.** The existing rule says to spend one resume message on the worker with the most context to lose, and to "hold on the clock only once the probe has refused". That is written around a *reply*, and step 2 is right that the reply is the read — but a resumed worker that is working does not reply for many minutes, so a mayor waiting for words waits out most of the interval the probe existed to cut short. The addition: ask the harness whether that agent is RUNNING. One call, decisive in one direction only — an agent under an exhausted allowance dies within seconds of being resumed, so minutes of running is positive evidence the allowance came back, while an empty listing restores the ambiguity rather than settling it. It is cross-referenced to the per-item fetch-head clock in the same section, which is read with exactly that asymmetry, rather than restating the reasoning.

Both paragraphs carry their measurement: six workers dead inside the same minute, three of them holding work that was not on the remote; a stated reset two and a half hours out; the operator re-authenticated; the probe read *running* five minutes in; all six resumed on that reading, none redispatched, every one keeping its context.

Authored in a mayor-occupied worktree, as the guard requires — the mayor checkout's pre-commit hook refuses non-tracker surfaces, and that refusal is the guard working.

## Quality gates

- `python scripts/check_doc_slugs.py` — **exit 0**. This is the gate that covers `docs/**` link targets and heading anchors, and it is the only anchor gate: `mkdocs build --strict` grades a missing anchor at INFO and `--strict` promotes WARNING but not INFO.
  - **Control (the deliverable):** one broken anchor planted at a line this change edits → **exit 1**, naming `docs\the-mayor-method\loops.md:951 -> #no-such-anchor-planted-control`. The fault existed only in this worktree, so the red also proves the gate read this tree. The planted blob (`dd2a5314…`) differed from the pre-plant blob, so the plant genuinely applied rather than silently no-opping.
  - **Restore verified by blob hash, not by reading a diff:** working file `90636141207ac95850fbb424b22d741c475aaa6d` == the committed object. Gate re-run after restore: **exit 0**.
- `mkdocs build --strict` — **not run; not claimed.** `mkdocs` is not on PATH in this environment (exit 127, command not found). `docs/the-mayor-method/` is inside `docs_dir` and absent from `mkdocs.yml`'s `exclude_docs`, so the build does cover this page for link targets; that coverage is CI's here, not this worker's.
- **By hand:** both edits are prose, not inside fenced blocks — which matters in this tree specifically, because `docs/the-mayor-method/` is one of the two trees where a doc link inside a fence is itself reported. No fenced content changed. No table columns changed.
- No code, no tests, no workflow files touched: one file, `docs/the-mayor-method/loops.md`.
