### PR TITLE
fix(migration): qualified and unrecognised binders shadow a bare path head

### DIFF
--- a/migration/from-re-frame-v1/codemod/README.md
+++ b/migration/from-re-frame-v1/codemod/README.md
@@ -54,8 +54,14 @@ mechanical and flags the rest (`rf2-8odvg`):
   what a bare head *denotes*, so a **bare** `path` must also survive the
   lexical scopes around the call site: a `let`, `fn`, `defn`, `letfn`,
   `for`/`doseq` (or any of their kin) that rebinds the name makes the call a
-  local, and the site flags. A qualified head such as `rf/path` cannot be
-  shadowed — locals are always simple symbols — so it is unaffected.
+  local, and the site flags. What counts as "kin" is a rule rather than a
+  roster: a binder is matched by its **simple name**, so a qualified spelling
+  (`clojure.core/let`, `cljs.core/let`) counts, and a form whose head is
+  outside the vocabulary altogether — `defmethod`, `when-first`, `dotimes`, a
+  project macro — still counts as a binder when a vector child of it binds the
+  name. Both readings can only ever *add* a flag. A qualified head such as
+  `rf/path` cannot be shadowed — locals are always simple symbols — so it is
+  unaffected.
   Positional chains are wrapped (or merged) into the one metadata-map
   `:interceptors` form; entry declaration order is preserved.
 - **Entries that are already v2 refs are preserved verbatim.**
