### PR TITLE
fix(machines): record the durable spawn order instead of parsing it from actor ids (rf2-1vlyg)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
@@ -32,28 +32,43 @@
      `:machines/teardown-on-frame-destroy!`; called from
      `frame/destroy-frame!`.
 
-  Source-of-truth on order: a process-side
-  `re-frame.machines.spawn-order` atom records each spawned actor at
-  install time. Snapshots that landed via direct `[:rf.runtime/machines :snapshots]` assoc
-  (test fixtures, hydration payloads, `replace-runtime-db!`, `restore-epoch!`)
-  are not tracked in the transient channel but DO live in the durable
-  runtime-db — the walker covers them as a stragglers pass after the
-  recorded vector drains.
+  Source-of-truth on order: the DURABLE `[:rf.runtime/machines
+  :spawn-order]` vector, appended by `install-spawn!` in the same
+  runtime-db swap that lands each snapshot and pruned by the unified
+  teardown projection in the swap that dissocs it. Reversing that vector
+  IS the reverse-creation walk, and because it rides the durable
+  runtime-db value it survives every supported round trip —
+  `replace-runtime-db!`, `restore-epoch!`, SSR hydration — with no restore
+  callback. The process-side `re-frame.machines.spawn-order` atom is a
+  transient cache of the same order (Spec 002 §Durable vs transient) and
+  is NOT consulted for ordering here.
 
