### PR TITLE
fix(http): no request is issued after an abort has completed (rf2-rsv2n audit residual)

### DIFF
--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -1651,22 +1651,38 @@
         ;; one-cell atom that the JVM body fills after construction; the
         ;; abort-fn reads it lazily through `@cf-holder`.
         #?@(:clj  [cf-holder (atom nil)])
+        ;; rf2-rsv2n — the ISSUANCE REGION's mutex (JVM only; CLJS is single-
+        ;; threaded and has no region to guard). Two short critical sections
+        ;; take it: the host-entry region below — commit CAS, `jvm-fetch`
+        ;; (`HttpClient.sendAsync`), publication of the returned future — and
+        ;; the abort closure's cancel step. Serializing those two is what makes
+        ;; the invariant hold in BOTH orderings: an abort that gets here first
+        ;; commits `issue-phase` to `:aborted`, so the host call never happens;
+        ;; an abort that arrives while the host call is in flight cannot
+        ;; complete (it blocks before its cancel step, so its registry clear and
+        ;; its cancelled reply come after) and finds the future already
+        ;; published when it does. Neither side ever runs app code while
+        ;; holding it: the region contains only the CAS, the transport call and
+        ;; a `reset!`, and `.whenComplete` / `clear-in-flight!` /
+        ;; `dispatch-aborted!` are all outside.
+        #?@(:clj  [issue-lock (Object.)])
         ;; rf2-rsv2n — one-cell issuance-phase CAS closing the request-
         ;; preparation → host-transport window. `nil` until one side commits:
-        ;; the post-prep gate below CASes it to `:issued` immediately before
-        ;; entering the host transport, and the abort closure CASes it to
-        ;; `:aborted` after winning the once-only reply guard. Exactly one
-        ;; winner. An abort that lands while `prepare-body!` is blocked inside
-        ;; a body thunk wins this cell, so the attempt NEVER calls
-        ;; `cljs-fetch` / `jvm-fetch` after the canonical cancelled reply went
-        ;; out — previously `@finalised?` was sampled only BEFORE prep, and on
-        ;; the JVM `cf-holder` was still nil during prep so the abort had no
+        ;; the host-entry region below CASes it to `:issued` as its first act
+        ;; inside the region, and the abort closure CASes it to `:aborted`
+        ;; after winning the once-only reply guard. Exactly one winner, and the
+        ;; winner is decided at the host call itself rather than anywhere
+        ;; earlier — a cell flipped to `:issued` therefore means the request
+        ;; really was issued. An abort that lands while `prepare-body!` is
+        ;; blocked inside a body thunk wins this cell, so the attempt NEVER
+        ;; calls `cljs-fetch` / `jvm-fetch` after the canonical cancelled reply
+        ;; went out — previously `@finalised?` was sampled only BEFORE prep, and
+        ;; on the JVM `cf-holder` was still nil during prep so the abort had no
         ;; future to cancel: `HttpClient.sendAsync` issued a side-effecting
         ;; request AFTER the framework told the app it was cancelled. When
         ;; issuance wins the cell instead, the JVM abort path cancels via
-        ;; `cf-holder` — or, in the residual instant before publication, the
-        ;; issuing thread's post-publication `aborted?` re-check cancels its
-        ;; own future (see below). Per-attempt like `cf-holder`, never
+        ;; `cf-holder`, which `issue-lock` guarantees is published by the time
+        ;; that abort can read it. Per-attempt like `cf-holder`, never
         ;; threaded through the retry handoff — each attempt owns its own
         ;; issuance; the handoff window itself is covered by the shared-cell
         ;; re-check further down (rf2-6nczv9).
