### PR TITLE
fix(examples/websocket): settle in-flight requests on :ws/fatal (rf2-ni0ko)

### DIFF
--- a/examples/patterns/websocket/connection.cljs
+++ b/examples/patterns/websocket/connection.cljs
@@ -288,6 +288,26 @@
       (fn action-fail-in-flight [{data :data}]
         (fail-in-flight data))
 
+      :on-fatal-error
+      ;; `:ws/fatal` is the app-level escape hatch out of `:active` — the
+      ;; app itself declaring the connection unrecoverable (a protocol
+      ;; violation, a server telling us not to come back) and going
+      ;; straight to `:failed` without retrying. It leaves `:active`, so
+      ;; the runtime destroys the socket just as surely as a drop or a
+      ;; clean disconnect does, and the SAME invariant applies: every
+      ;; request accepted into `:in-flight` settles exactly once on the
+      ;; way out. Recording the error is only half the job — without the
+      ;; `fail-in-flight` half the slot and its waiting `:reply-event`
+      ;; survive teardown forever, because the scheduled timeout carries
+      ;; the destroyed socket's id and `:current-socket?` rejects it once
+      ;; the socket is gone. That leak outlives a later manual
+      ;; `:ws/connect` out of `:failed` too, so the caller never learns
+      ;; anything. Unlike `:on-socket-lost` there's no retry bump: we are
+      ;; giving up, not retrying, so the counter is beside the point.
+      (fn action-on-fatal-error [{data :data [_ {:keys [error]}] :event}]
+        (-> (fail-in-flight data)
+            (update :data assoc :error error)))
+
       :reset-retries
       (fn action-reset-retries [{data :data}]
         {:data (assoc data :retries 0)})
@@ -485,8 +505,16 @@
        :on    {:ws/closed   {:guard  :current-socket?
                              :target :reconnecting
                              :action :on-socket-lost}
+               ;; The app-level escape hatch. It leaves :active, so it kills
+               ;; the wire — and therefore settles the in-flight set on the
+               ;; way out as well as recording the error (see the
+               ;; :on-fatal-error action). Every door out of :active that
+               ;; can be taken from :connected now settles :in-flight
+               ;; exactly once: this one, the guarded :ws/closed drop
+               ;; (:on-socket-lost) and the clean :ws/disconnect
+               ;; (:fail-in-flight).
                :ws/fatal    {:target :failed
-                             :action :record-error}
+                             :action :on-fatal-error}
                :ws/send     {:action :enqueue-message}
                :ws/request  {:action :enqueue-message}
                :ws/rotate-cred {:action :rotate-cred}
@@ -528,6 +556,17 @@
                  ;; and a bare keyword would be read as the sibling
                  ;; `[:active :failed]` — which doesn't exist. The absolute
                  ;; vector says "from the root, please".
+                 ;;
+                 ;; This door leaves :active too, but it needs no
+                 ;; in-flight settlement — plain :record-error is correct
+                 ;; here, not an oversight. :register-request is the only
+                 ;; writer into :in-flight and it is bound only on
+                 ;; :connected; everywhere else a :ws/request enqueues
+                 ;; instead. Reaching :authenticating means we have not
+                 ;; been :connected since the last :active entry, and
+                 ;; every door out of :active from :connected clears
+                 ;; :in-flight on the way out. So :in-flight is provably
+                 ;; empty whenever this fires.
                  :ws/auth-failed {:guard  :current-socket?
                                   :target [:failed]
                                   :action :record-error}}}

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -826,6 +826,110 @@
             (is (= 1 (count (log)))
                 "the callback count stays exactly one across the reconnect")))))))
 
