### PR TITLE
fix(migration): shadowed bare `path` no longer lowered; wire codemod :integration into CI (rf2-8odvg, rf2-36u96)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5015,7 +5015,14 @@ jobs:
             ~/.m2/repository
             ~/.gitlibs
             ~/.deps.clj
-          key: ${{ runner.os }}-clj-migration-v1-codemod-${{ hashFiles('migration/from-re-frame-v1/codemod/deps.edn') }}
+          # No salt is needed to separate the two aliases — one deps.edn
+          # declares both, so one cache entry serves both steps. But the
+          # `:integration` alias reaches implementation/core through a
+          # :local/root, and THAT artefact's own deps are not in this hash:
+          # without the second file the key would go stale whenever core's
+          # dependencies move, silently restoring a cache that lacks them
+          # (rf2-36u96).
+          key: ${{ runner.os }}-clj-migration-v1-codemod-${{ hashFiles('migration/from-re-frame-v1/codemod/deps.edn', 'implementation/core/deps.edn') }}
           restore-keys: |
             ${{ runner.os }}-clj-migration-v1-codemod-
             ${{ runner.os }}-clj-
@@ -5039,6 +5046,28 @@ jobs:
       # property that has no other witness anywhere in this repo.
       - name: Run JVM tests (from-re-frame-v1 codemod artefact)
         run: clojure -M:test
+
+      # rf2-36u96 — the `:integration` alias landed with rf2-8odvg's chain
+      # normalization and was then invoked by NOTHING: not this workflow, not
+      # scripts/test-jvm-tools.sh. The PR that added it therefore ran only
+      # `clojure -M:test`, leaving the artefact's one runtime proof orphaned.
+      #
+      # What that proof holds is the half `:test` structurally cannot: `:test`
+      # keeps re-frame2 off its classpath on purpose (self-containment, so the
+      # codemod runs on a bare JVM against any v1 corpus), which means it can
+      # only assert the SHAPE of the emitted text. `:integration` pulls
+      # implementation/core via :local/root and evaluates that text against the
+      # real v2 `reg-event` contract at namespace load — plus four negative
+      # controls (`:rf.error/path-removed`, `/reg-event-bad-middle-slot`,
+      # `/inline-interceptor-removed`, `/unregistered-interceptor`) that prove
+      # the harness observes registration rather than parsing. A codemod whose
+      # output the target rejects is exactly the failure rf2-8odvg was filed
+      # for, and shape alone cannot see it.
+      #
+      # Kept a SEPARATE invocation from the step above so `:test`'s
+      # self-contained classpath stays pinned by an actual run of it.
+      - name: Run JVM integration tests (emitted output vs. the real v2 reg-event contract)
+        run: clojure -M:integration
 
   node-ssr-node:
     name: Node implementation/ssr-node (bounded SSR service suite)

--- a/migration/from-re-frame-v1/codemod/README.md
+++ b/migration/from-re-frame-v1/codemod/README.md
@@ -50,9 +50,14 @@ mechanical and flags the rest (`rf2-8odvg`):
   A custom function that merely shares the simple name `path` — say
   `(app.interceptors/path :tenant)` — is *not* the standard constructor: it
   flags like any other custom inline call below rather than being silently
-  replaced (`rf2-8odvg` reopen). Positional chains are wrapped (or merged)
-  into the one metadata-map `:interceptors` form; entry declaration order is
-  preserved.
+  replaced (`rf2-8odvg` reopen). What the ns form makes *available* is not
+  what a bare head *denotes*, so a **bare** `path` must also survive the
+  lexical scopes around the call site: a `let`, `fn`, `defn`, `letfn`,
+  `for`/`doseq` (or any of their kin) that rebinds the name makes the call a
+  local, and the site flags. A qualified head such as `rf/path` cannot be
+  shadowed — locals are always simple symbols — so it is unaffected.
+  Positional chains are wrapped (or merged) into the one metadata-map
+  `:interceptors` form; entry declaration order is preserved.
 - **Entries that are already v2 refs are preserved verbatim.**
 - **Anything else flags the whole site** (`:flag :interceptors`, source
   unchanged): a custom value, a var, `(rf/debug)`, a `path` call whose head
