### PR TITLE
fix(ci): arm skills_structural for reagent-migration and pair-retro (rf2-g1m2q)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -2202,6 +2202,49 @@ else
             ;;
         esac
         ;;
+      skills/re-frame2-pair-retro/*)
+        # rf2-g1m2q — this tree armed NOTHING AT ALL, not merely
+        # skills_structural=false: the four arms above were the whole of the
+        # `skills_structural` surface and the main case has no default arm, so
+        # a diff confined here classified to zero of 28 outputs.
+        #
+        # IT CANNOT INHERIT THE PAIR ARM, and that is the whole reason it needs
+        # its own. `skills/re-frame2-pair/*` requires a `/` immediately after
+        # `pair`; this tree has `-retro` there, so the pattern never matches and
+        # the near-identical prefix reads as though it were already covered.
+        #
+        # rf2-qad4l wired `skills/re-frame2-pair-retro/tests/*_test.clj` into the
+        # `skills-structural` job as its own step (a bb loop mirroring the
+        # setup-skill one), gated on this output — so until this arm existed the
+        # step fired only on a change to one of the OTHER armed trees or on an
+        # --all run, never on a change to the tests it gates. That is the
+        # surface-armed gate skipped on the very push that breaks it.
+        #
+        # ONE output, structural only. The tree is prose plus a Babashka
+        # command-contract test that loads no re-frame2 runtime, drives no live
+        # Pair op and compiles into no example build, so the expensive lanes its
+        # `skills/re-frame2-pair/*` neighbour arms have nothing to do here.
+        skills_structural=true
+        ;;
+      skills/reagent-migration/*)
+        # rf2-g1m2q — the same silent hole in the second of the two trees the
+        # measurement covered, and the same zero-output classification.
+        #
+        # rf2-vpdrf / rf2-bbe91 wired `skills/reagent-migration/tests/fixture/`
+        # into `reagent-migration-fixture-cold-start` — a MIG-23 SSR cold-start
+        # :node-test build — gated on this output. The
+        # fixture is the skill's executable half: it pins the migrated output
+        # against the real substrate, so an unclassified edit to it merged with
+        # its own suite unrun.
+        #
+        # ONE output, structural only, and the fixture is why that is not an
+        # oversight: it resolves its own deps and builds its own :node-test, so
+        # `reagent-migration-fixture-cold-start` (which skills_structural gates)
+        # is the job that runs it. Arming `cljs_node_test` or `examples_compile`
+        # instead would schedule the implementation's own heavy lanes for a diff
+        # that cannot reach them, and still not run this fixture.
+        skills_structural=true
+        ;;
       docs/tools/playground/*|docs/cljs/playground.js|docs/cljs/playground.css|scripts/playground-sci-input-digest.mjs)
         # rf2-ee38b.22 — the docs/cljs live-cell playground (CM6 + Scittle
         # bootstrap + the re-frame2 SCI bundle). The tools-playground job

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -2211,6 +2211,64 @@ test('NON-preload re-frame2-pair skill file does NOT arm cljs_browser / mcp_live
   assert.equal(result.skills_structural, 'true');
 });
 
+// rf2-g1m2q — `skills/re-frame2-pair-retro/**` and `skills/reagent-migration/**`
+// armed NOTHING AT ALL. `skills_structural` had four case arms
+// (skills/re-frame2-pair/tests/fixture/*, skills/re-frame2-pair/preload/*,
+// skills/re-frame2-pair/* with skills/shared/*, skills/re-frame2-setup/*) and
+// the main case carries no default arm, so a diff confined to either tree
+// classified to ZERO outputs — not merely skills_structural=false. Measured
+// with a passing control first, because an instrument that can answer "nothing
+// here" answers it the same way when misused: skills/re-frame2-setup/SKILL.md
+// returned skills_structural=true while both trees below returned 0 of 28.
+//
+// Both trees carry tests that the skills_structural tier is what schedules:
+//   - skills/re-frame2-pair-retro/tests/*_test.clj, looped by the pair-retro
+//     step in the `skills-structural` job (rf2-qad4l).
+//   - skills/reagent-migration/tests/fixture/, whose MIG-23 SSR cold-start
+//     :node-test build runs in `reagent-migration-fixture-cold-start`
+//     (rf2-vpdrf / rf2-bbe91).
+// So each tree's own gate was skipped on exactly the push that could break it.
+//
+// THE PAIR / PAIR-RETRO BOUNDARY IS THE TRAP, and it is why the retro tree
+// cannot inherit an existing arm: the `skills/re-frame2-pair/*` pattern needs a
+// `/` straight after `pair`, and `skills/re-frame2-pair-retro/...` has a `-`
+// there, so it never matches. The negative assertions pin that boundary from
+// the other side — retro paths must not arm the PAIR tree's expensive gates.
+const SKILLS_STRUCTURAL_ONLY_FILES = [
+  'skills/re-frame2-pair-retro/SKILL.md',
+  'skills/re-frame2-pair-retro/tests/duplicate_search_test.clj',
+  'skills/re-frame2-pair-retro/references/known-frictions.md',
+  'skills/reagent-migration/SKILL.md',
+  'skills/reagent-migration/references/procedure.md',
+  'skills/reagent-migration/tests/fixture/test/reagent_migration/mig23_cold_start_test.cljs',
+  'skills/reagent-migration/tests/fixture/shadow-cljs.edn',
+];
+for (const file of SKILLS_STRUCTURAL_ONLY_FILES) {
+  test(`${file} arms skills_structural (rf2-g1m2q)`, () => {
+    const result = classify(file);
+    assert.equal(
+      result.skills_structural,
+      'true',
+      `${file} is scheduled by the skills_structural tier; before rf2-g1m2q this tree armed nothing at all`,
+    );
+    // Scope discipline: structural ONLY. Neither tree drives a runtime, a live
+    // Pair op, an example build or an emitted-scaffold compile, so neither may
+    // queue the expensive lanes the pair/setup trees legitimately arm.
+    for (const key of [
+      'cljs_browser',
+      'mcp_live',
+      'examples_compile',
+      'template_expensive',
+    ]) {
+      assert.equal(
+        result[key],
+        'false',
+        `${file} is prose plus a self-contained fixture; it must NOT arm ${key}`,
+      );
+    }
+  });
+}
+
 test('cljs-browser job is job-level gated on cljs_browser (browser consumer, rf2-11yjq)', () => {
   const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'cljs-browser');
   assert.match(block, /needs: detect_changed_surfaces/);
@@ -5633,9 +5691,16 @@ const DECLARED_NO_SURFACE_OUTPUT = {
   'skills/re-frame-migration': SKILLS_ALWAYS_ON,
   'skills/re-frame2-implementor': SKILLS_ALWAYS_ON,
   'skills/re-frame2-improver': SKILLS_ALWAYS_ON,
-  'skills/re-frame2-pair-retro': SKILLS_ALWAYS_ON,
+  // rf2-g1m2q — `skills/re-frame2-pair-retro` and `skills/reagent-migration`
+  // are DELIBERATELY ABSENT from this table now. Both used to sit here as
+  // SKILLS_ALWAYS_ON, which was true of them as pure prose trees; rf2-qad4l and
+  // rf2-vpdrf / rf2-bbe91 then gave each an executable half gated on
+  // `skills_structural` (the pair-retro bb step in `skills-structural`, and
+  // `reagent-migration-fixture-cold-start`), and this bead armed the two case
+  // arms that schedule them. A tree that arms an output must not stay declared:
+  // the `staleDeclarations` half of the check below fails on exactly that, so
+  // re-adding either entry reds this suite rather than passing quietly.
   'skills/re-frame2-xray': SKILLS_ALWAYS_ON,
-  'skills/reagent-migration': SKILLS_ALWAYS_ON,
   tools: {
     why: "A DECLARED HOLE, and since rf2-i2uoc a MEASURED one rather than an open question. The tree is four files. tools/README.md IS covered — the always-on verify-readme-links job walks it (measured: it is in check_readme_links.py's _iter_scanned set). tools/.gitignore is config no gate reads. The two build coordinators have no CI consumer AT ALL, and arming them was refused on evidence rather than guessed: no workflow runs from tools/ (every working-directory in .github/workflows is tools/<artefact>, never the bare root); scripts/test-jvm-tools.sh iterates per-tool directories and never the aggregate :test alias; tools/deps.edn says so itself, in its own comment — 'Production CI runs each tool's :test alias separately (per-tool gates)'; CI compiles the pair-mcp server from tools/re-frame2-pair-mcp/shadow-cljs.edn, not the tools/ mirror of it; and verify-version-lockstep.sh reads the per-artefact deps.edn files, not this coordinator. So NO existing output would exercise either file, and arming one — tools_jvm was the candidate — would schedule four probes that never read the edited file, which the tools_jvm_machines_viz note beside it calls worse than nothing. They are developer-convenience aggregates whose breakage surfaces on the next `cd tools && clojure -M:test`, to the developer who caused it. Delete this entry if either coordinator ever gains a real CI consumer.",
     coveredBy: ['scripts/check_readme_links.py'],


### PR DESCRIPTION
Closes rf2-g1m2q.

## The bug

`skills_structural` was armed from four case arms only — `skills/re-frame2-pair/tests/fixture/*`, `skills/re-frame2-pair/preload/*`, `skills/re-frame2-pair/*|skills/shared/*`, `skills/re-frame2-setup/*` — and the main `case` in `.github/scripts/report-changed-surfaces.sh` carries **no default `*)` arm**. So a diff confined to `skills/re-frame2-pair-retro/**` or `skills/reagent-migration/**` classified to **nothing at all**: zero of 28 outputs true, not merely `skills_structural=false`.

The finding was re-measured at this branch's base rather than taken from the bead, and it still held. Control first, because the classifier is an instrument that can answer "nothing here" and this bug *is* that failure mode:

| path | outputs true |
|---|---|
| `skills/re-frame2-setup/SKILL.md` (control) | `skills_structural` |
| `skills/re-frame2-pair-retro/SKILL.md` | 0 of 28 |
| `skills/re-frame2-pair-retro/tests/duplicate_search_test.clj` | 0 of 28 |
| `skills/reagent-migration/SKILL.md` | 0 of 28 |
| `skills/reagent-migration/tests/fixture/test/reagent_migration/mig23_cold_start_test.cljs` | 0 of 28 |

Both trees had just been given an executable half gated on that output — the pair-retro `bb` step inside `skills-structural` (rf2-2jeh5 / rf2-qad4l) and `reagent-migration-fixture-cold-start` (rf2-vpdrf / rf2-bbe91). Until these arms existed, each fired only on a change to one of the four already-armed trees or on an `--all` run, never on a change to the tests it gates — the surface-armed gate skipped on exactly the push that breaks it. Both jobs say so in an in-place comment naming rf2-g1m2q as the owner of the widening.

**Why it was easy to miss:** the pair-retro tree cannot inherit the pair arm. `skills/re-frame2-pair/*` requires a `/` immediately after `pair`, and `skills/re-frame2-pair-retro/...` has a `-` there, so the near-identical prefix never matches. The mirror pins that boundary from both sides.

## The change

Two case arms, each setting **one** output, placed beside the other skills arms:

- `skills/re-frame2-pair-retro/*)` → `skills_structural=true`
- `skills/reagent-migration/*)` → `skills_structural=true`

Structural only. Neither tree drives a runtime, a live Pair op or an example build, and the reagent-migration fixture resolves its own deps and builds its own `:node-test`, so arming `cljs_node_test` or `examples_compile` would schedule the implementation's heavy lanes for a diff that cannot reach them and *still* not run the fixture.

**No default `*)` arm was added.** The bug is these two missing arms; a catch-all would change classification for every unmatched path in the repository, which is a far larger change than this warrants.

In `implementation/scripts/_changed-surfaces.test.cjs`: seven new pins across both trees (SKILL.md, references, the test and fixture files), each asserting `skills_structural=true` plus four negatives holding scope (`cljs_browser`, `mcp_live`, `examples_compile`, `template_expensive`). `skills/re-frame2-pair-retro` and `skills/reagent-migration` also **leave** `DECLARED_NO_SURFACE_OUTPUT` — a tree that arms an output must not stay declared dark, and the suite's existing `staleDeclarations` check enforces that from the other side.

Both halves move in **one commit**: the test pins the script's outputs, so a tree where only one moved has a suite that contradicts the script.

## Quality gates

Covering gate derived from the tree, not taken on faith: the mirror is discovered by `implementation/package.json`'s `test:scripts` (a `node --test` glob over `scripts/*.test.cjs`), which runs in `test.yml`'s **`js-harness-self-tests`** job. That job carries no `if:` — it is unconditional, so this surface is gated on every PR. The compound script was **split into its three phases** rather than detached; each ran in the foreground to completion, and every number below is the runner's own captured exit code, not a harness report.

Re-run in full **after** the rebase onto `302467d66b` (the trunk moved twice during the work; a pre-rebase green is evidence about a tree that no longer exists).

| gate | captured exit | result |
|---|---|---|
| `node --test scripts/*.test.cjs` (the job's substantive phase) | `0` | 42/42 files, incl. `changed-surfaces tests: 299 passed.` |
| `node scripts/run-hicasso-native-ime-witness.cjs --self-test` | `0` | self-test pass |
| `node --test core/test/re_frame/bench/*.test.cjs hicasso/scripts/*.test.cjs` | `0` | 80 pass / 0 fail |
| `bash -n .github/scripts/report-changed-surfaces.sh` | `0` | syntax clean |

**Pass-count delta: 292 → 299, +7** — the count *grew* by exactly the seven pins added, so no existing test was substituted.

**The control is the deliverable, and it was run in both directions.**

1. *Pins before the widening* (the prescribed control): the seven pins were added with the script untouched. Captured exit **`1`**, `changed-surfaces tests: 7 failed.`, each failure naming its tree — "…before rf2-g1m2q this tree armed nothing at all". Since those pins exist only in this branch, that red is also positive evidence the gate read **this** worktree rather than a sibling's.
2. *Sabotage after the fix*: with both halves committed, the `skills/re-frame2-pair-retro/*)` pattern was neutralised (anchor match count checked as exactly `1` first, so the plant could not silently no-op). The runtime was confirmed to have observed the plant — pair-retro dropped to 0 outputs while reagent-migration still armed, so the plant was scoped and discriminating. Gate captured exit **`1`**: the three pair-retro pins failed **and** the pre-existing `every tracked tree arms an output or is DECLARED (rf2-skvce)` test failed alongside them, confirming the declaration removal is enforced in both directions. Restore verified by **git blob hash** against the committed object (`6bfea0f873…`, matched exactly), not by reading a diff.

**Not verified locally, stated rather than implied:** `shellcheck` is **not installed on this host**, and `portability.yml` shellchecks every tracked `.github/scripts/*.sh`. That verdict is CI's; `bash -n` above is a syntax check, not a lint. `bash -n` and `shellcheck` are not substitutes.

A change to the classifier itself arms **all 28 outputs**, so this PR runs the full matrix — including `skills-structural` and `reagent-migration-fixture-cold-start`, the two jobs the fix is about.

## Follow-up, not folded in

`.github/workflows/**` is hot-zone and out of scope here, so it is untouched. Once this lands, the in-place caveats in `test.yml` at the pair-retro step and above `reagent-migration-fixture-cold-start` — both stating that `skills_structural` "does not yet fire for this tree" and naming rf2-g1m2q as the owner — become **stale prose describing a fixed condition**. They need a follow-up bead against whoever next holds `test.yml`.
