### PR TITLE
fix(uix): rf/reg-view* returns a MetaFn React cannot mount (rf2-oz7wr)

### DIFF
--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -196,6 +196,40 @@
   first-encounter warning cannot suppress a later test's same-id warning."
   (:clear-warned-non-dom-roots! spine-fns))
 
+;; ---- registered-view component head — UIx-NATIVE half (rf2-oz7wr) ---------
+;;
+;; `views/reg-view*` hands its composed wrapper to `:adapter/componentize-view`
+;; and registers whatever comes back, so `(rf/view id)` is what a caller mounts.
+;; Without this the registered value is a `MetaFn` (the `:contextType` meta
+;; Reagent's class machinery reads), which React rejects as an element type —
+;; the documented `($ (rf/view ::row) props)` form could not mount at all.
+;;
+;; The spine builds the mountable shell; the ONE substrate-native step is
+;; stamping UIx's own component marker on it, and it belongs here for exactly
+;; the rf2-z7hfp reason `frame-provider` does. The marker is what makes
+;; `uix.compiler.alpha/component-element` take the `uix-component-element`
+;; branch, which stashes the ORIGINAL CLJS props map on `argv` and folds
+;; trailing `$` children onto `:children` — the lossless channel. Unmarked, `$`
+;; would fall through to `react-component-element` → `interpret-attrs`, which
+;; is what stringified keyword prop values and dropped their namespaces before
+;; rf2-z7hfp (`:frame` silently becoming `:rf/default`). So stripping the meta
+;; alone would have produced a head React could mount and then mangled its
+;; props; the marker is the half that makes the mount CORRECT.
+;;
+;; Not a `defui`: `defui` glues `argv` into a CLJS map for its own body, and
+;; this shell must hand the props object DOWN untouched so the registered
+;; component — itself typically a `defui` — reads them in its own idiom. The
+;; shell is a marked forwarder, which is what keeps `(rf/reg-view* ::row row)`
+;; free of any wrapper ceremony for the caller.
+
+(defn- componentize-view
+  "Build the UIx component head for a registered view. Delegates the shell
+  to the spine core and stamps UIx's `uix-component?` marker on it."
+  [id metadata wrapped]
+  (let [shell ((:componentize-view spine-fns) id metadata wrapped)]
+    (set! (.-uix-component? ^js shell) true)
+    shell))
+
 ;; ---- adapter Var ----------------------------------------------------------
 
 (def adapter
@@ -209,5 +243,6 @@
   lifecycle wiring. The native provider stays in this namespace so the spine
   has no dependency on UIx's element macro."
   (spine/make-react-adapter spine-fns
-                            {:kind           :rf.adapter/uix
-                             :frame-provider frame-provider}))
+                            {:kind              :rf.adapter/uix
+                             :frame-provider    frame-provider
+                             :componentize-view componentize-view}))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_reg_view_direct_mount_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_reg_view_direct_mount_dom_cljs_test.cljs
@@ -1,0 +1,324 @@
+(ns re-frame.adapter.uix-reg-view-direct-mount-dom-cljs-test
+  "rf2-oz7wr — the ADVERTISED registry-keyed UIx mount, exercised as a
+  consumer writes it.
+
+  `docs/api/re-frame.adapter.uix.md` tells UIx users to reach for
+  `rf/reg-view*` for registry-keyed view addressing, and Spec 001
+  §`(re-frame.core/view id)` makes `(rf/view id)` the runtime handle for
+  what was registered. Composing those two gives
+  `($ (rf/view ::row) {…})` — and that form did not work. `reg-view*`
+  registered `(with-meta (fn frame-aware-view …) {:contextType …})`, and
+  `cljs.core/with-meta` on a fn yields a `MetaFn`: an IFn OBJECT, which
+  React rejects as an element type before the registered view renders.
+
+  The pre-existing React-hook coverage could not see it. Every registry-head
+  mount in `react-shared-suite` went through a hand-written host component
+  that INVOKED the registered value — so those rows proved teardown and
+  annotation BELOW the workaround, never the advertised head itself. This
+  file mounts the head directly and contains no such host by construction:
+  the registered value is only ever handed to `$` as a component type.
+
+  What each row is for:
+
+    - `direct-mount-*` — AC1/AC2/AC3. `($ (rf/view id) props child)` under
+      the normal `frame-provider` boundary, with a nested namespaced-keyword
+      prop asserted for EXACT equality inside the registered component (the
+      losslessness half: a marked UIx head carries the original CLJS props
+      on `argv`, an unmarked one would be converted through
+      `interpret-attrs` and lose the namespace), a `use-subscribe` +
+      `use-frame` hook boundary that must survive a dispatch and re-render,
+      and a console/page-error capture that must stay free of both the
+      invalid-element-type and the hook-boundary diagnostics.
+
+    - `native-defui-control-*` — AC5's NON-VACUITY control. The SAME probe
+      body, mounted as an unregistered native `defui`, so the harness is
+      shown to pass independently of the registry path. When the registry
+      row is deliberately broken (restoring the metadata-wrapped head, or
+      removing the componentization seam) this row must stay green — that
+      is what makes the registry row's red attributable to the seam under
+      test rather than to the harness.
+
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test` build
+  (ns-regexp `-dom-cljs-test$`) discovers it. `:node-test`'s `cljs-test$`
+  regex matches too, where every row self-gates on `(browser?)` and no-ops
+  cleanly — a real `createRoot` commit is required for any of this to mean
+  anything."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            ["react" :as React]
+            ["react-dom/client" :as react-dom-client]
+            [uix.core :as uix :refer-macros [defui $]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter}))
+
+;; ---- DOM gate ladder -------------------------------------------------------
+;; Mirrors the shared suite's ladder (its helpers are private), so this file
+;; stays self-contained and can be read without cross-referencing core/test.
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- get-act []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try
+        (let [test-utils (js/require "react-dom/test-utils")]
+          (.-act test-utils))
+        (catch :default _ nil))))
+
+(defn- with-browser-act
+  "Skip under :node-test (no DOM) and when act() is unreachable; otherwise
+  opt into React's act environment and call `(f act-fn)`."
+  [f]
+  (if-not (browser?)
+    (is true ":node-test: no DOM — the :browser-test runner exercises the assertions")
+    (let [act-fn (get-act)]
+      (if (nil? act-fn)
+        (is true "act() not reachable from this runner; skipping")
+        (do (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+            (f act-fn))))))
+
+(defn- with-captured-errors
+  "Record `console.error` / `console.warn` messages AND any window
+  `error` event raised across `thunk`. Returns the vector of joined
+  message strings; restores everything on the way out even if thunk
+  throws.
+
+  Both channels matter here. React reports an invalid element type by
+  THROWING (which surfaces as a page error), and reports a hook-order or
+  invalid-hook-call violation via `console.error` while rendering — so a
+  capture of only one of the two would let half the failure mode through
+  silently."
+  [thunk]
+  (let [calls      (atom [])
+        orig-warn  (.-warn js/console)
+        orig-error (.-error js/console)
+        on-error   (fn [^js e]
+                     (swap! calls conj (str (or (.-message e) e))))]
+    (.addEventListener js/window "error" on-error)
+    (try
+      (set! (.-warn js/console)  (fn [& args] (swap! calls conj (apply str args))))
+      (set! (.-error js/console) (fn [& args] (swap! calls conj (apply str args))))
+      (try
+        (thunk)
+        (catch :default e
+          (swap! calls conj (str "THROWN: " (.-message e)))))
+      @calls
+      (finally
+        (set! (.-warn js/console)  orig-warn)
+        (set! (.-error js/console) orig-error)
+        (.removeEventListener js/window "error" on-error)))))
+
+(defn- matching
+  "Messages matching `re`. Fixed-shape helper so each assertion reports the
+  offending text rather than a bare false."
+  [re msgs]
+  (filterv #(and (string? %) (re-find re %)) msgs))
+
+;; The two diagnostics this bead is about. `invalid-element-type-re` is what
+;; React raises when handed the `MetaFn` — the pre-fix symptom. `hook-boundary-re`
+;; covers the failure a repair could introduce instead: a head that mounts but
+;; owns no genuine React component boundary makes every hook below it an invalid
+;; call.
+(def ^:private invalid-element-type-re #"(?i)element type is invalid|not a valid (react )?(element|component)")
+(def ^:private hook-boundary-re        #"(?i)invalid hook call|hooks can only be called|rendered more hooks|order of Hooks")
+
+;; ---- the probe body --------------------------------------------------------
+;;
+;; ONE body, mounted two ways: through the registry head, and (the AC5
+;; control) as an unregistered native `defui`. Sharing the body is what makes
+;; the control a control — a difference in outcome can only come from the
+;; mount path, because nothing else differs.
+;;
+;; It is a native `defui`, which is the documented UIx idiom and the shape the
+;; bead's repro registers. `defui` reads its props off UIx's `argv` channel, so
+;; a mount that reached it through JS-prop conversion would arrive with the
+;; namespace stripped from `:tenant/id` and the equality assertion below would
+;; fail — the losslessness half of the invariant, checked by construction
+;; rather than by inspecting the props object.
+
+(def ^:private probe-frame :rf.uix-direct-mount/frame)
+(def ^:private probe-query [:rf.uix-direct-mount/n])
+
+;; The nested CLJS prop under test: a map value carrying a namespaced keyword,
+;; which is precisely what `interpret-attrs` mangles.
+(def ^:private probe-payload {:tenant/id      :tenant/admin
+                              :tenant/limits  {:seats 12 :tier :tier/enterprise}})
+
+(def ^:private observed-payload  (atom ::unset))
+(def ^:private observed-children (atom ::unset))
+(def ^:private observed-ops      (atom nil))
+
+(defui probe-body
+  "Receives a nested CLJS prop and a trailing child, and calls BOTH hooks —
+  `use-subscribe` for the read and `use-frame` for the frame-locked ops —
+  so the mount is proved to own a real React hook boundary rather than
+  merely to render.
+
+  The ops map is stashed on a side-channel atom so the driver can dispatch
+  through the SAME map the hook handed the component. That is what makes
+  the re-render assertion a statement about this mount's frame: an ops map
+  captured under a broken boundary would be locked to the wrong frame, and
+  the dispatch would move a `:n` nothing on screen is reading."
+  [{:keys [payload children]}]
+  (let [n   (uix-adapter/use-subscribe probe-query)
+        ops (uix-adapter/use-frame)]
+    (reset! observed-payload payload)
+    (reset! observed-children (some? children))
+    (reset! observed-ops ops)
+    ($ :div {:data-testid "probe"}
+       ($ :span {:data-testid "n"} (str n))
+       children)))
+
+;; ---- shared registration + world setup -------------------------------------
+
+(defn- seed-world!
+  "Create the frame, register the event + sub, and seed app-db. Returns nil."
+  []
+  (rf/make-frame {:id probe-frame :doc "rf2-oz7wr direct-mount probe frame"})
+  (rf/reg-event :rf.uix-direct-mount/seed (fn [_ _] {:db {:n 1}}))
+  (rf/reg-event :rf.uix-direct-mount/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
+  (rf/reg-sub (first probe-query) (fn [db _] (:n db)))
+  (rf/dispatch-sync [:rf.uix-direct-mount/seed] {:frame probe-frame})
+  nil)
+
+(defn- text-of [^js node testid]
+  (some-> node (.querySelector (str "[data-testid='" testid "']")) .-textContent))
+
+(defn- run-mount-case
+  "Mount `head` (a UIx component head) under the normal `frame-provider`
+  boundary with the probe payload and one trailing child, drive a dispatch,
+  and hand the collected facts back as a map.
+
+  `head` is passed STRAIGHT to `$` as the component type. Nothing here
+  invokes it — that is the whole point of the file, and it is why the two
+  cases can share this driver."
+  [act-fn head]
+  (reset! observed-payload ::unset)
+  (reset! observed-children ::unset)
+  (reset! observed-ops nil)
+  (let [mount-node (.createElement js/document "div")
+        root       (react-dom-client/createRoot mount-node)]
+    ;; Clear the fixture's ambient `:rf/default` dynamic scope so the
+    ;; 1-arg `use-subscribe` resolves through the React-context (provider)
+    ;; tier — the shape a real app has.
+    (binding [frame/*current-frame* nil]
+      (let [msgs    (with-captured-errors
+                      (fn []
+                        (act-fn
+                          (fn []
+                            (.render root
+                              ($ uix-adapter/frame-provider {:frame probe-frame}
+                                 ($ head
+                                    {:payload probe-payload}
+                                    ($ :em {:data-testid "child"} "kid"))))))))
+            initial (text-of mount-node "n")
+            ops     @observed-ops
+            ;; Dispatch through the ops map `use-frame` handed the mounted
+            ;; component. Wrapped in act so React commits the update the
+            ;; spine's useSyncExternalStore path schedules — the same
+            ;; convention every other UIx DOM row here uses.
+            more    (with-captured-errors
+                      (fn []
+                        (act-fn
+                          (fn []
+                            (when-let [ds (:dispatch-sync ops)]
+                              (ds [:rf.uix-direct-mount/inc]))))))
+            after   (text-of mount-node "n")]
+        (try
+          {:msgs     (into msgs more)
+           :initial  initial
+           :after    after
+           :child    (text-of mount-node "child")
+           :payload  @observed-payload
+           :children @observed-children
+           :ops      ops}
+          (finally
+            (try (.unmount root) (catch :default _ nil))))))))
+
+(defn- assert-mount-case
+  "The shared assertion block. `label` names which mount path produced
+  `facts` so a failure message says which of the two rows broke."
+  [label facts]
+  (let [{:keys [msgs initial after child payload children ops]} facts]
+    (is (empty? (matching invalid-element-type-re msgs))
+        (str label ": React accepted the value as a component type; got "
+             (pr-str (matching invalid-element-type-re msgs))))
+    (is (empty? (matching hook-boundary-re msgs))
+        (str label ": the mount owns a real React hook boundary; got "
+             (pr-str (matching hook-boundary-re msgs))))
+    (is (= probe-payload payload)
+        (str label ": the nested CLJS prop arrived intact — namespaced keyword"
+             " keys AND values, by value equality; got " (pr-str payload)))
+    (is (true? children)
+        (str label ": the trailing `$` child reached the component; got "
+             (pr-str children)))
+    (is (= "kid" child)
+        (str label ": the trailing child rendered into the DOM; got " (pr-str child)))
+    (is (= probe-frame (:frame ops))
+        (str label ": use-frame resolved the SURROUNDING provider's frame, so"
+             " the hook read the context this mount established; got "
+             (pr-str (:frame ops))))
+    (is (= "1" initial)
+        (str label ": use-subscribe's initial value rendered; got " (pr-str initial)))
+    (is (= "2" after)
+        (str label ": the DOM re-rendered after a dispatch off use-frame's ops"
+             " map; got " (pr-str after)))))
+
+;; ---- AC1 / AC2 / AC3 — the registry path ----------------------------------
+
+(deftest direct-mount-of-registered-view-head
+  (testing "UIx — ($ (rf/view id) props child) mounts DIRECTLY: lossless CLJS
+            props, a real hook boundary, and a re-render on dispatch (rf2-oz7wr)"
+    (with-browser-act
+      (fn [act-fn]
+        (seed-world!)
+        (rf/reg-view* :rf.uix-direct-mount/row probe-body)
+        (let [head (rf/view :rf.uix-direct-mount/row)]
+          ;; `fn?` is NOT the discriminator here and would pass either way:
+          ;; `cljs.core/MetaFn` implements the `Fn` marker protocol, so
+          ;; `(fn? metafn)` is true while React still rejects the object.
+          ;; `instance? js/Function` is the property React actually needs.
+          (is (instance? js/Function head)
+              "the registered head is a real JS function React can use as an
+               element type — NOT the MetaFn `with-meta` yields (rf2-oz7wr)")
+          (is (true? (.-uix-component? ^js head))
+              "and it carries UIx's own component marker, which is what makes
+               `$` route props through the lossless `argv` channel instead of
+               converting them and dropping keyword namespaces")
+          (assert-mount-case "registry head" (run-mount-case act-fn head)))))))
+
+;; ---- AC5 — the non-vacuity control ----------------------------------------
+
+(deftest native-defui-control-mounts-independently-of-the-registry
+  (testing "UIx — the SAME probe mounted as an unregistered native defui passes
+            the identical harness, so the registry row's verdict is about the
+            registry path and not about this file (rf2-oz7wr AC5)"
+    (with-browser-act
+      (fn [act-fn]
+        (seed-world!)
+        (assert-mount-case "native defui control" (run-mount-case act-fn probe-body))))))
+
+;; ---- the registered head keeps its other contracts ------------------------
+
+(deftest registered-head-is-stable-and-still-callable
+  (testing "UIx — componentizing the head does not cost the registry its other
+            guarantees: instance identity is stable across lookups, and the
+            head remains the callable render fn Spec 001 describes (rf2-oz7wr)"
+    (seed-world!)
+    (rf/reg-view* :rf.uix-direct-mount/stable
+                  (fn [props] (React/createElement "div" #js {} (str (:label props)))))
+    (let [a (rf/view :rf.uix-direct-mount/stable)
+          b (rf/view :rf.uix-direct-mount/stable)]
+      (is (identical? a b)
+          "two lookups return the SAME object — React reconciles it as one
+           component type rather than remounting on every render")
+      (let [out (a {:label "hi"})]
+        (is (some? out) "the head is still directly callable (headless invocation)")
+        (is (= "div" (.-type ^js out))
+            "and returns the registered view's own React element")))))

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -1058,6 +1058,11 @@
     :chained?    true
     :design-bead "rf2-00li"
     :description "Substrate-side source-coord injection on rendered React elements."}
+   {:key         :adapter/componentize-view
+    :producer-ns '[re-frame.adapter.uix]
+    :chained?    true
+    :design-bead "rf2-oz7wr"
+    :description "Turns the composed registration wrapper into the substrate's own mountable COMPONENT HEAD — the value `views/reg-view*` registers and `(rf/view id)` returns. `build-frame-aware-view` yields `(with-meta (fn …) {:contextType frame-context})`, and `cljs.core/with-meta` on a fn is a `MetaFn` (an IFn object, not a JS function): Reagent's create-class machinery reads that meta and converts it, so Reagent does NOT publish this hook and its head stays unchanged; React has no such conversion and rejects the MetaFn as an element type, so UIx publishes a shell that React can mount. The spine (`make-componentize-view`) builds the substrate-agnostic forwarding shell and the adapter stamps its substrate's component marker on it — the rf2-z7hfp seam split, so `$` routes props through UIx's lossless `argv` channel rather than the keyword-mangling JS-prop conversion. Absent-hook fallback in `apply-adapter-componentize-view` returns the wrapper unchanged."}
    {:key         :adapter/arm-hiccup-emitter-if-unarmed!
     :producer-ns '[re-frame.adapter.reagent
                    re-frame.adapter.reagent-slim

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -2152,6 +2152,96 @@
           wrapped)
         user-fn))))
 
+;; ---- registered-view component head — substrate-agnostic CORE (rf2-oz7wr) --
+;;
+;; `views/reg-view*` composes its wrappers and hands back
+;; `(with-meta (fn frame-aware-view …) {:contextType frame-context})`. On
+;; Reagent that MetaFn IS the right head: Reagent's create-class / fn-to-class
+;; machinery reads the `:contextType` meta for the React static field and
+;; converts the IFn into a component type. A React-hook substrate has no such
+;; conversion — `cljs.core/with-meta` on a fn yields a `MetaFn` OBJECT, which
+;; `React.createElement` rejects as an element type — so `(rf/view id)`, the
+;; value the public docs advertise as a UIx component head, could not be
+;; mounted at all (rf2-oz7wr). The existing React-hook coverage only ever
+;; mounted it through a hand-written host component that INVOKED it, which
+;; proved teardown below the workaround rather than the advertised head.
+;;
+;; Seam placement mirrors rf2-z7hfp's `frame-provider` split, for the same
+;; reason: the substrate-agnostic CORE is here, and the substrate-NATIVE half
+;; lives in the adapter, ABOVE where that substrate's element macro marshals
+;; props. This core builds the outer SHELL — a genuine JS function React can
+;; mount, forwarding to the composed wrapper — and each adapter stamps it with
+;; its own substrate's component marker so `$` routes props through the
+;; LOSSLESS channel (UIx's `argv`) rather than converting them to JS props and
+;; dropping keyword namespaces. Merely stripping the meta would have produced a
+;; mountable head on the CONVERTING path, which is the silent-mangling class
+;; rf2-z7hfp closed at the provider seam.
+
+(defn- react-props?
+  "True when `x` is the props OBJECT React passes a function component, and
+  not a CLJS value a direct caller passed positionally.
+
+  Mirrors `uix.compiler.alpha/pojo?`: a plain JS object that is not a React
+  element. CLJS collections fail the constructor test (theirs is their own
+  deftype), and a React element passed positionally to a direct invocation
+  fails the `$$typeof` test — so the two calling conventions the registered
+  head serves stay distinguishable. The constructor test runs FIRST so a
+  null-prototype object answers false rather than throwing on the absent
+  `hasOwnProperty`."
+  [x]
+  (and (some? x)
+       (identical? (.-constructor ^js x) js/Object)
+       (not (.hasOwnProperty ^js x "$$typeof"))))
+
+(defn make-componentize-view
+  "Return the `componentize-view` CORE (rf2-oz7wr) — shape
+  `(id metadata wrapped) -> js-fn`, where `wrapped` is the fully-composed
+  registration wrapper `views/build-frame-aware-view` produced.
+
+  The returned shell is a plain JS function, so React mounts it as an
+  ordinary function component and every hook the registered view calls
+  (`use-subscribe`, `use-frame`, the spine wrap-view's frame read) belongs
+  to a REAL fiber of its own — no caller-supplied host, and instance
+  lifetime belongs to the registered view rather than to an ad-hoc wrapper.
+  It is built ONCE at registration, so `(rf/view id)` is reference-stable
+  across renders and React reconciles it as the same component type.
+
+  Two calling conventions reach the shell and it keeps them apart:
+
+    * REACT RENDER — `Component(props, secondArg)`. react-dom 19.2.0's
+      `updateFunctionComponent` passes `void 0` for `secondArg`, so the call
+      arrives with arity 2. The shell forwards the props object ALONE, which
+      is what keeps that stray `undefined` out of the user render-fn and out
+      of the dev-only render-args capture `:rf.view/rendered` carries
+      (rf2-rpgq8).
+    * DIRECT INVOCATION — `((rf/view id) {:label \"hi\"} 42)`, the headless
+      shape Spec 001 §`(re-frame.core/view id)` describes and the render-
+      trace suites use. Forwarded unchanged, so the registered head stays a
+      callable render fn as well as a mountable component.
+
+  The props object is forwarded UNCONVERTED. A substrate that marks the
+  shell as its own component type has already carried the original CLJS
+  props on that object (UIx stashes them on `argv`), and the registered
+  render-fn — typically that substrate's own native component — reads them
+  in its own idiom. Nothing in this path converts props, so a nested
+  namespaced keyword survives the mount by construction.
+
+  `displayName` is stamped from `performance/entry-id` — the same single
+  source `wrap-view` and `build-name` use, so the name React DevTools shows
+  for the mounted registry head is the `<id>` of its own `rf:render:<id>`
+  measure (Spec 009 §Naming convention, rf2-976bw). Dev-only: the shell
+  itself is a CORRECTNESS seam and is built in production too, but the name
+  string rides `interop/debug-enabled?` and elides with the rest."
+  []
+  (fn componentize-view [id _metadata wrapped]
+    (let [shell (fn view-component [& args]
+                  (if (react-props? (first args))
+                    (wrapped (first args))
+                    (apply wrapped args)))]
+      (when interop/debug-enabled?
+        (set! (.-displayName ^js shell) (performance/entry-id id)))
+      shell)))
+
 (defn install-clear-warn-once-step!
   "Wire `clear-fn` into the chained `:adapter/clear-warn-once-caches!`
   late-bind hook. The hook is chained — each adapter and re-frame.views
@@ -2507,6 +2597,7 @@
        :flush-views!               …
        :flush-render!              …
        :wrap-view                  …
+       :componentize-view          …
        :clear-warned-non-dom-roots! …}
 
   Note (rf2-z7hfp): the spine no longer produces `:frame-provider` or
@@ -2578,6 +2669,10 @@
                                (subs s 0 (dec n))
                                s))
         wrap-view-fn       (make-wrap-view warn-fn)
