### PR TITLE
fix(api-manifest): inventory the published re-frame.hicasso door on both hosts (rf2-phm7g)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -2,9 +2,7 @@
 
 This is the complete public API reference for the manifest-tracked namespaces of
 the ClojureScript implementation of re-frame2 — one page per public namespace, with
-the boundary of "manifest-tracked" set out under Completeness below. The one
-public surface that falls outside it is the Hicasso view layer, which keeps its own
-reference: [Hicasso API reference](../core/hicasso/api-reference.md). Entries use a
+the boundary of "manifest-tracked" set out under Completeness below. Entries use a
 consistent shape: Kind, Signature, Description (contract, including error
 ids where they are part of the surface), and an Example where a call is worth
 showing. The Example is optional — many contract-only surfaces (compile-time template
@@ -21,7 +19,7 @@ chose it.
 | Day-to-day app API | [`re-frame.core`](re-frame.core.md) (the facade) |
 | Optional capabilities | machines, routing, resources, flows, schemas, HTTP, SSR |
 | Substrate adapters | `re-frame.adapter.{reagent,uix}` — first-class and permanent |
-| The Hicasso view layer | [Hicasso API reference](../core/hicasso/api-reference.md) — a separate corpus, not a page here |
+| The Hicasso view layer | [`re-frame.hicasso`](re-frame.hicasso.md) for the door's vars; [Hicasso API reference](../core/hicasso/api-reference.md) for the full contract and the optional modules |
 | Tests | [`re-frame.test-support`](re-frame.test-support.md), [`re-frame.test-helpers`](re-frame.test-helpers.md) |
 | Production timing | [`re-frame.performance`](re-frame.performance.md) |
 
@@ -46,16 +44,23 @@ no page — or an eligible var with no member heading (`### \`var\``, or a
 red. A member heading may be written bare (`### \`sub\``) or namespace-qualified
 (`### \`re-frame.machines/machine-transition\``).
 
-Where Hicasso sits. `re-frame.hicasso` and its optional modules carry no
-api-manifest rows, so the enforcement above neither demands a page here nor notices
-their absence. That is deliberate rather than an oversight: the view layer is
-pre-alpha, its surface is still moving, and it documents itself in
-[its own API reference](../core/hicasso/api-reference.md) alongside the guide that
-teaches it. Read this corpus for the pipeline — events, app-db, subscriptions,
-effects, the optional capabilities and the substrate adapters — and read the Hicasso
-reference for `h/defview`, `h/sub`, `h/mount!` and the rest of the authoring model.
-The two do not overlap: a Hicasso application uses both, because Hicasso replaces the
-view notation and nothing else.
+Where Hicasso sits. The **door** — `re-frame.hicasso` — is manifest-tracked like
+any other published namespace, and has been since rf2-phm7g. It is a split-host
+`.cljc`: its three authoring macros are the `:clj` arm the JVM generator
+introspects, and its eleven runtime vars are the `:cljs` arm the analyzer probe
+reconciles, so a public added, removed or renamed on either host turns the
+api-manifest gate red. Its **optional modules** (`.forms`, `.overlay`, `.motion`,
+`.native`, `.substrate`, `.server`, the test kit and the tool tier) still carry no
+rows, so the enforcement above neither demands a page for them nor notices their
+absence — deliberately, while that surface is still moving.
+
+The split follows the depth, not the coverage. Read
+[`re-frame.hicasso`](re-frame.hicasso.md) here for the door's var index, and the
+[Hicasso API reference](../core/hicasso/api-reference.md) for the full authoring
+contract and every optional module. Read this corpus for the pipeline — events,
+app-db, subscriptions, effects, the optional capabilities and the substrate
+adapters. A Hicasso application uses both, because Hicasso replaces the view
+notation and nothing else.
 
 ## Namespaces
 
@@ -85,6 +90,7 @@ view notation and nothing else.
 |---|---|
 | [re-frame.adapter.reagent](re-frame.adapter.reagent.md) | Stock / slim Reagent substrate |
 | [re-frame.adapter.uix](re-frame.adapter.uix.md) | UIx substrate |
+| [re-frame.hicasso](re-frame.hicasso.md) | The Hicasso view layer's door — authoring macros, reads, roots, markup |
 | [re-frame.test-support](re-frame.test-support.md) | Fixtures, registrar snapshot, poll, sequester |
 | [re-frame.test-helpers](re-frame.test-helpers.md) | Hiccup walkers, testids |
 | [re-frame.performance](re-frame.performance.md) | Compile-time User-Timing flags |
@@ -108,7 +114,8 @@ view notation and nothing else.
 
 - [Core guide](../core/introduction.md) — progressive teaching
 - [Hicasso API reference](../core/hicasso/api-reference.md) — the view layer's own
-  corpus, outside the api-manifest
+  corpus: the door's full contract, and the optional modules, which carry no
+  api-manifest rows
 - [spec/API.md](../../spec/API.md) — normative var catalogue with tiers (projection of
   the api-manifest)
 - Feature guides under Machines, Resources, Routing, SSR, Async tabs

--- a/docs/api/re-frame.hicasso.md
+++ b/docs/api/re-frame.hicasso.md
@@ -1,0 +1,275 @@
+# re-frame.hicasso
+
+`re-frame.hicasso` is the public door of Hicasso, the re-frame-native view layer.
+Everything an author writes against lives here; everything below it is
+`re-frame.hicasso.impl.*` and is not a consumer surface. The intended spelling is
+one alias:
+
+```clojure
+(:require [re-frame.hicasso :as h])
+```
+
+Hicasso replaces the view notation and nothing else. Events, app-db,
+subscriptions and effects are unchanged — read [`re-frame.core`](re-frame.core.md)
+for the pipeline and this page for the authoring surface.
+
+This page is the manifest-tracked index of the door's public vars: Kind,
+Signature, and what the var is. The **full contract** — the four shapes an `on-*`
+prop may take, the `defhost` options table, the `mount!` / `hydrate!` asymmetry,
+the render discipline — lives in the [Hicasso API reference](../core/hicasso/api-reference.md),
+alongside the guide that teaches it. This page deliberately does not duplicate it;
+where an entry below is terse, that reference is where the depth is.
+
+**A split-host namespace.** The door is a `.cljc` whose two arms are disjoint. The
+three authoring macros are its `#?(:clj …)` arm and are what `ns-publics` returns
+on the JVM; the eleven runtime vars are its `#?(:cljs …)` arm and exist only under
+ClojureScript. Both arms are inventoried — the JVM manifest generator owns the
+macros, the CLJS analyzer probe owns the runtime vars — so neither host can
+silently gain or lose a public.
+
+## Authoring macros
+
+### `defview`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (h/defview name docstring? [props] body …)
+  ```
+- **Description**: Mints a boundary — a real React function component, and a legal
+  hiccup head. `argv` is the ordinary one-props-map argument vector, so
+  destructuring reads as it does in any Clojure fn.
+  - The macro **reads no body**. It expands to a `def` of the minted head plus a
+    source coordinate, so a refusal raised while the body runs can name where the
+    boundary was written.
+  - The `fn` it emits is **anonymous**, so nothing it binds can shadow a helper of
+    the same name — `(h/defview todo-row [p] (todo-row-body p))` is safe at the
+    ordinary spelling.
+  - The name is also registered in re-frame's `:view` registrar under
+    `(keyword "<ns>" "<sym>")`, for **forward resolution only** — a tool holding a
+    keyword the author wrote reaches the view they meant. It carries no
+    `:handler-fn`, and rides the `debug-enabled?` gate, so a production build
+    registers nothing.
+  - Hooks do not belong in a body: a body is dynamically composed, so a hook
+    written there would make its own call order depend on a data path. Put
+    hook-intensive behaviour in a React island reached through `defhost`.
+- **Example**:
+  ```clojure
+  (h/defview todo-row [{:keys [id]}]
+    (let [todo (h/sub [:todo/by-id id])]
+      [:li {:on-click [:todo/toggle id]} (:text todo)]))
+  ```
+
+### `defhost`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (h/defhost name docstring? component)
+  (h/defhost name docstring? component opts)
+  ```
+- **Description**: The interop door. Names the crossing to a foreign React
+  component once; the resulting var is a hiccup head anywhere, indistinguishable
+  from a view. Callback contracts are inferred from each prop's spelling, exactly
+  as at a native tag. `opts` carries four optional keys — `:callbacks`, `:slots`,
+  `:server`, `:fallback` — and any other key is refused. Anything written past
+  `opts` is refused rather than silently dropped
+  (`:rf.error/hicasso-bad-host-declaration`).
+- **Example**:
+  ```clojure
+  (h/defhost date-picker DatePicker)
+  (h/defhost modal Modal {:slots #{:title :footer}})
+  ```
+
+### `event`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (h/event [args …] body …)
+  ```
+- **Description**: The one callback form, for a position where the event itself is
+  wanted. It expands to a marked `fn` and nothing else, so the value is an ordinary
+  function. Which of two contracts it carries is selected by **position**, not by
+  the name: at an `on*`-spelled prop a returned vector is dispatched and any other
+  return ignored; at any other walked prop it is a render position, pure, whose
+  return is the render output.
+- **Example**:
+  ```clojure
+  [:input {:on-change (h/event [e] [:draft/set (.. e -target -value)])}]
+  ```
+
+## Reads
+
+### `sub`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (h/sub query-v)
+  ```
+- **Description**: The ambient collector — read a subscription's value from
+  anywhere inside a body, including inside a `when`, a `for` or an inlined helper.
+  The edge is recorded where the read happens, so a branch not taken contributes no
+  edge. The frame doors are core's rather than duplicated here:
+  `(rf/current-frame-id)` and zero-arity `(rf/capture-frame)` are legal inside a
+  body.
+
+## Roots
+
+Four doors and one handle. Every one is root-scoped: a page may hold as many roots
+as it likes, and no call here reaches a root the caller did not name.
+
+### `mount!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (h/mount! container config view)
+  ```
+- **Description**: The root door. Ensures a frame, associates it with a DOM
+  container and one root view, and answers the handle the other three take.
+  `config` carries `:frame` (required — the frame keyword this root scopes, created
+  if absent or joined as it stands), `:initial-events` (dispatched synchronously
+  **only when this mount creates the frame**, draining before the call returns) and
+  `:identifier-prefix` (React's `identifierPrefix`, a pass-through).
+- **Example**:
+  ```clojure
+  (h/mount! (js/document.getElementById "app")
+            {:frame :rf/default :initial-events [[:counter/initialise]]}
+            [counter])
+  ```
+
+### `hydrate!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (h/hydrate! container config view)
+  ```
+- **Description**: Adopts a container's existing server-rendered DOM rather than
+  replacing it. `config` carries `:frame` and optionally `:identifier-prefix` — and
+  no `:initial-events`. **It is not `mount!`'s symmetric twin**: it does not ensure
+  its frame, it returns *before* adoption finishes, and it must be handed the same
+  `:identifier-prefix` the server render used. State comes first and through a
+  different door: `re-frame.ssr/hydrate!` installs the server's app-db and must run
+  before this.
+
+### `render!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (h/render! handle view)
+  ```
+- **Description**: Re-renders a mounted root in place, synchronously, and answers
+  its handle — the hot-reload door. React reconciles the new tree against the one
+  on the page. Calling `mount!` again instead would create a second root and
+  discard every node, subscription and scrap of component state.
+
+### `unmount!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (h/unmount! handle)
+  ```
+- **Description**: Takes this root down — `mount!`'s inverse, and idempotent. Leaves
+  sibling roots' subscriptions and frames exactly where they were, and leaves the
+  container in the document, which React empties but does not remove.
+
+## Markup
+
+### `error-boundary`
+
+- **Kind**: Var (React class component; a legal hiccup head)
+- **Signature**:
+  ```clojure
+  [h/error-boundary {:fallback f :reset-key k :on-error e} child …]
+  ```
+- **Description**: The runtime's own error boundary, named for React's term of art.
+  A React class, so React hands it a render-phase throw from anything below. It is
+  not a Hicasso *reactive* boundary: it reads no subscription, holds no cell and
+  spends no hook.
+
+### `portal`
+
+- **Kind**: Var (minted host head)
+- **Signature**:
+  ```clojure
+  [h/portal {:target node :fallback markup} child …]
+  ```
+- **Description**: Hiccup into `createPortal`. Three facts and nothing else: events
+  bubble through the **React** tree, so an ancestor's `:on-click` sees clicks inside
+  the portalled subtree; a changed `:target` is a remount, so keep it stable; and it
+  is client-only, so the subtree is absent from a server response and `:fallback` is
+  what takes its tree position. Anchoring, dismissal and focus conduct belong to the
+  overlay module, not here.
+
+### `route-link`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (h/route-link {:to route :params p :query q :fragment s} child …)
+  ```
+- **Description**: One real anchor, as data — href and click decision taken whole
+  from routing's late-bound seams. A plain function, not a boundary: it mints no
+  boundary and adds no hook.
+
+### `as-element`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (h/as-element hiccup)
+  ```
+- **Description**: The one explicit hiccup→ReactNode conversion, under the frame of
+  the boundary currently rendering. It exists because a declared `:render` return
+  crosses **unconverted**: a returned hiccup vector would reach React, which refuses
+  it. Also the answer at the two places a declaration cannot reach — a `[:>]` escape,
+  and past the native fence. Where the crossing *is* declared, prefer `defhost`'s
+  `:slots`, which lowers those positions for every use site at once.
+
+### `as-component`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (h/as-component view)
+  ```
+- **Description**: The outward bridge — answers a real React component for a hiccup
+  head, so a UIx or plain-JavaScript parent mounts a minted Hicasso view under the
+  frame it is already in. Declared once at top level, beside the view. The parent's
+  props arrive as the view's ordinary props map, children at `:children`, and the
+  frame comes from React context: no second root, state owner or props ABI appears
+  anywhere.
+
+## Local state
+
+### `reg-state`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (h/reg-state concern opts?)
+  ```
+- **Description**: The instance-key sugar. Mints one parametric subscription and one
+  setter event under `[:ui ::concern ikey]`, and nothing else.
+
+## What this door does not carry
+
+The optional modules are reached separately, so an application that never asks for
+one carries none of it — `presence` is `re-frame.hicasso.motion/presence`, and
+`.forms`, `.overlay`, `.motion`, `.substrate` and the `.server` SSR module each cost
+a classpath entry and no bundle bytes until required. The door names none of them,
+and that is the point rather than an omission: one `:require` here would put the
+retention machine into every bundle that ever touched the door. Those modules, the
+test kit and the tool tier are documented in the
+[Hicasso API reference](../core/hicasso/api-reference.md); they carry no
+api-manifest rows of their own.
+
+The marker keywords need no export. `::h/value`, `::h/prevent`, `::h/revision`,
+`::h/checked` and `::h/clear` read `:re-frame.hicasso/…`, so aliasing this namespace
+as `h` resolves the auto-resolved spelling the guide teaches with no keyword changing
+value.

--- a/docs/core/hicasso/api-reference.md
+++ b/docs/core/hicasso/api-reference.md
@@ -48,7 +48,7 @@ changed](#names-that-changed).
 
 ## `re-frame.hicasso` — the door
 
-The one namespace an ordinary application requires. Fifteen names, and every
+The one namespace an ordinary application requires. Fourteen names, and every
 optional module is reached separately so that an application which never asks
 for one carries none of it.
 

--- a/implementation/scripts/api-manifest/deps.edn
+++ b/implementation/scripts/api-manifest/deps.edn
@@ -34,6 +34,12 @@
          day8/re-frame2-ssr      {:local/root "../../ssr"}
          day8/re-frame2-ssr-ring {:local/root "../../ssr-ring"}
          day8/re-frame2-epoch    {:local/root "../../epoch"}
+         ;; Hicasso publishes `re-frame.hicasso` — a `.cljc` door whose
+         ;; `:clj` arm is the three authoring macros. Those load on the JVM
+         ;; (the `:cljs` arm's impl requires are reader-conditional away), so
+         ;; the generator introspects them like any other artefact; the door's
+         ;; CLJS runtime aliases are the probe's half.
+         day8/re-frame2-hicasso  {:local/root "../../hicasso"}
          ;; Tool artefacts with JVM-loadable (.cljc) public namespaces.
          day8/re-frame2-story    {:local/root "../../../tools/story"}
          day8/re-frame2-mcp-base {:local/root "../../../tools/mcp-base"}}

--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -19,6 +19,17 @@
     entire public surface IS the documented adapter API (spec/API.md
     §UIx adapter), so BOTH directions are checked (a var added
     without a row, or a row with no live var, → RED).
+  - `re-frame.hicasso` (rf2-phm7g) — fully-rowed, and the one covered
+    namespace that is NOT CLJS-only. The door is a SPLIT-HOST `.cljc`:
+    its `#?(:clj …)` arm is three authoring macros the JVM generator
+    introspects and rows under `:classification`, and its `#?(:cljs …)`
+    arm is eleven runtime aliases the JVM cannot see, rowed under
+    `:cljs-only`. Both arms land on ONE live analyzer surface, because
+    the macros are `:require-macros`-referred by the door's own
+    ClojureScript arm — so `reconcile-rows` carries both row sets and
+    the probe holds the whole door to full completeness. This is the
+    case `:jvm-only-classification` mirrors from the other side, and
+    the reason that key needs no entry here.
   - The Xray public surface (rf2-jhn46) — curated subsets (direction 1
     only). spec/API.md tiers the Xray surfaces `internal-public` (the
     `mount` shell lifecycle + the `panels` `mount-<panel>!` family — the
@@ -62,6 +73,7 @@
             ;; requires are load-bearing.
             [re-frame.adapter.reagent]
             [re-frame.adapter.uix]
+            [re-frame.hicasso]
             [day8.re-frame2-xray.mount]
             [day8.re-frame2-xray.panels]
             [day8.re-frame2-xray.panels.epoch-panel]
@@ -89,6 +101,14 @@
    namespace, enumerated off the analyzer at compile time."
   {"re-frame.adapter.reagent"  (emit-ns-publics re-frame.adapter.reagent)
    "re-frame.adapter.uix"      (emit-ns-publics re-frame.adapter.uix)
+   ;; The Hicasso door (rf2-phm7g) — a SPLIT-HOST `.cljc`, and the first
+   ;; namespace the probe covers that the JVM generator ALSO owns. The
+   ;; analyzer surface here is the door's `#?(:cljs …)` arm (the runtime
+   ;; aliases, rowed under `:cljs-only`) plus the three `:require-macros`-
+   ;; referred authoring macros (rowed under `:classification`, because the
+   ;; JVM introspects them). `reconcile-rows` below carries both sets, so
+   ;; the two arms reconcile against one live surface.
+   "re-frame.hicasso"          (emit-ns-publics re-frame.hicasso)
    "day8.re-frame2-xray.mount" (emit-ns-publics day8.re-frame2-xray.mount)
    ;; The Xray public surface (rf2-jhn46) — curated subsets (direction 1).
    "day8.re-frame2-xray.panels"                      (emit-ns-publics day8.re-frame2-xray.panels)
@@ -111,19 +131,38 @@
 (def fully-rowed
   "Namespaces whose ENTIRE public surface must be rowed (direction 2).
    The two adapter namespaces — their public surface IS the documented
-   adapter API. The Xray mount surface stays a curated subset (direction 1
-   only), so it is deliberately absent here."
+   adapter API — and the Hicasso door, which is likewise its whole
+   documented authoring surface (`re-frame.hicasso.impl.*` is where the
+   non-surface lives, and the door re-exports none of it). The Xray mount
+   surface stays a curated subset (direction 1 only), so it is deliberately
+   absent here."
   #{"re-frame.adapter.reagent"
-    "re-frame.adapter.uix"})
+    "re-frame.adapter.uix"
+    "re-frame.hicasso"})
 
 (def cljs-only-rows
   "The `:cljs-only` rows from spec/api-manifest-metadata.edn, embedded at
    compile time (no runtime filesystem)."
   (emit-cljs-only-rows))
 
