### PR TITLE
fix(docs): the UIx consumer recipe must name com.pitch/uix.dom (rf2-5x1xt)

### DIFF
--- a/docs/core/how-to/use-uix-or-slim.md
+++ b/docs/core/how-to/use-uix-or-slim.md
@@ -74,8 +74,20 @@ A build *may* carry two adapters on its classpath, but `init!` installs exactly 
 | Substrate | Coordinate | View library |
 |---|---|---|
 | Reagent | `day8/re-frame2-reagent` | `reagent` (hiccup) |
-| UIx | `day8/re-frame2-uix` | `com.pitch/uix.core` (UIx 2 publishes as Maven 1.x) |
+| UIx | `day8/re-frame2-uix` | `com.pitch/uix.core` **and** `com.pitch/uix.dom` (UIx 2 publishes as Maven 1.x) |
 | reagent-slim | `day8/reagent-slim` | `reagent2` (ships inside it) |
+
+UIx is the one row that needs two view-library coordinates, and it is worth a sentence because the adapter will not supply the second for you. `day8/re-frame2-uix` depends on `com.pitch/uix.core` — the adapter's own source needs it — but it deliberately does *not* depend on `com.pitch/uix.dom`, because mounting a React root is the application's call, not the adapter's, and a headless or server-side UIx consumer should not pay for it. Every mount you will write from Step 4 on calls `uix.dom/create-root`, so name both, at the same version:
+
+```clojure
+;; deps.edn for a UIx app — the complete recipe.
+{:deps {day8/re-frame2     {:mvn/version "<latest>"}   ; core
+        day8/re-frame2-uix {:mvn/version "<latest>"}   ; the UIx adapter
+        com.pitch/uix.core {:mvn/version "1.4.4"}      ; defui / $ / hooks
+        com.pitch/uix.dom  {:mvn/version "1.4.4"}}}    ; create-root / render-root
+```
+
+`<latest>` is the released `day8/re-frame2` version (every re-frame2 artefact ships in lockstep at that one version); the two `com.pitch` coordinates are third-party and carry their own version, which must match each other. Drop `com.pitch/uix.dom` and everything still *reads* fine right up until the compiler cannot resolve `uix.dom` at your mount.
 
 !!! note "Coordinates are not published yet"
 

--- a/examples/substrates/uix/counter/README.md
+++ b/examples/substrates/uix/counter/README.md
@@ -94,3 +94,25 @@ npm run dev:example -- examples/counter-uix
 
 Edits recompile live; the command prints a local URL to open. Add
 `--no-watch` for a one-shot compile-and-serve.