+        ;; rf2-oz7wr — the substrate-agnostic half of the registered-view
+        ;; component head. The adapter marks the shell this returns with its
+        ;; own substrate's component marker before publishing it.
+        componentize-fn    (make-componentize-view)
         render-fn          (make-render active-roots-cell after-render-sentinel)
         dispose-fn         (make-dispose-adapter!
                              {:active-roots-cell active-roots-cell
@@ -3134,6 +3229,10 @@
      ;; :flush-render! contract slot by make-react-adapter.
      :flush-render!               flush-render!
      :wrap-view                   wrap-view-fn
+     ;; rf2-oz7wr — `:adapter/componentize-view` CORE. The adapter marks the
+     ;; shell as its own substrate's component type and passes the marking
+     ;; wrapper to make-react-adapter as `:componentize-view`.
+     :componentize-view           componentize-fn
      :clear-warned-non-dom-roots! clear-warned
      ;; rf2-334d9 — :adapter/after-render impl. Each adapter publishes
      ;; this via substrate-adapter/route-hook!.
@@ -3183,6 +3282,14 @@
 ;;     excludes the four hooks above does NOT apply. Without this hook
 ;;     `(interop/after-render f)` under these adapters would be a silent
 ;;     no-op.
+;;   :adapter/componentize-view — rf2-oz7wr. Turns the composed registration
+;;     wrapper into a head the substrate can MOUNT: a genuine JS function
+;;     component stamped with the substrate's own component marker, so
+;;     `(rf/view id)` is directly usable as a `$` / createElement component
+;;     type and its props reach the registered view through the substrate's
+;;     lossless channel. Not published by Reagent, whose class machinery
+;;     already converts the `:contextType` MetaFn; the absent-hook fallback
+;;     in `views/reg-view*` keeps that head unchanged.
 ;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord injection
 ;;     via React.cloneElement (the views.cljs inline hiccup-walk would
 ;;     mis-classify React-element output as a non-DOM root). Production-
@@ -3204,6 +3311,16 @@
                         element-macro dependency, mirroring how
                         `make-ratom-adapter` takes the Reagent-component
                         `register-context-provider` in.
+      :componentize-view — the substrate's registered-view head factory
+                        (rf2-oz7wr), shape `(id metadata wrapped) -> head`.
+                        Passed in for the SAME reason as `:frame-provider`:
+                        the shell must carry that substrate's own component
+                        marker, and stamping it is the one substrate-native
+                        step, so the adapter wraps the spine's
+                        `:componentize-view` core with it. Keeping the marker
+                        out of the spine is what stops this ns growing a
+                        per-substrate branch — the drift rf2-z7hfp removed
+                        from the provider seam.
 
   Builds the 9-key substrate adapter map, routes the five React-hook
   late-bind hooks against it (`substrate-adapter/route-hook!`), and wires
@@ -3222,7 +3339,7 @@
   `spine-fns` map, `:kind`, and native `:frame-provider`. The former
   hand-copied route-hook block + chained installs (byte-identical across
   the UIx twins) now live once."
-  [spine-fns {:keys [kind frame-provider]}]
+  [spine-fns {:keys [kind frame-provider componentize-view]}]
   (let [adapter {:kind                      kind
                  :make-state-container      (:make-state-container      spine-fns)
                  :read-container            (:read-container            spine-fns)
@@ -3249,6 +3366,11 @@
       rf-disposable/-dispose)
     (substrate-adapter/route-hook! adapter :adapter/wrap-view
       (:wrap-view spine-fns))
+    ;; rf2-oz7wr — the registered-view component head. Routed (not chained by
+    ;; identity) like every other `:adapter/*` hook, so a loaded-but-inactive
+    ;; React-hook adapter cannot claim a Reagent registration.
+    (substrate-adapter/route-hook! adapter :adapter/componentize-view
+      componentize-view)
     (substrate-adapter/route-hook! adapter :adapter/after-render
       (:after-render-hook spine-fns))
     ;; Chained warn-once clear (rf2-4edk): chained (NOT routed by installed-

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -3311,8 +3311,12 @@
                         element-macro dependency, mirroring how
                         `make-ratom-adapter` takes the Reagent-component
                         `register-context-provider` in.
-      :componentize-view — the substrate's registered-view head factory
-                        (rf2-oz7wr), shape `(id metadata wrapped) -> head`.
+      :componentize-view — OPTIONAL. The substrate's registered-view head
+                        factory (rf2-oz7wr), shape
+                        `(id metadata wrapped) -> head`. Omit it and the hook
+                        stays unpublished, so `reg-view*` keeps the composed
+                        wrapper as the head — the right answer for a
+                        React-shaped substrate that owns its own view path.
                         Passed in for the SAME reason as `:frame-provider`:
                         the shell must carry that substrate's own component
                         marker, and stamping it is the one substrate-native
@@ -3369,8 +3373,18 @@
     ;; rf2-oz7wr — the registered-view component head. Routed (not chained by
     ;; identity) like every other `:adapter/*` hook, so a loaded-but-inactive
     ;; React-hook adapter cannot claim a Reagent registration.
-    (substrate-adapter/route-hook! adapter :adapter/componentize-view
-      componentize-view)
+    ;;
+    ;; OPTIONAL, and the `when` is load-bearing: `route-hook!` stores whatever
+    ;; it is handed and calls it once its adapter is the installed one, so
+    ;; routing a nil impl publishes a hook that throws on the first
+    ;; registration rather than one that declines. Every React-shaped caller
+    ;; that does NOT need componentization — hicasso, which owns its own view
+    ;; path, and the spine's own bench/test adapters — passes nothing here, and
+    ;; must be left with the hook UNPUBLISHED so `reg-view*`'s absent-hook
+    ;; fallback returns the wrapper unchanged, exactly as on Reagent.
+    (when componentize-view
+      (substrate-adapter/route-hook! adapter :adapter/componentize-view
+        componentize-view))
     (substrate-adapter/route-hook! adapter :adapter/after-render
       (:after-render-hook spine-fns))
     ;; Chained warn-once clear (rf2-4edk): chained (NOT routed by installed-

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -422,9 +422,10 @@
 ;;   2. `view-coord-attr`                 — debug-only source-coord stamp
 ;;   3. `trace/handler-scope-from-meta`   — pre-compute view's HandlerScope
 ;;   4. `build-frame-aware-view`          — assemble the per-render wrapped fn
-;;   5. `registrar/register!`             — install in the :view kind
+;;   5. `apply-adapter-componentize-view` — substrate's mountable head
+;;   6. `registrar/register!`             — install in the :view kind
 ;;
-;; reg-view* itself becomes a five-line straight-line composition.
+;; reg-view* itself becomes a six-line straight-line composition.
 
 (defn- apply-adapter-wrap-view
   "Consult the `:adapter/wrap-view` late-bind hook (rf2-00li) for a
@@ -461,6 +462,33 @@
     (if (some? wrapped)
       [wrapped true]
       [render-fn false])))
+
+(defn- apply-adapter-componentize-view
+  "Consult the `:adapter/componentize-view` late-bind hook (rf2-oz7wr) for
+  the substrate's own COMPONENT HEAD, given the fully-composed wrapper.
+  Returns the head to register and hand back from `reg-view*`.
+
+  `build-frame-aware-view` returns `(with-meta (fn frame-aware-view …)
+  {:contextType frame-context})`, and `cljs.core/with-meta` on a fn yields a
+  `MetaFn` — an IFn OBJECT, not a JS function. Reagent's create-class /
+  fn-to-class machinery reads that meta and converts the MetaFn into a React
+  component type, so Reagent does NOT publish this hook and the head is
+  returned unchanged. A React-hook substrate has no such conversion: React
+  rejects the MetaFn as an element type, so `(rf/view id)` — the value the
+  public docs advertise as a UIx component head — could not be mounted at
+  all. Those adapters publish the hook and hand back a mountable, marked
+  shell that forwards to this wrapper.
+
+  Consulted LAST, after the substrate wrap and the frame-aware wrapper have
+  been composed, so the shell is the OUTERMOST layer and every existing
+  wrapper keeps its frame, tracing, source-coordinate and unmount behaviour
+  underneath it. Same sticky-hook / routed-resolution contract as
+  `:adapter/wrap-view` above: nil means \"this substrate needs no
+  componentization\" — keep the wrapper as the head."
+  [id metadata wrapped]
+  (let [hook (late-bind/get-fn-cached :adapter/componentize-view)
+        head (when hook (hook id metadata wrapped))]
+    (if (some? head) head wrapped)))
 
 (defn- view-coord-attr
   "Capture the source-coord stamp for the inline hiccup-walk
@@ -638,16 +666,26 @@
   (Handler-meta `:sensitive?` annotation has been removed; per-path
   classification is the v2 mechanism.)
 
-  The body is a five-line pipeline; the work lives in the named
+  The value registered and returned is the substrate's own COMPONENT HEAD
+  (rf2-oz7wr). On Reagent that is the `:contextType`-carrying wrapper
+  itself, which Reagent's class machinery converts. A React-hook substrate
+  publishes `:adapter/componentize-view` and the head is a mountable,
+  substrate-marked shell wrapping it — so `(rf/view id)` can be handed
+  straight to `$` / `React.createElement` as a component type, as the public
+  UIx docs advertise, while remaining the callable render fn Spec 001
+  §`(re-frame.core/view id)` describes.
+
+  The body is a six-line pipeline; the work lives in the named
   helpers above."
   [id metadata render-fn]
   (let [[render-fn wrap-applied?] (apply-adapter-wrap-view id metadata render-fn)
         coord-attr (view-coord-attr id metadata wrap-applied?)
         view-scope (trace/handler-scope-from-meta :view id metadata)
         wrapped    (build-frame-aware-view id render-fn view-scope coord-attr
-                                           wrap-applied?)]
-    (registrar/register! :view id (assoc metadata :handler-fn wrapped))
-    wrapped))
+                                           wrap-applied?)
+        head       (apply-adapter-componentize-view id metadata wrapped)]
+    (registrar/register! :view id (assoc metadata :handler-fn head))
+    head))
 
 ;; ---- late-bind publication (rf2-vh1k3) ------------------------------------
 ;;

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -6580,12 +6580,14 @@
 ;; mount/unmount needs a DOM (jsdom is NOT in the node runner), so this is
 ;; a browser-DOM assertion — the neighbour of refcount-cleanup-on-unmount.
 ;;
-;; A registered view's wrapper (`(rf/view id)`) is rendered through
-;; `React/createElement` as a function component so the spine wrap-view's
+;; The registered head `(rf/view id)` is rendered DIRECTLY through
+;; `React/createElement` as a function component, so the spine wrap-view's
 ;; useEffect belongs to a real React instance whose teardown fires the
-;; cleanup. The probe is built in the suite (raw `React/createElement`, no
-;; substrate `defui`/`$` needed) so every React-hook adapter forwards it
-;; unchanged — a gap on one is a gap on all.
+;; cleanup. Since rf2-oz7wr that head is the adapter's `componentize-view`
+;; shell — a genuine JS function — so no intermediate host is needed. The
+;; probe is built in the suite (raw `React/createElement`, no substrate
+;; `defui`/`$` needed) so every React-hook adapter forwards it unchanged — a
+;; gap on one is a gap on all.
 
 (defn assert-view-unmount-emits-on-react-hook-teardown
   "rf2-te71r: mounting then unmounting a registered view under a
@@ -6609,20 +6611,20 @@
               (swap! recorded conj ev))))
         ;; Register a trivial DOM-rooted view. Its wrapper carries the
         ;; spine wrap-view's unmount-sentinel child (which holds the
