### PR TITLE
fix(routing): make component URL encoding host-identical (rf2-j3tud)

### DIFF
--- a/implementation/routing/src/re_frame/routing/url.cljc
+++ b/implementation/routing/src/re_frame/routing/url.cljc
@@ -34,12 +34,48 @@
 ;; per-segment.
 
 (defn url-encode
-  "Encode a single component (named param or query value). Uses
-  encodeURIComponent semantics on CLJS; emulates it on JVM (URLEncoder
-  + + → %20 swap)."
+  "Encode a single component (named param or query value) with
+  `encodeURIComponent` semantics on BOTH hosts.
+
+  HOST-SYMMETRIC: identical route data produces one canonical URL byte
+  string on JVM (SSR) and CLJS (browser). CLJS calls
+  `encodeURIComponent` directly; the JVM arm emulates it on top of
+  `java.net.URLEncoder`, which needs TWO corrections rather than one:
+
+  1. `URLEncoder` is the `application/x-www-form-urlencoded` encoder, so
+     it emits `+` for a space where `encodeURIComponent` emits `%20`.
+  2. `URLEncoder`'s unescaped set is NARROWER. `encodeURIComponent`
+     leaves the whole RFC-2396 *mark* set literal — `- _ . ! ~ * ' ( )`
+     — while `URLEncoder` escapes five of those nine: `!` `'` `(` `)`
+     `~` (`- _ . *` already agree). Repairing only (1) left those five
+     divergent, so a legitimate slug like `draft~1` emitted
+     `/articles/draft%7E1` from SSR and `/articles/draft~1` from the
+     hydrated client (rf2-j3tud).
+
+  Both spellings decode to the same route, but that is weaker than the
+  invariant Spec 012 §Bidirectional URL ↔ params actually promises:
+  component-wise `encodeURIComponent` emission, one host-independent
+  canonical URL. `route-link`'s `:href`, SSR canonical head links
+  (`docs/ssr/head.md`), copied URLs, cache keys and snapshots all read
+  those bytes, and a differing `:href` between the server tree and the
+  first client tree is the Spec 011 hydration-mismatch class.
+
+  CLJS is normative — it IS `encodeURIComponent`, the de-facto browser
+  reference the spec names — so the JVM moves to match it, exactly as
+  `url-decode` below already does for `+`.
+
+  The five unescapes are unambiguous: every `%XX` in `URLEncoder` output
+  is one it generated, so a `%21` in that output can only have come from
+  a literal `!`. A literal `%` in the input is already `%25`, and no
+  `%25`-prefixed run can spell one of these escapes."
   [s]
   #?(:clj  (-> (java.net.URLEncoder/encode (str s) "UTF-8")
-               (.replace "+" "%20"))
+               (.replace "+" "%20")
+               (.replace "%21" "!")
+               (.replace "%27" "'")
+               (.replace "%28" "(")
+               (.replace "%29" ")")
+               (.replace "%7E" "~"))
      :cljs (js/encodeURIComponent (str s))))
 
 (defn url-encode-splat

--- a/implementation/routing/test/re_frame/route_link_ssr_parity_cljs_test.cljc
+++ b/implementation/routing/test/re_frame/route_link_ssr_parity_cljs_test.cljc
@@ -65,28 +65,43 @@
 (def ^:private parity-cases
   "One row per supported strategy shape: the frame id the row seats its
   strategy on, the strategy, and the href BOTH hosts must render for
-  `/active` and for `/articles/x?tab=comments`. The expected strings are the
-  contract — literal on purpose, never derived from `:encode`, so a door
-  that stopped consulting the strategy cannot also rewrite the expectation."
+  `/active`, for `/articles/x?tab=comments`, and for the
+  punctuation-bearing `/articles/draft~1?tab=it's(new)!`. The expected
+  strings are the contract — literal on purpose, never derived from
+  `:encode`, so a door that stopped consulting the strategy cannot also
+  rewrite the expectation.
+
+  The `:punct` column is rf2-j3tud's teeth at the LINK door. `url-encode`'s
+  JVM arm escaped `! ' ( ) ~` where `encodeURIComponent` leaves them
+  literal, so a `~`-bearing slug rendered `:href` `/articles/draft%7E1` on
+  the server and `/articles/draft~1` on the hydrated client — a Spec 011
+  hydration mismatch at the attribute the first client render compares.
+  The `x` / `comments` rows above could not see it: neither string carries
+  a character the two encoders disagree about."
   [{:frame    :parity/history
     :strategy strategy/history-url-strategy
     :active   "/active"
-    :article  "/articles/x?tab=comments"}
+    :article  "/articles/x?tab=comments"
+    :punct    "/articles/draft~1?tab=it's(new)!"}
    {:frame    :parity/history-base
     :strategy (strategy/with-base-path strategy/history-url-strategy "/demos")
     :active   "/demos/active"
-    :article  "/demos/articles/x?tab=comments"}
+    :article  "/demos/articles/x?tab=comments"
+    :punct    "/demos/articles/draft~1?tab=it's(new)!"}
    {:frame    :parity/hash
     :strategy strategy/hash-url-strategy
     :active   "#/active"
-    :article  "#/articles/x?tab=comments"}
+    :article  "#/articles/x?tab=comments"
+    :punct    "#/articles/draft~1?tab=it's(new)!"}
    {:frame    :parity/hash-base
     :strategy (strategy/with-base-path strategy/hash-url-strategy "/demos")
     :active   "/demos#/active"
-    :article  "/demos#/articles/x?tab=comments"}])
+    :article  "/demos#/articles/x?tab=comments"
+    :punct    "/demos#/articles/draft~1?tab=it's(new)!"}])
 
 (def ^:private active-props  {:to :parity/active})
 (def ^:private article-props {:to :parity/article :params {:slug "x"} :query {:tab "comments"}})
