### PR TITLE
fix(flows): attribute an output-path write failure to the write, not to :derive (rf2-gpj9r)

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1870,11 +1870,22 @@
   previously the failing flow id lived ONLY inside the thrown ex-data
   (`:rf.flow/failed-id`), unreachable once `:exception` is stripped. The id is
   read back off that ex-data (nil-safe: absent for a non-per-flow throw, in
-  which case only `:where` is stamped)."
+  which case only `:where` is stamped).
+
+  The record also carries the failing `:phase` (rf2-gpj9r) — `:derive` when the
+  application's callback threw, `:output-write` when it RETURNED and the
+  framework's install of that value at the flow's declared `:output-path`
+  threw. `evaluate-flow!` discriminates the two structurally (separate `try`
+  forms, not exception-message inspection) and stamps the phase into the thrown
+  ex-data; without it on axis 1 a production monitor reads an output-write
+  failure as the programmer's `:derive` fn throwing and sends them to code that
+  did not fail. Nil-safe on the same terms as `:flow-id`."
   [e event event-id frame start-ms]
   (let [end-ms     (interop/now-ms)
         elapsed-ms (elapsed-ms-from start-ms end-ms)
-        failed-id  (:rf.flow/failed-id (ex-data e))]
+        data       (ex-data e)
+        failed-id  (:rf.flow/failed-id data)
+        phase      (:rf.flow/failed-phase data)]
     ;; Fan out along BOTH channels (shared helper). Axis 1 — the
     ;; always-on corpus-wide listener fires in CLJS production where
     ;; the trace surface (axis 2) is compile-time elided.
@@ -1884,7 +1895,8 @@
       {:frame frame :event event :exception e}
       ;; axis-1 attribution that survives an `:exception`-dropping egress
       (cond-> {:where :flow-eval}
-        (some? failed-id) (assoc :flow-id failed-id)))))
+        (some? failed-id) (assoc :flow-id failed-id)
+        (some? phase)     (assoc :phase phase)))))
 
 (defn- emit-legacy-runtime-root!
   "Surface `:rf.error/legacy-runtime-root` through BOTH the always-on

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -264,9 +264,10 @@
                 (let [new-output      (::output derived)
                       flow-elapsed-ms (when interop/debug-enabled?
                                         (- (interop/now-ms) t0))
-                      old-output (when interop/debug-enabled?
-                                   (get-in db (:output-path flow)))
-                      new-db     (assoc-in db (:output-path flow) new-output)]
+                      old-output      (when interop/debug-enabled?
+                                        (get-in db (:output-path flow)))
+                      new-db          (assoc-in db (:output-path flow)
+                                                new-output)]
                   (registry/pass-set-flow-last-inputs!
                     pass flow-id new-inputs)
                   (when interop/debug-enabled?

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -145,12 +145,80 @@
                       (live?))))))))
         true))))
 
