### PR TITLE
fix(story): the address-bar writer preserves the params Story does not own (rf2-gee8n)

### DIFF
--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -62,7 +62,7 @@
   `build-params` emits them — the §URL scheme list in the ns docstring
   above, written down once so the three places that need it agree:
   `build-params` emits a SUBSET of it, `parse-params` reads ALL of it,
-  and `append-query-params` CLEARS all of it before appending.
+  and `apply-story-params` CLEARS all of it before appending.
 
   All of it, not merely the subset a given call emits (rf2-b7je1 audit).
   `build-params` deliberately omits empty / nil / default slots so the
@@ -391,16 +391,26 @@
     (subs fragment 0 idx)
     fragment))
 
-(defn- ^:no-doc append-query-params
-  "Merge already-encoded query `params` into `base-url`, inserting them
-  before any hash fragment.
+(defn apply-story-params
+  "Rewrite `base-url`'s query so the Story vocabulary reads exactly the
+  already-encoded `params`, inserting them before any hash fragment.
+
+  This is THE ownership boundary, and it is public because the address
+  bar has TWO writers that must not disagree about it: the share builder
+  `variant-share-url` below, and `re-frame.story.ui.url-state/
+  url-from-state`, which the state-watcher pushes on every URL-relevant
+  shell change. They call this one function rather than each keeping
+  their own notion of who owns what (rf2-gee8n — `url-from-state` used
+  to compose from `{:pathname :hash}` alone and discard
+  `location.search` wholesale, so the first state change after mount
+  erased the very params this fn takes care to preserve).
 
   Key-aware (rf2-b7je1): every existing occurrence of a key in
   `story-query-keys` is removed before the generated params are
-  appended, so the result carries exactly one value for each key the
-  builder owns and NO value for the ones this call chose to omit. The
-  browser hydrator (`re-frame.story.ui.url-state/params->getter`) reads
-  each key with `URLSearchParams.get`, whose first-value semantics would
+  appended, so the result carries exactly one value for each key Story
+  owns and NO value for the ones this call chose to omit. The browser
+  hydrator (`re-frame.story.ui.url-state/params->getter`) reads each key
+  with `URLSearchParams.get`, whose first-value semantics would
   otherwise select a stale value already on `base-url` — opening a
   different cell than the one shared. Unrelated existing entries
   (e.g. `from=index`, `embed=1`) are preserved verbatim, in order,
@@ -409,7 +419,9 @@
   The clear set is `story-query-keys` rather than the keys of `params`
   precisely because `build-params` omits empty / default slots: clearing
   only what is emitted leaves a stale `modes=` standing when the caller
-  requests no modes at all."
+  requests no modes at all.
+
+  Pure data → data; JVM + CLJS-portable."
   [base-url params]
   (let [[path fragment] (split-fragment base-url)
         qidx            (str/index-of path "?")
@@ -419,7 +431,17 @@
                           (->> (str/split (subs path (inc qidx)) #"&" -1)
                                (remove #(contains? owned (query-param-key %)))))
         query           (str/join "&" (concat kept params))
-        sep             (if (and (nil? qidx) (str/blank? path)) "" "?")
+        ;; No `?` for an empty query — clearing the last Story key off a
+        ;; base that carried nothing else must not leave a dangling `?`
+        ;; (rf2-gee8n: a bare `?` differs from `location.search`'s empty
+        ;; string, so the state-watcher would push a cosmetic history
+        ;; entry it can never match again). No `?` either for the bare
+        ;; `variant-share-url` 1-arity, whose empty base-url asks for a
+        ;; query FRAGMENT the caller glues onto a base of its own.
+        sep             (if (or (str/blank? query)
+                                (and (nil? qidx) (str/blank? path)))
+                          ""
+                          "?")
         with-query      (str bare sep query)]
     (if (some? fragment)
       (str with-query "#" fragment)
@@ -563,11 +585,14 @@
   this call's value, or REMOVED when this call omits that slot, so the
   reader lands on the requested cell and nothing else. Unrelated query
   params (`from=`, `embed=`, …) and the hash route survive untouched.
+  That boundary is `apply-story-params`, shared with the address-bar
+  writer `re-frame.story.ui.url-state/url-from-state` so the two writers
+  of this URL cannot drift apart (rf2-gee8n).
   Pure data → data; JVM + CLJS-portable."
   ([variant-id]                (variant-share-url variant-id "" nil))
   ([variant-id opts]           (variant-share-url variant-id "" opts))
   ([variant-id base-url opts]
-   (append-query-params
+   (apply-story-params
      (or base-url "")
      (build-params (assoc opts :variant-id variant-id)))))
 

--- a/tools/story/src/re_frame/story/ui/url_state.cljc
+++ b/tools/story/src/re_frame/story/ui/url_state.cljc
@@ -91,30 +91,37 @@
       (seq overrides) (assoc :cell-overrides overrides)
       substrate (assoc :substrate      substrate))))
 
-(defn query-string-from-state
-  "Build the canonical `?<query>` string (no path / hash) for `shell`.
-  Returns an empty string when no URL-relevant slots are populated.
-  Pure data → data; JVM-testable."
-  [shell]
-  (let [params (share/build-params (params-from-state shell))]
-    (if (seq params)
-      (str "?" (str/join "&" params))
-      "")))
-
 (defn url-from-state
   "Compose the full URL (path + query + fragment) for `shell` against
-  `location-shape`, a `{:pathname :hash}` map describing the current
-  browser location. Returns a string. Pure data → data; JVM-testable.
+  `location-shape`, a `{:pathname :search :hash}` map describing the
+  current browser location. Returns a string. Pure data → data;
+  JVM-testable.
+
+  Story owns exactly `share/story-query-keys` in that query and nothing
+  else. This call writes the keys `shell` populates, CLEARS the ones it
+  does not, and PRESERVES every unrelated param already on `:search` —
+  `embed=1` (rf2-pucku chrome state, read at mount and deliberately
+  never round-tripped through `share/parse-params`), a referrer `from=`,
+  whatever a host page appended — verbatim and in order, ahead of the
+  generated params.
+
+  That boundary is not restated here: the merge IS
+  `share/apply-story-params`, the same function `share/variant-share-url`
+  builds on. The two writers of this URL therefore cannot disagree about
+  who owns an unrelated param, which is the defect rf2-gee8n recorded —
+  this fn used to compose from `{:pathname :hash}` alone and rebuild the
+  query from shell state, discarding `location.search` wholesale, so the
+  first state change after mount dropped exactly the params rf2-b7je1
+  had just taught the share builder to keep. The loss showed on
+  copy/paste and reload, not in the live session.
 
   The encoder writes the query BEFORE the hash route (Story uses
-  hash-based routing under `#/stories`); same convention
-  `share/variant-share-url` honours so a hash-routed Story page keeps
-  its query in `location.search`."
-  [shell {:keys [pathname hash]}]
-  (let [qs (query-string-from-state shell)
-        path (or pathname "")
-        hash (or hash "")]
-    (str path qs hash)))
+  hash-based routing under `#/stories`), which `apply-story-params`
+  handles by splitting the fragment off first."
+  [shell {:keys [pathname search hash]}]
+  (share/apply-story-params
+    (str (or pathname "") (or search "") (or hash ""))
+    (share/build-params (params-from-state shell))))
 
 ;; ---- diff predicate -----------------------------------------------------
 
@@ -338,12 +345,18 @@
        (when (exists? js/window) js/window))
 
      (defn- ^:no-doc current-location-shape
-       "Snapshot `window.location` into the pure `{:pathname :hash}`
-       shape `url-from-state` consumes."
+       "Snapshot `window.location` into the pure
+       `{:pathname :search :hash}` shape `url-from-state` consumes.
+
+       `:search` is what makes the composed URL preserve the params
+       Story does not own (rf2-gee8n); without it `url-from-state` has
+       nothing to preserve FROM and the next push silently canonicalises
+       the address bar down to the shell's own vocabulary."
        []
        (when-let [w (safe-window)]
          (let [loc (.-location w)]
            {:pathname (.-pathname loc)
+            :search   (.-search loc)
             :hash     (.-hash loc)})))
 
      (defn- ^:no-doc current-url-search+hash

--- a/tools/story/src/re_frame/story/ui/url_state.cljc
+++ b/tools/story/src/re_frame/story/ui/url_state.cljc
@@ -56,7 +56,11 @@
   popstate-driven hydration sets an internal `*hydrating?*` flag so
   the state-watcher's reaction does NOT bounce back a push for the
   state it just absorbed."
-  (:require [clojure.string :as str]
+  ;; `clojure.string` is CLJS-only here: the pure half composes through
+  ;; `share/apply-story-params` and does no string work of its own, so
+  ;; the alias survives solely for `embed-flag-from-current-url`'s
+  ;; truthiness parse down in the `#?(:cljs ...)` block.
+  (:require #?(:cljs [clojure.string :as str])
             [re-frame.story.share :as share]))
 
 ;; ---- pure: shell-state → URL params -------------------------------------

--- a/tools/story/test/re_frame/story/ui/url_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/url_state_cljs_test.cljs
@@ -48,6 +48,88 @@
       (is (re-find #"#/stories$"  url)
           "hash route survives at the tail"))))
 
