### PR TITLE
fix(ci): arm the v1-codemod lane on implementation/core changes (rf2-fk5jy)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -726,6 +726,37 @@ else
         tools_jvm_machines_viz=true
         tools_jvm_testbed_support=true
         tools_cljs_machines_viz=true
+        # rf2-fk5jy — the migration/from-re-frame-v1 codemod's lane, a FOURTH
+        # reverse edge of exactly the shape of the three above, and the newest.
+        # That artefact's `:test` alias keeps re-frame2 off its classpath on
+        # purpose, which is why this arm did not carry the edge when the lane
+        # landed (rf2-0qzh) — the comment on the codemod's own arm still said
+        # `:paths ["src"]`, deps clojure and rewrite-clj only, and it was true.
+        # rf2-36u96 (PR #8857) then wired a SECOND step into the job,
+        # `clojure -M:integration`, and that alias declares
+        # `day8/re-frame2-core {:local/root "../../../implementation/core"}`:
+        # it evaluates the codemod's emitted output against the REAL v2
+        # `reg-event` contract at namespace load, with four negative controls
+        # proving the harness observes registration rather than parsing. A
+        # codemod whose output core REJECTS is precisely what that step exists
+        # to catch — and core is the half of the pair that can change under it.
+        #
+        # So between #8857 and this line the lane was armed by the codemod
+        # subtree alone: a core-only diff left it SKIPPED on exactly the commit
+        # that could break it, while the rollup read green throughout.
+        # TESTING.md's changed-surface section names that shape.
+        #
+        # SCOPED to this arm and no wider. implementation/core/deps.edn puts
+        # only `:paths ["src"]` and two mvn coordinates on its BASE classpath;
+        # its cross-artefact :local/root edges all sit under aliases, and a
+        # :local/root dependency never activates its target's aliases. Core's
+        # own tree is therefore the whole of what the :integration lane reaches,
+        # so the per-feature arm above stays dark for it.
+        #
+        # ONE-WAY, like the three edges above it: the codemod's own arm does
+        # NOT gain implementation_jvm in return. It is downstream of core, and
+        # `_changed-surfaces.test.cjs` pins both directions.
+        migration_v1_codemod=true
         ;;
       implementation/adapters/reagent-slim/*|examples/substrates/reagent_slim/counter/*|implementation/scripts/check-reagent-slim-bundle-isolation.cjs)
         # rf2-8cevm — the examples/ tree is test-free. counter_slim_and_fast

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -1287,16 +1287,70 @@ test('the v1 codemod lane arms on its own tree (rf2-0qzh)', () => {
   }
 });
 
+// rf2-fk5jy — the REVERSE edge, and the reason the dark list below no longer
+// names core. PR #8857 (rf2-36u96) wired `clojure -M:integration` into this
+// job as a second step, and that alias declares
+// `day8/re-frame2-core {:local/root "../../../implementation/core"}` — the
+// codemod's emitted output is evaluated against the REAL v2 `reg-event`
+// contract at namespace load. So core IS on this lane's classpath now, while
+// the arm still fired on the codemod subtree alone: a core-only diff left the
+// lane SKIPPED on exactly the commit that could break it, which is the
+// surface-armed gate that does not run on the breaking push while the rollup
+// reads green throughout.
+//
+// The edge is ONE-WAY, and the test after the dark list pins the other side:
+// core changes arm the codemod lane, but a codemod-only diff must still not
+// arm `implementation_jvm`. The codemod is downstream of core, not upstream,
+// so widening in that direction would be fan-out with no dependency behind it.
+//
+// Spelled as ONE boolean on an already-declared :local/root edge, the way every
+// other reverse edge in the classifier is — the `implementation/core/*` arm
+// already carries three of them under rf2-wq17m. Not a dependency-graph engine,
+// and not mark_all.
+//
+// SCOPED TO core, not to `implementation/*`: implementation/core/deps.edn puts
+// only `:paths ["src"]` and two mvn coordinates on the base classpath — its own
+// cross-artefact :local/root edges all sit under ALIASES, and a :local/root
+// dependency never activates its target's aliases. Core's own tree is therefore
+// the whole of what this lane reaches.
+
+test('a core change arms the v1 codemod lane over the :integration edge (rf2-fk5jy)', () => {
+  for (const file of [
+    'implementation/core/src/re_frame/core.cljc',
+    'implementation/core/src/re_frame/events.cljc',
+    'implementation/core/deps.edn',
+  ]) {
+    assert.equal(
+      classify(file)[V1_CODEMOD_LANE.output],
+      'true',
+      `${file} is on the codemod's :integration classpath and must arm ${V1_CODEMOD_LANE.output}`,
+    );
+  }
+  // The fan-out core already had is untouched — the new output is additional,
+  // not a replacement.
+  const result = classify('implementation/core/src/re_frame/core.cljc');
+  assert.equal(result.implementation_jvm, 'true');
+  assert.equal(result.tools_jvm_machines_viz, 'true');
+});
+
 test('the v1 codemod lane stays dark for surfaces it does not depend on (rf2-0qzh)', () => {
   // A rule that matches everything is as useless as one that matches nothing.
   // The prose siblings matter most: `migration/from-re-frame-v1/` also holds
   // five hand-written migration guides, and the arm is the codemod SUBTREE,
   // not the parent — a guide edit must not queue a JVM lane.
+  //
+  // rf2-fk5jy — implementation/core USED to sit in this list, and its
+  // removal is the tripwire that makes that reopen visible rather than
+  // silent: core is now on the lane's :integration classpath, pinned
+  // positively by the test above. A per-feature sibling stands in its place
+  // so the list still proves the edge is core-SPECIFIC — implementation/flows
+  // is reached by no alias of the codemod's deps.edn, so 'any implementation/
+  // change arms this lane' would fail here.
   for (const file of [
     'migration/from-re-frame-v1/README.md',
     'migration/from-re-frame-v1/http-fx-to-managed-http.md',
     'migration/reagent-to-hicasso/codemod/deps.edn',
-    'implementation/core/src/re_frame/core.cljc',
+    'implementation/flows/src/re_frame/flows.cljc',
     'spec/006-ReactiveSubstrate.md',
   ]) {
     assert.equal(
@@ -1308,9 +1362,11 @@ test('the v1 codemod lane stays dark for surfaces it does not depend on (rf2-0qz
 });
 
 test('a v1 codemod change does NOT fire the rest of the matrix (rf2-0qzh)', () => {
-  // `:paths ["src"]`, deps clojure + rewrite-clj, and no cross-tree edge at
-  // all — unlike its sibling, which reaches into implementation/freehand/test.
-  // So this lane is the ONLY thing a codemod-only diff should queue.
+  // The DOWNSTREAM half of the rf2-fk5jy edge. The artefact's base classpath
+  // is `:paths ["src"]` plus clojure and rewrite-clj, and its one cross-tree
+  // edge — `:integration`'s :local/root onto implementation/core — runs the
+  // OTHER way: core is this lane's dependency, not its dependent. So this lane
+  // is still the only thing a codemod-only diff should queue.
   const result = classify(V1_CODEMOD_LANE.armed);
   assert.equal(result[V1_CODEMOD_LANE.output], 'true');
   for (const output of [


### PR DESCRIPTION
Closes rf2-fk5jy.

## The hole

`migration_v1_codemod` fired on `migration/from-re-frame-v1/codemod/*` and nothing else. That was right when the lane landed (rf2-0qzh) — the artefact's `:test` alias keeps re-frame2 off its classpath on purpose, so it had no cross-tree edge to mirror, and the arm's own comment said so.

rf2-36u96 (PR #8857) then wired a **second step** into `jvm-migration-v1-codemod`: `clojure -M:integration`. That alias declares

```
day8/re-frame2-core {:local/root "../../../implementation/core"}
```

and evaluates the codemod's emitted output against the real v2 `reg-event` contract at namespace load, with four negative controls proving the harness observes registration rather than parsing. Core is now on the lane's classpath, and core is the half of the pair that can change under it — so between #8857 and this PR a core-only diff left the job **skipped on exactly the commit that could break it**, while the rollup read green throughout.

## Both premises verified at source

The bead asked for scepticism about its own text (its owning bead was already wrong about another script's roster). Both halves hold:

**(a) The arm's actual pattern.** `migration_v1_codemod=true` is set in exactly one arm, `migration/from-re-frame-v1/codemod/*)`, plus `mark_all()`. No earlier arm in the same `case` matches an `implementation/core/...` path, and the job's gate is `if: needs.detect_changed_surfaces.outputs.migration_v1_codemod == 'true'` with no `implementation_jvm` fallback.

**(b) The `:integration` edge.** `migration/from-re-frame-v1/codemod/deps.edn` declares the `:local/root` quoted above, and its own comment states it outright: *"only this alias pulls implementation/core."* The workflow runs both `clojure -M:test` and `clojure -M:integration` as separate steps.

Measured, before the change:

```
report-changed-surfaces.sh implementation/core/src/re_frame/core.cljc
  -> implementation_jvm=true  tools_jvm_machines_viz=true  migration_v1_codemod=false
```

## The change

One boolean added to the `implementation/core/*` arm, which already carries three reverse edges of exactly this shape under rf2-wq17m ("every other reverse edge in this file is spelled out the same way"). No dependency-graph engine, no `mark_all`, **no new job and no gate** — and no workflow-file edit.

**Scoped to core and no wider.** `implementation/core/deps.edn` puts only `:paths ["src"]` and two mvn coordinates on its base classpath; its cross-artefact `:local/root` edges all sit under **aliases**, which a `:local/root` dependency never activates. Core's own tree is the whole of what the `:integration` lane reaches, so the per-feature arm stays dark and so does the prose half of `migration/from-re-frame-v1/`.

**The edge is one-way.** The codemod's own arm does not gain `implementation_jvm` in return — it is downstream of core, not upstream. Both directions are pinned.

Script and its pinned mirror move in **one commit**, as the one-toucher pair requires. The mirror gains the positive pin and drops core from the v1 lane's dark list — the inversion that makes a reopen visible rather than silent, the same way rf2-wq17m recorded its own — with a per-feature sibling standing in core's place so the list still proves the edge is core-*specific*. The mirror's now-stale self-containment comment is corrected in place; it claimed "no cross-tree edge at all" and named `implementation/freehand/test`, a tree retired under rf2-0yp7w.

## Quality gates

The covering gate is CI job **`js-harness-self-tests`** → `npm run test:scripts` from `implementation/`. It is **ungated** — no `needs: detect_changed_surfaces`, no `if:` — so it runs on every PR. `implementation/scripts/_changed-surfaces.test.cjs` is picked up by that script's `scripts/*.test.cjs` glob, and it spawns the **real** `.github/scripts/report-changed-surfaces.sh` bytes rather than reimplementing it.

| run | gate | captured exit |
|---|---|---|
| baseline, before any edit | `node --test scripts/_changed-surfaces.test.cjs` | **0** — 291 passed |
| **control**: new pin added, script *un-widened* | same | **1** — 1 failed |
| after widening | same | **0** — 292 passed |
| full covering gate, after widening | `npm run test:scripts` | **0** — 122 test files, 0 fail, 209s |

Every number above is the runner's own exit code, captured with the redirect and the `echo` on one command line in one shell — not a harness-reported status, and never through a pipe.

**The control is the deliverable.** With the pin added and the script untouched, the run went red naming exactly what was planted:

```
FAIL a core change arms the v1 codemod lane over the :integration edge (rf2-fk5jy)
AssertionError: implementation/core/src/re_frame/core.cljc is on the
  codemod's :integration classpath and must arm migration_v1_codemod
```

That red is also the proof the gate read *this* checkout: the pin exists in no other tree, so a run that had wandered into a sibling worktree would have come back green. The pass count moving 291 → 292 (rather than collapsing) shows the new test was added, not substituted.

**Positive control on the classifier.** A surface classifier handed input it cannot parse reports every surface unaffected, which is indistinguishable from a genuinely unaffected change — so the instrument was exercised against an input it *must* flag before any negative result was believed:

```
report-changed-surfaces.sh migration/from-re-frame-v1/codemod/src/re_frame/migration/reg_event_codemod.clj
  -> migration_v1_codemod=true   implementation_jvm=false
```

It bites, and it discriminates. Four behaviours confirmed after the change:

| input | `migration_v1_codemod` | |
|---|---|---|
| `implementation/core/src/re_frame/core.cljc` | `true` | the fix |
| `migration/from-re-frame-v1/codemod/src/.../reg_event_codemod.clj` | `true` | positive control, still one-way (`implementation_jvm=false`) |
| `implementation/flows/src/re_frame/flows.cljc` | `false` | the edge is core-specific, not `implementation/*` |
| `migration/from-re-frame-v1/README.md` | `false` | still the codemod subtree, not the parent |

**Not claimed as run locally:** `shellcheck` (portability.yml shellchecks every tracked `.github/scripts/*.sh`) is not installed on this host. `bash -n` on the edited script exits 0, and the change is 30 comment lines plus one assignment identical in form to the three already-clean assignments immediately above it. CI's portability job is the verdict.

No markdown changed, so neither documentation link gate is in scope.
