### PR TITLE
fix(routing): make url-decode fail closed on invalid UTF-8 on both hosts (rf2-k2d2t)

### DIFF
--- a/implementation/routing/src/re_frame/routing/url.cljc
+++ b/implementation/routing/src/re_frame/routing/url.cljc
@@ -84,42 +84,145 @@
   [s]
   (clojure.string/join "/" (map url-encode (clojure.string/split (str s) #"/"))))
 
+#?(:clj
+   (defn- percent-escape-non-ascii
+     "Percent-escape every non-ASCII CHARACTER of `s` as its UTF-8 bytes,
+     leaving ASCII — existing `%XX` escapes included — untouched. The
+     result is pure ASCII, so `URLDecoder` under ISO-8859-1 recovers the
+     exact byte sequence the string denotes.
+
+     A literal (unescaped) non-ASCII character is legal input: both hosts
+     pass it through today (`decodeURIComponent(\"café\")` is `\"café\"`),
+     so escaping it here is what keeps that passthrough intact once the
+     bytes go through a STRICT decoder.
+
+     Runs are escaped whole, not character by character, so a surrogate
+     PAIR encodes as the one astral code point it spells rather than as
+     two unpaired halves.
+
+     Folding a literal into an ADJACENT escape run cannot change the
+     verdict in either direction. A literal character's UTF-8 encoding
+     always begins with a LEAD byte (`C2`–`F4`), never a continuation
+     byte, so it can never complete a truncated escape run that
+     `decodeURIComponent` would have rejected (`%C3é` throws on both
+     hosts); and the concatenation of two individually valid UTF-8
+     sequences is itself valid, so it can never spoil a run the browser
+     accepts (`%41é` is `\"Aé\"` on both)."
+     ^String [^String s]
+     (clojure.string/replace
+       s
+       #"[^\x00-\x7F]+"
+       (fn [^String run]
+         (apply str (map #(format "%%%02X" (bit-and (int %) 0xFF))
+                         (.getBytes run java.nio.charset.StandardCharsets/UTF_8)))))))
+
+#?(:clj
+   (defn- strict-utf8-decode
+     "Decode `bs` as UTF-8 with the REPORT malformed-input action, so an
+     invalid byte sequence THROWS instead of being replaced.
+
+     This is the whole of the JVM/CLJS decode-validity difference.
+     `String`'s own UTF-8 constructor (and `URLDecoder`, which uses it)
+     decodes with REPLACE, silently substituting U+FFFD; a
+     `CharsetDecoder` set to REPORT raises `CharacterCodingException`
+     exactly where `decodeURIComponent` raises `URIError`.
+
+     Note what this does NOT do: it never inspects the decoded OUTPUT for
+     U+FFFD. The discrimination happens at the BYTE level, under the
+     decoder's own UTF-8 validity rules — so `%EF%BF%BD`, which is the
+     valid three-byte encoding of a REAL U+FFFD, decodes successfully to
+     U+FFFD, while `%FF`, whose U+FFFD would be a substitution the
+     decoder invented, throws. An output-inspecting check cannot tell
+     those two apart: both end in the identical character."
+     ^String [^bytes bs]
+     (-> java.nio.charset.StandardCharsets/UTF_8
+         (.newDecoder)
+         (.onMalformedInput java.nio.charset.CodingErrorAction/REPORT)
+         (.onUnmappableCharacter java.nio.charset.CodingErrorAction/REPORT)
+         (.decode (java.nio.ByteBuffer/wrap bs))
+         (.toString))))
+
 (defn url-decode
   "Decode a percent-encoded string back to its raw form. Round-trip
   inverse of url-encode.
 
-  HOST-SYMMETRIC: `+` stays a LITERAL `+` on BOTH hosts (it is NOT
-  swapped to a space). `js/decodeURIComponent` (CLJS) leaves `+`
-  untouched; `java.net.URLDecoder/decode` (JVM) is the
-  `application/x-www-form-urlencoded` decoder, which would turn a bare
-  `+` into a space — the wrong semantics here. We pre-escape every bare
-  `+` to `%2B` before handing the string to URLDecoder, so the JVM path
-  reproduces `decodeURIComponent` exactly: `+` → `+`, `%2B` → `+`,
-  `%20` → space, real spaces → space.
+  HOST-SYMMETRIC: on both hosts this IS `decodeURIComponent`. The CLJS
+  arm calls it; the JVM arm emulates it on top of `java.net.URLDecoder`,
+  which needs TWO corrections rather than one:
 
-  Per Spec 012 §Bidirectional URL ↔ params §`+` is a literal: re-frame2
-  never emits a bare `+` (url-encode swaps `+` → `%20`), the de-facto
-  browser reference is `decodeURIComponent` (which is `+`-literal), and
-  RFC 3986 treats `+` in path segments as a literal. A host-divergent
-  `+` would yield a different `:params` / `:query` slice for the same URL
-  on JVM (SSR) vs CLJS (browser) — the exact Spec 011 hydration-mismatch
-  class. Making JVM match CLJS closes that gap."
+  1. `URLDecoder` is the `application/x-www-form-urlencoded` decoder, so
+     it turns a bare `+` into a SPACE. `+` must stay a LITERAL `+` on
+     both hosts, in path captures and query values alike, so every bare
+     `+` is pre-escaped to `%2B` before URLDecoder sees it: `+` → `+`,
+     `%2B` → `+`, `%20` → space, real spaces → space (rf2-9a9ix).
+  2. `URLDecoder` decodes bytes with the REPLACE malformed-input action,
+     so an INVALID UTF-8 sequence is silently rewritten to U+FFFD and a
+     string comes back; `decodeURIComponent` throws `URIError`. Repairing
+     only (1) left that standing, and it was the worse half: for
+     `%C0%80`, `%ED%A0%80`, `%FF` or `%E0%80%80` the JVM returned a
+     value and CLJS returned the nil sentinel, so `malformed-url?` read
+     FALSE on JVM and TRUE on CLJS (rf2-k2d2t).
+
+  The consequence of (2) was a whole-tree Spec 011 mismatch on a
+  security-adjacent sink, and the server was the PERMISSIVE side: a
+  hostile URL failed closed to a route-miss in the browser but MATCHED
+  under SSR, with replacement characters standing in for the bytes, so
+  the two hosts disagreed about whether the request was routable at all.
+  `safe-url-decode`'s fail-closed posture (see its docstring: \"hostile
+  URLs, partner integrations with broken escaping\") was not the posture
+  the JVM arm actually had.
+
+  So the JVM arm decodes in three stages: pre-escape (bare `+`, then
+  every literal non-ASCII character), then `URLDecoder` under ISO-8859-1
+  — the 1:1 byte↔char charset, which performs the SAME structural
+  validation as before (`%`, `%a`, `%zz` still throw
+  `IllegalArgumentException`) while substituting nothing — and finally a
+  STRICT UTF-8 decode of the recovered bytes.
+
+  Per Spec 012 §Bidirectional URL ↔ params §`+` is a literal:
+  `decodeURIComponent` is the de-facto reference, the browser is the
+  canonical host, and the JVM matches it. A host-divergent decoder
+  yields a different `:params` / `:query` slice for the same URL on JVM
+  (SSR) vs CLJS (browser) — the exact Spec 011 hydration-mismatch class
+  the spec names there. Both corrections are conformance repairs to that
+  standing requirement, not new policy; §Route-miss ¶5 already requires
+  malformed percent-encoding to fail the whole match closed."
   [s]
   #?(:clj  (-> (str s)
                (.replace "+" "%2B")
-               (java.net.URLDecoder/decode "UTF-8"))
+               (percent-escape-non-ascii)
+               (java.net.URLDecoder/decode "ISO-8859-1")
+               (.getBytes java.nio.charset.StandardCharsets/ISO_8859_1)
+               (strict-utf8-decode))
      :cljs (js/decodeURIComponent (str s))))
 
 (defn safe-url-decode
   "Wrap `url-decode` in try/catch; returns nil (sentinel for malformed
   `%`) on decode failure.
 