+;; ---- rf2-gee8n: unowned params survive a state-driven address-bar write --
+;;
+;; The JVM half of this pin asserts the composed STRING. Only the real
+;; `URLSearchParams` can answer what the shell will actually READ back off
+;; that string: `params->getter` and `embed-flag-from-current-url` both go
+;; through `.get`, whose first-value semantics are the reason rf2-b7je1
+;; had to clear rather than append. So read the composed URL back through
+;; the same API the hydrator uses.
+
+(deftest url-from-state-preserves-unowned-params-through-urlsearchparams
+  (testing "rf2-gee8n — url-from-state used to rebuild the query from shell
+            state alone and drop location.search wholesale, erasing every
+            param Story does not own on the first state change after mount.
+            Read back through the REAL URLSearchParams: the unowned params
+            are still there with their values, the embed flag still reads
+            truthy for embed-flag-from-current-url, every stale Story key is
+            absent (not merely later in the string — .get would return it),
+            and parse-params restores the requested cell and nothing else."
+    (let [stale  {"variant"    "story.old%2Fa"
+                  "workspace"  "story.old%2Fws"
+                  "mode-tab"   "docs"
+                  "modes"      "Mode.app%2Fstale"
+                  "viewport"   "tablet"
+                  "background" "dark"
+                  "tag-filter" "stale"
+                  "overrides"  "%7B%3Afoo%201%7D"
+                  "substrate"  "uix"}
+          search (str "?"
+                      (str/join "&" (map #(str (name %) "=" (get stale (name %)))
+                                         share/story-query-keys))
+                      "&from=index&embed=1")
+          url    (us/url-from-state
+                   {:selected-variant :story.new/b}
+                   {:pathname "/counter-with-stories/"
+                    :search   search
+                    :hash     "#/stories"})
+          usp    (js/URLSearchParams.
+                   (second (str/split (first (str/split url #"#" 2)) #"\?" 2)))]
+      (is (= (set (map name share/story-query-keys)) (set (keys stale)))
+          "the fixture carries a stale value for every key in the vocabulary")
+      (is (= "index" (.get usp "from"))
+          "the referrer param survives with its value")
+      (is (= "1" (.get usp "embed"))
+          "embed=1 survives — chrome state the shell reads at every mount")
+      (is (= "story.new/b" (.get usp "variant"))
+          "URLSearchParams.get returns the variant this state asked for")
+      (is (= 1 (count (.getAll usp "variant")))
+          "exactly one variant value")
+      (doseq [k (map name share/story-query-keys)
+              :when (not= k "variant")]
+        (is (zero? (count (.getAll usp k)))
+            (str "URLSearchParams sees no stale " k "= at all")))
+      (let [parsed (share/parse-params
+                     (into {} (map (fn [k] [k (.get usp k)]))
+                           (map name share/story-query-keys)))]
+        (is (= :story.new/b (:variant-id parsed))
+            "the hydrator's own read path recovers the requested variant")
+        (doseq [slot [:workspace-id :mode-tab :active-modes :viewport
+                      :background :tag-filter :cell-overrides :substrate]]
+          (is (nil? (get parsed slot))
+              (str "parse-params restores no stale " slot))))
+      (is (str/ends-with? url "#/stories")
+          "the hash route survives, after the query"))))
+
+(deftest url-from-state-consumes-a-browser-shaped-location
+  (testing "rf2-gee8n — `current-location-shape` snapshots the browser's own
+            {pathname, search, hash} triple off `window.location`. Drive the
+            composer from a real `js/URL`'s three properties — the same
+            accessors, with the same `?`/`#` prefix conventions — so the
+            merge is exercised against browser-produced values rather than
+            hand-written strings."
+    (let [loc (js/URL. (str "https://example.test/counter-with-stories/"
+                            "?from=index&embed=1&variant=story.old%2Fa"
+                            "#/stories"))
+          url (us/url-from-state
+                {:selected-variant :story.new/b}
+                {:pathname (.-pathname loc)
+                 :search   (.-search loc)
+                 :hash     (.-hash loc)})]
+      (is (= "/counter-with-stories/?from=index&embed=1&variant=story.new%2Fb#/stories"
+             url)))))
+
 ;; ---- params-from-state via the public share encoder ---------------------
 
 (deftest params-from-state-feeds-share-build-params

--- a/tools/story/test/re_frame/story/ui/url_state_test.cljc
+++ b/tools/story/test/re_frame/story/ui/url_state_test.cljc
@@ -6,11 +6,14 @@
   Playwright browser scenario. This ns pins the pure pieces:
 
   - `params-from-state`     — project shell-state slots onto build-params shape.
-  - `query-string-from-state` — round-trip ?key=val&... composition.
-  - `url-from-state`        — full path + query + hash composition.
+  - `url-from-state`        — full path + query + hash composition, and the
+                              ownership boundary it shares with the share
+                              builder (rf2-gee8n).
   - `url-relevant-slots-changed?` — diff for the state watcher.
   - `apply-parsed-to-state` — fold parsed slots back into shell-state."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.story.share :as share]
             [re-frame.story.ui.url-state :as us]))
 
 ;; ---- params-from-state ---------------------------------------------------
@@ -70,30 +73,6 @@
       (is (= {:n 5}         (:cell-overrides out)))
       (is (= :uix           (:substrate out))))))
 
-;; ---- query-string-from-state --------------------------------------------
-
-(deftest query-string-from-empty-state-is-blank
-  (is (= "" (us/query-string-from-state {}))))
-
-(deftest query-string-from-state-prepends-question-mark
-  (let [qs (us/query-string-from-state {:selected-variant :foo/bar})]
-    (is (re-find #"^\?variant=" qs))))
-
-(deftest query-string-from-state-includes-all-slots
-  (let [qs (us/query-string-from-state
-             {:selected-variant   :foo/bar
-              :active-mode-tab    {:foo/bar :docs}
-              :active-modes       [:m/dark]
-              :viewport           :tablet
-              :background         :dark
-              :tag-filter         #{:tag/a}})]
-    (is (re-find #"variant="    qs))
-    (is (re-find #"mode-tab="   qs))
-    (is (re-find #"modes="      qs))
-    (is (re-find #"viewport="   qs))
-    (is (re-find #"background=" qs))
-    (is (re-find #"tag-filter=" qs))))
-
 ;; ---- url-from-state ------------------------------------------------------
 
 (deftest url-from-state-composes-pathname-query-hash
@@ -106,6 +85,112 @@
 (deftest url-from-state-no-query-when-empty
   (let [url (us/url-from-state {} {:pathname "/foo/" :hash "#/stories"})]
     (is (= "/foo/#/stories" url))))
+
+(deftest url-from-state-includes-every-populated-slot
+  (testing "every URL-relevant shell slot reaches the composed query"
+    (let [url (us/url-from-state
+                {:selected-variant   :foo/bar
+                 :active-mode-tab    {:foo/bar :docs}
+                 :active-modes       [:m/dark]
+                 :viewport           :tablet
+                 :background         :dark
+                 :tag-filter         #{:tag/a}
+                 :substrate          :uix}
+                {:pathname "/foo/" :hash "#/stories"})]
+      (is (re-find #"\?variant=" url))
+      (is (re-find #"mode-tab="   url))
+      (is (re-find #"modes="      url))
+      (is (re-find #"viewport="   url))
+      (is (re-find #"background=" url))
+      (is (re-find #"tag-filter=" url))
+      (is (re-find #"substrate="  url)))))
+
+;; ---- rf2-gee8n: the address-bar writer owns the Story vocabulary only ----
+;;
+;; `url-from-state` is the SECOND writer of the address-bar URL — the
+;; state-watcher pushes its output on every URL-relevant change. It used to
+;; compose from `{:pathname :hash}` alone, rebuilding the query from shell
+;; state and discarding `location.search` wholesale, so the first state
+;; change after mount erased every param Story does not own: `embed=1`
+;; (rf2-pucku chrome state, read once at mount and never round-tripped),
+;; a referrer `from=`, a host page's analytics params.
+;;
+;; The share builder had already settled the boundary (rf2-b7je1): Story
+;; owns exactly `share/story-query-keys` and preserves everything else.
+;; These pin that this writer applies the SAME boundary — it calls the same
+;; merge — so the two cannot drift about who owns what.
+
+(def ^:private third-party-search
+  "A `location.search` of the shape a host page hands the shell: two
+  params Story does not own, plus a stale Story key left by an earlier
+  push. `embed=1` is the concrete casualty rf2-gee8n was filed for."
+  "?from=index&embed=1&variant=story.old%2Fa")
+
+(deftest url-from-state-preserves-unowned-query-params
+  (testing "rf2-gee8n — unrelated params survive verbatim and in order,
+            ahead of the generated ones, while the stale Story key is
+            replaced by this state's value"
+    (is (= "/counter-with-stories/?from=index&embed=1&variant=story.new%2Fb#/stories"
+           (us/url-from-state
+             {:selected-variant :story.new/b}
+             {:pathname "/counter-with-stories/"
+              :search   third-party-search
+              :hash     "#/stories"})))))
+
+(deftest url-from-state-clears-every-stale-story-key
+  (testing "rf2-gee8n — the clear set is the whole vocabulary, not the
+            subset this state emits: a slot the shell leaves empty must
+            not leave a stale value standing for the hydrator to restore
+            (the omission hole rf2-b7je1 closed on the share builder)"
+    (let [stale {"variant"    "story.old%2Fa"
+                 "workspace"  "story.old%2Fws"
+                 "mode-tab"   "docs"
+                 "modes"      "Mode.app%2Fstale"
+                 "viewport"   "tablet"
+                 "background" "dark"
+                 "tag-filter" "stale"
+                 "overrides"  "%7B%3Afoo%201%7D"
+                 "substrate"  "uix"}
+          search (str "?"
+                      (str/join "&" (map #(str (name %) "=" (get stale (name %)))
+                                         share/story-query-keys))
+                      "&from=index&embed=1")
+          url    (us/url-from-state
+                   ;; Only `:selected-variant` populated — every other slot
+                   ;; is omitted by `share/build-params`.
+                   {:selected-variant :story.new/b}
+                   {:pathname "/p/" :search search :hash "#/stories"})]
+      (is (= (set (map name share/story-query-keys)) (set (keys stale)))
+          "the fixture carries a stale value for every key in the vocabulary")
+      (is (= "/p/?from=index&embed=1&variant=story.new%2Fb#/stories" url)
+          "every stale Story key is gone; both unowned params survive"))))
+
+(deftest url-from-state-no-bare-question-mark-when-query-empties
+  (testing "rf2-gee8n — clearing the last Story key off a search that held
+            nothing else leaves no dangling `?`; a bare `?` differs from
+            `location.search`'s empty string, so the watcher would push a
+            cosmetic history entry the shell can never match again"
+    (is (= "/p/#/stories"
+           (us/url-from-state {} {:pathname "/p/"
+                                  :search   "?variant=story.old%2Fa"
+                                  :hash     "#/stories"})))))
+
+(deftest url-from-state-and-share-builder-agree-on-ownership
+  (testing "rf2-gee8n — the two writers of this URL apply one boundary
+            because they call one merge: given the same base and the same
+            cell, the address-bar composer and the share-URL builder
+            produce the same string"
+    (let [pathname "/counter-with-stories/"
+          search   "?from=index&embed=1&substrate=uix"
+          hash     "#/stories"]
+      (is (= (share/variant-share-url
+               :story.new/b
+               (str pathname search hash)
+               {:substrate :reagent})
+             (us/url-from-state
+               {:selected-variant :story.new/b :substrate :reagent}
+               {:pathname pathname :search search :hash hash}))
+          "same base + same cell ⇒ same URL from either writer"))))
 
 ;; ---- url-relevant-slots-changed? ----------------------------------------
 


### PR DESCRIPTION
Closes rf2-gee8n.

## The defect

`re-frame.story.ui.url-state/url-from-state` composed the address-bar URL as
`(str pathname query-string-from-state hash)`, and its location snapshot
`current-location-shape` captured `{:pathname :hash}` only. `location.search` was
therefore discarded wholesale: the query was rebuilt from shell state alone, so
**every query param Story does not own was erased on the first state change after
mount** — the state-watcher pushes `url-from-state`'s output on every URL-relevant
change.

`embed=1` (rf2-pucku) is the concrete casualty. It is read once at mount by
`embed-flag-from-current-url` / `hydrate-embed-flag!` and seeded into
`[:chrome-visibility :embed?]`, so the running shell kept behaving correctly — but
the address bar no longer carried the flag, so copying the URL, or reloading after
any interaction, lost embed mode. Same for a referrer `from=` or anything a host
page appended. Live shell behaviour was unaffected; the loss showed on copy/paste
and reload.

## The repair: one boundary, not two

PR #8877 (rf2-b7je1) had just settled this question for the *other* writer of the
same URL. The share builder owns exactly the nine keys of `share/story-query-keys`,
clears all of them rather than the subset `build-params` happens to emit, and
deliberately preserves everything else — `embed=` included, because it is chrome
state that never round-trips.

Rather than restate that boundary in a second place, **both writers now call one
function**. `share/append-query-params` is promoted from private to the public
`share/apply-story-params`, and `url-from-state` merges through it against a
`{:pathname :search :hash}` location shape:

```clj
[shell {:keys [pathname search hash]}]
(share/apply-story-params
  (str (or pathname "") (or search "") (or hash ""))
  (share/build-params (params-from-state shell)))
```

Story owns exactly `story-query-keys` — set what this state populates, clear what
it omits, preserve everything else verbatim and in order — because there is one
implementation of that sentence rather than two that can drift.

Two consequences worth naming:

- **`apply-story-params` no longer emits a bare `?` for an empty query.** Clearing
  the last Story key off a search that held nothing else used to leave a dangling
  `?`, which differs from `location.search`'s empty string — the watcher would push
  a cosmetic history entry it could never match again. The empty-base 1-arity of
  `variant-share-url` still returns a bare query fragment with no leading `?`, which
  `variant-share-url-no-base` pins.
- **`query-string-from-state` is removed.** It built a canonical query with *no*
  preservation — a second ownership boundary sitting in the very file the first one
  was being repaired in — and nothing called it after this change.

The fix also removes a spurious history entry: on a mount from `?embed=1&variant=x`,
the composed URL now equals `location.search` already, so `push!`'s idempotence
check no-ops instead of pushing a shortened URL.

## Quality gates

Both arms were run against the **unfixed** source first, so the control is a real
red, not an assumed one. Every exit code below is the runner's own, captured with
`echo $?` on the same command line as the redirect — never a filtered pipeline and
never a harness-reported number.

| Gate | Route | Control (pre-fix) | Final base |
|---|---|---|---|
| `jvm-tools-story`, focused | `clojure -M:test -n ...` from `tools/story` | **exit 1**, 3 failures | **exit 0** |
| `jvm-tools-story`, full suite | `clojure -M:test` from `tools/story` | — | **exit 0**, 1881 tests / 6890 assertions |
| `cljs` job, compile | `node scripts/compile-node-test.cjs node-test out/node-test.js` | exit 0 | **exit 0**, 0 warnings |
| `cljs` job, run (focused) | `node out/node-test.js --test=...` | **exit 1**, 3 failures | **exit 0** |
| `cljs` job, run (full suite) | `node out/node-test.js` | — | **exit 0**, 11148 tests / 54845 assertions |
| clj-kondo | `--lint` on the four changed files | — | **0 errors** |

The `Final base` column was measured **after** the rebase onto the current trunk,
not before it. The branch originally sat on an older base, and four files under
`implementation/core/` had landed in the interval — that tree is on the
`:node-test` build's source paths, so the earlier CLJS green was evidence about a
tree that no longer existed. The rebase was clean, the diffstat unchanged (nothing
of anyone else's is reverted: no landed commit touches these four files), and both
gates were run again from scratch on the rebased tree. The recompile touched 982
files and the suite total moved from 11139 to 11148 tests, which is the trunk's own
new coverage arriving rather than anything of this branch's changing.

Route derivation, confirmed at source rather than taken on trust: `TESTING.md` and
`.github/workflows/test.yml` put the JVM half in the `jvm-tools-story` job
(`clojure -M:test` from `tools/story`, gated on the `tools_jvm` surface, which
`.github/scripts/report-changed-surfaces.sh` arms for `tools/story/src/*` and
`tools/story/test/*`). The CLJS half rides the consolidated `:node-test` build —
`implementation/shadow-cljs.edn` carries `../tools/story/test` on its
`:source-paths`, and the `cljs-test$` `:ns-regexp` matches
`re-frame.story.ui.url-state-cljs-test`. The compound `test:cljs` script was split
into its compile and run halves so both verdicts stayed in the foreground; the run
half narrows by namespace at runtime, which the compile script's own header
documents as the safe alternative to `--config-merge` against a shared build id.

The control's red named the defect directly rather than merely failing:

```
expected: "/counter-with-stories/?from=index&embed=1&variant=story.new%2Fb#/stories"
  actual: "/counter-with-stories/?variant=story.new%2Fb#/stories"
```

and on the CLJS arm, read back through the real `URLSearchParams`:

```
embed=1 survives — chrome state the shell reads at every mount
expected: (= "1" (.get usp "embed"))
  actual: (not (= "1" nil))
```

**Sabotage run.** With the tree green and committed, one line of the *shared* merge
was planted (`(when qidx` becomes `(when false`, removing preservation). The result
is the evidence for the central claim of this PR: **9 failures across both writers'
suites at once** — `url_state_test.cljc` (rf2-gee8n) and `story_share_test.clj`
(rf2-b7je1) — from a single-line change to one function. The agreement test did
*not* fail, which is correct and is the point: both writers degraded identically,
because there is only one boundary left to degrade. The plant was restored and the
restore verified by git **blob** hash against the committed object rather than by
reading a diff: working file, committed object and pre-plant value all agree.

That both gates read *this* worktree rather than a sibling's is established two
ways: the shadow-cljs compile prints its config path, which named this checkout, and
the control red names tests that exist only on this branch — a run that had wandered
into another checkout would have come back green.

## Tests

JVM (`.cljc`, so these also ride the CLJS build):

- `url-from-state-preserves-unowned-query-params` — unrelated params survive
  verbatim and in order, ahead of the generated ones, while a stale Story key is
  replaced.
- `url-from-state-clears-every-stale-story-key` — the clear set is the whole
  vocabulary, not the subset this state emits (the omission hole rf2-b7je1 closed on
  the builder), driven off a fixture built from `share/story-query-keys` itself.
- `url-from-state-no-bare-question-mark-when-query-empties` — the dangling-`?`
  regression guard. This one *passed* pre-fix, because the old composer discarded
  the search entirely; it guards the repair rather than witnessing the bug.
- `url-from-state-and-share-builder-agree-on-ownership` — same base, same cell, same
  string from either writer.
- `url-from-state-includes-every-populated-slot` — carries forward the slot coverage
  the removed `query-string-from-state` tests provided.

CLJS, where the defect is only fully observable, since `params->getter` and
`embed-flag-from-current-url` both read through first-value `.get` semantics that a
string assertion cannot model:

- `url-from-state-preserves-unowned-params-through-urlsearchparams` — reads the
  composed URL back through the real `URLSearchParams`: unowned params present with
  their values, `embed` truthy, exactly one `variant`, zero occurrences of every
  other Story key, and `share/parse-params` restoring the requested cell and nothing
  stale.
- `url-from-state-consumes-a-browser-shaped-location` — drives the composer from a
  real `js/URL`'s `pathname` / `search` / `hash`, the same accessors with the same
  `?` / `#` conventions `current-location-shape` reads off `window.location`.

## Notes

- No spec change. The share invariant is already stated normatively and the code was
  what disagreed with it; `spec/*.md` is untouched.
- `current-location-shape` is private and reads the live `window.location`, so it is
  the one line covered by inspection rather than by assertion. The `js/URL`-driven
  test exercises the exact triple it produces.
- `url-state`'s `clojure.string` require is now scoped to `:cljs`. With
  `query-string-from-state` gone the pure half does no string work of its own, and
  the alias survives only for `embed-flag-from-current-url` inside the
  `#?(:cljs ...)` block; clj-kondo reported the unscoped require as unused on the
  JVM side. The one remaining warning on these files, an unused `w` binding in
  `parse-current-url-or-empty`, is pre-existing — it reproduces on the trunk
  revision this branch left.
- Reordering caveat, benign: where the current URL is `?variant=x&embed=1`, the
  merge returns `?embed=1&variant=x`, unowned params leading. The values are
  identical and the watcher only composes when a URL-relevant slot has already
  changed, so no extra history entry results.
