### PR TITLE
ci(skills): wire the MIG-23 and pair-retro fixtures into skills-structural; retire a stale record-as- citation (rf2-qad4l, rf2-bbe91, rf2-udumn)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5770,6 +5770,93 @@ jobs:
         run: npm run test:pure
 
   # ---------------------------------------------------------------------------
+  # reagent-migration MIG-23 SSR cold-start node-test (rf2-vpdrf / rf2-bbe91).
+  #
+  # The reagent-migration skill's MIG-23 recipe tells a migrating app how to
+  # install an adapter on BOTH cold halves — server render and client mount.
+  # `skills/reagent-migration/tests/fixture/` is the executable evidence that
+  # the recipe is right: a `:node-test` build whose negative controls prove a
+  # never-initialized process raises `:rf.error/no-adapter-installed` at both
+  # recipe entry points (`re-frame.hicasso.server/render` and `rf/make-frame`),
+  # and whose positive controls prove ONE `rf/init!` per process boot fixes
+  # both. Like its pair sibling it exercises the real in-repo artefacts, not a
+  # Babashka mirror that could drift from them.
+  #
+  # It ran on-demand only — PR #8838 added it with `.github/workflows/**` fenced
+  # out — so a change to core's adapter lifecycle, to ssr, to hicasso's server
+  # render, or to the recipe itself could regress the documented cold start with
+  # nothing to catch it. Wired here for the same reason the pair fixture is.
+  #
+  # `:deps true` routes the fixture's classpath through its deps.edn (core +
+  # ssr + hicasso + the stock Reagent adapter as `:local/root`), so shadow-cljs
+  # shells out to `clojure` for classpath resolution — hence JDK + Clojure CLI +
+  # Node. The fixture has no package-lock.json (dev-only, deps pinned exactly in
+  # package.json), so `npm install` — not `npm ci` — bootstraps shadow-cljs.
+  #
+  # GATED ON `skills_structural`, WHICH DOES NOT YET FIRE FOR THIS TREE
+  # (rf2-g1m2q). `.github/scripts/report-changed-surfaces.sh` arms that output
+  # from four case arms — `skills/re-frame2-pair/{tests/fixture,preload}/*`,
+  # `skills/re-frame2-pair/*|skills/shared/*`, `skills/re-frame2-setup/*` — and
+  # the main `case` has no default arm, so a diff confined to
+  # `skills/reagent-migration/**` classifies to NOTHING and this job is skipped
+  # on the very change it exists to gate. Widening the arm means touching that
+  # script AND its pinned mirror `implementation/scripts/_changed-surfaces.
+  # test.cjs`, the one-toucher-by-construction pair, which was held by another
+  # lane when this landed; rf2-g1m2q owns it. The wiring is still the right half
+  # to land first: it is what makes the arm worth widening, and the job already
+  # fires on a `--all` run and on any other `skills_structural` path.
+  # ---------------------------------------------------------------------------
+  reagent-migration-fixture-cold-start:
+    name: reagent-migration MIG-23 SSR cold-start node-test (rf2-vpdrf)
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.skills_structural == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: skills/reagent-migration/tests/fixture
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        run: "$GITHUB_WORKSPACE/.github/scripts/install-clojure-cli.sh"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+
+      # The fixture resolves core + ssr + hicasso + reagent as `:local/root`
+      # entries, so a cold-cache run pulls every transitive dep (Reagent, Malli,
+      # …) before shadow-cljs can compile. Same cache shape as
+      # re-frame2-pair-fixture-pure.
+      - name: Cache Maven / gitlibs (MIG-23 cold-start fixture deps)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-reagent-migration-fixture-${{ hashFiles('skills/reagent-migration/tests/fixture/deps.edn', 'skills/reagent-migration/tests/fixture/shadow-cljs.edn', 'implementation/core/deps.edn', 'implementation/ssr/deps.edn', 'implementation/hicasso/deps.edn', 'implementation/adapters/reagent/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-reagent-migration-fixture-
+            ${{ runner.os }}-cljs-
+
+      # No package-lock.json (dev-only fixture) — `npm install` bootstraps the
+      # pinned shadow-cljs + react devDeps.
+      - name: Install fixture deps (shadow-cljs)
+        run: npm install --no-audit --no-fund
+
+      - name: Run MIG-23 SSR cold-start node-test
+        run: npm run test:cold-start
+
+  # ---------------------------------------------------------------------------
   # docs/cljs live-cell playground (rf2-ee38b.22).
   #
   # docs/tools/playground is the roll-your-own CM6 + Scittle + re-frame2-SCI
@@ -6143,6 +6230,12 @@ jobs:
       - mcp-conformance-wire-vocab
       - skills-structural
       - re-frame2-pair-fixture-pure
+      # rf2-bbe91 — required, mirroring its pair sibling above. What it holds is
+      # the reagent-migration skill's MIG-23 cold-start promise: that ONE
+      # `rf/init!` per process boot arms both the server render and the client
+      # mount. That promise is made to somebody else's migrating repository, and
+      # advisory would leave it one `if:` from the on-demand nowhere it ran.
+      - reagent-migration-fixture-cold-start
       - tools-playground
     steps:
       # `needs.*.result` is the spread of every dependency's final result.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5698,6 +5698,31 @@ jobs:
             bb "$test_file"
           done
 
+      # re-frame2-pair-retro command-contract fixture (rf2-2jeh5 / rf2-qad4l).
+      # `tests/duplicate_search_test.clj` pins the all-state duplicate-search
+      # contract the skill prescribes: the exact argv is EXTRACTED FROM SKILL.md
+      # and checked against a gh state-filter model over a closed-owner /
+      # no-match / query-error fixture set. So the test fails when the prose
+      # drifts from the contract — which is the drift class that matters here,
+      # a retro skill that tells an agent to search only open issues and thereby
+      # re-files a bead somebody already closed. PR #8848 added it with
+      # `.github/workflows/**` fenced out, leaving it local-only. Loop every
+      # *_test.clj, as the setup step above does, so a future pair-retro test is
+      # gated automatically rather than waiting on another wiring PR.
+      #
+      # Same `skills_structural` caveat as reagent-migration-fixture-cold-start
+      # below: the classifier has no arm for `skills/re-frame2-pair-retro/**`
+      # and no default arm, so a diff confined to that tree classifies to
+      # nothing and this step does not run. rf2-g1m2q owns widening it.
+      - name: Run re-frame2-pair-retro structural tests
+        working-directory: skills/re-frame2-pair-retro
+        run: |
+          set -euo pipefail
+          for test_file in tests/*_test.clj; do
+            echo "== $test_file =="
+            bb "$test_file"
+          done
+
   # ---------------------------------------------------------------------------
   # re-frame2-pair SHIPPED-preload pure-core node-test (rf2-etsj8p / rf2-pxxbjk).
   #

--- a/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
@@ -679,10 +679,12 @@ allowlist). What verbs do they take?
   `trace-window` / `watch-epochs`; `watch-` becomes a locked prefix
   for blocking-on-a-predicate.
 - **`record-as-recording` + `watch-epochs`-style bare `watch`.** The
-  `record-as-` prefix means *capture as a persisted artefact* (story-
-  mcp's `record-as-variant`) — a live change-log observer is a
-  different semantic, so reusing the prefix would conflate two ideas
-  the agent must keep distinct.
+  `record-as-` prefix means *capture as a persisted artefact* — at
+  this lock's date story-mcp's `record-as-variant`, retired since
+  under rf2-5saz7, which leaves the prefix catalogued but borne by no
+  shipped tool. A live change-log observer is a different semantic,
+  so reusing the prefix would conflate two ideas the agent must keep
+  distinct.
 - **Fold both into `eval-cljs`.** The escape hatch can express either,
   but that's exactly the per-session boilerplate + timing footgun the
   bead exists to kill — a first-class op is the whole point.


### PR DESCRIPTION
Three items: one prose repair to a spec design record, and two CI-wiring items
that both edit `.github/workflows/test.yml`'s skills lane. The two CI items are
clustered deliberately — that file is hot-zone and one-toucher, so one worker
takes both rather than two racing.

## Item 1 — rf2-udumn: Lock #8's `record-as-` example named a retired tool

`tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md` Lock #8 cited story-mcp's
`record-as-variant` as the live bearer of the `record-as-` prefix. That tool was
retired under rf2-5saz7; the shipped Story-MCP surface is a headless 19-tool
registry that does not carry it (`tools/story-mcp/test/fixtures/tool-names.json`
holds 19 names and `record-as-variant` is not among them). The lock's reasoning
and its historical citation are both preserved — the prefix is now stated as
catalogued and borne by no shipped tool, matching the repair made to the
cross-MCP verb table in `tools/mcp-conformance/NAMING.md` by PR #8865.

This was the last open site from rf2-udumn's enumeration. PR #8865 repaired the
other nine and left this one standing because `tools/re-frame2-pair-mcp/` was
fenced to another lane at the time; that fence cleared when PR #8862 merged.
Prose only.

## Item 2 — rf2-bbe91: the MIG-23 SSR cold-start fixture now runs at PR time

`skills/reagent-migration/tests/fixture/` (PR #8838) is a `:node-test` suite
proving the MIG-23 recipe's adapter-boot contract against the in-repo
artefacts — never-initialized negative controls at `re-frame.hicasso.server/render`
and `rf/make-frame`, a positive server control with one `init!` and two renders,
and a client-shaped control on the stock Reagent adapter. It ran on-demand only.

New job `reagent-migration-fixture-cold-start`, mirroring
`re-frame2-pair-fixture-pure` step for step: JDK 21 + Clojure CLI + Node 24, the
same Maven/gitlibs cache shape keyed on the fixture's build files plus the four
`:local/root` artefacts it resolves, `npm install` (the fixture has no
lockfile), then `npm run test:cold-start`. Added to `all-required-passed`'s
`needs:` for the reason its sibling is there: a job absent from that list is
advisory whatever its own gate says.

## Item 3 — rf2-qad4l: pair-retro's fixture now runs at PR time

`skills/re-frame2-pair-retro/tests/duplicate_search_test.clj` (PR #8848) pins
the all-state duplicate-search contract — the prescribed argv is extracted from
`SKILL.md` and checked against a `gh` state-filter model over a
closed-owner / no-match / query-error fixture set, so the test fails when the
prose drifts from the contract. It had no CI lane.

New `Run re-frame2-pair-retro structural tests` step in `skills-structural`,
mirroring the setup-skill loop: working-directory `skills/re-frame2-pair-retro`,
every `tests/*_test.clj` through `bb`, so a future pair-retro test is gated
without another wiring PR.

## The classifier arm does NOT cover either tree — filed as rf2-g1m2q

rf2-qad4l asked me to CONFIRM that `detect_changed_surfaces`' `skills_structural`
trigger covers `skills/re-frame2-pair-retro/**`. It does not, and it does not
cover `skills/reagent-migration/**` either. `.github/scripts/report-changed-surfaces.sh`
arms that output from four case arms only — `skills/re-frame2-pair/tests/fixture/*`,
`skills/re-frame2-pair/preload/*`, `skills/re-frame2-pair/*` with `skills/shared/*`,
and `skills/re-frame2-setup/*` — and the main `case` has no default arm, so a
diff confined to either tree classifies to NOTHING AT ALL, not merely to
`skills_structural=false`.

Measured, with the control run FIRST so that a zero is a check that passed
rather than an instrument answering "nothing here":

| classifier input | `skills_structural` | outputs true |
| --- | --- | --- |
| `skills/re-frame2-setup/SKILL.md` (control — must flag) | `true` | at least 1 |
| `skills/re-frame2-pair-retro/tests/duplicate_search_test.clj` | `false` | 0 |
| `skills/reagent-migration/**` (SKILL.md + the fixture test) | `false` | 0 |

So both gates wired here fire today only on a change to one of the four armed
trees or on an `--all` run — not on a change to the fixture or skill they gate.
Widening the arm means touching `report-changed-surfaces.sh` AND its pinned
mirror `implementation/scripts/_changed-surfaces.test.cjs`, the
one-toucher-by-construction pair, which was held by another lane; that work is
rf2-g1m2q and is deliberately **not** in this PR. Neither file is touched here.

The wiring is still the right half to land first — it is what makes the arm
worth widening — and both the new job's comment and the new step's comment state
the gap in place rather than implying coverage they do not have.

## Quality gates

Every exit code below is the runner's own, captured with the redirect and the
exit-code echo on one command line, never a harness report about the same run.

| gate | exit | note |
| --- | --- | --- |
| `scripts/check_doc_slugs.py` | 0 | the gate for item 1 (`tools/*/spec` is inside its roots) |
| `scripts/check_doc_slugs.py` — SABOTAGE | 1 | planted broken anchor at a line I edited; named `DESIGN-RATIONALE.md:684 -> Principles.md#planted-anchor-does-not-exist` |
| `scripts/check_readme_links.py --ci`, same plant in place | 0 | roster split settled empirically, not assumed: the same plant reds doc-slugs and is invisible to readme-links |
| `scripts/check_workflow_yaml.py` | 0 | 11 workflow files parse |
| `scripts/check_workflow_job_timeouts.py` | 0 | 114 jobs across 11 files capped |
| `check_workflow_job_timeouts.py` — SABOTAGE | 1 | dropped `timeout-minutes` from the new job; named `reagent-migration-fixture-cold-start` |
| `scripts/check_jvm_lane_rosters.py` | 0 | 31 rostered artefacts; the new job runs `npm`, not `clojure -M:test`, so R2 does not reach it |
| `scripts/check_test_lane_bijection.py` | 0 | 1514 test-defining files, 45 lanes |
| `scripts/check_fast_pr_gap.py` | 0 | informational; clean |
| `bb tests/duplicate_search_test.clj` from `skills/re-frame2-pair-retro` | 0 | 5 tests, 16 assertions — the exact command the new step runs |
| `npm install --no-audit --no-fund` in the MIG-23 fixture | 0 | 16 packages |
| `npm run test:cold-start` in the MIG-23 fixture | 0 | 1 test, 12 assertions — the exact command the new step runs |

**Both sabotage runs named what was planted**, and each fault existed only in
this branch's checkout, so a run that had read another tree would have come back
green. Both restores were verified by **git blob hash** against the committed
object, not by reading a diff: `a9dff0b8b44005ec6c28def8fb759f9cf4ba2925` for
`DESIGN-RATIONALE.md` and `250c9e4223b2a5e03cd8f327cffe96a54c1f1908` for
`test.yml`, each matching before and after.

**The job wiring itself is verified by CI on this PR, not locally.** What is
verified locally is that the two commands the steps run are green from their
skill roots, and that the YAML the steps live in parses, caps its job and keeps
both lane bijections. Whether the runner provisions and schedules them correctly
is what this PR's own run answers.

By hand, because no gate covers it: the two markdown tables in this body, the
job-key discriminator (the two-space form reads exactly 1 added job key; the
unindented form reads 0, as expected), and the structural shape of both edits
read back out of the parsed YAML — job `if:`, working-directory, timeout, step
list, and the aggregator's `needs:`.

Every gate above was re-run on the FINAL base after the rebase onto
`fd5ffc47f3`. The merge-base diff was read for reverts as well as conflicts: the
files changed on `origin/main` since this branch left it have an EMPTY
intersection with the two files changed here, and the only deletions in
`origin/main...HEAD` are the four prose lines item 1 deliberately replaces —
`test.yml` is pure insertion.