-  Restore/hydration/full-runtime-db-replacement repopulate
-  durable runtime-db snapshots WITHOUT repopulating the process-side
-  spawn-order atom (the atom is transient bookkeeping, not durable state per
-  Spec 002 §Durable vs transient). A restored SPAWNED actor's snapshot
-  carries `:rf/machine-type` at its root (stamped by `install-spawn!`; a
-  SINGLETON snapshot never carries it — actor_liveness_test:213). The
-  straggler pass therefore SPLITS on that durable discriminator: spawned
-  stragglers run the full `destroy/destroy-single-actor!` teardown (registrar
-  cleanup, system-id release, timer cancel, snapshot dissoc) in
-  reverse-creation order DERIVED from the durable actor-id (the
-  `#<n>` suffix), not the singleton straggler path that skips all of that.
-  True singletons keep the exit-cascade-only straggler path."
-  (:require [clojure.string :as str]
-            [re-frame.frame :as frame]
+  rf2-1vlyg — this used to be the other way round. The atom was the
+  authority, and a restored actor absent from it was ranked by parsing the
+  `#<n>` suffix off its actor-id. That suffix is allocated by a
+  **per-id-prefix** counter, so it sequences one machine type and cannot
+  order two: three actors created `:probe/a#1`, `:probe/a#2`, `:probe/b#1`
+  sorted to `[:probe/a#2 :probe/a#1 :probe/b#1]`, exiting the OLDER
+  `:probe/a#2` ahead of the NEWEST actor and inverting the stack
+  discipline Spec 005 §Cross-Spec Interactions §1 pins. An id supplied
+  through `:fixed-actor-id` carries no suffix at all. The parse was
+  attempting to reconstruct information the durable state did not contain,
+  which no cleverer parse could fix — so the order is now recorded.
+
+  Snapshots can still land by direct `[:rf.runtime/machines :snapshots]`
+  assoc, outside any spawn (test fixtures, hand-built payloads); those
+  carry no durable order entry and are walked as an UNSEQUENCED tail,
+  deterministically but with no reverse-creation claim attached — there is
+  no order to honour for actors nothing ever sequenced.
+
+  A restored SPAWNED actor's snapshot carries `:rf/machine-type` at its
+  root (stamped by `install-spawn!`; a SINGLETON snapshot never carries it
+  — actor_liveness_test:213). The walk SPLITS on that durable
+  discriminator: spawned actors run the full
+  `destroy/destroy-single-actor!` teardown (registrar cleanup, system-id
+  release, timer cancel, snapshot dissoc); true singletons keep the
+  exit-cascade-only straggler path."
+  (:require [re-frame.frame :as frame]
             [re-frame.machines.lifecycle-fx.destroy :as destroy]
             [re-frame.machines.lifecycle-fx.exit-cascade :as exit-cascade]
             [re-frame.machines.lifecycle-fx.finalize :as finalize]
@@ -64,16 +79,15 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-(defn- frame-machines-snapshot
-  "Snapshot of `[:rf.runtime/machines :snapshots]` on `frame-id`'s
-  RUNTIME-DB (a map of actor-id → snapshot), or an empty map. Read at the
-  start of the walk so we have a stable view of which actors were live; the
-  walk itself swaps the container and these reads are not re-evaluated.
+(defn- frame-runtime-db
+  "`frame-id`'s RUNTIME-DB value, or nil. Read ONCE at the start of the
+  walk so the snapshot map and the durable spawn-order vector come from
+  the same instant and cannot disagree; the walk itself swaps the
+  container and this read is not re-evaluated.
   EP-0001: machine snapshots are durable runtime-db state."
   [frame-id]
-  (let [container (frame/runtime-db-container frame-id)
-        rt        (when container (adapter/read-container container))]
-    (or (get-in rt (paths/snapshot-path)) {})))
+  (when-let [container (frame/runtime-db-container frame-id)]
+    (adapter/read-container container)))
 
 (defn- spawned-snapshot?
   "True iff `snapshot` is a spawned actor's snapshot, not
@@ -88,29 +102,21 @@
   [snapshot]
   (some? (:rf/machine-type snapshot)))
 
-(defn- creation-rank
-  "Derive a best-effort creation-order rank for a restored
-  spawned `actor-id` whose process-side spawn-order entry was lost across
-  restore/hydration. Spawned ids are allocated as `<type>#<n>` with a
-  monotonic per-type counter (`allocate-actor-id-in-runtime-db`), so the
-  trailing `#<n>` integer is the durable creation sequence the spawn-order
-  vector would otherwise carry. Returns the parsed `n` as a Long, or -1
-  for an id with no `#<n>` suffix (explicit `:fixed-actor-id` literals,
-  region-prefixed ids) so those sort oldest — there is no reverse-creation
-  contract to honour for ids the allocator never sequenced.
+(defn- unsequenced-order
+  "Deterministic walk order for spawned actors the durable spawn-order
+  vector does NOT carry — snapshots assoc'd straight into
+  `[:rf.runtime/machines :snapshots]` by a fixture or a hand-built
+  payload, which no spawn ever sequenced.
 
-  Ordering the spawned-straggler walk by DESCENDING rank reconstructs the
-  newest-first exit order Spec 005 §Cross-Spec Interactions §1 requires,
-  derived purely from durable runtime-db."
-  [actor-id]
-  (let [s (name actor-id)
-        i (str/last-index-of s "#")]
-    (if (and i (< (inc i) (count s)))
-      (let [tail (subs s (inc i))]
-        (if (re-matches #"\d+" tail)
-          #?(:clj (Long/parseLong tail) :cljs (js/parseInt tail 10))
-          -1))
-      -1)))
+  Sorted by the printed actor-id purely so the walk is REPRODUCIBLE
+  (runtime-db map iteration order is not). This is explicitly **not** a
+  creation order and makes no reverse-creation claim: nothing recorded one
+  for these actors, and per rf2-1vlyg the id spelling cannot supply it —
+  the `#<n>` suffix sequences a single id-prefix, and a `:fixed-actor-id`
+  has no suffix at all. Every actor that went through `install-spawn!`
+  carries a real durable rank and never reaches this tail."
+  [actor-ids]
+  (sort-by str actor-ids))
 
 (defn- emit-lifecycle-destroyed!
   "Emit the `:rf.machine.lifecycle/destroyed` notification per actor,
@@ -164,17 +170,24 @@
   against double-invocation, fail-soft against missing artefacts.
 
   The orchestration is:
-   1. Snapshot `[:rf.runtime/machines :snapshots]` once.
+   1. Read the frame's runtime-db once — both the
+      `[:rf.runtime/machines :snapshots]` map and the durable
+      `[:rf.runtime/machines :spawn-order]` vector come from that one
+      instant.
    2. Build the disposal order in three segments:
-      a. Recorded spawn-order reversed (newest first) — the live-process
-         spawned actors, walked in true reverse-creation order.
-      b. SPAWNED stragglers — snapshots that carry `:rf/machine-type` but
-         are absent from the (transient) spawn-order atom. This is the
-         restore / hydration / `replace-runtime-db!` case:
-         durable runtime-db carries the snapshot, the transient atom does
-         not. Walked newest-first by `creation-rank` derived from the
-         durable `<type>#<n>` actor-id, so reverse-creation order is
-         reconstructed from durable state alone.
+      a. The durable spawn-order vector REVERSED (newest first) — every
+         actor that went through `install-spawn!`, in true
+         reverse-creation order. This is the whole of the ordering
+         contract, and it holds identically for a live process and for a
+         frame that has been restored, hydrated or wholesale-replaced,
+         because the vector is durable runtime-db state rather than
+         process-side bookkeeping (rf2-1vlyg).
+      b. UNSEQUENCED spawned actors — snapshots carrying
+         `:rf/machine-type`, or ids recorded in the transient cache, that
+         the durable vector does not name. Only a directly-assoc'd
+         fixture / hand-built payload reaches here. Walked in
+         `unsequenced-order`: deterministic, with no reverse-creation
+         claim, because nothing ever sequenced them.
       c. Singleton stragglers — snapshots with no `:rf/machine-type`
          (registered via `reg-machine`, seeded directly). Runtime-db iteration
          order — there is no reverse-creation contract for singletons.
@@ -183,7 +196,7 @@
          work so trace consumers see the signal while the handler
          still resolves — same convention as Spec 005 §Cancellation
          cascade D6.
-      b. Spawned actors (recorded OR restored straggler): run the full
+      b. Spawned actors (durably sequenced OR unsequenced): run the full
          single-actor destroy — exit-cascade → http-abort →
          timer cancel → unified teardown projection →
          system-id-release trace → registrar cleanup → spawn-order forget.
@@ -195,30 +208,43 @@
    4. Clear the frame's spawn-order slot."
   [frame-id]
   (when frame-id
-    (let [snapshots    (frame-machines-snapshot frame-id)
-          recorded     (spawn-order/frame-order frame-id)
-          ;; Reverse recorded vector → newest spawn first.
-          newest-first (reverse recorded)
-          recorded-set (set recorded)
-          ;; Stragglers: actor-ids in [:rf.runtime/machines :snapshots] but absent
-          ;; from the recorded spawn-order vector. Covers singleton
-          ;; machines (registered via `reg-machine`), hydrated SSR
-          ;; payloads, restored runtime-db, and test fixtures that seed
-          ;; snapshots directly.
-          stragglers   (remove recorded-set (keys snapshots))
-          ;; Partition stragglers on the durable
-          ;; `:rf/machine-type` discriminator. Spawned stragglers (restore
-          ;; / hydration / replace-runtime-db! repopulated the durable
-          ;; snapshot but not the transient spawn-order atom) MUST get the
-          ;; full spawned teardown, ordered newest-first by the durable
-          ;; `#<n>` creation rank. Singletons keep the exit-only path.
-          {spawned-stragglers   true
-           singleton-stragglers false}
-          (group-by (fn [actor-id] (spawned-snapshot? (get snapshots actor-id)))
-                    stragglers)
-          spawned-stragglers'  (sort-by creation-rank #(compare %2 %1)
-                                        spawned-stragglers)]
-      ;; (b) Recorded spawned actors: full destroy in reverse-creation order.
+    (let [runtime-db   (frame-runtime-db frame-id)
+          snapshots    (or (get-in runtime-db (paths/snapshot-path)) {})
+          ;; The DURABLE total creation order, oldest → newest. Written by
+          ;; `install-spawn!` inside the swap that landed each snapshot and
+          ;; pruned by the teardown projection inside the swap that removed
+          ;; it, so it names exactly the live spawned actors — and it says so
+          ;; identically before and after a restore / hydration /
+          ;; `replace-runtime-db!`, which is the whole point (rf2-1vlyg).
+          durable      (spawn-order/durable-order runtime-db)
+          durable-set  (set durable)
+          ;; Reverse the durable vector → newest spawn first. THE
+          ;; reverse-creation walk, per Spec 005 §Cross-Spec Interactions §1.
+          newest-first (reverse durable)
+          ;; Spawned actors the durable order does not name. A spawn always
+          ;; records itself, so this is the directly-assoc'd fixture /
+          ;; hand-built payload case only. The transient cache is unioned in
+          ;; so an actor recorded there but already gone from runtime-db is
+          ;; still reaped, exactly as before.
+          unsequenced  (->> (concat (keys snapshots)
+                                    (spawn-order/frame-order frame-id))
+                            (remove durable-set)
+                            distinct
+                            ;; Partition on the durable `:rf/machine-type`
+                            ;; discriminator: a spawned snapshot MUST get the
+                            ;; full teardown (registrar cleanup / system-id
+                            ;; release / timer cancel / snapshot dissoc), while
+                            ;; a singleton keeps the exit-only path below. An
+                            ;; id present only in the transient cache has no
+                            ;; snapshot to classify and is treated as spawned —
+                            ;; it is one only a spawn could have recorded.
+                            (group-by (fn [actor-id]
+                                        (if-let [snapshot (get snapshots actor-id)]
+                                          (spawned-snapshot? snapshot)
+                                          true))))
+          singleton-stragglers (get unsequenced false)
+          unsequenced-spawned  (unsequenced-order (get unsequenced true))]
+      ;; (a) Durably sequenced spawned actors: full destroy, newest first.
       (doseq [actor-id newest-first]
         (let [snapshot (get snapshots actor-id)]
           (emit-lifecycle-destroyed! frame-id actor-id snapshot))
@@ -227,11 +253,10 @@
         ;; bad actor can't strand the rest of the cascade.
         (try (destroy/destroy-single-actor! frame-id actor-id)
              (catch #?(:clj Throwable :cljs :default) _ nil)))
-      ;; (b') Restored spawned stragglers: SAME full destroy, newest-first
-      ;; by durable creation rank. These get the complete spawned teardown
-      ;; (registrar cleanup / system-id release / timer cancel / snapshot
-      ;; dissoc), not the exit-only singleton straggler path.
-      (doseq [actor-id spawned-stragglers']
+      ;; (b) Unsequenced spawned actors: the SAME full teardown, in a
+      ;; deterministic order that claims no creation sequence — nothing ever
+      ;; recorded one for them (see `unsequenced-order`).
+      (doseq [actor-id unsequenced-spawned]
         (let [snapshot (get snapshots actor-id)]
           (emit-lifecycle-destroyed! frame-id actor-id snapshot))
         (try (destroy/destroy-single-actor! frame-id actor-id)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -558,6 +558,19 @@
             install-fn (fn [_rt]
                          (cond-> rt-after-alloc
                            spec      (assoc-in (paths/snapshot-path spawned-id) initial-snap)
+                           ;; rf2-1vlyg — append the actor to the DURABLE
+                           ;; spawn-order vector in the SAME swap that lands its
+                           ;; snapshot, so the frame's total creation order is
+                           ;; recorded rather than reconstructed. The per-prefix
+                           ;; `#<n>` suffix of `spawned-id` cannot order actors
+                           ;; of different machine types and is absent entirely
+                           ;; on a `:fixed-actor-id`, so frame destroy has no
+                           ;; other durable fact to read; the transient
+                           ;; `spawn-order/record!` below is a cache that any
+                           ;; restore / hydration / `replace-runtime-db!` wipes.
+                           ;; Gated on the same `spec` as the snapshot assoc: the
+                           ;; order tracks exactly the actors that have snapshots.
+                           spec      (spawn-order/record-in-runtime-db spawned-id)
                            system-id (assoc-in (paths/system-id-path system-id) spawned-id)
                            track?    (assoc-in (paths/spawned-path parent-id invoke-id) spawned-id)))
             written    (if owner-token

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/teardown.cljc
@@ -7,6 +7,12 @@
   destroy) the runtime applies a five-step runtime-db projection:
 
     1. dissoc snapshot at `[:rf.runtime/machines :snapshots actor-id]`
+    1b. drop the actor from the durable spawn-order vector at
+       `[:rf.runtime/machines :spawn-order]` — the frame's recorded
+       total creation order (rf2-1vlyg), pruned when it empties. This
+       is the teardown half of the append `install-spawn!` makes; both
+       ride the same swap as the snapshot mutation, so the order can
+       never name a dead actor or omit a live one.
     2. release `[:rf.runtime/machines :system-ids <sid>]` reverse-index
        entry (if bound)
     3. clear `[:rf.runtime/machines :spawned parent-id invoke-id]` slot
@@ -40,8 +46,12 @@
   This namespace is PURE — it does not unregister handlers, abort
   in-flight HTTP, or emit traces. Those are caller side effects whose
   ordering relative to db mutation is contract (Spec 005 §Cancellation
-  cascade D6-D8)."
-  (:require [re-frame.machines.paths :as paths]))
+  cascade D6-D8). The `spawn-order` fns it reaches for step 1b are
+  likewise pure runtime-db → runtime-db; the transient atom that ns also
+  owns is untouched here (its `forget!` stays a caller side effect,
+  because it must run even when no runtime-db swap lands)."
+  (:require [re-frame.machines.paths :as paths]
+            [re-frame.machines.spawn-order :as spawn-order]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -104,6 +114,17 @@
         new-db       (cond-> db
                        actor-id     (update-in (paths/snapshot-path)
                                                dissoc actor-id)
+                       ;; (1b) rf2-1vlyg — drop the actor from the DURABLE
+                       ;; spawn-order vector in the same swap that dissocs its
+                       ;; snapshot, so the recorded creation order tracks the
+                       ;; LIVE actors exactly. Every destroy path routes through
+                       ;; this projection (explicit / tracked / exit-cascade /
+                       ;; `:final?` auto-destroy), so one removal site covers
+                       ;; them all: a destroyed actor can neither be exited a
+                       ;; second time by a later frame destroy nor accumulate as
+                       ;; an unbounded stale entry. The slot is pruned when it
+                       ;; empties (`forget-in-runtime-db`), mirroring `:spawned`.
+                       actor-id     (spawn-order/forget-in-runtime-db actor-id)
                        released-sid (update-in (paths/system-id-path)
                                                dissoc released-sid)
                        track?       (update-in (paths/spawned-path parent-id)

--- a/implementation/machines/src/re_frame/machines/paths.cljc
+++ b/implementation/machines/src/re_frame/machines/paths.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.machines.paths
   "Runtime-db path constructors for the runtime-owned machines slots.
 
-  The machines runtime keeps four sibling maps under the reserved
+  The machines runtime keeps five sibling slots under the reserved
   `:rf.runtime/machines` child of each frame's **runtime-db** partition
   (Conventions §Reserved runtime-db keys — machine snapshots are durable
   framework state, so they live in the runtime-db partition):
@@ -10,6 +10,34 @@
     - `:system-ids`    — system-id → actor-id reverse index
     - `:spawned`       — parent-id → invoke-id → join-state / spawned-id
     - `:spawn-counter` — machine-id → int (hand-emitted-spawn fallback)
+    - `:spawn-order`   — vector of actor-id, **oldest → newest**
+
+  `:spawn-order` is the durable TOTAL creation order over the frame's live
+  spawned actors, and it is the ONLY authority for the reverse-creation
+  disposal contract (Spec 005 §Cross-Spec Interactions §1). It exists
+  because no other durable fact carries a frame-global sequence:
+  `:spawn-counter` (and the parent-snapshot-resident `:rf/spawn-counter`
+  the declarative path bumps) are **per-id-prefix** allocators, so the
+  `#<n>` suffix of an actor-id sequences that prefix ALONE and cannot
+  order two actors of different machine types — and an id supplied
+  through `:fixed-actor-id` carries no suffix at all. Deriving disposal
+  order from the id spelling is therefore reconstructing information the
+  durable state does not contain; this slot records it instead (rf2-1vlyg).
+
+  It is written by exactly two places, each inside the SAME runtime-db
+  swap as the snapshot mutation it accompanies, so the order and the
+  snapshots can never disagree: the spawn install
+  (`lifecycle-fx.spawn/install-spawn!`) appends, and the unified teardown
+  projection (`lifecycle-fx.teardown/teardown-actor`) removes. Because it
+  rides the durable runtime-db value it survives every supported round
+  trip — `replace-runtime-db!`, epoch restore, and the SSR machine-runtime
+  projection (which re-projects `:snapshots` and carries its siblings
+  verbatim) — without a restore callback. Allocated lazily and pruned when
+  it empties, mirroring `:spawned`.
+
+  The pure constructors/removers for the slot live in
+  `re-frame.machines.spawn-order` alongside the transient process-side
+  cache of the same order.
 
   These constructors are the single source of truth for the literal
   path vectors that `src/` reads and writes (`get-in` / `update-in` /
@@ -50,6 +78,15 @@
     (system-id-path sid) => [:rf.runtime/machines :system-ids sid]"
   ([]    [:rf.runtime/machines :system-ids])
   ([sid] [:rf.runtime/machines :system-ids sid]))
+
+(defn spawn-order-path
+  "Path (in the runtime-db value) to the `:spawn-order` slot — the durable
+  oldest-to-newest vector of live spawned actor-ids that carries the
+  frame's TOTAL creation order (see ns docstring).
+
+    (spawn-order-path) => [:rf.runtime/machines :spawn-order]"
+  []
+  [:rf.runtime/machines :spawn-order])
 
 (defn spawned-path
   "Path (in the runtime-db value) to the `:spawned` slot, optionally

--- a/implementation/machines/src/re_frame/machines/spawn_order.cljc
+++ b/implementation/machines/src/re_frame/machines/spawn_order.cljc
@@ -5,22 +5,94 @@
   actors leaf-to-root in **reverse-creation order** — the most recently
   spawned instance disposes first.
 
-  `[:rf.runtime/machines :snapshots]` snapshots live in runtime-db keyed by actor-id; the map
-  iteration order is not insertion order, so an explicit order channel
-  is required to satisfy the spec's reverse-creation invariant.
+  `[:rf.runtime/machines :snapshots]` snapshots live in runtime-db keyed
+  by actor-id; the map iteration order is not insertion order, so an
+  explicit order channel is required to satisfy the spec's
+  reverse-creation invariant.
 
-  Shape: `{<frame-id> [<actor-id-1> <actor-id-2> ...]}` — a vector used
-  as an append-only stack. Spawn appends; explicit destroy (single
-  actor, `:spawn-all` per-child, final-state auto-destroy) removes;
-  frame destroy walks the vector in reverse and clears the entry.
+  ## Two channels, one authority
 
-  Process-side (defonce atom) rather than app-db slot — the channel is
-  pure runtime bookkeeping, has no observer contract, and never
-  participates in revertibility (destroyed actors stay destroyed). The
-  same pattern is used for the `:after` timer table in
-  `re-frame.machines.timer/after-timers`.")
+  **The DURABLE vector at `[:rf.runtime/machines :spawn-order]` is the
+  source of truth** (`paths/spawn-order-path`; see that ns docstring for
+  the slot's contract). It is an oldest-to-newest vector of live spawned
+  actor-ids, written by `record-in-runtime-db` / `forget-in-runtime-db`
+  below — each called from inside the SAME runtime-db swap as the
+  snapshot install or teardown it accompanies, so order and snapshots
+  cannot disagree. Because it rides the durable runtime-db value it
+  survives `replace-runtime-db!`, epoch restore, and SSR hydration, which
+  is precisely what the transient channel below does not.
+
+  **The process-side `spawn-order` atom is a transient CACHE of the same
+  order, never the authority** (rf2-1vlyg). It is runtime bookkeeping in
+  the Spec 002 §Durable vs transient sense: it has no observer contract,
+  is not serialised, and is empty after any state round trip. Destroy
+  keeps consulting it as a liveness bit (`destroy/actor-live?` — it is
+  set on spawn and cleared on destroy regardless of whether a runtime-db
+  swap landed), but frame destroy takes its ORDER from the durable vector
+  alone. Before rf2-1vlyg, frame destroy fell back to parsing the `#<n>`
+  suffix of a restored actor-id when this atom was empty; that suffix is a
+  per-id-prefix sequence and cannot order actors of different machine
+  types, so the fallback emitted a confident wrong order. The durable
+  vector replaced it.
+
+  Shape (both channels): a vector used as an append-only stack, the
+  transient one keyed by frame — `{<frame-id> [<actor-id-1> …]}`. Spawn
+  appends; explicit destroy (single actor, `:spawn-all` per-child,
+  final-state auto-destroy) removes; frame destroy walks in reverse and
+  clears. The transient atom follows the same pattern as the `:after`
+  timer table in `re-frame.machines.timer/after-timers`."
+  (:require [re-frame.machines.paths :as paths]))
 
 #?(:clj (set! *warn-on-reflection* true))
+
+;; ---- durable channel: [:rf.runtime/machines :spawn-order] ----------------
+;;
+;; PURE runtime-db → runtime-db functions. They are called from inside the
+;; callers' own swap fns (`install-spawn!`'s `install-fn`,
+;; `teardown/teardown-actor`), never as standalone writes, so the order
+;; mutation and the snapshot mutation commit atomically together.
+
+(defn durable-order
+  "The frame's durable spawn-order vector, OLDEST → NEWEST, read out of
+  `runtime-db`. Empty when no spawn has landed (the slot is allocated
+  lazily) or when every spawned actor has been torn down (it is pruned
+  when it empties)."
+  [runtime-db]
+  (or (get-in runtime-db (paths/spawn-order-path)) []))
+
+(defn record-in-runtime-db
+  "Append `actor-id` to the durable spawn-order vector in `runtime-db`,
+  returning the updated runtime-db. Idempotent by value: an id already in
+  the vector keeps its ORIGINAL position rather than being re-appended, so
+  a re-install can never double-enter an actor and make frame destroy exit
+  it twice."
+  [runtime-db actor-id]
+  (if (nil? actor-id)
+    runtime-db
+    (update-in runtime-db (paths/spawn-order-path)
+               (fn [v]
+                 (let [v (or v [])]
+                   (if (some #(= actor-id %) v)
+                     v
+                     (conj v actor-id)))))))
+
+(defn forget-in-runtime-db
+  "Remove `actor-id` from the durable spawn-order vector in `runtime-db`,
+  returning the updated runtime-db. Prunes the slot entirely once it
+  empties — the lazy-allocation mirror `:spawned` follows, so a frame whose
+  actors have all been destroyed carries no residue. Absent slot / absent
+  id are clean no-ops (destroy is silent-idempotent)."
+  [runtime-db actor-id]
+  (if (or (nil? actor-id)
+          (not (contains? (get runtime-db :rf.runtime/machines) :spawn-order)))
+    runtime-db
+    (let [remaining (filterv #(not= actor-id %)
+                             (get-in runtime-db (paths/spawn-order-path)))]
+      (if (empty? remaining)
+        (update-in runtime-db [:rf.runtime/machines] dissoc :spawn-order)
+        (assoc-in runtime-db (paths/spawn-order-path) remaining)))))
+
+;; ---- transient channel: the process-side cache ---------------------------
 
 (defonce
   ^{:doc "Runtime-owned per-frame spawn-order vectors. See ns docstring."}
@@ -47,8 +119,11 @@
   nil)
 
 (defn frame-order
-  "Return `frame-id`'s spawn-order vector (oldest → newest), or an empty
-  vector when no spawns have been recorded."
+  "Return `frame-id`'s TRANSIENT spawn-order vector (oldest → newest), or
+  an empty vector when no spawns have been recorded in this process. This
+  is the cache, not the authority — it is empty after any state round
+  trip, so a caller that needs the frame's real creation order reads
+  `durable-order` off the runtime-db instead."
   [frame-id]
   (or (get @spawn-order frame-id) []))
 

--- a/implementation/machines/src/re_frame/machines/ssr.cljc
+++ b/implementation/machines/src/re_frame/machines/ssr.cljc
@@ -36,8 +36,12 @@
 
   Snapshots whose frame classifies no matching `:data` path ride VERBATIM — the
   projection is precise, not a blanket scrub. The sibling registry slots
-  (`:system-ids`, `:spawned`, `:spawn-counter`) are durable bookkeeping (reverse
-  indexes + counters — no user `:data`) and ride unchanged.
+  (`:system-ids`, `:spawned`, `:spawn-counter`, `:spawn-order`) are durable
+  bookkeeping (reverse indexes, counters, and the creation-order vector — no
+  user `:data`) and ride unchanged. `:spawn-order` riding the wire verbatim is
+  what lets a HYDRATED frame dispose its actors in true reverse-creation order
+  (rf2-1vlyg): it is a vector of actor-id keywords, so it survives the
+  hydration payload's EDN round trip like every other bookkeeping sibling.
 
   ## Late-binding
 

--- a/implementation/machines/test/re_frame/frame_destroy_cascade_test.clj
+++ b/implementation/machines/test/re_frame/frame_destroy_cascade_test.clj
@@ -302,8 +302,9 @@
 ;; SPAWNED actor (snapshot carries `:rf/machine-type`) flows through the FULL
 ;; `destroy-single-actor!` teardown — dissoc the snapshot, release the
 ;; system-id reverse index, clear schema marks, cancel `:after` timers,
-;; unregister a handler — in reverse-creation order derived from the durable
-;; `<type>#<n>` actor-id. (The straggler `run-singleton-exit-cascade!` path
+;; unregister a handler — in reverse-creation order read off the durable
+;; `[:rf.runtime/machines :spawn-order]` vector, which rides the runtime-db
+;; value through the round trip. (The straggler `run-singleton-exit-cascade!` path
 ;; runs the `:exit` cascade + HTTP abort only and is reserved for restored
 ;; SINGLETON snapshots that carry no `:rf/machine-type`.)
 ;;
@@ -358,12 +359,19 @@
           "spawn-order atom is empty post-restore (the bug's precondition)")
       ;; Destroy the frame.
       (rf/destroy-frame! :rs/auth)
-      ;; :exit fired for all three children, NEWEST-FIRST by the durable
-      ;; #<n> rank. (Filter to children — the boot singleton's :exit, if
-      ;; any, is irrelevant to the spawned-ordering contract.)
+      ;; :exit fired for all three children, NEWEST-FIRST off the durable
+      ;; spawn-order vector. (Filter to children — the boot singleton's
+      ;; :exit, if any, is irrelevant to the spawned-ordering contract.)
+      ;;
+      ;; These three share ONE id-prefix, so this case cannot distinguish the
+      ;; durable order from the per-prefix `#<n>` suffix the pre-rf2-1vlyg
+      ;; fallback parsed — which is exactly why it stays here as the
+      ;; SAME-PREFIX CONTROL, green across the repair, while
+      ;; `restored-mixed-prefix-actors-exit-in-reverse-creation-order` below
+      ;; is the discriminator.
       (is (= [:rs/child#3 :rs/child#2 :rs/child#1]
              (filterv #{:rs/child#1 :rs/child#2 :rs/child#3} @exit-log))
-          ":exit ran newest-first, order derived from the durable actor-id (not the lost spawn-order atom)")
+          ":exit ran newest-first, order read off the durable spawn-order vector (not the lost transient atom)")
       ;; FULL teardown: every restored SPAWNED snapshot is dissoc'd. The
       ;; singleton straggler path would have LEFT these in runtime-db.
       (is (empty? (keep (fn [[id snap]]
@@ -430,3 +438,132 @@
       ;; ...but its TYPE handler stays globally registered (outlives the frame).
       (is (some? (registrar/lookup :event :rsg/single))
           "singleton handler stays registered — NOT unregistered by the straggler path"))))
+
+;; ---- durable spawn-order: the frame-global creation sequence (rf2-1vlyg) ----
+;;
+;; The tests above restore a frame whose actors all share ONE id-prefix, so the
+;; per-prefix `#<n>` suffix happens to be a valid total order and the defect
+;; below is invisible. These tests use TWO machine types, which the suffix
+;; cannot order: `:probe/a#1`, `:probe/a#2` and `:probe/b#1` were created in
+;; that sequence, but descending-suffix sorting puts `:probe/a#2` (rank 2)
+;; ahead of the NEWEST actor `:probe/b#1` (rank 1). The information the old
+;; fallback tried to reconstruct is simply not in the actor-id — so the frame's
+;; total creation order is now RECORDED, in the durable
+;; `[:rf.runtime/machines :spawn-order]` vector that rides the runtime-db value
+;; through restore / hydration / `replace-runtime-db!`.
+
+(defn- runtime-spawn-order
+  "The durable `[:rf.runtime/machines :spawn-order]` vector (oldest →
+  newest) on `frame-id`'s runtime-db, or nil when the slot is absent."
+  [frame-id]
+  (get-in (:rf.db/runtime (rf/frame-state-value frame-id))
+          [:rf.runtime/machines :spawn-order]))
+
+(defn- reg-probe-machines!
+  "Register two child machine types under DIFFERENT id-prefixes, each
+  appending its own stamped `:rf/self-id` to `exit-log` from its active
+  state's `:exit`, plus a boot machine whose action emits three
+  `:rf.machine/spawn` effects in the order A, A, B."
+  [exit-log]
+  (let [child (fn [] {:initial :running
+                      :data    {}
+                      :states  {:running
+                                {:exit (fn [{data :data}]
+                                         (swap! exit-log conj (:rf/self-id data))
+                                         {})}}})
+        spawn (fn [t] [:rf.machine/spawn {:machine-id t :id-prefix t}])]
+    (rf/reg-machine :probe/a (child))
+    (rf/reg-machine :probe/b (child))
+    (rf/reg-machine :probe/boot
+                    {:initial :idle
+                     :data    {}
+                     :states  {:idle {:on {:spawn-mixed
+                                           {:action (fn [_]
+                                                      {:fx [(spawn :probe/a)
+                                                            (spawn :probe/a)
+                                                            (spawn :probe/b)]})}}}}})))
+
+(deftest restored-mixed-prefix-actors-exit-in-reverse-creation-order
+  (testing "a restored frame holding actors of TWO machine types disposes them newest-first — the per-prefix #<n> suffix cannot order them, the durable spawn-order vector can"
+    (rf/make-frame {:id :probe/auth :doc "mixed-prefix restore frame"})
+    (let [exit-log (atom [])]
+      (reg-probe-machines! exit-log)
+      (rf/dispatch-sync [:probe/boot [:spawn-mixed]] {:frame :probe/auth})
+      ;; --- non-vacuity controls, BEFORE the round trip -------------------
+      ;; All three actors are live...
+      (is (= #{:probe/a#1 :probe/a#2 :probe/b#1}
+             (set (keep (fn [[id snap]]
+                          (when (some? (:rf/machine-type snap)) id))
+                        (runtime-snapshots :probe/auth))))
+          "three spawned snapshots are live before the round trip")
+      ;; ...and the DURABLE order records the exact sequence they were
+      ;; created in. This is the fact the old code had no way to know.
+      (is (= [:probe/a#1 :probe/a#2 :probe/b#1]
+             (runtime-spawn-order :probe/auth))
+          "durable spawn-order carries the frame-global creation sequence, across id-prefixes")
+      ;; --- the loss boundary --------------------------------------------
+      ;; Model epoch restore / SSR hydration: the durable runtime-db
+      ;; survives, the transient process-side atom does not.
+      (spawn-order/reset-all!)
+      (is (= [] (spawn-order/frame-order :probe/auth))
+          "transient spawn-order atom is empty post-restore (the bug's precondition)")
+      (is (= [:probe/a#1 :probe/a#2 :probe/b#1]
+             (runtime-spawn-order :probe/auth))
+          "the durable order is untouched by the loss of the transient atom")
+      ;; --- the discriminator --------------------------------------------
+      (rf/destroy-frame! :probe/auth)
+      (is (= [:probe/b#1 :probe/a#2 :probe/a#1]
+             (filterv #{:probe/a#1 :probe/a#2 :probe/b#1} @exit-log))
+          (str "exact reverse creation order. Descending-suffix sorting — the pre-rf2-1vlyg "
+               "fallback — yields [:probe/a#2 :probe/a#1 :probe/b#1], exiting :probe/a#2 "
+               "ahead of the newest actor :probe/b#1 and inverting the stack discipline "
+               "Spec 005 §Cross-Spec Interactions §1 pins."))
+      (is (= 3 (count (filterv #{:probe/a#1 :probe/a#2 :probe/b#1} @exit-log)))
+          "each child exited exactly once")
+      (is (empty? (keep (fn [[id snap]]
+                          (when (some? (:rf/machine-type snap)) id))
+                        (runtime-snapshots :probe/auth)))
+          "every restored spawned snapshot was dissoc'd (full teardown, not exit-only)"))))
+
+(deftest durable-spawn-order-is-transport-safe
+  (testing "the durable ordering fact is plain data — it round-trips through EDN unchanged and carries no fn / atom / host handle"
+    (rf/make-frame {:id :probeedn/auth :doc "spawn-order transport frame"})
+    (let [exit-log (atom [])]
+      (reg-probe-machines! exit-log)
+      (rf/dispatch-sync [:probe/boot [:spawn-mixed]] {:frame :probeedn/auth})
+      (let [order (runtime-spawn-order :probeedn/auth)]
+        (is (= [:probe/a#1 :probe/a#2 :probe/b#1] order)
+            "the order is recorded before the round trip (non-vacuity control)")
+        (is (vector? order) "a vector — an ordered, indexable value")
+        (is (every? keyword? order)
+            "actor-id keywords only: no function, atom, or host handle enters runtime-db")
+        (is (= order (read-string (pr-str order)))
+            "survives pr-str / read-string unchanged — so it rides the SSR hydration payload and an epoch snapshot")))))
+
+(deftest explicit-destroy-prunes-durable-spawn-order
+  (testing "a successful explicit destroy removes the actor from the durable order, so a later frame destroy neither re-exits it nor leaves a stale entry"
+    (rf/make-frame {:id :probedd/auth :doc "spawn-order prune frame"})
+    (let [exit-log (atom [])]
+      (reg-probe-machines! exit-log)
+      ;; Add a destroy trigger to the boot machine's state.
+      (rf/reg-machine :probedd/boot
+                      {:initial :idle
+                       :data    {}
+                       :states  {:idle {:on {:drop-middle
+                                             {:action (fn [_]
+                                                        {:fx [[:rf.machine/destroy :probe/a#2]]})}}}}})
+      (rf/dispatch-sync [:probe/boot [:spawn-mixed]] {:frame :probedd/auth})
+      (is (= [:probe/a#1 :probe/a#2 :probe/b#1]
+             (runtime-spawn-order :probedd/auth))
+          "all three recorded before the destroy (non-vacuity control)")
+      (rf/dispatch-sync [:probedd/boot [:drop-middle]] {:frame :probedd/auth})
+      (is (= [:probe/a#1 :probe/b#1] (runtime-spawn-order :probedd/auth))
+          "the explicitly destroyed actor is pruned from the durable order, the survivors keep their sequence")
+      (is (= [:probe/a#2] @exit-log)
+          "the destroyed actor's :exit ran once, at destroy time")
+      ;; The frame destroy that follows must not re-exit the dead actor.
+      (rf/destroy-frame! :probedd/auth)
+      (is (= [:probe/a#2 :probe/b#1 :probe/a#1] @exit-log)
+          "frame destroy exits only the two survivors, newest-first — the dead actor is not exited a second time")
+      (is (nil? (runtime-spawn-order :probedd/auth))
+          "the slot is pruned once it empties — no unbounded stale entry survives the frame"))))


### PR DESCRIPTION
Closes rf2-1vlyg.

## The finding, re-derived

`teardown-on-frame-destroy!` promised reverse-creation disposal even for a frame whose process-side spawn-order atom had been lost to epoch restore or SSR hydration. Its fallback sorted restored actor ids by the trailing `#<n>` suffix parsed by `creation-rank`.

That suffix is allocated by a **per-id-prefix** counter (`spawn.cljc`'s `allocate-actor-id-in-runtime-db`, keyed on `(or :id-prefix :machine-id)`), so it sequences one machine type and cannot order two — and an id supplied through `:fixed-actor-id` carries no suffix at all. Three actors created `:probe/a#1`, `:probe/a#2`, `:probe/b#1` disposed as `[:probe/a#2 :probe/a#1 :probe/b#1]`: the older `:probe/a#2` exits ahead of the newest actor `:probe/b#1`, inverting the stack discipline Spec 005 §Cross-Spec Interactions §1 pins.

Every line the bead cited was verified at this tip and **all of them still resolve exactly — line-number delta zero**: `creation-rank` at `frame_destroy.cljc:91-113`, the two order claims at `:168-177` and `:209-220`, the per-prefix allocator at `spawn.cljc:60-75` and `:909-914`, the same-prefix restore control at `frame_destroy_cascade_test.clj:321-366`.

## Which repair, and why

The bead's own sentence settles it: *"The implementation is attempting to reconstruct information that the durable state does not contain."* No cleverer parse can succeed against absent information, so the honest options were to **persist** the order or to **refuse loudly**. This persists it, which is what the item rules and what the code makes cheap.

A new durable `[:rf.runtime/machines :spawn-order]` sibling holds the frame-global creation sequence, oldest → newest:

- **`install-spawn!` appends** inside the same exact-owner swap that lands the snapshot (`spawn.cljc`'s `install-fn`), gated on the same `spec` as the snapshot assoc. That is the *only* snapshot-install site in the artefact, so one append covers every spawn shape.
- **`teardown/teardown-actor` removes**, inside the swap that dissocs the snapshot, and prunes the slot when it empties. That pure projection is the single chokepoint all four destroy paths route through (explicit, tracked, exit-cascade, `:final?` auto-destroy), so one removal site covers them all — which is what makes the "no double exit, no unbounded stale entry" criterion structural rather than something to remember.
- **Frame destroy reverses that vector and consults nothing else.**

Order and snapshots therefore cannot disagree: each pair of mutations commits atomically. Because the fact rides the durable runtime-db value it survives `replace-runtime-db!`, epoch restore, and the SSR machine-runtime projection — verified at source: `machines/ssr.cljc` re-projects `:snapshots` entry-by-entry via `(assoc machines :snapshots …)` and carries every sibling verbatim. No restore callback is needed.

The suffix parser is deleted (its `Long/parseLong` reader conditional goes with it). The process-side atom is **retained as a transient liveness cache only** — `destroy/actor-live?` still needs it, since it is set and cleared regardless of whether a runtime-db swap landed — and is now documented as a cache rather than an authority. Actors that no spawn ever sequenced (a fixture assoc'ing a snapshot directly) are walked in a deterministic `unsequenced-order` tail that explicitly claims no creation order.

Per the item's non-goals: public actor ids, the per-prefix counters, `:system-id`, join semantics and callback APIs are all unchanged.

## Quality gates

| Run | Command | Captured exit |
|---|---|---|
| 1 — repaired tree | `clojure -M:test` from `implementation/machines` | **0** (1207 tests, 4212 assertions) |
| 2 — **sabotage** | same, with the pre-repair suffix sort planted | **1** (2 failures) |
| 3 — post-rebase, final base | same | **0** (1207 tests, 4212 assertions) |

Exit codes were captured with the redirect and `echo $?` on one command line, and are the numbers quoted here.

**The control.** The plant restored the pre-repair ordering (descending `#<n>` rank over the durable ids) at the one line frame destroy takes its order from. It produced **exactly the order the bead measured on main**:

```
expected: [:probe/b#1 :probe/a#2 :probe/a#1]
  actual: [:probe/a#2 :probe/a#1 :probe/b#1]
```

Only the two ordering assertions went red. Every non-vacuity control stayed green — the pre-round-trip live set, the recorded durable order, the EDN round-trip, and the prune assertion — which is the negative control the item asks for. Namespace and assertion counts were identical across the sabotage and control runs (1207 / 4212), so the plant stopped no namespace. The failures also confirm positively that the runtime executed the new test code.

The **same-prefix restore control** (`:rs/child#3, #2, #1`) stayed green under the sabotage, as it must: with one id-prefix the suffix happens to be a valid total order. That is precisely why it could never have caught this, and why it stays as the control while the mixed-prefix case is the discriminator. A comment on it now says so.

Restores were verified by **git blob hash** against the committed object, not by reading a diff — `core.autocrlf` is on in this checkout, so a byte digest of the working file would be the wrong instrument. The planted file returned to blob `a25c7c6d9ecd1c60876742e0ca49534905f54c8b`, matching the pre-plant object, with a clean tree.

Gates re-run after the rebase onto the current trunk; run 3 is the verdict for the base this PR actually merges from.

**Required checks this local run does not cover.** The lane above is `test.yml`'s `jvm-machines` job. My diff is `.cljc`, so it also compiles into the consolidated `cljs` job's `:node-test` build (`.github/scripts/report-changed-surfaces.sh`'s `cljs_node_test` output), which no JVM run exercises. CI owns that one.

## Spec surface — one row is owed, and I did not take it

I did **not** edit `spec/005-StateMachines.md`, and the fleet is not serialised against it. Nothing in 005 became false: it states the reverse-creation *requirement*, which was correct all along and is now met for the first time on the restore path. The wrong claims were in the implementation docstrings, and those are repaired here.

What a new durable runtime-db sibling does owe is a row in the reserved-slot bookkeeping, and that lives in files outside this dispatch's fence — so I have filed **rf2-pg5w6** rather than touching them:

- `spec/Conventions.md` — the `:rf.runtime/machines` child list and the §Reserved runtime-db keys table
- `spec/Spec-Schemas.md` — the `Machines` schema and its prose bullet
- `spec/002-Frames.md` and `spec/Runtime-Subsystems.md` — one-line slot enumerations

None of these gates the correctness of this change: `Machines` is an open `[:map …]` with no `{:closed true}`, so the new key validates today. The in-tree schema commentary that *is* in my surface — `paths.cljc`'s ns docstring, which is the artefact's own source of truth for these slot vectors — carries the full contract for the new slot.

Markdown link targets and anchors are not in scope here: this PR touches no `.md` file.