-  Per Spec 012 §Routing failure semantics, both
-  `URLDecoder/decode` (JVM) and `decodeURIComponent` (CLJS) throw on
-  malformed percent-encoded sequences (`%`, `%a`, `%XX`, …). Hostile
-  URLs, partner integrations with broken escaping, or back-button to a
-  malformed link must produce a **route-miss** (404 path), never a
-  request-handler crash. Callers propagate the nil sentinel uniformly:
+  Per Spec 012 §Routing failure semantics, `url-decode` throws on both
+  hosts for the two distinct ways a percent-encoded string can be
+  undecodable, and this sentinel covers both:
+
+  1. **Structurally malformed escapes** — `%`, `%a`, `%zz`: a `%` not
+     followed by two hex digits.
+  2. **Structurally well-formed escapes spelling INVALID UTF-8** —
+     `%C0%80`, `%ED%A0%80`, `%FF`, `%E0%80%80`: every `%XX` parses, but
+     the bytes are not a legal UTF-8 sequence (overlong, lone surrogate,
+     invalid lead byte). Until rf2-k2d2t the JVM arm returned a U+FFFD-
+     bearing string here while CLJS threw, so this sentinel — and with
+     it `malformed-url?` — was host-divergent on exactly the hostile
+     input it exists for.
+
+  `%EF%BF%BD` is NOT in class 2. It is the valid encoding of a real
+  U+FFFD and decodes successfully on both hosts; see `url-decode`'s
+  `strict-utf8-decode` on why the check is made over bytes rather than
+  over the decoded characters, which cannot tell the two apart.
+
+  Hostile URLs, partner integrations with broken escaping, or
+  back-button to a malformed link must produce a **route-miss** (404
+  path), never a request-handler crash. Callers propagate the nil
+  sentinel uniformly:
   `match-against` returns nil for the whole match (path captures);
   `match-url`'s query-parse loop short-circuits to a malformed sentinel
   the moment any key or value fails to decode; `split-fragment` reports its

