### PR TITLE
fix(skills): give the issue-filing recipe one concrete path both tools can address (rf2-2zkrz)

### DIFF
--- a/scripts/check_skill_mcp_drift.py
+++ b/scripts/check_skill_mcp_drift.py
@@ -767,6 +767,192 @@ def check_title_safety_rules(
 
 
 # ---------------------------------------------------------------------------
+# Body-path-identity axis (rf2-2zkrz).
+#
+# The title-safety axis above proves a filing recipe SAYS `--body-file`. It
+# says nothing about whether the path handed to `--body-file` can ever name
+# the file `Write` created — and for a year it could not. Both recipes gave
+# the temp path only as a shell expression
+# (`${TMPDIR:-/tmp}/re-frame2-issue-$$-$RANDOM.md` on POSIX,
+# `$env:TEMP\re-frame2-issue-$([guid]::NewGuid()).md` on Windows), and:
+#
+#   - `Write` is not a shell. It stores `file_path` literally, so the
+#     expression became part of the FILENAME rather than being replaced.
+#   - Even in a shell, `$$`/`$RANDOM`/`NewGuid` re-roll on every evaluation,
+#     so the `gh` step named a DIFFERENT file than the `Write` step. Measured
+#     on the fixing branch: three evaluations of the one POSIX expression
+#     produced three distinct paths, and the Windows expression is not even
+#     parseable by the `Bash(gh issue *)` shell the skills grant (syntax
+#     error near `)`).
+#
+# So the invariant is path IDENTITY as concrete strings, and it is
+# structural, not prose: every `--body-file` ARGUMENT in a filing recipe must
+# be one concrete absolute path carrying no expansion syntax, and that exact
+# string must also appear elsewhere in the recipe — the `Write` example it is
+# supposed to reuse. Prose that merely NAMES `${TMPDIR:-/tmp}` or `$RANDOM`
+# is untouched: warning the agent off those tokens is the fix, not the defect,
+# so the ban is scoped to the argument position alone.
+#
+# The `--body-file` mentions that carry no value (a bare `` `--body-file` ``
+# in running prose) are not argument usages and do not match. A recipe with
+# NO argument usage at all fails as `missing-body-path`: a zero-match census
+# is not a check that passed.
+# ---------------------------------------------------------------------------
+
+# `--body-file <value>`, value optionally quoted. Matched against a
+# whitespace-flattened copy of the recipe, because these docs hard-wrap and a
+# command can carry a newline between the flag and its value — or inside a
+# quoted placeholder. A bare `` `--body-file` `` in prose is followed by a
+# backtick, not whitespace, so it never matches.
+_BODY_FILE_ARG_RE = re.compile(
+    r"--body-file +(?:'([^']*)'|\"([^\"]*)\"|([^\s`]+))"
+)
+
+# Expansion syntax that must never survive into a `--body-file` argument.
+_EXPANSION_TOKENS: tuple[str, ...] = (
+    "${", "$$", "$RANDOM", "$env:", "$(", "NewGuid", "`", "%TEMP%",
+)
+
+# Concrete worked path examples the recipe must show for BOTH host shapes,
+# so an agent on either host has an already-substituted model to copy.
+_POSIX_EXAMPLE_RE = re.compile(r"(?<![\w\\])/(?:[\w.\-]+/)*re-frame2-issue-[\w.\-]+\.md")
+_WINDOWS_EXAMPLE_RE = re.compile(r"[A-Za-z]:\\(?:[\w.\-<>]+\\)*re-frame2-issue-[\w.\-]+\.md")
+
+
+def _is_concrete_absolute_path(value: str) -> bool:
+    """True for a POSIX `/...` or Windows `X:\\...` / `X:/...` literal."""
+    if value.startswith("/"):
+        return True
+    return len(value) > 2 and value[0].isalpha() and value[1] == ":" and value[2] in "\\/"
+
+
+def check_body_path_identity(
+    rules: Iterable[TitleSafetyRule],
+) -> tuple[list[Drift], list[str]]:
+    """Every filing recipe hands `--body-file` one concrete, reused path.
+
+    Returns (drift, info). Drift directions:
+      `missing-body-path`   — no `--body-file` argument usage at all.
+      `expression-body-path`— the argument still carries expansion syntax,
+                              or is not an absolute path.
+      `unpaired-body-path`  — the argument is concrete but appears nowhere
+                              else in the recipe, so nothing shows `Write`
+                              being given that same string.
+      `missing-path-example`— the recipe lacks a concrete POSIX or Windows
+                              worked path.
+    """
+    drift: list[Drift] = []
+    info: list[str] = []
+
+    for rule in rules:
+        for doc in rule.docs:
+            if not doc.exists():
+                raise FileNotFoundError(
+                    f"body-path-identity: {rule.consumer} names a doc that "
+                    f"does not exist: {doc}"
+                )
+        raw = "\n".join(d.read_text(encoding="utf-8") for d in rule.docs)
+        # Flatten every whitespace run to one space so a hard-wrapped command
+        # reads as one line. Concrete paths carry no whitespace, so neither
+        # the argument values nor the worked examples are disturbed.
+        text = re.sub(r"\s+", " ", raw)
+        name = f"body-path-identity:{rule.consumer}"
+
+        args = [
+            (m.group(1) or m.group(2) or m.group(3) or "").strip()
+            for m in _BODY_FILE_ARG_RE.finditer(text)
+        ]
+        args = [a for a in args if a]
+
+        if not args:
+            drift.append(Drift(name, "missing-body-path", rule.consumer))
+            info.append(
+                f"body-path-identity: {rule.consumer} shows no `--body-file` "
+                f"argument at all -- DRIFT."
+            )
+            continue
+
+        bad = [a for a in args if any(t in a for t in _EXPANSION_TOKENS)
+               or not _is_concrete_absolute_path(a)]
+        if bad:
+            drift.append(Drift(name, "expression-body-path", bad[0]))
+            info.append(
+                f"body-path-identity: {rule.consumer} passes a non-concrete "
+                f"`--body-file` argument ({bad[0]!r}) -- DRIFT."
+            )
+            continue
+
+        unpaired = [a for a in args if text.count(a) < 2]
+        if unpaired:
+            drift.append(Drift(name, "unpaired-body-path", unpaired[0]))
+            info.append(
+                f"body-path-identity: {rule.consumer} passes "
+                f"{unpaired[0]!r} to `--body-file` but shows it nowhere "
+                f"else -- DRIFT."
+            )
+            continue
+
+        missing_shapes = [
+            shape for shape, rx in (("POSIX", _POSIX_EXAMPLE_RE),
+                                    ("Windows", _WINDOWS_EXAMPLE_RE))
+            if not rx.search(text)
+        ]
+        if missing_shapes:
+            drift.append(Drift(name, "missing-path-example",
+                               "/".join(missing_shapes)))
+            info.append(
+                f"body-path-identity: {rule.consumer} shows no concrete "
+                f"{'/'.join(missing_shapes)} worked path -- DRIFT."
+            )
+            continue
+
+        info.append(
+            f"body-path-identity: {rule.consumer} reuses "
+            f"{len(args)} concrete `--body-file` path(s), both host shapes "
+            f"shown -- OK."
+        )
+
+    return drift, info
+
+
+# A body carrying every character class the `--body-file` boundary exists to
+# keep out of argv: command substitution, a backtick, a backslash, both quote
+# kinds, a bare `$`, and a newline.
+_NASTY_BODY = (
+    "## spec-gap(EP-042): reproduction\n"
+    "command substitution: $(rm -rf /)\n"
+    "backtick: `whoami`\n"
+    "backslash: C:\\Users\\nobody\\AppData\n"
+    "quotes: \"double\" and 'single'\n"
+    "bare dollar: $HOME and ${TMPDIR:-/tmp} and $RANDOM\n"
+)
+
+
+class _LiteralPathHost:
+    """A `Write` with literal-path semantics and a `gh` that reads --body-file.
+
+    The filesystem is a dict keyed by the EXACT string handed to `Write`.
+    That is the whole point: a real `Write` tool is not a shell, so whatever
+    expression is in `file_path` becomes part of the key rather than being
+    expanded. `gh_issue_create` then looks up the exact `--body-file` string,
+    and the two only meet when they are the same string.
+    """
+
+    def __init__(self) -> None:
+        self.files: dict[str, str] = {}
+        self.written_paths: list[str] = []
+
+    def write(self, file_path: str, content: str) -> None:
+        self.written_paths.append(file_path)
+        self.files[file_path] = content
+
+    def gh_issue_create(self, body_file: str) -> str:
+        if body_file not in self.files:
+            raise FileNotFoundError(body_file)
+        return self.files[body_file]
+
+
+# ---------------------------------------------------------------------------
 # Doc-coverage axis — every server tool must have a documented semantic home
 # (rf2-l2y4n).
 #
@@ -900,6 +1086,47 @@ class Drift:
                 f"(no `--title-file`, restricted safe alphabet, never paste "
                 f"evidence into `--title`). Add the clauses to the consumer's "
                 f"local recipe. (rf2-4kyg6)"
+            )
+        if self.direction == "missing-body-path":
+            return (
+                f"{self.mapping_name}: gh-issue-writing consumer "
+                f"'{self.tool}' shows no `--body-file` ARGUMENT anywhere in "
+                f"its filing recipe. A recipe that never demonstrates the "
+                f"flag with a value cannot demonstrate path identity — and a "
+                f"zero-match census is not a check that passed. Show the "
+                f"`gh issue create ... --body-file '<concrete path>'` call. "
+                f"(rf2-2zkrz)"
+            )
+        if self.direction == "expression-body-path":
+            return (
+                f"{self.mapping_name}: the filing recipe passes "
+                f"{self.tool!r} to `--body-file`. That is not a concrete "
+                f"absolute path: it is either shell/PowerShell expansion "
+                f"syntax or a placeholder. `Write` is not a shell and stores "
+                f"`file_path` literally, and a nonce expression re-rolls on "
+                f"every evaluation, so the `Write` step and the `gh` step "
+                f"would address two different files and filing would die on "
+                f"a missing body. Substitute the temp directory and the "
+                f"nonce BEFORE either tool call and show the resulting "
+                f"string. (rf2-2zkrz)"
+            )
+        if self.direction == "unpaired-body-path":
+            return (
+                f"{self.mapping_name}: the filing recipe passes "
+                f"{self.tool!r} to `--body-file`, but that exact string "
+                f"appears nowhere else in the recipe — so nothing shows "
+                f"`Write` being given the same path. Path identity is the "
+                f"invariant: `Write.file_path` and `--body-file` must be one "
+                f"string used twice. (rf2-2zkrz)"
+            )
+        if self.direction == "missing-path-example":
+            return (
+                f"{self.mapping_name}: the filing recipe shows no concrete "
+                f"{self.tool} worked temp path. Both host shapes need an "
+                f"already-substituted example (a POSIX `/tmp/...` and a "
+                f"Windows `C:\\...\\Temp\\...`), because an agent cannot "
+                f"derive one from an expression it has no shell to run. "
+                f"(rf2-2zkrz)"
             )
         if self.direction == "missing-doc-row":
             return (
@@ -1354,6 +1581,153 @@ def _run_self_test(ci: bool) -> int:
                 "tool (rf2-l2y4n)."
             )
 
