### PR TITLE
fix(reagent-slim): name the Form-3 update callbacks' second slot prev-argv (rf2-08hx1)

### DIFF
--- a/implementation/adapters/reagent-slim/FORM-3.md
+++ b/implementation/adapters/reagent-slim/FORM-3.md
@@ -18,11 +18,18 @@ the keys it excludes, and walks through the canonical Form-3 use case
 |---|---|
 | `:reagent-render` | The render function. Returns hiccup. Called on every render. |
 | `:component-did-mount` | Fires once, after the first commit. Use to attach DOM-dependent state (refs read, JS libraries instantiated). |
-| `:component-did-update` | Fires after every re-render commit (not the first). Receives `(this prev-props prev-state snapshot)`. The fourth arg is the value returned by `:get-snapshot-before-update` if set, else `nil`. |
+| `:component-did-update` | Fires after every re-render commit (not the first). Receives `(this prev-argv prev-state snapshot)`. The fourth arg is the value returned by `:get-snapshot-before-update` if set, else `nil`. |
 | `:component-will-unmount` | Fires once, just before unmount. The canonical disposal seam — release timers, listeners, JS-library instances. |
-| `:get-snapshot-before-update` | Fires just before commit, with `(this prev-props prev-state)`. Returns any value; that value is passed as the 4th arg to `:component-did-update`. Use to capture pre-commit DOM measurements (e.g. scroll position) for restoration after the commit. |
+| `:get-snapshot-before-update` | Fires just before commit, with `(this prev-argv prev-state)`. Returns any value; that value is passed as the 4th arg to `:component-did-update`. Use to capture pre-commit DOM measurements (e.g. scroll position) for restoration after the commit. |
 | `:component-did-catch` | Error-boundary callback. Fires with `(this error info)` when a descendant throws during render. Logging-only — re-frame2 ships only the `componentDidCatch` half of React's error-boundary contract. Apps that want stateful fallback rendering pair this with a local `(reagent2.core/atom)` flipped from inside the callback. |
 | `:display-name` | A string used by React DevTools and error messages. Compile-time only — zero runtime cost. |
+
+**`prev-argv`, not `prevProps`.** The two update callbacks receive the component's
+*previous* hiccup arg vector, translated out of React's `prevProps` by the bridge.
+It has the same head-included shape `reagent2.core/argv` returns for the current
+render — `[component-fn props & children]` — so the old props map is `argv[1]`, not
+the vector itself. `prev-state` and `snapshot` pass through verbatim; only
+`prevProps` is translated.
 
 **Any other key throws.** The throw fires at `create-class` call time (registration
 time, not render time — fail fast) with the canonical discriminator
@@ -109,11 +116,18 @@ render (pure) and capture any pre-commit measurement via
 
 ;; New
 :component-did-update