+(def ^:private punct-props   {:to :parity/article :params {:slug "draft~1"} :query {:tab "it's(new)!"}})
 
 (defn- seat-frame!
   "Construct the row's frame with its strategy declared. The registration-time
@@ -108,17 +123,21 @@
 
 (deftest route-link-href-agrees-across-hosts-for-every-strategy-shape
   (register-routes!)
-  (doseq [{:keys [frame active article] :as row} parity-cases]
+  (doseq [{:keys [frame active article punct] :as row} parity-cases]
     (seat-frame! row)
     (testing (str "rf/route-link render inside frame " frame)
       (is (= active (rendered-href frame active-props))
           (str frame ": the rendered :href for /active is the strategy-encoded form on this host"))
       (is (= article (rendered-href frame article-props))
-          (str frame ": params + query ride inside the encoded form on this host")))))
+          (str frame ": params + query ride inside the encoded form on this host"))
+      (is (= punct (rendered-href frame punct-props))
+          (str frame ": punctuation in the slug and query value stays LITERAL on"
+               " this host — the JVM SSR render and the first CLJS render emit"
+               " the same :href (rf2-j3tud)")))))
 
 (deftest link-model-href-agrees-across-hosts-for-every-strategy-shape
   (register-routes!)
-  (doseq [{:keys [frame active article] :as row} parity-cases]
+  (doseq [{:keys [frame active article punct] :as row} parity-cases]
     (seat-frame! row)
     (testing (str ":routing/link-model seam for frame " frame)
       (let [model (link/link-model active-props frame)]
@@ -129,7 +148,10 @@
             (str frame ": the navigation payload stays PATH-FORM — only the href is encoded"))
         (is (false? (:native? model)) "a plain link is not a native anchor"))
       (is (= article (:href (link/link-model article-props frame)))
-          (str frame ": params + query ride inside link-model's encoded href")))))
+          (str frame ": params + query ride inside link-model's encoded href"))
+      (is (= punct (:href (link/link-model punct-props frame)))
+          (str frame ": punctuation stays literal through link-model's href too"
+               " — the second door reads the same canonical bytes (rf2-j3tud)")))))
 
 (deftest no-frame-and-default-frame-keep-the-path-form-href
   (testing "a frame that declares no strategy renders path-form on both hosts"

--- a/implementation/routing/test/re_frame/routing_url_encoding_parity_cljs_test.cljc
+++ b/implementation/routing/test/re_frame/routing_url_encoding_parity_cljs_test.cljc
@@ -1,0 +1,169 @@
+(ns re-frame.routing-url-encoding-parity-cljs-test
+  "Per rf2-j3tud — component URL encoding is `encodeURIComponent` on BOTH
+  hosts, byte for byte.
+
+  `url-encode`'s JVM arm emulates `encodeURIComponent` on top of
+  `java.net.URLEncoder`. It used to repair only ONE of the two
+  differences — the form-urlencoded `+`-for-space — and left the second
+  standing: `URLEncoder`'s unescaped set is narrower, so it escapes `!`
+  `'` `(` `)` `~` where `encodeURIComponent` leaves them literal. The
+  same route data therefore emitted different URL bytes on server and
+  browser: a legitimate slug `draft~1` became `/articles/draft%7E1` from
+  SSR and `/articles/draft~1` from the hydrated client.
+
+  Both spellings decode to the same route, which is why nothing caught
+  it — but Spec 012 §Bidirectional URL ↔ params promises the stronger
+  invariant: component-wise `encodeURIComponent` emission, ONE
+  host-independent canonical URL. `route-link`'s `:href`, SSR canonical
+  head links, copied URLs, cache keys and snapshots all read those
+  bytes, and an `:href` that differs between the server tree and the
+  first client tree is the Spec 011 hydration-mismatch class.
+
+  CLJS is normative: it IS `encodeURIComponent`, the de-facto browser
+  reference the spec names. The JVM moved to match it — the same
+  direction `url-decode` already took for `+` (rf2-9a9ix).
+
+  Named `*-cljs-test.cljc` so it is discovered by BOTH the cognitect JVM
+  runner (`.*-test$`) and the shadow-cljs `:node-test` build
+  (`cljs-test$`). Every assertion below is asserted IDENTICALLY on both
+  hosts against LITERAL expected strings — that host-symmetry IS the
+  contract, so the expectations are never derived from `url-encode`
+  itself. An encoder that changed on one host only cannot also rewrite
+  what it is compared against.
+
+  Reverting the JVM arm to `URLEncoder` plus the `+`→`%20` swap alone
+  turns the JVM half of this namespace red on the boundary set, the
+  production `route-url` case and the round-trip, while the
+  escaped-character controls stay green — proving those controls are not
+  what carries the suite."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   [re-frame.routing :as routing]
+   [re-frame.routing.url :as url]
+   [re-frame.test-support :as test-support]
+   #?(:clj  [re-frame.substrate.plain-atom :as substrate]
+      :cljs [re-frame.adapter.reagent :as substrate])))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter substrate/adapter
+     :init-fn routing/reset-counters!}))
+
+;; ---- the encodeURIComponent boundary ------------------------------------
+;;
+;; `encodeURIComponent` escapes everything except the unreserved set
+;; (`A-Z a-z 0-9`) plus the nine RFC-2396 *mark* characters. Those nine
+;; are the whole boundary; four of them (`- _ . *`) `URLEncoder` already
+;; agreed on, and five (`! ' ( ) ~`) it did not. The table pins all nine
+;; so a future encoder swap cannot half-move the line.
+
+(def ^:private unescaped-marks
+  "Every character `encodeURIComponent` leaves LITERAL, one row per
+  character so a failure names the exact offender rather than a diff of
+  a nine-character blob."
+  [["!" "exclamation — URLEncoder escaped this to %21"]
+   ["'" "apostrophe — URLEncoder escaped this to %27"]
+   ["(" "open paren — URLEncoder escaped this to %28"]
+   [")" "close paren — URLEncoder escaped this to %29"]
+   ["~" "tilde — URLEncoder escaped this to %7E"]
+   ["*" "asterisk — both encoders already agreed"]
+   ["-" "hyphen — both encoders already agreed"]
+   ["." "period — both encoders already agreed"]
+   ["_" "underscore — both encoders already agreed"]])
+
+(def ^:private escaped-controls
+  "Characters that MUST stay percent-escaped. These are the controls: the
+  suite cannot be passed by weakening `url-encode` towards `identity`,
+  because every one of these would go literal if it were."
+  [[" " "%20" "space — %20, never the form-urlencoded `+`"]
+   ["/" "%2F" "slash — a raw `/` would forge an extra path segment"]
+   ["%" "%25" "percent — a raw `%` makes the URL malformed on re-parse"]
+   ["&" "%26" "ampersand — a raw `&` would forge an extra query pair"]
+   ["=" "%3D" "equals — a raw `=` would forge a query key/value split"]
+   ["?" "%3F" "question mark — a raw `?` would forge a query string"]
+   ["#" "%23" "hash — a raw `#` would forge a fragment"]
+   ["+" "%2B" "plus — escaped on emission so it survives as a literal"]])
+
+(deftest url-encode-leaves-every-unescaped-mark-literal-on-both-hosts
+  (testing "the complete encodeURIComponent unescaped boundary is literal
+            on JVM and CLJS alike (rf2-j3tud)"
+    (doseq [[ch why] unescaped-marks]
+      (is (= ch (url/url-encode ch)) why)))
+  (testing "the whole mark set at once, as one component"
+    (is (= "!'()~*-._" (url/url-encode "!'()~*-._"))
+        "no character in the mark set is escaped on this host")
+    (is (= "draft~1" (url/url-encode "draft~1"))
+        "the failure scenario from the finding: a `~`-bearing slug")))
+
+(deftest url-encode-still-escapes-the-structural-characters-on-both-hosts
+  (testing "the controls: characters that must NOT go literal, so the
+            boundary test above cannot pass by disabling encoding"
+    (doseq [[ch expected why] escaped-controls]
+      (is (= expected (url/url-encode ch)) why)))
+  (testing "non-ASCII still percent-encodes as UTF-8 on both hosts"
+    (is (= "%C3%A9" (url/url-encode "é"))
+        "`é` is two UTF-8 bytes, uppercase hex on both hosts")))
+
+(deftest url-encode-splat-inherits-the-boundary-per-segment
+  (testing "splat encoding preserves structural `/` while each segment
+            gets the same literal mark set (Spec 012 §Splat)"
+    (is (= "a~b/c!d/e(f)" (url/url-encode-splat "a~b/c!d/e(f)"))
+        "marks stay literal inside each chunk; separators stay raw")
+    (is (= "my%20file/50%25.txt" (url/url-encode-splat "my file/50%.txt"))
+        "the controls still escape per chunk")))
+
+;; ---- production route-url: one canonical URL on both hosts ---------------
+
+(deftest route-url-emits-one-canonical-url-across-hosts
+  (testing "punctuation in an ordinary path param, a query key, a query
+            value AND the fragment all emit the SAME literal URL on JVM
+            and CLJS — this is the production prism, not a re-derivation"
+    (rf/reg-route :parity/probe {:params [:map [:slug :string]]} "/p/:slug")
+    (is (= "/p/~?!=()#~!"
+           (routing/route-url {:to     :parity/probe
+                               :params {:slug "~"}
+                               :query  {"!" "()"}
+                               :fragment "~!"}))
+        "the finding's own reproduction: JVM used to emit /p/%7E?%21=%28%29#%7E%21")
+    (is (= "/p/draft~1"
+           (routing/route-url {:to :parity/probe :params {:slug "draft~1"}}))
+        "the failure scenario: SSR used to emit /p/draft%7E1")
+    (is (= "/p/it's~a(test)!"
+           (routing/route-url {:to :parity/probe :params {:slug "it's~a(test)!"}}))
+        "the whole divergent set inside one ordinary path param"))
+  (testing "the structural controls still escape inside the production
+            prism, so this case cannot pass by disabling encoding"
+    (rf/reg-route :parity/probe2 {:params [:map [:slug :string]]} "/p/:slug")
+    (is (= "/p/a%20b?q=x%26y%3Dz#50%25%20done"
+           (routing/route-url {:to     :parity/probe2
+                               :params {:slug "a b"}
+                               :query  {"q" "x&y=z"}
+                               :fragment "50% done"}))
+        "space, `&`, `=` and `%` stay escaped across all three positions")))
+
+(deftest route-url-round-trips-through-match-url-on-both-hosts
+  (testing "match-url(route-url(address)) recovers the address exactly —
+            the encode/decode pair is still an inverse after the JVM
+            encoder moved to the encodeURIComponent boundary"
+    (rf/reg-route :parity/round {:params [:map [:slug :string]]} "/r/:slug")
+    (let [slug  "it's~a(test)!*-._"
+          frag  "~sec!(1)"
+          built (routing/route-url {:to       :parity/round
+                                    :params   {:slug slug}
+                                    :query    {"q!" "a(b)~c"}
+                                    :fragment frag})]
+      (is (= "/r/it's~a(test)!*-._?q!=a(b)~c#~sec!(1)" built)
+          "the built URL is the literal canonical form on this host")
+      (let [parsed (routing/match-url built)]
+        (is (some? parsed)
+            "the canonical URL is NOT a malformed-URL route-miss")
+        (is (= :parity/round (:route-id parsed))
+            "it matches back to the route it was built from")
+        (is (= slug (get-in parsed [:params :slug]))
+            "the path param recovers byte-exactly, punctuation included")
+        (is (= "a(b)~c" (get-in parsed [:query "q!"]))
+            "the punctuation-bearing query key AND value both recover")
+        (is (= frag (:fragment parsed))
+            "the fragment recovers byte-exactly")))))