@@ -143,7 +148,9 @@ clojure -M:integration
 The migration tests in `test/` exercise the full coverage matrix over
 representative v1 snippets: simple `-db`, `-db` with a path interceptor (every
 mechanical chain shape — metadata / positional / bare / metadata-plus-vector —
-lowered to `[:rf.interceptor/path [p…]]` refs), custom inline interceptors
+lowered to `[:rf.interceptor/path [p…]]` refs), path-head resolution (custom
+`*/path` fns and lexically shadowed bare `path` heads flag; qualified heads are
+unaffected by a local of the same name), custom inline interceptors
 flagged as unresolved M-70 Type B, the `reg-event` invalid-survivor rescan,
 `-fx` rename, `-ctx`, nil-capable bodies (`when` / `if` / `get` / `cond` / `and` / `or` /
 `some->` / literal `nil`), complex `-db` (var / multi-arity / destructured db

--- a/migration/from-re-frame-v1/codemod/src/re_frame/migration/reg_event_codemod.clj
+++ b/migration/from-re-frame-v1/codemod/src/re_frame/migration/reg_event_codemod.clj
@@ -48,10 +48,12 @@
         metadata-`:interceptors`, positional-vector, bare-middle, and
         metadata-plus-vector source shapes. The call HEAD must actually
         resolve to `re-frame.core/path` through the file's ns form (the full
-        namespace, an `:as` alias of it, or a bare `path` it `:refer`s); a
-        custom function that merely SHARES the simple name `path` is NOT the
-        standard constructor and flags like any other custom inline call
-        (rf2-8odvg reopen; decision table at `path-head-context` below).
+        namespace, an `:as` alias of it, or a bare `path` it `:refer`s) AND,
+        for a bare head, survive the lexical scopes around the call site: a
+        custom function that merely SHARES the simple name `path`, or a
+        `let`/`fn`/`letfn`/`defn` binding that rebinds it, is NOT the standard
+        constructor and flags like any other custom inline call (rf2-8odvg
+        reopen; decision table at `path-head-context` below).
         Positional chains are wrapped into (or merged into) the ONE
         metadata-map `:interceptors` form; entry declaration order is
         preserved.
@@ -315,6 +317,60 @@
       p0)))
 
 ;; ---------------------------------------------------------------------------
