### PR TITLE
docs: SSR chapter installs the Node adapter; M-57 renames onto the owning namespace (rf2-byig6, rf2-3lhuj)

### DIFF
--- a/docs/core/hicasso/18-ssr-and-hydration.md
+++ b/docs/core/hicasso/18-ssr-and-hydration.md
@@ -45,14 +45,23 @@ The example page reads a feed from app-db and includes a browser-only chart:
 
 No view code is specific to SSR.
 
-Use the optional server module to render one request:
+Use the optional server module to render one request. The Node renderer is a
+separate process from the browser, and nothing installs an adapter for it:
+`server/render` mints a frame per request, and building that frame's state
+container raises `:rf.error/no-adapter-installed` in a process where
+`rf/init!` never ran — before any HTML is produced. Install the headless SSR
+adapter once at process startup. It is boot work, not request work.
 
 ```clojure
 (ns app.server
-  (:require [re-frame.hicasso.server :as server]
+  (:require [re-frame.core :as rf]
+            [re-frame.ssr :as ssr]
+            [re-frame.hicasso.server :as server]
             [app.views :as views]
             [app.subs]
             [app.events]))
+
+(rf/init! ssr/adapter)   ;; once, at process startup — never per request
 
 (defn page-response
   "Render one request from an app-db snapshot."
@@ -112,7 +121,9 @@ a view body. Put browser work in client-only effects such as
 
 The first client render must see the same state used by the server, and the
 frame that state lands in must already exist. A hydrating boot therefore has
-three ordered steps:
+three ordered steps. They share the adapter precondition every browser boot
+has — install one with `rf/init!` before the first frame, per
+[Installation](00-installation.md#hicasso-needs-a-substrate-adapter).
 
 ```clojure
 (ns app.client

--- a/migration/from-re-frame-v1/README.md
+++ b/migration/from-re-frame-v1/README.md
@@ -2322,17 +2322,17 @@ Per audit-of-audits state-machines #12, the machine-handler builder is renamed f
 
 | Old | New | Surface |
 |---|---|---|
-| `re-frame.core/create-machine-handler` | `re-frame.core/make-machine-handler` | the public builder fn |
+| `re-frame.core/create-machine-handler` | `re-frame.machines/make-machine-handler` | the public builder fn |
 | `:machines/create-machine-handler` | `:machines/make-machine-handler` | the late-bind hook key |
 
-**Detect.** v2-pre-rename codebases trip this. v1 had no machine substrate; v1-→-v2 migrations land directly on the new name.
+**Detect.** v2-pre-rename codebases trip this. v1 had no machine substrate; v1-→-v2 migrations land directly on the new name. The builder also moved off the `re-frame.core` facade in [M-28](#m-28-state-machines-spec-005-ship-in-a-separate-artefact--day8re-frame2-machines) — apply both changes together, so the renamed call lands on `re-frame.machines`.
 
 ```clojure
 ;; before
 (def my-handler (rf/create-machine-handler my-machine-spec))
 
 ;; after
-(def my-handler (rf/make-machine-handler my-machine-spec))
+(def my-handler (rf.machines/make-machine-handler my-machine-spec))
 ```
 
 **No alias.** Per pre-alpha posture (no back-compat shims), the old name is **removed** — stale call sites raise unresolved-symbol at compile time.


### PR DESCRIPTION
Two documentation corrections on disjoint surfaces. Both fix a page that teaches something the code does not do.

## rf2-byig6 — the Node renderer chapter never installed an adapter

`docs/core/hicasso/18-ssr-and-hydration.md` carried **zero** occurrences of `rf/init!`. Premise re-verified at this tip before editing (fixed-string grep, exit 1; the same grep run as a control against `00-installation.md` returns 7 hits, so the pattern works).

The Node renderer is a new, separate process the chapter itself introduces, and no earlier chapter installs an adapter in it. Verified at source:

- `server/render` mints a frame per request — `implementation/hicasso/src/re_frame/hicasso/server.cljs`.
- `make-state-container` raises `:rf.error/no-adapter-installed` before `(rf/init! ...)` — `implementation/core/src/re_frame/substrate/adapter.cljc`.
- `re-frame.ssr/adapter` is a plain public `def` (`implementation/ssr/src/re_frame/ssr.cljc:64`), and its own docstring in `ssr/substrate.cljc` carries exactly `(rf/init! ssr/adapter)`.

The server example now requires `re-frame.core` and `re-frame.ssr` and installs the adapter once at process startup, with prose naming the cold-process condition. The client half keeps its three ordered hydration steps and gains **one** sentence deferring the adapter precondition to `00-installation.md`, which owns the browser boot invariant. Mirrors the already-landed sibling rf2-vpdrf (PR #8838).

## rf2-3lhuj — premise partly overtaken, one residual site fixed

**The item's main body was already done at trunk.** The M-28 Public API paragraphs in `migration/from-re-frame-v1/README.md` were corrected by commit `37b97142ae` (PR #8835, merged 2026-08-31T23:12:47Z), which cites rf2-3lhuj in its own subject line. The bead was closed on PR-open at 05:25 +10:00 and then **reopened at 09:16:46 +10:00 — four minutes after that merge**, so the reopen postdates the fix rather than reflecting outstanding work.

Its load-bearing premise still holds, verified at source rather than taken from the item:

- `spec/API.md` front-porch boundary paragraph — the optional features' non-registration helpers are explicitly NOT re-exported; reach them through `re-frame.machines`.
- `spec/api-manifest.edn` — `machine-meta`, `machines`, `machine-transition`, `make-machine-handler` all `:facade? false`.
- `docs/api/re-frame.machines.md` — the same two-way surface split.
- `implementation/core/src/re_frame/core.cljc` — no re-export. `machine-transition` and `machine-meta` have zero textual hits; the single `make-machine-handler` hit is inside a docstring.

A full fixed-string sweep of the README for all five `rf/`-prefixed helper spellings then found **one site the earlier fix missed**: M-57's rename table and its "after" code block both landed the renamed builder on `re-frame.core`, contradicting M-28 earlier in the same document. That is corrected here, with a pointer so the two entries compose when applied in order.

## Quality gates

All exit codes below are the runner's own status, captured with the redirect and the `echo $?` on one command line, and quoted from the captured `.exit` file.

| Run | Gate | Exit |
|---|---|---|
| Baseline | `scripts/check_doc_slugs.py` | **0** |
| Baseline | `scripts/check_readme_links.py --ci` | **0** |
| Baseline | `python -m mkdocs build --strict` | **0** |

### Gate-roster result, settled empirically rather than assumed

A broken anchor was planted in each of the two files in turn, outside any fence, at a line this PR already edits. Both plants were blob-hash-verified as applied, and both restores blob-hash-verified against the committed object.

| Planted fault | `check_doc_slugs.py` | `check_readme_links.py --ci` |
|---|---|---|
| `docs/core/hicasso/18-ssr-and-hydration.md` | **1** — `BROKEN ANCHOR: docs\core\hicasso\18-ssr-and-hydration.md:126` | 0 (silent) |
| `migration/from-re-frame-v1/README.md` | **1** — `BROKEN ANCHOR: migration\from-re-frame-v1\README.md:2328` | 0 (silent) |

**Both files are the doc-slugs gate's surface; the readme-links gate covers neither** — despite `migration/from-re-frame-v1/README.md` being literally named `README.md`, which is exactly the shape that invites the wrong nomination. `check_readme_links.py` names the reason in its own source: `DOCS_GATE_ROOTS = frozenset({Path("docs"), Path("spec"), Path("migration"), Path("skills")})`, deliberately excluded so the two gates do not overlap.

Each plant existed only in this branch's checkout, so the red is itself the proof that the gate read this tree rather than a sibling's. Both scripts derive their repo root from `Path(__file__).resolve().parent.parent`, and both were invoked by absolute path.

### Coverage limits worked around by hand

**Neither gate reads inside a fenced code block**, and rf2-byig6's fix is *inside* a code example, so no gate validated it. Hand-checked:

- Every namespace in the edited fences resolves: `re-frame.core` → `implementation/core/src/re_frame/core.cljc`; `re-frame.ssr` → `implementation/ssr/src/re_frame/ssr.cljc`; `re-frame.hicasso.server` → `implementation/hicasso/src/re_frame/hicasso/server.cljs`; `re-frame.machines` → `implementation/machines/src/re_frame/machines.cljc`.
- Every alias matches its use: `:as rf` → `rf/init!`, `:as ssr` → `ssr/adapter`, `:as server` → `server/render`.
- `(rf/init! ssr/adapter)` is spelled as `re-frame.ssr/adapter`'s own docstring spells it.
- Paren and bracket balance is 0/0 in both edited fences (checked mechanically).
- `rf.machines/` in the M-57 block matches the alias M-28 already uses at line 1356.

**Nothing validates prose, tables or rendering.** The one table touched is M-57's rename table: 3 columns in the header, 3 in the delimiter row, 3 in each of the 2 body rows — unchanged column count, only the "New" cell's content edited.

`python -m mkdocs build --strict` is **not** the anchor gate (MkDocs grades a missing anchor at INFO, and `--strict` promotes WARNING but not INFO), and is reported only for link/nav coverage. Its two INFO lines about `codemod/README.md` are pre-existing and unrelated. Its gitignored output (`site/`, staged `docs/spec/`, `docs/migration/`) was removed afterwards; the tree is clean.