+(def hicasso-classification-rows
+  "The `re-frame.hicasso` `:classification` rows — the door's three
+   authoring macros (rf2-phm7g).
+
+   Every other namespace this probe covers is CLJS-only, so all its rows
+   live under `:cljs-only`. The Hicasso door does not: it is a `.cljc` the
+   JVM generator owns, so its macros are curated under `:classification`
+   and their `:kind`/`:tier` are the generator's. They still need
+   reconciling HERE, because they are `:require-macros`-referred into the
+   door's own ClojureScript arm and so appear on the live analyzer surface
+   — and without them the `fully-rowed` completeness check above would
+   report three live publics with no row."
+  (emit-classification-rows "re-frame.hicasso"))
+
 (def reconcile-rows
-  "Every row the probe reconciles: the `:cljs-only` surfaces."
-  cljs-only-rows)
+  "Every row the probe reconciles: the `:cljs-only` surfaces, plus the
+   Hicasso door's JVM-owned `:classification` rows."
+  (into (vec cljs-only-rows) hicasso-classification-rows))
 
 ;; ---------------------------------------------------------------------------
 ;; The probe.
@@ -152,3 +191,30 @@
       (is (contains? live-publics ns-str)
           (str ns-str " is marked :fully-rowed but is not in live-publics "
                "— add its :require + emit-ns-publics entry.")))))