+(defn- fatal-fails-in-flight-request-test []
+  ;; rf2-ni0ko — the last door out of :active that did not settle :in-flight.
+  ;; :ws/fatal is the documented app-level escape hatch (spec/Pattern-WebSocket
+  ;; §The machine, ':active / * --:ws/fatal--> :failed'), and leaving :active
+  ;; destroys the socket actor exactly as a drop or a clean disconnect does —
+  ;; so the SAME invariant applies: every in-flight request settles exactly
+  ;; once on the way out. Before the fix the transition carried :record-error
+  ;; alone, so the slot and its waiting :reply-event survived teardown
+  ;; forever: the scheduled timeout carries the destroyed socket's id, so
+  ;; :current-socket? rejects it once the socket is gone and the only cleanup
+  ;; path has left with it — including across a later manual :ws/connect out
+  ;; of :failed, which is the leak this asserts against.
+  ;;
+  ;; Mirrors websocket-clean-disconnect-fails-in-flight-request (rf2-b2jpr)
+  ;; with :ws/fatal as the exit door, and adds the assertion that door owns:
+  ;; the error is still recorded. Composing onto the shared fail-in-flight
+  ;; helper rather than replacing :record-error is what keeps both true.
+  (rf/reg-event :ws.test/log-fatal-reply
+    (fn handler-ws-test-log-fatal-reply [{:keys [db]} [_ body]]
+      {:db (update-in db [:messages :reply-log] (fnil conj []) body)
+       :fx [[:dispatch [:ws.app/request-reply body]]]}))
+  (with-sync-mock!
+    (fn []
+      (with-new-frame [f (new-frame)]
+        (rf/dispatch-sync [:ws/connection
+                           [:ws/connect {:url "ws://mock" :cred-ref :ws.demo/cred-a}]]
+                          {:frame f})
+        (is (true? (machine-has-tag? f :websocket/connected)))
+        (let [old-id (socket-id-of (snapshot (:rf.db/runtime (rf/frame-state-value f))))
+              rid    (random-uuid)
+              log    #(get-in (rf/app-db-value f) [:messages :reply-log])]
+          (is (some? old-id))
+          ;; A request whose wire :type the mock does NOT echo, so it sits
+          ;; in-flight with no reply to clear it — genuinely on the wire.
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/request {:request-id rid
+                                           :body       {:type :silent-no-echo}
+                                           :reply      [:ws.test/log-fatal-reply]
+                                           :timeout-ms 5000}]]
+                            {:frame f})
+          ;; Positive control: the request is genuinely in :in-flight and no
+          ;; reply has fired — the witness below cannot pass vacuously.
+          (is (contains? (get-in (snapshot (:rf.db/runtime (rf/frame-state-value f)))
+                                 [:data :in-flight])
+                         rid)
+              "positive control: the silent request sits in :in-flight before :ws/fatal")
+          (is (nil? (log))
+              "positive control: no reply-event invocation before :ws/fatal")
+          ;; The app declares the connection unrecoverable, mid-flight.
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/fatal {:error :ws/protocol-violation}]]
+                            {:frame f})
+          (let [s (snapshot (:rf.db/runtime (rf/frame-state-value f)))]
+            (is (true? (machine-has-tag? f :websocket/failed)))
+            (is (nil? (socket-id-of s)) "the socket actor is torn down")
+            (is (= :ws/protocol-violation (get-in s [:data :error]))
+                "the error is still recorded — fail-in-flight COMPOSES with
+                 :record-error rather than displacing it")
+            (is (= {} (get-in s [:data :in-flight]))
+                ":in-flight cleared on :ws/fatal — no stranded slot")
+            (is (= [{:origin :ws/local :request-id rid :ok false :error :ws/connection-lost}]
+                   (log))
+                "exactly one reply-event invocation, with the documented connection-termination body")
+            (is (= {:origin :ws/local :request-id rid :ok false :error :ws/connection-lost}
+                   (get-in (rf/app-db-value f) [:messages :last-reply]))
+                "the synthesised failure body passes the closed RequestOutcome boundary"))
+          ;; At-most-once control: deliver the already-scheduled timeout,
+          ;; stamped with the DESTROYED socket's id, exactly as
+          ;; :register-request scheduled it (new-frame suppresses the real
+          ;; :dispatch-later). Nothing may fire twice or resurrect the slot.
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/request-timeout {:request-id       rid
+                                                   :source-socket-id old-id}]]
+                            {:frame f})
+          (let [s (snapshot (:rf.db/runtime (rf/frame-state-value f)))]
+            (is (true? (machine-has-tag? f :websocket/failed))
+                "the stale timeout does not move the machine")
+            (is (= {} (get-in s [:data :in-flight]))
+                "the stale timeout resurrects no slot")
+            (is (= 1 (count (log)))
+                "the callback count stays exactly one after the stale timeout"))
+          ;; No leak across the manual recovery :failed offers: :ws/connect
+          ;; out of :failed spawns a FRESH socket, then the old-socket-stamped
+          ;; timeout lands as a straggler. :current-socket? drops it against
+          ;; the new epoch; the new connection inherits no stale bookkeeping.
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/connect {:url "ws://mock" :cred-ref :ws.demo/cred-a}]]
+                            {:frame f})
+          (is (true? (machine-has-tag? f :websocket/connected)))
+          (let [new-id (socket-id-of (snapshot (:rf.db/runtime (rf/frame-state-value f))))]
+            (is (some? new-id))
+            (is (not= old-id new-id) "the manual reconnect spawned a fresh socket"))
+          (rf/dispatch-sync [:ws/connection
+                             [:ws/request-timeout {:request-id       rid
+                                                   :source-socket-id old-id}]]
+                            {:frame f})
+          (let [s (snapshot (:rf.db/runtime (rf/frame-state-value f)))]
+            (is (true? (machine-has-tag? f :websocket/connected))
+                "the straggler timeout leaves the fresh connection up")
+            (is (= {} (get-in s [:data :in-flight]))
+                "no stale bookkeeping crossed the manual reconnect out of :failed")
+            (is (= 1 (count (log)))
+                "the callback count stays exactly one across the reconnect")))))))
+
 (defn- queued-request-registers-and-replies-on-connect-test []
   ;; rf2-ryt25d — a :ws/request issued OFF-connection must be buffered as its
   ;; event and, on connect, rejoin :register-request so it registers, sends
@@ -1473,6 +1577,15 @@
             :ws/connection-lost failure, and the destroyed socket's stale
             timeout resurrects nothing — before or after a reconnect"
     (clean-disconnect-fails-in-flight-request-test)))
