### PR TITLE
docs(method): the draft interlock fails in both directions

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -515,6 +515,33 @@ commit guard both have, and the reason they hold. The rejected alternative, havi
 worker liveness before every merge, works but must be remembered on every merge forever, and it
 re-introduces exactly the worktree-activity sweep the merge loop deliberately does not do.
 
+**But the flag is only as good as the author eventually setting it, and it fails in BOTH
+directions.** Both were measured in one session, and neither is visible from the change.
+
+**Stale-OPEN — a fix dispatch inherits a flag somebody else already set.** A fix worker goes onto an
+EXISTING change whose original author finished and marked it ready, so the flag is set before the
+second worker arrives and nothing in the change records that anyone is inside it now. The merge loop
+reads a ready change, the criterion passes, and the merge lands under a live worker — the exact
+failure the flag exists to prevent, arriving by the one path where the flag was never the current
+worker's to set. Measured here; nothing was lost, because the commits that went green were the ones
+that landed, but that was timing rather than protection. So on a fix dispatch the flag is stale by
+construction, and the only record that a second worker is there is the mayor's dispatch ledger.
+
+**Stuck-CLOSED — an author goes silent holding a green draft.** Both remedies above assume the author
+answers: wait for the ready mark, or message them. Measured here: three workers registered as
+*running* while idle for over an hour — no writes, tips unmoved, worktrees clean, everything pushed —
+two of them holding drafts, one reading exactly at band with nothing non-terminal and nothing failing.
+Direct messages went unanswered for half an hour. A finished change is then blocked by an interlock
+whose protected party may no longer exist, and the fleet loses the slot as well as the change.
+
+**Do not answer that by flipping the flag on an inference.** *It looks done* is the proxy the reaping
+rules refuse one surface over, and every reason the paragraph above rejects a per-merge liveness check
+still holds. What differs is scope: this is a rare exception path — one otherwise-mergeable draft whose
+author has stopped — rather than a test on every merge. Settle it the way reaping is settled, by a read
+rather than an inference: the agent's own report, or the operator's decision to stop that agent, which
+settles liveness by making it false. Until one of those arrives the change waits, and the honest report
+says a finished change is stranded and why.
+
 ---
 
 ## Pasting a block
@@ -1006,7 +1033,9 @@ moved most. In the dominant toolchain that is the three-dot form, `<TRUNK>...HEA
 - Worktree cleanup deleting *through* a link into the shared tree it points at → the worker unlinks before reporting
   done, and the cleanup path disarms before removing.
 - A change merged out from under a worker still working on it → it is published as a draft and marked ready
-  only as the author's last act, which the host enforces by refusing to merge a draft.
+  only as the author's last act, which the host enforces by refusing to merge a draft. **Except on a fix
+  dispatch, where the flag was already set by somebody else and protects nothing** — and the same flag
+  strands a finished change when its author goes silent. Both are under *Publishing the change*.
 - "Green locally" merged into a red CI gate → gate the transitive surface; merge on CI, not on the hand-off; a real
   failure gets a fix worker, never an override.
 - A passing synthetic test that routes around the real bug → reproduce the actual failing path.


### PR DESCRIPTION
Found by the method-reread loop, checking a rule I had been *enforcing* all session against what the tree actually does — not by re-reading unchanged prose. Nothing had landed in the method tree since my own last two commits, so the pass went entirely to enforcement.

**The gap, and the doc half-names it already.** `loops.md` conditions the merge loop's draft rule on *"for as long as that author is alive"* — a phrase that admits the author might not be, while the section gives no test for that liveness and no branch for when it fails. That is precisely the category this loop is told to hunt: a hazard recorded without its discriminating test.

`## Publishing the change` is where the interlock is justified, and it justifies it well: the draft flag is enforced where it cannot be forgotten, and a per-merge mayor-side liveness check is explicitly rejected as something that must be remembered forever and re-introduces the worktree-activity sweep the merge loop deliberately avoids. All still true. What was missing is that **the flag's guarantee depends on the author eventually setting it**, and one session measured that failing in both directions.

**Stale-OPEN.** A fix dispatch goes onto an *existing* change whose original author finished and marked it ready. The flag is set before the second worker arrives, and nothing in the change records that anyone is inside it now. The merge loop reads a ready change, the criterion passes, and the merge lands under a live worker — the exact failure the flag exists to prevent, arriving by the one path where the flag was never the current worker's to set. It happened here on PR #8873. Nothing was lost, because the commits that went green were the ones that landed, but that was timing rather than protection.

**Stuck-CLOSED.** Both documented remedies assume the author answers: wait for the ready mark, or message them. Measured here: three workers registered as *running* while idle for over an hour — no writes, tips unmoved, worktrees clean, everything pushed — two of them holding drafts, one reading exactly at band with nothing non-terminal and nothing failing. Direct messages went unanswered for half an hour. A finished change is then blocked by an interlock whose protected party may no longer exist, and the fleet loses the slot as well as the change. (Filed separately as an operational item for the operator; the doc change here is the general rule, not that incident.)

**What the addition deliberately does NOT say.** It does not license flipping the flag. *It looks done* is the proxy the reaping rules refuse one surface over, and every reason this section rejects a per-merge liveness check still holds. The distinction drawn instead is one of **scope** — a rare exception path, one otherwise-mergeable draft whose author has stopped, rather than a test on every merge — and the resolution is the same shape reaping uses: a read, not an inference. Either the agent's own report, or the operator's decision to stop that agent, which settles liveness by making it false. Until then the change waits and the report says so.

Also corrected: the sibling entry in `## Failure modes these shapes close`, which asserted the protection unconditionally. Leaving it would have been the *"bounded repair bounds the change, not the search"* failure the method-reread loop records against itself — a repair that leaves an identical sibling standing for the next pass to find.

## Quality gates

- `python scripts/check_doc_slugs.py` — **exit 0** on the final base. This is the covering gate and the only anchor gate for this path: `docs/the-mayor-method/` is inside `docs_dir`, but `mkdocs build --strict` grades a missing anchor at INFO and `--strict` promotes WARNING, not INFO.
  - **Control (the deliverable):** the cross-reference this change adds, broken → **exit 1**, naming `docs\the-mayor-method\dispatch-prompt-template.md:1038 -> #no-such-anchor-planted-control`. Match count read as 1 before planting; the planted blob (`b88a590e…`) differed from the pre-plant blob, so it applied rather than silently no-opping. The fault existed only in this worktree, so the red is also the proof the gate read this tree.
  - **Restore verified by blob hash, not by reading a diff:** working file `c261e8a0a67882b7c50d836021d0e356b9edd6a0` == the committed object. Gate re-run after restore: **exit 0**.
- `python scripts/check_readme_links.py --ci` — **exit 0**. Not the covering gate for this path; run to confirm nothing else moved.
- **By hand:** prose only, one file. No fenced blocks changed — which matters here specifically, since `docs/the-mayor-method/` is one of the two trees where a doc link *inside* a fence is itself reported. No headings added or renamed, no tables, no anchors introduced beyond the one italicised section reference.

Authored in a mayor-occupied worktree, as the guard requires — the mayor checkout's pre-commit hook refuses non-tracker surfaces, and that refusal is the guard working.