+
+(deftest runtime-verified-rows-are-actually-covered
+  (testing ":runtime-verified? true means the probe really covers that namespace"
+    ;; NON-VACUITY, and generic (rf2-phm7g). Every check above is conditional
+    ;; on a namespace being IN `live-publics`: `reconcile` filters its rows to
+    ;; the covered set, so deleting a namespace's `emit-ns-publics` entry
+    ;; removes its rows from the reconciliation and the probe goes GREEN over a
+    ;; surface it no longer looks at — the exact fail-open shape that left the
+    ;; Hicasso door uninventoried on both hosts.
+    ;;
+    ;; The sidecar already states the intended invariant, in a field: a
+    ;; `:cljs-only` row is `:runtime-verified? true` "once the probe covers its
+    ;; namespace". That was a hand-maintained boolean nothing executed. Here it
+    ;; is executed. Uncovered-by-design rows (`re-frame.core`'s reader-
+    ;; conditional pair, which the JVM generator owns) carry `false` and are
+    ;; unaffected, so this asserts the flag rather than the roster and needs no
+    ;; edit when a namespace is legitimately added or dropped.
+    (doseq [ns-str (->> cljs-only-rows
+                        (filter :runtime-verified?)
+                        (map :namespace)
+                        distinct
+                        sort)]
+      (is (contains? live-publics ns-str)
+          (str ns-str " has :cljs-only rows marked :runtime-verified? true, "
+               "but the probe does not enumerate it — either add its :require "
+               "+ emit-ns-publics entry, or set those rows "
+               ":runtime-verified? false in spec/api-manifest-metadata.edn.")))))

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -103,6 +103,13 @@
     re-frame.ssr
     re-frame.ssr.ring
     re-frame.epoch
