### PR TITLE
fix(mcp-conformance): make the project-stories run arm witness execution (rf2-3n3dk)

### DIFF
--- a/tools/mcp-conformance/test/end-to-end-project-stories.cjs
+++ b/tools/mcp-conformance/test/end-to-end-project-stories.cjs
@@ -31,7 +31,8 @@
 //   2. list-stories — the fixture project's story is discoverable
 //   3. get-story — its body reads back (doc round-trips)
 //   4. get-variant — the pre-authored variant reads back
-//   5. run-variant — the variant executes (vacuous pass, unified shape)
+//   5. run-variant — the variant's LIFECYCLE EXECUTES, witnessed by the
+//      assertion record only a real run can mint (see phase 5 below)
 //   6. clean disconnect
 //
 // Run with: `node test/end-to-end-project-stories.cjs` from this
@@ -58,6 +59,15 @@ const CLOJURE = process.env.STORY_MCP_CMD
 // (Cheshire keyword projection): no leading colon.
 const FIXTURE_STORY = 'story.fixture-app';
 const FIXTURE_VARIANT = 'story.fixture-app/default';
+
+// The EXECUTION WITNESS — the assertion record phase 5 requires, restated
+// here independently of the fixture (a witness that reads its own subject
+// cannot fail). The fixture variant's `:setup` seeds SEEDED_PATH with
+// SEEDED_VALUE and its `:script` asserts that value back out, so a record
+// with these slots exists ONLY if both lifecycle phases ran.
+const WITNESS_ASSERTION = 'rf.assert/path-equals';
+const SEEDED_PATH = ['fixture-app/article', 'headline'];
+const SEEDED_VALUE = 'Seeded by app.stories/setup';
 
 // ---------------------------------------------------------------------------
 // Phase 0 — a missing required namespace ABORTS the launch loudly.
@@ -194,10 +204,25 @@ runWithWatchdog(
     }
     console.log('OK   get-variant -> pre-authored variant body reads back');
 