+(defn- flow-eval-failure!
+  "Report one flow-evaluation failure, attributed to the phase that actually
+  threw, and re-raise it for the router.
+
+  `phase` is `:derive` when the authored `:derive` callback threw, and
+  `:output-write` when `:derive` RETURNED and the framework's own installation
+  of that value at the flow's declared `:output-path` threw — most often
+  because the pending app-db holds a container at that path which cannot accept
+  the path's final segment (a keyword segment over a vector, say).
+
+  The two are discriminated STRUCTURALLY, by which `try` in `evaluate-flow!`
+  caught the throw — never by reading the exception's message. The callback and
+  the install sit in separate `try` forms, so an install failure cannot reach
+  the derive handler and be reported as authored code failing.
+
+  Returns `stale-incarnation` when the owning incarnation died during the
+  callback: a callback may destroy A and then throw, and terminal loss wins —
+  the old callback's exception produces no B-attributed failure. Otherwise
+  emits the per-flow `:rf.flow/failed` trace and throws the aggregate
+  `:rf.error/flow-eval-exception`, carrying the phase on BOTH the dev trace and
+  the thrown ex-data so the router can lift it onto the always-on production
+  error record."
+  [frame-id owner-token exact-owner? flow new-inputs phase e]
+  (if-not (owner-live? frame-id owner-token exact-owner?)
+    stale-incarnation
+    (let [flow-id     (:id flow)
+          output-path (:output-path flow)]
+      (when interop/debug-enabled?
+        (trace/emit! :flow :rf.flow/failed
+                     {:flow-id           flow-id
+                      :phase             phase
+                      :path              output-path
+                      :exception-message #?(:clj (.getMessage ^Throwable e)
+                                            :cljs (.-message e))
+                      :exception-data    (ex-data e)
+                      :inputs            (elide-inputs frame-id flow new-inputs)
+                      :frame             frame-id}))
+      (if-not (owner-live? frame-id owner-token exact-owner?)
+        stale-incarnation
+        (error/throw-error!
+          :rf.error/flow-eval-exception
+          'rf/run-flows-on-db
+          (if (= :derive phase)
+            (str "a flow's :derive fn threw while recomputing flow "
+                 (pr-str flow-id)
+                 " during the drain; the event aborts before the :db install "
+                 "(no partial commit, app-db unchanged) and the flow "
+                 "re-attempts on the next drain. Fix the :derive fn so it "
+                 "does not throw on the inputs it is given.")
+            (str "flow " (pr-str flow-id)
+                 "'s :derive fn RETURNED normally, but re-frame could not "
+                 "install that value at the flow's declared :output-path "
+                 (pr-str output-path)
+                 " — the pending app-db holds a container at that path which "
+                 "cannot accept it. The :derive fn did not throw; the failure "
+                 "is the framework's output write. The event aborts before the "
+                 ":db install (no partial commit, app-db unchanged) and the "
+                 "flow re-attempts on the next drain. Fix the :output-path, or "
+                 "the shape the app-db holds at its parent path — do not go "
+                 "looking in the :derive fn."))
+          {:recovery :no-recovery
+           :extra    {:rf.flow/failed-id    flow-id
+                      :rf.flow/failed-phase phase
+                      :rf.flow/output-path  output-path
+                      :cause                e}})))))
+
 (defn- evaluate-flow!
   "Evaluate one flow against the pending frame-state.
 
-  Returns `[db dirty?]`. A thrown derivation is rethrown with the failing flow
-  id for router attribution; `run-flows-on-db` restores dirty-check state and
-  the router discards the pending db, so no partial output is committed.
+  Returns `[db dirty?]`. A failure is rethrown with the failing flow id AND the
+  failing PHASE for router attribution — `:derive` for the authored callback,
+  `:output-write` for the framework's install of its returned value (see
+  [[flow-eval-failure!]]); `run-flows-on-db` restores dirty-check state and the
+  router discards the pending db, so no partial output is committed either way.
 
   Trace payloads and their elision walks stay inside `debug-enabled?` branches
   so Closure removes them from production CLJS builds."
@@ -173,71 +241,59 @@
           (if (owner-live? frame-id owner-token exact-owner?)
             [db false]
             stale-incarnation))