+    ;; The Hicasso view substrate's public door. A `.cljc` whose `:clj` arm
+    ;; is the three authoring macros (`defview` / `event` / `defhost`) and
+    ;; whose `:cljs` arm is the runtime aliases — a SPLIT-HOST public
+    ;; namespace, so each host inventories the arm it can see: `ns-publics`
+    ;; here returns the macros, and the CLJS probe reconciles the aliases
+    ;; against these same `:classification` rows (rf2-phm7g).
+    re-frame.hicasso
     ;; Tool artefacts with JVM-loadable public surfaces.
     re-frame.story
     ;; MCP support namespaces — the tooling trace/egress surfaces the

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
@@ -190,3 +190,35 @@
           "precondition: facade rows exist")
       (is (empty? (gen/implementation-facade-rows rows))
           "the committed manifest must not carry an implementation-only facade row"))))
+
+;; ---------------------------------------------------------------------------
+;; Roster non-vacuity — every enrolled namespace actually contributes rows.
+;; ---------------------------------------------------------------------------
+
+(deftest every-jvm-namespace-contributes-rows
+  (testing "each namespace in the generator's roster yields at least one
+            committed manifest row — an enrolled namespace that silently
+            inventories NOTHING is the fail-open shape (rf2-phm7g)"
+    ;; NON-VACUITY, and generic. `--check` compares a regenerated manifest
+    ;; against the committed one, so it is green whenever the two AGREE —
+    ;; including when they agree that a rostered namespace contributes no
+    ;; rows at all. A namespace whose every public acquired `^:no-doc`, or
+    ;; whose surface moved wholesale behind a reader conditional, would
+    ;; drop out of the inventory with the drift check still reporting OK.
+    ;; That is how `re-frame.hicasso` could have been ADDED to the roster
+    ;; and still inventoried nothing on this host.
+    ;;
+    ;; Asserted over the roster rather than over a named namespace, so it
+    ;; needs no edit when an artefact joins or leaves. `extra-vars` is
+    ;; deliberately out of scope: it names individual vars whose home
+    ;; namespace is mostly internal, and `resolve-extra-var` already throws
+    ;; when one stops resolving.
+    (let [rows       (:vars (gen/read-committed-manifest))
+          rowed-nses (set (map :namespace rows))]
+      (is (seq rows) "precondition: the committed manifest carries rows")
+      (doseq [ns-sym gen/jvm-namespaces]
+        (is (contains? rowed-nses (name ns-sym))
+            (str ns-sym " is in the generator's jvm-namespaces roster but "
+                 "contributes NO row to the committed manifest — it either "
+                 "exposes no public var on this host (drop it from the "
+                 "roster) or its surface has silently vanished."))))))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -328,6 +328,7 @@ nav:
     - "re-frame.performance": api/re-frame.performance.md
     - "re-frame.adapter.reagent": api/re-frame.adapter.reagent.md
     - "re-frame.adapter.uix": api/re-frame.adapter.uix.md