+    # -----------------------------------------------------------------
+    # (5) Body-path-identity axis (rf2-2zkrz).
+    # -----------------------------------------------------------------
+
+    # (5a) Shipped recipes: no path-identity drift.
+    bp_drift, _ = check_body_path_identity(TITLE_SAFETY_RULES)
+    if bp_drift:
+        failures.append(
+            "shipped filing recipes produced body-path-identity drift "
+            f"({[d.direction for d in bp_drift]}) -- every consumer must hand "
+            "`--body-file` one concrete path it also shows `Write` receiving."
+        )
+
+    # (5b) BEHAVIOURAL: the concrete paths the SHIPPED recipes actually print
+    #      must survive a literal-path `Write` -> `gh --body-file` handoff
+    #      byte-for-byte, on both host shapes. This is what a token-presence
+    #      assertion could never say: that the recipe as written RUNS.
+    for rule in TITLE_SAFETY_RULES:
+        text = "\n".join(d.read_text(encoding="utf-8") for d in rule.docs)
+        shapes = {
+            "POSIX": _POSIX_EXAMPLE_RE.findall(text),
+            "Windows": _WINDOWS_EXAMPLE_RE.findall(text),
+        }
+        for shape, paths in shapes.items():
+            if not paths:
+                failures.append(
+                    f"{rule.consumer}: no concrete {shape} worked path to "
+                    f"exercise -- the behavioural arm would pass vacuously."
+                )
+                continue
+            path = paths[0]
+            host = _LiteralPathHost()
+            host.write(path, _NASTY_BODY)
+            try:
+                delivered = host.gh_issue_create(path)
+            except FileNotFoundError:
+                failures.append(
+                    f"{rule.consumer}/{shape}: `gh --body-file {path}` could "
+                    f"not find the file `Write` created at the same string."
+                )
+                continue
+            if delivered != _NASTY_BODY:
+                failures.append(
+                    f"{rule.consumer}/{shape}: body did not reach `gh` "
+                    f"byte-for-byte through --body-file."
+                )
+            if host.written_paths[-1] != path:
+                failures.append(
+                    f"{rule.consumer}/{shape}: captured Write.file_path "
+                    f"({host.written_paths[-1]!r}) != captured --body-file "
+                    f"argument ({path!r})."
+                )
+
+    # (5c) BEHAVIOURAL CONTROL: the pre-fix recipe must FAIL this harness, or
+    #      the harness proves nothing. Two ways the old text broke, both real:
+    #      the expression reached `Write` literally, and the nonce re-rolled
+    #      before the `gh` step.
+    ctrl = _LiteralPathHost()
+    ctrl.write("${TMPDIR:-/tmp}/re-frame2-issue-$$-$RANDOM.md", _NASTY_BODY)
+    try:
+        ctrl.gh_issue_create("/tmp/re-frame2-issue-2984-24950.md")
+        failures.append(
+            "CONTROL DID NOT BITE: the pre-fix expression passed literally to "
+            "`Write` was still found by an expanded `--body-file` path. The "
+            "literal-path harness is not modelling `Write` correctly."
+        )
+    except FileNotFoundError:
+        pass
+
+    ctrl2 = _LiteralPathHost()
+    ctrl2.write("/tmp/re-frame2-issue-7f3a9c.md", _NASTY_BODY)
+    try:
+        ctrl2.gh_issue_create("/tmp/re-frame2-issue-b1d420.md")
+        failures.append(
+            "CONTROL DID NOT BITE: a nonce regenerated for the `gh` step "
+            "still found the body `Write` created under the first nonce."
+        )
+    except FileNotFoundError:
+        pass
+
+    # (5d) STRUCTURAL CONTROL: synthetic recipes that reintroduce the defect
+    #      must each fire, and a correct one must stay green.
+    with tempfile.TemporaryDirectory() as td:
+        td_path = Path(td)
+        _TITLE_TAIL = (
+            "\ngh issue create has no `--title-file` flag; author the title "
+            "from a restricted safe alphabet and never paste evidence into "
+            "`--title`.\nNever interpolate transcript text inline.\n"
+        )
+
+        def _bp(label: str, recipe: str) -> list[Drift]:
+            f = td_path / f"{label}.md"
+            f.write_text(recipe + _TITLE_TAIL, encoding="utf-8")
+            d, _ = check_body_path_identity(
+                [TitleSafetyRule(consumer=label, docs=(f,))]
+            )
+            return d
+
+        good = (
+            "Write the body to /tmp/re-frame2-issue-7f3a9c.md (Windows: "
+            "C:\\Users\\you\\AppData\\Local\\Temp\\re-frame2-issue-7f3a9c.md), "
+            "then run: gh issue create --body-file "
+            "'/tmp/re-frame2-issue-7f3a9c.md'\n"
+        )
+        for label, recipe, want in (
+            # The exact pre-fix text this bead was filed against.
+            ("synthetic-expression-path",
+             good.replace("'/tmp/re-frame2-issue-7f3a9c.md'",
+                          "\"${TMPDIR:-/tmp}/re-frame2-issue-$$-$RANDOM.md\""),
+             "expression-body-path"),
+            # The other pre-fix half: a prose placeholder, not a value.
+            ("synthetic-placeholder-path",
+             good.replace("'/tmp/re-frame2-issue-7f3a9c.md'",
+                          "\"<the exact path from step 2>\""),
+             "expression-body-path"),
+            # A concrete path the recipe never shows `Write` receiving.
+            ("synthetic-unpaired-path",
+             "Write the body to the temp file you chose (Windows: "
+             "C:\\Users\\you\\AppData\\Local\\Temp\\re-frame2-issue-7f3a9c.md), "
+             "then run: gh issue create --body-file "
+             "'/tmp/re-frame2-issue-0000ff.md'\n",
+             "unpaired-body-path"),
+            # A recipe with no `--body-file` argument at all.
+            ("synthetic-no-body-path",
+             "Write the body to /tmp/re-frame2-issue-7f3a9c.md and file it "
+             "with `--body-file`.\n",
+             "missing-body-path"),
+            # POSIX-only: the Windows agent has nothing to copy.
+            ("synthetic-posix-only",
+             "Write the body to /tmp/re-frame2-issue-7f3a9c.md, then run: "
+             "gh issue create --body-file '/tmp/re-frame2-issue-7f3a9c.md'\n",
+             "missing-path-example"),
+        ):
+            if not [d for d in _bp(label, recipe) if d.direction == want]:
+                failures.append(
+                    f"a synthetic recipe that should fire {want} did NOT -- "
+                    f"the body-path-identity axis is a no-op for {label} "
+                    f"(rf2-2zkrz)."
+                )
+
+        if _bp("synthetic-concrete-path", good):
+            failures.append(
+                "a synthetic recipe handing `--body-file` one concrete, "
+                "reused path with both host shapes shown was flagged -- the "
+                "body-path-identity green path is broken (rf2-2zkrz)."
+            )
+
     if failures:
         for f in failures:
             _emit_error(f"self-test: {f}", ci)