+
+(deftest websocket-fatal-fails-in-flight-request
+  (testing "rf2-ni0ko — :ws/fatal, the app-level escape hatch out of :active,
+            settles every in-flight request exactly once AND still records the
+            error: the slot clears, the waiting reply-event fires one
+            :ws/connection-lost failure, and the destroyed socket's stale
+            timeout resurrects nothing — before or after the manual :ws/connect
+            recovery out of :failed"
+    (fatal-fails-in-flight-request-test)))
 
 (deftest websocket-queued-request-registers-and-replies-on-connect
   (testing "rf2-ryt25d — a :ws/request buffered off-connection registers and


### PR DESCRIPTION
## Summary

`rf2-b2jpr` routed the clean `:ws/disconnect` door through the shared `fail-in-flight` helper so that leaving `:active` settles every in-flight request exactly once. One door still bypassed that invariant: `:ws/fatal`, the documented app-level escape hatch, carried `:action :record-error` alone (rf2-ni0ko).

Fired from `:connected` with a non-empty `:in-flight` it destroys the socket actor and strands every slot — the scheduled timeout carries the destroyed socket's id, so `:current-socket?` rejects it after teardown and the only cleanup path is gone, including across a later manual `:ws/connect` out of `:failed`. Nothing in the example dispatches `:ws/fatal`, so the leak was reachable only by consumer code using the pattern as written.

**Compose, don't replace.** The new `:on-fatal-error` action runs `fail-in-flight` *and* records the error in one action, so the door keeps what it already owned and gains the invariant. No retry bump — unlike `:on-socket-lost` we are giving up, not retrying. Machine topology, request/reply API, socket-epoch guard and queue/reconnect behaviour are unchanged.

**`:ws/auth-failed` verified safe, and now says why.** The item claimed this sibling door is provably safe; checked at source and it holds. `:register-request` is the only writer into `:in-flight` (`assoc-in data [:in-flight request-id]`) and it is bound only on `:connected` — everywhere else a `:ws/request` takes `:enqueue-message`, and `:flush-queue` replays *into* the machine, so a queued request only registers once `:connected`. Reaching `:authenticating` therefore means we have not been `:connected` since the last `:active` entry, and every door out of `:active` from `:connected` clears `:in-flight` on the way out. So `:in-flight` is provably empty whenever `:ws/auth-failed` fires, and plain `:record-error` is correct there rather than an oversight. A comment now records that reasoning so the asymmetry does not read as a second bug. With this change every door out of `:active` reachable from `:connected` — the guarded `:ws/closed` drop, the clean `:ws/disconnect`, and `:ws/fatal` — settles `:in-flight` exactly once.

**No spec edit.** `spec/Pattern-WebSocket.md` states the settle invariant scoped to the *drop* door (§5 item 5, and the "Leaking in-flight requests when the socket drops" pitfall), not as a general "every door out of `:active`" rule, so nothing in it becomes false. Its worked-example listing is a teaching rendering already abridged relative to the example — it carries no `:ws/disconnect` transition at all, and still shows `:on-socket-lost` with the fail inlined rather than through the `fail-in-flight` helper rf2-b2jpr introduced. See "Follow-up" below.

## Coverage

New wrapper test `websocket-fatal-fails-in-flight-request` (external wrapper, per the test-free-examples policy rf2-8cevm), mirroring `websocket-clean-disconnect-fails-in-flight-request` with `:ws/fatal` as the exit door:

- parks a `:silent-no-echo` request genuinely in `:in-flight` through a counting reply target (positive controls: slot present, zero replies fired — the witness cannot pass vacuously),
- fires `:ws/fatal` mid-flight: asserts `:websocket/failed`, socket actor gone, `:in-flight` empty, exactly ONE reply invocation with the documented `{:ok false :error :ws/connection-lost}` body, and **the error still recorded** — the assertion that pins composition rather than replacement,
- forwards each logged reply to the boundary-validated `:ws.app/request-reply`, so the synthesised failure body is also proven to pass the closed `RequestOutcome` contract,
- at-most-once control: delivers the already-scheduled timeout stamped with the destroyed socket's id — nothing fires twice, nothing resurrects,
- recovery control: after a manual `:ws/connect` out of `:failed` spawns a fresh socket, the same stale timeout is dropped against the new epoch — no stale bookkeeping crosses the recovery.

## Quality gates

Run in the worker worktree, foreground to completion; every exit captured by redirect + `echo $?` on one command line in one shell, and the number quoted is the captured one.

**Gate derivation.** `implementation/adapters/reagent/test` is a `:source-paths` entry for the `:node-test` build in `implementation/shadow-cljs.edn`, so the wrapper suite runs under `npm run test:cljs`. That npm script is a two-phase chain (`compile-node-test.cjs` then `node out/node-test.js`), so it was split and each phase run separately rather than detached.

**All figures below are from the re-run on the FINAL rebased base** (merge-base `a7fd573ad8`). The pre-rebase run was green too, but its test population differed (11131 / 54732), so it is superseded rather than quoted.

| Gate | Exit |
|---|---|
| `test:cljs` compile phase | **0** — 1867 files, 1119 compiled, 0 warnings |
| `test:cljs` run phase | **0** — 11105 tests / 54776 assertions, 0 failures, 0 errors |
| `:examples/websocket` shadow-cljs compile | **0** — 215 files, 0 warnings |

**Which tree the gate read:** shadow-cljs prints its config path on every run, and that line named this worker worktree's `implementation/shadow-cljs.edn` on every run — not the primary checkout.

**Control (planted fault), re-run on the final base.** With the single transition line reverted to the unrepaired `:action :record-error` (anchor match count read as exactly 1 before running, so the plant could not silently no-op), recompile **exit 0** with **5 files recompiled** — positive evidence the runtime observed the plant, not a stale compile — and the run went **exit 1, 7 failures, 0 errors**, all seven in `websocket-fatal-fails-in-flight-request` and none anywhere else. The red shows exactly the reported defect:

- `:in-flight` expected `{}`, actual `{#uuid "7e37…" {:reply-event [:ws.test/log-fatal-reply], :timeout-ms 5000}}` — **the stranded slot with its waiting `:reply-event`**;
- the reply log expected one `:ws/connection-lost` outcome, actual `nil` — **the reply-event never fired**;
- and both survive the stale timeout *and* the manual `:ws/connect` recovery out of `:failed`, reproducing the across-reconnect half of the leak.

Test and assertion counts under the plant were identical to the green run (11105 / 54776), so the plant crashed no namespace and truncated no lane. Critically **`websocket-clean-disconnect-fails-in-flight-request` stayed green under the plant** (0 failures in it) — that is what proves the change composes onto the shared `fail-in-flight` helper rather than replacing it.

**Restore verified by git blob hash**, not by reading a diff: worktree object `4f9ed1a9b843ebabbcaf879ab9deb7174039b10a` == `HEAD:examples/patterns/websocket/connection.cljs`. Recompile **exit 0** and rerun **exit 0** (11105 / 54776, 0 failures) on the restored source.

**Rebased, then re-gated.** The branch was rebased onto current `origin/main` (`a7fd573ad8`) so its check set is recomputed against the live workflow matrix, and **every gate above was then re-run on that final base**, including the full control cycle — plant, red, hash-verified restore, green. The pre-rebase logs are not quoted.

**Merge-base check.** `git diff origin/main...HEAD` (three-dot) contains exactly the two fenced files, and the only deleted line in the whole diff is the `:action :record-error}` line this change replaces — nothing a sibling landed is reverted. Nothing has landed under `examples/patterns/websocket/**` or in the websocket adapter test since the original base, so the rebase was conflict-free and content-neutral (the file's blob hash is unchanged across it).

**Not covered locally.** The full `test:examples-compile` sweep — `implementation/scripts/check-examples-compile.cjs` — compiles every declared `:examples/*` and `:testbeds/*` build and exceeded the local harness runtime ceiling, producing no exit-code file and therefore no verdict. Rather than quote a killed run, it was split: the one build this change can affect, `:examples/websocket`, was compiled on its own and is the row in the table above. The remaining builds in that sweep are unaffected by this diff and are CI's to confirm, along with the browser, bundle-isolation and lint/docs lanes.

No doc pages touched — code plus comments/docstrings only — so there are no anchors or table column counts to verify by hand.

## Follow-up

`spec/Pattern-WebSocket.md`'s worked-example listing still shows `:ws/fatal {:target :failed :action :record-error}`, i.e. the shape this PR just proved strands in-flight requests. That is a hot-zone file outside this change's fence and is deliberately left alone here; follow-up bead **rf2-0g60h** is filed to bring the listing (and the same `:ws/fatal` row in `skills/re-frame2/patterns/websocket.md`, which shows no action at all) in line with the repaired example.
