### PR TITLE
fix(testbed-support): decline Windsurf endpoint launches that would drop the coordinate (rf2-1i1ec)

### DIFF
--- a/tools/testbed-support/README.md
+++ b/tools/testbed-support/README.md
@@ -75,6 +75,16 @@ files return 422 before Node is spawned so the browser client can fall back to
 its `editor://` URI. The handler lives in a `.clj` file and is never compiled
 into a browser bundle.
 
+A 200 from this endpoint means the whole source coordinate reached an editor,
+not merely that a process exited. `launch-editor` encodes a position per editor
+binary and has no case for `windsurf`, so it would launch Windsurf with the
+bare file and still exit 0. A coordinate-bearing `editor=windsurf` request is
+therefore declined with 422 `editor-position-unsupported` before Node is
+spawned, and the browser's `windsurf://file/<path>:<line>:<column>` fallback —
+which does carry the position — opens the file at the right place. A Windsurf
+request with no line or column is served normally. Every other editor in the
+vocabulary is unaffected.
+
 ## Wiring
 
 The testbed builds add `tools/testbed-support/src` to their shadow-cljs source

--- a/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
+++ b/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
@@ -35,6 +35,34 @@
   (when (and (string? editor) (not (str/blank? editor)))
     (get editor-command-by-keyword (str/lower-case (str/trim editor)))))
 
