### PR TITLE
docs(method): two stale self-claims — sizing an item by its title, and the extraction size constant

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -330,6 +330,27 @@ one-worker-per-item, and do not reflexively bundle everything.
   every change. Measured: four slices of one item in one session, each its own change,
   none colliding, closed once with four cross-references.
 
+**Three of those rules consume a SIZE, and the size you are holding is usually a TITLE.** Sizing
+happens at the listing — the ready queue, the backlog view — and a listing prints names. This page
+already argues that a name is not evidence about *files* (see *Fences*), and that an item's own
+scope claim is a name wearing a reviewer's authority. Magnitude is the third thing a name gets
+wrong, and it is the one no fence catches, because it corrupts the decision before any fence is
+derived. Measured: an item whose title named one test that could pass vacuously — the archetypal
+small same-surface cluster candidate — carried a body that deleted four public tools, removed an
+entire subsystem, and ran to seven acceptance criteria with explicit non-goals. Clustered on its
+title it would have produced both failures the list warns about at once, a bundle that times out
+and a large item padded into a cluster, and it would have carried an unreviewed public-interface
+deletion inside a change whose stated subject was trivia.
+
+**So open every candidate before you cluster it, and read for SHAPE rather than for content** —
+acceptance criteria, non-goals, the length of the evidence, whether the body names a few files or
+names a subsystem. None of that requires understanding the work, which is why it is cheap: it is a
+few reads against a listing you were going to act on anyway. The asymmetry is what settles it,
+because a misread item does not merely arrive oversized — it poisons the change its siblings ride
+in. **And where a title and its body disagree, correct it on the item** rather than only in your
+own decision. The listing is what the next reader sees, so an item that misled you will mislead
+them identically, and a retitle is the only repair that does not have to be made twice.
+
 **One agent owns a surface; surfaces run in parallel.** That is how you avoid serial handling:
 same-surface items ride one agent, which never collides with itself, while genuinely separable
 surfaces dispatch as concurrent agents.

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -562,18 +562,27 @@ extraction that silently returns the wrong two hundred lines is worse than eithe
 that trade-off was weighing. Match the block's opening and closing text instead.
 
 **But match that closing text as a HEADING — anchored to the start of a line — because a block
-that documents its own boundaries contains its own end anchor.** The gate-mechanics block opens
-by naming where it stops and which neighbouring section it is not, so BOTH of its boundary
-strings occur twice in this file: once as the real heading, once inside that sentence. A plain
-search for the closing text stops at the mention, and the extraction returns the block's first
-five lines out of a hundred and sixty-four — 206 characters of 11,925 — while raising no error,
-because both anchors were found. Measured on this document.
+that documents its own boundaries contains its own end anchor.** The gate-mechanics block opens by
+naming where it stops, so its CLOSING string occurs twice in this file: once as the real heading,
+once inside that opening sentence. A plain search for it stops at the mention, and the extraction
+returns the block's opening paragraph instead of the block — raising no error, because both anchors
+were found. Measured on this document.
+
+**The opening heading is NOT doubled, and that asymmetry is the durable part.** A block that says
+where it stops must name its closing anchor; whether it also repeats its own heading text is an
+accident of phrasing, and this one stopped repeating it when that sentence was reworded to say
+"from this heading". So the trap sits on the closing anchor specifically, which is where anchoring
+to the start of a line is load-bearing.
 
 That is a worse failure than the stale line range this rule exists to avoid, and worse in the way
 that matters: a stale range returns the wrong two hundred lines, which reads wrong on sight, where
 this returns a plausible opening paragraph that reads like a short block. **So check the extracted
