### PR TITLE
fix(ssr): select the Form-2 inner's arity instead of catching it (rf2-mocn3)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -377,20 +377,72 @@
        :extra    {:head    (first el)
                   :element el}})))
 
+#?(:clj
+   (defn- accepts-arity?
+     "Does the compiled fn `f` accept an invocation of EXACTLY `k` arguments?
+
+     Read off the class, not discovered by calling: a Clojure fn compiles to
+     a class declaring one `invoke` method per FIXED arity, and a variadic fn
+     additionally extends `clojure.lang.RestFn`, whose `getRequiredArity`
+     gives the number of params before the `&`. Both halves are needed —
+     `(fn [& xs] …)` declares NO `invoke` method, and `(fn [a & xs] …)`
+     accepts any arity from ONE up, so \"variadic\" must never be read as
+     \"accepts zero\".
+
+     Only ever called on a `fn?` value (`resolve-component-head` guards),
+     which matters: a Var is `ifn?` but not `fn?`, and `clojure.lang.Var`
+     declares `invoke` for arities 0–21 regardless of what it holds, so
+     inspecting one would answer yes to everything."
+     [f k]
+     (boolean
+       (or (some (fn [^java.lang.reflect.Method m]
+                   (and (= "invoke" (.getName m))
+                        (= k (alength (.getParameterTypes m)))))
+                 (.getDeclaredMethods (class f)))
+           (and (instance? clojure.lang.RestFn f)
+                (>= k (.getRequiredArity ^clojure.lang.RestFn f)))))))
+
+#?(:clj
+   (defn- form-2-invocation-arity
+     "How many of the component's `n` args to pass `inner`: `n` itself when
+     `inner` accepts them all, else the LONGEST accepted prefix (zero
+     included), else `nil` when `inner` declares no arity at or below `n`."
+     [inner n]
+     (first (filter #(accepts-arity? inner %) (range n -1 -1)))))
+
 (defn- invoke-form-2-render-fn
   "Invoke a Form-2 inner render fn with `args`, tolerating an inner that
   declares FEWER params than the component was passed. The idiomatic
   Reagent/UIx Form-2 inner either takes the SAME args as the outer
-  (`(fn [x] …)`) or ignores them and closes over the outer's (`(fn [] …)`).
-  On CLJS these are equivalent — JS arity leniency drops extra args — so
-  `(apply inner args)` renders both. The JVM is strict: `(apply inner args)`
-  throws `ArityException` for a lower-arity inner, so emulate CLJS leniency
-  by falling back to a no-arg call (the `(fn [] …)` shape)."
+  (`(fn [x] …)`), ignores them and closes over the outer's (`(fn [] …)`), or
+  — just as validly — takes a non-zero PREFIX of them (`(fn [kept] …)` under
+  an `(fn [kept ignored] …)` outer). On CLJS all three are equivalent, since
+  JS arity leniency drops extra args, so `(apply inner args)` renders them
+  all. The JVM is strict, so this helper emulates that leniency by CHOOSING
+  the call shape.
+
+  rf2-mocn3 — it used to DISCOVER the shape instead, with
+  `(try (apply inner args) (catch ArityException _ (inner)))`, and that is
+  wrong twice over. The catch enclosed execution of programmer code, so an
+  `ArityException` raised INSIDE a correctly-invoked render (an ordinary
+  wrong-arity bug in a helper it calls) was indistinguishable from an
+  invocation mismatch: the render body ran a SECOND time, duplicating the
+  effects of a non-pure render and reporting the retry's outcome instead of
+  the original failure — or, for a variadic inner, succeeding at arity zero
+  and silently shipping different HTML. And the retry tried only arity ZERO,
+  so a prefix-taking inner was rejected on the server while rendering fine in
+  the browser.
+
+  So: select from the inner's DECLARED arities (`accepts-arity?`), then
+  invoke exactly once. No user code runs inside a catch here, and anything
+  the render throws propagates unchanged. When the inner declares no
+  compatible arity at all there is no shape to choose — CLJS has no
+  equivalent of supplying missing args, so widening is not on the table —
+  and `(apply inner args)` lets the inner's own `ArityException` report the
+  real call rather than a fabricated zero-arity retry."
   [inner args]
-  #?(:clj  (try
-             (apply inner args)
-             (catch clojure.lang.ArityException _
-               (inner)))
+  #?(:clj  (let [k (form-2-invocation-arity inner (count args))]
+             (apply inner (if k (take k args) args)))
      :cljs (apply inner args)))
 
 (defn resolve-component-head

--- a/implementation/ssr/test/re_frame/ssr_emit_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_emit_test.clj
@@ -895,3 +895,130 @@
                             #":rf.error/ssr-nonrenderable-component"
                             (streaming/render-shell [deep "z"]))
           "streaming fails loud on a deeper-than-Form-2 component"))))
