### PR TITLE
fix(template): re-register the app schema from every emitted after-load hook (rf2-a0442)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_reagent/core.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/core.cljs
@@ -38,7 +38,17 @@
 ;; (running the `:initial-events` seed synchronously, so the initial render sees
 ;; the seeded app-db), and REUSES the live frame WITHOUT re-seeding on every
 ;; later render — so a reload leaves your app-db exactly as you left it.
+;;
+;; The schema registration is here rather than in `init` for the same reason
+;; the render is: registration is a fn call, not a load-time side effect, so
+;; reloading schema.cljs re-evaluates `CounterDb` and re-registers nothing.
+;; Running it here — the one path both boot and every reload take — is what
+;; makes an edited schema validate the live frame instead of the boot-time
+;; value. It replaces the entry for the same (frame, path) in place, and on
+;; the first call it still runs BEFORE `frame-root` creates the frame, so the
+;; `:initial-events` seed is validated from the very first write.
 (defn ^:dev/after-load mount! []
+  (schema/register-schema!)
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
     (when-not @react-root
@@ -66,7 +76,6 @@
   ;;        :large     [[:documents :upload]]}))
   ;; See the README's privacy section for HTTP carriers and response bodies.
   ;;
-  ;; Schema attachment is frame-local; it names the app frame explicitly so
-  ;; the `:initial-events` seed is validated from the very first write.
-  (schema/register-schema!)
+  ;; `mount!` attaches the app-db schema before it renders — see its comment
+  ;; above for why that belongs on the reload path rather than here.
   (mount!))

--- a/tools/template/resources/day8/re_frame2_template/_reagent/core_with_ssr.cljc
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/core_with_ssr.cljc
@@ -74,7 +74,9 @@
 ;;
 ;; ssr-handler owns the per-request frame id. Its initial events run inside
 ;; that frame, so the zero-arity helper attaches to the ambient request frame.
-;; The browser knows its frame id and uses the explicit arity.
+;; The browser knows its frame id and uses the explicit arity — at boot in
+;; `init`, and again from the `^:dev/after-load` hook so an edited `CounterDb`
+;; reaches the live client frame without a page refresh.
 (defn register-schema!
   ([] (rf/reg-app-schema [] CounterDb))
   ([frame-id] (rf/reg-app-schema [] {:frame frame-id} CounterDb)))
@@ -152,8 +154,16 @@
 ;; It never creates a root and never re-hydrates: the root is established once
 ;; in `init`, and HYDRATE happens once there too, so a reload cannot re-seed the
 ;; server slice over live interactive state.
+;;
+;; It DOES re-attach the app-db schema, against the already-live `app-frame`.
+;; Registration is a fn call, not a load-time side effect, so reloading this
+;; file re-evaluates `CounterDb` and re-registers nothing — without that call
+;; the client keeps validating against the boot-time schema until you refresh
+;; the page. Re-registering replaces the entry for the same (frame, path) in
+;; place: no new frame, no re-seed, and the adopted server DOM is untouched.
 #?(:cljs
    (defn ^:dev/after-load render! []
+     (register-schema! app-frame)
      (when-let [root @react-root]
        ;; Render inside the app-frame's `frame-provider`, so every `dispatch`
        ;; and `subscribe` down in the view tree resolves to the hydrated frame.

--- a/tools/template/resources/day8/re_frame2_template/_reagent/core_with_stories.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/core_with_stories.cljs
@@ -92,7 +92,15 @@
 ;; same root. `frame-root` reuses the already-live frame without re-seeding, so
 ;; your app-db survives the save. See
 ;; `docs/core/how-to/boot-and-mount-an-app.md` §Host listeners.
+;;
+;; It also re-attaches the app-db schema. Registration is a fn call, not a
+;; load-time side effect, so reloading schema.cljs re-evaluates `CounterDb`
+;; and re-registers nothing — without this line the framework keeps
+;; validating the live frame against the boot-time schema until you refresh
+;; the page. Re-registering replaces the entry for the same (frame, path) in
+;; place; the frame, its app-db and both roots are untouched.
 (defn ^:dev/after-load reload! []
+  (schema/register-schema!)
   (install-hash-listener!)
   (on-hash-change!))
 
@@ -108,6 +116,7 @@
   ;;
   ;; Schema attachment is frame-local; it names the app frame explicitly so
   ;; the frame-root `:initial-events` seed is validated from the first write.
+  ;; `reload!` re-runs this after every save — see its comment above.
   (schema/register-schema!)
   ;; Install the reload-safe route listener before applying the current hash.
   (install-hash-listener!)

--- a/tools/template/resources/day8/re_frame2_template/_shared/README_with_ssr.md
+++ b/tools/template/resources/day8/re_frame2_template/_shared/README_with_ssr.md
@@ -276,6 +276,16 @@ the scaffold attaches the schema under a live frame scope
 client via the explicit-frame arity), never at namespace load. Closed maps
 (`{:closed true}`) catch typos.
 
+Because the attachment is a fn call rather than a top-level form, a hot reload
+re-evaluates `CounterDb` and re-registers nothing on its own. The client's
+`^:dev/after-load render!` hook therefore calls `register-schema!` again on
+every save, so an edited `CounterDb` validates the live client frame instead of
+the boot-time value — without a page refresh, and without re-hydrating: the
+re-registration replaces the entry for the same frame and path in place, leaving
+the frame, its `app-db` and the adopted server DOM alone. (The server side needs
+no equivalent: its frame is per-request and short-lived, so every request
+re-runs `:ssr/register-schema` against freshly loaded code.)
+
 **A release build registers these schemas and never checks them.** That is the
 designed posture rather than a gap — schema validation is a development tool and
 production trusts the programmer. The registration is still worth keeping: it

--- a/tools/template/resources/day8/re_frame2_template/_shared/schema.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/schema.cljs
@@ -36,13 +36,24 @@
   [:map {:closed true}
    [:counter/value :int]])
 