+    - "re-frame.hicasso": api/re-frame.hicasso.md
     - "re-frame.test-support": api/re-frame.test-support.md
     - "re-frame.test-helpers": api/re-frame.test-helpers.md
 

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -183,7 +183,46 @@
   {:namespace "day8.re-frame2-xray.runtime" :var "egress-record" :kind :fn  :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.runtime" :var "egress-runtime-db-value" :kind :fn  :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.runtime" :var "egress-value"  :kind :fn  :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
-  {:namespace "day8.re-frame2-xray.runtime" :var "session-id"    :kind :var :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}]
+  {:namespace "day8.re-frame2-xray.runtime" :var "session-id"    :kind :var :facade? false :tier :tooling :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+
+  ;; ---- re-frame.hicasso — the CLJS ARM of a SPLIT-HOST door (rf2-phm7g) ----
+  ;;
+  ;; Unlike every block above, this namespace IS JVM-loadable: it sits in the
+  ;; generator's `jvm-namespaces`, where `ns-publics` returns its `#?(:clj …)`
+  ;; arm — the three authoring macros, rowed under `:classification` below.
+  ;; What the JVM cannot see is the `#?(:cljs (do …))` arm: eleven runtime
+  ;; aliases that exist only under ClojureScript. So the rows land HERE, for
+  ;; the reason this key exists — a row the JVM generator cannot introspect —
+  ;; and the CLJS probe reconciles them against the live analyzer surface.
+  ;; This is the exact MIRROR of `:jvm-only-classification` below, which does
+  ;; the same bookkeeping in the other direction for the same class of `.cljc`
+  ;; door; between them a split-host namespace is inventoried on both hosts
+  ;; and neither can silently gain or lose a public.
+  ;;
+  ;; `advanced` throughout, restrictive-by-default per spec/API.md §Tier
+  ;; taxonomy: Hicasso is an OPT-IN published substrate, so its door is not
+  ;; the front-porch set the Guide and skills load by default (that set is
+  ;; `re-frame.core`'s, which is what doc-guide-check projects against).
+  ;; `:kind` is the curated human assertion the probe deliberately does NOT
+  ;; reconcile (see `cljs-probe`'s "Why `:kind` is NOT reconciled"):
+  ;; `error-boundary` and `portal` are value-`def`s bound to component objects
+  ;; placed in hiccup rather than called, so they read `:var`; the rest are
+  ;; `defn`s or explicit `fn`s. Owner splits on the contract that actually
+  ;; owns each door: the four root-lifecycle verbs are 004C's
+  ;; (§Roots-and-Mount names `re-frame.hicasso`'s `impl/mount.cljs` as its
+  ;; in-tree realisation), the rest are 006's, which carries Hicasso's row in
+  ;; the canonical substrate inventory.
+  {:namespace "re-frame.hicasso" :var "as-component"   :kind :fn  :facade? false :tier :advanced :owner "006"  :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.hicasso" :var "as-element"     :kind :fn  :facade? false :tier :advanced :owner "006"  :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.hicasso" :var "error-boundary" :kind :var :facade? false :tier :advanced :owner "006"  :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.hicasso" :var "hydrate!"       :kind :fn  :facade? false :tier :advanced :owner "004C" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.hicasso" :var "mount!"         :kind :fn  :facade? false :tier :advanced :owner "004C" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.hicasso" :var "portal"         :kind :var :facade? false :tier :advanced :owner "006"  :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.hicasso" :var "reg-state"      :kind :fn  :facade? false :tier :advanced :owner "006"  :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.hicasso" :var "render!"        :kind :fn  :facade? false :tier :advanced :owner "004C" :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.hicasso" :var "route-link"     :kind :fn  :facade? false :tier :advanced :owner "006"  :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.hicasso" :var "sub"            :kind :fn  :facade? false :tier :advanced :owner "006"  :status "v1" :runtime-verified? true}
+  {:namespace "re-frame.hicasso" :var "unmount!"       :kind :fn  :facade? false :tier :advanced :owner "004C" :status "v1" :runtime-verified? true}]
 
  ;; --------------------------------------------------------------------------
  ;; :jvm-only-classification — the MIRROR of :cljs-only above, and the
@@ -1593,4 +1632,24 @@
   ;; cross-tool egress helper, not an application surface.
   ["re-frame.mcp-base.sensitive" "sensitive-stamp?"]     {:tier :tooling :owner "Tool-Pair" :status "post-v1 lib"}
   ["re-frame.mcp-base.sensitive" "malformed-count"]      {:tier :tooling :owner "Tool-Pair" :status "post-v1 lib"}
-  ["re-frame.mcp-base.sensitive" "reset-malformed-count!"] {:tier :tooling :owner "Tool-Pair" :status "post-v1 lib"}}}
+  ["re-frame.mcp-base.sensitive" "reset-malformed-count!"] {:tier :tooling :owner "Tool-Pair" :status "post-v1 lib"}
+
+  ;; =========================================================================
+  ;; re-frame.hicasso — the JVM ARM of the split-host door (rf2-phm7g).
+  ;; =========================================================================
+  ;; The door's `#?(:clj …)` arm is these three authoring macros and nothing
+  ;; else, so `ns-publics` on the JVM returns exactly them and the generator
+  ;; derives their `:kind :macro` from the live vars. Their CLJS-arm siblings
+  ;; — the eleven runtime aliases the JVM cannot see — are rowed under
+  ;; `:cljs-only` above; that block carries the reasoning for the shared
+  ;; `advanced` tier and the 004C/006 owner split.
+  ;;
+  ;; These rows need NO `:jvm-only-classification` entry. Each macro is
+  ;; `:require-macros`-referred by the door's own `:cljs` arm
+  ;; (`hicasso.cljc`'s `#?(:cljs (:require-macros [re-frame.hicasso :refer
+  ;; [defview defhost event]]))`), so the CLJS analyzer carries it and the
+  ;; probe reconciles it normally — the case that key's own docstring
+  ;; excludes ("an entry is needed only where the CLJS host has NOTHING").
+  ["re-frame.hicasso" "defview"]  {:tier :advanced :owner "006" :status "v1"}
+  ["re-frame.hicasso" "defhost"]  {:tier :advanced :owner "006" :status "v1"}
+  ["re-frame.hicasso" "event"]    {:tier :advanced :owner "006" :status "v1"}}}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 479,
+ :var-count 493,
  :tier-vocab
  [:front-porch
   :advanced
@@ -189,6 +189,20 @@
   {:namespace "re-frame.flows", :var "reset-flows!", :tier :implementation, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.flows", :var "reset-last-inputs!", :tier :implementation, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.flows", :var "run-flows-on-db", :tier :implementation, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.hicasso", :var "as-component", :tier :advanced, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.hicasso", :var "as-element", :tier :advanced, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.hicasso", :var "defhost", :tier :advanced, :kind :macro, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.hicasso", :var "defview", :tier :advanced, :kind :macro, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.hicasso", :var "error-boundary", :tier :advanced, :kind :var, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.hicasso", :var "event", :tier :advanced, :kind :macro, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.hicasso", :var "hydrate!", :tier :advanced, :kind :fn, :owner "004C", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.hicasso", :var "mount!", :tier :advanced, :kind :fn, :owner "004C", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.hicasso", :var "portal", :tier :advanced, :kind :var, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.hicasso", :var "reg-state", :tier :advanced, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.hicasso", :var "render!", :tier :advanced, :kind :fn, :owner "004C", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.hicasso", :var "route-link", :tier :advanced, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.hicasso", :var "sub", :tier :advanced, :kind :fn, :owner "006", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.hicasso", :var "unmount!", :tier :advanced, :kind :fn, :owner "004C", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.http", :var "delete", :tier :advanced, :kind :fn, :owner "014", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.http", :var "get", :tier :advanced, :kind :fn, :owner "014", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.http", :var "head", :tier :advanced, :kind :fn, :owner "014", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
Closes rf2-phm7g.

The API-manifest gate promised drift detection for public vars, but the published
`re-frame.hicasso` door was absent from **both** host inventories. Both arms of the
item's claim hold, and they fail for different reasons:

| Host | Cause, verified at source |
|---|---|
| JVM | `implementation/scripts/api-manifest/deps.edn` had no Hicasso local root, and `gen.clj`'s `jvm-namespaces` roster did not name the namespace. The generator could not have loaded it. |
| CLJS | `cljs_manifest_probe_cljs_test.cljs` neither `:require`d the namespace nor listed it in `live-publics` or `fully-rowed`. The probe never enumerated it. |

So an added, removed or renamed public in this published door was invisible to the
repository's generic API-contract gate on either host.

## What the diff is, and what it is not

**All 14 manifest rows are initial inventory, not drift.** The generated diff is
exactly 14 added rows plus the `:var-count` line (479 → 493). No row was removed and
no row changed, so enrolling the door caught **no pre-existing drift on arrival** —
the surface was correct all along, merely unwatched.

The door is a **split-host `.cljc`** and each host inventories the arm it can see:

- `#?(:clj …)` — three authoring macros (`defview`, `defhost`, `event`). `ns-publics`
  returns exactly these on the JVM, and the generator derives `:kind :macro` from the
  live vars. Rowed under `:classification`.