-(fn [this prev-props _prev-state _snapshot]
-  (let [[_ new-props] (reagent2.core/argv this)]
-    (when (not= prev-props new-props)
+(fn [this prev-argv _prev-state _snapshot]
+  (let [[_ old-props] prev-argv                     ; previous argv, head included
+        [_ new-props] (reagent2.core/argv this)]    ; current argv, same shape
+    (when (not= old-props new-props)
       (do-side-effect!))))
 ```
+
+Note the symmetry: `prev-argv` is a full arg vector, exactly like the one
+`reagent2.core/argv` returns, so both sides need the same destructuring before the
+comparison is props-to-props. Comparing `prev-argv` directly against `new-props`
+compares a vector with a map — never equal, so the side effect would fire on every
+single update.
 
 If the side effect needs a pre-commit DOM measurement (e.g. scroll position),
 capture it in `:get-snapshot-before-update` and consume it in
@@ -276,7 +290,7 @@ cleanup. The four audited codebases use Form-3 for exactly this — Vega-Embed
                           :zoom   (:zoom props)}))))
 
        :component-did-update
-       (fn [this _prev-props _prev-state _snapshot]
+       (fn [this _prev-argv _prev-state _snapshot]
          (let [[_ new-props] (r/argv this)]
            (when-let [m @map-instance]
              (.setCenter m #js {:lat (-> new-props :center :lat)
@@ -313,7 +327,7 @@ cleanup. The four audited codebases use Form-3 for exactly this — Vega-Embed
    later lifecycle phases can manipulate it.
 
 4. **`:component-did-update`** reacts to prop changes imperatively. The lifecycle
-   callback receives `(this prev-props prev-state snapshot)`; we read the *new*
+   callback receives `(this prev-argv prev-state snapshot)`; we read the *new*
    args via `r/argv` and tell the JS library to update. (The reagent-slim
    contract: `:component-did-update` is the only cap path for "props changed,
    update the imperative thing." Compare with how Form-1 would react to data
@@ -435,7 +449,7 @@ Three variations worth knowing:
                     (reset! vega-instance (.-view result))))))
 
        :component-did-update
-       (fn [this _prev-props _prev-state _snapshot]
+       (fn [this _prev-argv _prev-state _snapshot]
          (let [[_ new-spec] (r/argv this)]
            (.then (js/vegaEmbed @el-ref (clj->js new-spec))
                   (fn [result]
@@ -507,14 +521,14 @@ are committed.
       {:display-name "scroll-preserving-log"
 
        :get-snapshot-before-update
-       (fn [_this _prev-props _prev-state]
+       (fn [_this _prev-argv _prev-state]
          ;; Runs against the PREVIOUS DOM, just before commit.
          ;; Capture whatever measurement we need to restore.
          (when-let [el @container-ref]
            {:scroll-top (.-scrollTop el)}))
 
        :component-did-update
-       (fn [_this _prev-props _prev-state snapshot]
+       (fn [_this _prev-argv _prev-state snapshot]
          ;; Runs AFTER commit, with the snapshot as the 4th arg.
          (when-let [el @container-ref]
            (when-let [target (:scroll-top snapshot)]

--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -664,16 +664,17 @@ This is the React-blessed lifecycle that pairs with `:component-did-update`. The
 
 Stage 4 ships test coverage that mirrors the 10x `code` component's scroll-restoration pattern (panels/event/views.cljs:54-64 per rf2-cgcv §3): capture `scrollTop` in `:get-snapshot-before-update`, restore it in `:component-did-update`. Asserts the snapshot value flows through correctly.
 
-The implementation: the React class's `componentDidUpdate` method delegates to a CLJS impl that destructures `[prev-props prev-state snapshot]` and passes them to the user's `:component-did-update` fn:
+The implementation: the React class's `componentDidUpdate` method receives `[prev-props prev-state snapshot]` and delegates to the user's `:component-did-update` fn. `prevProps` is *translated* to the previous argv — the head-included hiccup arg vector stashed on React's props as `__rfArgv`, the same shape `reagent2.core/argv` returns — so the user callback's second slot is `prev-argv`, never React's raw props object. `prevState` and `snapshot` pass through verbatim:
 
 ```clojure
-(fn [this prev-props prev-state]
-  (let [snapshot (j/get this :__rf-snapshot)
-        user-fn  (:component-did-update spec)]
-    (when user-fn (user-fn this prev-props prev-state snapshot))))
+(fn [prev-props prev-state snapshot]
+  (this-as this
+    (let [user-fn (:component-did-update spec)]
+      (when user-fn
+        (user-fn this (prev-argv-from prev-props) prev-state snapshot)))))
 ```
 
-(`j/get` is `goog.object/get`-shaped; Stage 4 picks the exact accessor.)
+(`prev-argv-from` reads `__rfArgv` off React's props; Stage 4 picks the exact accessor. `:get-snapshot-before-update` translates identically, one argument shorter.)
 
 ---
 

--- a/implementation/adapters/reagent-slim/README.md
+++ b/implementation/adapters/reagent-slim/README.md
@@ -31,11 +31,16 @@ The escape hatch is Form-3 via `reagent2.core/create-class` (the slim equivalent
   {:display-name              "<name>"
    :reagent-render            (fn [props] ...)
    :component-did-mount       (fn [this] ...)
-   :component-did-update      (fn [this prev-props prev-state snapshot] ...)
+   :component-did-update      (fn [this prev-argv prev-state snapshot] ...)
    :component-will-unmount    (fn [this] ...)
-   :get-snapshot-before-update (fn [this prev-props prev-state] ...)
+   :get-snapshot-before-update (fn [this prev-argv prev-state] ...)
    :component-did-catch       (fn [this err info] ...)})
 ```
+
+`prev-argv` is the *previous* hiccup arg vector — the same head-included shape
+`reagent2.core/argv` returns for the current render, not React's raw `prevProps`
+object. Destructure the old props out of it (`(let [[_ old-props] prev-argv] ...)`)
+before comparing them against the new ones.
 
 The slim adapter enforces a 7-key cap — these 6 keys plus `:display-name`. Any other key throws at `create-class` call time. The cap is empirical (the union of what Day8's 4 production codebases use, plus nothing else); see [`DESIGN-RATIONALE.md` §4](DESIGN-RATIONALE.md) for the framing.
 


### PR DESCRIPTION
Completes the rf2-08hx1 audit residual (audit of PR #8844). Docs only; no API or compatibility change.

## The premise, verified at source

The audit's load-bearing claim holds. `implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs` translates React's `prevProps` to the full previous hiccup argv before either paired update callback:

- `prev-argv-from` (`:358-362`) returns `(.-__rfArgv prev-props)`.
- `componentDidUpdate` (`:446-458`) calls the user fn as `(f this (prev-argv-from prev-props) prev-state snapshot)`.
- `getSnapshotBeforeUpdate` (`:460-467`) calls it as `(f this (prev-argv-from prev-props) prev-state)`.

`__rfArgv` is the head-included hiccup vector (`template.cljs:1049` packs it; `component.cljs/get-argv` documents "Includes the user-fn head as the first element"), and `reagent2.core/argv` returns that same shape. So the user callback's second slot is an argv vector whose props map sits at index 1 — not a props map. The published contract nevertheless called it `prev-props`.

The source is right; the docs were wrong. No behaviour changed here.

## The behavioural half — the migration recipe

`FORM-3.md` §3's `:component-will-receive-props` recipe compared the whole previous argv vector against the current props map, so the inequality was always true and the side effect ran on **every** update. It now destructures both sides symmetrically:

```clojure
:component-did-update
(fn [this prev-argv _prev-state _snapshot]
  (let [[_ old-props] prev-argv                     ; previous argv, head included
        [_ new-props] (reagent2.core/argv this)]    ; current argv, same shape
    (when (not= old-props new-props)
      (do-side-effect!))))
```

## Rename census

`prev-props` / `prevProps` under `implementation/adapters/reagent-slim/`, docs only:

| File | Started | Changed | Kept |
|---|---|---|---|
| `README.md` | 2 | 2 | 0 |
| `FORM-3.md` | 9 | 9 | 0 |
| `IMPL-SPEC.md` | 7 | 3 | 4 |

Every survivor is prose explicitly describing React's own raw lifecycle method arguments, which the audit says to retain:

- `IMPL-SPEC.md` §6.4 table rows for `:component-did-update` and `:get-snapshot-before-update` — the middle column is headed "React lifecycle method"; `componentDidUpdate(prevProps, prevState, snapshot)` is the React signature. The "3rd arg" wording in that row is likewise true of the React method (the previous audit of PR #8827 explicitly asked to keep it).
- `IMPL-SPEC.md` §6.6 steps 1 and 3 — the numbered contract describes React calling `getSnapshotBeforeUpdate(prevProps, prevState)` and `componentDidUpdate(prevProps, prevState, snapshot)`.

Plus new deliberate mentions naming the raw value in order to contrast it: 3 in `FORM-3.md`'s new note, 1 in `README.md`'s new gloss, 2 in the rewritten `IMPL-SPEC.md` §6.6 sketch (whose JS-facing fn parameter is React's props object, matching the shipped source's own naming).

Source and tests already agreed: `component.cljs` uses `prev-props` only for React's raw props object arriving into the bridge, and `component_cljs_test.cljs` / `lifecycle_prev_state_dom_cljs_test.cljs` already name the translated value `prev-argv`. No Clojure source changed.

Outside the adapter, `implementation/adapters/reagent/README.md` and `skills/reagent-migration/**` use `prev-props` about **stock** Reagent, which is a different surface and out of scope here.

## Quality gates

**`python scripts/check_readme_links.py --ci` — the gate for markdown beside source.** `check_doc_slugs.py` is *not* the gate for these paths: `implementation/**` is outside its roots, where it exits 0 on a broken link. `mkdocs build --strict` is likewise not a candidate — `docs_dir` is `docs`.

| Run | Captured exit |
|---|---|
| Clean, pre-plant | `0` (empty log) |
| **Planted fault** | **`1`** |
| Fence probe (see below) | `0` |
| Clean, final tree | `0` (empty log) |

Control: a broken link target `./NO-SUCH-FILE-…-probe.md` was planted at a line being edited in each of the three files. The gate went red naming all three, at the exact edited lines:

```
BROKEN TARGET: implementation\adapters\reagent-slim\README.md:43 -> ./NO-SUCH-FILE-...
BROKEN TARGET: implementation\adapters\reagent-slim\FORM-3.md:32 -> ./NO-SUCH-FILE-...
BROKEN TARGET: implementation\adapters\reagent-slim\IMPL-SPEC.md:667 -> ./NO-SUCH-FILE-...
```

That red is the discrimination — the fault existed only in this branch's checkout, so a run reading any other tree would have come back green. It also proves all three files are on this gate's roster, including the two non-`README.md` ones. Restore verified by comparing each file's git **blob** hash against the committed object (all three matched); `git status` clean.

### What the gate could not check — verified by hand

**The corrected recipe is inside a fenced code block, and neither doc gate reads inside fences.** Measured here rather than assumed: a broken link planted *inside* the recipe fence returned captured exit `0` with zero mentions in the log, where the identical link four lines above it in prose returned exit `1`. So the gate's green says nothing at all about the sample that matters most.

Checked by hand instead, and by execution:

1. **The destructuring form is valid Clojure.** `[_ old-props] prev-argv` is sequential destructuring of a vector; against `['my-view {:a 1} :child]` it binds `old-props` to `{:a 1}`.
2. **The comparison is now props-to-props.** Both sides are `argv[1]`: `old-props` from `prev-argv`, `new-props` from `(reagent2.core/argv this)`.
3. **The old recipe's bug reproduces and the new one fixes it.** Both recipes were transcribed verbatim into a Clojure script that models the bridge (callback slot 2 = previous argv; `argv` = current argv) and run:

   | Recipe | props unchanged | props changed |
   |---|---|---|
   | old (`prev-props` vs `new-props`) | fires **1** — the bug | fires 1 |
   | new (`old-props` vs `new-props`) | fires **0** | fires 1 |

Also checked by hand, being prose the gate does not grade: the `FORM-3.md` §1 cap table keeps its 2 columns and 7 key rows, and the `IMPL-SPEC.md` §6.4 table its 3 columns and 7 rows — no row edited here changes a column count. No heading text or anchor target was touched in any of the three files, so no cross-reference moved.

**No Clojure source changed**, so no CLJS suite is nominated. CI covers the shipped behaviour these docs describe via the reagent-slim component lane (`component_cljs_test.cljs`, `lifecycle_prev_state_dom_cljs_test.cljs`), which already pins the translated `prev-argv` and the four-argument user callback.