### PR DESCRIPTION
Closes rf2-j3tud.

## The finding, verified at source

`re-frame.routing.url/url-encode` promises `encodeURIComponent` semantics on both hosts, but its JVM arm repaired only **one** of the two differences between `java.net.URLEncoder` and `encodeURIComponent` — the form-urlencoded `+`-for-space. The second stood: `URLEncoder`'s unescaped set is narrower.

Both probes were run against **production** code, not a reimplementation:

| char | code | JVM `url-encode` (before) | JS `encodeURIComponent` |
|---|---|---|---|
| `!` | 33  | `%21` | `!` |
| `'` | 39  | `%27` | `'` |
| `(` | 40  | `%28` | `(` |
| `)` | 41  | `%29` | `)` |
| `~` | 126 | `%7E` | `~` |
| `*` `-` `.` `_` | 42/45/46/95 | literal | literal (already agreed) |
| space, `/`, `%` | 32/47/37 | `%20` `%2F` `%25` | `%20` `%2F` `%25` (already agreed) |

And through the production prism, the item's own reproduction:

```
;; :probe registered at /p/:slug
route-url {:to :probe :params {:slug "~"} :query {"!" "()"} :fragment "~!"}
  JVM before:  /p/%7E?%21=%28%29#%7E%21
  JVM after:   /p/~?!=()#~!          ; == what CLJS emits
route-url {:to :probe :params {:slug "draft~1"}}
  JVM before:  /p/draft%7E1
  JVM after:   /p/draft~1
```