-;; App-db schemas are frame-local, so core/init calls this at boot instead of
+;; App-db schemas are frame-local, so core calls this explicitly instead of
 ;; registering it as a namespace-load side effect. The registration names the
 ;; app frame EXPLICITLY (`{:frame :rf/default}`), so it can run BEFORE the
 ;; `rf/frame-root` mount creates the frame — the frame's `:initial-events`
 ;; seed is then validated from the very first write.
+;;
+;; BECAUSE it is a fn call and not a load-time side effect, a hot reload of
+;; THIS file re-evaluates `CounterDb` but re-registers nothing on its own.
+;; That is why core's `^:dev/after-load` hook calls it again: editing the
+;; schema above must reach the live frame without a page refresh. Re-
+;; registering the same (frame, path) replaces the entry in place — the
+;; frame, its app-db and the React root are untouched (Spec 010 §Multiple
+;; schemas at the same path). When the live app-db no longer fits a
+;; tightened schema, the runtime emits a `:rf.schema/violation` warning
+;; and keeps running; it does not clear or rewind your state.
 (defn register-schema!
-  "Attach the whole-app-db schema to the app's frame. Call once at boot
-   (see core/init)."
+  "Attach the whole-app-db schema to the app's frame. Called at boot and
+   again from core's `^:dev/after-load` hook, so an edited schema takes
+   effect on the next save rather than the next page refresh."
   []
   (rf/reg-app-schema [] {:frame :rf/default} CounterDb))

--- a/tools/template/resources/day8/re_frame2_template/_uix/core.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_uix/core.cljs
@@ -33,7 +33,17 @@
 ;; (running the `:initial-events` seed synchronously, so the initial render sees
 ;; the seeded app-db), and REUSES the live frame WITHOUT re-seeding on every
 ;; later render — so a reload leaves your app-db exactly as you left it.
+;;
+;; The schema registration is here rather than in `init` for the same reason
+;; the render is: registration is a fn call, not a load-time side effect, so
+;; reloading schema.cljs re-evaluates `CounterDb` and re-registers nothing.
+;; Running it here — the one path both boot and every reload take — is what
+;; makes an edited schema validate the live frame instead of the boot-time
+;; value. It replaces the entry for the same (frame, path) in place, and on
+;; the first call it still runs BEFORE `frame-root` creates the frame, so the
+;; `:initial-events` seed is validated from the very first write.
 (defn ^:dev/after-load mount! []
+  (schema/register-schema!)
   (when-let [el (and (exists? js/document)
                      (js/document.getElementById "app"))]
     (when-not @react-root
@@ -62,7 +72,6 @@
   ;;        :large     [[:documents :upload]]}))
   ;; See the README's privacy section for HTTP carriers and response bodies.
   ;;
-  ;; Schema attachment is frame-local; it names the app frame explicitly so
-  ;; the `:initial-events` seed is validated from the very first write.
-  (schema/register-schema!)
+  ;; `mount!` attaches the app-db schema before it renders — see its comment
+  ;; above for why that belongs on the reload path rather than here.
   (mount!))

--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -60,6 +60,17 @@ Three mechanisms combine to give you a clean reload:
    add: the new `id` shows up live, but the old `id` stays registered
    until that refresh.)
 