@@ -1365,7 +1739,11 @@ def _run_self_test(ci: bool) -> int:
           "search-clause negative fires + positive stays green; implementor "
           "enforced via its local body+title+search clauses. doc-coverage: "
           "shipped rules green; synthetic covered stays green; missing row and "
-          "phantom row both fire).")
+          "phantom row both fire. body-path-identity: shipped recipes green; "
+          "both host shapes survive a literal-path Write -> gh --body-file "
+          "handoff byte-for-byte; the pre-fix expression and a regenerated "
+          "nonce both fail that handoff; expression / placeholder / unpaired / "
+          "absent / POSIX-only recipes all fire).")
     return 0
 
 
@@ -1438,6 +1816,19 @@ def main(argv: Iterable[str]) -> int:
         title_drift, title_info = [], []
     all_info.extend(title_info)
     for d in title_drift:
+        all_drift.append((None, d))
+
+    # Body-path-identity axis (rf2-2zkrz) — the `--body-file` argument must be
+    # ONE concrete path the recipe also shows `Write` being handed. Same
+    # consumers as the title-safety axis, same accumulator, mapping=None.
+    try:
+        path_drift, path_info = check_body_path_identity(TITLE_SAFETY_RULES)
+    except FileNotFoundError as e:
+        _emit_error(str(e), ci)
+        saw_setup_error = True
+        path_drift, path_info = [], []
+    all_info.extend(path_info)
+    for d in path_drift:
         all_drift.append((None, d))
 
     # Doc-coverage axis (rf2-l2y4n) — every server tool must have a table row