- `#?(:cljs …)` — eleven runtime aliases the JVM cannot see. Rowed under `:cljs-only`,
  the key that exists for rows the generator cannot introspect.

## The repair stayed generic

No Hicasso-shaped branch anywhere. The fix is a classpath entry, a roster entry, and
sidecar rows — plus the probe's existing `.cljc` split-host facility,
`emit-classification-rows`, which **had been written with `:jvm-only-classification`
and had zero call sites**. This is the case it was built for and its first user.

`:jvm-only-classification` needs **no** entry here, and that was measured rather than
assumed: its own docstring says a `:require-macros`-referred `#?(:clj (defmacro …))`
is carried by the CLJS analyzer and reconciles normally. The door does exactly that,
so all three macros appear on the live analyzer surface — the probe reconciles green
with those rows present, which it could not do if the analyzer omitted them.

## Two generic non-vacuity assertions

Both gates were green over a namespace they never enumerated, so coverage now asserts
itself. Neither names Hicasso, so neither needs editing when an artefact joins or leaves:

- **`runtime-verified-rows-are-actually-covered`** makes the sidecar's curated
  `:runtime-verified?` flag executable. Every probe check is conditional on a namespace
  being in `live-publics`, so deleting an entry turns the probe green over a surface it
  stopped looking at. The flag already claimed "true once the probe covers its
  namespace"; nothing executed it.