-        ;; useEffect arm). `(rf/view id)` returns a CLJS `MetaFn` (the
-        ;; `:contextType` meta makes it an object, not a raw JS function),
-        ;; so React cannot use it as a component type directly — mount it
-        ;; via a plain JS-function host component that INVOKES the
-        ;; registered view. The spine sentinel element rides in the
-        ;; returned tree and React renders it as a real instance whose
-        ;; teardown fires the cleanup.
+        ;; useEffect arm), and `(rf/view id)` is the adapter's mountable
+        ;; component head (rf2-oz7wr), so it goes STRAIGHT into
+        ;; `React/createElement` as the component type — no host component
+        ;; invoking it. The spine sentinel element rides in the returned
+        ;; tree and React renders it as a real instance whose teardown fires
+        ;; the cleanup. Mounting the registered head itself is what makes
+        ;; this a proof about the advertised value rather than about a
+        ;; workaround wrapped around it.
         (rf/reg-view* view-id (fn [] (React/createElement "div" #js {} "probe")))
-        (let [render-fn  (rf/view view-id)
-              host       (fn host-cmp [_props] (render-fn))
+        (let [head       (rf/view view-id)
               mount-node (make-mount-node!)
               root       (react-dom-client/createRoot mount-node)]
           (try
-            (act-fn (fn [] (.render root (React/createElement host #js {}))))
+            (act-fn (fn [] (.render root (React/createElement head #js {}))))
             (is (empty? @recorded)
                 "no :rf.view/unmounted before teardown")
             (act-fn (fn [] (.unmount root)))
@@ -6666,16 +6668,16 @@
               (swap! recorded conj ev))))
         ;; Registered view returns a VOID DOM root (an <input>). The spine's
         ;; wrap-view must Fragment-wrap it with the sentinel as a sibling so
-        ;; React never sees children on the void element.
+        ;; React never sees children on the void element. Mounted through the
+        ;; registered head directly (rf2-oz7wr) — no manual-invocation host.
         (rf/reg-view* view-id (fn [] (React/createElement "input" #js {:type "text"})))
-        (let [render-fn  (rf/view view-id)
-              host       (fn host-cmp [_props] (render-fn))
+        (let [head       (rf/view view-id)
               mount-node (make-mount-node!)
               root       (react-dom-client/createRoot mount-node)
               ;; Capture console.warn + console.error across the mount: React
               ;; reports the void-element-children violation via console.error.
               warns      (with-captured-console-warn+error
-                           (fn [] (act-fn (fn [] (.render root (React/createElement host #js {}))))))
+                           (fn [] (act-fn (fn [] (.render root (React/createElement head #js {}))))))
               void-msgs  (filter #(and (string? %)
                                        (re-find #"(?i)void element" %))
                                  warns)]
@@ -6703,13 +6705,15 @@
   what a developer READS in the component tree; rf2-fa4ly pinned the stamp
   and never exercised the mount.
 
-  `wrap-view` is the right head to mount on this substrate: the registered
-  handler-fn from `views/reg-view*` carries `:contextType` metadata, and
-  `cljs.core/with-meta` on a fn yields a `MetaFn` — an IFn, not a JS
-  function — so it is Reagent's class machinery that turns it into a React
-  component type. A React-hook substrate has no such conversion; its
-  component head is the `wrap-view` output, which is where the spine's stamp
-  lands.
+  `wrap-view` is the head this row mounts because it is the surface whose
+  OWN stamp is under test: `wrap-view` is published for direct use by
+  code-gen and library scaffolding (`re-frame.adapter.uix/wrap-view`), so
+  its `displayName` has to be right independently of the registry. Since
+  rf2-oz7wr a REGISTERED view's mounted head is instead the adapter's
+  `componentize-view` shell, which carries the same
+  `performance/entry-id` stamp from the same single source; the registry
+  path's own direct mount is covered by
+  `re-frame.adapter.uix-reg-view-direct-mount-dom-cljs-test`.
 
   Browser-DOM gate (real createRoot); skipped on node-test via
   `with-browser-act`. cfg keys: :substrate-kw, :name, :wrap-view."


### PR DESCRIPTION
Closes rf2-oz7wr.

## The defect

`rf/reg-view*` registered `(with-meta (fn frame-aware-view …) {:contextType frame-context})`. `cljs.core/with-meta` on a fn yields a **`MetaFn` — an IFn object, not a JS function** — so the value `rf/view` hands back could not be used as a React element type at all. Reagent was never affected: its create-class / fn-to-class machinery reads that meta and converts the MetaFn into a component type. React has no such conversion, so the documented UIx form

```clojure
($ (rf/view ::row) {:payload {:tenant/id :tenant/admin}})
```

threw `Element type is invalid: … but got: object` before the registered view rendered.

The existing React-hook coverage could not see it. Every registry-head mount in `react_shared_suite.cljs` went through a hand-written host component that *invoked* the registered value, so those rows proved teardown **below** the workaround rather than the advertised head.

## The repair

A new optional `:adapter/componentize-view` seam, consulted last in `reg-view*` — after the substrate wrap and the frame-aware wrapper have composed, so the shell is the outermost layer and every existing wrapper keeps its frame, tracing, source-coord, display-name and unmount behaviour underneath it.

Seam placement follows **rf2-z7hfp**'s `frame-provider` split exactly: the substrate-agnostic core (`spine/make-componentize-view`) builds the forwarding shell, and the UIx adapter stamps UIx's own `uix-component?` marker on it. That marker is the half that makes the mount *correct* rather than merely possible — it routes props through UIx's lossless `argv` channel instead of `interpret-attrs`, which is what stringified keyword prop values and dropped their namespaces before rf2-z7hfp. **Merely stripping the meta would have produced a mountable head with mangled props**, which the bead explicitly rules out.

The shell is a marked *forwarder*, not a `defui`: `defui` glues `argv` into a CLJS map for its own body, and the shell must hand the props object down untouched so the registered component — itself typically a `defui` — reads it in its own idiom. That is what keeps `(rf/reg-view* ::row row)` free of wrapper ceremony for the caller (a Non-goal of the bead).

The head stays the callable render fn Spec 001 §`(re-frame.core/view id)` describes. The shell keeps React's `Component(props, secondArg)` call apart from direct positional invocation — react-dom 19.2.0's `updateFunctionComponent` passes `void 0` as `secondArg`, so without that discrimination a stray `undefined` would reach the user render-fn and the dev-only render-args capture (rf2-rpgq8).

Reagent publishes no hook and is byte-for-byte unaffected.

## Verified by hand (no gate covers this)

Anchors and table column counts: this PR adds no markdown and no tables. The one prose surface touched is CLJS docstrings/comments.

## Quality gates

Run from the worker worktree. Every number below is the runner's own captured exit code, not a harness report.

| Gate | Exit | Result |
|---|---|---|
| `npx shadow-cljs compile browser-test` | `0` | 1012 files, 0 warnings |
| `node scripts/serve-and-run-browser-tests.cjs` | `0` | **755 tests, 4130 assertions, 0 failures, 0 errors** |
| `npm run test:cljs` (node lane) | `0` | **11124 tests, 54590 assertions, 0 failures, 0 errors** |
| `clojure -M:test -n re-frame.late-bind-drift-test` | `0` | 8 tests, 683 assertions |
| `npx shadow-cljs release browser-test-prod-elision` | `0` | 308 files, 0 warnings |
| `check_source_coord_elision.cjs` + prod-elision browser run | `0` | 91 tests, 289 assertions, 0 failures, 0 errors |

Both phases of `npm run test:browser` were run split, so each verdict is its own captured number. The compile log names this worktree's `shadow-cljs.edn`, which is how the run is tied to the tree under test.

The `:advanced` + `goog.DEBUG=false` prod-elision lane was run deliberately rather than left to CI, because it is the one that could have surprised: the shell is built in production (it is a correctness seam, not a dev one), only its `displayName` rides `interop/debug-enabled?`, and `uix-component?` is a property name under a release compile. It is green, so both hold.

Every gate above was re-run on the **final rebased base** (`fd0113d5bf`); the pre-rebase numbers are not the ones reported.

### Control — the gate bites (AC5)

Sabotage: restored the metadata-wrapped head by pointing `apply-adapter-componentize-view` at a non-existent hook key, so `reg-view*` registers the `MetaFn` again. Source change confirmed by blob hash (`35f57741…` → `0e0a5c25…`, not a no-op); the runtime saw it — the rebuild recompiled 313 files.

Browser run **exit 1**, 9 failures + 2 errors, and the discrimination is exact:

- `direct-mount-of-registered-view-head` — **9 failures**, the first reading
  `THROWN: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.`
  — verbatim the symptom the bead predicted.
- `view-unmount-emits-on-react-hook-teardown` and `void-root-view-unmount-no-warning` — **1 error each**. These are the two shared-suite rows whose manual-invocation host this PR removes. They passed on a broken tree before; they do not now. That is the bypass removal being load-bearing rather than cosmetic.
- `native-defui-control-mounts-independently-of-the-registry` — **passed**. Same probe body, same assertion block, mounted as an unregistered native `defui`. Its assertions carry a distinct `native defui control:` prefix and none appear in the failure set, so the harness is shown green independently of the registry path.

Restored and verified by **git blob hash against the committed object**: `35f57741a4467ede665e33b162a1523e5779f426` on both sides, working tree clean.

A second control was run on the other gate this PR implicates. Removing the `:adapter/componentize-view` row from the late-bind directory turns that JVM drift test **red in both directions** (undocumented publication *and* orphaned entry, exit 1), so its green above is not vacuous. Restored and hash-verified likewise (`792398395c81e37005d83d9344351e78345c2d4f`).

### Found while gating

The node lane caught a defect the browser lane could not: `make-react-adapter` routed the new hook **unconditionally**, so every React-shaped caller supplying no head factory published a `nil` impl — and `route-hook!` stores what it is handed and calls it once its adapter is installed, so the first `reg-view*` under that adapter threw rather than declining. 16 errors, all on `re-frame.hicasso.substrate`, which owns its own view path. The spine's own bench and test adapters are in the same position. Fixed in the second commit by guarding the routing on the factory being present; an absent hook is already the documented decline.

### Not covered locally

The release-bundle gates other than prod-elision did not run here — the closest to this change is the UIx bundle-isolation build, which compiles `examples/counter-uix` under `:advanced` and asserts the bundle stays Reagent-free; see `implementation/scripts/check-uix-reagent-free.cjs`. This PR adds no new `:require`, so the bundle's shape is unchanged, but CI owns the proof.
