### PR TITLE
test(http): fix the supersede flake and the solo-ordering privacy failure (rf2-o9e15, rf2-zvbm9)

### DIFF
--- a/implementation/http/test/re_frame/http_privacy_integration_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_integration_test.clj
@@ -5,13 +5,23 @@
   Exercises the real :rf.http/managed dispatch path against an in-process
   HTTP server and asserts the emitted trace events on the trace bus are
   correctly redacted / stamped per the per-call, per-request, and
-  handler-meta sensitivity sources."
+  handler-meta sensitivity sources.
+
+  The schemas artefact is a test-only dep here, so requiring it binds the
+  shared walker hooks (`:schemas/extract-sensitive-paths-from-schema` etc.)
+  — the same load-bearing require the sibling `re-frame.http-privacy-body-test`
+  carries. Without it `privacy-body/decode-schema-marks` finds the hook
+  unbound, returns no marks, and every `:decode`-schema-classified assertion
+  below reads its secret back VERBATIM (rf2-zvbm9)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
             [re-frame.registrar :as registrar]
             [re-frame.http.managed :as http-managed]
+            ;; load-bearing: binds the shared schema walker hooks the
+            ;; `:decode`-schema redaction/elision path late-binds (rf2-zvbm9).
+            [re-frame.schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])

--- a/implementation/http/test/re_frame/http_reply_lowering_test.clj
+++ b/implementation/http/test/re_frame/http_reply_lowering_test.clj
@@ -77,6 +77,35 @@
      #(let [db (rf/app-db-value :rf/default)] (when (pred db) db))
      {:timeout-ms timeout-ms :label "http-reply-lowering"})))
 
+(defn- start-held-server!
+  "Start the test server with every exchange HELD until `release` is counted
+  down, then answering `200 {\"v\":1}`. The supersession tests below use it.
+
+  This is what makes a supersede DETERMINISTIC (rf2-o9e15).
+  `registry/supersede!` supersedes only a request that is still IN FLIGHT: it
+  reads the in-flight registry, and a request clears its own slot the moment
+  it finalises. A test that issues #1 and then #2 therefore supersedes
+  NOTHING unless #1 is still unfinished when #2 is issued — and over loopback
+  #1's entire round trip can complete inside the gap between two
+  `dispatch-sync` calls, which is precisely what a loaded runner makes
+  likely. Holding the response until the TEST releases it removes that race
+  by construction: #1 cannot finalise before #2 is issued, because its reply
+  has not been written yet. This is a property of the ordering, not of how
+  fast the machine happens to be, so no bound is being relied on.
+
+  The write is guarded: the superseded request's transport future is
+  cancelled by the supersede itself, so its connection may already be gone by
+  the time this thread is released. A broken pipe there is the expected
+  outcome of a correct supersede, not a failure — and letting it escape would
+  kill the single dispatcher thread before the SURVIVING request is served."
+  [^java.util.concurrent.CountDownLatch release]
+  (start-server!
+    (fn [^HttpExchange ex]
+      (try (.await release 30 java.util.concurrent.TimeUnit/SECONDS)
+           (catch InterruptedException _ nil))
+      (try (write-response! ex 200 "application/json" "{\"v\":1}")
+           (catch java.io.IOException _ nil)))))
+
 ;; ===========================================================================
 ;; Group 1 — the CANONICAL reply map (pure).
 ;; ===========================================================================