- **`every-jvm-namespace-contributes-rows`** asserts each rostered namespace yields at
  least one committed row. `--check` is green whenever generated and committed *agree* —
  including agreeing that a rostered namespace inventories nothing.

## A stale disposition this overturns

`docs/api/README.md` said the door "carries no api-manifest rows" and that this "is
deliberate rather than an oversight". That was rf2-wf1ey's disposition of 2026-08-16;
rf2-phm7g names it and rules past it, so the paragraph described the opposite of the
tree. Rewritten to what is true: the **door** is tracked on both hosts, its **optional
modules** still are not.

Enrolment also gave `doc-api-check` an opinion it never had — every manifest var at an
eligible tier needs a `docs/api/<namespace>.md` page and a member heading, and the door
had neither. Added as a terse var index pointing at the existing 631-line
`docs/core/hicasso/api-reference.md` rather than duplicating it. The
`:doc-api-coverage-exempt` hatch was deliberately **not** used: it is for a var
documented only as a facade pointer elsewhere, and misusing it would recreate the exact
fail-open shape this item exists to close.

Curated axes, flagged for review: `:tier :advanced` throughout
(restrictive-by-default per API.md §Tier taxonomy — Hicasso is an opt-in substrate, so
its door is not the front-porch set the Guide loads); `:owner` splits 004C for the four
root-lifecycle verbs (§Roots-and-Mount names this door's `impl/mount.cljs` as its in-tree
realisation) and 006 for the rest.