-SIZE before you paste it** — a block you can read in one screen is not the one you meant to send,
-and that check costs nothing where the paste costs a worker.
+size before you paste it — and check it as a CLASS, not against a remembered number.** The two
+outcomes are orders of magnitude apart, a few hundred characters against many thousands, so the
+reliable test is whether the extraction ENDS at the closing heading, which cannot drift. A count
+here would be a measured constant about a living document, and the one this passage used to quote
+had drifted about a fifth before a reread caught it — [the same failure](#counts-are-claims-and-they-go-stale-first)
+one section up, wearing the other hat.
 
 ---
 


### PR DESCRIPTION
Retrospective output from a session acting as mayor. One bounded addition, not a sweep — three candidate findings were checked against the document first and two were already covered, which is recorded below because a retro that reports only what it added hides how much of the doc is already working.

**The gap.** `## Choosing solo or cluster` has three rules that consume a size — second tier clusters only when items are "genuinely small", many small same-surface items cluster, and any LARGE item goes solo. All three assume the size is known. But sizing happens at the tracker's listing, and a listing prints titles. The page argues at length that a name is not evidence about *files* (the whole *Fences* section) and that an item's own scope claim is "a name wearing a reviewer's authority" — so the concept is present and well made, but it is applied only to collisions. Magnitude is the third thing a name gets wrong, it is decided in a different section from a different artefact, and nothing connected the two.

It is also the failure mode no fence catches, because it corrupts the decision *before* any fence is derived.

**Measured this session.** An item whose title named a single test that could pass vacuously on its baseline — the archetypal small same-surface cluster candidate — turned out to carry a body that deletes four public tools, removes an entire subsystem, and runs to seven acceptance criteria with explicit non-goals. Clustered on its title it would have produced both failures the existing list already warns about, simultaneously: a bundle that times out, and a large item padded into a cluster. Worse than either, it would have carried an unreviewed public-interface deletion inside a change whose stated subject was trivia. Only opening the body stopped it.

**What was added**: two paragraphs after the bullet list — the finding with its measurement, then the discriminator (open each candidate and read for *shape*: acceptance criteria, non-goals, length of evidence, whether the body names a few files or a subsystem) and the corollary that a title/body mismatch is corrected **on the item**, since the listing is what the next reader sees and a retitle is the only repair that does not have to be made twice.

**What was NOT added, having been checked at source:**

- *The mayor's own diagnostic readings are subject to the exit-code rules it enforces on workers.* Already covered twice, from two angles: `loops.md` "Never wire a remedy behind a pipe" names the mechanism, and the mayor-side commit-guard passage already says to read the command's own exit rather than the output tail.
- *A gate nomination is a claim the worker should verify.* Already explicit inside the premises-are-claims sentence, which names the gate case in its own words: "that a gate it names covers your path".

## Quality gates

- `python scripts/check_doc_slugs.py` — **exit 0**. This is the correct and only anchor gate for this path: `docs/the-mayor-method/` sits inside `docs_dir` and is absent from `mkdocs.yml`'s `exclude_docs`, but `mkdocs build --strict` grades a missing anchor at INFO and `--strict` promotes WARNING, not INFO.
  - **Control (the deliverable):** one broken anchor planted at a line this change adds → **exit 1**, naming `docs\the-mayor-method\dispatch-prompt-template.md:335 -> #no-such-anchor-planted-control`. The fault existed only in this worktree, so the red is also the proof the gate read this tree. Anchor match count read as 1 before planting, and the planted blob (`d7d6f258…`) differed from the pre-plant blob, so the plant genuinely applied rather than silently no-opping.
  - **Restore verified by blob hash, not by reading a diff:** working file `4a36e3f168b66f8b2bdff2a59e6ffe366f400b19` == the committed object. Gate re-run after restore: **exit 0**.
- `python scripts/check_readme_links.py --ci` — **exit 0**. Not the covering gate for this path (that roster is repo-root markdown and markdown beside source), run only to confirm nothing else moved.
- `mkdocs build --strict` — **not run; not claimed.** `mkdocs` is not on PATH in this environment. It does cover this page for link *targets* in CI; that coverage is CI's here.
- **By hand:** the addition is prose. No fenced blocks changed — which matters in this tree specifically, since `docs/the-mayor-method/` is one of the two trees where a doc link inside a fence is itself reported. No tables, no headings, no anchors introduced; the one cross-reference is italic text rather than a link, matching how the surrounding page refers to its own sections.
- One file. No code, tests or workflow files touched.

Authored in a mayor-occupied worktree, as the guard requires — the mayor checkout's pre-commit hook refuses non-tracker surfaces, and that refusal is the guard working.


---

# Second commit — the method-reread loop, on this same file

Added after the reread loop fired on the tick following the retro. Same file, so it rides this change rather than a conflicting branch. Two stale self-claims, both in the passage that governs an extraction performed on **every** dispatch — which is why they were worth catching rather than tidy-ups.

**1. The size constant had drifted about a fifth.** The passage told you to check the extracted size against "a hundred and sixty-four" lines / "11,925" characters. Measured at this tip: **192 lines / 14,414 characters**. The truncated-extraction figure had moved too, 206 → 304 characters.

Refreshing three numbers would have been the obvious repair and the wrong one — they will re-drift the next time the block grows, which is exactly how they got here. This page's own *Counts are claims, and they go stale first* section says what to do instead: *"when the number will keep moving, brief the fix to name the CLASS rather than the count. A rule written as a class does not re-drift."* So the check is restated as a class — the two outcomes are orders of magnitude apart, a few hundred characters against many thousands — with the exact test being **whether the extraction ends at the closing heading**, which cannot drift at all. The measurement stays as evidence, not as the thing you compare against.

**2. "BOTH of its boundary strings occur twice in this file" is now false.** Verified by count: the closing string `## Reviewing what comes back` occurs twice (line 756 inside the block's own opening sentence, line 944 as the real heading), but the opening heading occurs **once**. The block's opening sentence was at some point reworded to say "from **this** heading" rather than repeating the heading text, which silently removed the second occurrence and left the justification overstating.

The rule it underwrites — anchor the closing match to the start of a line — is unaffected and still correct. But the asymmetry is the durable part and is now stated: a block that says where it stops *must* name its closing anchor, whereas repeating its own heading text is an accident of phrasing. So the trap lives on the closing anchor specifically.

## Quality gates — second commit

- `python scripts/check_doc_slugs.py` — **exit 0** on the final rebased base `40dfff6687`.
  - **Control:** the new cross-reference anchor added by this commit, broken → **exit 1**, naming `docs\the-mayor-method\dispatch-prompt-template.md:584 -> #counts-are-claims-planted-control`. Match count read as 1 before planting; planted blob (`8f7237c6…`) differed from pre-plant (`8e9cbb3a…`), so it applied rather than no-opping. The fault existed only in this worktree, so the red is also proof the gate read this tree.
  - **Restore verified by blob hash:** working file `8e9cbb3a28619d88eaed7662e89870d55b771f51` == the committed object. Re-run after restore: **exit 0**.
  - That green is also a positive check in its own right: the commit adds a real intra-page anchor, and the gate validating it is what confirms it resolves.
- `python scripts/check_readme_links.py --ci` — **exit 0**. Not the covering gate for this path; run to confirm nothing else moved.
- **By hand:** prose only, no fenced blocks touched, no headings added or renamed, no tables. The three measurements quoted above were each taken at this tip rather than carried from the previous text.
- Rebased onto `40dfff6687` and gates re-run on that final base. Three-dot diff against the merge base reverts nothing: both commits are additions plus one replaced paragraph of my own.