+   **`schema.cljs` is the one exception, and the scaffold handles it for
+   you.** Its `reg-app-schema` call lives inside `register-schema!`
+   rather than at the top level (it has to — see [§Typed app-db
+   boundaries](#typed-app-db-boundaries)), so a reload re-evaluates
+   `CounterDb` and re-registers *nothing*. The `^:dev/after-load` hook
+   therefore calls `register-schema!` again on every save. Without that,
+   the framework would go on validating against the boot-time schema:
+   add an optional key and a write using it would still be rejected;
+   tighten the schema and a now-invalid write would still be accepted —
+   until you refreshed the page.
+
 3. **`rf/init!` runs once, in `init`, and does NOT reset anything by
    itself.** It is idempotent and installs the substrate adapter
    **only when none is already seated**. Per EP-0002 (Spec 002 §Frame
@@ -418,9 +429,12 @@ no explicit `:frame` raises `:rf.error/no-frame-context` — so a bare
 `reg-app-schema` call at namespace-load time would throw. The scaffold
 therefore puts the registration in a `register-schema!` fn that names
 the app frame **explicitly** (the optional middle metadata map's
-`:frame` slot) and that `core/init` calls at boot — before the
-`rf/frame-root` mount even creates the frame, so the frame's
-`:initial-events` seed is validated from its very first write:
+`:frame` slot). `core.cljs` calls it from the `^:dev/after-load` hook,
+which is the one path both the first load and every hot reload take —
+so the first call still lands before the `rf/frame-root` mount creates
+the frame (the frame's `:initial-events` seed is validated from its very
+first write), and every later call replaces the registration with
+whatever `schema.cljs` now says:
 
 ```clojure
 (def CounterDb
@@ -431,9 +445,24 @@ the app frame **explicitly** (the optional middle metadata map's
 (defn register-schema! []
   (rf/reg-app-schema [] {:frame :rf/default} CounterDb))
 
-;; in core.cljs — called once at boot (see init)
-(schema/register-schema!)
+;; in core.cljs — at boot AND after every hot reload.
+;; (`mount!` here; `reload!` in the Story scaffold.)
+(defn ^:dev/after-load mount! []
+  (schema/register-schema!)
+  ;; ... create the root once, then render ...
+  )
 ```
+
+Because the registration is a fn call rather than a top-level form, a
+reload of `schema.cljs` re-evaluates `CounterDb` but re-registers
+nothing on its own — the hook's call is what makes an edited schema
+take effect on the next save instead of the next page refresh.
+Re-registering the same path replaces the previous schema in place
+(last-write-wins, exactly like re-registering a handler); the frame,
+your `app-db` and the React root are untouched. If the live `app-db`
+no longer fits a schema you have just tightened, the runtime logs a
+`:rf.schema/violation` warning and keeps running — it does not clear
+or rewind your state.
 
 If you are already inside an established frame scope
 (`rf/with-frame`, a handler, a view), the two-slot form

--- a/tools/template/spec/002-Generated-Shape.md
+++ b/tools/template/spec/002-Generated-Shape.md
@@ -101,6 +101,37 @@ and the canonical
 [`examples/core/counter`](../../../examples/core/counter/)
 example.
 
+## Hot-reload contract
+
+shadow-cljs calls a `:browser` build's module `:init-fn` exactly once, at
+bundle load, and thereafter invokes only `^:dev/after-load` hooks. Every
+emitted browser entry point therefore carries such a hook — `mount!` on the
+Reagent and UIx scaffolds, `reload!` on the Story scaffold, `render!` on the
+SSR client — and that hook, not `init`, is what a save re-runs.
+
+Two things must ride it, and both are normative for every variant:
+
+1. **Re-render into the retained root.** The React root lives in a `defonce`
+   cell; the hook renders into it rather than creating a second root over a
+   live DOM node, and `rf/frame-root` reuses the already-live frame without
+   re-seeding.
+2. **Re-register the app-db schema.** `reg-app-schema` is invoked from a
+   `register-schema!` fn rather than at namespace load (an app-db schema is
+   frame-local, so a bare load-time call would raise
+   `:rf.error/no-frame-context`). A reload therefore re-evaluates the schema
+   `def` but re-registers nothing on its own, and the framework keeps
+   validating against the boot-time value until a page refresh. The hook
+   calls `register-schema!` so the just-loaded schema reaches the live frame.
+   Re-registering the same `(frame, path)` replaces the entry in place, so
+   the frame, its `app-db` and the mounted root are untouched — see
+   [Spec 010 §Multiple schemas at the same path](../../../spec/010-Schemas.md#multiple-schemas-at-the-same-path).
+
+On the Reagent and UIx scaffolds `init` delegates to the hook, so boot and
+reload traverse one path. The Story and SSR scaffolds have their own one-time
+boot ceremonies (route-listener install; frame → schema → hydrate → root), so
+there `init` attaches the schema itself and the hook re-attaches it. The SSR
+hook must NOT re-hydrate or replay seed events.
+
 ## Xray devtools
 
 The **Reagent** scaffold ships [Xray](../../xray/) — the in-app

--- a/tools/template/test-support/schema_reload_test.cljs
+++ b/tools/template/test-support/schema_reload_test.cljs
@@ -1,0 +1,172 @@
+(ns acme.my-app.schema-reload-test
+  "Executable regression for rf2-a0442 — the hot-reload schema seam.
+
+   NOT part of the emitted scaffold. `emitted_test_run_test.clj` copies
+   this file into a generated project's `test/` tree, where the emitted
+   shadow-cljs `:test` build (`:ns-regexp \"-test$\"`) compiles and runs
+   it alongside the scaffold's own `events_test.cljs`. It therefore runs
+   against REAL generated source — the emitted `schema.cljs`,
+   `events.cljs` and `subs.cljs` — not against a hand-built stand-in. The
+   generated project is always `acme/my-app`, so the namespace is fixed.
+
+   ## What it pins
+
+   `reg-app-schema` is frame-local, so the scaffold cannot call it at
+   namespace load: it lives inside `schema/register-schema!`. A hot
+   reload therefore re-evaluates `schema.cljs`'s `CounterDb` `def` and
+   re-registers NOTHING on its own. Before rf2-a0442 the only caller was
+   `core/init`, which shadow runs once at bundle load — so an edited
+   schema never reached the live frame, and the framework went on
+   validating it against the boot-time value until a page refresh.
+
+   `core.cljs`'s `^:dev/after-load` hook now calls `register-schema!`
+   again, and `template_emission_test.clj` pins that call (its presence
+   AND its position before the render) for all four emitted entry
+   points. What THIS file proves is the other half — that the call does
+   what the hook needs it to do on a LIVE frame:
+
+     * a reload widens the schema, and a write the boot-time schema
+       rejected then commits;
+     * a reload tightens it back, and the same write is rejected again
+       (the inverse direction rf2-a0442 also names);
+     * across both, the frame is never recreated and the counter value
+       set before the reload survives it.
+
+   ## What a reload is, mechanically
+
+   Two steps, and this file performs both:
+
+     1. shadow re-evaluates the changed namespace's top-level forms —
+        for `schema.cljs` that is the `CounterDb` `def`, modelled here
+        by assigning the var.
+     2. shadow calls the `^:dev/after-load` hooks — the hook calls
+        `schema/register-schema!`, modelled here by calling the very
+        same fn.
+
+   The React root and `frame-root` render the hook also re-runs are out
+   of scope: they need a DOM, and the retained-root half already has its
+   own coverage (rf2-r0kk7 / rf2-w1k3i)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core                 :as rf]
+            [re-frame.schemas              :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support         :as ts]
+            ;; Requiring these installs the generated registrations.
+            [acme.my-app.events]
+            [acme.my-app.subs]
+            [acme.my-app.schema            :as schema]))
+
+;; The edit an author makes in schema.cljs: one optional string key added
+;; to the closed map.
+(def WidenedCounterDb
+  [:map {:closed true}
+   [:counter/value :int]
+   [:counter/label {:optional true} :string]])
+
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn []
+                (rf/make-frame {:id :rf/default :preset :test}))}))
+
+;; --- the reload seam -------------------------------------------------------
+
+(defn- save-and-reload!
+  "Model one `shadow-cljs watch` save of schema.cljs: re-evaluate the
+  `CounterDb` def, then run what the `^:dev/after-load` hook runs. No
+  frame is created, destroyed or re-seeded — exactly as in the browser,
+  where the hook renders into the retained root and `frame-root` reuses
+  the live frame."
+  [schema-value]
+  (set! schema/CounterDb schema-value)
+  (schema/register-schema!))
+
+(defn- app-db []
+  (rf/app-db-value :rf/default))
+
+(defn- write-label!
+  "Dispatch an ordinary event that writes `:counter/label`. A write the
+  registered schema forbids is rolled back; depending on the frame's
+  error policy it may also throw, which is still a rejection — the
+  caller asserts on app-db, the observable that matters."
+  [label]
+  (try
+    (rf/dispatch-sync [:counter/set-label label])
+    (catch :default _ nil)))
+
+(defn- register-label-event! []
+  (rf/reg-event :counter/set-label
+    (fn [{:keys [db]} [_ label]]
+      {:db (assoc db :counter/label label)})))
+
+;; --- Tests -----------------------------------------------------------------
+
+(deftest reload-replaces-the-live-app-schema
+  (testing "re-registering after a schema edit installs the NEW schema on the
+            already-live frame, and the pre-reload counter state survives"
+    (register-label-event!)
+    ;; Boot: the scaffold's own registration, closed CounterDb.
+    (schema/register-schema!)
+    (rf/dispatch-sync [:counter/initialise])
+    (rf/dispatch-sync [:counter/increment])
+    (rf/dispatch-sync [:counter/increment])
+    (rf/dispatch-sync [:counter/increment])
+    (is (= 3 (:counter/value (app-db)))
+        "counter carries non-default state into the reload")
+    (is (= schema/CounterDb
+           (schemas/app-schema-at [] {:frame :rf/default}))
+        "the boot-time schema is what validates the live frame")
+
+    ;; NON-VACUITY CONTROL. Before the reload the closed boot schema must
+    ;; REJECT the new key. Without this the widened-write assertion below
+    ;; would pass even if nothing were ever re-registered.
+    (write-label! "before")
+    (is (nil? (:counter/label (app-db)))
+        "the closed boot-time schema rejects :counter/label — the write is
+         rolled back")
+    (is (= 3 (:counter/value (app-db)))
+        "a rejected write leaves the rest of app-db intact")
+
+    ;; The save.
+    (save-and-reload! WidenedCounterDb)
+    (is (= WidenedCounterDb
+           (schemas/app-schema-at [] {:frame :rf/default}))
+        "the reload replaced the registered schema for [] on :rf/default —
+         this is the assertion that fails when the ^:dev/after-load hook
+         does not call register-schema! (rf2-a0442)")
+
+    ;; The same write now commits, against the same frame and the same
+    ;; app-db — no reseed, no frame recreation.
+    (write-label! "after")
+    (is (= "after" (:counter/label (app-db)))
+        "the source-valid write commits once the edited schema is live")
+    (is (= 3 (:counter/value (app-db)))
+        "the counter value set before the reload is untouched by it")))
+
+(deftest reload-tightening-a-schema-takes-effect-too
+  (testing "the inverse direction: re-registering a TIGHTER schema makes a
+            write the previous, laxer schema admitted fail — the runtime does
+            not clear or rewind the app-db that no longer fits"
+    (register-label-event!)
+    (save-and-reload! WidenedCounterDb)
+    (rf/dispatch-sync [:counter/initialise])
+    (rf/dispatch-sync [:counter/increment])
+    (write-label! "admitted")
+    (is (= "admitted" (:counter/label (app-db)))
+        "the widened schema admits :counter/label")
+
+    ;; Tighten: back to the scaffold's own closed CounterDb.
+    (save-and-reload! [:map {:closed true} [:counter/value :int]])
+    (is (= [:map {:closed true} [:counter/value :int]]
+           (schemas/app-schema-at [] {:frame :rf/default}))
+        "the tightened schema is live after the reload")
+    (is (= "admitted" (:counter/label (app-db)))
+        "the live app-db is NOT cleared or rewound by a tightening reload —
+         the runtime reports the drift and keeps running")
+
+    (write-label! "rejected")
+    (is (= "admitted" (:counter/label (app-db)))
+        "a write the tightened schema forbids no longer commits — the stale
+         permissive schema is gone (rf2-a0442)")
+    (is (= 1 (:counter/value (app-db)))
+        "the counter survives the tightening reload")))

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -1028,6 +1028,118 @@
           (when (and @clojure-cli-available? @node-available?)
             (compile-and-run-emitted-test! :uix))))))
 
