### PR TITLE
docs(story-mcp): make the published MCP-host config actually work (rf2-cfq8a)

### DIFF
--- a/tools/story-mcp/README.md
+++ b/tools/story-mcp/README.md
@@ -108,13 +108,17 @@ Code did set:
             "args": ["-c", "cd \"$CLAUDE_PROJECT_DIR\" && exec clojure -M:story-mcp"]}}}
 ```
 
-On Windows, `cmd` reads the same variable, and `%VAR%` is outside that
-grammar for the same reason (`cd /d` so the drive changes too):
+On Windows `sh` is usually absent; `cmd` reads the same variable, and
+`%VAR%` is outside that grammar for the same reason. Leave
+`%CLAUDE_PROJECT_DIR%` unquoted — hosts spawn the server through Node,
+which escapes an embedded `"` as `\"`, and `cmd` takes that literally
+and fails. `cd` reads to the `&&`, so a project path containing spaces
+is fine without them; use `cd /d` so the drive changes too.
 
 ```json
 {"mcpServers":
  {"story": {"command": "cmd",
-            "args": ["/c", "cd /d \"%CLAUDE_PROJECT_DIR%\" && clojure -M:story-mcp"]}}}
+            "args": ["/c", "cd /d %CLAUDE_PROJECT_DIR% && clojure -M:story-mcp"]}}}
 ```
 
 Cursor puts no project root in the server's environment, but its config

--- a/tools/story-mcp/README.md
+++ b/tools/story-mcp/README.md
@@ -89,28 +89,57 @@ variable:
 
 Claude Code's project-scoped `.mcp.json` and Cursor's
 `.cursor/mcp.json` document no `cwd` field, so there the command itself
-must establish the directory (swap `sh -c` for your shell on Windows).
-Claude Code sets `CLAUDE_PROJECT_DIR` (the project root) in the
-server's environment and expands `${VAR}` in `command`/`args`:
+must establish the directory — and the two hosts hand you the project
+root by different routes.
+
+Claude Code sets `CLAUDE_PROJECT_DIR` to the project root in the
+**spawned server's** environment, and its docs are explicit that this is
+not Claude Code's own environment: a `${VAR}` reference in a
+project-scoped `.mcp.json` therefore needs a `${CLAUDE_PROJECT_DIR:-.}`
+default, and that default resolves to wherever the host launched, not to
+your project. So leave the braces off. `$CLAUDE_PROJECT_DIR` is outside
+the config expander's `${VAR}` / `${VAR:-default}` grammar, so it
+reaches `sh` untouched and `sh` expands it from the environment Claude
+Code did set:
 
 ```json
 {"mcpServers":
  {"story": {"command": "sh",
-            "args": ["-c", "cd \"${CLAUDE_PROJECT_DIR}\" && exec clojure -M:story-mcp"]}}}
+            "args": ["-c", "cd \"$CLAUDE_PROJECT_DIR\" && exec clojure -M:story-mcp"]}}}
 ```
 
-Cursor documents no equivalent project-root variable (entries carry
-only `command`/`args`/`env`/`envFile`), so write the absolute project
-path into that `cd` yourself. From any other working directory
-`clojure` cannot see your project's deps.edn — neither the alias nor
-your stories are reachable.
+On Windows, `cmd` reads the same variable, and `%VAR%` is outside that
+grammar for the same reason (`cd /d` so the drive changes too):
+
+```json
+{"mcpServers":
+ {"story": {"command": "cmd",
+            "args": ["/c", "cd /d \"%CLAUDE_PROJECT_DIR%\" && clojure -M:story-mcp"]}}}
+```
+
+Cursor puts no project root in the server's environment, but its config
+expander does substitute `${workspaceFolder}` — the folder holding
+`.cursor/mcp.json` — in `args`. There the braces are right: Cursor
+replaces the variable before `sh` ever runs, so the same entry works
+with `${workspaceFolder}` in place of `$CLAUDE_PROJECT_DIR`.
+
+From any other working directory `clojure` cannot see your project's
+deps.edn — neither the alias nor your stories are reachable.
 
 Repeat the `-e` form (or require several namespaces in one) as needed;
-init-opts run in command order. Add `--allow-writes` to the host's
-`args` only when you want the author/refine loop. A missing or throwing
-namespace aborts the launch loudly — the ordinary `require` failure on
-stderr and a non-zero exit — so the server never comes up over a
-silently empty project registry.
+init-opts run in command order. A missing or throwing namespace aborts
+the launch loudly — the ordinary `require` failure on stderr and a
+non-zero exit — so the server never comes up over a silently empty
+project registry.
+
+Add `--allow-writes` only when you want the author/refine loop, and add
+it where the server's own argv is. In the VS Code entry that is the
+`args` array, after `-M:story-mcp`. In a shell-wrapper entry it is
+**inside the command string** — `... && exec clojure -M:story-mcp
+--allow-writes`. A further array element after a `sh -c` script becomes
+the shell's `$0`, not an argument to anything the script runs, so a
+flag parked there is dropped without a word and the server comes up
+read-only.
 
 Two rules the required namespaces must obey:
 