-    // 5. run-variant — execute it. No :setup / :script, so the run is a
-    // vacuous pass in the unified result shape; what matters here is that
-    // a PROJECT-AUTHORED variant is runnable on first connect, with no
-    // write surface open.
+    // 5. run-variant — the variant's LIFECYCLE EXECUTES.
+    //
+    // The claim this phase makes is EXECUTION, so it must assert evidence
+    // that cannot exist without it. A success-shaped envelope is not such
+    // evidence: Story grades an assertion-free variant with a clean tape
+    // `:pass` on purpose (tools/story/src/re_frame/story/result.cljc
+    // §Status), so `isError` false plus `:status "pass"` is precisely what
+    // a variant that did NOTHING returns. Until rf2-3n3dk this phase
+    // checked only those two, and a regression that stopped playing
+    // launch-preloaded variants altogether would have left it green — as
+    // one measurably did: with no reactive substrate installed, run-variant
+    // dispatched nothing, played nothing, and still answered `:status
+    // "pass"` over an empty app-db.
+    //
+    // So the check is the ASSERTION RECORD, which the `:rf.assert/*`
+    // handler mints DURING play and the runner folds into `:assertions`:
+    //   - absent entirely if the script never played
+    //   - `:passed? false` with `:actual` nil if `:setup` never seeded
+    // Neither degradation can wear a passing witness.
     const runResp = await client.callTool({
       name: 'run-variant',
       arguments: { 'variant-id': FIXTURE_VARIANT },
@@ -206,12 +231,65 @@ runWithWatchdog(
       throw new Error('run-variant on the fixture variant failed: ' + JSON.stringify(runResp));
     }
     const runStruct = structured(runResp);
-    if (runStruct.status !== 'pass') {
+    const records = Array.isArray(runStruct.assertions) ? runStruct.assertions : [];
+    if (records.length !== 1) {
       throw new Error(
-        'run-variant :status expected "pass"; got: ' + JSON.stringify(runResp),
+        'run-variant returned ' + records.length + ' assertion records; the ' +
+          'project-authored variant plays exactly one, and an EMPTY vector is ' +
+          'the no-execution shape this phase exists to reject (a variant that ' +
+          'ran nothing also answers :status "pass"). Got: ' +
+          JSON.stringify(runStruct),
       );
     }
-    console.log('OK   run-variant -> :status="pass" on the project-authored variant');
+    const witness = records[0];
+    if (witness.assertion !== WITNESS_ASSERTION) {
+      throw new Error(
+        'the execution witness must be a ' + WITNESS_ASSERTION + ' record; got: ' +
+          JSON.stringify(witness),
+      );
+    }
+    if (JSON.stringify(witness.path) !== JSON.stringify(SEEDED_PATH)) {
+      throw new Error(
+        'the execution witness must name the app-db path the fixture :setup ' +
+          'seeds (' + JSON.stringify(SEEDED_PATH) + '); got: ' + JSON.stringify(witness),
+      );
+    }
+    if (witness.expected !== SEEDED_VALUE) {
+      throw new Error(
+        'the execution witness must expect the seeded value ' +
+          JSON.stringify(SEEDED_VALUE) + '; got: ' + JSON.stringify(witness),
+      );
+    }
+    // The `:actual` slot is read out of the LIVE frame app-db at assertion
+    // time — the one slot in the record that no amount of author data can
+    // supply. It carrying the seeded value is the proof that `:setup` ran.
+    if (witness.actual !== SEEDED_VALUE) {
+      throw new Error(
+        'the execution witness read ' + JSON.stringify(witness.actual) + ' at ' +
+          JSON.stringify(SEEDED_PATH) + ', not the seeded ' +
+          JSON.stringify(SEEDED_VALUE) + ' — the variant\'s :setup phase did ' +
+          'not run (or did not reach app-db). Got: ' + JSON.stringify(witness),
+      );
+    }
+    if (witness['passed?'] !== true || witness.status !== 'pass') {
+      throw new Error(
+        'the execution witness must be a PASSING record (:passed? true, ' +
+          ':status "pass"); got: ' + JSON.stringify(witness),
+      );
+    }
+    // Only now is the aggregate verdict worth reading: it is the agreement
+    // floor over evidence we have already established is non-empty.
+    if (runStruct.status !== 'pass') {
+      throw new Error(
+        'run-variant :status expected "pass" over the passing witness; got: ' +
+          JSON.stringify(runResp),
+      );
+    }
+    console.log(
+      'OK   run-variant -> lifecycle EXECUTED: ' + WITNESS_ASSERTION +
+        ' read ' + JSON.stringify(witness.actual) + ' at ' +
+        JSON.stringify(SEEDED_PATH) + ' (:passed? true), aggregate :status="pass"',
+    );
 
     // 6. Clean disconnect — runner handles client.close() on success.
     console.log('\nSTORY-MCP PROJECT-STORIES GOLDEN PATH GREEN');

--- a/tools/mcp-conformance/test/fixtures/project-stories/src/app/stories.cljc
+++ b/tools/mcp-conformance/test/fixtures/project-stories/src/app/stories.cljc
@@ -16,7 +16,36 @@
 
   Keep load-time printing off stdout: the story-mcp stdio loop owns stdout
   for JSON-RPC frames, so a stray `println` here would corrupt the wire."
-  (:require [re-frame.story :as story]))
+  (:require [re-frame.core                 :as rf]
+            [re-frame.story                :as story]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+;; The consuming project's own boot step, and a PRECONDITION of the execution
+;; witness below rather than boilerplate. `story-mcp`'s server installs Story's
+;; canonical vocabulary but deliberately does NOT choose a reactive substrate —
+;; per spec/006 §Adapter selection at boot that choice belongs to the app, and
+;; in a browser app it is already made (Reagent / UIx) before any story runs.
+;; The headless server JVM has no such prior boot, so a project that wants its
+;; variants to RUN there makes the choice here, in the namespace the launch
+;; alias preloads. `plain-atom` is the renderer-free substrate for exactly this
+;; case.
+;;
+;; Without it `run-variant` is INERT and silent: setup dispatches reach no
+;; adapter, the script plays nothing, and the run still returns `:status
+;; "pass"` over an empty app-db and zero assertions — the same success envelope
+;; a genuine run returns (measured under rf2-3n3dk). `init!` is idempotent.
+(rf/init! plain-atom/adapter)
+
+;; The fixture project's own event — an ordinary `reg-event`, registered at
+;; namespace load exactly like a consuming project's. Pure data → data: no
+;; renderer, no substrate, no clock, no I/O, so it runs deterministically on
+;; the headless server JVM. The literal it seeds is stated a second time, by
+;; hand, in the variant's `:script` assertion below: an expectation that reads
+;; its own production site cannot fail, so the two literals are deliberately
+;; independent and a drift between them is meant to go red.
+(rf/reg-event :fixture-app/seed-article
+  (fn [{:keys [db]} _]
+    {:db (assoc-in db [:fixture-app/article :headline] "Seeded by app.stories/setup")}))
 
 (story/reg-story :story.fixture-app
   {:doc        "The fixture app's article card — the pre-authored project story the golden-path launch must expose on first connect."
@@ -24,7 +53,27 @@
    :substrates #{:hicasso}
    :tags       #{:dev}})
 
+;; The variant carries REAL lifecycle work, and that is load-bearing rather
+;; than decorative: `end-to-end-project-stories.cjs` phase 5 claims the
+;; project-authored variant EXECUTED on first connect, and the only way to
+;; witness execution is evidence that cannot exist without it. Story's result
+;; contract deliberately grades an assertion-free variant `:pass`
+;; (tools/story/src/re_frame/story/result.cljc §Status), so a variant with no
+;; :setup and no :script returns the SAME success envelope whether the
+;; lifecycle ran or not — which is exactly the false green rf2-3n3dk removed.
+;;
+;;   phase 2 :setup  — dispatches the fixture project's own event, seeding
+;;                     `[:fixture-app/article :headline]` in the frame's app-db
+;;   phase 4 :script — asserts that seeded value back out
+;;
+;; The resulting `:rf.assert/path-equals` record is the execution witness: it
+;; is minted by the assertion handler DURING the run, so it is absent if the
+;; script never played, and it reads `:passed? false` with `:actual nil` if
+;; the setup event never fired. Both halves are pure app-db work — no
+;; renderer, no browser — so the headless JVM host runs it as-is.
 (story/reg-variant :story.fixture-app/default
-  {:doc  "Default article card. No :setup and no :script, so the variant is vacuously runnable on the headless JVM host; :component and :substrates fold down from the parent story."
-   :args {:title "Hello from the fixture project"}
-   :tags #{:dev}})
+  {:doc    "Default article card. :setup seeds the headline the card renders and :script asserts it back — deterministic, renderer-free lifecycle work that gives the golden-path witness something execution-only to observe. :component and :substrates fold down from the parent story."
+   :args   {:title "Hello from the fixture project"}
+   :setup  [[:fixture-app/seed-article]]
+   :script [[:dispatch-sync [:rf.assert/path-equals [:fixture-app/article :headline] "Seeded by app.stories/setup"]]]
+   :tags   #{:dev}})


### PR DESCRIPTION
Closes rf2-3n3dk.

## The defect

`tools/mcp-conformance/test/end-to-end-project-stories.cjs` phase 5 claims the pre-authored project variant EXECUTED on first connect. It checked `runResp.isError` and `runStruct.status === 'pass'` and nothing else, over a fixture variant that deliberately carried no `:setup` and no `:script`.

Story grades an assertion-free variant with a clean tape `:pass` on purpose (`tools/story/src/re_frame/story/result.cljc` §Status), so that success envelope is precisely what a variant which did *nothing* returns. Delete the signal, keep the fault, and the check stays green — the arm proved registration, lookup, request routing and envelope shape, never execution.

## The repair

**Fixture** (`test/fixtures/project-stories/src/app/stories.cljc`) — the variant now does deterministic, renderer-free lifecycle work:

- `:setup` dispatches the fixture project's own `:fixture-app/seed-article` event, seeding `[:fixture-app/article :headline]`
- `:script` asserts that value back out with `:rf.assert/path-equals`

The expected literal is written out by hand on both sides rather than shared through a `def`: an expectation that reads its own production site cannot fail, and a shared constant would have made the "plant a wrong expected value" control a no-op.

**Witness** — the phase-5 assertion is **replaced**, not supplemented. It now requires the single `:rf.assert/path-equals` record and inspects it before the aggregate verdict is read at all: the assertion id, the `:path`, `:expected`, the live `:actual` read out of the frame app-db at assertion time, and `:passed? true` / `:status "pass"`. An empty `:assertions` vector is rejected by name as the no-execution shape. The aggregate `:status` is checked last, as an agreement floor over evidence already established to be non-empty.

## A second finding, recorded in the fixture

Building the control surfaced this: `run-variant` on the headless JVM stdio host is **inert without a reactive substrate** — setup dispatches reach no adapter, the script plays nothing — and still answers `:status "pass"` over an empty app-db and zero assertions. That is the same false-green class one level down, and the old arm could not have distinguished it.

story-mcp's server installs Story's canonical vocabulary but deliberately does not choose a substrate; per spec/006 §Adapter selection at boot that choice belongs to the app, and a browser app has already made it. The fixture project therefore makes it in the namespace its launch alias preloads (`rf/init!` with the renderer-free `plain-atom` adapter, idempotent) — the way a consuming project would. No server, transport, tool-catalogue or launch-flag change.

## Preserved

The missing-namespace launch arm, the first-connect discovery/read arms (`list-stories`, `get-story`, `get-variant`), the no `--allow-writes` posture, the consumer-alias `-M:story-mcp` launch and the clean SDK teardown are untouched and green.

## Quality gates

Every exit code below was captured in the same shell as the runner, never through a pipe. All runs are on the final rebased base (`96c224e904`); the primary gate was re-run after the rebase.

| Gate | Command (from `tools/mcp-conformance`) | Exit |
|---|---|---|
| Primary witness | `npm run test:story-project` | 0 |
| Full story lane (this witness + the 20-tool catalogue harness) | `npm run test:story` | 0 |
| Focused Node unit cluster | `npm run test:unit` | 0 — 119 tests, 110 pass, 0 fail, 9 platform skips |

### Non-vacuity control

Three plants, each restored and each verified byte-for-byte by comparing the working file's git **blob** hash against the committed object (`aa4c94e7dac3a646766c6bf8e74f813de216254c`). Every plant changed that hash, so none silently no-opped.

| Plant | `npm run test:story-project` | What the failure named |
|---|---|---|
| `:setup []` — the seeding action disabled | **exit 1** | the witness read `null` at `["fixture-app/article","headline"]` instead of the seeded value; `:setup` did not run |
| `:script []` — the assertion removed (the exact pre-fix shape) | **exit 1** | `0 assertion records`; the empty vector rejected by name as the no-execution shape |
| expected literal changed to `"PLANTED WRONG EXPECTATION"` | **exit 1** | the witness must expect the seeded value; record shows `:passed? false` |
| restored | **exit 0** | full golden path green |

The `:script []` plant is the decisive one: its rejected payload still reads `"status":"pass"`, which is exactly what the old arm accepted. The old check would have been green on that tree; the new one is red.

Each red also names the failing line inside this worktree's own copy of the witness, and each plant existed only here — a run that had wandered into another checkout would have come back green.

No markdown was touched, so neither `check_doc_slugs.py` nor `check_readme_links.py --ci` applies.