Identical route data produced different URL bytes on server and browser. Both spellings decode to the same route — which is why nothing caught it — but that is weaker than the invariant `spec/012-Routing.md` actually promises: component-wise `encodeURIComponent` emission, one host-independent canonical URL. `route-link`'s `:href`, SSR canonical head links, copied URLs, cache keys and snapshots all read those bytes, and an `:href` differing between the server tree and the first client tree is the Spec 011 hydration-mismatch class.

## Which host is normative, and why

**CLJS.** Checked against the code and the spec rather than assumed:

- `spec/012-Routing.md` names `encodeURIComponent` as the semantics ("percent-encoded **per component** on emission (encodeURIComponent semantics)"), not "whatever each host's stdlib does". It names a specific JavaScript function.
- The CLJS arm *is* `js/encodeURIComponent`; the JVM arm is explicitly labelled the *emulation* ("emulates it on JVM"). An incomplete emulation is a conformance bug in the emulator, not a disagreement between two peers.
- `url-decode` directly below already took this exact direction for `+` (rf2-9a9ix, Mike-ruled): JVM moved to match `decodeURIComponent`. Moving the JVM here is the consistent call.

So **no normative text changes** — Spec 012 already requires this. This is a conformance repair, and it needed no hot-zone `spec/*.md` edit.