@@ -149,8 +155,11 @@ The migration tests in `test/` exercise the full coverage matrix over
 representative v1 snippets: simple `-db`, `-db` with a path interceptor (every
 mechanical chain shape — metadata / positional / bare / metadata-plus-vector —
 lowered to `[:rf.interceptor/path [p…]]` refs), path-head resolution (custom
-`*/path` fns and lexically shadowed bare `path` heads flag; qualified heads are
-unaffected by a local of the same name), custom inline interceptors
+`*/path` fns and lexically shadowed bare `path` heads flag — under qualified
+binders such as `clojure.core/let` and under unrecognised binders such as
+`defmethod` / `when-first` / a project macro, while an enclosing form that binds
+some *other* name still lowers; qualified heads are unaffected by a local of the
+same name), custom inline interceptors
 flagged as unresolved M-70 Type B, the `reg-event` invalid-survivor rescan,
 `-fx` rename, `-ctx`, nil-capable bodies (`when` / `if` / `get` / `cond` / `and` / `or` /
 `some->` / literal `nil`), complex `-db` (var / multi-arity / destructured db

--- a/migration/from-re-frame-v1/codemod/src/re_frame/migration/reg_event_codemod.clj
+++ b/migration/from-re-frame-v1/codemod/src/re_frame/migration/reg_event_codemod.clj
@@ -326,6 +326,15 @@
 ;; free-occurrence analysis (`free-in-form?`) walks DOWN through a handler body
 ;; asking "is this param ever read?". Opposite directions, one vocabulary — so
 ;; the vocabulary lives here, above both.
+;;
+;; The two consumers consult it differently, and deliberately: the shadow check
+;; matches a head by its SIMPLE name and treats an unrecognised head as a
+;; possible binder (`binding-head` / `unrecognised-form-binds?`), because a MISS
+;; there fails open into a silent semantic swap. A miss in the free-occurrence
+;; walk fails the safe way — an unrecognised head falls through to
+;; `free-in-children?`, whose bare LHS occurrence reads as free, and "referenced"
+;; is the branch that keeps the name-preserving rebind — so it consults the sets
+;; directly and stays as it is.
 
 (def ^:private binding-vector-forms
   "Head symbols whose SECOND child is a binding vector of name/value pairs
@@ -431,6 +440,23 @@
 ;; direction only: an enclosing binding sends the site down the M-70 flag
 ;; route, so the worst case is a human glance at a site that could have been
 ;; lowered, never a silent semantic swap.
+;;
+;; WHAT COUNTS AS A BINDER IS A RULE, NOT A ROSTER (rf2-8odvg reopen). Asking
+;; the roster whether it holds this exact spelling is what reopened this bead
+;; three times, each on the next spelling of the same hole — most recently
+;; `(clojure.core/let [path ...] ...)`, which the unqualified vocabulary missed
+;; and therefore lowered. Two rules replace the roster lookup, and both fail
+;; CLOSED, i.e. towards the flag:
+;;
+;;   * a recognised binder is matched by its SIMPLE name, so every qualified
+;;     spelling of it counts (`binding-head`); and
+;;   * a head OUTSIDE the vocabulary no longer binds nothing — a vector child
+;;     that binds the name, read as either a binding vector or a params vector,
+;;     makes the form a binder (`unrecognised-form-binds?`).
+;;
+;; Together they cover the spellings nobody has enumerated yet — a project
+;; macro, `defmethod`, `when-first`, `dotimes` — without a general analyser,
+;; which the bead's non-goals exclude.
 
 (def ^:private standard-path-ns
   "The one v1 namespace whose `path` is the standard interceptor constructor."
@@ -549,16 +575,51 @@
   attr-map? [params] body)` or `(head name ([params] body)+)`."
   '#{defn defn- defmacro})
 
+(defn- binding-head
+  "Normalise a call-head symbol to the SIMPLE name the binding vocabulary above
+  is keyed by, so a namespace-qualified spelling of a binder is recognised
+  (`clojure.core/let`, `cljs.core/let`, a `[clojure.core :as c]` alias's
+  `c/let`). Returns nil for a non-symbol head.
+
+  The namespace is DISCARDED rather than resolved (rf2-8odvg reopen — a
+  `(clojure.core/let [path app.interceptors/path] ...)` around the registration
+  was lowered as the framework constructor). Resolving it would be the fail-OPEN
+  choice: an unrecognised `my.macros/let` would then bind nothing, and a site it
+  really does shadow would be silently rewritten. Discarding it is fail-CLOSED —
+  a custom macro that merely shares a binder's simple name sends the site down
+  the M-70 flag route, which costs a human glance and never a semantic swap."
+  [hd]
+  (when (symbol? hd) (symbol (name hd))))
+
+(defn- unrecognised-form-binds?
+  "Catch-all for an enclosing form whose head is NOT in the binding vocabulary
+  (`defmethod`, `when-first`, `dotimes`, `deftype`/`defrecord` methods, `are`,
+  any project macro): does any vector child bind `target`, read either as a
+  `let`-shaped binding vector or as a params vector?
+
+  Enumerating binder spellings one at a time is what reopened rf2-8odvg three
+  times, so the unrecognised case gets a rule instead of a roster. It is narrow
+  in practice — it fires only when a form enclosing the registration has a
+  vector child that literally binds the name — and, like every other branch
+  here, it can only ever produce a flag."
+  [target vector-kids arity-params]
+  (boolean (or (some #(binding-vector-binds? target %) vector-kids)
+               (some #(params-bind? target %) vector-kids)
+               (some #(params-bind? target %) arity-params))))
+
 (defn- form-binds?
   "Does the list NODE `node` lexically bind the simple name `target` anywhere in
   its scope? Recognises the same binding vocabulary as the free-occurrence
   analysis — `let`-shape, `for`/`doseq`-shape, `fn`/`fn*`, `letfn` — plus the
-  `defn` family, whose params scope over a registrar call in the body. A head
-  we do not recognise binds nothing."
+  `defn` family, whose params scope over a registrar call in the body, each
+  matched by SIMPLE name so a qualified spelling counts (`binding-head`). A head
+  outside that vocabulary falls to `unrecognised-form-binds?` rather than
+  binding nothing."
   [target node]
   (let [kids (sig-children node)
-        hd   (when (and (seq kids) (= :token (n/tag (first kids))))
-               (try (n/sexpr (first kids)) (catch Exception _ nil)))
+        hd   (some-> (when (and (seq kids) (= :token (n/tag (first kids))))
+                       (try (n/sexpr (first kids)) (catch Exception _ nil)))
+                     binding-head)
         rest-kids (rest kids)
         vector-kids (filter #(= :vector (n/tag %)) rest-kids)
         ;; `(fn ([a] ..) ([a b] ..))` / `(defn f ([a] ..))` — an arity is a
@@ -569,7 +630,7 @@
                                  (when (= :vector (some-> p n/tag)) p))))
                            rest-kids)]
     (cond
-      (not (symbol? hd)) false
+      (nil? hd) (unrecognised-form-binds? target vector-kids arity-params)
 
       (contains? binding-vector-forms hd)
       (boolean (some #(binding-vector-binds? target %) (take 1 vector-kids)))
@@ -596,7 +657,7 @@
                       (sig-children vnode)))
               (take 1 vector-kids)))
 
-      :else false)))
+      :else (unrecognised-form-binds? target vector-kids arity-params))))
 
 (defn- enclosing-scope-binds?
   "Walking OUT from `zloc` (a registrar call site), does any enclosing form

--- a/migration/from-re-frame-v1/codemod/test/re_frame/migration/reg_event_codemod_test.clj
+++ b/migration/from-re-frame-v1/codemod/test/re_frame/migration/reg_event_codemod_test.clj
@@ -410,6 +410,107 @@
         (is (= :interceptors (:flag (first findings))) (str label " flag kind"))
         (is (= src source) (str label " left unchanged"))))))
 
+(deftest shadowed-bare-path-flagged-under-a-qualified-binder
+  (testing "a QUALIFIED spelling of a binder shadows too (rf2-8odvg reopen probe)"
+    ;; `clojure.core/let` is valid Clojure and binds exactly as `let` does, but
+    ;; the binding vocabulary is keyed by simple names — matching the head
+    ;; verbatim missed it and lowered the local as the framework constructor.
+    (doseq [[label binder]
+            [["clojure.core/let" "clojure.core/let"]
+             ["cljs.core/let"    "cljs.core/let"]
+             ["aliased core/let" "c/let"]
+             ["clojure.core/fn"  nil]]]
+      (let [src (if binder
+                  (str "(ns app.events\n"
+                       "  (:require [re-frame.core :refer [reg-event-db path]]))\n"
+                       "(" binder " [path app.interceptors/path]\n"
+                       "  (reg-event-db :counter/inc\n"
+                       "    {:interceptors [(path :tenant)]}\n"
+                       "    (fn [db _] (update db :value inc))))\n")
+                  (str "(ns app.events\n"
+                       "  (:require [re-frame.core :refer [reg-event-db path]]))\n"
+                       "((clojure.core/fn [path]\n"
+                       "   (reg-event-db :counter/inc\n"
+                       "     {:interceptors [(path :tenant)]}\n"
+                       "     (fn [db _] (update db :value inc))))\n"
+                       " app.interceptors/path)\n"))
+            {:keys [source findings]} (cm/rewrite-string src)]
+        (is (= [:flag :interceptors]
+               ((juxt :action :flag) (first findings)))
+            (str label " must flag, not lower"))
+        (is (not (str/includes? source ":rf.interceptor/path"))
+            (str label " must never emit the framework ref"))
+        (is (= src source) (str label " left byte-for-byte unchanged"))))))
+
+(deftest shadowed-bare-path-flagged-under-an-unrecognised-binder
+  (testing "a head outside the vocabulary that binds `path` in a vector child flags"
+    ;; The roster will never hold every binder spelling; a form enclosing the
+    ;; registration whose vector child binds the name is treated as a binder
+    ;; whatever its head, which can only ever produce a flag.
+    (doseq [[label open close]
+            [["defmethod"  "(defmethod install! :web [_ path]"        ")"]
+             ["when-first" "(when-first [path paths]"                 ")"]
+             ["dotimes"    "(dotimes [path 3]"                        ")"]
+             ["project macro" "(app.macros/with-scope [path :tenant]" ")"]]]
+      (let [src (str "(ns app.events\n"
+                     "  (:require [re-frame.core :refer [reg-event-db path]]))\n"
+                     open "\n"
+                     "  (reg-event-db :x\n"
+                     "    {:interceptors [(path :tenant)]}\n"
+                     "    (fn [db _] (assoc db :k 1)))" close "\n")
+            {:keys [source findings]} (cm/rewrite-string src)]
+        (is (= [:flag :interceptors]
+               ((juxt :action :flag) (first findings)))
+            (str label " must flag"))
+        (is (= src source) (str label " left unchanged"))))))
+
+(deftest unrecognised-head-without-a-path-binding-still-lowers
+  (testing "the catch-all is narrow: an enclosing form that does NOT bind `path` is inert"
+    ;; Non-vacuity for the branch above — `deftest`/`testing`/`comment` and a
+    ;; `doseq` binding some OTHER name must leave the standard site mechanical.
+    (doseq [[label open close]
+            [["deftest"  "(deftest registers (testing \"x\""       "))"]
+             ["comment"  "(comment"                                ")"]
+             ["defmethod other param" "(defmethod install! :web [_ opts]" ")"]
+             ["doseq other name"      "(doseq [k [:a :b]]"          ")"]]]
+      (let [src (str "(ns app.events\n"
+                     "  (:require [re-frame.core :refer [reg-event-db path]]))\n"
+                     open "\n"
+                     "  (reg-event-db :x\n"
+                     "    {:interceptors [(path :counter)]}\n"
+                     "    (fn [db _] (assoc db :k 1)))" close "\n")
+            {:keys [source findings]} (cm/rewrite-string src)]
+        (is (= :rewrite (:action (first findings))) (str label " must still rewrite"))
+        (is (str/includes? source "[[:rf.interceptor/path [:counter]]]")
+            (str label " must still lower the standard head"))))))
+
+(deftest qualified-binder-shadowing-does-not-suppress-a-qualified-head
+  (testing "a `clojure.core/let` local named `path` cannot shadow `rf/path`"
+    (let [src (str "(ns app.events (:require [re-frame.core :as rf]))\n"
+                   "(clojure.core/let [path app.interceptors/path]\n"
+                   "  (rf/reg-event-db :counter/inc\n"
+                   "    {:interceptors [(rf/path :counter)]}\n"
+                   "    (fn [db _] (update db :value inc))))\n")
+          {:keys [source findings]} (cm/rewrite-string src)]
+      (is (= :rewrite (:action (first findings))))
+      (is (str/includes? source "{:interceptors [[:rf.interceptor/path [:counter]]]}")))))
+
+(deftest qualified-binder-shadow-idempotent
+  (testing "the qualified-binder site is stable across a second run"
+    (let [src (str "(ns app.events\n"
+                   "  (:require [re-frame.core :refer [reg-event-db path]]))\n"
+                   "(clojure.core/let [path app.interceptors/path]\n"
+                   "  (reg-event-db :counter/inc\n"
+                   "    {:interceptors [(path :tenant)]}\n"
+                   "    (fn [db _] (update db :value inc))))\n")
+          once  (rewrite src)
+          twice (rewrite once)]
+      (is (= src once) "first run leaves the source unchanged")
+      (is (= once twice) "second run is a no-op too")
+      (is (= [:flag :interceptors]
+             ((juxt :action :flag) (only-finding twice)))
+          "the flag survives the re-scan"))))
+
 (deftest shadowing-does-not-suppress-a-qualified-head
   (testing "a local named `path` cannot shadow `rf/path` — the standard site still lowers"
     (let [src (str "(ns app.events (:require [re-frame.core :as rf]))\n"


### PR DESCRIPTION
Closes the lexical-shadow boundary of rf2-8odvg, reopened by the audit of PR #8857.

## The defect, reproduced at source before any edit

The M-73 codemod's call-site shadow check (`enclosing-scope-binds?` → `form-binds?`) asked its binding vocabulary whether it held a head **verbatim**. The vocabulary is keyed by unqualified symbols, so a qualified spelling of a binder was not a binder at all.

The audit's probe, run at this branch's base:

```
(ns app.events (:require [re-frame.core :refer [reg-event-db path]]))
(clojure.core/let [path app.interceptors/path]
  (reg-event-db :counter/inc
    {:interceptors [(path :tenant)]}
    (fn [db _] (update db :value inc))))
```

returned `[:rewrite nil]` and emitted `[:rf.interceptor/path [:tenant]]` — silently replacing the author's custom interceptor with the framework constructor, which is precisely the outcome the path-head resolution work exists to prevent. The bare-`let` control on the same run correctly returned `[:flag :interceptors]`, isolating the qualification as the cause. `(clojure.core/let [path (fn [x] [:custom x])] (path :tenant))` evaluates to `[:custom :tenant]` in the same JVM, so the probe form is real Clojure rather than a synthetic shape.

## The fix: a rule, not a roster

Enumerating binder spellings one at a time is what reopened this bead three times, each on the next spelling of the same hole. Two rules replace the roster lookup, and **both fail closed — towards the flag**:

- **A recognised binder is matched by its SIMPLE name** (`binding-head`), so `clojure.core/let`, `cljs.core/let` and an aliased `c/let` all count. The namespace is *discarded* rather than resolved deliberately: resolving it would be the fail-open choice, leaving an unrecognised `my.macros/let` binding nothing and its shadowed sites silently rewritten.
- **A head outside the vocabulary no longer binds nothing** (`unrecognised-form-binds?`): a vector child that binds the name, read as either a binding vector or a params vector, makes the form a binder. This covers `defmethod`, `when-first`, `dotimes`, `deftype` methods and project macros without a general analyser, which the item's non-goals exclude.

The catch-all is narrow in practice — it fires only when a form enclosing the registration has a vector child that literally binds `path` — and, like every other branch here, it can only ever produce a flag. The worst case stays a human glance at a site that could have been lowered, never a semantic swap.

**The free-occurrence walk is deliberately unchanged.** It shares this vocabulary but consults it in the opposite direction, and a miss there *fails safe*: an unrecognised head falls through to `free-in-children?`, whose bare LHS occurrence reads as free, and "referenced" is the branch that keeps the name-preserving rebind. Normalising it would have been an unrelated behaviour change. The asymmetry is now stated at the shared vocabulary rather than left for the next reader to rediscover.

## Tests

Five new deftests, all on the flag/lower boundary:

- `shadowed-bare-path-flagged-under-a-qualified-binder` — the audit probe itself, plus `cljs.core/let`, an aliased `c/let` and `clojure.core/fn`.
- `shadowed-bare-path-flagged-under-an-unrecognised-binder` — `defmethod`, `when-first`, `dotimes`, a project macro.
- `unrecognised-head-without-a-path-binding-still-lowers` — **non-vacuity for the catch-all**: `deftest`/`testing`, `comment`, a `defmethod` binding some other param, and a `doseq` binding another name must all still lower the standard site.
- `qualified-binder-shadowing-does-not-suppress-a-qualified-head` — the over-reach control: a `clojure.core/let` local cannot shadow `rf/path`.
- `qualified-binder-shadow-idempotent` — a second run neither rewrites nor loses the flag.

## Gates

| Gate | Captured exit | Result |
|---|---|---|
| `clojure -M:test` (baseline, pre-edit) | 0 | 77 tests / 276 assertions |
| `clojure -M:test` (post-fix) | 0 | 82 tests / 310 assertions |
| `clojure -M:integration` (baseline) | 0 | 6 tests / 10 assertions |
| `clojure -M:integration` (post-fix) | 0 | 6 tests / 10 assertions |
| `python scripts/check_doc_slugs.py` | see below | codemod README |

Every exit code was captured with the redirect and the `echo $?` on one command line in one shell, and is the runner's own number rather than one reported about the run.

The README edit is prose and a link-free list, so no link or anchor changed inside or outside a fenced block; the two doc gates do not read inside fences and nothing here needed hand-checking beyond that.

## Documentation

`migration/from-re-frame-v1/codemod/README.md` carried the guarantee this fix widens, in both the M-70 × M-73 section and the test-coverage paragraph; both now state that "kin" is a rule rather than a roster. The hot-zone `migration/from-re-frame-v1/README.md` is **not** touched — it does not state the shadow guarantee, so nothing in it became untrue.