-        (try
-          (let [t0         (when interop/debug-enabled? (interop/now-ms))
-                new-output (apply (:derive flow) new-inputs)]
+        ;; The authored `:derive` callback and the framework's own output
+        ;; installation are caught by SEPARATE `try` forms.  The split is the
+        ;; whole attribution mechanism: an `assoc-in` that cannot write the
+        ;; declared `:output-path` into the pending app-db is structurally
+        ;; unreachable from the derive handler, so it can never be reported as
+        ;; the programmer's `:derive` fn throwing (rf2-gpj9r).
+        (let [t0      (when interop/debug-enabled? (interop/now-ms))
+              derived (try
+                        {::output (apply (:derive flow) new-inputs)}
+                        (catch #?(:clj Throwable :cljs :default) e
+                          {::thrown e}))]
+          (if (contains? derived ::thrown)
+            (flow-eval-failure! frame-id owner-token exact-owner?
+                                flow new-inputs :derive (::thrown derived))
             ;; `:derive` is the principal authored callback boundary.  Its
             ;; value is inert once A loses ownership; no cache write, trace,
             ;; validation or later flow may be attributed to B.
             (if-not (owner-live? frame-id owner-token exact-owner?)
               stale-incarnation
-              (let [flow-elapsed-ms (when interop/debug-enabled?
-                                      (- (interop/now-ms) t0))
-                    old-output (when interop/debug-enabled?
-                                 (get-in db (:output-path flow)))
-                    new-db     (assoc-in db (:output-path flow) new-output)]
-                (registry/pass-set-flow-last-inputs!
-                  pass flow-id new-inputs)
-                (when interop/debug-enabled?
-                  (trace/emit! :flow :rf.flow/computed
-                               {:flow-id      flow-id
-                                :input-values (elide-inputs frame-id flow new-inputs)
-                                :before       (elision/elide-wire-value
-                                                old-output
-                                                {:frame frame-id
-                                                 :path (:output-path flow)})
-                                :result       (elision/elide-wire-value
-                                                new-output
-                                                {:frame frame-id
-                                                 :path (:output-path flow)})
-                                :path         (:output-path flow)
-                                :elapsed-ms   flow-elapsed-ms
-                                :frame        frame-id}))
-                (if-not (owner-live? frame-id owner-token exact-owner?)
-                  stale-incarnation
-                  (if (or (not interop/debug-enabled?)
-                          (validate-output! frame-id owner-token exact-owner?
-                                            flow new-output))
-                    [new-db true]
-                    stale-incarnation)))))
-          (catch #?(:clj Throwable :cljs :default) e
-            ;; A callback may destroy A and then throw.  Terminal loss wins:
-            ;; the old callback's exception produces no B-attributed failure.
-            (if-not (owner-live? frame-id owner-token exact-owner?)
-              stale-incarnation
-              (do
-                (when interop/debug-enabled?
-                  (trace/emit! :flow :rf.flow/failed
-                               {:flow-id           flow-id
-                                :exception-message #?(:clj (.getMessage ^Throwable e)
-                                                      :cljs (.-message e))
-                                :exception-data    (ex-data e)
-                                :inputs            (elide-inputs frame-id flow new-inputs)
-                                :frame             frame-id}))
-                (if-not (owner-live? frame-id owner-token exact-owner?)
-                  stale-incarnation
-                  (error/throw-error!
-                    :rf.error/flow-eval-exception
-                    'rf/run-flows-on-db
-                    (str "a flow's :derive fn threw while recomputing flow "
-                         (pr-str flow-id)
-                         " during the drain; the event aborts before the :db install "
-                         "(no partial commit, app-db unchanged) and the flow "
-                         "re-attempts on the next drain. Fix the :derive fn so it "
-                         "does not throw on the inputs it is given.")
-                    {:recovery :no-recovery
-                     :extra    {:rf.flow/failed-id flow-id
-                                :cause             e}}))))))))))
+              (try
+                (let [new-output      (::output derived)
+                      flow-elapsed-ms (when interop/debug-enabled?
+                                        (- (interop/now-ms) t0))
+                      old-output (when interop/debug-enabled?
+                                   (get-in db (:output-path flow)))
+                      new-db     (assoc-in db (:output-path flow) new-output)]
+                  (registry/pass-set-flow-last-inputs!
+                    pass flow-id new-inputs)
+                  (when interop/debug-enabled?
+                    (trace/emit! :flow :rf.flow/computed
+                                 {:flow-id      flow-id
+                                  :input-values (elide-inputs frame-id flow new-inputs)
+                                  :before       (elision/elide-wire-value
+                                                  old-output
+                                                  {:frame frame-id
+                                                   :path (:output-path flow)})
+                                  :result       (elision/elide-wire-value
+                                                  new-output
+                                                  {:frame frame-id
+                                                   :path (:output-path flow)})
+                                  :path         (:output-path flow)
+                                  :elapsed-ms   flow-elapsed-ms
+                                  :frame        frame-id}))
+                  (if-not (owner-live? frame-id owner-token exact-owner?)
+                    stale-incarnation
+                    (if (or (not interop/debug-enabled?)
+                            (validate-output! frame-id owner-token exact-owner?
+                                              flow new-output))
+                      [new-db true]
+                      stale-incarnation)))
+                (catch #?(:clj Throwable :cljs :default) e
+                  (flow-eval-failure! frame-id owner-token exact-owner?
+                                      flow new-inputs :output-write e))))))))))
 
 (defn- run-flows-on-db*
   [frame-id db runtime-db owner-token exact-owner?]

--- a/implementation/flows/test/re_frame/flows_output_write_attribution_cljs_test.cljc
+++ b/implementation/flows/test/re_frame/flows_output_write_attribution_cljs_test.cljc
@@ -1,0 +1,268 @@
+(ns re-frame.flows-output-write-attribution-cljs-test
+  "rf2-gpj9r — a flow's output-path WRITE failure is attributed to the write,
+  not to the application's `:derive` fn.
+
+  `evaluate-flow!` used to wrap the whole recompute-and-install block in ONE
+  `try`, so a `:derive` fn that returned perfectly good value could still be
+  blamed for a throw raised afterwards by the framework's own
+  `(assoc-in db (:output-path flow) new-output)`. Both the dev-only
+  `:rf.flow/failed` trace and the always-on production error record said \"a
+  flow's :derive fn threw\" and \"Fix the :derive fn\" — sending the programmer
+  to code that ran to completion, and concealing the output-path / container
+  mismatch that actually aborted the event.
+
+  The repair is STRUCTURAL rather than message-sniffing: the authored callback
+  and the framework install now sit in separate `try` forms, so an install
+  failure is unreachable from the derive handler. The phase (`:derive` /
+  `:output-write`) rides the `:rf.flow/failed` trace, the thrown ex-data
+  (`:rf.flow/failed-phase`, `:rf.flow/output-path`) and — via the router's
+  `emit-flow-eval-exception!` — the always-on error record's `:phase` slot, so
+  a production monitor sees the honest attribution too.
+
+  This file is `*-cljs-test.cljc` so the shadow-cljs `:node-test` build
+  (ns-regexp `cljs-test$`) discovers it AND the JVM runner runs it: `assoc` on
+  a vector with a keyword key throws on BOTH hosts (`IllegalArgumentException`
+  \"Key must be integer\" on the JVM; `js/Error` \"Vector's key for assoc must
+  be a number.\" on CLJS), so one fixture exercises the boundary on both."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   [re-frame.trace :as trace]
+   [re-frame.test-support :as test-support]
+   #?(:clj  [re-frame.substrate.plain-atom :as substrate]
+      :cljs [re-frame.adapter.reagent :as substrate])))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter substrate/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; Recorders.  The reset fixture clears both registries between tests, so each
+;; test's recorders start empty and need no teardown.
+;; ---------------------------------------------------------------------------
+
+(defn- record-flow-traces!
+  "Capture every `:flow`-op-type trace event into `sink`."
+  [sink]
+  (trace/register-listener!
+    ::flow-trace-recorder
+    (fn [ev]
+      (when (= :flow (:op-type ev))
+        (swap! sink conj ev)))))
+
+(defn- record-errors!
+  "Capture every always-on error-emit record into `sink`.  This is the
+  PRODUCTION-surviving axis — it fires under CLJS `:advanced` +
+  `goog.DEBUG=false`, where the trace surface above is compile-time elided —
+  so asserting it is what stops production attribution silently staying wrong."
+  [sink]
+  (rf/register-listener! :errors ::error-recorder
+                         (fn [record] (swap! sink conj record))))
+
+(defn- by-op [events op]
+  (filterv #(= op (:operation %)) events))
+
+;; The scenario the bead specifies: app-db holds a VECTOR at `[:items]`, and a
+;; flow declares the leaf `[:items :total]`.  Every segment is legal, so
+;; registration correctly accepts it (it cannot prove the shape of a future
+;; pending app-db); the mismatch only bites at install time.
+(def ^:private output-path [:items :total])
+
+(defn- seed!
+  "Install `{:source 1 :items <items>}` with no flow registered yet, so the
+  first flow evaluation happens on the LATER `:bump` drain."
+  [items]
+  (rf/reg-event :init (fn [_ _] {:db {:source 1 :items items}}))
+  (rf/reg-event :bump (fn [{:keys [db]} _] {:db (assoc db :source 2)}))
+  (rf/dispatch-sync [:init]))
+
+;; ---------------------------------------------------------------------------
+;; 1. The repro: derive RETURNS, the output write throws.
+;; ---------------------------------------------------------------------------
+
+(deftest output-write-failure-is-attributed-to-the-write-not-to-derive
+  (testing "rf2-gpj9r — a successful :derive followed by a failing output
+            install reports phase :output-write on both the dev trace and the
+            always-on error record, and never advises fixing :derive"
+    (let [traces (atom [])
+          errors (atom [])
+          calls  (atom 0)]
+      (record-flow-traces! traces)
+      (record-errors! errors)
+      (seed! [])
+      (rf/reg-flow :flow/output-write
+                   {:inputs [[:source]] :output-path output-path}
+                   (fn [_source] (swap! calls inc) 42))
+      (let [before (rf/app-db-value :rf/default)]
+        (rf/dispatch-sync [:bump])
+
+        ;; --- non-vacuity: derive really ran, and really returned -----------
+        (is (= 1 @calls)
+            "the :derive fn was called exactly once and RETURNED — the failure
+             is not a derive throw, and this counter is what makes every
+             assertion below non-vacuous")
+
+        ;; --- atomicity is untouched ---------------------------------------
+        (is (= before (rf/app-db-value :rf/default))
+            "the event aborted before the :db install — app-db is unchanged
+             (the :bump handler's own write did not land either)")
+
+        ;; --- the dev-only per-flow trace ----------------------------------
+        (let [failed (last (by-op @traces :rf.flow/failed))
+              tags   (:tags failed)]
+          (is (some? failed) ":rf.flow/failed fired for the failing flow")
+          (is (= :flow/output-write (:flow-id tags))
+              "the trace attributes the failure to the right flow")
+          (is (= :output-write (:phase tags))
+              "the trace names the phase that ACTUALLY threw — the framework's
+               output write, not the application's :derive fn")
+          (is (= output-path (:path tags))
+              "the structural output path rides the trace, so the programmer
+               can see which declared path could not be written")
+          (is (= :rf/default (:frame tags))
+              "frame attribution is preserved"))
+
+        ;; --- the always-on production error record ------------------------
+        (is (= 1 (count @errors))
+            "exactly one always-on record fired for one flow-eval failure")
+        (let [r (first @errors)]
+          (is (= :rf.error/flow-eval-exception (:error r))
+              ":rf.error/flow-eval-exception remains the aggregate
+               flow-evaluation category — no new public error id")
+          (is (= :flow-eval (:where r)) ":where still discriminates the path")
+          (is (= :flow/output-write (:flow-id r))
+              "flow attribution rides the production record")
+          (is (= :output-write (:phase r))
+              "the PHASE rides the production record too — an off-box monitor
+               reading this in an :advanced build is told the output write
+               failed, not that the application's :derive fn threw")
+          ;; The attribution must survive an egress profile that strips
+          ;; :exception, exactly as :where / :flow-id already do.
+          (let [public (dissoc r :exception)]
+            (is (= :output-write (:phase public))
+                ":phase survives an :exception-dropping egress profile")))
+
+        ;; --- the thrown diagnostic ----------------------------------------
+        (let [thrown (:exception (first @errors))
+              data   (ex-data thrown)
+              msg    (ex-message thrown)]
+          (is (= :flow/output-write (:rf.flow/failed-id data))
+              "the existing flow-attribution slot is unchanged")
+          (is (= :output-write (:rf.flow/failed-phase data))
+              "the phase is machine-readable off the thrown ex-data")
+          (is (= output-path (:rf.flow/output-path data))
+              "the declared output path is machine-readable off the ex-data")
+          (is (some? (:cause data))
+              "the original install exception is preserved under :cause")
+          ;; The whole point of the bead: the human sentence must not send the
+          ;; programmer to working code.
+          (is (nil? (re-find #":derive fn threw" msg))
+              "the message does not CLAIM the :derive fn threw")
+          (is (nil? (re-find #"Fix the :derive fn" msg))
+              "the message does not ADVISE fixing the :derive fn")
+          (is (some? (re-find #":output-path" msg))
+              "the message names the output write as the failing phase")
+          (is (some? (re-find (re-pattern (pr-str output-path)) msg))
+              "the message quotes the declared output path that could not be
+               written"))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. Negative control: :derive itself throws, BEFORE any output install.
+;;    The pre-existing contract must be untouched — same error id, same
+;;    message, flow attribution, atomic abort — now with phase :derive and no
+;;    output-write attribution anywhere.
+;; ---------------------------------------------------------------------------
+
+(deftest derive-throw-still-reports-phase-derive
+  (testing "rf2-gpj9r negative control — when :derive itself throws, the
+            existing :rf.error/flow-eval-exception contract still holds and the
+            phase is :derive"
+    (let [traces (atom [])
+          errors (atom [])]
+      (record-flow-traces! traces)
+      (record-errors! errors)
+      (seed! {})
+      (rf/reg-flow :flow/derive-throws
+                   {:inputs [[:source]] :output-path output-path}
+                   (fn [_source] (throw (ex-info "derive boom" {:why :test}))))
+      (let [before (rf/app-db-value :rf/default)]
+        (rf/dispatch-sync [:bump])
+
+        (is (= before (rf/app-db-value :rf/default))
+            "atomic abort is unchanged for a derive throw")
+
+        (let [tags (:tags (last (by-op @traces :rf.flow/failed)))]
+          (is (= :flow/derive-throws (:flow-id tags)) "flow attribution")
+          (is (= :derive (:phase tags))
+              "the trace names :derive — the authored callback really did throw")
+          (is (= "derive boom" (:exception-message tags))
+              "the structured exception summary is unchanged")
+          (is (= {:why :test} (:exception-data tags))
+              "the ex-data summary is unchanged"))
+
+        (is (= 1 (count @errors)) "one always-on record")
+        (let [r      (first @errors)
+              data   (ex-data (:exception r))
+              msg    (ex-message (:exception r))]
+          (is (= :rf.error/flow-eval-exception (:error r))
+              "the same aggregate category")
+          (is (= :flow/derive-throws (:flow-id r)) "flow attribution")
+          (is (= :derive (:phase r)) "the production record names :derive")
+          (is (= :flow/derive-throws (:rf.flow/failed-id data))
+              "the ex-data attribution slot is unchanged")
+          (is (= :derive (:rf.flow/failed-phase data))
+              "the ex-data phase is :derive")
+          (is (= :no-recovery (:recovery data))
+              "the catalogued disposition is unchanged")
+          ;; The pre-existing derive-throw wording is preserved verbatim.
+          (is (some? (re-find #":derive fn threw" msg))
+              "the derive-throw message is unchanged — it still says the
+               :derive fn threw, because here it did")
+          (is (some? (re-find #"Fix the :derive fn" msg))
+              "and still advises fixing it")
+          (is (nil? (re-find #"output-write" msg))
+              "no output-write attribution leaks onto a genuine derive throw"))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. Positive control: the SAME derive and the SAME output path, over a MAP at
+;;    `[:items]`.  Nothing about the repair may make a legal write fail.
+;; ---------------------------------------------------------------------------
+
+(deftest legal-output-write-commits-and-emits-no-failure
+  (testing "rf2-gpj9r positive control — the same [:items :total] output path
+            over a map commits, advances dirty-check state, and emits no
+            failure on either axis"
+    (let [traces (atom [])
+          errors (atom [])
+          calls  (atom 0)]
+      (record-flow-traces! traces)
+      (record-errors! errors)
+      (seed! {})
+      (rf/reg-flow :flow/output-write
+                   {:inputs [[:source]] :output-path output-path}
+                   (fn [_source] (swap! calls inc) 42))
+      (rf/dispatch-sync [:bump])
+
+      (is (= 1 @calls) ":derive ran once")
+      (is (= 42 (get-in (rf/app-db-value :rf/default) output-path))
+          "the derived value COMMITTED at the declared output path")
+      (is (= 2 (:source (rf/app-db-value :rf/default)))
+          "the handler's own :db write committed alongside it")
+      (is (empty? (by-op @traces :rf.flow/failed))
+          "no :rf.flow/failed trace")
+      (is (empty? @errors)
+          "no always-on error record")
+      (is (seq (by-op @traces :rf.flow/computed))
+          ":rf.flow/computed fired for the successful evaluation")
+
+      ;; Dirty-check state advanced: a second drain that leaves the flow's
+      ;; inputs value-equal SKIPS the recompute rather than re-running it.
+      (reset! traces [])
+      (rf/dispatch-sync [:bump])
+      (is (= 1 @calls)
+          ":derive was NOT re-run — last-inputs was recorded by the successful
+           install, so the value-equal input short-circuits")
+      (let [skip (last (by-op @traces :rf.flow/skip))]
+        (is (some? skip) ":rf.flow/skip fired on the second drain")
+        (is (= :inputs-value-equal (:reason (:tags skip)))
+            "the skip is the dirty-check short-circuit")))))

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -537,12 +537,20 @@
         (is (= :boom (:flow-id r))
             ":flow-id is the failing flow's id — the prod-surviving attribution
              (Spec 013:234), lifted out of the thrown ex-data")
+        ;; rf2-gpj9r: and the PHASE that actually threw. Here the authored
+        ;; `:derive` really did throw, so the honest phase is `:derive`; an
+        ;; output-path write failure after a successful derive reports
+        ;; `:output-write` instead (see
+        ;; `re-frame.flows-output-write-attribution-cljs-test`).
+        (is (= :derive (:phase r))
+            ":phase names the failing flow-eval phase — :derive here, because
+             the authored callback is what threw")
         (is (= #{:error :event :event-id :frame :time :exception :elapsed-ms
-                 :source-coord :where :flow-id}
+                 :source-coord :where :flow-id :phase}
                (set (keys r)))
             "record carries the tight rf2-bacs4 keys plus rf2-3un2g
              :source-coord plus the rf2-z1332c flow attribution
-             (:where / :flow-id)")
+             (:where / :flow-id) plus the rf2-gpj9r :phase")
         ;; The attribution must survive an egress profile that strips
         ;; :exception (015 public-error): the failing flow is still
         ;; identifiable WITHOUT reaching into (ex-data (:exception r)).


### PR DESCRIPTION
Closes rf2-gpj9r.

## The bug

`evaluate-flow!` opened **one** `try` before `(apply (:derive flow) new-inputs)` and closed it after the output install, the dirty-cache write, the debug trace and schema observation. So a `:derive` fn that returned a perfectly good value was still blamed when the framework's own `(assoc-in db (:output-path flow) new-output)` threw — the common cause being a pending app-db holding a container at that path which cannot accept the path's final segment (a keyword segment over a vector, say; `assoc` on a vector with a keyword key throws on both hosts).

Both the dev-only `:rf.flow/failed` trace and the always-on production error record then said *"a flow's :derive fn threw"* and *"Fix the :derive fn"*. That attribution is false, and it costs the programmer real time: it sends them to code that ran to completion and conceals the output-path/container mismatch that actually aborted the event.

## The repair

The discriminator is **where the throw came from**, not what the exception says, so the split is structural rather than a message inspection:

- the authored `:derive` call sits in its own `try`, whose result is a one-key marker map (`::output` / `::thrown`);
- the framework install — `assoc-in`, the `last-inputs` write, the `:rf.flow/computed` trace, schema observation — sits in a second `try`.

An install failure is therefore *unreachable* from the derive handler. A new `flow-eval-failure!` helper takes the phase as an argument and threads it through every surface:

| surface | new attribution |
| --- | --- |
| `:rf.flow/failed` trace tags | `:phase` (`:derive` / `:output-write`) and `:path` (the declared output path, the spelling `:rf.flow/computed` already uses) |
| thrown ex-data | `:rf.flow/failed-phase`, `:rf.flow/output-path` (alongside the existing `:rf.flow/failed-id` / `:cause`) |
| always-on error record | `:phase`, lifted off the ex-data by the router's `emit-flow-eval-exception!` beside the existing `:where` / `:flow-id` |

The `:output-write` message names the output path, states that `:derive` did **not** throw, and points at the path or the shape at its parent instead.

`:rf.error/flow-eval-exception` remains the aggregate flow-evaluation category — no new public error id, per the bead. The derive-throw message is preserved verbatim, and the exact-owner fence, pass-level dirty-cache rollback, path-segment grammar, schema observation and event atomicity are all untouched. Nothing was added to registration-time validation: a legal output path stays legal, because the app-db shape can change before evaluation.

## Was there a test pinning the wrong attribution?

**No.** Searched the tree for a test driving a successful derive followed by an output install throw — there is none (the bead says so too, and it checks out: `flows_vector_parent_vacation_test.clj` covers vector *indices*, which are a legal write, and every other `:rf.flow/failed` test throws from inside `:derive`). So nothing was flipped or renamed.

One existing test was **extended**, not flipped: `flows-trace-test/flow-eval-exception-routes-through-error-emit-substrate` pins the always-on record's exact key set, which now gains `:phase`. Its scenario is a genuine derive throw, so it asserts `:phase :derive` — the same behaviour it always described, now stated explicitly.

## New test

`implementation/flows/test/re_frame/flows_output_write_attribution_cljs_test.cljc` — one `.cljc` file, so the JVM runner (`-test` suffix) and the shadow-cljs `:node-test` build (ns-regexp `cljs-test$`) both run it. Three tests:

1. **The repro.** `{:source 1 :items []}`, flow `:flow/output-write` with input `[:source]` and output path `[:items :total]`, derive counts its calls and returns `42`. One drain. Asserts the counter is exactly `1` (derive ran *and returned* — this is the non-vacuity control), app-db unchanged, then `:phase :output-write` on the trace, on the always-on record (and on the record with `:exception` dissoc'd, the egress-profile case), and on the ex-data; plus the message neither claims nor advises `:derive`.
2. **Negative control.** `:derive` itself throws. Same error id, `:phase :derive` everywhere, the pre-existing wording preserved verbatim, atomic abort, and no `output-write` string anywhere in the message.
3. **Positive control.** The same derive and the same `[:items :total]` path over `:items {}`. Commits `42`, emits no failure on either axis, and a second value-equal drain skips the recompute — proving the successful install advanced the dirty-check state.

## Quality gates

### `clojure -M:test` from `implementation/flows` (foreground, exit captured in the same shell)

```
Ran 244 tests containing 6087 assertions.
0 failures, 0 errors.
```
Captured exit: **0** (the runner's own status, echoed into an exit-code file in the same shell as the run — never a pipeline's, and never a number reported about the run by anything else).

### Non-vacuity control

**The new test fails against the current implementation.** With `implementation/flows/src/re_frame/flows.cljc` and `implementation/core/src/re_frame/router.cljc` checked out at the merge base (`d2688dd381`) and the tests left in place:

```
Ran 244 tests containing 6087 assertions.
14 failures, 0 errors.
```
Captured exit: **1**. Same 244 tests / 6087 assertions as the green run, so nothing was skipped or aborted — every red is a genuine assertion. The failures are exactly the attribution claims, including:

```
FAIL in (output-write-failure-is-attributed-to-the-write-not-to-derive) (...:116)
  the trace names the phase that ACTUALLY threw

FAIL in (output-write-failure-is-attributed-to-the-write-not-to-derive) (...:159)
  the message does not CLAIM the :derive fn threw
  expected: (nil? (re-find #":derive fn threw" msg))
```

That red is also the proof the gate read *this* worktree: the test file exists nowhere else, so a run that had wandered into a sibling checkout would have come back green.

Sources were then restored with `git checkout HEAD --`, verified by **git blob hash** against the committed objects (`c7ef8ad8f79a0eff66b086589d2bd99ba926e1e6` for `flows.cljc`, `ed2cc1706ea3329ee801e4b880cbd9375cbb70ae` for `router.cljc`) rather than by reading a diff — an unapplied patch and an unchanged file produce the same diff.

### Sabotage / restore

**One-line revert of the repair.** `:output-write` → `:derive` at the install `catch`'s call site (anchor match count read as `1` before running anything; the blob hash moved to `44b32d827ffe3a029d0d62504478ae4ac68dc974`, proving the plant applied rather than silently no-opping):

```
Ran 244 tests containing 6087 assertions.
7 failures, 0 errors.
```
Captured exit: **1**. Bounded and discriminating: the same 244/6087 (no namespace aborted), and only the repro test's phase assertions fire — the derive negative control and the legal-write positive control stay green, which is correct, since mis-tagging the output-write path cannot affect either.

Restored and verified by blob hash back to `c7ef8ad8f79a0eff66b086589d2bd99ba926e1e6`, with `git status --porcelain` empty.

### Transitive surface

`implementation/core/src/re_frame/router.cljc`'s `emit-flow-eval-exception!` is the only consumer-side change. The record's key set is pinned in exactly one place tree-wide — `implementation/flows/test/re_frame/flows_trace_test.clj`, updated here (verified with a fixed-string `git grep -F "source-coord :where :flow-id"`, run once against a string known to be present as a control). `error_emit.cljc` merges `record-attrs` as a free-form nil-dropping map under the base observability fields, so an added key needs no change there. `emit-flow-eval-exception!` adds no new error id, so `error_catalogue_channel_conformance_test.clj` (which parses Spec 009's catalogue for channel classification) is unaffected.

### CLJS lane

The `.cljc` source is exercised by the CLJS node-test lane too. That lane is heavy and belongs to CI — **declaring reliance on it here**: the `cljs-*` node-test jobs in `.github/workflows/test.yml` cover `implementation/flows/{src,test}` (both are on the `:node-test` build's source paths in `implementation/shadow-cljs.edn`), and the new test file is named `*_cljs_test.cljc` precisely so that build's `cljs-test$` ns-regexp discovers it. Locally the file was reader-checked under both feature sets; result below.

Both `.cljc` files read cleanly under `#{:clj}` and under `#{:cljs}` (`read` with `:read-cond :allow`), 28 and 10 top-level forms respectively, captured exit **0**. The reader-check was itself exercised once against a file it should flag — an unclosed `#?(:cljs …` — which returned exit **1** with `EOF while reading`, so the clean result is a check that ran rather than an instrument answering "nothing here" because it was misused.

### Spec / docs follow-up (NOT in this PR)

`spec/` is hot-zone and out of this bead's scope, which names only `implementation/flows/**`, the router's consumer-side record and focused tests. Three committed surfaces now understate the contract and want a sequenced follow-up:

- `spec/009-Instrumentation.md` — the `:rf.flow/failed` catalogue row's tag list and the `:rf.error/flow-eval-exception` row's always-on slot list (both now also carry the phase).
- `spec/013-Flows.md` §Failure semantics — describes the failure purely as a `:derive` throw.
- `docs/api/re-frame.flows.md:249,271` and `docs/core/flows.md:286,395` — same.

Filed as **rf2-ywdvp** rather than editing hot-zone files from a worker branch.