## The fix

Five `.replace` calls on the JVM arm, alongside the existing `+` to `%20`. The unescapes are unambiguous: every `%XX` in `URLEncoder` output is one it generated, so a `%21` there can only have come from a literal `!`; a literal `%` in the input is already `%25`, and no `%25`-prefixed run can spell one of these escapes. No configuration knob, no escaping abstraction, no change to routing grammar, URL strategies, matching/ranking, schemas/coercion or decoding.

`url-encode-splat` composes `url-encode` per chunk, so it inherits the correction; that is pinned rather than assumed.

## Tests — one `.cljc` table, both hosts

New `implementation/routing/test/re_frame/routing_url_encoding_parity_cljs_test.cljc` (named `*-cljs-test.cljc` so the cognitect JVM runner and the shadow-cljs `:node-test` build both discover it). Expectations are **literal**, never derived from `url-encode`, so an encoder that changed on one host cannot also rewrite what it is compared against:

- the complete `encodeURIComponent` unescaped boundary — all nine marks, one assertion per character so a failure names the offender;
- controls that must stay escaped — space `%20`, `/` `%2F`, `%` `%25`, plus `&` `=` `?` `#` `+`, and non-ASCII to `%C3%A9`. The suite therefore cannot be passed by weakening the encoder toward `identity`;
- splat per-chunk encoding;
- the production `route-url` prism over a path param, a query key, a query value and a fragment, plus a controls case in the same three positions;
- exact `match-url(route-url(address))` recovery.