+;; --- the hot-reload schema seam (rf2-a0442) --------------------------------
+;;
+;; `reg-app-schema` is frame-local, so the scaffold cannot call it at namespace
+;; load — it lives inside `schema/register-schema!`. A hot reload therefore
+;; re-evaluates `schema.cljs`'s `CounterDb` def and re-registers NOTHING on its
+;; own, and before rf2-a0442 the only caller was `core/init`, which shadow runs
+;; once at bundle load. An edited schema never reached the live frame: a
+;; source-valid write stayed rejected, a newly invalid one stayed accepted,
+;; until a full page refresh.
+;;
+;; `template_emission_test.clj` pins the fix's static half — every emitted
+;; `^:dev/after-load` hook calls `register-schema!`, before its render. This
+;; tier proves the other half EXECUTABLY, against real generated source: that
+;; the call replaces the schema on a LIVE frame, in both directions, without
+;; recreating the frame or disturbing the counter state set before it.
+;;
+;; Deliberately the CHEAPEST tier that can prove it: only the `:test`
+;; (`:node-test`) build compiles, so there is no `:browser` build, no
+;; `node_modules` requirement and no Chromium. The hook's OTHER job — the
+;; retained-root re-render — is DOM-bound and already covered (rf2-r0kk7 /
+;; rf2-w1k3i); this tier is about the schema registry alone.
+
+(defn- install-schema-reload-regression!
+  "Copy `test-support/schema_reload_test.cljs` into the generated project's
+  test tree. The emitted `:test` build's `:ns-regexp \"-test$\"` picks it up
+  alongside the scaffold's own `events_test.cljs`, so it compiles and runs
+  against the REAL emitted `schema.cljs` / `events.cljs` / `subs.cljs`.
+
+  Kept out of the scaffold on purpose: it is a regression net for the
+  template, not something a newcomer should find in their first app."
+  [^java.io.File root ^java.io.File proj]
+  (let [src (io/file root "tools/template/test-support/schema_reload_test.cljs")
+        dst (io/file proj "test/acme/my_app/schema_reload_test.cljs")]
+    (io/make-parents dst)
+    (io/copy src dst)
+    (.isFile dst)))
+
+(deftest schema-reload-seam-runs-test
+  (testing "in a generated project, re-running the scaffold's own
+            register-schema! after a schema edit replaces the schema on the
+            live frame — the seam the ^:dev/after-load hook depends on
+            (rf2-a0442)"
+    (if-not @enabled?
+      (skip-if-disabled! :schema-reload)
+      (do
+        (is @clojure-cli-available?
+            "`clojure` CLI must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
+        (is @node-available?
+            "`node` must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
+        (when (and @clojure-cli-available? @node-available?)
+          (let [root      (repo-root)
+                node-mods (io/file root "implementation/node_modules")
+                ;; The `:node-test` bundle SHIMS its npm requires and resolves
+                ;; them at RUN time, where Node honours NODE_PATH — so this
+                ;; tier needs no project-local node_modules symlink/junction
+                ;; (that is a `:browser`-compile requirement, and this tier
+                ;; compiles no `:browser` build).
+                env       {"NODE_PATH" (.getCanonicalPath node-mods)}
+                tmp       (tmp-dir "rf2-template-schema-reload-")]
+            (try
+              (let [proj (run-template! tmp "acme/my-app" :reagent)]
+                (rewrite-deps-for-local-run! root proj :reagent)
+                (is (install-schema-reload-regression! root proj)
+                    "the rf2-a0442 regression namespace must land in the
+                     generated project's test tree")
+                (is (.isDirectory node-mods)
+                    (str "implementation/node_modules must exist for the "
+                         "compiled :node-test bundle to resolve its npm "
+                         "requires at run time (`npm install` in "
+                         "implementation/). Looked in "
+                         (.getPath node-mods)))
+                (testing "schema-reload — shadow-cljs compile test"
+                  (let [{:keys [exit out]}
+                        (run-process! ["clojure" "-M:shadow"
+                                       "-m" "shadow.cljs.devtools.cli"
+                                       "compile" "test"]
+                                      proj env)]
+                    (is (zero? exit)
+                        (str "`clojure -M:shadow compile test` exited " exit
+                             " for the rf2-a0442 schema-reload regression. "
+                             "Output:\n" out))))
+                (testing "schema-reload — node out/node-test.js"
+                  (let [bundle (io/file proj "out/node-test.js")]
+                    (is (.isFile bundle)
+                        "the compile step produced out/node-test.js")
+                    (when (.isFile bundle)
+                      (let [{:keys [exit out]}
+                            (run-process! ["node" "out/node-test.js"] proj env)]
+                        ;; Pin the namespace line first: a regression file that
+                        ;; failed to land, or an `:ns-regexp` that stopped
+                        ;; matching it, would otherwise ship a green
+                        ;; "0 failures" that proved nothing.
+                        (is (string/includes?
+                              out "Testing acme.my-app.schema-reload-test")
+                            (str "the rf2-a0442 regression namespace must be "
+                                 "IN the compiled bundle — without this line "
+                                 "the run below is green about the scaffold's "
+                                 "own tests only. Output:\n" out))
+                        (is (zero? exit)
+                            (str "`node out/node-test.js` exited " exit
+                                 " with the rf2-a0442 schema-reload regression "
+                                 "installed. Output:\n" out))
+                        (is (re-find #"Ran \d+ tests? containing \d+ assertions" out)
+                            (str "expected the cljs.test summary line — a "
+                                 "silent zero-test run would otherwise pass. "
+                                 "Got:\n" out))
+                        (is (re-find #"0 failures, 0 errors" out)
+                            (str "expected '0 failures, 0 errors'. Got:\n"
+                                 out)))))))
+              (finally
+                (delete-recursively tmp)))))))))
+
 (deftest reagent-with-story-emitted-tests-run-test
   ;; The only tier that actually shadow-compiles +
   ;; node-runs the `:include-story? true` scaffold. Reagent-only because

--- a/tools/template/test/day8/re_frame2_template/template_emission_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_emission_test.clj
@@ -1173,6 +1173,171 @@
           (finally
             (delete-recursively tmp)))))))
 
+;; --- the hot-reload hook re-registers the app-db schema --------------------
+;;
+;; rf2-a0442. The hook above closed HALF of the reload loop: an edited VIEW
+;; repaints. An edited SCHEMA did not take effect. `reg-app-schema` is
+;; frame-local, so the scaffold cannot call it at namespace load (a bare
+;; load-time call raises `:rf.error/no-frame-context`) — it lives inside a
+;; `register-schema!` fn. A reload therefore re-evaluates `CounterDb` and
+;; re-registers NOTHING on its own, and every emitted entry point called
+;; `register-schema!` from `init` alone. shadow calls `init` once, so the
+;; framework went on validating the live frame with the boot-time schema:
+;; adding an optional key left a source-valid write rejected with
+;; `:rf.error/schema-validation-failure`, and tightening a schema left a
+;; now-invalid write accepted, until a full page refresh.
+;;
+;; The remedy is one call per hook. Re-registering a `(frame, path)` is an
+;; in-place replace (Spec 010 §Multiple schemas at the same path), so nothing
+;; about the frame, its app-db or the mounted root changes.
+;;
+;; The ORDER matters as much as the presence: the call must precede the
+;; hook's render work, so the first (boot) call still lands before
+;; `frame-root` creates the frame and the `:initial-events` seed is validated
+;; from the very first write — and so a DOM-free host, where the render is
+;; skipped, still registers.
+
+(defn- after-load-hook-body
+  "The source text of the `^:dev/after-load <hook>` form: from its metadata
+  tag to the start of the next TOP-LEVEL form — `(def…` at column 0, or a
+  `#?(` reader conditional, which is how the SSR `core.cljc` opens its next
+  form. Returns nil when the hook is absent, so a caller asserts the absence
+  rather than passing vacuously over an empty body."
+  [^String core ^String hook]
+  (let [i (.indexOf core (str "^:dev/after-load " hook))]
+    (when-not (neg? i)
+      (let [tail (subs core i)
+            ends (->> ["\n(def" "\n#?("]
+                      (map #(.indexOf tail ^String %))
+                      (remove neg?))]
+        (if (seq ends) (subs tail 0 (apply min ends)) tail)))))
+
+(deftest after-load-hook-re-registers-app-schema-test
+  (testing "every emitted ^:dev/after-load hook re-attaches the app-db schema
+            BEFORE it renders — shadow re-runs the hook, not the module
+            :init-fn, so without this an edited schema.cljs never reaches the
+            live frame and the boot-time schema keeps validating it until a
+            page refresh (rf2-a0442)"
+    (doseq [[label opts rel hook call renders]
+            [["reagent"       {:substrate :reagent}
+              "src/acme/my_app/core.cljs" "mount!"
+              "(schema/register-schema!)" "rdc/render"]
+             ["uix"           {:substrate :uix}
+              "src/acme/my_app/core.cljs" "mount!"
+              "(schema/register-schema!)" "uix-dom/render-root"]
+             ["reagent+story" {:substrate :reagent :include-story? true}
+              "src/acme/my_app/core.cljs" "reload!"
+              "(schema/register-schema!)" "(on-hash-change!)"]
+             ["reagent+ssr"   {:substrate :reagent :include-ssr? true}
+              "src/acme/my_app/core.cljc" "render!"
+              "(register-schema! app-frame)" "rdc/render"]]]
+      (let [tmp (tmp-dir "rf2-emission-schema-reload-")]
+        (try
+          (let [proj (run-template-opts! tmp "acme/my-app" opts)
+                core (slurp (io/file proj rel))
+                body (after-load-hook-body core hook)]
+            (is (some? body)
+                (str label ": core must define `^:dev/after-load " hook "`"))
+            (when body
+              (is (.contains body call)
+                  (str label ": the `^:dev/after-load " hook "` body must call `"
+                       call "` — shadow does NOT re-run the module :init-fn "
+                       "after a reload, so this call is the ONLY thing that "
+                       "makes an edited schema validate the live frame "
+                       "(rf2-a0442)"))
+              (when (.contains body call)
+                (is (< (.indexOf body call) (.indexOf body ^String renders))
+                    (str label ": the schema re-registration must precede `"
+                         renders "` in the hook body — on the first (boot) "
+                         "call it has to land before the frame exists, so the "
+                         ":initial-events seed is validated from the very "
+                         "first write, and a DOM-free host that skips the "
+                         "render must still register (rf2-a0442)")))))
+          (finally
+            (delete-recursively tmp)))))))
+
+(deftest ssr-after-load-hook-registers-without-rehydrating-test
+  (testing "the SSR client's ^:dev/after-load hook re-attaches the schema
+            against the LIVE app-frame without re-hydrating or replaying the
+            seed events (rf2-a0442 / rf2-w1k3i)"
+    (let [tmp (tmp-dir "rf2-emission-ssr-schema-reload-")]
+      (try
+        (let [proj (run-template-opts! tmp "acme/my-app"
+                                       {:substrate :reagent :include-ssr? true})
+              core (slurp (io/file proj "src/acme/my_app/core.cljc"))
+              body (after-load-hook-body core "render!")]
+          (is (some? body) "core.cljc must define `^:dev/after-load render!`")
+          (when body
+            (is (.contains body "(register-schema! app-frame)")
+                "the hook must re-attach against the already-live app-frame —
+                 the explicit-frame arity, not the ambient-scope one")
+            ;; The body legitimately MENTIONS hydration in a comment ("the
+            ;; hydrated frame"), so pin the CALLS rather than the word.
+            (is (not (.contains body "ssr/hydrate!"))
+                "the hook must not re-hydrate: hydration is a one-time boot
+                 step and re-running it would re-seed the server slice over
+                 live interactive state")
+            (is (not (.contains body "hydrate-root"))
+                "the hook must not re-adopt the server DOM — the root is
+                 established once, in init")
+            (is (not (.contains body ":counter/initialise"))
+                "the hook must not replay the client seed event — a reload
+                 preserves app-db, it does not reset it")))
+        (finally
+          (delete-recursively tmp))))))
+
+(deftest schema-registration-is-a-fn-not-a-load-time-side-effect-test
+  (testing "the emitted schema.cljs keeps `reg-app-schema` inside
+            `register-schema!` — a top-level call would raise
+            :rf.error/no-frame-context, and it is precisely that indirection
+            which makes the after-load re-registration necessary (rf2-a0442)"
+    (let [tmp (tmp-dir "rf2-emission-schema-shape-")]
+      (try
+        (let [proj   (run-template! tmp "acme/my-app" :reagent)
+              schema (slurp (io/file proj "src/acme/my_app/schema.cljs"))]
+          (is (.contains schema "(defn register-schema!")
+              "schema.cljs must define register-schema!")
+          (is (not (re-find #"(?m)^\(rf/reg-app-schema" schema))
+              "schema.cljs must NOT call reg-app-schema at the top level — an
+               app-db schema is frame-local and a load-time call raises
+               :rf.error/no-frame-context (which is why the after-load hook
+               has to call register-schema! explicitly)")
+          (is (not (re-find #"(?i)once at boot" schema))
+              "schema.cljs must not tell the reader registration happens only
+               once at boot — the after-load hook re-runs it on every save
+               (rf2-a0442)"))
+        (finally
+          (delete-recursively tmp))))))
+
+(deftest schema-reload-prose-is-accurate-test
+  (testing "both emitted READMEs teach schema registration at boot AND after
+            load, and neither claims it happens only once at boot (rf2-a0442)"
+    (doseq [[label opts] [["spa" {:substrate :reagent}]
+                          ["ssr" {:substrate :reagent :include-ssr? true}]]]
+      (let [tmp (tmp-dir "rf2-emission-schema-prose-")]
+        (try
+          (let [proj   (run-template-opts! tmp "acme/my-app" opts)
+                readme (slurp (io/file proj "README.md"))
+                norm   (string/replace readme #"\s+" " ")]
+            (is (not (re-find #"(?i)once at boot" norm))
+                (str label " README must NOT say the schema is registered only
+                      once at boot — the ^:dev/after-load hook re-registers it
+                      on every save (rf2-a0442)"))
+            ;; Positively require the corrected teaching, so the claim can be
+            ;; deleted rather than fixed and still ship green.
+            (is (re-find #"(?i)\^:dev/after-load" norm)
+                (str label " README must name the ^:dev/after-load hook"))
+            (is (re-find #"(?i)register-schema!" norm)
+                (str label " README must name register-schema!"))
+            (is (re-find #"(?i)re-registers? nothing on its own" norm)
+                (str label " README must explain WHY the hook has to call
+                      register-schema! again: a reload re-evaluates CounterDb
+                      but re-registers nothing on its own, because the
+                      registration is a fn call and not a top-level form
+                      (rf2-a0442)")))
+          (finally
+            (delete-recursively tmp)))))))
+
 (deftest hot-reload-prose-is-accurate-test
   (testing "the emitted shadow-cljs.edn + README do NOT claim shadow re-runs the
             module :init-fn after a hot reload — measured false on shadow-cljs


### PR DESCRIPTION
Fixes rf2-a0442.

## The defect

shadow-cljs calls a `:browser` build's module `:init-fn` **once**, at bundle
load, and thereafter invokes only `^:dev/after-load` hooks. Every emitted entry
point registered its app-db schema from `init` alone.

`reg-app-schema` is frame-local, so the scaffold cannot call it at namespace
load — a bare load-time call raises `:rf.error/no-frame-context`, so it lives
inside `schema/register-schema!`. That indirection is what makes the bug: a hot
reload re-evaluates `schema.cljs`'s `CounterDb` `def` and re-registers
**nothing** on its own. The framework therefore went on validating the live
frame with the boot-time schema — adding an optional key left a source-valid
write rejected with `:rf.error/schema-validation-failure`, and tightening a
schema left a now-invalid write accepted — until a full page refresh.

Confirmed at source in all four emitted entry points before the fix.

## The fix

Each hook re-attaches the schema, **before** its render work:

| scaffold | hook | change |
|---|---|---|
| Reagent default | `mount!` | registration folded into `mount!`, which `init` already delegates to |
| UIx | `mount!` | same |
| Reagent + Story | `reload!` | `reload!` re-attaches; `init` keeps its own boot ceremony |
| Reagent SSR client | `render!` | `render!` re-attaches against the live `app-frame`; no re-hydration, no seed replay |

Order matters as much as presence: on the first (boot) call the registration
still lands before `rf/frame-root` creates the frame, so the `:initial-events`
seed is validated from the very first write — and a DOM-free host, where the
render is skipped, still registers.

Generated comments, both emitted READMEs and `tools/template/spec/002-Generated-Shape.md`
now teach registration at boot **and** after load.

## Two questions the brief asked me to settle

**1. Is re-registering from the hook correct against the framework's own
semantics, or does it paper over a framework gap?** It is correct; no framework
change is needed, and no follow-up bead was filed.

- `spec/010-Schemas.md` §Multiple schemas at the same path: "Re-registering a
  schema at a path replaces the previous one (last-write-wins) … a same-form
  re-register (hot reload) is benign."
- `spec/010-Schemas.md` §Schema migration on hot-reload defines the exact
  scenario, including the tightened-schema case: the runtime emits a
  `:rf.schema/violation` warning and the app keeps running; `app-db` is not
  cleared or rewound.
- `implementation/schemas/src/re_frame/schemas/storage.cljc` §hot-reload
  semantics: `reg-app-schema` writes only to `schemas-by-frame`; re-registering
  a `(frame-id, path)` is an ordinary atomic `swap!` and the per-frame map *is*
  the validation cache.
- Executable framework coverage already exists —
  `schemas_storage_test.clj/meta-at-reflects-hot-reload-replacement`,
  `schemas_reg_side_effects_test.clj`, and a hot-reload race stress test.

**2. One shared hot-reload helper, or four parallel edits?** Four parallel
edits, deliberately.

- The fix is one call at the point a reader is already looking. A helper would
  still have to be *called* from each hook, so it saves nothing at the call
  site — it only relocates a comment.
- It could not cover all four anyway: the SSR scaffold has no `schema.cljs`;
  its `register-schema!` is inline in `core.cljc` with a different arity.
- The emitted files are user-facing source. The reader must see, in the hook
  they are reading, what a reload re-does.
- It keeps rf2-zq34m's options open: removing a scaffold removes its line, with
  no shared abstraction to unwind.

## Coverage

**Static, unconditional** (`tools/template` default `clojure -M:test`) —
`template_emission_test.clj`:

- every emitted `^:dev/after-load` hook calls `register-schema!`, and calls it
  before its render (all four variants);
- the SSR hook re-attaches against the live `app-frame` and neither re-hydrates
  nor replays the seed event;
- `schema.cljs` keeps `reg-app-schema` inside `register-schema!` rather than at
  the top level;
- both emitted READMEs teach boot **and** after-load, and neither claims
  registration happens only once at boot.

**Executable** — `test-support/schema_reload_test.cljs`, copied by
`emitted_test_run_test.clj` into a generated project's test tree, where the
emitted `:test` build compiles and runs it against the real generated
`schema.cljs` / `events.cljs` / `subs.cljs`. It models one save exactly:
re-evaluate the `CounterDb` `def`, then call what the hook calls. It boots with
the closed schema, holds a counter value of 3, proves the closed schema
**rejects** a `:counter/label` write (the built-in non-vacuity control),
reloads with a widened schema, and proves the live frame's schema is replaced
and the same write now commits with the counter intact. A second test drives
the inverse: tightening on reload makes a previously admitted write fail, and
does not clear or rewind the app-db that no longer fits.

It rides the existing `RF2_TEMPLATE_RUN_EMITTED_TESTS` gate that CI's
`jvm-tools-template` job sets on every PR, and is deliberately the cheapest
tier that can prove the seam: `:test` build only — no `:browser` compile, no
project-local `node_modules`, no Chromium. It also pins the
`Testing acme.my-app.schema-reload-test` line in the node output, so a
regression file that failed to land cannot ship a green that proved nothing.

## Gates

| gate | scope | exit |
|---|---|---|
| `clojure -M:test` in `tools/template` (post-rebase) | the artefact | **0** — 71 tests, 728 assertions |
| `clojure -M:test -v …/schema-reload-seam-runs-test` with `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` (post-rebase) | generate + compile + run the emitted project | **0** — 1 test, 10 assertions |
| `scripts/check_doc_slugs.py` | `tools/template/spec/**` | **0** |
| `scripts/check_readme_links.py --ci` | the emitted `README.md` resources | **0** |
| `clj-kondo --fail-level error` on `tools/template/{src,test}` | new test code | **0** — 0 errors |
| `clojure -M:splint --fail-on-errors` over the template lint surface | new `.cljs` fixture parses | **0** — 9 files, 0 errors |

Three sabotage controls, each red only because the fault existed in this
checkout:

1. Removing `(schema/register-schema!)` from the Reagent `mount!` → template
   suite **exit 1**, naming `reagent: the ^:dev/after-load mount! body must
   call (schema/register-schema!)`.
2. Removing `(schema/register-schema!)` from the regression's reload seam →
   emitted-run **exit 1**, with 4 assertion failures inside the generated
   project (5 tests ran: 3 scaffold + 2 regression), exactly the four that
   depend on re-registration.
3. Breaking the `spec/010-Schemas.md` anchor in the new spec section →
   `check_doc_slugs.py` **exit 1** naming the file, line and anchor.

Each plant was restored and verified by git blob hash against the committed
object, not by reading a diff.

Gate-coverage note, verified in both directions rather than assumed: the
emitted `README.md` template resources are **outside** `check_doc_slugs.py`
(a planted broken anchor there returns exit 0) and **inside**
`check_readme_links.py --ci` (the same plant returns exit 1 naming it). The
`tools/template/spec/` page is the reverse. Both gates were nominated by path.

## Fences

Confined to `tools/template/**`. No `implementation/**` runtime change, no new
CI job or workflow file, no `implementation/shadow-cljs.edn` edit, no `.beads`
path. The scaffold set is untouched structurally, so rf2-zq34m stays unruled
and unprejudiced.