Incidental: the reference page said the door has "Fifteen names" while its own code block
listed fourteen. The probe now measures it — full completeness in both directions
reconciles against exactly 14 — so the prose is corrected.

## Quality gates

All exit codes are the runner's own, captured with `echo $?` on the same command line and
re-run on the **final rebased base** (`8451531aed`).

| Gate | Exit |
|---|---|
| `re-frame.api-manifest.gen --check` | **0** — in sync, 493 public vars |
| `api-md-check` / `story-spec-check` / `xray-spec-check` | **0** / **0** / **0** |
| `skills-check` / `doc-guide-check` / `doc-api-check` | **0** / **0** / **0** (171 eligible vars have page + member) |
| `clojure -M:test` (api-manifest reconcilers) | **0** — 74 tests, 156 assertions |
| `node out/node-test.js` (full CLJS suite) | **0** — 11,149 tests, 54,867 assertions |
| probe focused (`--test=…cljs-manifest-probe-cljs-test`) | **0** — 4 tests, 44 assertions |
| `check_doc_slugs.py` / `check_readme_links.py --ci` | **0** / **0** |
| `mkdocs build --strict` | **0** |
| `check_guide_samples.py` | **0** — 74 verbs at 378 sites |

### Controls — the gate is red when the property is removed

Every restore verified by **git blob hash** against the committed object, never by
reading a diff.

**Positive control before believing any green** (the gate's whole defect was reporting
green over something it never enumerated). A public var added to `re-frame.epoch`, a
namespace already covered: exit **2**, naming `re-frame.epoch/planted-control-var`.
Restored, blob `dde73810a5220ec7be31969573363ed2c94b5e3e`.

**JVM arm red.** The door's 14 rows stripped from the committed manifest:
`gen --check` exit **1** naming all 14, *and* `every-jvm-namespace-contributes-rows`
exit **1** — 1 failure of 74, so the plant was scoped and did not cascade. Restored,
blob `2ae92d2e08a1b3b198f195a9932eda91ae909d53`.

**CLJS arm red.** A public added to the door's `:cljs` arm: probe exit **1**, naming
`re-frame.hicasso/planted-control-public (:var)` via direction 2. The recompile
reported 113 files rebuilt, which is positive evidence the runtime observed the plant
rather than serving a stale compile. Restored, blob
`03ba4a6d8411ff8ac21801fa62f39ded7761b1f0`; recompiled and re-run green.

**Which tree the gates read.** The shadow-cljs compile prints this worktree's
`shadow-cljs.edn` path. `check_doc_slugs.py` was proved by a planted broken link — exit
**1** naming `docs/api/re-frame.hicasso.md:269`, a file that exists only in this
worktree, so a run that had wandered into a sibling checkout would have come back green.
Restored, blob `367fae488e7ba89014931cbde9e3aae76ff0ac62`.

One verdict was discarded rather than trusted: a backgrounded full-suite run left **no
exit-code file** while the harness reported success. Treated as no verdict and re-run in
the foreground for the number quoted above.

No `spec/*.md` normative document was touched. No new CI job.