`route_link_ssr_parity_cljs_test.cljc` gains a `:punct` column — a `~`-bearing slug with a punctuation-bearing query value — across all four strategy shapes and both link doors, proving the JVM SSR render and the first CLJS render emit the same `:href`. Its existing `x` / `comments` rows could not see the defect: neither string carries a character the two encoders disagree about.

## Quality gates

Gates derived from `implementation/routing/deps.edn`, `implementation/package.json` and `implementation/shadow-cljs.edn` rather than taken on faith. Every number below is the runner's own captured exit code, not a harness report.

**Re-run in full on the current base after a second rebase** (this branch now sits on `3ab6c3c5c8`; the trunk had moved eleven commits since the first pass). A pre-rebase green is evidence about a tree that no longer exists, so these are fresh numbers, not the earlier ones restated.

| gate | command | exit | result |
|---|---|---|---|
| JVM routing | `clojure -M:test` in `implementation/routing` | **0** | 536 tests, 3219 assertions, 0 failures |
| JVM http | `clojure -M:test` in `implementation/http` | **0** | 508 tests, 3881 assertions, 0 failures |
| CLJS compile | `node scripts/compile-node-test.cjs node-test out/node-test.js` | **0** | 1867 files, 0 warnings |
| CLJS full node suite | `node out/node-test.js` | **0** | 11136 tests, 54758 assertions, 0 failures |

The CLJS lane genuinely executes this artefact: `routing/test` is on `:source-paths` and the `:node-test` build's `:ns-regexp "cljs-test$"` matches both `.cljc` namespaces.

**Which tree the gates read.** The shadow-cljs lane prints its root and it names this worktree's `implementation/shadow-cljs.edn`. The JVM http lane prints no root, so it was discriminated by a planted fault instead — see below. `implementation/node_modules` in this checkout is a real directory, not a junction into a shared tree, so no gate could write through a link into another checkout.

## The red check, and why it needed no code change

`JVM http (clojure -M:test)` was red on the previous head. It is **not** this change's doing, and the fix is a re-run, not an edit.

**What actually failed.** Not an assertion — an async backstop. `re-frame.http-reply-lowering-test/supersede-distinct-work-ids-and-canonical-stale-trace` ended `0 failures, 1 errors` with `poll-until timed out — supersede-stale`, `:elapsed-ms 30022`. That test's own source comment documents this exact class: its backstop was already raised from 5 s to 30 s because the async supersede "landed AFTER the window, timing the machine, not the canonicalisation", and it names an unrelated PR it had redded before.

**Why this diff cannot reach it.** `implementation/http` has its **own** encoder. `re-frame.http.encoding/url-encode` imports `java.net.URLEncoder` directly and requires nothing from `re-frame.routing`; the two functions merely share a name. Probed at runtime on http's own classpath, with both namespaces loaded together:

```
SAME VAR? false
"!" http=%21    routing=!      DIFFER
"'" http=%27    routing='      DIFFER
"(" http=%28    routing=(      DIFFER
")" http=%29    routing=)      DIFFER
"~" http=%7E    routing=~      DIFFER
" " http=%20    routing=%20    same
"&" http=%26    routing=%26    same
"=" http=%3D    routing=%3D    same
```

So http still emits `%21 %27 %28 %29 %7E` after this change, exactly as before it. `http_encoding_test.clj`'s `url-encode-escapes-reserved-characters` pin was never at risk on two independent counts: it tests a different var, and it asserts only space, `&`, `=` and `+`, none of which this change touches. **There is therefore no Spec 012 / Spec 014 conflict to resolve** — Spec 012's `encodeURIComponent` semantics govern the routing prism, Spec 014's reserved-query escaping governs http's form-encoder, they are separate functions in separate artefacts, and both hold simultaneously. Nothing was weakened or deleted to get green.

**Evidence it was a flake.** `JVM http` is green on `main` wherever it runs (13 successes, 0 failures across the recent `main` runs where it was not surface-skipped); the whole http suite passes locally on this branch at the rebased base (captured exit **0**, 508 tests / 3881 assertions); and CI's `JVM http` is **green on the rebased head** with no code change between the two runs.

### The control — that the http gate read *this* worktree

The http gate prints no root, so the discrimination is a planted red. Tree committed and clean first, so `git checkout` restores to the intended state.