@@ -1717,18 +1733,15 @@
                                 ;; is a no-op past the first call.
                                 (when (compare-and-set! finalised? false true)
                                   ;; rf2-rsv2n — claim the issuance phase.
-                                  ;; Winning (nil → `:aborted`) means
-                                  ;; preparation has not handed off to the
-                                  ;; host transport yet: the post-prep gate's
-                                  ;; own CAS will now fail, so no fetch is
-                                  ;; ever issued for this cancelled attempt.
-                                  ;; Losing (already `:issued`) means the
-                                  ;; transport call is in flight or done —
-                                  ;; the JVM branch below cancels via
-                                  ;; `cf-holder`, and when the future is not
-                                  ;; yet published there, the issuing
-                                  ;; thread's post-publication `aborted?`
-                                  ;; re-check cancels it on our behalf.
+                                  ;; Winning (nil → `:aborted`) means the host
+                                  ;; call has not been made yet: the host-entry
+                                  ;; region's own CAS will now fail, so no
+                                  ;; fetch is ever issued for this cancelled
+                                  ;; attempt. Losing (already `:issued`) means
+                                  ;; the transport call is in flight or done —
+                                  ;; the JVM branch below cancels it via
+                                  ;; `cf-holder`, which the issuance region
+                                  ;; publishes before releasing `issue-lock`.
                                   (compare-and-set! issue-phase nil :aborted)
                                   #?(:cljs
                                      (try
@@ -1745,9 +1758,23 @@
                                      ;; the same :finalised? flag and
                                      ;; bails before re-emitting.
                                      ;; `true` = may-interrupt-if-running.
-                                     (when-let [^CompletableFuture cf @cf-holder]
-                                       (try (.cancel cf true)
-                                            (catch Throwable _ nil))))
+                                     ;; rf2-rsv2n — under `issue-lock`: when
+                                     ;; issuance won the cell we may be racing
+                                     ;; the host call itself, and taking the
+                                     ;; monitor is what makes this read see a
+                                     ;; PUBLISHED future instead of the nil it
+                                     ;; used to find. It also holds the rest of
+                                     ;; this cascade — registry clear and the
+                                     ;; cancelled reply — behind the in-flight
+                                     ;; host call, so the abort can never
+                                     ;; complete and then have a request go out
+                                     ;; behind it. The region it waits on
+                                     ;; contains no app code, so the wait is
+                                     ;; the transport call and nothing else.
+                                     (locking issue-lock
+                                       (when-let [^CompletableFuture cf @cf-holder]
+                                         (try (.cancel cf true)
+                                              (catch Throwable _ nil)))))
                                   ;; Registry cleanup happens
                                   ;; here once; finalise-failure! is
                                   ;; bypassed. Pass the stamped handle (via
@@ -1897,18 +1924,26 @@
         ;; canonical cancelled reply and cleared the registry, and this
         ;; attempt must not now enter the host transport (Spec 014 §Abort
         ;; precedence: body realization is a managed phase; a cancelled
-        ;; request must not issue). The CAS makes the abort/issuance race
-        ;; have exactly one winner: losing here (the abort closure already
-        ;; CASed `:aborted`) skips the fetch entirely, with nothing left to
-        ;; do — reply and registry were the abort's. Winning commits this
-        ;; attempt to issuance BEFORE any side effect, so an abort landing
-        ;; from here on takes the cancel-the-future path instead. Shared
-        ;; CLJC, no reader conditional — the same gate covers a re-entrant
-        ;; external abort fired during CLJS body realization, so no Fetch
-        ;; call follows a delivered cancellation on either host.
-        (when (compare-and-set! issue-phase nil :issued)
+        ;; request must not issue). The `issue-phase` CAS below makes the
+        ;; abort/issuance race have exactly one winner: losing it (the abort
+        ;; closure already CASed `:aborted`) skips the fetch entirely, with
+        ;; nothing left to do — reply and registry were the abort's.
+        ;;
+        ;; THE COMMIT IS THE HOST CALL. Each host CASes the shared cell as the
+        ;; first act of its own host-entry region, never earlier: committing
+        ;; ahead of the call would re-open the hole one step further down,
+        ;; where an abort loses the cell (so it cannot suppress the send) yet
+        ;; finds no future to cancel (so it cannot stop it either) and returns
+        ;; having told the app the request was cancelled — after which the
+        ;; request goes out anyway. On CLJS the region is implicit: the host is
+        ;; single-threaded and nothing can run between the CAS and `cljs-fetch`,
+        ;; so the CAS alone orders the only interleaving that host can produce
+        ;; (a re-entrant external abort fired during body realization). On the
+        ;; JVM the region is `issue-lock`, held across CAS → `sendAsync` →
+        ;; publication so the abort path is serialized against it.
         (interleave! :issue/before-send ctx')
         #?(:cljs
+           (when (compare-and-set! issue-phase nil :issued)
            (-> (transport-cljs/cljs-fetch
                            {:method              method
                             :url                 url
@@ -1955,7 +1990,7 @@
                ;; natural-completion sink without a bespoke "did we abort?"
                ;; check here.
                (.catch (fn [err]
-                         (maybe-retry! ctx' (transport-cljs/classify-cljs-error err url)))))
+                         (maybe-retry! ctx' (transport-cljs/classify-cljs-error err url))))))
            :clj
            ;; Monotonic start mark for the per-host timeout
            ;; `:elapsed-ms`. `System/nanoTime` is the JDK's monotonic clock
@@ -1965,51 +2000,55 @@
            (let [started-ns (System/nanoTime)
                  elapsed-ms #(quot (- (System/nanoTime) started-ns) 1000000)]
              (try
-               (let [^CompletableFuture cf
-                     (transport-jvm/jvm-fetch
-                                {:method     method
-                                 :url        url
-                                 :headers    headers
-                                 :body       enc-body
-                                 :timeout-ms timeout-ms
-                                 ;; Thread the resolved `:decode`
-                                 ;; so `jvm-fetch` can read the response body
-                                 ;; with `ofByteArray` for binary decode modes
-                                 ;; (`:blob` / `:array-buffer` / `:form-data`)
-                                 ;; and ride the raw bytes under `:body-binary`
-                                 ;; instead of the lossy String fallback.
-                                 :decode     (:decode ctx)
-                                 ;; Honour the spec's `:redirect`
-                                 ;; envelope key on the JVM (default `:follow`).
-                                 ;; Selects the redirect-policy-specific client.
-                                 :redirect   (:redirect request)
-                                 :sensitive? (true? (:sensitive? ctx))
-                                 ;; The originating frame stamps the warning and
-                                 ;; supplies its general elision policy; HTTP
-                                 ;; carrier names come from effect registration.
-                                 :frame      (:frame ctx)})]
-                 ;; Publish cf to the abort closure's holder
-                 ;; BEFORE wiring whenComplete. A racing abort that arrives
-                 ;; between `jvm-fetch` returning and `.whenComplete`
-                 ;; registering still finds cf in the holder and can cancel
-                 ;; it.
-                 (reset! cf-holder cf)
-                 ;; rf2-rsv2n — residual-window re-check. An abort that fired
-                 ;; after this attempt won the issuance-phase CAS but before
-                 ;; the `reset!` above found `cf-holder` still nil and had
-                 ;; nothing to cancel; it has already delivered the canonical
-                 ;; cancelled reply and cleared the registry (it won the
-                 ;; once-only guard), so the one thing left undone is stopping
-                 ;; the work. Re-read the abort-precedence cell now that the
-                 ;; future is published and cancel it on the abort's behalf.
-                 ;; `.cancel` is idempotent, so racing the abort path's own
-                 ;; cancel is harmless; the `whenComplete` below then fires
-                 ;; with a CancellationException and `finalise-failure!` bails
-                 ;; on the won `:finalised?` CAS — the abort's reply stays the
-                 ;; only one.
-                 (when (some? @aborted?)
-                   (try (.cancel cf true)
-                        (catch Throwable _ nil)))
+               ;; rf2-rsv2n — THE ISSUANCE REGION. Commit, issue and publish
+               ;; hold `issue-lock` together, so the abort closure's cancel
+               ;; step cannot land between them. An abort that reaches the
+               ;; monitor first wins the cell, this CAS fails, and `sendAsync`
+               ;; is never called — `when-let` yields nil and there is nothing
+               ;; to wire. An abort that arrives once this region is running
+               ;; waits at its cancel step: it cannot clear the registry or
+               ;; deliver its cancelled reply until the region ends, and by
+               ;; then `cf-holder` carries the future it cancels. Either way
+               ;; the app is never told a request was cancelled and then has
+               ;; one issued behind that reply. The region deliberately holds
+               ;; nothing but the CAS, the transport call and the `reset!` —
+               ;; `.whenComplete` and every reply a completion dispatches run
+               ;; outside the monitor.
+               (when-let [^CompletableFuture cf
+                          (locking issue-lock
+                            (when (compare-and-set! issue-phase nil :issued)
+                              (let [cf (transport-jvm/jvm-fetch
+                                         {:method     method
+                                          :url        url
+                                          :headers    headers
+                                          :body       enc-body
+                                          :timeout-ms timeout-ms
+                                          ;; Thread the resolved `:decode`
+                                          ;; so `jvm-fetch` can read the response
+                                          ;; body with `ofByteArray` for binary
+                                          ;; decode modes (`:blob` /
+                                          ;; `:array-buffer` / `:form-data`) and
+                                          ;; ride the raw bytes under
+                                          ;; `:body-binary` instead of the lossy
+                                          ;; String fallback.
+                                          :decode     (:decode ctx)
+                                          ;; Honour the spec's `:redirect`
+                                          ;; envelope key on the JVM (default
+                                          ;; `:follow`). Selects the
+                                          ;; redirect-policy-specific client.
+                                          :redirect   (:redirect request)
+                                          :sensitive? (true? (:sensitive? ctx))
+                                          ;; The originating frame stamps the
+                                          ;; warning and supplies its general
+                                          ;; elision policy; HTTP carrier names
+                                          ;; come from effect registration.
+                                          :frame      (:frame ctx)})]
+                                ;; Publish cf to the abort closure's holder
+                                ;; before the monitor is released. This is the
+                                ;; publication a racing abort is waiting for,
+                                ;; and the future it goes on to cancel.
+                                (reset! cf-holder cf)
+                                cf)))]
                  ;; The whenComplete callback fires even after
                  ;; `.cancel cf true`: the cancel completes-exceptionally
                  ;; with a CancellationException, which routes through this
@@ -2017,7 +2056,9 @@
                  ;; `finalise-failure!` is then guarded by the once-only
                  ;; `:finalised?` CAS (the abort-fn already finalised), so
                  ;; the abort's reply is the only one that ever reaches the
-                 ;; user.
+                 ;; user. An abort that cancelled cf between the region
+                 ;; ending and this line lands the same way — registering on
+                 ;; an already-cancelled future fires the callback at once.
                  (.whenComplete cf
                                 (reify java.util.function.BiConsumer
                                   (accept [_ result throwable]
@@ -2025,4 +2066,4 @@
                                       (maybe-retry! ctx' (transport-jvm/classify-jvm-error throwable timeout-ms (elapsed-ms)))
                                       (handle-response! ctx' result))))))
                (catch Throwable t
-                 (maybe-retry! ctx' (transport-jvm/classify-jvm-error t timeout-ms (elapsed-ms))))))))))))))
+                 (maybe-retry! ctx' (transport-jvm/classify-jvm-error t timeout-ms (elapsed-ms)))))))))))))

--- a/implementation/http/test/re_frame/http_abort_body_prep_race_test.clj
+++ b/implementation/http/test/re_frame/http_abort_body_prep_race_test.clj
@@ -17,21 +17,31 @@
   attempt).
 
   Fix: a one-cell issuance-phase CAS (`issue-phase`, nil → `:issued` |
-  `:aborted`) shared between the abort closure and the post-preparation
-  gate, so the abort/issuance race has exactly one winner. Abort-before-
-  send wins the cell and the transport is never entered; send-before-abort
-  loses the cell to issuance, which publishes the cancellable future and
-  re-reads the abort-precedence cell after publication, cancelling its own
-  future when the abort landed in the residual publish window. The gate is
-  shared CLJC with no reader conditional, so the same guard covers a
-  re-entrantly fired abort during CLJS body realization (the third test
-  here drives that exact single-threaded re-entrant ordering through the
-  shared code path on the JVM).
+  `:aborted`) shared between the abort closure and the host-entry region,
+  so the abort/issuance race has exactly one winner — and the commit is
+  the host call itself, not a point ahead of it. Abort-before-entry wins
+  the cell and the transport is never entered; entry-before-abort wins it
+  and publishes the cancellable future. On the JVM the commit CAS, the
+  `sendAsync` call and that publication are one critical region under a
+  per-attempt monitor which the abort closure's cancel step also takes, so
+  an abort racing an in-flight host call cannot complete ahead of it: it
+  waits, then cancels a published future. CLJS needs no monitor — the host
+  is single-threaded, so the CAS immediately before `cljs-fetch` orders the
+  only interleaving that host can produce (a re-entrantly fired abort
+  during body realization; the third test here drives exactly that
+  single-threaded ordering through the JVM's copy of the same gate).
+
+  Committing ahead of the host call is what the audit of PR #8842 found
+  still open, and the last two tests here are its regression pair: an
+  abort that COMPLETES at the issuance boundary must leave zero host
+  calls behind it, and an abort that races an in-flight host call must be
+  unable to complete until that call has published its future.
 
   All tests stub `transport-jvm/jvm-fetch` (the host-transport seam the
   bug escapes through — the `with-managed-request-stubs` layer overrides
   the whole `:rf.http/managed` fx and so sits ABOVE the lifecycle under
-  test) and use latches/promises, never timing sleeps."
+  test) and use latches / promises / thread-state observation, never
+  timing sleeps."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.http.managed :as http-managed]
@@ -40,7 +50,8 @@
             [re-frame.http.transport-jvm :as transport-jvm]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support])
-  (:import [java.util.concurrent CompletableFuture]))
+  (:import [java.lang Thread$State]
+           [java.util.concurrent CompletableFuture]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
@@ -51,6 +62,21 @@
    (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
                                   :label "http-abort-body-prep-race condition"})
    true))
+
+(defn- await-blocked!
+  "Poll `t` until it reports `BLOCKED` — waiting to enter a monitor — or the
+  budget runs out; returns true iff BLOCKED was observed. This is a state
+  observation, not a timing assumption, and it is decisive in both
+  directions: a thread that must take a monitor another thread holds enters
+  BLOCKED and stays there until released, while a thread with no monitor to
+  take never enters it at all and the poll runs out its budget."
+  [^Thread t timeout-ms]
+  (let [deadline (+ (System/nanoTime) (* (long timeout-ms) 1000000))]
+    (loop []
+      (cond
+        (= Thread$State/BLOCKED (.getState t)) true
+        (> (System/nanoTime) deadline)         false
+        :else                                  (do (Thread/sleep 5) (recur))))))
 
 (defn- register-recorder-and-issue!
   "Register the shared `:reply/recorder` event plus an `:issue` event that
@@ -204,7 +230,7 @@
           (is (= :rf.http/aborted (get-in reply [:error :kind]))))
         (is (empty? (registry/in-flight-snapshot)))))))
 
-;; ---- (4) handoff controls: issuance wins the phase CAS ---------------------
+;; ---- (4) handoff control: issuance wins, the future is cancellable ---------
 
 (deftest abort-after-issuance-cancels-published-future
   (testing "rf2-rsv2n (handoff control) — when issuance wins, the future is published and cancellable: a subsequent abort cancels it via cf-holder and produces no double reply"
@@ -236,8 +262,18 @@
           (is (= :rf.http/aborted (get-in reply [:error :kind]))))
         (is (empty? (registry/in-flight-snapshot)))))))
 
-(deftest abort-in-residual-publish-window-still-cancels-future
-  (testing "rf2-rsv2n (residual window) — an abort landing AFTER issuance won the phase CAS but BEFORE the future is published (cf-holder still nil, injected deterministically at :issue/before-send) is honoured by the issuing thread's post-publication re-check: the future is cancelled on the abort's behalf, one reply, clean registry"
+;; ---- (5) the issuance boundary: a completed abort issues nothing -----------
+
+;; This test was `abort-in-residual-publish-window-still-cancels-future`
+;; before the audit of PR #8842. It fired the same abort at the same seam and
+;; then asserted `(= 1 @fetch-calls)` — blessing the very ordering the bead
+;; forbids, where an abort completes (returns true, clears the registry,
+;; delivers the cancelled reply) and the request is issued afterwards, with a
+;; post-`sendAsync` `.cancel` standing in for not having sent it. Cancelling a
+;; future cannot un-send a POST, so the assertion is inverted here rather than
+;; widened: the abort completes at the issuance boundary and NOTHING is sent.
+(deftest abort-completing-at-issuance-boundary-issues-no-request
+  (testing "rf2-rsv2n (audit residual) — an abort injected at :issue/before-send COMPLETES before the host call; because the commit is the host call itself, the abort wins the issuance cell and jvm-fetch is NEVER entered — zero host calls, one cancelled reply, clean registry"
     (let [fetch-calls  (atom 0)
           returned-cf  (atom nil)
           abort-result (atom ::not-fired)
@@ -249,32 +285,96 @@
                                                   (reset! returned-cf cf)
                                                   cf))]
           (register-recorder-and-issue!
-            replies :residual-window
+            replies :issuance-boundary
             {:url "http://127.0.0.1:0/x" :method :post :body "plain"})
-          ;; The seam: fire the abort at the point where issuance has
-          ;; committed (phase CAS won) but nothing is published yet — the
-          ;; exact window the abort closure's cf-holder read finds nil.
+          ;; The seam: preparation has succeeded and the attempt is one step
+          ;; from the host call. The abort runs to completion here — registry
+          ;; cleared, canonical cancelled reply dispatched — so no request may
+          ;; follow it.
           (transport/set-test-interleave-hook!
             (fn [point ctx]
               (when (and (= point :issue/before-send)
-                         (= :residual-window (:request-id ctx))
+                         (= :issuance-boundary (:request-id ctx))
                          (= ::not-fired @abort-result))
                 (reset! abort-result
-                        (registry/abort-in-flight! :residual-window :user)))))
+                        (registry/abort-in-flight! :issuance-boundary :user)))))
           (rf/dispatch-sync [:issue])
           (is (true? @abort-result)
-              "the injected abort resolved the handle inside the residual window")
-          (is (= 1 @fetch-calls)
-              "issuance had already committed, so the transport WAS entered in this ordering")
-          (is (some? @returned-cf))
-          (is (.isCancelled ^CompletableFuture @returned-cf)
-              "the issuing thread's post-publication re-check cancelled the future on the abort's behalf")
+              "the injected abort resolved the live handle at the issuance boundary")
+          (is (zero? @fetch-calls)
+              "jvm-fetch was NEVER entered after the abort completed — the framework must not issue a request it has already told the app was cancelled")
+          (is (nil? @returned-cf)
+              "no transport future was ever created: there was nothing to cancel because nothing was sent")
           (await-condition! #(seq @replies))
           (is (= 1 (count @replies)) "exactly one terminal reply — the abort's")
           (let [reply (first @replies)]
             (is (= :cancelled (:status reply)))
-            (is (= :rf.http/aborted (get-in reply [:error :kind]))))
+            (is (= :rf.http/aborted (get-in reply [:error :kind])))
+            (is (= :user (get-in reply [:error :reason]))))
           (is (empty? (registry/in-flight-snapshot)))
           (is (empty? (registry/actor-in-flight-snapshot))))
         (finally
           (transport/set-test-interleave-hook! nil))))))
+
+;; ---- (6) the opposite ordering: the abort waits, then cancels --------------
+
+(deftest concurrent-abort-cannot-complete-while-host-call-is-in-flight
+  (testing "rf2-rsv2n (audit residual, opposite ordering) — an abort racing an in-flight host call BLOCKS on the issuance monitor: it cannot clear the registry or deliver its reply until the call has published its future, which it then cancels. Issuance genuinely won, so exactly one host call is correct here"
+    (let [fetch-calls        (atom 0)
+          returned-cf        (atom nil)
+          abort-result       (atom ::not-fired)
+          aborter            (atom nil)
+          observed-blocked   (atom ::not-observed)
+          registry-in-region (atom ::not-sampled)
+          replies-in-region  (atom ::not-sampled)
+          replies            (atom [])]
+      (with-redefs [transport-jvm/jvm-fetch
+                    (fn [_]
+                      ;; This stub runs INSIDE the issuance region, standing
+                      ;; in for `HttpClient.sendAsync`. A competing abort
+                      ;; fired from here is racing a host call that has begun
+                      ;; and not yet published its future — the window the
+                      ;; audit named.
+                      (swap! fetch-calls inc)
+                      (let [cf (CompletableFuture.)
+                            t  (Thread.
+                                 ^Runnable
+                                 (fn []
+                                   (reset! abort-result
+                                           (registry/abort-in-flight! :handshake :user)))
+                                 "rf2-rsv2n-aborter")]
+                        (reset! returned-cf cf)
+                        (reset! aborter t)
+                        (.start t)
+                        (reset! observed-blocked (await-blocked! t 2000))
+                        ;; Sampled while the abort is parked on the monitor:
+                        ;; it has NOT completed, so the app has not been told
+                        ;; the request was cancelled.
+                        (reset! registry-in-region (registry/in-flight-snapshot))
+                        (reset! replies-in-region @replies)
+                        cf))]
+        (register-recorder-and-issue!
+          replies :handshake
+          {:url "http://127.0.0.1:0/x" :method :post :body "plain"})
+        (rf/dispatch-sync [:issue])
+        (.join ^Thread @aborter 5000)
+        (is (true? @observed-blocked)
+            "the competing abort BLOCKED on the issuance monitor — host entry and the abort's cancel step are serialized")
+        (is (contains? @registry-in-region :handshake)
+            "while the host call was in flight the abort had not cleared the registry — it cannot complete ahead of the request it is cancelling")
+        (is (empty? @replies-in-region)
+            "and it had not delivered its cancelled reply either")
+        (is (true? @abort-result)
+            "the abort resolved the live handle once the region released")
+        (is (= 1 @fetch-calls)
+            "issuance won this ordering, so exactly one host call is correct — the abort is the one that waited")
+        (is (some? @returned-cf))
+        (is (.isCancelled ^CompletableFuture @returned-cf)
+            "the future was published before the abort could complete, so the abort cancelled it")
+        (await-condition! #(seq @replies))
+        (is (= 1 (count @replies)) "exactly one terminal reply — the abort's")
+        (let [reply (first @replies)]
+          (is (= :cancelled (:status reply)))
+          (is (= :rf.http/aborted (get-in reply [:error :kind]))))
+        (is (empty? (registry/in-flight-snapshot)))
+        (is (empty? (registry/actor-in-flight-snapshot)))))))


### PR DESCRIPTION
## What this fixes

The audit of PR #8842 (rf2-rsv2n) found the post-body-prep gate correct for the
ordering it was written for and the JVM issuance handoff still wrong. The cell
was committed to `:issued` **before any host side effect**, and the actual
`jvm-fetch` / `HttpClient.sendAsync` call came ~60 lines later, with the future
published ~30 lines after that. An abort landing in that window lost the cell,
so it could not suppress the send; found `cf-holder` still nil, so it had
nothing to cancel; and completed anyway — clearing the registry and delivering
the canonical cancelled reply — after which the request went out. The
post-publication re-check that followed could only `.cancel` a future whose
`sendAsync` had already happened, and cancelling a future cannot un-send a POST.
The source comment there said as much: "the one thing left undone is stopping
the work".

So the framework could tell an app its request was cancelled and then issue it.

## The fix

**The commit is the host call.** `issue-phase` is now CASed as the first act
inside each host's own entry region rather than at a point ahead of it, so a
cell reading `:issued` means the request really was issued.

On the JVM that region — commit CAS → `jvm-fetch` (`sendAsync`) → publication of
the returned future — is held under a new per-attempt monitor, `issue-lock`,
which the abort closure's cancel step also takes. That is the audit's first
shape (serialize host entry and future publication with abort), and it settles
both orderings the bead's invariant names:

* an abort that reaches the monitor first wins the cell, the issuance CAS then
  fails, and no host call is ever made;
* an abort that arrives while the host call is in flight **cannot complete**: it
  parks before its cancel step, so its registry clear and its cancelled reply
  land only after the region ends — by which time `cf-holder` carries the future
  it goes on to cancel. That is the bead's "if issuance wins first, the future
  must be published before the abort returns", now true by construction rather
  than by a re-check after the fact.

The region deliberately contains nothing but the CAS, the transport call and one
`reset!`. `.whenComplete`, `clear-in-flight!` and `dispatch-aborted!` all run
outside the monitor, so no app code executes while it is held and the wait an
abort can incur is the transport call and nothing else.

The now-dead residual-window re-check after publication is removed: with the
region serialized there is no ordering in which an abort observes `:issued` and
an unpublished future.

**CLJS is unchanged in production semantics** and needs no monitor. The host is
single-threaded, so nothing can run between the CAS and `cljs-fetch`; the CAS
alone orders the only interleaving that host can produce — a re-entrant external
abort fired during body realization — and it still sits immediately before the
Fetch call. Test (3) in the suite drives exactly that single-threaded re-entrant
ordering through the JVM's copy of the same gate. The only CLJS-visible delta is
that the test-only `interleave!` seam (nil in production) now runs before the
CAS instead of after it.

No public API change, no new cancellation surface, no retry/lifecycle redesign,
and no spec edit: Spec 014 §Abort precedence and §Aborts already mandate this
behaviour (`spec/014-HTTPRequests.md:218`, `:414`, `:493-497`) — nothing there
blesses send-then-cancel, so there was nothing to change.

## The test that codified the defect

`abort-in-residual-publish-window-still-cancels-future` asserted `fetch-calls =
1` for an abort that had already returned true, cleared the registry and
delivered the cancelled reply — pinning the exact ordering the bead's invariant
forbids, with a post-`sendAsync` `.cancel` standing in for not having sent it. A
test pinning that and the fix for it are mutually invalidating, so it is
**flipped and renamed**, never deleted and never loosened to accept both
outcomes:

* **was** `abort-in-residual-publish-window-still-cancels-future` — same seam,
  asserted one host call plus a cancelled future;
* **now** `abort-completing-at-issuance-boundary-issues-no-request` — the same
  abort is injected at the same `:issue/before-send` seam and still completes,
  and the test asserts **zero** `jvm-fetch` calls and that **no future was ever
  created**, because nothing was sent. One cancelled reply, clean registry.

`concurrent-abort-cannot-complete-while-host-call-is-in-flight` is new and
covers the opposite ordering as a live handshake rather than a sequential
stand-in. The `jvm-fetch` stub runs *inside* the issuance region, so it is the
`sendAsync` seam: it starts a competing abort on another thread, observes that
thread reach `BLOCKED` on the issuance monitor, samples the registry and the
delivered replies while it is parked there (both show the abort has **not**
completed), and only then returns the future the abort goes on to cancel. One
host call is correct in that ordering — issuance genuinely won, and the abort is
the side that waited.

The `BLOCKED` observation is a thread-state check, not a timing assumption, and
is decisive both ways: a thread that must take a held monitor enters `BLOCKED`
and stays there; a thread with no monitor to take never enters it.

## Quality gates

Run from `implementation/http` in the worker worktree, foreground, exit code
captured in the same shell as the run and quoted from that capture (never from
the harness's report).

| Gate | Result |
| --- | --- |
| `clojure -M:test` (full JVM suite, post-fix) | **exit 0** — Ran 508 tests containing 3881 assertions, 0 failures, 0 errors |
| `clojure -M:test -n re-frame.http-abort-body-prep-race-test` (post-fix) | **exit 0** — Ran 6 tests containing 54 assertions, 0 failures, 0 errors |
| Same namespace against the **pre-fix** `transport.cljc` (control) | **exit 1** — Ran 6 tests containing 54 assertions, **4 failures** |

**Non-vacuity control — the deliverable.** The red run is the new tests against
the pre-fix source, restored from the merge base while the flipped tests stayed
in place. Its four failures are the audit's defect, measured:

* `jvm-fetch was NEVER entered after the abort completed` —
  `expected: (zero? @fetch-calls) / actual: (not (zero? 1))`. The abort
  completed at the issuance boundary and the request was issued anyway.
* `no transport future was ever created` — actual: a
  `CompletableFuture … [Completed exceptionally: CancellationException]`. The
  send-then-cancel shape the old test blessed, in full.
* `the competing abort BLOCKED on the issuance monitor` —
  `expected: (true? @observed-blocked) / actual: (not (true? false))`. Nothing
  serialized the two sides.
* `while the host call was in flight the abort had not cleared the registry` —
  `actual: (not (contains? {} :handshake))`. The registry was **already empty**
  while `sendAsync` was executing: the abort had completed, and the app had been
  told the request was cancelled, before the request went out.

The suite's own in-tree non-vacuity control (test 2, the identical harness with
no abort) still enters the host transport exactly once, so the gate did not
merely disable the send branch.

The source was restored from `HEAD` after the control run and the restore
verified by hashing the bytes against the committed object rather than by
reading a diff: the working file's git blob hash and `HEAD`'s blob for that path
both read `e19f173c53f4da288efcde8142758bc23ede7710`, with `git status` clean.
That control run is also the evidence the gate read this worktree: the reverted
source exists nowhere else, and its red names assertions that exist only here.

**Transitive surface.** `issue-phase`, `issue-lock` and `cf-holder` are lexical
locals inside `run-attempt!`; the `:issue/before-send` seam has exactly one
consumer, the test file in this PR (the other `set-test-interleave-hook!`
consumer, `http_abort_retry_race_test.clj`, uses `:retry/*` and `:backoff/*`
points and is green in the full run above). The only reference to
`re-frame.http.transport` outside `implementation/http` source is a prose
comment in `implementation/epoch/src/re_frame/epoch/tool_pair.cljc`.

**Relying on CI** for the heavy lanes, not compiled locally: the CLJS lane
(`npm run test:cljs`) covers the shared CLJC path — `http_cljs_test.cljs`,
`http_reply_lowering_cljs_test.cljc`, the `implementation/resources` CLJS specs
— and the browser/bundle lanes cover the rest. The file was reader-checked under
both `:features #{:clj}` and `:features #{:cljs}` (36 forms, exit 0 each), which
validates the CLJS branch's form structure; its symbols and semantics are
unchanged from the merge base.