--- a/implementation/routing/test/re_frame/routing_url_decoding_parity_cljs_test.cljc
+++ b/implementation/routing/test/re_frame/routing_url_decoding_parity_cljs_test.cljc
@@ -1,0 +1,222 @@
+(ns re-frame.routing-url-decoding-parity-cljs-test
+  "Per rf2-k2d2t — component URL decoding is `decodeURIComponent` on BOTH
+  hosts, INCLUDING its UTF-8 validity check.
+
+  `url-decode`'s JVM arm emulates `decodeURIComponent` on top of
+  `java.net.URLDecoder`. It used to repair only ONE of the two
+  differences — the form-urlencoded `+`-for-space (rf2-9a9ix) — and left
+  the second standing: `URLDecoder` decodes bytes with the REPLACE
+  malformed-input action, so an INVALID UTF-8 sequence was silently
+  rewritten to U+FFFD and a string came back, where
+  `decodeURIComponent` throws `URIError`.
+
+  So for `%C0%80`, `%ED%A0%80`, `%FF` or `%E0%80%80` the JVM returned a
+  value and CLJS returned the nil sentinel, and the public predicate
+  read `(malformed-url? \"/p/%FF\")` => FALSE on JVM, TRUE on CLJS.
+
+  The consequence was worse than the attribute-level divergence
+  rf2-j3tud fixed, and the SERVER was the permissive side: a hostile URL
+  failed closed to a route-miss in the browser but MATCHED under SSR
+  with replacement characters standing in for the bytes, so the two
+  hosts disagreed about whether the request was routable at all — a
+  whole-tree Spec 011 hydration mismatch on the sink whose own docstring
+  names \"hostile URLs, partner integrations with broken escaping\" as
+  its motivation.
+
+  CLJS is normative: it IS `decodeURIComponent`, the de-facto browser
+  reference Spec 012 §`+` is a literal names, and §Route-miss ¶5 already
+  requires malformed percent-encoding to fail the whole match closed.
+  The JVM moved to match — the same direction rf2-9a9ix took for `+` and
+  rf2-j3tud took for the encoder.
+
+  THE NEAR-MISS CONTROL IS THE POINT OF THIS SUITE. `%EF%BF%BD` is the
+  valid three-byte encoding of a REAL U+FFFD and MUST still decode. A
+  naive \"does the decoded output contain U+FFFD?\" check would reject
+  it, trading this bug for a fresh one — and could not do better, since
+  the substituted and the legitimate character are identical. The fix
+  discriminates at the BYTE level instead, under the UTF-8 decoder's own
+  validity rules, which is why that row can pass alongside the four
+  invalid ones.
+
+  Named `*-cljs-test.cljc` so it is discovered by BOTH the cognitect JVM
+  runner (`.*-test$`) and the shadow-cljs `:node-test` build
+  (`cljs-test$`). Every assertion below is asserted IDENTICALLY on both
+  hosts against LITERAL expected values — that host-symmetry IS the
+  contract, so no expectation is ever derived from `url-decode` itself.
+  A decoder that changed on one host only cannot also rewrite what it is
+  compared against.
+
+  Reverting the JVM arm to `URLDecoder` under UTF-8 turns the JVM half
+  of this namespace red on the invalid-UTF-8 table, on the
+  `malformed-url?` positions and on the production `match-url` prism,
+  while every valid-input control — `%EF%BF%BD` included — stays green,
+  proving those controls are not what carries the suite."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   [re-frame.routing :as routing]
+   [re-frame.routing.url :as url]
+   [re-frame.test-support :as test-support]
+   #?(:clj  [re-frame.substrate.plain-atom :as substrate]
+      :cljs [re-frame.adapter.reagent :as substrate])))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter substrate/adapter
+     :init-fn routing/reset-counters!}))
+
+;; ---- the UTF-8 validity boundary ----------------------------------------
+;;
+;; Every escape below is STRUCTURALLY well-formed — each `%` is followed
+;; by two hex digits, so the structural validation both arms already had
+;; passes them. What they spell is not legal UTF-8. This is the whole of
+;; the divergence: it is invisible to a `%`-shape check.
+
+(def ^:private invalid-utf8
+  "Percent-escapes that parse as escapes but spell invalid UTF-8. One row
+  per sequence so a failure names the exact offender."
+  [["%C0%80"    "overlong NUL — C0 80 encodes U+0000 in two bytes; the shortest form is mandatory"]
+   ["%ED%A0%80" "lone surrogate — D800 has no UTF-8 encoding at all"]
+   ["%FF"       "invalid lead byte — FF can never begin a UTF-8 sequence"]
+   ["%E0%80%80" "overlong — a three-byte encoding of a code point that needs one"]
+   ["%C3"       "truncated — a two-byte lead with no continuation byte"]
+   ["%80"       "bare continuation byte — 80 with no lead"]])
+
+(def ^:private valid-decodes
+  "Inputs that MUST still decode, with their literal expected output.
+  These are the controls: the table above cannot be satisfied by
+  weakening `url-decode` towards `(constantly nil)`, because every one of
+  these would go nil if it were."
+  [["%C3%A9"    "é"       "valid two-byte sequence — the ordinary non-ASCII case"]
+   ["%EF%BF%BD" "�"  "THE NEAR-MISS: the valid encoding of a REAL U+FFFD. An output-inspecting check would reject this, since its result is character-identical to a substitution"]
+   ["%E6%97%A5" "日"       "valid three-byte sequence"]
+   ["%F0%9F%92%A9" "💩" "valid four-byte sequence — an astral code point"]
+   ["%20"       " "       "space"]
+   ["a+b"       "a+b"     "`+` stays a literal on both hosts (rf2-9a9ix)"]
+   ["%2B"       "+"       "an escaped `+` decodes to `+`"]
+   ["caf%C3%A9" "café"    "escapes mixed with ASCII"]])
+
+(def ^:private structurally-malformed
+  "The pre-existing structural failures. Both hosts ALREADY agreed here;
+  the rows are present so a regression in the structural half — which the
+  fix re-routes through ISO-8859-1 — cannot pass unnoticed."
+  [["%"   "a bare `%` with nothing after it"]
+   ["%a"  "a `%` with one hex digit"]
+   ["%zz" "a `%` with two non-hex characters"]
+   ["%C3%ZZ" "a valid lead byte followed by a structurally bad escape"]])
+
+(deftest safe-url-decode-fails-closed-on-invalid-utf8-on-both-hosts
+  (testing "invalid UTF-8 yields the nil sentinel on JVM and CLJS alike —
+            the JVM used to return a U+FFFD-bearing string here (rf2-k2d2t)"
+    (doseq [[in why] invalid-utf8]
+      (is (nil? (url/safe-url-decode in)) why)))
+  (testing "structurally malformed escapes stay nil on both hosts, as they
+            already did — the fix must not disturb this half"
+    (doseq [[in why] structurally-malformed]
+      (is (nil? (url/safe-url-decode in)) why))))
+
+(deftest safe-url-decode-still-decodes-every-valid-input-on-both-hosts
+  (testing "the controls: valid input must NOT be rejected, so the
+            fail-closed table above cannot pass by nil-ing everything"
+    (doseq [[in expected why] valid-decodes]
+      (is (= expected (url/safe-url-decode in)) why)))
+  (testing "a legitimately-encoded U+FFFD survives, stated on its own
+            because conflating it with a SUBSTITUTED one is the specific
+            fresh bug a naive fix introduces"
+    (is (= "�" (url/safe-url-decode "%EF%BF%BD"))
+        "the valid encoding of U+FFFD decodes to U+FFFD")
+    (is (= 1 (count (url/safe-url-decode "%EF%BF%BD")))
+        "exactly one character — not an escape that leaked through raw")
+    (is (nil? (url/safe-url-decode "%FF"))
+        "while the sequence whose U+FFFD would be INVENTED by the decoder
+         is refused — the two are character-identical on output, so this
+         pair is what proves the check is made over bytes")))
+
+(deftest url-decode-leaves-literal-non-ascii-alone-on-both-hosts
+  (testing "an unescaped non-ASCII character is legal input and passes
+            through unchanged on both hosts — the JVM fix routes bytes
+            through a STRICT decoder, and must not fail closed on this"
+    (doseq [[in why] [["café"    "literal é in a bare string"]
+                      ["/p/café" "literal é in a path segment"]
+                      ["日本"     "literal three-byte characters"]
+                      ["a©b"     "a literal latin-1-range character between ASCII"]
+                      ["%41é"    "a valid escape ADJACENT to a literal — decodeURIComponent yields \"Aé\""]]]
+      (is (= (if (= in "%41é") "Aé" in) (url/safe-url-decode in)) why)))
+  (testing "a literal adjacent to a TRUNCATED escape still fails closed —
+            the literal's UTF-8 begins with a lead byte, so it can never
+            complete the truncated run"
+    (is (nil? (url/safe-url-decode "%C3é"))
+        "decodeURIComponent throws here on both hosts")
+    (is (nil? (url/safe-url-decode "%E2%82é"))
+        "same, with a two-byte truncation")))
+
+;; ---- the public predicate, in all four URL positions ---------------------
+
+(deftest malformed-url?-agrees-across-hosts-in-every-url-position
+  (testing "an invalid-UTF-8 escape flips the predicate wherever it sits.
+            `malformed-url?` discriminates the fail-closed route-miss
+            ({:url url :reason :malformed-url}) from a bare miss, and it
+            read FALSE on JVM / TRUE on CLJS for every one of these"
+    (doseq [[u why] [["/p/%FF"          "path segment — the finding's own reproduction"]
+                     ["/p/%C0%80"       "path segment, overlong NUL"]
+                     ["/p/x?%FF=1"      "query KEY"]
+                     ["/p/x?q=%FF"      "query VALUE"]
+                     ["/p/x#%FF"        "fragment"]
+                     ["/p/%ED%A0%80"    "path segment, lone surrogate"]
+                     ["/a/b/%E0%80%80"  "a later path segment"]]]
+      (is (true? (routing/malformed-url? u)) why)))
+  (testing "the controls: a URL whose escapes are all VALID is not
+            malformed, in the same four positions — so the assertions
+            above cannot pass by flagging every URL"
+    (doseq [[u why] [["/p/%EF%BF%BD"    "path segment carrying a legitimate U+FFFD"]
+                     ["/p/%C3%A9"       "path segment carrying é"]
+                     ["/p/x?%C3%A9=1"   "query key carrying é"]
+                     ["/p/x?q=%EF%BF%BD" "query value carrying a legitimate U+FFFD"]
+                     ["/p/x#%EF%BF%BD"  "fragment carrying a legitimate U+FFFD"]
+                     ["/search?q=clojure&page=2" "an ordinary URL"]
+                     ["/p/café"         "a literal non-ASCII path segment"]]]
+      (is (false? (routing/malformed-url? u)) why)))
+  (testing "the structural case still flips it, unchanged (rf2-4ic0f)"
+    (is (true? (routing/malformed-url? "/p/%")))))
+
+;; ---- production prism: the SSR/browser disagreement itself ---------------
+
+(deftest hostile-url-is-a-route-miss-on-both-hosts
+  (testing "the whole-tree divergence, through production `match-url`: a
+            registered route whose path param carries an invalid-UTF-8
+            escape must NOT match on either host. The JVM used to match
+            it, binding the param to replacement characters, so the SSR
+            tree and the hydrating client tree rendered different routes"
+    (rf/reg-route :decode-parity/probe {:params [:map [:slug :string]]} "/p/:slug")
+    (doseq [[u why] [["/p/%FF"       "invalid lead byte in the capture"]
+                     ["/p/%C0%80"    "overlong NUL in the capture"]
+                     ["/p/%ED%A0%80" "lone surrogate in the capture"]]]
+      (is (nil? (routing/match-url u))
+          (str why " — fails the whole match closed, per Spec 012 §Route-miss ¶5"))))
+  (testing "the control: the SAME route matches when the escape is valid,
+            so the case above cannot pass by breaking the route table"
+    (rf/reg-route :decode-parity/probe2 {:params [:map [:slug :string]]} "/p/:slug")
+    (let [matched (routing/match-url "/p/%EF%BF%BD")]
+      (is (some? matched)
+          "a legitimately-encoded U+FFFD is a MATCH, not a route-miss")
+      (is (= "�" (get-in matched [:params :slug]))
+          "and the capture is the one replacement character it encodes"))
+    (let [matched (routing/match-url "/p/caf%C3%A9")]
+      (is (some? matched) "an ordinary non-ASCII capture still matches")
+      (is (= "café" (get-in matched [:params :slug]))
+          "decoded byte-exactly"))))
+
+(deftest route-url-round-trips-through-match-url-after-the-decoder-moved
+  (testing "the encode/decode pair is still an inverse — including over a
+            value containing a REAL U+FFFD, which `url-encode` emits as
+            %EF%BF%BD and the strict decoder must read back"
+    (rf/reg-route :decode-parity/round {:params [:map [:slug :string]]} "/r/:slug")
+    (doseq [slug ["café" "日本" "a�b" "it's~a(test)!" "50% done"]]
+      (let [built  (routing/route-url {:to :decode-parity/round :params {:slug slug}})
+            parsed (routing/match-url built)]
+        (is (some? parsed)
+            (str "the URL re-frame2 itself emitted for " (pr-str slug)
+                 " must not be a malformed-URL route-miss"))
+        (is (= slug (get-in parsed [:params :slug]))
+            (str "and recovers byte-exactly: " (pr-str slug)))))))


### PR DESCRIPTION
`re-frame.routing.url/url-decode` promises `decodeURIComponent` semantics on both hosts, but its JVM arm repaired only ONE of the two differences between `java.net.URLDecoder` and `decodeURIComponent` — the form-urlencoded `+`-for-space (rf2-9a9ix). The second stood, and it was the worse half: `URLDecoder` decodes bytes with the REPLACE malformed-input action, so an INVALID UTF-8 sequence was silently rewritten to U+FFFD and a string came back, where `decodeURIComponent` throws `URIError`.

## The defect, measured on both hosts before the change

| input | JVM `safe-url-decode` | CLJS `safe-url-decode` |
|---|---|---|
| `%C0%80` (overlong NUL) | `"��"` NON-NIL | `nil` |
| `%ED%A0%80` (lone surrogate) | `"�"` NON-NIL | `nil` |
| `%FF` (invalid lead byte) | `"�"` NON-NIL | `nil` |
| `%E0%80%80` (overlong) | `"���"` NON-NIL | `nil` |
| `%C3%A9` (valid, control) | `"é"` | `"é"` (agree) |
| `%EF%BF%BD` (valid U+FFFD, control) | `"�"` | `"�"` (agree) |
| `%`, `%a`, `%zz` (structural) | `nil` | `nil` (agree) |

At the public predicate: `(malformed-url? "/p/%FF")` read **false on JVM, true on CLJS**.

## Why this is a P2

`malformed-url?` is the discriminator `:rf.route/transitioned` / `:rf.route/handle-url-change` use to separate a bare route-miss (`{:url url}`) from the fail-closed malformed case (`{:url url :reason :malformed-url}`). So a hostile URL failed closed to a route-miss in the browser but **MATCHED under SSR**, binding the param to replacement characters — the two hosts disagreed about whether the request was routable at all, and **the server was the permissive side**. That is a whole-tree Spec 011 hydration mismatch on a security-adjacent sink, strictly worse than the attribute-level divergence #8873 fixed. The fail-closed posture `safe-url-decode`'s own docstring claims — "hostile URLs, partner integrations with broken escaping" — was not the posture the JVM arm had.

## The fix, and the trap it avoids

`%EF%BF%BD` is the valid three-byte encoding of a **real** U+FFFD and must still decode. A naive "does the decoded output contain U+FFFD?" check would reject it, trading this bug for a fresh one — and could not do better, because the substituted character and the legitimate one are **identical**.

So the discrimination is made at the **byte** level, never over the decoded output: the recovered bytes go through a `CharsetDecoder` set to `REPORT`, under UTF-8's own validity rules. `%EF%BF%BD` is a legal three-byte sequence and decodes; `%FF` is not and throws. The decoded characters are never inspected.

The JVM arm decodes in three stages: pre-escape (bare `+`, then every literal non-ASCII character), `URLDecoder` under **ISO-8859-1** — the 1:1 byte↔char charset, which performs the SAME structural validation as before (`%`, `%a`, `%zz` still throw `IllegalArgumentException`) while substituting nothing — and a strict UTF-8 decode of the recovered bytes.

Literal non-ASCII is pre-escaped because both hosts pass it through today (`decodeURIComponent("café")` is `"café"`), and a strict decoder reached via a latin-1 round trip would otherwise newly reject it — the same divergence class, re-introduced. Folding a literal into an adjacent escape run cannot change the verdict either way: a literal's UTF-8 always begins with a lead byte, never a continuation, so it can neither complete a truncated run nor spoil a valid one.

**Two latent divergences fall out of this**, not named on the item: `%C3é` and `%E2%82é` threw on CLJS and returned a U+FFFD-bearing string on the JVM. Both now fail closed on both hosts.

## No spec edit is owed

Spec 012 §`+` is a literal ¶1 already names `decodeURIComponent` as the de-facto reference and states the browser is the canonical host "so the JVM matches it"; the paragraph above it names a host-divergent decoder as the Spec 011 hydration-mismatch class. §Route-miss ¶5 already requires malformed percent-encoding to fail the whole match closed. This is a conformance repair to standing requirements, not new policy — the same conclusion #8873 reached for the encode half. `spec/011-SSR.md` and `spec/012-Routing.md` are untouched.

## Tests

Both hosts off one `.cljc` table, named `*-cljs-test.cljc` so it is discovered by the cognitect JVM runner (`.*-test$`) and the shadow-cljs `:node-test` build (`cljs-test$`) alike. Expectations are literal values, never derived from `url-decode`, so a decoder that changed on one host cannot rewrite what it is compared against.

New `routing_url_decoding_parity_cljs_test.cljc` pins the invalid-UTF-8 set (overlong, lone surrogate, invalid lead byte, bare continuation, truncated); the valid-decode controls — `%EF%BF%BD`, an astral code point, `%2B`, `+`-literal — so the table cannot pass by nil-ing everything; the literal-non-ASCII passthrough; `malformed-url?` across path segment / query key / query value / fragment with valid-escape controls in the **same four positions**; the production `match-url` prism; and the `route-url` → `match-url` round trip over a value containing a real U+FFFD.

## Quality gates

All exit codes captured with the redirect and the echo on one command line, and quoted from the captured `.exit` file — not from harness-reported status. Re-run on the final base after the rebase onto `77d6ecbbaa`.

| gate | command | result |
|---|---|---|
| JVM, focused | `clojure -M:test -n re-frame.routing-url-decoding-parity-cljs-test` (in `implementation/routing`) | **exit 0** — 6 tests, 60 assertions, 0 failures |
| JVM, full routing artefact | `clojure -M:test` (in `implementation/routing`) | **exit 0** — 542 tests, 3279 assertions, 0 failures |
| CLJS, focused | `node out/node-test.js --test=re-frame.routing-url-decoding-parity-cljs-test` | **exit 0** — 6 tests, 60 assertions, 0 failures |
| CLJS, full `node-test` | `node scripts/compile-node-test.cjs node-test out/node-test.js && node out/node-test.js` | **exit 0** — 11143 tests, 54841 assertions, 0 failures |
| Lint | `clj-kondo --lint <the two changed files> --fail-level error` | **exit 0** — 0 errors |

The focused counts are **identical on both hosts** (6/60), which is the host-symmetry the suite exists to assert. 

The first CI run caught one real clj-kondo error in this diff — a static FIELD (`StandardCharsets/UTF_8`) wrapped in parens as if it were a call. Fixed in the amended commit; behaviour is identical, and both full suites were re-run green afterwards. The one remaining warning on the file (`Unresolved namespace clojure.string`, line 27) is pre-existing at `origin/main` — confirmed by linting the base revision — and warnings are informational in this gate.

### Control — the deliverable

The property was removed and the gate shown red. A single-line plant (`CodingErrorAction/REPORT` → `REPLACE` on `.onMalformedInput`) reproduces exactly the old REPLACE behaviour. Anchor match count checked as `1` before running, so the plant could not silently no-op.

- **Sabotaged JVM run: exit 1 — 19 failures**, over the same 6 tests / 60 assertions as the control run (no namespace crashed, no assertions lost).
- Every one of the 19 is a fail-closed assertion: 6 invalid-UTF-8 rows, 7 `malformed-url?` positions, 3 `match-url` prism cases, the `%FF` half of the near-miss pair, and the two truncated-plus-literal cases.
- **Zero failures mention `%EF%BF%BD`.** Every valid-decode control stayed green under sabotage — including the near-miss, which is what proves the fix does not over-reject and that the controls are not what carries the suite.
- Restore verified by **git blob hash** against the committed object (`git hash-object --path` vs `git rev-parse HEAD:<path>`), matching exactly — line endings are translated in this checkout, so a byte digest of the working file would not have been sound. Re-ran green afterwards (exit 0, 6/60), proving behaviour was restored and not merely bytes.

### Verified by hand

Both link-validating gates (`scripts/check_doc_slugs.py`, `scripts/check_readme_links.py --ci`) are irrelevant here: this PR touches no markdown. No committed document links a version-ignored working file.

Closes rf2-k2d2t.