+;; launch-editor encodes a source position PER EDITOR BINARY. A binary it has
+;; no case for falls through to a bare-file launch — silently, and with a
+;; successful exit, which this endpoint would otherwise report as a 200.
+
+(def commands-without-position-support
+  "launch-editor commands it invokes with the BARE FILE, dropping any
+  requested line/column.
+
+  `launch-editor`'s `get-args.js` switches on the command's basename and
+  encodes a position for `code`, `code-insiders`, `cursor`, `zed` and the
+  JetBrains binaries, then falls through to `return [fileName]` for
+  everything else. At the pinned 2.14.1 — which is also the newest published
+  release — it has no `windsurf` case, so Windsurf alone in this endpoint's
+  vocabulary loses the coordinate. Drop an entry here when a pinned release
+  starts encoding that editor's position; the contract test comes with it."
+  #{"windsurf"})
+
+(defn position-would-be-dropped?
+  "Whether launching `command` would discard a requested `line`/`column`.
+
+  A request carrying no coordinate loses nothing by going through the
+  endpoint, and the endpoint's classpath resolution is real value the
+  client-side `editor://` URI fallback cannot supply — so only a
+  coordinate-BEARING request to a position-blind command is declined."
+  [command line column]
+  (boolean (and (or line column)
+                (contains? commands-without-position-support command))))
+
 ;; Core owns classpath URL decoding; this endpoint adds runtime cwd fallback.
 
 (defn resolve-file
@@ -324,7 +352,11 @@
 
   Query keys are `file` (required), `line`, `column`, and `editor`. Only a
   local POST reaches `launch!`. Invalid input produces JSON 400/403/405
-  responses; missing files and launch failures produce 422."
+  responses; missing files and launch failures produce 422, as does a
+  coordinate-bearing request for an editor whose `launch-editor` command
+  cannot carry the position (`position-would-be-dropped?`) — every one of
+  those non-2xx answers hands the launch to the client's `editor://` URI
+  fallback, which does carry it."
   [{:keys [uri request-method query-string] :as req}]
   (when (= uri endpoint-path)
     (let [ao (allow-origin req)]
@@ -353,8 +385,18 @@
                 line   (->int (get q "line"))
                 column (->int (get q "column"))
                 cmd    (editor-hint (get q "editor"))]
-            (if (str/blank? file)
+            (cond
+              (str/blank? file)
               (json-resp 400 ao {:ok false :error "missing-file"})
+
+              ;; A 200 here is a claim that the COORDINATE arrived, not merely
+              ;; that a process exited. Where the launcher would drop it,
+              ;; decline before spawning so the client's coordinate-preserving
+              ;; `editor://` URI fallback gets its turn (rf2-1i1ec).
+              (position-would-be-dropped? cmd line column)
+              (json-resp 422 ao {:ok false :error "editor-position-unsupported"})
+
+              :else
               (let [abs-path (resolve-file file)
                     {:keys [ok message]} (launch! abs-path line column cmd)]
                 (if ok

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_client_cljs_test.cljs
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_client_cljs_test.cljs
@@ -1,0 +1,219 @@
+(ns re-frame.testbed.open-in-editor-client-cljs-test
+  "Client half of the open-in-editor contract (rf2-1i1ec).
+
+  `re-frame.testbed.open-in-editor-server` decides; this namespace pins what
+  the BROWSER does with that decision, because the defect rf2-1i1ec fixes
+  lives across the seam rather than on either side of it. The endpoint's 200
+  was a claim about a child process EXITING, not about the source coordinate
+  ARRIVING: `launch-editor` has no `windsurf` case in its `get-args.js`
+  switch, so it launched Windsurf with the bare file, exited 0, and the
+  endpoint answered 200 — and that 200 is exactly what makes
+  `fetch-launcher!` skip the `windsurf://file/…:27:9` fallback that would
+  have carried the coordinate. Every layer reported success; the programmer
+  landed at the wrong line.
+
+  A server-only test asserting a status code would pass while that
+  user-visible defect survived, so the property pinned here is the one the
+  user feels: a DECLINED endpoint answer runs the coordinate-preserving
+  fallback exactly once, and a 2xx suppresses it.
+
+  The server-side half is `re-frame.testbed.open-in-editor-server-test`.
+
+  This suite drives the REAL client seam — `build-url` and `fetch-launcher!`
+  from `re-frame.source-coords.open-endpoint`, unmodified — with
+  `globalThis.fetch` stubbed to answer a chosen status. Nothing is launched
+  and no dev server is required, which is what makes it runnable in CI."
+  (:require [cljs.test :refer-macros [deftest is testing async]]
+            [re-frame.source-coords.editor-uri :as editor-uri]
+            [re-frame.source-coords.open-endpoint :as open-endpoint]))
+
+(def ^:private coord
+  "The bead's reproduction coordinate: `src/app.cljs`, line 27, column 9."
+  {:file "src/app.cljs" :line 27 :column 9})
+
+(def ^:private windsurf-uri
+  "What the coordinate-preserving fallback produces for `coord`. Derived from
+  `editor-uri` rather than typed, so this suite cannot drift from the URI
+  builder it is asserting reaches the OS."
+  (editor-uri/editor-uri :windsurf coord))
+
+(def ^:private declining-statuses
+  "Every non-2xx the server can answer with: 400 (`missing-file`,
+  `malformed-query`), 403 (`forbidden`), 405 (`method-not-allowed`), 422
+  (`file-not-found`, `launch-failed`, and — rf2-1i1ec — the Windsurf
+  `editor-position-unsupported` decline). The client's contract is on the
+  CLASS, not on any one member: whatever the endpoint declines with, the
+  coordinate-preserving URI gets its turn."
+  [400 403 405 422])
+
+(def ^:private real-fetch
+  "The platform `fetch`, captured at load.
+
+  `click!` swaps this process global and puts it back. Every test below
+  asserts the global is `identical?` to THIS again afterwards, because a stub
+  left installed would silently answer for every later namespace in the shared
+  `:node-test` build — a leak a green suite hides rather than reports."
+  (.-fetch js/globalThis))
+
+(defn- ->response
+  "A minimal `fetch` Response stand-in. `fetch-launcher!` reads only `.ok`,
+  which the platform derives from the status the same way."
+  [status]
+  #js {:ok (and (>= status 200) (<= status 299)) :status status})
+
+(defn- click!
+  "Drive one source-coord click through the real client seam and return a
+  promise of what the user would have got.
+
+  `globalThis.fetch` is replaced by a stub answering `status` — standing in
+  for the dev-server's decision — and the fallback thunk is the one the Xray
+  and Story open-seams pass: it resolves the coordinate through
+  `editor-uri/editor-uri` and hands the URI to a capturing navigator instead
+  of `Location.assign`.
+
+  Resolves to `{:requested <endpoint url> :navigated <uri-or-nil>
+  :fallbacks <n>}`. The original `fetch` is restored on both outcomes."
+  [{:keys [editor status]}]
+  (let [requested (atom nil)
+        navigated (atom nil)
+        fallbacks (atom 0)
+        original  (.-fetch js/globalThis)
+        restore!  (fn [] (set! (.-fetch js/globalThis) original))]
+    (set! (.-fetch js/globalThis)
+          (fn [url _opts]
+            (reset! requested url)
+            (js/Promise.resolve (->response status))))
+    (-> (open-endpoint/fetch-launcher!
+          (open-endpoint/build-url coord editor)
+          (fn []
+            (swap! fallbacks inc)
+            (reset! navigated (editor-uri/editor-uri editor coord))))
+        (.then (fn [_]
+                 (restore!)
+                 {:requested @requested
+                  :navigated @navigated
+                  :fallbacks @fallbacks}))
+        (.catch (fn [err] (restore!) (throw err))))))
+
+(defn- click-each!
+  "Run `click!` over `specs` ONE AT A TIME, resolving to a vector of outcomes
+  each merged with its spec.
+
+  Sequential deliberately. `click!` swaps a process global, so overlapping
+  runs nest their save/restore — the second saves the first's stub as the
+  `original` it will later reinstate, and the suite finishes with a stub still
+  answering `fetch` for every namespace after it. `js/Promise.all` over these
+  is exactly that mistake; `real-fetch` is the assertion that catches it."
+  [specs]
+  (reduce (fn [p spec]
+            (.then p (fn [acc]
+                       (.then (click! spec)
+                              (fn [outcome] (conj acc (merge spec outcome)))))))
+          (js/Promise.resolve [])
+          specs))
+
+(defn- fetch-restored?
+  "Whether the process-global `fetch` is the platform's again."
+  []
+  (identical? real-fetch (.-fetch js/globalThis)))
+
+;; ---- the request the client sends ---------------------------------------
+
+(deftest endpoint-request-carries-the-whole-coordinate
+  (testing "the client asks for 27:9 explicitly — the coordinate is present
+            in the request, so any later loss is the server's or the
+            launcher's, not a malformed ask"
+    (let [url (open-endpoint/build-url coord :windsurf)]
+      (is (= (str open-endpoint/endpoint-path
+                  "?file=src%2Fapp.cljs&line=27&column=9&editor=windsurf")
+             url)))))
+
+(deftest open-coord-hands-the-built-url-to-the-launcher
+  (testing "`open-coord!` composes `build-url` with the launcher seam, so the
+            contract pinned below on `fetch-launcher!` is the contract the
+            tool open-seams actually get"
+    (let [seen (atom nil)
+          prev (open-endpoint/set-launcher!
+                 (fn [url _fallback!] (reset! seen url)))]
+      (try
+        (open-endpoint/open-coord! coord :windsurf (fn [] nil))
+        (is (= (open-endpoint/build-url coord :windsurf) @seen))
+        (finally
+          (open-endpoint/set-launcher! prev))))))
+
+;; ---- what the client does with the server's answer -----------------------
+
+(deftest declined-answer-runs-the-coordinate-preserving-fallback-once
+  (testing "rf2-1i1ec — a declined endpoint answer hands the launch to the
+            `windsurf://` URI, which carries 27:9, exactly once"
+    (async done
+      (-> (click! {:editor :windsurf :status 422})
+          (.then (fn [{:keys [requested navigated fallbacks]}]
+                   (is (some? requested)
+                       "the stub fetch was reached — the endpoint IS preferred;
+                        this also proves the stub took effect, so the assertions
+                        below are about the chosen status and not a thrown fetch")
+                   (is (= 1 fallbacks) "the fallback ran exactly once, not twice")
+                   (is (= "windsurf://file/src/app.cljs:27:9" navigated))
+                   (is (= windsurf-uri navigated)
+                       "and it is the URI `editor-uri` builds — line 27, column 9
+                        reach Windsurf after all")
+                   (is (fetch-restored?) "the fetch stub was not left installed")
+                   (done)))
+          (.catch (fn [err] (is false (str "click! threw: " err)) (done)))))))
+
+(deftest every-declining-status-reaches-the-fallback
+  (testing "the client's contract is on non-2xx as a CLASS: each status the
+            endpoint can decline with runs the coordinate-preserving fallback
+            exactly once, so the server may choose any of them"
+    (async done
+      (-> (click-each! (map (fn [status] {:editor :windsurf :status status})
+                            declining-statuses))
+          (.then (fn [outcomes]
+                   (is (= (count declining-statuses) (count outcomes))
+                       "every declining status was actually exercised")
+                   (doseq [{:keys [status navigated fallbacks]} outcomes]
+                     (is (= 1 fallbacks) (str "status " status " → one fallback"))
+                     (is (= windsurf-uri navigated)
+                         (str "status " status " → the coordinate survived")))
+                   (is (fetch-restored?) "the fetch stub was not left installed")
+                   (done)))
+          (.catch (fn [err] (is false (str "click! threw: " err)) (done)))))))
+
+(deftest a-2xx-answer-suppresses-the-fallback
+  (testing "rf2-1i1ec, the other half of the defect: a 200 is FINAL to this
+            client — the URI fallback never runs, so the coordinate a
+            bare-file launch dropped is gone for good. This is why the repair
+            had to be the endpoint declining rather than anything downstream"
+    (async done
+      (-> (click! {:editor :windsurf :status 200})
+          (.then (fn [{:keys [requested navigated fallbacks]}]
+                   (is (some? requested) "the endpoint was asked")
+                   (is (zero? fallbacks)
+                       "a 2xx suppresses the fallback — had the endpoint kept
+                        answering 200 for Windsurf, nothing downstream could
+                        have recovered 27:9")
+                   (is (nil? navigated)
+                       "no coordinate-preserving URI was ever navigated")
+                   (is (fetch-restored?) "the fetch stub was not left installed")
+                   (done)))
+          (.catch (fn [err] (is false (str "click! threw: " err)) (done)))))))
+
+(deftest position-carrying-editors-keep-preferring-the-endpoint
+  (testing "the repair must not make every editor fall back: for an editor the
+            endpoint still serves, a 2xx is final and no URI is navigated —
+            the positive control for rf2-1i1ec"
+    (async done
+      (-> (click-each! (map (fn [editor] {:editor editor :status 200})
+                            [:vscode :cursor :zed :idea]))
+          (.then (fn [outcomes]
+                   (is (= 4 (count outcomes))
+                       "every position-carrying editor was actually exercised")
+                   (doseq [{:keys [editor requested navigated fallbacks]} outcomes]
+                     (is (some? requested) (str editor " reached the endpoint"))
+                     (is (zero? fallbacks)
+                         (str editor " kept the endpoint's success — no fallback"))
+                     (is (nil? navigated) (str editor " navigated no URI")))
+                   (is (fetch-restored?) "the fetch stub was not left installed")
+                   (done)))
+          (.catch (fn [err] (is false (str "click! threw: " err)) (done)))))))

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -706,6 +706,119 @@
         (is (nil? (nth (first @calls) 3))
             "no editor param → nil hint")))))
 
+;; rf2-1i1ec — endpoint success must mean the COORDINATE arrived.
+;;
+;; `launch-editor`'s `get-args.js` switches on the command basename: `code`,
+;; `code-insiders`, `cursor`, `zed` and the JetBrains binaries get a position
+;; argument, everything else falls through to a bare-file launch that exits 0.
+;; Windsurf is in this endpoint's vocabulary and NOT in that switch, so before
+;; this decline the endpoint answered 200 to a `line=27&column=9` request that
+;; had opened the file at an arbitrary prior cursor position — and that 200
+;; suppressed the client's `windsurf://…:27:9` fallback, which does carry it.
+;;
+;; The complementary client-side half (a declined answer runs the
+;; coordinate-preserving fallback exactly once; a 200 suppresses it) is
+;; `re-frame.testbed.open-in-editor-client-cljs-test`.
+
+(deftest position-blind-commands-are-declared-not-guessed
+  (testing "the position-blind set names exactly the vocabulary commands
+            launch-editor has no get-args case for"
+    (is (= #{"windsurf"} oies/commands-without-position-support))
+    (is (every? (set (vals oies/editor-command-by-keyword))
+                oies/commands-without-position-support)
+        "every declared position-blind command is a command this endpoint can
+         actually be asked for — the set cannot drift onto a phantom binary"))
+  (testing "position-would-be-dropped? fires only for a coordinate-BEARING
+            request to a position-blind command"
+    (is (true?  (oies/position-would-be-dropped? "windsurf" 27 9)))
+    (is (true?  (oies/position-would-be-dropped? "windsurf" 27 nil))
+        "a line alone is a coordinate")
+    (is (true?  (oies/position-would-be-dropped? "windsurf" nil 9))
+        "a column alone is a coordinate (build-file-spec supplies line 1)")
+    (is (false? (oies/position-would-be-dropped? "windsurf" nil nil))
+        "no coordinate → nothing to lose; the endpoint's classpath resolution
+         is still worth having")
+    (is (false? (oies/position-would-be-dropped? "code" 27 9)))
+    (is (false? (oies/position-would-be-dropped? "cursor" 27 9)))
+    (is (false? (oies/position-would-be-dropped? "zed" 27 9)))
+    (is (false? (oies/position-would-be-dropped? "idea" 27 9)))
+    (is (false? (oies/position-would-be-dropped? "code-insiders" 27 9)))
+    (is (false? (oies/position-would-be-dropped? nil 27 9))
+        "auto-detect is not declined — launch-editor picks the binary and we
+         have made no claim about which")))
+
+(deftest endpoint-declines-coordinate-bearing-windsurf-request
+  (testing "editor=windsurf with line+column is DECLINED before Node is
+            spawned: a bare-file launch is not success for a
+            coordinate-bearing request"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     {:uri            oies/endpoint-path
+                      :request-method :post
+                      :query-string   "file=fake_ns/core.cljs&line=27&column=9&editor=windsurf"
+                      :headers        {"host" "localhost:8031"}})]
+          (is (= 422 (:status resp))
+              "a 200 here would be a false claim that 27:9 reached the editor")
+          (is (not (<= 200 (:status resp) 299))
+              "non-2xx is the whole contract with the client: `fetch-launcher!`
+               runs the coordinate-preserving URI fallback on any non-2xx")
+          (is (re-find #"\"ok\":false" (:body resp)))
+          (is (re-find #"\"error\":\"editor-position-unsupported\"" (:body resp))
+              "the client-visible error names the capability, not launch-failed")
+          (is (zero? (count @calls))
+              "launch! was never called — no editor opens at the wrong place")))))
+  (testing "a coordinate-FREE windsurf request still uses the endpoint: it
+            loses nothing, and classpath resolution is what the URI fallback
+            cannot do"
+    (let [calls (atom [])]
+      (with-launch-spy calls
+        (let [resp (oies/handle
+                     {:uri            oies/endpoint-path
+                      :request-method :post
+                      :query-string   "file=fake_ns/core.cljs&editor=windsurf"
+                      :headers        {"host" "localhost:8031"}})]
+          (is (= 200 (:status resp)))
+          (is (= 1 (count @calls)))
+          (is (= "windsurf" (nth (first @calls) 3))
+              "the windsurf hint still reaches launch! when no coordinate is
+               at stake — the vocabulary is unchanged"))))))
+
+(deftest endpoint-still-serves-every-position-carrying-editor
+  (testing "rf2-1i1ec must not make every editor fall back: each vocabulary
+            entry launch-editor CAN encode a position for still reaches
+            launch! with 27:9 and returns 2xx"
+    (doseq [[editor expected-cmd] [["vscode"          "code"]
+                                   ["vscode-insiders" "code-insiders"]
+                                   ["cursor"          "cursor"]
+                                   ["zed"             "zed"]
+                                   ["idea"            "idea"]]]
+      (testing (str "editor=" editor)
+        (let [calls (atom [])]
+          (with-launch-spy calls
+            (let [resp (oies/handle
+                         {:uri            oies/endpoint-path
+                          :request-method :post
+                          :query-string   (str "file=fake_ns/core.cljs&line=27&column=9&editor=" editor)
+                          :headers        {"host" "localhost:8031"}})]
+              (is (<= 200 (:status resp) 299)
+                  "the endpoint is still preferred for this editor")
+              (is (= 1 (count @calls)) "launch! was invoked")
+              (let [[_abs line column cmd] (first @calls)]
+                (is (= expected-cmd cmd))
+                (is (= 27 line)   "the line survived to the launcher")
+                (is (= 9 column)  "the column survived to the launcher")))))))))
+
+(deftest declined-windsurf-launch-would-have-lost-the-coordinate
+  (testing "the file spec the endpoint WOULD have handed launch-editor still
+            carries 27:9 — the loss happens inside the dependency's argv
+            mapping, which is why the decline sits at the endpoint boundary
+            and not in build-file-spec"
+    (is (= "/abs/src/app.cljs:27:9"
+           (#'oies/build-file-spec "/abs/src/app.cljs" 27 9))
+        "the endpoint's own encoding is correct; launch-editor 2.14.1's
+         get-args.js drops it for a command it has no case for")))
+
 ;; Windows paths exercise the JSON backslash and quote rules.
 
 (deftest escape-json-string-escapes-backslash-and-doublequote


### PR DESCRIPTION
Closes rf2-1i1ec.

## The defect

The dev-server open-in-editor endpoint's `200` was a claim about a child
process **exiting**, not about the source coordinate **arriving**.

`launch-editor` encodes a source position per editor binary. Its
`get-args.js` switches on the command basename — `code`, `code-insiders`,
`cursor`, `zed` and the JetBrains binaries each get a position argument —
then falls through to a bare-file `return [fileName]` for everything else.
`windsurf` is in this endpoint's vocabulary and **not** in that switch, so a
`file=src/app.cljs&line=27&column=9&editor=windsurf` request launched
Windsurf with only the file, exited 0, and the endpoint answered 200.

That 200 is the second half of the bug: `fetch-launcher!` treats any 2xx as
final, so it skipped the `windsurf://file/src/app.cljs:27:9` fallback that
*would* have carried the coordinate. Every layer reported success while the
programmer landed at an arbitrary prior cursor position.

Probe on the installed dependency, the bead's own:

```
windsurf  ["C:/repo/src/app.cljs"]
code      ["-r","-g","C:/repo/src/app.cljs:27:9"]
cursor    ["-r","-g","C:/repo/src/app.cljs:27:9"]
zed       ["C:/repo/src/app.cljs:27:9"]
idea      ["--line","27","--column","9","C:/repo/src/app.cljs"]
```

**The version premise holds, and is not close to being overtaken.** The bead
names `launch-editor@2.14.1`; `package-lock.json` pins 2.14.1, that is what
installs, and 2.14.1 is also the **newest published release** — there is no
later version to upgrade into. Windsurf is the only entry in the endpoint's
five-editor vocabulary without a position mapping.

## The repair, and why this one

Decline, rather than teach the server to encode a Windsurf position.

The endpoint-preferred / editor-URI-fallback architecture already contains a
correct path for this exact case, and it is already implemented and tested:
`editor-uri` builds `windsurf://file/<path>:<line>:<column>`, and the client
runs it on any non-2xx. Encoding the position server-side would instead mean
a second per-editor process launcher living beside `launch-editor` — more
machinery to keep in step with a dependency, to fix a case the existing
design already handles.

A coordinate-bearing `editor=windsurf` request now returns
`422 editor-position-unsupported` before Node is spawned, and the existing
fallback runs exactly once.

Two things the decline deliberately does **not** do:

- **It is not unconditional.** A Windsurf request carrying no line or column
  loses nothing by going through the endpoint, and the endpoint's classpath
  resolution is real value the client-side URI path cannot supply — so it is
  still served. The invariant is about *coordinate-bearing* requests.
- **It does not touch the vocabulary or auto-detection.** `:windsurf` stays a
  supported hint, `editor-hint` is unchanged, and a request with no `editor`
  is not declined — we have made no claim about which binary auto-detect
  picks. Only the transport chosen for one editor changes, and only while the
  dependency lacks position support; `commands-without-position-support` is a
  one-line edit to reverse, with the contract test that comes with it.

## Testing the half a status code cannot reach

The suppressed fallback lives on the **client**, so a server-only test
asserting a status code would pass while the user-visible defect survived.
Coverage therefore spans the seam:

- **Server** (`open_in_editor_server_test.clj`) — the decline and its error
  string, `launch!` never reached, the coordinate-free Windsurf request still
  served, and the positive control: all four position-carrying editors still
  reach `launch!` with 27 and 9 intact and return 2xx.
- **Client** (`open_in_editor_client_cljs_test.cljs`, new) — drives the real
  `build-url` / `fetch-launcher!` seam with `globalThis.fetch` stubbed, so
  nothing launches and no dev server is needed. It pins that a declined
  answer navigates `windsurf://file/src/app.cljs:27:9` **exactly once**, that
  every non-2xx the endpoint can emit (400/403/405/422) does the same, and —
  the defect's other half stated executably — that a **2xx suppresses the
  fallback outright**, which is why the repair had to sit at the endpoint and
  not downstream of it.

The client suite needs no build wiring: `../tools/testbed-support/test` is
already a shadow-cljs source path and the namespace matches the existing
testbed-support `-cljs-test` selector, so it rides both the focused lane and
the always-on `:node-test` gate.

## Quality gates

Three gates cover this change; each was run to completion in the foreground
and each number below is the runner's own captured exit code.

| Gate | Command | Exit | Result |
| --- | --- | --- | --- |
| JVM artefact suite | `clojure -M:test` in `tools/testbed-support` | `0` | 36 tests, 199 assertions, 0 failures |
| CLJS client lane | `npm run test:testbed-support` | `0` | 58 tests, 158 assertions, 0 failures |
| README links | `python scripts/check_readme_links.py --ci` | `0` | clean |

The first is the PR-time lane for this artefact (`jvm-tools-testbed-support`);
the second is the named focused surface for the namespaces that also ride the
always-on `:node-test` gate; the third is the gate that actually covers a
`README.md` beside source code — `check_doc_slugs.py` does not reach outside
its `docs/`, `spec/`, `skills/`, `migration/` and `tools/*/spec` roots.

**Sabotage runs — each gate shown red with the property removed, then
restored and the restore verified by git blob hash against the committed
object** (a byte digest would not survive line-ending translation, and an
unchanged diff cannot tell "restored" from "never applied"):

| Property removed | Gate | Exit | What went red |
| --- | --- | --- | --- |
| the endpoint's decline branch | JVM | `1` | 5 failures, all in `endpoint-declines-coordinate-bearing-windsurf-request`; the body came back as the unrepaired 200 verbatim |
| the client's non-2xx to fallback rule | CLJS | `1` | 11 failures across both decline tests; the coordinate arrived as `nil` |
| the client suite's `fetch` restore | CLJS | `1` | 4 failures, exactly the stub-leak guards |
| a link target in the touched README section | README | `1` | named `tools/testbed-support/README.md` line 78 |

Each sabotage run kept the same test and assertion totals as its control
(36/199 and 58/158), so no namespace was dropped and the reds are the
assertions named, not collateral. The CLJS reds are also positive evidence
the runtime observed the plant: the "endpoint declined" lines vanish from the
log, and the build reports 28 files recompiled.

Discrimination: the planted faults existed only in this worktree, so a run
that had wandered into another checkout would have come back green. The CLJS
gate additionally prints the config path it read, and it named this worktree
on every run.

**Not covered locally.** Everything else in `.github/workflows/test.yml`'s
`all-required-passed` `needs:` list — including the full `:node-test` suite
this new namespace also rides, of which only the focused testbed-support
slice was run here. CI is the authority on those.

**Verified by hand, since no gate checks it:** both markdown tables above are
4 columns, header and separator and every body row alike; the README addition
introduces no links or anchors.

## One thing found along the way

The first draft of the client suite ran its multi-case tests through
`js/Promise.all`. Stubbing `fetch` means swapping a **process global**, and
overlapping runs nest their save/restore — the second saves the first's stub
as the "original" it will later reinstate — so the suite finished with a stub
still answering `fetch` for every namespace after it in the shared
`:node-test` build. It passed anyway, because nothing later in the focused
lane calls `fetch`. The cases now run one at a time, and each test asserts the
global is the platform's again at the end; that guard is the third sabotage
row above.

## Fence

Confined to `tools/testbed-support/**`. Nothing here touches the client-side
checkout-root pipeline rf2-3xq1v retires, and the client URI fallback is
strengthened rather than weakened — the repair depends on it.