+
+;; ===========================================================================
+;; rf2-mocn3 — Form-2 arity adaptation is a DECISION taken before the render
+;; runs, never an exception caught after it
+;;
+;; `invoke-form-2-render-fn` used to probe arity BY EXCEPTION:
+;;
+;;     (try (apply inner args) (catch ArityException _ (inner)))
+;;
+;; That catch encloses execution of PROGRAMMER code, which is two independent
+;; defects:
+;;
+;;   1. An `ArityException` raised INSIDE a correctly-invoked inner render —
+;;      an ordinary wrong-arity bug in a helper that render calls — is
+;;      indistinguishable from an invocation-arity mismatch. The renderer ran
+;;      the render body a SECOND time and reported the retry's outcome, so a
+;;      non-pure render duplicated its effects and the user's own failure was
+;;      replaced by the retry's.
+;;   2. The fallback tried only arity ZERO, so an inner accepting a non-zero
+;;      PREFIX of the outer's props — valid under the CLJS/JS extra-argument
+;;      semantics this helper exists to emulate — was rejected on the JVM.
+;;      The same `.cljc` app rendered in the browser and failed SSR.
+;;
+;; The helper now selects a compatible call shape from the compiled fn's
+;; DECLARED arities and invokes exactly once. Both public server paths share
+;; the one resolver (`emit/resolve-component-head`), so every row below
+;; asserts through BOTH `emit/emit-element` and `streaming/render-shell`;
+;; a fix proven through one of them is proven for half the surface.
+;;
+;; NOTE ON NON-VACUITY: the inners below are FIXED arity where prefix
+;; selection is the thing under test (a variadic inner accepts the full arg
+;; list and would pass without exercising selection at all), and the
+;; double-invocation rows COUNT their calls — an idempotent test double is
+;; green against the unrepaired helper and proves nothing.
+;; ===========================================================================
+
+(deftest emit-renders-form-2-partial-arity-inner
+  (testing "rf2-mocn3 — an inner render declaring a non-zero PREFIX of the
+            outer's args renders on the JVM exactly as it does on CLJS,
+            through BOTH the sync emitter and the streaming shell walker"
+    ;; Fixed arity 1, taking the first of the outer's two props — the
+    ;; failure scenario on the bead: the client drops the extra JS argument,
+    ;; the JVM used to try 2 args, catch, retry at 0, and throw.
+    (let [form2-partial (fn [kept _ignored] (fn [kept] [:p kept]))]
+      (is (= "<p>kept</p>" (emit/emit-element [form2-partial "kept" "ignored"]))
+          "sync emit passes the inner the longest prefix it accepts")
+      (is (= "<p>kept</p>"
+             (:shell-html (streaming/render-shell [form2-partial "kept" "ignored"])))
+          "streaming passes the inner the longest prefix it accepts"))))
+
+(deftest emit-form-2-inner-body-arity-exception-propagates-once
+  (testing "rf2-mocn3 — an ArityException raised INSIDE a correctly-invoked
+            inner render propagates unchanged, and the render body runs
+            exactly ONCE, on BOTH server paths"
+    ;; A VALID zero-arity inner — precisely the shape the old zero-arity
+    ;; retry could re-enter successfully — whose body carries an ordinary
+    ;; wrong-arity bug in a helper it calls.
+    (let [calls       (atom 0)
+          needs-two   (fn [a b] [:span a b])
+          form2-buggy (fn [x] (fn []
+                                (swap! calls inc)
+                                [:div (needs-two x)]))]
+      (reset! calls 0)
+      (is (thrown? clojure.lang.ArityException
+                   (emit/emit-element [form2-buggy "x"]))
+          "sync emit propagates the inner body's own ArityException")
+      (is (= 1 @calls)
+          "sync emit invoked the inner render EXACTLY once (the old
+           catch-and-retry reached 2)")
+      (reset! calls 0)
+      (is (thrown? clojure.lang.ArityException
+                   (streaming/render-shell [form2-buggy "x"]))
+          "streaming propagates the inner body's own ArityException")
+      (is (= 1 @calls)
+          "streaming invoked the inner render EXACTLY once (the old
+           catch-and-retry reached 2)"))))
+
+(deftest emit-form-2-variadic-inner-body-failure-is-not-swallowed
+  (testing "rf2-mocn3 — the old zero-arity retry SUCCEEDED on a variadic
+            inner, silently replacing a failing render with different HTML.
+            The programmer's failure must surface on BOTH paths instead"
+    ;; With args the render is reached and its helper bug throws; with NO
+    ;; args it returns a different tree. Under the old catch-and-retry the
+    ;; no-args branch is what shipped — a silent wrong render, no exception
+    ;; anywhere, which is the severest form of defect 1.
+    (let [needs-two (fn [a b] [:span a b])
+          form2     (fn [x] (fn [& xs]
+                              (if (seq xs)
+                                [:div (needs-two x)]
+                                [:p "zero-arity retry reached this"])))]
+      (is (thrown? clojure.lang.ArityException
+                   (emit/emit-element [form2 "x"]))
+          "sync emit surfaces the render's own failure rather than
+           re-entering the variadic inner with no args")
+      (is (thrown? clojure.lang.ArityException
+                   (streaming/render-shell [form2 "x"]))
+          "streaming surfaces the render's own failure rather than
+           re-entering the variadic inner with no args"))))
+
+(deftest emit-passes-form-2-variadic-inner-the-whole-arg-seq
+  (testing "rf2-mocn3 — a VARIADIC inner receives the complete original
+            argument sequence, once, preserving ordinary Reagent/CLJS
+            semantics on BOTH server paths"
+    ;; `(fn [& xs] …)` accepts any arity from zero up; selection must hand it
+    ;; the FULL list, not confuse \"accepts any arity\" with \"accepts zero\".
+    (let [calls (atom 0)
+          seen  (atom nil)
+          form2 (fn [_a _b] (fn [& xs]
+                              (swap! calls inc)
+                              (reset! seen (vec xs))
+                              [:p (str/join "," xs)]))]
+      (reset! calls 0)
+      (reset! seen nil)
+      (is (= "<p>a,b</p>" (emit/emit-element [form2 "a" "b"]))
+          "sync emit renders the variadic inner's output")
+      (is (= ["a" "b"] @seen)
+          "sync emit passed the variadic inner the complete arg sequence")
+      (is (= 1 @calls)
+          "sync emit invoked the variadic inner exactly once")
+      (reset! calls 0)
+      (reset! seen nil)
+      (is (= "<p>a,b</p>" (:shell-html (streaming/render-shell [form2 "a" "b"])))
+          "streaming renders the variadic inner's output")
+      (is (= ["a" "b"] @seen)
+          "streaming passed the variadic inner the complete arg sequence")
+      (is (= 1 @calls)
+          "streaming invoked the variadic inner exactly once"))))

--- a/implementation/ssr/test/re_frame/ssr_emit_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_emit_test.clj
@@ -962,7 +962,11 @@
           needs-two   (fn [a b] [:span a b])
           form2-buggy (fn [] (fn []
                                (swap! calls inc)
-                               [:div (needs-two "x")]))]
+                               ;; Deliberately wrong arity — this call IS the fixture payload: the row needs
+                               ;; a genuine ArityException raised INSIDE the render body. clj-kondo is right
+                               ;; that it is a mismatch and cannot know it is intentional.
+                               [:div #_{:clj-kondo/ignore [:invalid-arity]}
+                                     (needs-two "x")]))]
       (reset! calls 0)
       (is (thrown? clojure.lang.ArityException
                    (emit/emit-element [form2-buggy]))
@@ -990,7 +994,11 @@
           needs-two   (fn [a b] [:span a b])
           form2-buggy (fn [x] (fn [x]
                                 (swap! calls inc)
-                                [:div (needs-two x)]))]
+                                ;; Deliberately wrong arity — this call IS the fixture payload: the row needs
+                                ;; a genuine ArityException raised INSIDE the render body. clj-kondo is right
+                                ;; that it is a mismatch and cannot know it is intentional.
+                                [:div #_{:clj-kondo/ignore [:invalid-arity]}
+                                      (needs-two x)]))]
       (reset! calls 0)
       (is (thrown-with-msg? clojure.lang.ArityException
                             #"Wrong number of args \(1\)"
@@ -1017,7 +1025,11 @@
     (let [needs-two (fn [a b] [:span a b])
           form2     (fn [x] (fn [& xs]
                               (if (seq xs)
-                                [:div (needs-two x)]
+                                ;; Deliberately wrong arity — this call IS the fixture payload: the row needs
+                                ;; a genuine ArityException raised INSIDE the render body. clj-kondo is right
+                                ;; that it is a mismatch and cannot know it is intentional.
+                                [:div #_{:clj-kondo/ignore [:invalid-arity]}
+                                      (needs-two x)]
                                 [:p "zero-arity retry reached this"])))]
       (is (thrown? clojure.lang.ArityException
                    (emit/emit-element [form2 "x"]))

--- a/implementation/ssr/test/re_frame/ssr_emit_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_emit_test.clj
@@ -946,31 +946,65 @@
           "streaming passes the inner the longest prefix it accepts"))))
 
 (deftest emit-form-2-inner-body-arity-exception-propagates-once
-  (testing "rf2-mocn3 — an ArityException raised INSIDE a correctly-invoked
-            inner render propagates unchanged, and the render body runs
-            exactly ONCE, on BOTH server paths"
-    ;; A VALID zero-arity inner — precisely the shape the old zero-arity
-    ;; retry could re-enter successfully — whose body carries an ordinary
-    ;; wrong-arity bug in a helper it calls.
+  (testing "rf2-mocn3 — a zero-arity inner invoked with zero args REACHES its
+            body, and an ArityException raised THERE is not an invocation
+            mismatch: the render runs exactly ONCE, on BOTH server paths"
+    ;; The shape the old catch-and-retry could re-enter successfully. The
+    ;; first call already matches, so the body runs, throws, is caught, and
+    ;; the retry runs the body a SECOND time. ONLY a counting inner detects
+    ;; that — the exception is the same either way, so an idempotent test
+    ;; double is green against the unrepaired helper and proves nothing.
+    ;;
+    ;; The arity must match on the FIRST call for this to bite: a zero-arity
+    ;; inner under a one-arg component throws before entering the body, the
+    ;; counter never reaches 2, and the row is vacuous.
     (let [calls       (atom 0)
           needs-two   (fn [a b] [:span a b])
-          form2-buggy (fn [x] (fn []
-                                (swap! calls inc)
-                                [:div (needs-two x)]))]
+          form2-buggy (fn [] (fn []
+                               (swap! calls inc)
+                               [:div (needs-two "x")]))]
       (reset! calls 0)
       (is (thrown? clojure.lang.ArityException
-                   (emit/emit-element [form2-buggy "x"]))
+                   (emit/emit-element [form2-buggy]))
           "sync emit propagates the inner body's own ArityException")
       (is (= 1 @calls)
           "sync emit invoked the inner render EXACTLY once (the old
            catch-and-retry reached 2)")
       (reset! calls 0)
       (is (thrown? clojure.lang.ArityException
-                   (streaming/render-shell [form2-buggy "x"]))
+                   (streaming/render-shell [form2-buggy]))
           "streaming propagates the inner body's own ArityException")
       (is (= 1 @calls)
           "streaming invoked the inner render EXACTLY once (the old
-           catch-and-retry reached 2)"))))
+           catch-and-retry reached 2)")))
+
+  (testing "rf2-mocn3 — the inner body's ORIGINAL failure propagates
+            unchanged rather than being replaced by the retry's"
+    ;; A SAME-arity inner. The old helper caught the body's
+    ;; `Wrong number of args (1)` and re-invoked at arity ZERO, which this
+    ;; arity-1 inner rejects — so the programmer was shown
+    ;; `Wrong number of args (0)` about a call they never wrote and their
+    ;; real bug vanished. The arg COUNT in the message is the discriminator
+    ;; here; the invocation counter cannot tell these two apart.
+    (let [calls       (atom 0)
+          needs-two   (fn [a b] [:span a b])
+          form2-buggy (fn [x] (fn [x]
+                                (swap! calls inc)
+                                [:div (needs-two x)]))]
+      (reset! calls 0)
+      (is (thrown-with-msg? clojure.lang.ArityException
+                            #"Wrong number of args \(1\)"
+                            (emit/emit-element [form2-buggy "x"]))
+          "sync emit surfaces the render's own failing call, not a
+           fabricated zero-arity retry")
+      (is (= 1 @calls) "sync emit invoked the inner render exactly once")
+      (reset! calls 0)
+      (is (thrown-with-msg? clojure.lang.ArityException
+                            #"Wrong number of args \(1\)"
+                            (streaming/render-shell [form2-buggy "x"]))
+          "streaming surfaces the render's own failing call, not a
+           fabricated zero-arity retry")
+      (is (= 1 @calls) "streaming invoked the inner render exactly once"))))
 
 (deftest emit-form-2-variadic-inner-body-failure-is-not-swallowed
   (testing "rf2-mocn3 — the old zero-arity retry SUCCEEDED on a variadic


### PR DESCRIPTION
## What

`invoke-form-2-render-fn` in `implementation/ssr/src/re_frame/ssr/emit.cljc` probed arity **by exception**:

```clojure
(try (apply inner args) (catch clojure.lang.ArityException _ (inner)))
```

That is wrong twice over, and the two defects are independent.

**1. The catch enclosed execution of programmer code.** An `ArityException` raised *inside* a correctly-invoked inner render — an ordinary wrong-arity bug in a helper that render calls — is indistinguishable from an invocation-arity mismatch. The renderer ran the render body a **second** time, so a non-pure render duplicated its effects and the retry's outcome replaced the original failure. For a **variadic** inner the retry *succeeded* at arity zero, silently shipping different HTML with no exception anywhere — the severest form, since nothing at all signals it.

**2. The fallback tried only arity ZERO.** An inner declaring a non-zero *prefix* of the outer's props is valid under the CLJS/JavaScript extra-argument semantics this helper explicitly promises. The JVM tried all args, caught, then tried zero, and rejected everything in between — so the same `.cljc` app rendered in the browser and failed SSR on both server paths.

## How

Detect arity; don't catch it. On the JVM a compiled fn's accepted arities are **inspectable**, so the call shape is chosen *before* any user code runs:

- one `invoke` method per declared **fixed** arity, read off `(.getDeclaredMethods (class f))`;
- plus `clojure.lang.RestFn/getRequiredArity` for a **variadic** tail.

Both halves are needed. `(fn [& xs] …)` declares no `invoke` method at all, and `(fn [a & xs] …)` accepts any arity from **one** up — so "variadic" is never read as "accepts zero", which is exactly the confusion that made the old zero-arity retry succeed on a variadic inner.

Selection is then the whole rule in one expression: the full arg count when accepted, else the longest accepted prefix (zero included). The inner is invoked **exactly once**. No user code runs inside a catch, and anything the render throws propagates unchanged.

When the inner declares no compatible arity there is no shape to choose — CLJS has no equivalent of supplying *missing* args, so widening is not on the table — and `(apply inner args)` lets the inner's own `ArityException` report the real call rather than a fabricated zero-arity retry. That is strictly better than before: the reported arg count is now the one the programmer actually wrote.

The CLJS branch, the single Form-2 unwrap, and the `:rf.error/ssr-nonrenderable-component` failure for a still-fn result are all unchanged. No spec edit: this is a JVM implementation bug against semantics `spec/011-SSR.md` already promises.

## Coverage — both public consumers

`emit/emit-element` and `streaming/render-shell` share one resolver (`emit/resolve-component-head`), so a fix proven through one is proven for half the surface. **Every new row asserts through both**, on exact rendered bytes where it renders:

| Row | Property |
|---|---|
| `emit-renders-form-2-partial-arity-inner` | a **fixed**-arity-1 inner under a two-arg outer renders `<p>kept</p>` |
| `emit-form-2-inner-body-arity-exception-propagates-once` | body `ArityException` propagates; **invocation counter is exactly 1** |
| ” (second row) | the **original** failure propagates, not the retry's |
| `emit-form-2-variadic-inner-body-failure-is-not-swallowed` | a variadic inner's failure is not replaced by a zero-arity retry |
| `emit-passes-form-2-variadic-inner-the-whole-arg-seq` | a variadic inner receives the complete arg sequence, once |

The existing same-arity and zero-arity Form-2 controls, and the deeper-than-Form-2 failure, are untouched and still green — those are what prove the supported surface did not change.

## Quality gates

Covering gate derived from `.github/workflows/test.yml` job **`jvm-ssr`** ("JVM ssr (clojure -M:test)", `working-directory: implementation/ssr`, gated on `implementation_jvm`), run locally as that exact command. Exit codes captured on the runner's own command line and quoted verbatim.

| Run | Tree | Captured exit | Result |
|---|---|---|---|
| 3 | fix + controls | **0** | `Ran 603 tests containing 2943 assertions. 0 failures, 0 errors.` |
| 4 | **sabotage** — helper reverted to the `try/catch` form | **1** | `6 failures, 2 errors` |
| 5 | fix + controls, **on the final rebased base** | **0** | `Ran 603 tests containing 2943 assertions. 0 failures, 0 errors.` |

The sabotage run is the control, and it bites on all three defect rows:

- `emit-renders-form-2-partial-arity-inner` — `ArityException: Wrong number of args (0) passed to: …form2-partial…/fn…`, on **both** sync and streaming, reproducing the finding's `:partial-error` evidence.
- `emit-form-2-inner-body-arity-exception-propagates-once` — `expected: (= 1 @calls) / actual: (not (= 1 2))`, on **both** paths: the double invocation, matching the finding's `:inner-calls 2`.
- `emit-form-2-variadic-inner-body-failure-is-not-swallowed` — `expected: (thrown? ArityException …) / actual: nil`, i.e. the unrepaired helper returned HTML where the render had failed.

Namespace and assertion counts are **identical** across the green and sabotage runs (603 / 2943), so the plant failed rows rather than crashing a lane. The plant was applied and reverted by git **blob** hash, not by reading a diff: `4098f07bf9799b30c7eba719d60c4178c2d0f923` before, `72b406e69fee7c41446b8a201f46b634f7c91710` planted, `4098f07bf9799b30c7eba719d60c4178c2d0f923` restored and equal to the committed object. No reflection warnings in either log.

**The sabotage run caught a defect in the control itself**, which is why the second commit exists. The double-invocation row originally used a zero-arity inner under a *one-arg* component: the old `(apply inner args)` threw on the invocation before ever entering the render body, the catch then re-invoked at arity zero, the body ran for the first time, and the counter finished at 1. The row was **green against exactly the defect it existed to detect**. For the catch-and-retry to bite, the inner's arity must match on the *first* call so the body is genuinely re-entered — it now renders a zero-arity inner with zero args, where the unrepaired helper reaches 2. The companion row (same-arity inner, discriminating on the arg count in the message) was added at the same time to cover what the counter cannot express.

Rebased onto `0f8ab8c898` and re-run there (run 5) rather than resting on the pre-rebase green: nothing landed on `implementation/ssr/**` in the interval, but `implementation/core/src/re_frame/late_bind/directory.cljc` did, and that `.cljc` is loaded by this suite. The merge-base diff is two files with no reversions.

### clj-kondo — what was red, and why the fix is a suppression

The first CI run failed `clj-kondo (fail on errors, warnings informational)`, taking the `Lint required` aggregate with it. Every other check passed. Three errors, all in the new test block:

```
implementation/ssr/test/re_frame/ssr_emit_test.clj:965:38: error: needs-two is called with 1 arg but expects 2
implementation/ssr/test/re_frame/ssr_emit_test.clj:993:39: error: needs-two is called with 1 arg but expects 2
implementation/ssr/test/re_frame/ssr_emit_test.clj:1020:39: error: needs-two is called with 1 arg but expects 2
```

**The test is right, and the linter is right about the code it can see.** `needs-two` is `(fn [a b] …)`, a plain two-arity test helper called with one argument *on purpose*, inside the Form-2 inner's render body. That deliberately-wrong call is the fixture's payload: it is how each row obtains an `ArityException` raised from a nested helper call — the acceptance criterion the double-invocation and variadic rows are built on. Satisfying the linter by correcting the arity would delete the very failure those rows exist to observe, leaving a green PR that no longer tests its own subject.

Worth naming precisely, because it is easy to read these as the partial-arity case and they are not: `form2-partial` (`emit-renders-form-2-partial-arity-inner`) is the fixture for the newly-legal shape, it is **never called directly** — the renderer selects its arity at run time — so clj-kondo sees no call site there and flagged none. The three flagged sites are ordinary wrong-arity calls whose wrongness *is* the test input. clj-kondo cannot know that, and there is no static signal that would tell it.

**Suppression scope: the narrowest of the three options.** A per-form `#_{:clj-kondo/ignore [:invalid-arity]}` at each of the three call sites, each with a one-line reason so a later reader does not delete it as noise. The broader two were rejected: a single ignore over the enclosing fixture would blind `:invalid-arity` across a whole `let` body that also contains the calls under test, and a `.clj-kondo/config.edn` entry would weaken arity checking repository-wide to serve three lines in one test file. **`.clj-kondo/config.edn` is not touched** — this PR is not a one-toucher on shared lint config, and `:invalid-arity` stays live everywhere else in the tree, this file included.

**The shape does not recur.** All three occurrences are flagged and all three are fixed; the fourth Form-2 row (`emit-passes-form-2-variadic-inner-the-whole-arg-seq`) carries no deliberate mismatch, and clj-kondo now reports zero errors across the entire lint surface.

Gate run locally exactly as CI runs it — the `--lint` path list and `--fail-level error` taken from `.github/workflows/lint.yml`, at the version CI pins (`clj-kondo v2026.04.15`, fetched from the same pinned release URL; the locally-installed v2025.10.23 was not used, since a pass from another version proves nothing).

| Run | Tree | Captured exit | `errors:` | `warnings:` |
|---|---|---|---|---|
| 1 | before — reproducing CI | **3** | 3 | 2078 |
| 2 | after the three ignores | **0** | 0 | 2078 |
| 3 | **sabotage** — one ignore removed | **3** | 1 | 2078 |

**The suppression is exactly scoped.** Diffing the complete finding lists of runs 1 and 2 shows the three `error:` lines gone and nothing else: the warning total is unchanged at 2078, and the only other movement is one pre-existing `unused binding x` warning shifting four lines down where the comment was inserted. No other finding disappeared.

**The sabotage run is the control.** Removing a single ignore turns the gate red at that exact call site and nowhere else, which settles three things at once: the ignore is load-bearing, the green in run 2 is not vacuous, and the run read this branch's tree — `needs-two` does not exist on the merge base, so the same gate against any other checkout returns zero errors. Planted and restored by git **blob** hash rather than by reading a diff: `96004999cfa52decf11b67f702682b66b79e2ea4` committed, `76b066c4c1bcfa147e4a18e3a6af1754a72c8b26` planted, restored equal to the committed object.

Only `error:` lines gate this job. The 2078 warnings are pre-existing, overwhelmingly under `examples/`, and identical in count before and after.

The SSR suite was re-run on the final base after the change, to confirm the ignore is inert — the reader discards `#_`, but "inert" is a claim like any other and the suite is cheap: captured exit **0**, `Ran 603 tests containing 2943 assertions. 0 failures, 0 errors.`, the same counts as runs 3 and 5 above.

Closes rf2-mocn3.


