### PR TITLE
docs(method): give the line-ending anchor bullet its measurement

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -969,7 +969,11 @@ restore. Five cautions on the plant itself:
   carriage return sits between the text and the line ending. This defeats a single-line anchor as
   readily as a multi-line one, so the caution above does not cover it. **Read the match count
   before you run the gate**: zero is unambiguous and free, where the hash convicts a no-op plant
-  only after a whole run has been spent.
+  only after a whole run has been spent. Measured, and it is the CHECK rather than the hazard that
+  the measurement is of: a worker's plant matched zero lines because an intervening checkout had
+  restored the translated endings, and the match count caught it before a run was spent. Note what
+  that implies about timing — the endings can change under you *between* one plant and the next, so
+  the count is read per plant rather than once per session.
 * **A hash proves the SOURCE changed, not that the runtime ever saw it.** One plant applied
   genuinely — the hashes differed — but the file was not in the build's module graph, so the
   watcher served the pre-plant compile and the witness came back green. A green sabotage run is


### PR DESCRIPTION
Found by the method-reread loop, checking a rule I have been *enforcing* against what the tree actually does. Only my own two commits had landed in this tree since the last pass, so the pass went entirely to enforcement — and the drift turned out to be mine.

**The category is one the loop names explicitly: a block diverged from what gets pasted.** The gate-mechanics block travels verbatim into every editing dispatch, and the page permits *adding* to it — "verbatim forbids WEAKENING a block, not adding to it… add whatever caution the lane needs". I had been doing exactly that: recent dispatches carried a CRLF measurement on the line-ending anchor bullet that the document itself did not have. Permitted, useful, and it quietly opened a gap between the canonical text and the text workers actually receive. Left alone it widens, because each paste starts from the document and each addition is made afresh.

**The measurement is worth folding in rather than dropping, and the reason is what kind of measurement it is.** The bullet already described the hazard — a carriage return sits between the text and the line ending, so an end-of-line anchor matches nothing — and already prescribed the remedy: read the match count before running the gate. What it lacked was evidence that the remedy *works*. A worker's plant matched zero lines because an intervening checkout had restored the translated endings, and the match count caught it before a whole gate run was spent. That is a measurement of the CHECK biting, not of the hazard merely existing, which is the stronger of the two and the one that makes a reader actually do it.

**And it carries a timing consequence the bullet did not state.** The endings changed *between* plants, under a worker that had already planted successfully once. So the count is read per plant rather than once per session — which is not obvious from a bullet that reads as a property of the file rather than of the moment.

**Bounded in change, not in search.** One bullet, one addition. I checked for siblings: the other cautions I have been adding to dispatches (the backtick-eats-terms trap, the `-e` alias trap) live in brief *body* text rather than inside a pasted block, so they are not divergences of this kind — the backtick one concerns writing tracker notes rather than running gates, and belongs nearer the tracker mechanics if it belongs in the method at all.

## Quality gates

- `python scripts/check_doc_slugs.py` — **exit 0** on the final base. This is the covering gate and the only anchor gate for this path: `docs/the-mayor-method/` sits inside `docs_dir`, but `mkdocs build --strict` grades a missing anchor at INFO and `--strict` promotes WARNING, not INFO.
  - **Control (the deliverable):** a broken anchor planted at a line this change adds → **exit 1**, naming `docs\the-mayor-method\dispatch-prompt-template.md:976 -> #no-such-anchor-planted-control`. Match count read as 1 before planting; the planted blob (`aded8f26…`) differed from the pre-plant blob, so it applied rather than silently no-opping. The fault existed only in this worktree, so the red is also proof the gate read this tree.
  - **Restore verified by blob hash:** working file `eaf676317ee98d0f70450c8fa598930fcaaeedc3` == the committed object. Gate re-run after restore: **exit 0**.
  - Worth noting given the subject: this control is itself an instance of the bullet's advice — the match count was read before the run, and had it come back zero the plant would have been known bad for free.
- **By hand:** prose only, one file, one bullet inside an existing list. No fenced blocks changed — which matters in this tree specifically, since `docs/the-mayor-method/` is one of the two trees where a doc link *inside* a fence is itself reported. No headings, no tables, no anchors introduced beyond the planted-and-removed control.

Authored in a mayor-occupied worktree, as the guard requires — the mayor checkout's pre-commit hook refuses non-tracker surfaces, and that refusal is the guard working.
