### PR TITLE
fix(mcp-base): dedup references are spelled, not merely namespaced (rf2-kjv05)

### DIFF
--- a/tools/mcp-base/spec/dedup.md
+++ b/tools/mcp-base/spec/dedup.md
@@ -37,8 +37,8 @@ Unreached upstream surface (`map-from-seq`, `contains-compressed-elements?`, `pa
 
 `dedup` owns:
 
-- `cache-element-ns` / `make-cache-element` — the cache-element wire shape.
-- `de-dupe-eq` — the equality-based compression walk, producing a raw cache map.
+- `cache-element-ns` / `make-cache-element` — the cache-element wire shape, and with it the reference grammar and collision rule below.
+- `de-dupe-eq` — the equality-based compression walk, producing a raw cache map (escaping colliding payload literals first).
 - `expand` — its exact inverse, over a raw cache map.
 - `empty-payload?` — the no-win short-circuit predicate (nil / empty / scalar, checked BEFORE `de-dupe-eq`).
 - `no-substitutions?` — the post-`de-dupe-eq` one-entry-root-only-cache detector (a non-empty collection with no repeated subtrees).
@@ -63,6 +63,26 @@ Unreached upstream surface (`map-from-seq`, `contains-compressed-elements?`, `pa
 ```
 
 Slot `0` is always the root. The namespace stayed `de-dupe.cache` through the absorb because it is a **wire** constant, not an implementation detail: the Node conformance decoder pins `de-dupe.cache/cache-0` (`tools/mcp-conformance/lib/dedup-envelope.cjs`), the wire-vocab `DedupTable` schema rejects a cache without that root, and Spec 009 / Tool-Pair document it. Renaming it would be a wire break bought for nothing; `cache-keys-are-de-dupe-cache-namespaced-symbols` makes an attempt a red build.
+
+### Reference grammar and the collision rule
+
+Occupying the namespace is not the same as owning it. A re-frame app may legitimately hold `de-dupe.cache/whatever` in app-db, a story may emit one in rendered or diagnostic data, and — once JSON has erased the symbol/string distinction — an ordinary payload *string* of that spelling is indistinguishable from a serialised reference symbol. A decoder that classified a value by its namespace alone therefore turned payload data into `nil`, into another slot's subtree, or into a thrown missing-entry error (rf2-kjv05). References are spelled, not merely namespaced.
+
+**In value position**, a token `de-dupe.cache/<name>` — a symbol on the Clojure side, a string once JSON has flattened it — is exactly one of:
+
+| `<name>` | reads as |
+| --- | --- |
+| `cache-<digits>` | a **reference** to that cache slot |
+| `!<rest>` | an **escaped literal** of `de-dupe.cache/<rest>` — strip one `!` |
+| anything else | ordinary **payload data**, passed through verbatim |
+
+**The collision rule.** The encoder escapes — one leading `!` — every payload token that would otherwise read as one of the first two forms, so its own output is unambiguous *by construction*: no ambiguous spelling can reach the wire, whatever the payload contains. Escaping is reversible under repetition, because the escaped form is itself escapable: a payload token spelled `de-dupe.cache/!cache-1` rides out as `de-dupe.cache/!!cache-1` and sheds exactly one marker on decode. Both symbols and same-spelled strings are escaped, and the escape is type-preserving (a string comes back a string), which is what keeps the JSON projection exact as well as the Clojure round-trip.
+
+**Cache keys are untouched.** Slot keys are the allocator's own `cache-N` symbols and never carry an escape; only values are subject to the grammar. Id allocation is likewise untouched — the encoder does not skip ids to dodge a colliding payload literal, because escaping has already removed the collision.
+
+**A missing reference stays a loud failure.** `cache-<digits>` is a reference whether or not the table holds that slot, so a truncated or hand-mangled table is rejected rather than silently re-read as data — pinned in the Node decoder by its own positive control, alongside the tests that prove ordinary namespace-occupying values decode verbatim.
+
+Both decoders implement this one grammar: `re-frame.mcp-base.dedup` (`cache-element?` / `escape-token` / `unescape-token`) and its Node mirror `tools/mcp-conformance/lib/dedup-envelope.cjs` (`CACHE_REF_RE` / `unescapeToken`). No prefix-only decoder remains. The cross-host pins are `payload-symbols-in-the-reference-namespace-round-trip-as-data` and `colliding-payload-tokens-are-escaped-on-the-wire` in `re-frame.mcp-base.dedup-test`; the Node counterparts live in `tools/mcp-conformance/test/dedup-envelope.test.cjs`.
 
 ### `de-dupe-eq form` → cache map
 
@@ -123,7 +143,7 @@ Keeping it test-side means no production consumer namespace re-exports a test-on
 
 ## Wire shape
 
-A deduped payload is wrapped in a top-level marker `{:rf.mcp/dedup-table <cache-map>}`, sourced from `vocab/dedup-table-key` so both servers use the same slot key — an agent that learned the slot on one server recognises it on the other. Agents reconstruct by calling `re-frame.mcp-base.dedup/expand` on the cache-map value.
+A deduped payload is wrapped in a top-level marker `{:rf.mcp/dedup-table <cache-map>}`, sourced from `vocab/dedup-table-key` so both servers use the same slot key — an agent that learned the slot on one server recognises it on the other. Agents reconstruct by calling `re-frame.mcp-base.dedup/expand` on the cache-map value. What counts as a reference *inside* that cache map is [§Reference grammar and the collision rule](#reference-grammar-and-the-collision-rule).
 
 ## See also
 

--- a/tools/mcp-base/src/re_frame/mcp_base/dedup.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/dedup.cljc
@@ -63,6 +63,39 @@
   schemas validate against it, and Spec 009 / Tool-Pair document it.
   Renaming it would be a wire break bought for nothing.
 
+  ## Reference grammar — why a payload symbol is not a reference
+
+  Occupying a namespace is not the same as owning it: a re-frame app may
+  legitimately hold `de-dupe.cache/whatever` in app-db, and a decoder
+  that reads EVERY symbol in the namespace as a slot reference turns
+  that value into nil, into somebody else's subtree, or into a thrown
+  error (rf2-kjv05). So references are spelled, not merely namespaced.
+  In VALUE position a token `de-dupe.cache/<name>` is
+
+  - a REFERENCE to slot N, when `<name>` is exactly `cache-<digits>`;
+  - an ESCAPED LITERAL of `de-dupe.cache/<rest>`, when `<name>` is
+    `!<rest>`;
+  - ordinary payload data otherwise.
+
+  The encoder escapes — one leading `!` — every payload token that would
+  otherwise read as one of the first two forms, so its own output is
+  unambiguous by construction. Escaping is reversible under repetition
+  (a payload `de-dupe.cache/!cache-1` rides out as `…/!!cache-1`), which
+  is what makes the round-trip exact rather than merely usually-exact.
+
+  Both a SYMBOL and a same-spelled STRING are escaped, because JSON
+  erases the distinction between them: Cheshire renders the symbol
+  `de-dupe.cache/cache-1` and the string \"de-dupe.cache/cache-1\" as one
+  JSON string, so escaping only symbols would leave the JSON projection
+  inexact even though the Clojure round-trip held. Cache KEYS are
+  unaffected — they are the allocator's own `cache-N` symbols and never
+  carry an escape.
+
+  A missing reference stays a LOUD failure: `cache-<digits>` is a
+  reference whether or not the table holds that slot, so a truncated or
+  hand-mangled table is rejected by the Node decoder rather than
+  silently re-read as data.
+
   ## Idempotence on no-dedup-opportunity
 
   A payload with no repeated subtrees deduplicates to a one-entry cache
@@ -91,7 +124,8 @@
     (its CLJS test corpus's shared test-helper ns).
   - story-mcp keeps it in `re-frame.story-mcp.test-support`
     (its JVM test corpus's shared test-helper ns)."
-  (:require [re-frame.mcp-base.vocab :as vocab])
+  (:require [clojure.string :as str]
+            [re-frame.mcp-base.vocab :as vocab])
   #?(:clj (:import [java.util HashMap])))
 
 ;; ---------------------------------------------------------------------------
@@ -142,6 +176,15 @@
 ;;   4. Everything not on the public surface — the walkers, the bucket store,
 ;;      the counting pass — is now `^:private`. The public codec is
 ;;      `cache-element-ns`, `make-cache-element`, `de-dupe-eq` and `expand`.
+;;   5. Upstream classified a value as a reference on its NAMESPACE alone, so
+;;      an ordinary payload symbol in `de-dupe.cache` was aliased to a cache
+;;      slot and `expand` stopped being the exact inverse it promised
+;;      (rf2-kjv05). References are now spelled `cache-<digits>` and colliding
+;;      payload tokens are escaped by the encoder — see the namespace
+;;      docstring's §Reference grammar. This IS a wire change, taken as one
+;;      pre-alpha cut across the codec, the spec and the Node decoder; the
+;;      cache-element namespace, the `cache-N` key spelling and the
+;;      `:rf.mcp/dedup-table` envelope are untouched.
 ;;
 ;; ---------------------------------------------------------------------------
 
@@ -157,12 +200,88 @@
   [id]
   (symbol cache-element-ns (str "cache-" id)))
 
+;; ---- Reference grammar (rf2-kjv05) -----------------------------------------
+;;
+;; See the namespace docstring's §Reference grammar for the WHY. In value
+;; position `de-dupe.cache/cache-<digits>` is a reference, `de-dupe.cache/!…`
+;; is an escaped literal, and everything else in the namespace is data.
+
+(def ^:private cache-element-prefix
+  "`de-dupe.cache/` — the same wire namespace as `cache-element-ns`, in
+  the flat prefix form JSON leaves behind once it has erased the
+  symbol/string distinction. Derived from `cache-element-ns` so the two
+  spellings cannot drift apart."
+  (str cache-element-ns "/"))
+
+(def ^:private escape-marker
+  "The single character prefixed to a payload token that would otherwise
+  read as a reference (or as an escape)."
+  "!")
+
+(defn ^:private slot-name?
+  "True when `nm` is a name the id allocator emits — `cache-<digits>`."
+  [nm]
+  (boolean (re-matches #"cache-\d+" nm)))
+
+(defn ^:private escaped-name?
+  "True when `nm` carries the escape marker."
+  [nm]
+  (str/starts-with? nm escape-marker))
+
+(defn ^:private token-name
+  "For a SYMBOL or STRING spelled `de-dupe.cache/<name>`, that `<name>`;
+  nil for every other value. Strings count as well as symbols because
+  JSON collapses the two onto one spelling — see the namespace
+  docstring's §Reference grammar."
+  [x]
+  (cond
+    (symbol? x) (when (= cache-element-ns (namespace x)) (name x))
+    (string? x) (when (str/starts-with? x cache-element-prefix)
+                  (subs x (count cache-element-prefix)))
+    :else       nil))
+
+(defn ^:private retoken
+  "A token of the same TYPE as `x` (symbol in, symbol out; string in,
+  string out) spelled `de-dupe.cache/<nm>`. Type preservation is what
+  keeps the Clojure round-trip exact while the JSON one flattens."
+  [x nm]
+  (if (symbol? x)
+    (symbol cache-element-ns nm)
+    (str cache-element-prefix nm)))
+
 (defn ^:private cache-element?
-  "True when `x` is a cache-element symbol (a reference to another slot
-  in the same cache) rather than an ordinary value."
+  "True when `x` is a cache-element symbol — a reference to another slot
+  in the same cache — rather than an ordinary value. The allocator's
+  exact `cache-<digits>` name is required, not merely the namespace: an
+  ordinary payload symbol such as `de-dupe.cache/not-a-ref` shares the
+  namespace and is DATA. Payload tokens that WOULD spell a reference are
+  escaped on the way in (`escape-token`), so the encoder never emits an
+  ambiguous one."
   [x]
   (and (symbol? x)
-       (= cache-element-ns (namespace x))))
+       (= cache-element-ns (namespace x))
+       (slot-name? (name x))))
+
+(defn ^:private escape-token
+  "One `!` in front of any payload token that would otherwise read as a
+  reference or as an escape; every other value is returned unchanged.
+  Reversible under repetition, so a payload token already spelled
+  `de-dupe.cache/!cache-1` rides out as `…/!!cache-1` and comes back."
+  [x]
+  (if-let [nm (token-name x)]
+    (if (or (slot-name? nm) (escaped-name? nm))
+      (retoken x (str escape-marker nm))
+      x)
+    x))
+
+(defn ^:private unescape-token
+  "The exact inverse of `escape-token` — strip ONE escape marker."
+  [x]
+  (if-let [nm (token-name x)]
+    (if (escaped-name? nm)
+      (retoken x (subs nm (count escape-marker)))
+      x)
+    x))
 
 ;; ---- Mutable hash-bucket store (platform-specific) -------------------------
 ;;
@@ -301,6 +420,16 @@
         (bucket-set! store h (conj bucket [element cache-id]))
         (with-meta element {:cache-id cache-id})))))
 
+(defn ^:private escape-literals
+  "`escape-token` applied throughout `form`.
+
+  Runs BEFORE the counting pass, not folded into it: the counter hashes
+  subtrees top-down, so escaping later would leave the two passes
+  hashing different values for any subtree holding a colliding literal,
+  and the pooling would quietly stop firing for exactly those subtrees."
+  [form]
+  (side-prewalk escape-token (fn [_org-element element] element) form))
+
 (defn de-dupe-eq
   "Compress `form` into a flat cache map keyed by `de-dupe.cache/cache-N`
   symbols, pooling subtrees by EQUALITY. Slot `cache-0` always holds the
@@ -308,11 +437,17 @@
   has been replaced, at each occurrence, by its cache-element symbol.
   `expand` is the exact inverse.
 
+  Payload tokens that would themselves read as references are escaped
+  first (`escape-literals`), so the cache the encoder emits is
+  unambiguous by construction — see the namespace docstring's §Reference
+  grammar.
+
   A form with no repeated subtrees yields a one-entry root-only cache —
   see `no-substitutions?`, which is how `dedup-value` avoids growing a
   payload it cannot shrink."
   [form]
-  (let [counter          (volatile! 1)
+  (let [form             (escape-literals form)
+        counter          (volatile! 1)
         compressed-cache (volatile! {})
         candidate-counts (count-cacheable-elements form)
         values-store     (new-bucket-store)
@@ -352,7 +487,10 @@
                 (seq? value)           (doall (map expand-value value))
                 (record?* value)       (reduce (fn [r x] (conj r (expand-value x))) value value)
                 (coll? value)          (into (empty value) (map expand-value value))
-                :else                  value))
+                ;; Scalars — and the one scalar shape that is not simply
+                ;; itself: an escaped literal, which sheds one marker
+                ;; here (§Reference grammar).
+                :else                  (unescape-token value)))
             (expand-entry [cache-id]
               (if (contains? @expanded cache-id)
                 (get @expanded cache-id)

--- a/tools/mcp-base/test/re_frame/mcp_base/dedup_test.cljc
+++ b/tools/mcp-base/test/re_frame/mcp_base/dedup_test.cljc
@@ -183,6 +183,121 @@
        (is (= payloads results)
            "32 concurrent encodes each round-trip to their own payload"))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-kjv05 — a payload value that OCCUPIES the reference namespace is data.
+;;
+;; The decoder used to classify every symbol namespaced `de-dupe.cache` as a
+;; reference to a cache slot, so an ordinary payload symbol was aliased to
+;; whatever that slot held: nil when the slot was absent, somebody else's
+;; subtree when it was not. `expand` therefore was not the exact inverse the
+;; codec promises, for payloads a re-frame app can legitimately hold. Every
+;; test below is forced through a REAL wrap by an unrelated repeated subtree —
+;; the collision is not itself a dedup opportunity, so without that control
+;; `dedup-value` would return the payload verbatim and the assertions would
+;; pass vacuously against a codec that never ran.
+;; ---------------------------------------------------------------------------
+
+(deftest payload-symbols-in-the-reference-namespace-round-trip-as-data
+  (let [shared  {:big [:repeat :me]}
+        payload {:literal    'de-dupe.cache/not-a-ref
+                 :look-alike 'de-dupe.cache/cache-1
+                 :a          shared
+                 :b          shared}
+        out     (dedup/dedup-value payload true)
+        cache   (get out vocab/dedup-table-key)
+        back    (dedup/expand cache)]
+    (testing "non-vacuity — the unrelated repeated subtree really did wrap"
+      (is (map? out))
+      (is (contains? out vocab/dedup-table-key)
+          "without a real wrap the round-trip below proves nothing"))
+    (testing "expand is the exact inverse"
+      (is (= payload back)))
+    (testing "both literals come back as SYMBOLS with their exact values"
+      (is (symbol? (:literal back)))
+      (is (= 'de-dupe.cache/not-a-ref (:literal back)))
+      (is (symbol? (:look-alike back)))
+      (is (= 'de-dupe.cache/cache-1 (:look-alike back))
+          "a generated-LOOKING payload symbol is still payload"))))
+
+(deftest colliding-payload-tokens-are-escaped-on-the-wire
+  ;; The wire spelling itself, pinned here because the Node conformance
+  ;; decoder's fixtures mirror it (tools/mcp-conformance/test/
+  ;; dedup-envelope.test.cjs). In ONE cache, `cache-1` in value position is a
+  ;; reference and `!cache-1` is the payload symbol that merely looks like one.
+  (let [shared  {:big [:repeat :me]}
+        payload {:literal    'de-dupe.cache/not-a-ref
+                 :look-alike 'de-dupe.cache/cache-1
+                 :a          shared
+                 :b          shared}
+        cache   (dedup/de-dupe-eq payload)
+        root    (get cache 'de-dupe.cache/cache-0)]
+    (testing "a look-alike token carries one escape marker"
+      (is (= 'de-dupe.cache/!cache-1 (:look-alike root))))
+    (testing "an ordinary token in the namespace is left alone — it reads as data already"
+      (is (= 'de-dupe.cache/not-a-ref (:literal root))))
+    (testing "the genuine reference names a real slot, and both occurrences share it"
+      (let [ref (:a root)]
+        (is (= 2 (count cache)) "root plus the one pooled subtree")
+        (is (= (dedup/make-cache-element 1) ref)
+            "the allocated id is cache-1 — the very spelling the payload literal carries")
+        (is (= ref (:b root)) "both occurrences point at the one slot")
+        (is (= shared (get cache ref)) "and that slot holds the shared subtree")))))
+
+(deftest escaping-is-reversible-under-repetition
+  ;; A payload token already spelled like an ESCAPE must not be mistaken for
+  ;; one on the way back: it gains a marker on encode and sheds exactly one on
+  ;; decode. Without this the escape would be a second aliasing bug wearing the
+  ;; first one's clothes.
+  (let [shared  {:big [:repeat :me]}
+        payload {:once   'de-dupe.cache/!cache-1
+                 :twice  'de-dupe.cache/!!cache-1
+                 :other  'de-dupe.cache/!not-a-ref
+                 :a      shared
+                 :b      shared}
+        out     (dedup/dedup-value payload true)]
+    (is (contains? out vocab/dedup-table-key) "non-vacuity: a real wrap")
+    (is (= payload (dedup/expand (get out vocab/dedup-table-key))))))
+
+(deftest payload-strings-that-spell-a-reference-round-trip-as-strings
+  ;; JSON erases the symbol/string distinction — Cheshire renders the symbol
+  ;; `de-dupe.cache/cache-1` and the string "de-dupe.cache/cache-1" as one JSON
+  ;; string — so the codec escapes both, and the escape is TYPE-preserving: a
+  ;; string comes back a string, never a symbol.
+  (let [shared  {:big [:repeat :me]}
+        payload {:s     "de-dupe.cache/cache-1"
+                 :plain "de-dupe.cache/not-a-ref"
+                 :a     shared
+                 :b     shared}
+        out     (dedup/dedup-value payload true)
+        back    (dedup/expand (get out vocab/dedup-table-key))]
+    (is (contains? out vocab/dedup-table-key) "non-vacuity: a real wrap")
+    (is (= payload back))
+    (is (string? (:s back)) "an escaped string comes back a string, not a symbol")
+    (is (= "de-dupe.cache/cache-1" (:s back)))
+    (is (= "de-dupe.cache/not-a-ref" (:plain back)))))
+
+(deftest colliding-literals-survive-inside-a-pooled-subtree
+  ;; The collision need not sit at the root. A look-alike token nested inside
+  ;; the very subtree that gets pooled must still round-trip — the escape runs
+  ;; before the counting pass, so both passes hash the same escaped subtree and
+  ;; the pooling still fires.
+  (let [shared  {:tag 'de-dupe.cache/cache-1 :body (vec (range 20))}
+        payload {:a shared :b shared :c [shared]}
+        out     (dedup/dedup-value payload true)
+        cache   (get out vocab/dedup-table-key)]
+    (is (contains? out vocab/dedup-table-key) "non-vacuity: a real wrap")
+    (is (< 1 (count cache))
+        "the pooling still fires on a subtree carrying a look-alike token")
+    (is (= payload (dedup/expand cache)))))
+
+(deftest a-reference-namespace-payload-alone-is-not-a-dedup-opportunity
+  ;; The complement, and the reason the tests above force a wrap: a payload
+  ;; whose only remarkable feature is a look-alike token has no repeated
+  ;; subtree, so `dedup-value` returns it verbatim and nothing can alias it.
+  (let [v {:literal 'de-dupe.cache/cache-1 :n 1}]
+    (is (identical? v (dedup/dedup-value v true))
+        "no repeats ⇒ verbatim passthrough, escaping and all")))
+
 (deftest expand-round-trips-every-collection-kind
   ;; The codec's structure-preserving guarantee, now ours to keep: lists,
   ;; seqs, sets, nested maps and map entries all rebuild as themselves.

--- a/tools/mcp-conformance/lib/dedup-envelope.cjs
+++ b/tools/mcp-conformance/lib/dedup-envelope.cjs
@@ -46,6 +46,31 @@
 // matching string with its expanded cache entry, memoising to keep
 // shared subtrees shared in the reconstructed tree.
 //
+// ## Reference grammar (rf2-kjv05) — MIRRORED, not invented here
+//
+// Occupying the namespace is not the same as owning it: an ordinary
+// payload value can spell `de-dupe.cache/…` — a symbol a re-frame app
+// holds in app-db, or, once JSON has erased the symbol/string
+// distinction, a plain string of that spelling. A PREFIX-only decoder
+// reads all of those as references and turns payload data into another
+// subtree, into `undefined`, or into a thrown missing-entry error. So in
+// VALUE position a token `de-dupe.cache/<name>` is
+//
+//   - a REFERENCE to slot N, when `<name>` is exactly `cache-<digits>`;
+//   - an ESCAPED LITERAL of `de-dupe.cache/<rest>`, when `<name>` is
+//     `!<rest>` — strip one `!`;
+//   - ordinary payload data otherwise (passed through verbatim).
+//
+// This mirrors `re-frame.mcp-base.dedup`, which is where the grammar is
+// stated normatively (`tools/mcp-base/spec/dedup.md` §Reference
+// grammar); the encoder escapes every payload token that would
+// otherwise read as one of the first two forms, so a conformant
+// server's output is unambiguous by construction.
+//
+// A `cache-<digits>` token is a reference whether or not the table holds
+// that slot, so a truncated or hand-mangled table still fails LOUD here
+// rather than being silently re-read as payload data.
+//
 // ## API
 //
 // `decodeDedupEnvelope(structuredContent)` — return the expanded
@@ -58,9 +83,27 @@
 const DEDUP_TABLE_KEY = 'rf.mcp/dedup-table';
 const CACHE_NS_PREFIX = 'de-dupe.cache/';
 const ROOT_CACHE_ID = 'de-dupe.cache/cache-0';
+const ESCAPE_MARKER = '!';
+
+// The allocator's own spelling, anchored at both ends. Anchoring is the
+// whole fix: `startsWith(CACHE_NS_PREFIX)` matched every payload value
+// in the namespace, not just the ids `make-cache-element` emits.
+const CACHE_REF_RE = /^de-dupe\.cache\/cache-\d+$/;
 
 function isCacheRefString(v) {
-  return typeof v === 'string' && v.startsWith(CACHE_NS_PREFIX);
+  return typeof v === 'string' && CACHE_REF_RE.test(v);
+}
+
+// Strip ONE escape marker from an escaped literal; every other value is
+// returned unchanged. The inverse of the encoder's escape, and reversible
+// under repetition — a payload token spelled `de-dupe.cache/!cache-1`
+// arrives as `de-dupe.cache/!!cache-1` and sheds exactly one marker.
+function unescapeToken(v) {
+  if (typeof v !== 'string' || !v.startsWith(CACHE_NS_PREFIX)) return v;
+  const name = v.slice(CACHE_NS_PREFIX.length);
+  return name.startsWith(ESCAPE_MARKER)
+    ? CACHE_NS_PREFIX + name.slice(ESCAPE_MARKER.length)
+    : v;
 }
 
 // Distinct in-progress sentinel. Installed in the memo
@@ -111,8 +154,9 @@ function expandCache(cache) {
       }
       return out;
     }
-    // Scalars (numbers, booleans, null, non-ref strings) pass through.
-    return v;
+    // Scalars (numbers, booleans, null, non-ref strings) pass through —
+    // save for an escaped literal, which sheds one marker here.
+    return unescapeToken(v);
   }
 
   function expandEntry(cacheId) {

--- a/tools/mcp-conformance/test/dedup-envelope.test.cjs
+++ b/tools/mcp-conformance/test/dedup-envelope.test.cjs
@@ -22,6 +22,11 @@
 //      reconstructs correctly — real caches decode cleanly.
 //   3. a dangling ref (no matching entry) throws its own distinct
 //      error, pinned alongside.
+//   4. the reference grammar (rf2-kjv05): only `de-dupe.cache/cache-N`
+//      is a reference, `de-dupe.cache/!…` is an escaped payload literal,
+//      and any other string in the namespace is ordinary data — with a
+//      positive control that a genuinely missing reference still fails
+//      loudly, so the data rule cannot have disabled resolution.
 
 'use strict';
 
@@ -197,4 +202,112 @@ test('a well-formed orphan entry is harmless — root value unaffected', () => {
   };
   const out = decodeDedupEnvelope(envelope(cache));
   assert.deepEqual(out, { fine: 1 });
+});
+
+// ---------------------------------------------------------------------
+// rf2-kjv05: an ordinary payload value that OCCUPIES the reference
+// namespace is data, not a reference.
+//
+// This decoder used to classify every string beginning `de-dupe.cache/`
+// as a reference — broader even than the Clojure side, because JSON has
+// already erased the symbol/string distinction by the time the string
+// arrives. An ordinary payload value spelled that way therefore decoded
+// as another cached subtree, or threw the missing-entry error, in a
+// payload a conformant server had encoded perfectly well.
+//
+// The fixtures below are the JSON projection of what
+// `re-frame.mcp-base.dedup/de-dupe-eq` actually emits for the matching
+// Clojure payload — the escaped spelling `de-dupe.cache/!cache-1` is
+// pinned cross-host by `colliding-payload-tokens-are-escaped-on-the-wire`
+// in `re-frame.mcp-base.dedup-test`.
+// ---------------------------------------------------------------------
+
+// An escaped literal: what the encoder emits for a payload token that
+// would otherwise read as a reference.
+function escaped(name) {
+  return CACHE_NS_PREFIX + '!' + name;
+}
+
+test('ordinary payload strings in the reference namespace decode verbatim, beside a real reference (rf2-kjv05)', () => {
+  const cache = {
+    [cacheId(0)]: {
+      literal: CACHE_NS_PREFIX + 'not-a-ref', // ordinary: no escape needed
+      'look-alike': escaped('cache-1'), // ordinary, but spells a reference
+      a: cacheId(1), // the real reference
+      b: cacheId(1),
+    },
+    [cacheId(1)]: { big: ['repeat', 'me'] },
+  };
+  const out = decodeDedupEnvelope(envelope(cache));
+  assert.deepEqual(out, {
+    literal: 'de-dupe.cache/not-a-ref',
+    'look-alike': 'de-dupe.cache/cache-1',
+    a: { big: ['repeat', 'me'] },
+    b: { big: ['repeat', 'me'] },
+  });
+  // The real reference still resolved — and still shares structurally.
+  assert.equal(out.a, out.b, 'the genuine reference is still pooled');
+});
+
+test('POSITIVE CONTROL: a missing GENUINE reference still fails loudly (rf2-kjv05)', () => {
+  // The same shape, with the genuine `cache-1` entry deleted. Reference
+  // resolution must NOT have been disabled wholesale by the data rule
+  // above: a `cache-<digits>` token is a reference whether or not the
+  // table holds the slot, so this is still the loud missing-entry error.
+  const cache = {
+    [cacheId(0)]: {
+      literal: CACHE_NS_PREFIX + 'not-a-ref',
+      'look-alike': escaped('cache-1'),
+      a: cacheId(1),
+    },
+    // cache-1 deliberately absent.
+  };
+  assert.throws(
+    () => decodeDedupEnvelope(envelope(cache)),
+    /no matching entry/i,
+    'a genuinely dangling reference must still be rejected loudly',
+  );
+});
+
+test('escaping is reversible under repetition — one marker is stripped, not all (rf2-kjv05)', () => {
+  const cache = {
+    [cacheId(0)]: {
+      once: escaped('cache-1'), // payload was `…/cache-1`
+      twice: escaped('!cache-1'), // payload was `…/!cache-1`
+      other: escaped('not-a-ref'), // payload was `…/not-a-ref`
+      a: cacheId(1),
+      b: cacheId(1),
+    },
+    [cacheId(1)]: { big: ['repeat', 'me'] },
+  };
+  const out = decodeDedupEnvelope(envelope(cache));
+  assert.equal(out.once, 'de-dupe.cache/cache-1');
+  assert.equal(out.twice, 'de-dupe.cache/!cache-1');
+  assert.equal(out.other, 'de-dupe.cache/not-a-ref');
+});
+
+test('a namespace-occupying string is not a reference even when a same-named slot exists (rf2-kjv05)', () => {
+  // The aliasing case at its sharpest: the table really does hold
+  // `cache-1`, and the payload really does contain that spelling as
+  // data. Before the fix the literal decoded as the cached subtree.
+  const cache = {
+    [cacheId(0)]: { data: escaped('cache-1'), ref: cacheId(1) },
+    [cacheId(1)]: { i: 'am the subtree' },
+  };
+  const out = decodeDedupEnvelope(envelope(cache));
+  assert.deepEqual(out, {
+    data: 'de-dupe.cache/cache-1',
+    ref: { i: 'am the subtree' },
+  });
+});
+
+test('an escaped literal used as a map KEY is unescaped too (rf2-kjv05)', () => {
+  // Keys route through the same value walk (see the de-duped-KEY test
+  // above), so the escape has to survive the key path as well.
+  const cache = {
+    [cacheId(0)]: { [escaped('cache-1')]: 'value-under-a-look-alike-key' },
+  };
+  const out = decodeDedupEnvelope(envelope(cache));
+  assert.deepEqual(Object.keys(out), ['de-dupe.cache/cache-1']);
+  assert.equal(out['de-dupe.cache/cache-1'], 'value-under-a-look-alike-key');
 });


### PR DESCRIPTION
Fixes rf2-kjv05.

## The bug

Both dedup decoders classified a value as a cache reference on its **namespace alone** — the CLJC one for any symbol in `de-dupe.cache`, the Node mirror for any string carrying that prefix, JSON having already erased the symbol/string distinction. Occupying a namespace is not the same as owning it: a re-frame app may legitimately hold `de-dupe.cache/whatever` in app-db, and a structured payload may carry a string of that spelling. Such a value was aliased to a cache slot and expanded to `nil`, to another slot's subtree, or to a thrown missing-entry error. `expand` was therefore not the exact inverse the codec promises, on data both shipped servers (Pair-MCP, Story-MCP) run this codec over.

The collision does not need to repeat to fire: any unrelated repeated subtree is enough to activate the wrapper, and then a single colliding scalar corrupts the reconstruction.

## The repair — references are spelled, not merely namespaced

In **value position**, a token `de-dupe.cache/<name>` is exactly one of:

| `<name>` | reads as |
| --- | --- |
| `cache-<digits>` | a **reference** to that cache slot |
| `!<rest>` | an **escaped literal** of `de-dupe.cache/<rest>` — strip one `!` |
| anything else | ordinary **payload data**, verbatim |

The encoder escapes — one leading `!` — every payload token that would otherwise read as one of the first two forms, so its own output is unambiguous **by construction**. The escape is reversible under repetition (a payload `de-dupe.cache/!cache-1` rides out as `…/!!cache-1`), and type-preserving: symbols and same-spelled strings are both escaped, and a string comes back a string, which is what keeps the JSON projection exact as well as the Clojure round-trip.

Escaping runs as a pre-pass, **before** the counting walk, so both passes hash the same subtrees and pooling still fires on a subtree that carries a colliding literal.

### Why not the bead's suggested id-skipping

The bead recommended recording colliding literals and allocating cache ids that skip those spellings, with the decoder classifying only tokens **present in the current cache**. That cannot satisfy the bead's own acceptance criterion 2: table-presence classification means a genuinely missing reference is silently re-read as payload data, which is exactly the loud failure AC2 requires kept. Escaping satisfies both halves — `cache-<digits>` is a reference whether or not the slot exists, so a truncated or mangled table still fails loud, while ordinary namespace-occupying values decode verbatim. The bead permits a smaller closed representation taken as one pre-alpha cut; that is what this is. No compatibility path for the old ambiguous form.

## Unchanged

Wire namespace `de-dupe.cache`, the `cache-N` key spelling, the `cache-0` root, the `:rf.mcp/dedup-table` envelope, id allocation, tool names, arguments, opt-out behaviour. Cache **keys** never carry an escape — only values are subject to the grammar. No consumer source needed touching: the round-trip tests prove Pair-MCP and Story-MCP are unaffected, and the wire-vocab `DedupTable` schema (which pins only the root key) is untouched.

The Clojure-side `expand` keeps its existing quiet-`nil` behaviour for a hand-written table with a dangling reference; hardening that further is a stated non-goal of the bead.

## Quality gates

All run in the foreground on the final rebased base (`origin/main` at `4e27fbbe49`), each with its exit code captured on the same command line as the redirect and quoted below.

| Gate | Exit | Result |
| --- | --- | --- |
| `clojure -M:test -n re-frame.mcp-base.dedup-test` (tools/mcp-base) | **0** | 20 tests, 69 assertions, 0 failures |
| `clojure -M:test` (tools/mcp-base, full) | **0** | 283 tests, 972 assertions, 0 failures |
| `npm run test:cljs` (tools/mcp-base, shadow-cljs node-test) | **0** | 43 tests, 263 assertions, 0 failures |
| `npm run test:dedup-envelope --prefix tools/mcp-conformance` | **0** | 16 tests, 16 pass, 0 fail |
| `python scripts/check_doc_slugs.py` | **0** | no broken links or anchors |

### Planted-fault controls — each gate proved to bite

Every control was planted at a line this PR edits, run to a captured exit code, then restored and the restore **verified by git blob hash** against the committed object.

1. **Node decoder** — reverted `isCacheRefString` to the prefix-only form. Gate went **exit 1**, with 4 of the 5 new tests red and all 11 pre-existing tests still green (the discrimination: the plant is visible only to the new property). Restored; blob hash matches.
2. **CLJC codec** — removed the escape pre-pass from `de-dupe-eq`. Focused JVM gate went **exit 1**: 5 failures + 1 error, all in the new rf2-kjv05 tests, with the namespace and assertion counts unchanged from the green run (so the plant stopped nothing else from running). Restored; blob hash matches.
3. **Spec doc** — planted a broken in-page anchor on a line this PR edits. `check_doc_slugs.py` went **exit 1**, naming the file, line and anchor. Restored; blob hash matches.

The new fixtures are themselves the non-vacuity control: each is forced through a **real** wrap by an unrelated repeated subtree and asserts `:rf.mcp/dedup-table` is present, because the collision alone is not a dedup opportunity and `dedup-value` would otherwise return the payload verbatim and pass the round-trip assertions against a codec that never ran.

### Coverage notes

- The docs gate does not look inside fenced code blocks. The spec edit adds a markdown **table** and a prose cross-reference anchor, both outside fences and both therefore covered — the anchor is what control 3 exercised. The table's column counts were checked by hand: 2 columns in the header, 2 in the delimiter row, 2 in each of the 3 body rows.
- `mkdocs build --strict` is not nominated: `tools/*/spec` is outside `docs_dir`, so the build never sees this page.
- No README or repo-root markdown changed, so `check_readme_links.py` has no surface here.
- The conformance suites that consume this codec transitively are owned by the `mcp-conformance` lanes in `.github/workflows/test.yml`; the mcp-base JVM and CLJS lanes in the same file own the codec itself.