@@ -503,24 +532,21 @@
 
 (deftest supersede-suppresses-prior-app-reply
   (testing "a same-:request-id supersede suppresses the FIRST request's :on-failure app target"
-    ;; A slow server keeps request #1 in flight; issuing request #2 with the
+    ;; A held server keeps request #1 in flight; issuing request #2 with the
     ;; same :request-id supersedes #1. Per Spec 014 §`:request-id` (internal)
     ;; the superseded request's reply is trace-only — its app target MUST NOT
     ;; fire. #2 completes normally and IS delivered.
-    (let [gate (java.util.concurrent.CountDownLatch. 1)
-          srv  (start-server!
-                 (fn [^HttpExchange ex]
-                   ;; Block the FIRST connection until the gate opens; the
-                   ;; SECOND request opens the gate so both eventually drain.
-                   (.countDown gate)
-                   (try (.await gate 2 java.util.concurrent.TimeUnit/SECONDS)
-                        (catch InterruptedException _ nil))
-                   (write-response! ex 200 "application/json" "{\"v\":1}")))
+    (let [release (java.util.concurrent.CountDownLatch. 1)
+          replied (java.util.concurrent.CountDownLatch. 1)
+          srv     (start-held-server! release)
           replies (atom [])]
       (try
         (rf/reg-event :search/replied
           (fn [{:keys [db]} [_ payload]]
             (swap! replies conj payload)
+            ;; The delivered reply IS the completion signal — count it down
+            ;; here rather than sampling a clock for it (rf2-o9e15).
+            (.countDown replied)
             {:db db}))
         (rf/reg-event :search/go
           (fn [_ _]
@@ -530,15 +556,15 @@
                     :decode     :json
                     :on-success [:search/replied]
                     :on-failure [:search/replied]}]]}))
-        ;; Fire #1, then #2 (supersedes #1). dispatch-sync drains each event.
+        ;; Fire #1, then #2 (supersedes #1). dispatch-sync drains each event,
+        ;; and the held server guarantees #1 is still in flight for #2 to
+        ;; supersede — see `start-held-server!`.
         (rf/dispatch-sync [:search/go])
         (rf/dispatch-sync [:search/go])
-        ;; Open the gate so any in-flight transport drains, then wait for at
-        ;; least one delivered reply.
-        (.countDown gate)
-        (test-support/poll-until
-          #(when (seq @replies) true)
-          {:timeout-ms 5000 :label "supersede"})
+        ;; Release both exchanges, then wait on the reply handler's own latch.
+        (.countDown release)
+        (is (.await replied 30 java.util.concurrent.TimeUnit/SECONDS)
+            "the surviving request's app reply was delivered")
         (Thread/sleep 200) ;; quiescence window for any (wrongly) delivered #1 reply
         ;; The superseded request #1's app target is NOT dispatched: exactly
         ;; one delivered reply (request #2's), never the supersede of #1.
@@ -546,24 +572,25 @@
             "only the surviving request's reply is delivered; the superseded one is suppressed")
         (is (= :ok (:status (first @replies)))
             "the surviving reply is request #2's canonical :status :ok success")
-        (finally (stop-server! srv))))))
+        (finally
+          (.countDown release)
+          (stop-server! srv))))))
 
 (deftest supersede-distinct-work-ids-and-canonical-stale-trace
   (testing "rf2-azcmd3 — superseded + superseding attempts have DISTINCT :work/id, and the superseded one records a canonical :status :stale / :rf.reply/work-status :suppressed reply-envelope trace with carried/current correlation; only the new app reply fires"
-    (let [gate    (java.util.concurrent.CountDownLatch. 1)
-          srv     (start-server!
-                    (fn [^HttpExchange ex]
-                      (.countDown gate)
-                      (try (.await gate 2 java.util.concurrent.TimeUnit/SECONDS)
-                           (catch InterruptedException _ nil))
-                      (write-response! ex 200 "application/json" "{\"v\":1}")))
+    (let [release (java.util.concurrent.CountDownLatch. 1)
+          replied (java.util.concurrent.CountDownLatch. 1)
+          srv     (start-held-server! release)
           replies (atom [])
           traces  (atom [])
           lid     ::supersede-stale]
       (try
         (trace/register-listener! lid (fn [ev] (swap! traces conj ev)))
         (rf/reg-event :search/replied
-          (fn [{:keys [db]} [_ payload]] (swap! replies conj payload) {:db db}))
+          (fn [{:keys [db]} [_ payload]]
+            (swap! replies conj payload)
+            (.countDown replied)
+            {:db db}))
         (rf/reg-event :search/go
           (fn [_ _]
             {:fx [[:rf.http/managed
@@ -572,37 +599,33 @@
                     :decode     :json
                     :on-success [:search/replied]
                     :on-failure [:search/replied]}]]}))
-        ;; #1 (issuance 1) goes in flight; #2 (issuance 2) supersedes it.
+        ;; #1 (issuance 1) goes in flight; #2 (issuance 2) supersedes it. The
+        ;; held server is what guarantees #1 is STILL in flight when #2 is
+        ;; issued — see `start-held-server!`.
         (rf/dispatch-sync [:search/go])
         (rf/dispatch-sync [:search/go])
-        (.countDown gate)
-        ;; Wait on the SIGNAL, not the clock (rf2-xagmz). The supersede is a
-        ;; real async round-trip: transport reply → reply lowering → app
-        ;; dispatch → stale-suppression trace. `poll-until` returns the
-        ;; instant the pred below is truthy — a delivered app reply AND the
-        ;; superseded attempt's `:rf.http/stale-suppressed` trace row have
-        ;; both landed. So the wait is bounded by the supersede signal, never
-        ;; a fixed sleep; the `:timeout-ms` is a pure backstop that fires only
-        ;; if the signal genuinely never arrives (a real regression). The old
-        ;; 5 s backstop was comfortable idle but marginal under this machine's
-        ;; six concurrent worker agents (each running shadow-cljs + JVM +
-        ;; Chromium) and a loaded CI runner — the async supersede landed
-        ;; AFTER the window, timing the machine, not the canonicalisation
-        ;; (it redded unrelated PRs, e.g. #6817). A generous, load-tolerant
-        ;; bound makes that false timeout unreachable while still failing
-        ;; fast on a genuinely stuck supersede. The probe interval is gentled
-        ;; so the poll itself adds little contention on a saturated JVM.
-        (test-support/poll-until
-          (fn []
-            (when (and (seq @replies)
-                       (some (fn [ev] (= :rf.http/stale-suppressed (:operation ev))) @traces))
-              true))
-          {:timeout-ms 30000 :interval-ms 25 :label "supersede-stale"})
-        (Thread/sleep 200)
-        ;; Exactly one DELIVERED app reply — request #2's; #1 suppressed.
-        (is (= 1 (count @replies))
-            "only the surviving request's app reply is delivered")
-        ;; The superseded attempt records a canonical stale reply-envelope row.
+        ;; NO WAIT HERE, and that is the point (rf2-o9e15). The supersede is
+        ;; SYNCHRONOUS with the dispatch above: `managed-handler` calls
+        ;; `registry/supersede!` and then `emit-superseded-stale-trace!`
+        ;; inline, in the fx phase, before `dispatch-sync` returns. The row
+        ;; below has therefore already landed and can simply be ASSERTED.
+        ;;
+        ;; This replaces a `poll-until` that waited up to 30 s for it, and the
+        ;; distinction matters because that wait could not be repaired by
+        ;; lengthening it. The bound had already been raised once, 5 s → 30 s,
+        ;; on the theory that "the async supersede landed AFTER the window"
+        ;; (it redded unrelated PRs, e.g. #6817); 30 s then timed out too, at
+        ;; :elapsed-ms 30022 on PR #8873, a routing-only diff that cannot
+        ;; reach this code path. The theory was wrong. The trace was never
+        ;; LATE — on the losing interleaving it is never emitted at all:
+        ;; `registry/supersede!` returns nil when nothing is in flight under
+        ;; the request-id, and request #1, unheld, could finish its whole
+        ;; loopback round trip in the gap between the two `dispatch-sync`
+        ;; calls. Both requests then delivered replies and no supersede ever
+        ;; happened, so the poll sat out its full backstop waiting for a row
+        ;; that could not arrive. No timeout is large enough for an event that
+        ;; is never emitted, which is why holding the server — establishing
+        ;; the precondition rather than timing the machine — is the repair.
         (let [stale (filter #(= :rf.http/stale-suppressed (:operation %)) @traces)]
           (is (= 1 (count stale)) "exactly one stale-suppression row for the superseded attempt")
           (let [tags (:tags (first stale))]
@@ -619,7 +642,22 @@
                       (:work/id (:rf.reply/current tags))))
             ;; The canonical join key reads the carried (superseded) work-id.
             (is (= [:rf.work/http :search 1 1] (:rf.reply/work-id tags)))))
+        ;; The surviving request's APP REPLY is the one genuinely async step
+        ;; (transport reply → reply lowering → app dispatch), and it publishes
+        ;; its own completion: the reply handler counts the latch down. So this
+        ;; waits on the event itself rather than sampling app-db on a timer.
+        ;; The bound is a deadlock guard, not a budget — the latch is released
+        ;; by the delivery, so a run either passes in milliseconds or is a real
+        ;; regression in which the reply never arrives.
+        (.countDown release)
+        (is (.await replied 30 java.util.concurrent.TimeUnit/SECONDS)
+            "the surviving request's app reply was delivered")
+        (Thread/sleep 200) ;; quiescence window for any (wrongly) delivered #1 reply
+        ;; Exactly one DELIVERED app reply — request #2's; #1 suppressed.
+        (is (= 1 (count @replies))
+            "only the surviving request's app reply is delivered")
         (finally
+          (.countDown release)
           (trace/unregister-listener! lid)
           (stop-server! srv))))))
 


### PR DESCRIPTION
Two defects in `implementation/http`'s test lane, both about the suite failing to establish or observe state deterministically. They turned out to have **independent root causes** — the shared shape is real but the mechanisms do not overlap, and neither repair helps the other.

Test-only change. No production source touched, no assertion weakened, no spec change.

## rf2-o9e15 — the supersede flake

`supersede-distinct-work-ids-and-canonical-stale-trace` timed out intermittently with `poll-until timed out — supersede-stale`, redding PRs whose diffs cannot reach the code under test (http takes routing as a `:local/root`, so a routing-only change schedules this job; PR #8873 cost a diagnosis dispatch at `:elapsed-ms 30022`).

**The recorded theory was wrong, which is why raising the bound had not worked.** The test's own comment said "the async supersede landed AFTER the window", and the backstop had already been raised once on that theory, 5 s to 30 s. Measured here instead:

1. **The stale-suppression trace is not async at all.** `managed-handler` calls `registry/supersede!` and then `transport/emit-superseded-stale-trace!` inline in the fx phase, so the row has already landed before the second `dispatch-sync` returns. Probed: present with *zero* wait.

2. **On the losing interleaving it is never emitted.** `supersede!` supersedes only a request still *in flight*; it returns `nil` when the registry slot is already cleared. The test's gate — a `CountDownLatch(1)` whose first act inside the handler is its own `.countDown`, leaving the following `.await` to return immediately — never held anything, so request #1 was free to finish its whole loopback round trip in the gap between the two `dispatch-sync` calls. Two app replies get delivered, no supersede ever happens, and the poll sits out its full backstop waiting for a row that cannot arrive.

So this was never lateness. **No timeout is large enough for an event that is never emitted**, which is why this does not raise the bound a third time.

**The repair establishes the precondition instead of timing it.** A new `start-held-server!` holds every exchange until the test releases it, so #1 cannot finalise before #2 is issued and the supersede becomes a property of the ordering rather than of machine speed. The stale row is then simply *asserted* — no wait at all — and the one genuinely async step, the surviving request's app reply, is awaited on a `CountDownLatch` the reply handler itself counts down rather than by sampling app-db on a timer. Its 30 s bound is a deadlock guard, not a budget: the latch is released by the delivery itself.

`supersede-suppresses-prior-app-reply` carried the identical no-op gate and the identical latent race (its `(= 1 (count @replies))` fails the same way, and did so under the probe); it moves to the same harness.

**Product finding: none.** The bead left open whether the timeout indicated real contention in the supersede path. It does not — the supersede path is correct and synchronous; the test simply was not exercising it when the race was lost. The one seam worth recording is that the superseded attempt's *transport* completion has no observable completion signal a test can await, which is why the repair holds the server rather than awaiting the abort.

## rf2-zvbm9 — the privacy namespace run alone

`clojure -M:test -n re-frame.http-privacy-integration-test` failed four tests that are green in the full-suite ordering — three asserting a `:decode`-schema `{:sensitive? true}` slot is redacted, one asserting a `{:large? true}` slot is elided — with the secrets riding **verbatim** (a bearer secret at `[:tags :value :token]`).

Root cause, measured at source rather than inferred: `privacy-body/decode-schema-marks` reaches the walker through the late-bind hooks `:schemas/extract-sensitive-paths-from-schema` and `:schemas/extract-large-paths-from-schema`, which `re-frame.schemas` publishes at **namespace load**. `extract-paths` returns an empty map when the hook is unbound, so an unloaded schemas artefact does not error — it silently classifies nothing. Probed directly under this namespace's own require set: hook unbound, no marks; after requiring `re-frame.schemas` the same schema yields the expected `[:token]` sensitive mark. In the full suite the alphabetically earlier `re-frame.http-privacy-body-test` — which already carries this require, commented "load-bearing" — bound the hooks first.

The repair is the one that sibling namespace already models: declare the dependency here too. **Nothing in core is touched deliberately**: the core reset fixture must not load an optional artefact, since the whole point of the late-bind seam is that core does not depend on schemas. No assertion was weakened — these pin that secrets are redacted, and making them laxer would convert a test-ordering defect into a silent privacy hole.

Note that CI only ever runs the full-suite ordering, which is why this stayed invisible.

## Quality gates

Covering gate derived, not taken on faith: **`jvm-http`** in `.github/workflows/test.yml` (`clojure -M:test`, `working-directory: implementation/http`, surface-gated on `implementation_jvm`). That is the full-suite ordering. The solo-namespace ordering is not run by CI, so it is reported here explicitly. Both orderings were run; every exit code below was captured with the redirect and `echo $?` on one command line and is quoted from that file, never from a harness report.

All figures below are from the **final rebased base**, re-run after the rebase rather than carried over from before it.

| Gate | Ordering | Exit | Result |
|---|---|---|---|
| `clojure -M:test` (= `jvm-http`) | full suite | **0** | 508 tests, 3883 assertions, 0 failures, 0 errors |
| `clojure -M:test -n re-frame.http-privacy-integration-test` | solo | **0** | 20 tests, 49 assertions, 0 failures, 0 errors |
| `clojure -M:test -n re-frame.http-reply-lowering-test` | solo | **0** | 25 tests, 137 assertions, 0 failures, 0 errors |

No markdown changed, so neither documentation link gate applies to this diff.

### Controls

**rf2-zvbm9 — clean red-to-green, both orderings deterministic.** On the untouched base: solo **exit 1** (20 tests, 3 failures, 1 error, secrets verbatim); full suite **exit 0** (508 tests, 3881 assertions). After the fix: solo **exit 0**, full suite still **exit 0**. The probe underwriting the diagnosis was exercised in both directions in one run — unbound hook yielding no marks, then bound hook yielding the expected mark — so its "nothing here" answer was checked against an input it should flag.

**rf2-o9e15 — a flake cannot be proved gone by a green run, so the evidence is stated in tiers.**

*Strongest (a demonstration that the old wait could time out and the new one cannot).* The same perturbation — a planted 300 ms pause widening the gap between the two `dispatch-sync` calls — was applied to both structures:

| Structure | Same planted 300 ms gap | Exit | Detail |
|---|---|---|---|
| old (`poll-until`, no-op gate) | planted | **1** | `poll-until timed out — supersede-stale`, `:elapsed-ms 30017`, 0 failures / 1 error, ~37 s wall |
| new (held server + latch) | planted | **0** | 25 tests, 137 assertions, ~8 s wall |

The old structure reproduces the production failure *deterministically*, with the same error, the same category and the same full-backstop elapsed time CI reported (30017 against 30022). The new structure is unaffected by the exact condition that reds the old one.

*Argument.* The stale row is no longer waited for at all — a 30 s timed wait became a synchronous assertion — and the remaining wait is on a latch released by the reply handler itself.

*Weak (repeated runs, reported as such).* Five consecutive solo runs of the namespace: exit 0 each, 137 assertions each — a stable count, so no run was cut short by an early exception.

**Sabotage control.** A wrong expectation planted at `http_reply_lowering_test.clj:640` drove **exit 1**, with the failure naming the planted value at the planted line. That fault existed only in this branch's checkout, so the red also establishes the gate read this tree rather than a sibling's — a wandering run would have come back green.

**Restores verified by git blob hash, not by reading a diff.** The pre-plant blob was restored byte-identically after each of the two plants, working tree clean, zero residual plant markers. One plant anchor initially matched **zero** lines after a `git checkout` restored CRLF endings; the match count was read before spending a run, and the anchor was made line-ending-aware rather than the miss being taken for a clean tree.

Closes rf2-o9e15. Closes rf2-zvbm9.