+;; Lexical binding vocabulary (shared)
+;; ---------------------------------------------------------------------------
+;;
+;; Two analyses below need to know which source forms BIND a name and which
+;; names they bind. The call-site shadow check (`enclosing-scope-binds?`) walks
+;; UP from an occurrence asking "is this bare symbol a local?"; the
+;; free-occurrence analysis (`free-in-form?`) walks DOWN through a handler body
+;; asking "is this param ever read?". Opposite directions, one vocabulary — so
+;; the vocabulary lives here, above both.
+
+(def ^:private binding-vector-forms
+  "Head symbols whose SECOND child is a binding vector of name/value pairs
+  (`let`-shape): the LHS names shadow within the rest of the form."
+  '#{let let* loop loop* binding if-let when-let if-some when-some
+     with-open with-local-vars with-redefs})
+
+(def ^:private seq-binding-forms
+  "Head symbols whose SECOND child is a seq-binding vector (`for`/`doseq`-shape):
+  `[x coll, y coll2, :let [...] ...]`. We treat every even-index non-keyword
+  entry as a bound LHS (conservative: over-binding only makes us MORE likely to
+  call a name unreferenced, but we additionally honour `:let` LHS names)."
+  '#{for doseq})
+
+(defn- collect-binding-names
+  "Collect every symbol that a destructuring LHS form `lhs` binds. Handles plain
+  symbols, vector/seq destructuring (incl. `:as`/`& rest`), and map destructuring
+  (`:keys`/`:strs`/`:syms`, `:as`, and `{local key}` pairs). Conservative: when
+  unsure we still add any contained symbol, which only widens shadowing."
+  [lhs]
+  (cond
+    (symbol? lhs) #{lhs}
+
+    (vector? lhs)
+    (into #{} (mapcat collect-binding-names) lhs)
+
+    (map? lhs)
+    (reduce-kv
+      (fn [acc k v]
+        (cond
+          ;; {:keys [a b]} / {:strs [..]} / {:syms [..]}
+          (and (keyword? k) (#{:keys :strs :syms} k) (vector? v))
+          (into acc (map (fn [s] (symbol (name s)))) v)
+          ;; {:as whole}
+          (= :as k) (conj acc v)
+          ;; {:or {...}} / {:keys ...} handled above; skip other keyword keys
+          (keyword? k) acc
+          ;; {local :some/key} — the LHS (k) is the binding
+          :else (into acc (collect-binding-names k))))
+      #{}
+      lhs)
+
+    :else #{}))
+
+;; ---------------------------------------------------------------------------
 ;; Middle-slot (interceptor chain) analysis — the M-70 x M-73 composition
 ;; ---------------------------------------------------------------------------
 ;;
@@ -340,7 +396,9 @@
 ;;                                     re-frame.core `:as A`.
 ;;   * bare `path`, ns form present  — standard iff the ns form refers `path`
 ;;                                     from re-frame.core (`:refer [... path
-;;                                     ...]` / `:refer :all` / `:use`).
+;;                                     ...]` / `:refer :all` / `:use`) AND no
+;;                                     enclosing lexical scope binds the name
+;;                                     (see below).
 ;;   * anything else, ns form present — NOT the standard constructor (a
 ;;                                     custom namespace or alias, an alias the
 ;;                                     ns form does not resolve, a local
@@ -357,6 +415,22 @@
 ;; A require clause the parser cannot read (e.g. one inside a reader
 ;; conditional) contributes nothing, so aliases it declares degrade to the
 ;; FLAG route — never to a silent rewrite.
+;;
+;; NS AVAILABILITY IS NOT CALL-SITE RESOLUTION (rf2-8odvg reopen). The table
+;; above answers "what does this file make the name `path` mean at the top
+;; level?"; a BARE head additionally has to survive the lexical scopes it sits
+;; inside. In
+;;
+;;   (let [path app.interceptors/path]
+;;     (reg-event-db :x {:interceptors [(path :tenant)]} ...))
+;;
+;; the ns form refers re-frame.core/path, yet the call denotes the local. So a
+;; bare head is standard only when NO enclosing form binds the simple name
+;; `path` (`enclosing-scope-binds?`) — a qualified head cannot be shadowed,
+;; because locals are always simple symbols. The check is conservative in one
+;; direction only: an enclosing binding sends the site down the M-70 flag
+;; route, so the worst case is a human glance at a site that could have been
+;; lowered, never a silent semantic swap.
 
 (def ^:private standard-path-ns
   "The one v1 namespace whose `path` is the standard interceptor constructor."
@@ -437,13 +511,115 @@
                                            (and (set? r) (contains? r "path"))))
                                     rf))}))))
 
+(defn- binding-vector-binds?
+  "Does the `let`/`for`-shaped binding VECTOR node `vnode` bind `target`?
+  Even-index entries are the LHS positions; a `:let` modifier (the
+  `for`/`doseq` shape) contributes the LHS positions of its own vector.
+  Deliberately POSITION-INSENSITIVE — a binding introduced after the call site
+  still counts — because the only error that direction can produce is a flag
+  where a lowering was possible, never a silent wrong rewrite. A binding
+  vector whose sexpr cannot be read counts as binding `target`, same reason."
+  [target vnode]
+  (let [v (try (n/sexpr vnode) (catch Exception _ ::unreadable))]
+    (cond
+      (= ::unreadable v) true
+      (not (vector? v))  false
+      :else
+      (boolean
+        (some (fn [[lhs rhs]]
+                (if (= :let lhs)
+                  (and (vector? rhs)
+                       (some #(contains? (collect-binding-names (first %)) target)
+                             (partition-all 2 rhs)))
+                  (contains? (collect-binding-names lhs) target)))
+              (partition-all 2 v))))))
+
+(defn- params-bind?
+  "Does the fn params VECTOR node `vnode` bind `target`? Unreadable params
+  count as binding it (conservative, as above)."
+  [target vnode]
+  (let [v (try (n/sexpr vnode) (catch Exception _ ::unreadable))]
+    (cond
+      (= ::unreadable v) true
+      (vector? v)        (contains? (collect-binding-names v) target)
+      :else              false)))
+
+(def ^:private defn-forms
+  "Head symbols whose arities are `defn`-shaped: `(head name docstring?
+  attr-map? [params] body)` or `(head name ([params] body)+)`."
+  '#{defn defn- defmacro})
+
+(defn- form-binds?
+  "Does the list NODE `node` lexically bind the simple name `target` anywhere in
+  its scope? Recognises the same binding vocabulary as the free-occurrence
+  analysis — `let`-shape, `for`/`doseq`-shape, `fn`/`fn*`, `letfn` — plus the
+  `defn` family, whose params scope over a registrar call in the body. A head
+  we do not recognise binds nothing."
+  [target node]
+  (let [kids (sig-children node)
+        hd   (when (and (seq kids) (= :token (n/tag (first kids))))
+               (try (n/sexpr (first kids)) (catch Exception _ nil)))
+        rest-kids (rest kids)
+        vector-kids (filter #(= :vector (n/tag %)) rest-kids)
+        ;; `(fn ([a] ..) ([a b] ..))` / `(defn f ([a] ..))` — an arity is a
+        ;; list whose FIRST child is the params vector.
+        arity-params (keep (fn [k]
+                             (when (= :list (n/tag k))
+                               (let [p (first (sig-children k))]
+                                 (when (= :vector (some-> p n/tag)) p))))
+                           rest-kids)]
+    (cond
+      (not (symbol? hd)) false
+
+      (contains? binding-vector-forms hd)
+      (boolean (some #(binding-vector-binds? target %) (take 1 vector-kids)))
+
+      (contains? seq-binding-forms hd)
+      (boolean (some #(binding-vector-binds? target %) (take 1 vector-kids)))
+
+      (or (#{'fn 'fn*} hd) (contains? defn-forms hd))
+      (boolean (or (some #(params-bind? target %) (take 1 vector-kids))
+                   (some #(params-bind? target %) arity-params)))
+
+      ;; letfn: the fnspec NAMES are in scope across the whole form, and each
+      ;; fnspec's params scope over its own body.
+      (= 'letfn hd)
+      (boolean
+        (some (fn [vnode]
+                (some (fn [spec]
+                        (when (= :list (n/tag spec))
+                          (let [ks (sig-children spec)]
+                            (or (= target (try (n/sexpr (first ks))
+                                               (catch Exception _ nil)))
+                                (some #(params-bind? target %)
+                                      (take 1 (filter #(= :vector (n/tag %)) ks)))))))
+                      (sig-children vnode)))
+              (take 1 vector-kids)))
+
+      :else false)))
+
+(defn- enclosing-scope-binds?
+  "Walking OUT from `zloc` (a registrar call site), does any enclosing form
+  lexically bind the simple name `target`? This is the call-site half of head
+  resolution: `path-head-context` establishes what the ns form makes AVAILABLE,
+  which is not the same question as what a bare `path` at this call site
+  actually DENOTES (rf2-8odvg reopen — a `(let [path app.interceptors/path] ...)`
+  around the registration was lowered as the framework constructor)."
+  [target zloc]
+  (loop [z (z/up zloc)]
+    (cond
+      (nil? z) false
+      (and (= :list (z/tag z)) (form-binds? target (z/node z))) true
+      :else (recur (z/up z)))))
+
 (defn- standard-path-head?
   "Does the call-head symbol `hv` — already known to carry the simple name
   `path` — actually denote the STANDARD `re-frame.core/path` constructor
-  under `path-ctx` (per `path-head-context`)? Decision table in the section
-  comment above."
-  [hv {:keys [ns? rf-aliases bare-path?]}]
+  under `path-ctx` (per `path-head-context`, plus the call site's
+  `:shadowed-bare-path?`)? Decision table in the section comment above."
+  [hv {:keys [ns? rf-aliases bare-path? shadowed-bare-path?]}]
   (if-let [q (namespace hv)]
+    ;; A namespace-qualified symbol names a var: no local binding can shadow it.
     (or (= q standard-path-ns)
         (if ns?
           (contains? rf-aliases q)
@@ -451,7 +627,8 @@
           ;; keep the conventional reading; a dotted one is a concrete
           ;; namespace and must BE re-frame.core (the branch above).
           (not (str/includes? q "."))))
-    (or (not ns?) (boolean bare-path?))))
+    (and (not shadowed-bare-path?)
+         (or (not ns?) (boolean bare-path?)))))
 
 (defn- path-literal?
   "A value usable as a literal path segment: keyword / string / number /
@@ -729,7 +906,13 @@
         base    {:file file :line line :col col :form form-kw}
         kids    (sig-children (z/node zloc))
         ;; kids: (HEAD ID middle... HANDLER)
-        middles (vec (drop 2 (or (butlast kids) ())))]
+        middles (vec (drop 2 (or (butlast kids) ())))
+        ;; `path-ctx` is derived once per SOURCE (what the ns form makes
+        ;; available); a bare `path` head also has to survive the lexical
+        ;; scopes enclosing THIS site, which is a per-call-site fact.
+        path-ctx (cond-> path-ctx
+                   (enclosing-scope-binds? 'path zloc)
+                   (assoc :shadowed-bare-path? true))]
     (case form-kw
       :reg-event-ctx
       {:finding (finding base {:action :flag :flag :ctx :target nil
@@ -827,49 +1010,10 @@
 ;; rebinds the same name). We walk the body's sexpr, tracking the set of names a
 ;; binding form has shadowed; a bare occurrence of the target name that is NOT in
 ;; the shadowed set counts as a free reference.
-
-(def ^:private binding-vector-forms
-  "Head symbols whose SECOND child is a binding vector of name/value pairs
-  (`let`-shape): the LHS names shadow within the rest of the form."
-  '#{let let* loop loop* binding if-let when-let if-some when-some
-     with-open with-local-vars with-redefs})
-
-(def ^:private seq-binding-forms
-  "Head symbols whose SECOND child is a seq-binding vector (`for`/`doseq`-shape):
-  `[x coll, y coll2, :let [...] ...]`. We treat every even-index non-keyword
-  entry as a bound LHS (conservative: over-binding only makes us MORE likely to
-  call a name unreferenced, but we additionally honour `:let` LHS names)."
-  '#{for doseq})
-
-(defn- collect-binding-names
-  "Collect every symbol that a destructuring LHS form `lhs` binds. Handles plain
-  symbols, vector/seq destructuring (incl. `:as`/`& rest`), and map destructuring
-  (`:keys`/`:strs`/`:syms`, `:as`, and `{local key}` pairs). Conservative: when
-  unsure we still add any contained symbol, which only widens shadowing."
-  [lhs]
-  (cond
-    (symbol? lhs) #{lhs}
-
-    (vector? lhs)
-    (into #{} (mapcat collect-binding-names) lhs)
-
-    (map? lhs)
-    (reduce-kv
-      (fn [acc k v]
-        (cond
-          ;; {:keys [a b]} / {:strs [..]} / {:syms [..]}
-          (and (keyword? k) (#{:keys :strs :syms} k) (vector? v))
-          (into acc (map (fn [s] (symbol (name s)))) v)
-          ;; {:as whole}
-          (= :as k) (conj acc v)
-          ;; {:or {...}} / {:keys ...} handled above; skip other keyword keys
-          (keyword? k) acc
-          ;; {local :some/key} — the LHS (k) is the binding
-          :else (into acc (collect-binding-names k))))
-      #{}
-      lhs)
-
-    :else #{}))
+;;
+;; The binding-form vocabulary this shares with the call-site shadow check
+;; (`binding-vector-forms`, `seq-binding-forms`, `collect-binding-names`) is
+;; defined once, above the middle-slot section.
 
 (declare free-in-form?)
 

--- a/migration/from-re-frame-v1/codemod/test/re_frame/migration/reg_event_codemod_test.clj
+++ b/migration/from-re-frame-v1/codemod/test/re_frame/migration/reg_event_codemod_test.clj
@@ -364,6 +364,92 @@
         (is (empty? (cm/scan-string once)) "normalized ns-ful output rescans clean")))))
 
 ;; ---------------------------------------------------------------------------
+;; path-head resolution — LEXICAL SHADOWING at the call site (rf2-8odvg reopen)
+;; ---------------------------------------------------------------------------
+;; What the ns form makes AVAILABLE is not what a bare head DENOTES. A file may
+;; refer `re-frame.core/path` and still rebind the name around a registration,
+;; in which case `(path :tenant)` is the local — lowering it to
+;; [:rf.interceptor/path [:tenant]] would swap the author's semantics silently.
+;; A qualified head cannot be shadowed (locals are simple symbols), so the
+;; check applies to bare heads only.
+
+(deftest shadowed-bare-path-flagged-not-lowered
+  (testing "the reopen probe: a `let` rebinding `path` around the registration flags"
+    (let [src (str "(ns app.events\n"
+                   "  (:require [re-frame.core :refer [reg-event-db path]]))\n"
+                   "\n"
+                   "(let [path app.interceptors/path]\n"
+                   "  (reg-event-db :counter/inc\n"
+                   "    {:interceptors [(path :tenant)]}\n"
+                   "    (fn [db _] (update db :value inc))))\n")
+          {:keys [source findings]} (cm/rewrite-string src)]
+      (is (= 1 (count findings)))
+      (is (= :flag (:action (first findings))))
+      (is (= :interceptors (:flag (first findings))))
+      (is (not (str/includes? source ":rf.interceptor/path"))
+          "a shadowed bare `path` must never be lowered as the framework constructor")
+      (is (= src source) "flagged site left byte-for-byte unchanged"))))
+
+(deftest shadowed-bare-path-flagged-across-binding-forms
+  (testing "fn params, defn params, letfn names and for/doseq bindings shadow too"
+    (doseq [[label open close]
+            [["let"     "(let [path app.interceptors/path]"            ")"]
+             ["if-let"  "(if-let [path (resolve-path)]"                " nil)"]
+             ["fn"      "((fn [path]"                                  ") app.interceptors/path)"]
+             ["defn"    "(defn install! [path]"                        ")"]
+             ["letfn"   "(letfn [(path [k] [k])]"                      ")"]
+             ["doseq"   "(doseq [path [:a :b]]"                        ")"]]]
+      (let [src (str "(ns app.events\n"
+                     "  (:require [re-frame.core :refer [reg-event-db path]]))\n"
+                     open "\n"
+                     "  (reg-event-db :x\n"
+                     "    {:interceptors [(path :tenant)]}\n"
+                     "    (fn [db _] (assoc db :k 1)))" close "\n")
+            {:keys [source findings]} (cm/rewrite-string src)]
+        (is (= :flag (:action (first findings))) (str label " must flag"))
+        (is (= :interceptors (:flag (first findings))) (str label " flag kind"))
+        (is (= src source) (str label " left unchanged"))))))
+
+(deftest shadowing-does-not-suppress-a-qualified-head
+  (testing "a local named `path` cannot shadow `rf/path` — the standard site still lowers"
+    (let [src (str "(ns app.events (:require [re-frame.core :as rf]))\n"
+                   "(let [path app.interceptors/path]\n"
+                   "  (rf/reg-event-db :counter/inc\n"
+                   "    {:interceptors [(rf/path :counter)]}\n"
+                   "    (fn [db _] (update db :value inc))))\n")
+          {:keys [source findings]} (cm/rewrite-string src)]
+      (is (= :rewrite (:action (first findings))))
+      (is (str/includes? source "{:interceptors [[:rf.interceptor/path [:counter]]]}")))))
+
+(deftest shadowing-elsewhere-does-not-suppress-a-referred-bare-path
+  (testing "a `path` binding in a SIBLING form leaves this site's bare head standard"
+    (let [src (str "(ns app.events\n"
+                   "  (:require [re-frame.core :refer [reg-event-db path]]))\n"
+                   "(defn helper [path] (str path))\n"
+                   "(reg-event-db :counter/inc\n"
+                   "  {:interceptors [(path :counter)]}\n"
+                   "  (fn [db _] (update db :value inc)))\n")
+          {:keys [source findings]} (cm/rewrite-string src)]
+      (is (= :rewrite (:action (first findings))))
+      (is (str/includes? source "{:interceptors [[:rf.interceptor/path [:counter]]]}")))))
+
+(deftest shadowed-bare-path-idempotent
+  (testing "the shadowed site is stable: a second run neither rewrites nor loses the flag"
+    (let [src (str "(ns app.events\n"
+                   "  (:require [re-frame.core :refer [reg-event-db path]]))\n"
+                   "(let [path app.interceptors/path]\n"
+                   "  (reg-event-db :counter/inc\n"
+                   "    {:interceptors [(path :tenant)]}\n"
+                   "    (fn [db _] (update db :value inc))))\n")
+          once  (rewrite src)
+          twice (rewrite once)]
+      (is (= src once) "first run leaves the source unchanged")
+      (is (= once twice) "second run is a no-op too")
+      (is (= [:flag :interceptors]
+             ((juxt :action :flag) (only-finding twice)))
+          "the unresolved M-70 finding persists across runs"))))
+
+;; ---------------------------------------------------------------------------
 ;; reg-event rescan — recovering a partially migrated tree
 ;; ---------------------------------------------------------------------------
 ;; The pre-rf2-8odvg codemod renamed heads while preserving v1 chains, leaving


### PR DESCRIPTION
Cluster of two migration-codemod items on disjoint files, one commit each.

## Item 1 — rf2-8odvg: a lexically shadowed bare `path` was still lowered

**Premise verified at this branch's base (`4e27fbbe49`) before any edit.** The
audit probe was reproduced verbatim and returned `[:rewrite nil true]` — a
successful rewrite emitting `[:rf.interceptor/path [:tenant]]` for a call that
denotes a local `let` binding. The structural claim held too: head resolution
was derived once per SOURCE from the ns form, with no call-site half.

**Design — reuse, not a second mechanism.** The free-occurrence analysis
already carried a binding-form vocabulary (`binding-vector-forms`,
`seq-binding-forms`, `collect-binding-names`). That vocabulary is hoisted into
one shared section above both consumers, and the new `enclosing-scope-binds?`
walks OUT from the registrar call over the same table — the two analyses ask
opposite questions in opposite directions over one vocabulary. The `defn`
family is added, since its params scope over a registration in the body and the
downward walk had no reason to know about it.

Conservative refusal, which the item permits explicitly: an enclosing binder
sends the site down the existing unresolved-M-70 flag route and leaves the
source byte-for-byte unchanged. The check is position-insensitive inside a
binding vector, and an unreadable binding vector counts as binding the name —
both errors can only produce a flag where a lowering was possible, never a
silent semantic swap. A QUALIFIED head is untouched: locals are always simple
symbols, so `rf/path` cannot be shadowed. Two tests pin that non-over-reach
directly (a qualified head inside a shadowing `let` still lowers; a `path`
binding in a sibling form does not suppress this site).

Files: `migration/from-re-frame-v1/codemod/src/re_frame/migration/reg_event_codemod.clj`,
its test namespace, and the artefact README.

## Item 2 — rf2-36u96: `clojure -M:integration` wired into `jvm-migration-v1-codemod`

One step added to the existing job. `:test` keeps re-frame2 off its classpath on
purpose, so it can only assert the SHAPE of the emitted text; `:integration`
pulls `implementation/core` via `:local/root` and evaluates that text against
the real v2 `reg-event` contract at namespace load, with four negative controls
proving the harness observes registration rather than parsing. Kept a separate
invocation so `:test`'s self-containment stays pinned by an actual run of it.

The cache key gains `implementation/core/deps.edn`. No salt is needed to
separate the aliases — one `deps.edn` declares both — but the `:local/root`
reaches an artefact whose own dependencies were outside the hash, which would
have let the key go stale while still restoring a cache that lacks them.

**One premise in the item did not hold, and is corrected here rather than
acted on:** the item says `scripts/test-jvm-tools.sh` does not cover the
codemod. It does — `migration/from-re-frame-v1/codemod` is on its roster (added
with the lane by rf2-0qzh). What is true is the operative half: that script
runs `clojure -M:test` per rostered artefact, so `:integration` was still
invoked by nothing.

## Quality gates

Every number below is the exit code captured in the same shell as the run, not
a harness report. Run from `migration/from-re-frame-v1/codemod`.

| Gate | Before | After |
|---|---|---|
| `clojure -M:test` | exit **0**, 72 tests / 245 assertions | exit **0**, 77 tests / 276 assertions |
| `clojure -M:integration` | exit **0**, 6 tests / 10 assertions | exit **0**, 6 tests / 10 assertions |
| audit probe (`rewrite-string`) | `[:rewrite nil true]` | `[:flag :interceptors false]`, source byte-identical |

**Non-vacuity control (item 1).** One-line revert of the repair —
`(not shadowed-bare-path?)` → `true` in `standard-path-head?` — run against the
committed tree: captured exit **1**, **25 failures**, falling in exactly the
three new shadow deftests (`shadowed-bare-path-flagged-not-lowered`,
`shadowed-bare-path-flagged-across-binding-forms`,
`shadowed-bare-path-idempotent`). Namespace and assertion totals were unchanged
at 77 / 276, so the plant stopped nothing; the two non-over-reach controls
stayed green, so they are not tautologies of the plant. Restore verified by
git blob hash against the committed object, not by reading a diff: blob
`accb6704ee51281b6b7cc519e6050bf767cbf10e` before the plant,
`d6445c7a96f3cb2792ac275136647e636fcc051a` planted, back to
`accb6704ee51281b6b7cc519e6050bf767cbf10e` after — identical to
`HEAD:.../reg_event_codemod.clj`.

**Doc gate for the README — the nomination in circulation is inverted, and the
plant settled it.** `check_readme_links.py` excludes `migration/` by name
(`DOCS_GATE_ROOTS`, to avoid double coverage) and `check_doc_slugs.py`'s
`DEFAULT_ROOTS` includes it, so the gate for this artefact's README is the docs
gate. Measured, not inferred: with a broken link planted at a line this PR
edits, `python scripts/check_doc_slugs.py` returned exit **1** naming
`migration/from-re-frame-v1/codemod/README.md:55 -> ./no-such-file-planted.md`,
while `python scripts/check_readme_links.py --ci` returned exit **0**. Both
returned exit 0 on the clean tree. The red also discriminates the tree: the
fault existed only in this checkout. Restore verified by blob hash —
`33351e3a54ee42a5977afbba85ebecc9b3e997c8` before and after, identical to the
committed object.

**Item 2 — hand verification (no local gate runs a workflow file; CI is the
real check).** Both instruments were first exercised against inputs they should
flag, so a zero means "checked" rather than "wrong pattern":

- Job-key discriminator, two leading spaces,
  `git diff origin/main...HEAD -- .github/workflows/ | grep -cE '^\+  [a-z][a-z0-9_-]*:[[:space:]]*$'`
  — **0 before, 0 after**. Control: reads `1` on `366e4fca79` (a commit that
  added a job) and `0` on `4cf4d711a2` (one that did not).
- Job-level `name:` changes, `grep -cE '^[+-]    name:'` on the same diff —
  **0**. Same control commit reads `1`.
- Structural comparison of the parsed YAML against `origin/main`: job keys
  added `[]`, removed `[]`; job-level name changes `{}`; steps in
  `jvm-migration-v1-codemod` **5 → 6**. The job's own `name:` still reads
  `JVM migration/from-re-frame-v1/codemod (clojure -M:test)` — deliberately
  left alone, since the reported check context is the job-level name.
- `python scripts/check_jvm_lane_rosters.py` exit **0** (31 rostered artefacts,
  roster ↔ CI bijection intact — it parses this job's `defaults.run`, which is
  untouched); `python scripts/check_test_lane_bijection.py` exit **0**.

**Prose, tables and anchors in the README edit were checked by hand** — no
gate covers them. The edit adds no links and no headings; the two tables in that
file are untouched.

**Not done, deliberately.** The `migration_v1_codemod` classifier arm fires on
`migration/from-re-frame-v1/codemod/*` only, so a change confined to
`implementation/core` will not run this job even though `:integration` now
depends on it. Widening that arm means editing
`.github/scripts/report-changed-surfaces.sh` and its pinned mirror, which is a
one-toucher pair outside this dispatch's surfaces.