### PR DESCRIPTION
Second audit residual on rf2-cfq8a (first fix #8810, second #8850). The audit of
#8850 reopened the bead on two claims about `tools/story-mcp/README.md`'s
MCP-host section. Both hold. Documentation only — no server flag, discovery
layer, wrapper namespace or test framework.

## Claim 1 — `${CLAUDE_PROJECT_DIR}` is not available to the config expander

Confirmed by reading Claude Code's own MCP reference
(https://code.claude.com/docs/en/mcp), not from memory. It separates the phases
verbatim:

> This variable is set in the server's environment, not in Claude Code's own
> environment, so referencing it via `${VAR}` expansion in the `command` or
> `args` of a project-scoped `.mcp.json` entry [...] requires a default such as
> `${CLAUDE_PROJECT_DIR:-.}`.

So the README's "expands `${VAR}` in `command`/`args`" joined two true
statements into a false conjunction. The documented remedy does not rescue it
either: `${CLAUDE_PROJECT_DIR:-.}` resolves to the host's launch directory, not
the project root, which is the one property the entry exists to establish. And
the page's missing-variable behaviour — load anyway, warn in `claude mcp list`,
pass the unexpanded `${VAR}` through — is exactly the parser-version behaviour
the audit said not to lean on.

The fix is the audit's: drop the braces. `$CLAUDE_PROJECT_DIR` is outside the
expander's documented `${VAR}` / `${VAR:-default}` grammar, so it reaches `sh`
untouched, and `sh` expands it from the environment Claude Code does set.

## Claim 2 — `--allow-writes` in the host's `args` never reaches the server

Confirmed by measurement, not by reading:

```
$ sh -c 'echo "0=[$0] 1=[$1] count=$#"' a b
0=[a] 1=[b] count=1

$ sh -c 'cd /tmp && exec printf "argv-of-inner: %s\n" "-M:story-mcp"' --allow-writes
argv-of-inner: -M:story-mcp
```

The first element after a `sh -c` script becomes `$0`, so with the wrapper entry
the flag lands in `$0` (`$#` is 0) and the inner `exec` sees argv of exactly
`-M:story-mcp`. Story-MCP would come up read-only with no diagnostic. The
instruction now says where the server's own argv is per entry shape: the `args`
array for the direct VS Code `clojure` command, inside the command string for a
shell wrapper.

## Two further findings, beyond the audit's two claims

**The Cursor sentence was stale.** It said Cursor "documents no equivalent
project-root variable (entries carry only `command`/`args`/`env`/`envFile`), so
write the absolute project path into that `cd` yourself". Cursor's own docs
list `${workspaceFolder}` — "project root (the folder that contains
`.cursor/mcp.json`)" — expandable in `args`. No hand-written absolute path is
needed, and there the braces *are* correct, because Cursor's expander does
substitute it. Corrected.

**The Windows form I first wrote was broken.** The audit asked for one, and the
obvious `cmd /c "cd /d \"%CLAUDE_PROJECT_DIR%\" && ..."` fails. Measured by
spawning the documented `command`/`args` exactly as a host does (Node
`child_process`, no shell), from a cwd that is not the project root:

| form | plain path | path with a space |
|---|---|---|
| `cd /d "%CLAUDE_PROJECT_DIR%"` (quoted) | exit 1 | exit 1 |
| `cd /d %CLAUDE_PROJECT_DIR%` (unquoted) | exit 0, lands on project root | exit 0, lands on project root |

Node escapes an embedded `"` as `\"` per the CRT convention and `cmd.exe` takes
the backslash literally — "The filename, directory name, or volume label syntax
is incorrect." Unquoted works even with spaces, because cmd's `cd` reads to the
`&&` rather than to the first space. The README states that at the block so the
quotes do not get helpfully restored later. (`where sh` also exits 1 outside Git
Bash, which is why a Windows form is worth carrying at all.)

## Witness alignment

`tools/mcp-conformance/test/end-to-end-project-stories.cjs` needs no change. Its
comment already states the same property generically — "`cwd` pins the fixture
project root — the explicit working-directory property the README's host entries
establish (a `cwd` field, or a command-established directory)" — which is exactly
what each corrected entry now does. Not touched.

`tools/story-mcp/spec/**` needs no change either: its `--allow-writes` mentions
are all gate semantics (CLI flag, sysprop, config atom), none repeats the
host-config claim. Checked with a search whose control returned 17 hits on the
README.

## Quality gates

`python scripts/check_readme_links.py --ci` — the gate for a README beside
source. `tools/story-mcp/README.md` is on its roster; `check_doc_slugs.py` is
not nominated (this file is outside its roots) and `mkdocs build --strict` is
not either (`docs_dir` is `docs`, so `tools/**` was never a candidate).

| run | captured exit |
|---|---|
| baseline, post-edit | `0` (silent on success) |
| planted broken link | `1` |
| after restore | `0` |
| final tree | `0` |

The planted fault is the control: a broken target added to a line of my own new
prose. The gate went red naming it exactly —

```
1 broken target file(s) in README / repo-root markdown links:
  BROKEN TARGET: tools\story-mcp\README.md:126 -> ./no-such-file-mcp-host-cfg.md
      (missing: tools\story-mcp\no-such-file-mcp-host-cfg.md)
```

— which also proves the run read this worktree, since the plant existed nowhere
else. Restore verified by git blob hash against the committed object
(`771bf733384a5554fb79f5efc0be0d3d7da46614`), not by reading a diff. Edits were
committed before planting, so the restore could not discard them.

### Verified by hand, because neither gate reads inside a fence

The entire deliverable is fenced JSON, which both link gates strip before
reading a single link — so their green says nothing about it.

- All three ```json blocks parse (`JSON.parse`, and independently `json.loads`).
- Each host entry was **executed** as spawned from the README: parse the block,
  take its `command`/`args`, swap only the final `clojure -M:story-mcp` for a cwd
  probe, and spawn from a directory that is not the project root. The `sh` entry
  and the `cmd` entry both land on the project root; the `cmd` entry was checked
  against a path containing a space as well.
- The `sh -c` positional behaviour under Claim 2 was demonstrated, not asserted.

Prose, tables and rendering are ungated here, so I checked the table column
counts and heading anchors in this change by hand.

Closes rf2-cfq8a.