--- a/skills/README.md
+++ b/skills/README.md
@@ -275,14 +275,18 @@ rather than theoretical attacks.
   rules, carried as a local worked recipe by every skill that files
   (`scripts/check_skill_mcp_drift.py` pins the clauses per consumer):
   - bodies: never interpolate transcript-derived text inline
-    (where `$`, `` ` ``, or `\` would expand). `Write` the body to a
-    fresh, per-filing temp file in the host OS's temp directory
-    (nonce-carrying `${TMPDIR:-/tmp}/…` on POSIX, `$env:TEMP\…` on
-    Windows — never a fixed, predictable name) and pass that exact
-    path via `gh issue create --body-file` — one bare `gh issue
-    create` invocation, runnable under the restricted
-    `Bash(gh issue *)` permission (a `cat > file` here-doc or a
-    `--body "$(cat …)"` subshell is not).
+    (where `$`, `` ` ``, or `\` would expand). Settle one **concrete
+    absolute path** in the host OS's temp directory first — the temp
+    directory resolved to a literal, plus a per-filing nonce the
+    agent picks itself, both substituted before any tool call
+    (`/tmp/re-frame2-issue-7f3a9c.md`; never a fixed, predictable
+    name, and never a `${TMPDIR:-/tmp}` / `$RANDOM` / `$env:TEMP` /
+    `NewGuid` expression, which `Write` stores literally and a
+    second shell evaluation resolves to a different file). `Write`
+    the body to that path, then pass the same string via `gh issue
+    create --body-file` — one bare `gh issue create` invocation,
+    runnable under the restricted `Bash(gh issue *)` permission (a
+    `cat > file` here-doc or a `--body "$(cat …)"` subshell is not).
   - titles, search keywords, labels, repos — every other
     user-influenced argv has no `--*-file` equivalent, so it is safe
     only because the agent authors it: from the restricted safe

--- a/skills/re-frame-migration/references/issue-filing.md
+++ b/skills/re-frame-migration/references/issue-filing.md
@@ -11,18 +11,31 @@ from the migration itself.
    duplicating. `--search` is an inline shell argument —
    there is no `--search-file` — so author the keywords from the safe
    alphabet below; never paste transcript, code, or error text into it.
-2. **Compose the body with the `Write` tool** into a fresh, per-filing temp
-   file (nonce-carrying `${TMPDIR:-/tmp}/…` on POSIX, `$env:TEMP\…` on
-   Windows — never a fixed, predictable name). Never interpolate
-   transcript-derived text inline into a shell command, where `$`,
-   `` ` ``, and `\` expand. The body cites rule ids, quotes `spec/` /
+2. **Settle one concrete path, then compose the body with the `Write`
+   tool.** Before either tool call, resolve the host's temp directory to
+   the concrete literal your session already shows you (`/tmp` on a
+   typical POSIX host, or whatever `TMPDIR` actually holds;
+   `C:\Users\<you>\AppData\Local\Temp` on Windows), pick a per-filing
+   nonce yourself, and join the two into one **absolute path string** —
+   `/tmp/re-frame2-issue-7f3a9c.md`, say, or
+   `C:\Users\you\AppData\Local\Temp\re-frame2-issue-7f3a9c.md`. Never a
+   fixed, predictable name. That string is a value, not a template:
+   `Write` is not a shell and takes `file_path` literally, so a
+   `${TMPDIR:-/tmp}`, `$$`, `$RANDOM`, `$env:TEMP` or
+   `$([guid]::NewGuid())` left in it becomes part of the filename, and
+   re-evaluating a nonce at step 3 names a different file.
+   Never interpolate transcript-derived text inline into a shell command,
+   where `$`, `` ` ``, and `\` expand. The body cites rule ids, quotes `spec/` /
    `MIGRATION.md` text, and shows a minimal reproduction shape — not the
    author's private code, paths, or anything they haven't seen.
-3. **File with one command:** `gh issue create --repo day8/re-frame2
-   --title "migration: <one-line>" --body-file "<the exact path from
-   step 2>"`. `--body-file` reads the body verbatim from disk, so no shell
-   expansion touches it, and the single bare `gh issue create` runs under
-   the skill's `Bash(gh issue *)` permission.
+3. **File with one command,** giving `--body-file` that same string from
+   step 2, character for character: `gh issue create --repo
+   day8/re-frame2 --title "migration: <one-line>" --body-file
+   '/tmp/re-frame2-issue-7f3a9c.md'`. `--body-file` reads the body
+   verbatim from disk, so no shell expansion touches it, and the single
+   bare `gh issue create` runs under the skill's `Bash(gh issue *)`
+   permission. Single-quote the path so a Windows path's backslashes stay
+   literal.
 4. **Title safety.** `gh issue create` has no `--title-file`, so the
    body-file trick cannot protect the title. Author the title — and every
    other inline argument (`--label`, `--repo`, search keywords) — from the

--- a/skills/re-frame2-implementor/references/cardinal-rules.md
+++ b/skills/re-frame2-implementor/references/cardinal-rules.md
@@ -54,20 +54,31 @@ gh issue list --repo day8/re-frame2 --search "<agent-authored safe keywords>"
 
 **Shell safety for `gh issue create`.** Even the public-evidence-only body above — quoted `spec/` text, a fixture id, a sanitized minimal-reproduction shape — can carry shell metacharacters the user never inspects character by character (a `$`, a backtick, a `\` inside a quoted spec snippet). Never interpolate that text inline into the shell command (where `$`, `` ` ``, and `\` would expand). Instead, **write the body to a file with the `Write` tool**, then pass it with `gh`'s native `--body-file` flag — a single `gh issue create` invocation with no `cat` subshell, so it runs under the skill's `Bash(gh issue *)` permission. The `--body-file` path is a shell-safety mechanism only; it does **not** widen what the body may contain — the public-evidence-only boundary above still holds. This local recipe is the skill's own shell-safety core (each filing skill owns its recipe; `scripts/check_skill_mcp_drift.py` pins the load-bearing clauses):
 
-1. Use the `Write` tool to compose the body into a **fresh, per-filing temp file in the host OS's temp directory** — never a fixed, shared, predictable name (a hard-coded `/tmp/spec-gap.md` fails on hosts without a POSIX `/tmp`, and a predictable name lets two rapid filings overwrite each other's redacted body). Pick the path for the OS and add a per-filing nonce, then **carry that exact path into `--body-file` below**:
+1. **Settle the path first — as a value, not a template.** Before either tool call, decide one **concrete absolute path** and write it down. That single string is what you use twice, unchanged. Build it from two things you resolve yourself:
 
-   - **POSIX:** `${TMPDIR:-/tmp}/re-frame2-issue-$$-$RANDOM.md`
-   - **Windows (PowerShell):** `$env:TEMP\re-frame2-issue-$([guid]::NewGuid()).md`
+   - **The host's temp directory, as the concrete literal your session already shows you** — `/tmp` on a typical POSIX host, or whatever `TMPDIR` actually holds; `C:\Users\<you>\AppData\Local\Temp` on Windows. Never a fixed, shared name like `/tmp/spec-gap.md`: it fails on hosts without a POSIX `/tmp`, and a predictable name lets two rapid filings overwrite each other's redacted body.
+   - **A per-filing nonce you pick yourself** — a few random characters, chosen once, before you call anything.
 
-2. File it with one `gh issue create` command (`--body-file` is the exact per-filing path you wrote in step 1, never a re-typed fixed name):
+   **Neither tool below expands shell syntax, so an expression left in this path is a bug, not a placeholder.** `Write` takes `file_path` literally — it is not a shell, so `${TMPDIR:-/tmp}`, `$$`, `$RANDOM`, `$env:TEMP` or `$([guid]::NewGuid())` would land in the *filename* rather than being replaced. And a nonce expression re-evaluated at step 3 produces a **different** name, so the two steps would address two different files and `gh` would fail on a missing body. Substitute everything before the first tool call.
+
+   So, having picked the nonce `7f3a9c`, the path is one concrete string:
+
+   - **POSIX:** `/tmp/re-frame2-issue-7f3a9c.md`
+   - **Windows:** `C:\Users\you\AppData\Local\Temp\re-frame2-issue-7f3a9c.md`
+
+2. Use the `Write` tool to compose the body into that file. Its `file_path` is the concrete string from step 1, character for character — nothing left to expand.
+
+3. File it with one `gh issue create` command, giving `--body-file` **that same string again** — never a re-typed fixed name, and never a freshly chosen nonce:
 
    ```bash
    gh issue create \
      --repo day8/re-frame2 \
      --title "spec-gap(EP-NNN): <one-line>" \
-     --body-file "<the per-filing temp path you wrote in step 1>" \
+     --body-file '/tmp/re-frame2-issue-7f3a9c.md' \
      --label spec-gap,from-implementor
    ```
+
+   Single-quote the path. It is agent-authored, so nothing in it needs expanding, and single quotes keep a Windows path's backslashes literal.
 
 `--body-file` reads the body verbatim from disk, so no shell expansion ever touches the transcript-derived text, and the only `Bash` call is a bare `gh issue create` — exactly what the skill's `allowed-tools` grants.
 


### PR DESCRIPTION
Fixes rf2-2zkrz.

## The defect, verified at source

The filing recipe told the agent to compose the issue body with the **non-shell `Write` tool**, but gave the temp path only as shell expressions:

- POSIX: `${TMPDIR:-/tmp}/re-frame2-issue-$$-$RANDOM.md`
- Windows: `$env:TEMP\re-frame2-issue-$([guid]::NewGuid()).md`

`Write` is not a shell. Reproduced on a Windows host, in a scratch directory:

| step | result |
|---|---|
| `Write` given the recipe string | created a file named **literally** `re-frame2-issue-$$-$RANDOM.md` |
| the same string evaluated by the shell | `re-frame2-issue-2984-24950.md` |
| the `--body-file` read | **exit 1**, `No such file or directory`, naming a *third* path `re-frame2-issue-2984-6493.md` — `$RANDOM` re-rolled again inside the one command line |

Three evaluations of the one POSIX expression produced three distinct paths, so identity was impossible by construction. And the Windows expression does not even parse under the `Bash(gh issue *)` shell the skills grant — bash reports a syntax error near the closing parenthesis of the `NewGuid` call and exits 2.

## The fix

The **injection boundary is unchanged**: the body is still composed with `Write` and still passed with `--body-file`, never through shell argv. What changes is that the path becomes a **value rather than a template**.

The agent resolves the host temp directory to a concrete literal it can already see, picks its own nonce, and substitutes **both before the first tool call** — then hands that one string to `Write.file_path` and again to `--body-file`. That works on both hosts because the result is an ordinary absolute filesystem path, which needs no expansion anywhere; the two variants exist only because the *directory* differs. The `gh` argument is single-quoted so a Windows path's backslashes stay literal.

## Census — every copy of the recipe at tip

The bead's file list was stale in membership: `skills/shared/` was retired by `f761539e46` under rf2-fqjys, so the shared leaf named in the description no longer exists. Re-derived at tip with fixed-string searches over tracked files (`re-frame2-issue-`, `TMPDIR`, `env:TEMP`, `NewGuid`, `body-file`, `RANDOM`, plus `mktemp` / `%TEMP%` / `GetTempPath`), each control-checked against a known-present site.

**Changed — carried the defective path expressions (3):**

| file | what it carried |
|---|---|
| `skills/re-frame2-implementor/references/cardinal-rules.md` §8 | both expressions, plus a prose placeholder as the `--body-file` argument |
| `skills/re-frame-migration/references/issue-filing.md` | both expressions (abbreviated), plus a prose placeholder as the `--body-file` argument |
| `skills/README.md` §Published-skill allowed-tools baseline | the published summary repeating both expressions |

**Left standing — correct already (5):** `skills/re-frame2-implementor/SKILL.md`, `skills/re-frame2-implementor/spec/design.md`, `skills/re-frame-migration/references/output-format.md` and `skills/re-frame-migration/references/guided-interceptors-subs.md` all name the `--body-file` flag without a path. `skills/re-frame2-pair-retro/**` is read-only, grants no `gh issue create`, and has no filing path at all.

The two filing consumers are exactly `re-frame2-implementor` and `re-frame-migration`, which agrees with `skills/README.md` and with `TITLE_SAFETY_RULES` in the drift gate.

## The new gate

`scripts/check_skill_mcp_drift.py` gains a **body-path-identity axis** over the same two consumers: every `--body-file` **argument** must be one concrete absolute path carrying no expansion syntax, and that same string must appear elsewhere in the recipe as the path `Write` is given. Both host shapes must have a worked example. A recipe with no `--body-file` argument at all fails too — a zero-match census is not a check that passed.

Prose that merely *names* `${TMPDIR:-/tmp}` or `$RANDOM` is untouched: warning the agent off those tokens is the fix, not the defect, so the ban is scoped to the argument position alone.

`--self-test` carries the behavioural proof the old token-presence assertion could not give: a fake `Write` with literal-path semantics and a fake `gh` that reads `--body-file` run the concrete paths the **shipped recipes actually print**, on both host shapes, with a body carrying `$()`, a backtick, a backslash, both quote kinds and a newline. The body must arrive byte-for-byte and the captured `Write.file_path` must equal the captured `--body-file` argument.

**Non-vacuity.** Run against the real pre-fix docs from `HEAD`, the new axis fires on **both** recipes with `expression-body-path` — it would have caught this bug. Its self-test controls also bite: the pre-fix expression passed literally to `Write`, and a nonce regenerated for the `gh` step, both fail the handoff; and synthetic recipes reintroducing the expression, the prose placeholder, an unpaired path, an absent argument, or a POSIX-only example each fire.

## Quality gates

Gate coverage was settled **empirically**, not from a roster. A broken link *and* a broken anchor were planted in prose at a line this PR edits (`cardinal-rules.md`), both gates run, then restored — and the restore verified against the pre-plant **git blob hash** `927d4144b1919f1aa9a4019c9203a6af1b49f941`, which matched exactly.

| gate | on the plant | verdict |
|---|---|---|
| `scripts/check_doc_slugs.py` | **exit 1** — reported both `BROKEN TARGET` and `BROKEN ANCHOR` at the planted line | **this is the covering gate for `skills/`** |
| `scripts/check_readme_links.py --ci` | exit 0 | `skills/` is outside its roster |

The plant existed only in this worktree, so the red is also positive evidence the gate read this checkout.

All gates below were re-run **after** the rebase onto `8451531aed`, with each exit code captured on the runner's own command line (never a pipeline status, never a harness-reported number). **33 gates, all exit 0.**

- `check_skill_mcp_drift.py` — `--verbose --ci` **0**, `--self-test --ci` **0**
- The other 29 python gates in `test.yml`'s `verify-skill-mcp-drift` job (migration cites / contract / o1617-router, implementor order and partition, re-frame2 drift, package refs, pair authoring, setup counter, eval packaging and docs, xray tab inventory, redirect anchors, retired spellings, inject-cofx residue — each with its `--self-test` arm) — **all 0**
- `check_doc_slugs.py` **0**; `check_readme_links.py --ci` **0**

### Two coverage limits, stated plainly

1. **Neither link gate reads inside fenced code blocks**, and one line of this change — the `--body-file` line in the `gh issue create` block in `cardinal-rules.md` — is inside one. More broadly, both gates validate only *link targets and anchors*: this change introduces no links at all, so the green above says nothing about the substance of the edit. `issue-filing.md` has no fences; the edited bullet in `skills/README.md` is prose.
2. **Nothing in CI validates whether the recipe WORKS.** That is exactly how this bug shipped — it was never executed end to end. The new axis narrows the gap structurally and behaviourally, but it models the tools rather than invoking them.

### So the recipe was executed, on this host

Followed as written, with a `gh` **stub** on `PATH` that parses argv as `gh` does and opens `--body-file`. No issue was created — confirmed afterwards: the repo's newest issue remains #8423 from 2026-08-16, and a title search returns an empty list.

1. Resolved the host temp directory to a concrete literal; picked the nonce `a41e2b`.
2. `Write` to that concrete Windows temp path, with a body carrying `$(rm -rf /)`, a backtick, backslashes, both quote kinds, `$HOME`, `${TMPDIR:-/tmp}`, `$RANDOM`, and a newline.
3. Ran the recipe's `gh issue create` verbatim, with that same string single-quoted.

Observed: **exit 0**. The stub reported `--body-file` received as exactly the string `Write` was given — every backslash intact, including the `\U`, `\A`, `\L` and `\T` sequences that a double-quoted argument would have made a reader worry about. The body came back **byte-for-byte**: 396 bytes in, 396 bytes out, SHA-256 `314b10cb9934b7853e0066fda2304c66fc4a94b0674fc92e2b740faba022c2f6` on both sides. Nothing expanded.

### Hand checks

Markdown was checked by hand, since no gate covers rendering: the two tables added to this PR body carry consistent column counts; the recipe's numbered list renumbers cleanly 1–3 with the fenced block correctly indented inside item 3; and no headings, anchors, or link targets were added, moved, or removed in any of the three docs.

## Found along the way — filed, not fixed

Executing the recipe turned up a **second, independent defect**: the implementor recipe ends with `--label spec-gap,from-implementor`, and neither label exists in `day8/re-frame2`. `gh` resolves label names before the create mutation, so the whole call dies at pre-flight with `could not add label: 'spec-gap' not found` and exit 1. The repo has exactly ten labels and neither is among them, so the recipe still cannot file even with this PR landed.

rf2-2zkrz's non-goals explicitly fence labels, and the disposition is a genuine ruling (create the labels, drop the flag, or point at an existing one), so it is filed as **rf2-v04qh** rather than fixed here. The migration recipe passes no `--label` and is unaffected.
