### PR TITLE
fix(story): the share-url builder owns its whole query vocabulary, omitted slots included (rf2-b7je1)

### DIFF
--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -55,6 +55,33 @@
             #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as edn])))
 
+;; ---- the Story-owned query vocabulary -----------------------------------
+
+(def ^:no-doc story-query-keys
+  "The COMPLETE set of query keys the Story share URL owns, in the order
+  `build-params` emits them — the §URL scheme list in the ns docstring
+  above, written down once so the three places that need it agree:
+  `build-params` emits a SUBSET of it, `parse-params` reads ALL of it,
+  and `append-query-params` CLEARS all of it before appending.
+
+  All of it, not merely the subset a given call emits (rf2-b7je1 audit).
+  `build-params` deliberately omits empty / nil / default slots so the
+  URL stays minimal, so a builder that cleared only the emitted keys
+  would leave a stale `modes=` / `overrides=` / `substrate=` standing on
+  the base-url when the caller asked for `[]` / `{}` / `:reagent` — and
+  the hydrator would then restore state nobody requested, which is the
+  exact-cell share invariant broken by omission rather than by order.
+  The builder is authoritative over its whole key set, including the
+  slots it declines to emit.
+
+  `embed` is deliberately NOT a member: per
+  `re-frame.story.ui.url-state/embed-flag-from-current-url` it is chrome
+  state rather than shell state and never round-trips through
+  `parse-params`, so the builder must PRESERVE it like any other
+  third-party param."
+  [:variant :workspace :mode-tab :modes :viewport :background :tag-filter
+   :overrides :substrate])
+
 ;; ---- pure: URL encoding -------------------------------------------------
 
 (defn- ^:no-doc url-encode
@@ -368,20 +395,26 @@
   "Merge already-encoded query `params` into `base-url`, inserting them
   before any hash fragment.
 
-  Key-aware (rf2-b7je1): every existing occurrence of a key emitted by
-  THIS call is removed before the generated value is appended, so the
-  result carries exactly one value per Story-owned key. The browser
-  hydrator (`re-frame.story.ui.url-state/params->getter`) reads each
-  key with `URLSearchParams.get`, whose first-value semantics would
+  Key-aware (rf2-b7je1): every existing occurrence of a key in
+  `story-query-keys` is removed before the generated params are
+  appended, so the result carries exactly one value for each key the
+  builder owns and NO value for the ones this call chose to omit. The
+  browser hydrator (`re-frame.story.ui.url-state/params->getter`) reads
+  each key with `URLSearchParams.get`, whose first-value semantics would
   otherwise select a stale value already on `base-url` — opening a
   different cell than the one shared. Unrelated existing entries
   (e.g. `from=index`, `embed=1`) are preserved verbatim, in order,
-  ahead of the generated params."
+  ahead of the generated params.
+
+  The clear set is `story-query-keys` rather than the keys of `params`
+  precisely because `build-params` omits empty / default slots: clearing
+  only what is emitted leaves a stale `modes=` standing when the caller
+  requests no modes at all."
   [base-url params]
   (let [[path fragment] (split-fragment base-url)
         qidx            (str/index-of path "?")
         bare            (if qidx (subs path 0 qidx) path)
-        owned           (into #{} (map query-param-key) params)
+        owned           (into #{} (map (comp url-encode name)) story-query-keys)
         kept            (when qidx
                           (->> (str/split (subs path (inc qidx)) #"&" -1)
                                (remove #(contains? owned (query-param-key %)))))
@@ -436,9 +469,14 @@
   - `:overrides`  — one `pr-str`-printed EDN map (delimiter-safe)
   - `:substrate`  — substrate id (omitted when `:reagent` default)
 
+  — i.e. exactly the keys of `story-query-keys`, which is where that
+  vocabulary is written down.
+
   Returns a vector of `k=v` URL fragments. Pure data → data;
   JVM-testable. Slots whose value is empty/nil/default are omitted so
-  the URL is the minimal canonical form."
+  the URL is the minimal canonical form — an omission the SHARE-URL
+  builder compensates for by clearing the whole of `story-query-keys`
+  off `base-url`, not just the subset returned here."
   [{:keys [variant-id workspace-id mode-tab
            active-modes viewport background tag-filter
            cell-overrides substrate]}]
@@ -519,6 +557,12 @@
   Empty / nil parts are omitted (e.g. no modes → no `modes=` param).
   If `base-url` contains a hash route, params are inserted before `#`
   so the query remains available via `window.location.search`.
+
+  The returned URL is authoritative for the whole Story vocabulary
+  (`story-query-keys`): a Story key already on `base-url` is replaced by
+  this call's value, or REMOVED when this call omits that slot, so the
+  reader lands on the requested cell and nothing else. Unrelated query
+  params (`from=`, `embed=`, …) and the hash route survive untouched.
   Pure data → data; JVM + CLJS-portable."
   ([variant-id]                (variant-share-url variant-id "" nil))
   ([variant-id opts]           (variant-share-url variant-id "" opts))

--- a/tools/story/test/re_frame/story_share_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_share_cljs_test.cljs
@@ -67,6 +67,56 @@
       (is (str/ends-with? url "#/stories")
           "the hash route survives, after the query"))))
 
+(deftest variant-share-url-clears-stale-omitted-keys-cljs
+  (testing "rf2-b7je1 audit — build-params omits empty / default optional
+            slots, so a base-url carrying stale modes / overrides /
+            substrate survived a call requesting [] / {} / :reagent. Read
+            through the REAL URLSearchParams the url-state hydrator uses:
+            every omitted Story key must be absent, not merely later in the
+            string, because .get would happily return the stale value."
+    (let [stale  {"variant"    "story.old%2Fa"
+                  "workspace"  "story.old%2Fws"
+                  "mode-tab"   "docs"
+                  "modes"      "Mode.app%2Fstale"
+                  "viewport"   "tablet"
+                  "background" "dark"
+                  "tag-filter" "stale"
+                  "overrides"  "%7B%3Afoo%201%7D"
+                  "substrate"  "uix"}
+          base   (str "https://example.test/?"
+                      (str/join "&" (map #(str (name %) "=" (get stale (name %)))
+                                         share/story-query-keys))
+                      "&from=index&embed=1#/stories")
+          url    (share/variant-share-url
+                   :story.new/b
+                   base
+                   {:active-modes [] :cell-overrides {} :substrate :reagent})
+          search (second (str/split (first (str/split url #"#" 2)) #"\?" 2))
+          usp    (js/URLSearchParams. search)]
+      (is (= (set (map name share/story-query-keys)) (set (keys stale)))
+          "the fixture carries a stale value for every key in the vocabulary")
+      (is (= "story.new/b" (.get usp "variant"))
+          "URLSearchParams.get returns the requested variant")
+      (is (= 1 (count (.getAll usp "variant")))
+          "exactly one variant value")
+      (doseq [k (map name share/story-query-keys)
+              :when (not= k "variant")]
+        (is (zero? (count (.getAll usp k)))
+            (str "URLSearchParams sees no stale " k "= at all")))
+      ;; The hydrator's own read path: getter map -> share/parse-params.
+      (let [parsed (share/parse-params
+                     (into {} (map (fn [k] [k (.get usp k)]))
+                           (map name share/story-query-keys)))]
+        (is (= :story.new/b (:variant-id parsed))
+            "parse-params over real URLSearchParams reads the requested variant")
+        (doseq [slot [:workspace-id :mode-tab :active-modes :viewport
+                      :background :tag-filter :cell-overrides :substrate]]
+          (is (nil? (get parsed slot))
+              (str "parse-params restores no stale " slot))))
+      (is (= "index" (.get usp "from")) "unrelated from= survives")
+      (is (= "1" (.get usp "embed")) "unrelated embed= survives")
+      (is (str/ends-with? url "#/stories") "the hash route survives"))))
+
 (deftest parse-share-url-params-cljs
   (testing "CLJS parser reconstructs the share URL tokens used by the shell hydrator"
     (is (= :story.counter/loaded

--- a/tools/story/test/re_frame/story_share_test.clj
+++ b/tools/story/test/re_frame/story_share_test.clj
@@ -160,6 +160,98 @@
       (is (str/ends-with? url "#/stories")
           "the hash route survives, after the query"))))
 
+;; ---- rf2-b7je1 (audit reopen): OMITTED slots clear their stale values ----
+;;
+;; The first repair cleared only the keys the call EMITTED. `build-params`
+;; deliberately omits empty / nil / default slots, so a base-url carrying
+;; `modes=` / `overrides=` / `substrate=` survived a call that requested
+;; `[]` / `{}` / `:reagent` — the hydrator then restored state the caller
+;; never asked for, breaking the exact-cell invariant by OMISSION rather
+;; than by order. The builder is authoritative over the whole
+;; `share/story-query-keys` vocabulary, including the slots it declines
+;; to emit.
+
+(def ^:private stale-story-params
+  "A stale, PARSEABLE wire value for every key in the Story vocabulary.
+  Parseable on purpose: a surviving value must be visible to
+  `parse-params` as restored state, not merely as an extra fragment."
+  {"variant"    "story.old%2Fa"
+   "workspace"  "story.old%2Fws"
+   "mode-tab"   "docs"
+   "modes"      "Mode.app%2Fstale"
+   "viewport"   "tablet"
+   "background" "dark"
+   "tag-filter" "stale"
+   "overrides"  "%7B%3Afoo%201%7D"
+   "substrate"  "uix"})
+
+(def ^:private stale-base-url
+  "Base URL carrying every stale Story key, in vocabulary order, plus two
+  unrelated params and a hash route."
+  (str "https://example.test/?"
+       (str/join "&" (map #(str (name %) "=" (get stale-story-params (name %)))
+                          share/story-query-keys))
+       "&from=index&embed=1#/stories"))
+
+(deftest story-query-keys-is-the-whole-build-params-vocabulary
+  (testing "rf2-b7je1 — the clear set is only correct while it equals what
+            build-params can emit. A slot added to build-params without a
+            matching story-query-keys entry silently reopens the stale-value
+            hole, so pin the two against each other."
+    (let [emitted (->> (share/build-params
+                         {:variant-id     :story.a/b
+                          :workspace-id   :story.a/ws
+                          :mode-tab       :docs        ; :dev is the omitted default
+                          :active-modes   [:Mode.app/dark]
+                          :viewport       :tablet
+                          :background     :dark
+                          :tag-filter     [:slow]
+                          :cell-overrides {:label "x"}
+                          :substrate      :my.lib/uix}) ; :reagent is the omitted default
+                       (map #(first (str/split % #"=" 2)))
+                       set)]
+      (is (= (set (map name share/story-query-keys)) emitted)
+          "build-params with every slot populated emits exactly the vocabulary"))))
+
+(deftest variant-share-url-clears-stale-omitted-keys
+  (testing "rf2-b7je1 audit — a base-url carrying stale values for keys this
+            call OMITS comes back carrying none of them; the browser
+            first-value read and parse-params see the requested cell with no
+            stale optional state; unrelated params and the hash survive."
+    (is (= (set (map name share/story-query-keys))
+           (set (keys stale-story-params)))
+        "the fixture carries a stale value for every key in the vocabulary")
+    (let [url    (share/variant-share-url
+                   :story.new/b
+                   stale-base-url
+                   ;; Every optional slot empty / default — so build-params
+                   ;; emits `variant=` and nothing else.
+                   {:active-modes [] :cell-overrides {} :substrate :reagent})
+          getter (first-value-getter url)
+          parsed (share/parse-params getter)]
+      (is (= 1 (query-key-count url "variant"))
+          "exactly one variant= — the requested one")
+      (doseq [k (map name share/story-query-keys)
+              :when (not= k "variant")]
+        (is (zero? (query-key-count url k))
+            (str "stale " k "= is cleared when the call omits that slot")))
+      (is (= "story.new/b" (get getter "variant"))
+          "browser first-value read sees the requested variant")
+      (is (= :story.new/b (:variant-id parsed))
+          "parse-params reconstructs the requested variant")
+      (doseq [slot [:workspace-id :mode-tab :active-modes :viewport
+                    :background :tag-filter :cell-overrides :substrate]]
+        (is (nil? (get parsed slot))
+            (str "parse-params restores no stale " slot)))
+      (is (= "index" (get getter "from"))
+          "unrelated from= survives with its value")
+      (is (= "1" (get getter "embed"))
+          "unrelated embed= survives — it is chrome state, not shell state")
+      (is (str/starts-with? url "https://example.test/?from=index&embed=1&variant=")
+          "unrelated entries keep their order ahead of the generated params")
+      (is (str/ends-with? url "#/stories")
+          "the hash route survives, after the query"))))
+
 (deftest variant-share-url-inserts-query-before-hash-route
   (testing "hash-routed Story links keep query params in location.search"
     (let [url (share/variant-share-url


### PR DESCRIPTION
Closes rf2-b7je1 (audit reopen of PR #8851).

## What was wrong

PR #8851 made `append-query-params` key-aware, but its clear set was
**the keys the call emitted**. `build-params` deliberately omits empty /
nil / default slots so the URL stays minimal, so a base-url carrying a
stale `modes=` / `overrides=` / `substrate=` survived a call that
requested `[]` / `{}` / `:reagent`, and the hydrator restored state
nobody asked for. Same broken invariant as the original bug — the
exact-cell share contract — reached by **omission** rather than by
first-value order.

The audit's finding held at tip, and is wider than the audit stated: the
public builder was probed against a base carrying all nine Story keys,
and **all eight non-`variant` keys survived**, not only the three named:

```
in :  ?modes=Mode.app%2Fstale&overrides=%7B%3Afoo%201%7D&substrate=uix
      &workspace=story.old%2Fws&mode-tab=docs&viewport=tablet
      &background=dark&tag-filter=a%2Cb&from=index#/stories
out:  ...every one of those, unchanged, then &variant=story.new%2Fb#/stories
```

## What changed

The Story query vocabulary was **implicit** — derived from whatever
`build-params` happened to emit on a given call. That is precisely why
the hole existed, so the repair is to write it down:

```clojure
(def ^:no-doc story-query-keys
  [:variant :workspace :mode-tab :modes :viewport :background :tag-filter
   :overrides :substrate])
```

Nine keys — the §URL scheme list already in the ns docstring, and exactly
what the hydrator's `params->getter` reads and `parse-params` consumes.
`append-query-params` now clears **all** of them before appending, rather
than the emitted subset. `embed=` is deliberately not a member: per
`url-state/embed-flag-from-current-url` it is chrome state, never
round-tripped through `parse-params`, so the builder preserves it like
any other third-party param — as the fixtures assert.

No API redesign: `variant-share-url`'s signature, the codec, and the
public surface are untouched; `append-query-params` stays private with
its one caller. No spec change — `tools/story/spec/005-SOTA-Features.md`
§Share URL already states the invariant this restores.

## Coverage

The defect is only observable through `URLSearchParams.get`'s
first-value semantics, so both hosts are covered.

- **JVM** (`re-frame.story-share-test`) — `variant-share-url-clears-stale-omitted-keys`
  builds from a base carrying a stale *parseable* value for every key in
  the vocabulary plus `from=index`, `embed=1` and `#/stories`, requests a
  variant with every optional slot empty/default, and asserts each omitted
  key is gone, the browser first-value read and `parse-params` recover the
  requested cell with no stale optional state, and the unrelated params
  and hash survive in order.
- **CLJS** (`re-frame.story-share-cljs-test`) — the same table against the
  **real** `js/URLSearchParams`, asserting `.getAll` is empty for every
  omitted key and feeding `.get` into `parse-params` the way the hydrator
  does.
- Both fixtures are **derived from `story-query-keys`** and assert they
  cover it, so a key added to the vocabulary is covered without editing
  them.
- `story-query-keys-is-the-whole-build-params-vocabulary` pins the clear
  set against `build-params` with every slot populated — a slot added to
  the builder without a vocabulary entry silently reopens this hole, and
  now reds instead.
- The two pre-existing merge tests (`variant-share-url-merges-existing-query`,
  `variant-share-url-replaces-stale-owned-keys`) are unchanged and stay
  green in **both** the red and green runs — this extends #8851's repair
  rather than replacing it.

## Quality gates

Runner-captured exit codes (`echo $?` immediately after the runner, same
shell), on the final rebased base `480df6b48e`.

| Gate | Result |
|---|---|
| JVM `clojure -M:test -n re-frame.story-share-test` (`jvm-tools-story`) | exit **0** — 34 tests / 106 assertions |
| JVM full `tools/story` `clojure -M:test` (`jvm-tools-story`) | exit **0** — 1879 tests / 6886 assertions |
| JVM full `tools/story-mcp` `clojure -M:test` (`jvm-tools-story-mcp`) | exit **0** — 278 tests / 1457 assertions |
| CLJS `node out/node-test.js --test=re-frame.story-share-cljs-test,re-frame.story.ui.url-state-cljs-test` (`cljs` / `cljs_node_test`) | exit **0** — 16 tests / 85 assertions |
| node-test compile (`scripts/compile-node-test.cjs`) | exit **0** — 1866 files, 0 warnings |

**Control — the property removed, red on both host arms.** The single
line restoring the pre-repair clear set (`(into #{} (map query-param-key) params)`):

| Sabotage run | Result |
|---|---|
| JVM focused | exit **1** — **17 failures**, all in `variant-share-url-clears-stale-omitted-keys`; counts unchanged at 34 tests / 106 assertions (no crashed namespace, no truncated lane) |
| CLJS focused | exit **1** — **16 failures**, all in `variant-share-url-clears-stale-omitted-keys-cljs`; counts unchanged at 7 tests / 45 assertions |

The CLJS arm was **recompiled between plant and run** (111 files
recompiled each time), so the runtime demonstrably observed the plant
rather than serving a stale bundle. Restore verified by **git blob hash**
against the committed object (`git hash-object` == `git rev-parse HEAD:<path>`),
not by reading a diff, and both arms re-run green after it.

`clojure -M:test` runs `tools/story`'s own suite from the artefact
directory, which is what `test.yml`'s `jvm-tools-story` job runs; the CLJS
namespaces end in `cljs-test` and `../tools/story/test` is on the
`:node-test` build's `:source-paths`, which is the `cljs` job's surface.
No `spec/*.md` touched.

## Incidental, not fixed here

`url-state/url-from-state` composes the address-bar URL from
`{:pathname :hash}` only, discarding `location.search` wholesale — so
`embed=1` (and any other third-party param) is dropped from the address
bar on the first state change after mount, even though the share builder
preserves it. Out of scope for this bead; flagged for triage.