- Anchor match count read **before** the run: `1` — so the plant could not silently no-op.
- Plant applied: `hello%20world` → `PLANTED-RF2-J3TUD-SABOTAGE` at `http_encoding_test.clj:275`. Confirmed applied by the git **blob** hash moving `1d42bc84...` → `0a3d945d...`.
- The plant exists in this worktree only (`grep -c` returns `1` here, `0` in the primary checkout), so a run that had wandered into another checkout would have come back green.
- **Sabotage run: captured exit 1**, failing at `http_encoding_test.clj:275` and naming the planted string in its `actual`.
- Counts were **508 / 3881 in both the green and the sabotage run**, so the plant crashed no namespace and truncated no lane.
- Restored, verified by git **blob** hash rather than by reading a diff: back to `1d42bc84...`, identical to the committed object and to the pre-plant hash, with a clean `git status`.

### The control — that the encoder tests bite

Reverting the JVM arm to `URLEncoder` plus the `+` to `%20` swap alone — the pre-fix implementation, planted after committing, plant confirmed applied by the git **blob** hash changing from `e39ad7bd...` to `f87f5413...`:

- **JVM `clojure -M:test` gave captured exit 1, 20 failures.** All five characters named individually; the whole-mark-set case, the `~`-bearing slug, splat per-chunk, the three production `route-url` literal cases and the `match-url` round-trip all red; **8** of the 20 in the route-link parity suite (4 strategy shapes by 2 link doors).
- **The escaped-character controls stayed GREEN** — `url-encode-still-escapes-the-structural-characters-on-both-hosts` and the production controls case do not appear among the failures, so the controls are meaningful rather than what carries the suite.
- Test and assertion counts were **536 / 3219 in both the green and the sabotage run**, so the plant crashed no namespace and truncated no lane.

Restored, and the restore verified by git **blob** hash rather than by reading a diff: working file back to `e39ad7bd...`, identical to the committed object and to the pre-plant hash.

## Not covered locally

The required-check set is defined in `.github/workflows/test.yml`; CI is the authority for everything outside the lanes above — notably the browser/adapter-smoke, bundle-isolation, docs and lint jobs, none of which this diff's surface (`implementation/routing/**`, src + test) touches.

## Found along the way, not asked for — decoding has a *different* asymmetry

Checked as instructed. The five characters at issue here **decode identically on both hosts** (`%21` to `!`, through `%7E` to `~`), so this defect has no decode counterpart and `url-decode` correctly stays untouched.

But probing the reverse direction did surface a separate host divergence, on **invalid UTF-8 byte sequences**:

| input | JVM `safe-url-decode` | CLJS `safe-url-decode` |
|---|---|---|
| `%C0%80` | U+FFFD U+FFFD (non-nil) | `nil` (URIError, fail-closed) |
| `%ED%A0%80` | U+FFFD (non-nil) | `nil` |
| `%FF` | U+FFFD (non-nil) | `nil` |
| `%E0%80%80` | U+FFFD U+FFFD U+FFFD (non-nil) | `nil` |
| `%` / `%a` / `%zz` | `nil` | `nil` (these already agree) |

`java.net.URLDecoder` substitutes U+FFFD where `decodeURIComponent` throws, so `malformed-url?` returns **`false`** on the JVM for `/p/%FF` and **`true`** on CLJS. A hostile URL is a fail-closed `:reason :malformed-url` route-miss in the browser but decodes to a replacement-character param under SSR.

That is a **second, different defect** — malformed-input fail-closed classification, not the unescaped-character set — and the item's non-goals explicitly keep decoding out of scope, so it is **not fixed here**. Filed as **rf2-k2d2t** (`discovered-from: rf2-j3tud`), with the measured table, the `malformed-url?` consequence, a recommended direction and acceptance criteria — including the trap that a legitimately-encoded U+FFFD (`%EF%BF%BD`) must still decode, so a naive "does the output contain U+FFFD?" check would introduce a new bug.

## Line-number delta

Nil, unusually — every citation on the item still resolves at tip: `url.cljc:36-43`, `registry.cljc:1477-1480` / `2240-2245` / `2251-2271`, `link.cljc:142` and `511-513`, and the parity table at `route_link_ssr_parity_cljs_test.cljc:66-88`. Only `spec/012-Routing.md:724-725` is marginal — the requirement is all on line 725 (a single long line).