+
+## Copying this into your own app
+
+The mount at the bottom of [`core.cljs`](core.cljs) calls
+`uix.dom/create-root`, so a standalone consumer needs **both** UIx
+coordinates. `day8/re-frame2-uix` brings `com.pitch/uix.core` with it, but
+never `com.pitch/uix.dom` — mounting a React root is your app's call, not the
+adapter's. The complete recipe:
+
+```clojure
+;; deps.edn
+{:deps {day8/re-frame2     {:mvn/version "<latest>"}
+        day8/re-frame2-uix {:mvn/version "<latest>"}
+        com.pitch/uix.core {:mvn/version "1.4.4"}
+        com.pitch/uix.dom  {:mvn/version "1.4.4"}}}
+```
+
+In this repo the file compiles against the aggregate build, which already
+carries both — which is exactly why the second coordinate is easy to miss on
+the way out. See
+[Use UIx or reagent-slim](../../../../docs/core/how-to/use-uix-or-slim.md#one-adapter-per-build-the-coordinate-table)
+for the recipe in context.

--- a/examples/substrates/uix/dashboard/README.md
+++ b/examples/substrates/uix/dashboard/README.md
@@ -131,6 +131,28 @@ npm run dev:example -- examples/dashboard-uix
 Edits recompile live, and the command prints a local URL to open. Add
 `--no-watch` for a one-shot compile-and-serve.
 
+## Copying this into your own app
+
+The mount at the bottom of [`core.cljs`](core.cljs) calls
+`uix.dom/create-root`, so a standalone consumer needs **both** UIx
+coordinates. `day8/re-frame2-uix` brings `com.pitch/uix.core` with it, but
+never `com.pitch/uix.dom` — mounting a React root is your app's call, not the
+adapter's. The complete recipe:
+
+```clojure
+;; deps.edn
+{:deps {day8/re-frame2     {:mvn/version "<latest>"}
+        day8/re-frame2-uix {:mvn/version "<latest>"}
+        com.pitch/uix.core {:mvn/version "1.4.4"}
+        com.pitch/uix.dom  {:mvn/version "1.4.4"}}}
+```
+
+In this repo the file compiles against the aggregate build, which already
+carries both — which is exactly why the second coordinate is easy to miss on
+the way out. See
+[Use UIx or reagent-slim](../../../../docs/core/how-to/use-uix-or-slim.md#one-adapter-per-build-the-coordinate-table)
+for the recipe in context.
+
 ## Accessibility + responsive — what to copy
 
 This is the UIx example meant to model a polished multi-pane app, so

--- a/examples/substrates/uix/login/README.md
+++ b/examples/substrates/uix/login/README.md
@@ -135,3 +135,25 @@ one-shot compile-and-serve.
 No backend ships. The login runs against the canned HTTP stub in
 [`core.cljs`](core.cljs), so the password `correct-horse` succeeds and anything
 else fails the way the machine expects.
+
+## Copying this into your own app
+
+The mount at the bottom of [`core.cljs`](core.cljs) calls
+`uix.dom/create-root`, so a standalone consumer needs **both** UIx
+coordinates. `day8/re-frame2-uix` brings `com.pitch/uix.core` with it, but
+never `com.pitch/uix.dom` — mounting a React root is your app's call, not the
+adapter's. The complete recipe:
+
+```clojure
+;; deps.edn
+{:deps {day8/re-frame2     {:mvn/version "<latest>"}
+        day8/re-frame2-uix {:mvn/version "<latest>"}
+        com.pitch/uix.core {:mvn/version "1.4.4"}
+        com.pitch/uix.dom  {:mvn/version "1.4.4"}}}
+```
+
+In this repo the file compiles against the aggregate build, which already
+carries both — which is exactly why the second coordinate is easy to miss on
+the way out. See
+[Use UIx or reagent-slim](../../../../docs/core/how-to/use-uix-or-slim.md#one-adapter-per-build-the-coordinate-table)
+for the recipe in context.

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_consumer_deps_recipe_test.clj
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_consumer_deps_recipe_test.clj
@@ -1,0 +1,178 @@
+(ns re-frame.adapter.uix-consumer-deps-recipe-test
+  "The clean-consumer guard for the UIx dependency recipe (rf2-5x1xt).
+
+   `day8/re-frame2-uix` ships `com.pitch/uix.core` and deliberately does NOT
+   ship `com.pitch/uix.dom` — mounting a React root is the application's call,
+   so the DOM half never arrives transitively. Every runnable UIx example
+   nevertheless requires `uix.dom` for its mount, and inside this monorepo they
+   all compile anyway, because the aggregate `implementation/shadow-cljs.edn`
+   build injects both UIx artefacts globally. That ambient dependency is
+   precisely why the per-example compile gate cannot see the omission a
+   standalone consumer hits: it is masked at exactly the layer the consumer
+   does not have.
+
+   So the guard is static rather than a compile. It reads the three example
+   sources, collects every `uix.*` namespace they require, and insists each one
+   has a named owner coordinate in every place the project publishes a UIx
+   dependency recipe — the spec's consumer block, the how-to's coordinate
+   table, and the three example READMEs — all pinned to the one version source,
+   the generator template. Drop `com.pitch/uix.dom` from any of those and this
+   goes red naming the file.
+
+   What this does NOT do is resolve a real classpath. A genuine clean-consumer
+   compile would need its own fixture project, its own Maven resolution and its
+   own build step — a new CI lane, which this bead is not worth. The invariant
+   it can prove cheaply is the one that actually broke: a namespace the copyable
+   mount requires with no consumer coordinate that owns it."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]))
+
+;; ---------------------------------------------------------------------------
+;; Paths, all repo-root-relative.
+
+(def ^:private adapter-deps-path
+  "implementation/adapters/uix/deps.edn")
+
+(def ^:private template-deps-path
+  "The single version source for the UIx pair — the generator template emits a
+   real consumer project, so whatever it pins is what a consumer gets."
+  "tools/template/resources/day8/re_frame2_template/_uix/deps.edn")
+
+(def ^:private example-sources
+  ["examples/substrates/uix/counter/core.cljs"
+   "examples/substrates/uix/login/core.cljs"
+   "examples/substrates/uix/dashboard/core.cljs"])
+
+(def ^:private recipe-pages
+  "Every document that publishes a copyable UIx dependency recipe."
+  ["spec/Conventions.md"
+   "docs/core/how-to/use-uix-or-slim.md"
+   "examples/substrates/uix/counter/README.md"
+   "examples/substrates/uix/login/README.md"
+   "examples/substrates/uix/dashboard/README.md"])
+
+(def ^:private ns->coordinate
+  "Which consumer coordinate owns each `uix.*` namespace. A namespace absent
+   from this map has no known owner, and the test says so rather than passing."
+  {"uix.core" 'com.pitch/uix.core
+   "uix.dom"  'com.pitch/uix.dom})
+
+;; ---------------------------------------------------------------------------
+;; Reading
+
+(defn- repo-root
+  "The nearest ancestor of the working directory carrying `mkdocs.yml`."
+  []
+  (loop [dir (.getAbsoluteFile (io/file (System/getProperty "user.dir")))]
+    (cond
+      (nil? dir)
+      (throw (ex-info "repo root not found: no mkdocs.yml above user.dir"
+                      {:user-dir (System/getProperty "user.dir")}))
+
+      (.exists (io/file dir "mkdocs.yml")) dir
+      :else (recur (.getParentFile dir)))))
+
+(defn- slurp-at [root rel]
+  (let [f (io/file root rel)]
+    (when-not (.exists f)
+      (throw (ex-info (str "missing file: " rel) {:path (str f)})))
+    (slurp f)))
+
+(defn- deps-map
+  "The `:deps` of an EDN deps file — shipping dependencies only, no aliases."
+  [root rel]
+  (-> (slurp-at root rel) edn/read-string :deps))
+
+(defn- required-uix-namespaces
+  "The `uix.*` namespaces `src` requires, as strings. Matches the opening of a
+   `:require` vector, which is how every example spells it:
+   `[uix.dom  :as uix-dom]`."
+  [src]
+  (->> (re-seq #"\[(uix\.[a-zA-Z0-9._-]+)[\s\]]" src)
+       (map second)
+       set))
+
+(defn- recipe-coordinates
+  "Every `com.pitch/uix.<x> {:mvn/version \"v\"}` pair written anywhere in
+   `md`, as `{\"uix.core\" \"1.4.4\", …}`. Deliberately a text scan: these live
+   inside fenced code blocks and markdown tables, which no doc gate reads."
+  [md]
+  (into {}
+        (for [[_ nm v] (re-seq #"com\.pitch/(uix\.[a-z]+)\s+\{:mvn/version\s+\"([^\"]+)\"\}" md)]
+          [nm v])))
+
+;; ---------------------------------------------------------------------------
+;; The premise: uix.dom is not transitive.
+
+(deftest adapter-ships-uix-core-but-not-uix-dom
+  (let [deps (deps-map (repo-root) adapter-deps-path)]
+    (testing "the adapter's shipping :deps carry uix.core"
+      (is (contains? deps 'com.pitch/uix.core)
+          (str adapter-deps-path " no longer ships com.pitch/uix.core.")))
+    (testing "and deliberately do NOT carry uix.dom"
+      ;; If this ever flips, the DOM half became transitive and the recipe
+      ;; assertions below stop being load-bearing — so the guard must be
+      ;; re-thought rather than left standing as a vacuous pass.
+      (is (not (contains? deps 'com.pitch/uix.dom))
+          (str adapter-deps-path " now ships com.pitch/uix.dom. That is a "
+               "deliberate non-goal (rf2-5x1xt); if it was intended, this "
+               "whole guard needs revisiting.")))))
+
+;; ---------------------------------------------------------------------------
+;; Every namespace the copyable mount requires has an owner coordinate.
+
+(deftest every-required-uix-namespace-has-an-owner-coordinate
+  (let [root (repo-root)]
+    (doseq [rel example-sources]
+      (testing rel
+        (let [required (required-uix-namespaces (slurp-at root rel))]
+          ;; Non-vacuity: a scan that found nothing would satisfy the
+          ;; ownership check below in the same voice as a clean file.
+          (testing "the scan has signal — the mount's uix.dom require is seen"
+            (is (contains? required "uix.dom")
+                (str rel " does not appear to require uix.dom. Either the "
+                     "example changed its mount, or the require-scanning "
+                     "regex in this test has gone blind.")))
+          (testing "and every uix.* namespace it requires has a known owner"
+            (is (empty? (remove ns->coordinate required))
+                (str rel " requires " (pr-str (vec (remove ns->coordinate required)))
+                     " — no consumer coordinate in this test owns it. Add the "
+                     "owner to ns->coordinate AND to every recipe in "
+                     (pr-str recipe-pages) "."))))))))
+
+;; ---------------------------------------------------------------------------
+;; Every published recipe names those owners, at the template's version.
+
+(deftest published-recipes-name-both-uix-coordinates-in-lockstep
+  (let [root       (repo-root)
+        template   (deps-map root template-deps-path)
+        core-ver   (get-in template ['com.pitch/uix.core :mvn/version])
+        dom-ver    (get-in template ['com.pitch/uix.dom :mvn/version])
+        ;; The union of owners across all three examples: what a consumer
+        ;; copying any of them must be able to resolve.
+        owners     (->> example-sources
+                        (mapcat #(required-uix-namespaces (slurp-at root %)))
+                        set)]
+    (testing "the template pins both UIx coordinates"
+      (is (some? core-ver) (str template-deps-path " has no com.pitch/uix.core."))
+      (is (some? dom-ver)  (str template-deps-path " has no com.pitch/uix.dom.")))
+    (testing "at the same version — the pair moves in lockstep"
+      (is (= core-ver dom-ver)
+          (str template-deps-path " pins uix.core at " core-ver
+               " and uix.dom at " dom-ver ".")))
+    (doseq [rel recipe-pages]
+      (testing rel
+        (let [found (recipe-coordinates (slurp-at root rel))]
+          (doseq [nm (sort owners)]
+            (testing (str "names com.pitch/" nm)
+              (is (contains? found nm)
+                  (str rel " publishes a UIx dependency recipe that does not "
+                       "name com.pitch/" nm ", but the examples require " nm
+                       ". A consumer copying this recipe cannot resolve it "
+                       "(rf2-5x1xt).")))
+            (testing (str "pins com.pitch/" nm " at the template's version")
+              (is (= core-ver (get found nm))
+                  (str rel " pins com.pitch/" nm " at " (pr-str (get found nm))
+                       " but " template-deps-path " pins " core-ver ".")))))))))

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -1824,9 +1824,14 @@ A consumer picks their substrate by adding the matching adapter alongside the co
 {:deps {day8/re-frame2         {:mvn/version "<latest>"}
         day8/re-frame2-reagent {:mvn/version "<latest>"}}}
 
-;; deps.edn for a UIx app
+;; deps.edn for a UIx app. UIx is third-party, so its two coordinates carry
+;; their own literal version rather than <latest>, and both are named
+;; directly: the adapter ships uix.core, but mounting a React root is the
+;; app's own call, so uix.dom is never transitive.
 {:deps {day8/re-frame2     {:mvn/version "<latest>"}
-        day8/re-frame2-uix {:mvn/version "<latest>"}}}
+        day8/re-frame2-uix {:mvn/version "<latest>"}
+        com.pitch/uix.core {:mvn/version "1.4.4"}
+        com.pitch/uix.dom  {:mvn/version "1.4.4"}}}
 
 ;; deps.edn for a Reagent app that uses Spec 010 schemas
 {:deps {day8/re-frame2         {:mvn/version "<latest>"}


### PR DESCRIPTION
Fixes rf2-5x1xt.

## The bug

Every runnable UIx example mounts through `uix.dom/create-root` / `render-root`, but the published downstream recipe named only `day8/re-frame2` and `day8/re-frame2-uix`, and the adapter deliberately keeps `com.pitch/uix.dom` out of its shipping `:deps` — it sits under the `:test` alias, with a comment saying so. A programmer who copied the documented coordinates and any worked UIx mount got a `uix.dom` that does not resolve.

All three premises were verified at source before anything was edited:

- `examples/substrates/uix/{counter,login,dashboard}/core.cljs` each `:require [uix.dom :as uix-dom]` and call both root functions.
- `implementation/adapters/uix/deps.edn` — `:deps` carries `com.pitch/uix.core` only; `com.pitch/uix.dom` lives under `:aliases :test :extra-deps`, and the file's own header says why ("uix.dom therefore stays test-only and out of the published pom").
- `spec/Conventions.md`'s UIx `deps.edn` snippet named neither `com.pitch` coordinate; `docs/core/how-to/use-uix-or-slim.md`'s coordinate table named `com.pitch/uix.core` alone, a dozen lines above a copyable snippet that requires `uix.dom`.

The positive control is the generator template, `tools/template/resources/day8/re_frame2_template/_uix/deps.edn`, which already emits `com.pitch/uix.core` **and** `com.pitch/uix.dom` at 1.4.4 — the same pair `implementation/shadow-cljs.edn` injects globally (lines 421–422), which is exactly why the examples compile in-tree and the omission is invisible here. This PR makes the published recipes agree with that existing pin rather than inventing a second version source.

## What changed

- **`spec/Conventions.md`** — the `;; deps.edn for a UIx app` snippet, and only that. One hunk: pre-image lines 1827–1829 become post-image 1827–1834 — a four-line `;;` comment saying why UIx needs two direct coordinates and why they carry a literal version rather than `<latest>`, plus the two `com.pitch` entries in the map. Entirely inside the fenced block; no prose, no table, no other snippet, nothing else in the file.
- **`docs/core/how-to/use-uix-or-slim.md`** — the coordinate table's UIx row now names both view-library coordinates, followed by a paragraph on why the second is not transitive and the complete copyable `deps.edn` recipe.
- **The three UIx example READMEs** — a `## Copying this into your own app` section carrying that recipe and linking back to the how-to.
- **`implementation/adapters/uix/test/re_frame/adapter/uix_consumer_deps_recipe_test.clj`** (new) — the regression; see below.

Non-goals honoured: no change to the adapter's published `:deps`, no change to any example's events / subs / views / mount, no change to the aggregate shadow build, no workflow or build-id change.

## Where the clean-consumer regression lives — and what it is not

The bead asks for an isolated-classpath compile. That needs its own fixture project, its own Maven resolution and its own build step — a new CI lane, which this repair does not justify and whose config files are hot-zone besides. So the guard is static, and it lives in a lane that already exists: the UIx adapter's JVM `:test` alias, next to `uix_component_recipe_docs_pin_test.clj`, which already pins a doc page to a source file the same way.

It reads the three example sources, collects every `uix.*` namespace they require, and insists each one has a named owner coordinate in all five places the project publishes a UIx recipe (the spec block, the how-to, the three READMEs), each pinned to the template's version. It also asserts the premise the whole thing rests on — that the adapter's shipping `:deps` still exclude `com.pitch/uix.dom` — so if that ever flips, the guard goes red instead of standing as a vacuous pass. Its own non-vacuity check is that the require scan actually sees `uix.dom` in each example: a blind regex would otherwise satisfy the ownership assertions in exactly the same voice as a clean file.

**Stated plainly: this does not prove a real clean classpath compiles.** It proves the invariant that actually broke — a namespace the copyable mount requires with no consumer coordinate that owns it. The remaining gap is deliberate, not overlooked.

## Quality gates

Nominated by path against the documented rosters.

| Gate | Covers | Captured exit |
|---|---|---|
| `python scripts/check_doc_slugs.py` | `docs/` + `spec/` — both edited here | **0** |
| `python scripts/check_readme_links.py --ci` | the three `examples/**/README.md` — outside the docs gate's roots | **0** |
| `clojure -M:test` in `implementation/adapters/uix/` | the new regression + the existing UIx JVM docs pin | **0** (4 tests, 34 assertions, 0 failures) |
| `mkdocs build --strict` | would cover `docs/core/**` link targets | **not run** — `mkdocs` is not installed in this environment (exit 127, `command not found`). It is not an anchor gate in any case (missing anchors grade at INFO), and `spec/` is outside `docs_dir`. |

All three runnable gates were re-run on the final rebased base (`origin/main` at the time of push), not only pre-rebase.

### Planted-fault controls (each restore blob-hash verified)

Every plant was made at a line this PR edits, from an already-committed tree, and the restore was verified by comparing `git hash-object` on the working file against `git rev-parse HEAD:<path>` — never by reading a diff.

1. **`check_doc_slugs.py`** — a broken in-page anchor planted in the paragraph added to `use-uix-or-slim.md`. Captured exit **1**, naming `docs/core/how-to/use-uix-or-slim.md:80 -> #rf2-5x1xt-planted-broken-anchor`. Restored; blob back to `4b45995…`.
2. **`check_readme_links.py --ci`** — the anchor on the new counter-README link repointed to a non-existent heading. Captured exit **1**, naming `examples/substrates/uix/counter/README.md:117`. Restored; blob back to `e50cd99…`. This also proves the real anchor (`#one-adapter-per-build-the-coordinate-table`) is genuinely validated rather than skipped.
3. **The new regression** — `com.pitch/uix.dom` deleted from the counter README's recipe, i.e. the exact bug this PR fixes, reintroduced in one of the five recipes. Captured exit **1** with two failures naming the file and the missing coordinate. Assertion count stayed at 34, matching the control run, so the plant did not knock out a namespace and shrink the suite. Restored; blob back to `e50cd99…`.

Each red exists only in this worktree, so a run that had wandered into a sibling checkout would have come back green — that is the discrimination, since a repo-relative path cannot tell two checkouts apart.

### Checked by hand — because no gate reads inside a fence

Neither doc gate looks inside fenced code blocks, and a dependency recipe *is* a fenced block, so the greens above say nothing about the snippets themselves. Verified by reading:

- **Coordinate spelling.** `com.pitch/uix.core` and `com.pitch/uix.dom` are spelled exactly as `implementation/adapters/uix/deps.edn`, `implementation/shadow-cljs.edn` and the generator template already spell them — same groupId, same artifactIds, `.` not `/` in `uix.dom`.
- **Version.** `1.4.4` in every new snippet, matching the template pair and the aggregate build's `[com.pitch/uix.core "1.4.4"]` / `[com.pitch/uix.dom "1.4.4"]`. The test now pins all five recipes to the template's value, so a future bump that misses one goes red.
- **The set resolves what the examples import.** The union of `uix.*` namespaces required across the three examples is exactly `{uix.core, uix.dom}`; each has an owner in the recipe. `re-frame.core` and `re-frame.adapter.uix` come from `day8/re-frame2` and `day8/re-frame2-uix`, both already named.
- **EDN validity.** Each new block is a well-formed `{:deps {…}}` map with balanced braces — the four-entry maps close `}}}`, and the whole file parses (the regression itself `edn/read-string`s the template and the adapter deps files).
- **Markdown.** The one edited table row keeps its three columns and its pipe count; the new section headings are unique within each README.
