### PR TITLE
fix(realworld-http): keep optimistic comment writes owned by the route that issued them (rf2-84iek)

### DIFF
--- a/examples/real-apps/realworld_http/comments.cljs
+++ b/examples/real-apps/realworld_http/comments.cljs
@@ -10,11 +10,12 @@
    - `:comment-form` in the plain form slice shape.
    - Route-driven loads that read the current slug off the runtime-db
      coeffect at `[:rf.runtime/routing :current :params :slug]`.
-   - Route-keyed reads that stay owned by the route identity: each slice
-     records the slug it is loading, replies carry the slug they were
-     requested for, and a settle that no longer belongs to the screen is
-     refused (see `reply-for-current-slug?` below — the same correlation
-     law article_editor.cljs spells for the editor).
+   - Route-keyed reads AND comment mutations that stay owned by the route
+     identity: each slice records the slug it is loading, the comment
+     reads and writes carry the slug they were requested for, and a settle
+     that no longer belongs to the screen is refused (see
+     `reply-for-current-slug?` below — the same correlation law
+     article_editor.cljs spells for the editor).
    - Optimistic post / delete flows that roll back through nothing fancier
      than ordinary events."
   (:require [clojure.string :as str]
@@ -55,14 +56,41 @@
 ;;
 ;; So each slice records WHICH slug it is loading (`[:article :slug]` /
 ;; `[:comments :slug]`, stamped by the load handler in the same write that
-;; starts the load), every reply target carries the slug it was REQUESTED
-;; for, and each terminal handler asks this one question before writing
+;; starts the load), the reply targets BELOW carry the slug they were
+;; REQUESTED for, and their handlers ask this one question before writing
 ;; anything — data, status, error, or timestamp. A late alpha settle while
 ;; the slice targets beta is dropped on the floor; a beta settle (success OR
 ;; failure) is beta's own and lands normally. Retained data follows the same
 ;; law: a SAME-slug refresh keeps the prior data up while `:fetching`
 ;; (never blank a loaded page on a refresh), but a slug CHANGE resets the
 ;; slice, so alpha's article is never renderable under `/article/beta`.
+;;
+;; EXACTLY these carry the slug and gate on it — the two route-driven READS
+;; (`:article/load`'s reply hat, `:comments/loaded` / `:comments/load-failed`)
+;; and the three comment MUTATION settles (`:comment-form/submit-success`,
+;; `:comment-form/submit-error`, `:comment/delete-rollback`). The mutations
+;; need it just as badly as the reads: they land on the one shared
+;; `[:comments :data]` / `[:comment-form]`, so alpha's late POST failure
+;; would otherwise banner beta's form and alpha's failed DELETE would
+;; re-insert alpha's comment into beta's list (rf2-84iek).
+;;
+;; Two deliberate NON-members, so nobody reads the list as "everything in
+;; this file is correlated":
+;;
+;;   - `:comment/delete-success` writes nothing at all (it exists to give
+;;     `:on-success` a target), so it needs neither the slug nor the gate.
+;;   - The article SOCIAL controls further down — `:article/author-follow-
+;;     synced` / `-rollback`, `:article/delete-failed` — are NOT gated. They
+;;     write `[:article :data ...]` from a button press rather than from the
+;;     route's own load, and no cross-route defect has been reproduced
+;;     against them; they are out of rf2-84iek's scope, not covered by it.
+;;
+;; The gate correlates ROUTE IDENTITY, not request identity: it asks which
+;; slug the screen is on, so alpha → beta → alpha readmits an alpha reply
+;; issued before the round trip. That is the same strength the reads have
+;; had since rf2-iy3d6, and it is deliberate — a per-request epoch or a
+;; cancellation scheme would buy a much narrower race at the cost of the
+;; machinery this example exists to stay clear of.
 ;;
 ;; article_editor.cljs spells this identical law for the editor
 ;; (`still-editing?`, with the full why-neither-request-id-nor-leafwise-seed-
@@ -202,7 +230,20 @@
          as :article/load — see THE CORRELATION GATE above), and the same
          refresh-vs-new-identity split applies on the way out: a same-slug
          re-entry keeps the loaded comments up while `:fetching`; a different
-         slug resets the slice."
+         slug resets the slice.
+
+         A new identity resets THE COMMENT FORM along with the slice, and
+         that pairing is load-bearing rather than tidiness. The form is a
+         single shared widget — `:comment-form/initialise` runs once at boot,
+         not on the route — so without this it carries alpha's half-finished
+         submission into beta: alpha's draft text, alpha's error banner, and
+         (because both the textarea and the Post button are `:disabled`
+         while `:status` is `:submitting`) a form beta can never type in.
+         That last one is what makes it load-bearing: once the mutation
+         settles are correlation-gated, a submit issued on alpha and answered
+         after the reader reached beta is refused, and refusing it is only
+         safe because the navigation has ALREADY released the form. Reset and
+         gate are two halves of one fix (rf2-84iek)."
    :rf.http/decode-schemas [schema/CommentsResponse]}
   (fn [{:keys [db] rt :rf.db/runtime} _]
     (let [slug     (get-in rt [:rf.runtime/routing :current :params :slug])
@@ -211,12 +252,16 @@
                      (:comments db)
                      {:status :idle :data [] :error nil
                       :loaded-at nil :attempt 0})]
-      {:db (assoc db :comments
-                  (-> slice
-                      (assoc :slug   slug
-                             :status (if (and refresh? (seq (:data slice))) :fetching :loading)
-                             :error  nil)
-                      (update :attempt (fnil inc 0))))
+      {:db (cond-> (assoc db :comments
+                          (-> slice
+                              (assoc :slug   slug
+                                     :status (if (and refresh? (seq (:data slice))) :fetching :loading)
+                                     :error  nil)
+                              (update :attempt (fnil inc 0))))
+             ;; New article identity → the page's form starts over too. A
+             ;; SAME-slug refresh leaves it alone, so a background re-load
+             ;; never eats what the reader is part-way through typing.
+             (not refresh?) (assoc :comment-form (comment-form-defaults)))
        :fx [[:rf.http/managed
              (rh/request {:method     :get
                           :path       (comment-path slug)
@@ -267,7 +312,14 @@
          in `:on-success` / `:on-failure` so the reply knows which card it's
          talking about. And it comes from the recordable
          `:realworld/temp-comment-id` coeffect above, never a fresh
-         `random-uuid` here — see that block for the why."
+         `random-uuid` here — see that block for the why.
+
+         Those same targets carry THE SLUG WE ARE POSTING TO, ahead of the
+         temp-id, because the two facts answer different questions: the slug
+         says WHICH PAGE this reply belongs to, the temp-id says WHICH CARD
+         on it. A POST answered after the reader has moved on has no page
+         left to land on, so both settles gate on the slug first — see THE
+         CORRELATION GATE above."
    :rf.http/decode-schemas [schema/CommentResponse]
    :rf.cofx/requires [:realworld/temp-comment-id]}
   (fn [{:keys [db] rt :rf.db/runtime temp-id :realworld/temp-comment-id} _]
@@ -306,40 +358,64 @@
                             :path       (comment-path slug)
                             :body       {:comment {:body body}}
                             :decode     schema/CommentResponse
-                            :on-success [:comment-form/submit-success temp-id]
-                            :on-failure [:comment-form/submit-error temp-id]})]]}))))
+                            :on-success [:comment-form/submit-success slug temp-id]
+                            :on-failure [:comment-form/submit-error slug temp-id]})]]}))))
 
 (rf/reg-event :comment-form/submit-success
-  (fn [{:keys [db]} [_ temp-id {:keys [value]}]]
-    {:db (let [saved (:comment value)]
-      (-> db
-          (assoc-in [:comment-form] (comment-form-defaults))
-          ;; Swap the optimistic temp card for the saved comment IN PLACE,
-          ;; right where it already sits. If we appended the saved one instead,
-          ;; the comment would visibly jump from the bottom (where it landed
-          ;; optimistically) to the top — a tiny teleport the eye absolutely
-          ;; catches. Same move as favorites.cljs/update-article-in-list: map
-          ;; over, replace the match, keep the order.
-          (update-in [:comments :data]
-                     (fn [comments]
-                       (mapv (fn [comment]
-                               (if (= temp-id (:id comment)) saved comment))
-                             (or comments []))))))}))
+  {:doc "The POST's `:on-success`, carrying the slug it was posted to.
+         Correlation-gated (THE CORRELATION GATE above): a save that comes
+         back for an article the reader has left writes nothing — it neither
+         clears the form under the new page nor reaches into its comments.
+         Nothing is stranded by that refusal: the optimistic temp card went
+         with the slice when `:comments/load` reset it for the new slug, the
+         comment really is saved server-side, and coming back to the article
+         re-reads it from there."}
+  (fn [{:keys [db]} [_ slug temp-id {:keys [value]}]]
+    (when (reply-for-current-slug? db :comments slug)
+      {:db (let [saved (:comment value)]
+             (-> db
+                 (assoc-in [:comment-form] (comment-form-defaults))
+                 ;; Swap the optimistic temp card for the saved comment IN
+                 ;; PLACE, right where it already sits. If we appended the
+                 ;; saved one instead, the comment would visibly jump from the
+                 ;; bottom (where it landed optimistically) to the top — a tiny
+                 ;; teleport the eye absolutely catches. Same move as
+                 ;; favorites.cljs/update-article-in-list: map over, replace the
+                 ;; match, keep the order.
+                 (update-in [:comments :data]
+                            (fn [comments]
+                              (mapv (fn [comment]
+                                      (if (= temp-id (:id comment)) saved comment))
+                                    (or comments []))))))})))
 
 (rf/reg-event :comment-form/submit-error
-  (fn [{:keys [db]} [_ temp-id {:keys [error]}]]
-    {:db (-> db
-        (update-in [:comments :data]
-                   (fn [comments]
-                     (vec (remove #(= temp-id (:id %)) comments))))
-        (assoc-in [:comment-form :status] :idle)
-        (assoc-in [:comment-form :submit-error]
-                  (rh/failure->message error)))}))
+  {:doc "The POST's `:on-failure`, correlated exactly as
+         `:comment-form/submit-success` is. A post that fails for an article
+         the reader has left must not banner the article now on screen with
+         the previous one's error, nor flip its form's lifecycle. There is
+         again nothing to strand: the temp card this would have yanked back
+         out went with the slice on the slug change, and that same reset put
+         the form back to `:idle`, so refusing here cannot leave the new
+         page's form stuck mid-submit."}
+  (fn [{:keys [db]} [_ slug temp-id {:keys [error]}]]
+    (when (reply-for-current-slug? db :comments slug)
+      {:db (-> db
+               (update-in [:comments :data]
+                          (fn [comments]
+                            (vec (remove #(= temp-id (:id %)) comments))))
+               (assoc-in [:comment-form :status] :idle)
+               (assoc-in [:comment-form :submit-error]
+                         (rh/failure->message error)))})))
 
 (rf/reg-event :comment/delete
   {:doc "Whisk a comment off the screen first, then send the DELETE. If the
          server says no, the rollback handler slots the comment back in at its
-         original index, as though nothing happened."}
+         original index, as though nothing happened.
+
+         The rollback target carries THE SLUG WE ARE DELETING FROM alongside
+         the captured `prior`, so a failure answered after the reader moved on
+         cannot slot the previous article's comment into the current one's
+         list (rf2-84iek). `:on-success` needs neither: it is a no-op."}
   (fn [{:keys [db] rt :rf.db/runtime} [_ id]]
     (let [slug     (get-in rt [:rf.runtime/routing :current :params :slug])
           comments (vec (get-in db [:comments :data]))
@@ -354,7 +430,7 @@
                           :path       (str (comment-path slug) "/" id)
                           :decode     :auto
                           :on-success [:comment/delete-success id]
-                          :on-failure [:comment/delete-rollback prior]})]]})))
+                          :on-failure [:comment/delete-rollback slug prior]})]]})))
 
 (rf/reg-event :comment/delete-success
   {:doc "Success means: do nothing, gracefully. The optimistic delete already
@@ -365,23 +441,33 @@
   (fn [{:keys [db]} _] {:db db}))
 
 (rf/reg-event :comment/delete-rollback
-  (fn [{:keys [db]} [_ {:keys [index comment]} _failure-payload]]
-    {:db (if (and (some? index) comment)
-      (update-in db [:comments :data]
-                 (fn [xs]
-                   ;; Clamp the re-insert point to the list's CURRENT length.
-                   ;; The index we saved was true at optimistic-delete time, but
-                   ;; the list may have shrunk since — a `:comments/loaded`
-                   ;; re-fetch, or a second delete racing this one. Skip the
-                   ;; clamp and `subvec` throws IndexOutOfBounds the moment
-                   ;; index > (count xs), taking the whole event drain down with
-                   ;; it. A little defensive arithmetic is cheaper than that.
-                   (let [xs (vec xs)
-                         i  (min (max 0 index) (count xs))]
-                     (vec (concat (subvec xs 0 i)
-                                  [comment]
-                                  (subvec xs i))))))
-      db)}))
+  {:doc "The DELETE's `:on-failure`, carrying the slug it was deleting from.
+         Correlation-gated: restoring a comment into a list that now belongs
+         to a DIFFERENT article would be pure fabrication — the comment is not
+         one of that article's. Refusing loses nothing, because the article
+         this comment does belong to had its list reset on the way out, and
+         the server still holds the comment (the DELETE failed), so coming
+         back re-reads it."}
+  (fn [{:keys [db]} [_ slug {:keys [index comment]} _failure-payload]]
+    (when (reply-for-current-slug? db :comments slug)
+      {:db (if (and (some? index) comment)
+             (update-in db [:comments :data]
+                        (fn [xs]
+                          ;; Clamp the re-insert point to the list's CURRENT
+                          ;; length. The index we saved was true at
+                          ;; optimistic-delete time, but the list may have
+                          ;; shrunk since — a `:comments/loaded` re-fetch, or a
+                          ;; second delete racing this one. Skip the clamp and
+                          ;; `subvec` throws IndexOutOfBounds the moment
+                          ;; index > (count xs), taking the whole event drain
+                          ;; down with it. A little defensive arithmetic is
+                          ;; cheaper than that.
+                          (let [xs (vec xs)
+                                i  (min (max 0 index) (count xs))]
+                            (vec (concat (subvec xs 0 i)
+                                         [comment]
+                                         (subvec xs i))))))
+             db)})))
 
 ;; ============================================================================
 ;; ARTICLE-DETAIL SOCIAL CONTROLS

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -506,9 +506,13 @@
     ;; A DELETE for a comment that WAS at index 3 in a since-shrunk list
     ;; fails. The captured prior carries the stale index 3 against the
     ;; current length-1 list. Before the clamp this threw on `subvec`.
+    ;; The rollback carries the slug it was deleting from ahead of the
+    ;; captured prior (rf2-84iek); the initialised slice targets nil, so a
+    ;; nil-slug rollback is the matching identity here — same convention as
+    ;; the `:comments/loaded nil` seed above.
     (rf/dispatch-sync
-      [:comment/delete-rollback {:index 3 :comment {:id 9 :body "rolled-back"
-                                                    :author {:username "mallory"}}}]
+      [:comment/delete-rollback nil {:index 3 :comment {:id 9 :body "rolled-back"
+                                                        :author {:username "mallory"}}}]
       {:frame f})
 
     (let [data (rf/compute-sub [:comments/data] (rf/frame-state-value f))]
@@ -2117,6 +2121,288 @@
             renderable under beta's URL) while a same-slug re-load keeps the
             loaded data up as a refresh (rf2-iy3d6)"
     (article-slug-change-resets-while-same-slug-refresh-retains-test)))
+
+;; ============================================================================
+;; article page — optimistic comment MUTATIONS stay owned by the route
+;; (rf2-84iek)
+;; ============================================================================
+;;
+;; rf2-iy3d6 (above) correlated the two route-driven READS. The comment
+;; WRITES land on the very same shared state — `[:comments :data]` and the
+;; single `[:comment-form]` — and were left slug-free, so a POST or DELETE
+;; issued on alpha and answered after the reader reached beta wrote into
+;; beta: a success reset beta's draft, a failure bannered beta's form, and a
+;; failed DELETE spliced ALPHA'S COMMENT into beta's list.
+;;
+;; The fix carries the issuing slug in the three settle targets and gates
+;; each on the same `reply-for-current-slug?` the reads use. What makes
+;; DROPPING those writes safe rather than merely quiet is the other half:
+;; `:comments/load` now resets `[:comment-form]` whenever it takes on a new
+;; article identity. Without that reset the form is a boot-time singleton
+;; that rides across the navigation still `:status :submitting` — and since
+;; the textarea and the Post button are both `:disabled` while submitting,
+;; refusing alpha's settle would have left beta's form permanently locked.
+;; The strand control below is what pins that pairing.
+
+(defn- comment-form* [f] (rf/compute-sub [:comment-form/slice] (rf/frame-state-value f)))
+
+(defn- req-by-method+url
+  "The captured lowered request with this HTTP method whose URL ends with
+   `url-suffix`. The comment POST / DELETE carry no `:request-id` — they are
+   one-shot writes, not re-issuable reads — so they are addressed by what
+   they are rather than by an id."
+  [lowered method url-suffix]
+  (some #(when (and (= method (get-in % [:request :method]))
+                    (str/ends-with? (get-in % [:request :url]) url-suffix))
+           %)
+        lowered))
+
+(defn- saved-comment [id body]
+  {:id id :createdAt "2026-05-02" :updatedAt "2026-05-02" :body body
+   :author {:username "alice" :bio nil :image nil :following false}})
+
+(defn- settle-ok! [f target value]
+  (rf/dispatch-sync (conj target {:status :ok :value value}) {:frame f}))
+
+(defn- settle-fail! [f target]
+  (rf/dispatch-sync (conj target {:status :error
+                                  :error {:kind :rf.http/http-5xx :status 500}})
+                    {:frame f}))
+
+(defn- with-held-comment-fx
+  "Run `body-fn` against a frame whose `:rf.http/managed` is a capturing stub:
+   every request is recorded and NONE settles by itself, so each reply can be
+   delivered by hand in the order a slow network would pick. `body-fn` gets
+   the frame and the atom of lowered requests."
+  [fx-id body-fn]
+  (let [lowered (atom [])]
+    (rf/reg-fx fx-id
+      {:platforms #{:client :server}}
+      (fn [_frame-ctx args] (swap! lowered conj args) nil))
+    (with-new-frame [f (frame/make-anon-frame-record!
+                         {:initial-events [[:app/initialise]]
+                          :fx-overrides {:rf.http/managed fx-id}})]
+      (rf/dispatch-sync [:article/initialise] {:frame f})
+      (rf/dispatch-sync [:comments/initialise] {:frame f})
+      (rf/dispatch-sync [:comment-form/initialise] {:frame f})
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :email "a@b.c"
+                                              :token "jwt" :bio nil :image nil}]
+                        {:frame f})
+      (body-fn f lowered))))
+
+(defn- comment-submit-cross-slug-late-settle-is-refused-test []
+  (with-held-comment-fx :realworld.test/comment-submit-cross-slug
+    (fn [f lowered]
+      ;; Load alpha, then post a comment there. The POST is held open.
+      (rf/dispatch-sync [:rf.route/handle-url-change "/article/alpha"] {:frame f})
+      (settle-comments-ok! f (req-by-id @lowered [:comments/load "alpha"]) "alpha")
+      (rf/dispatch-sync [:comment-form/edit-field :body "Posted on alpha"] {:frame f})
+      (rf/dispatch-sync [:comment-form/submit] {:frame f})
+      (let [post (req-by-method+url @lowered :post "/articles/alpha/comments")]
+        (is (some? post) "alpha's comment POST went out")
+        ;; The target vectors carry the issuing slug AHEAD of the temp-id
+        ;; (which is a fresh recordable uuid, so only the prefix is pinned).
+        (is (= [:comment-form/submit-success "alpha"] (subvec (:on-success post) 0 2))
+            "the POST's success target carries the slug it was posted to")
+        (is (= [:comment-form/submit-error "alpha"] (subvec (:on-failure post) 0 2))
+            "…and so does its failure target")
+        (is (= 2 (count (rf/compute-sub [:comments/data] (rf/frame-state-value f))))
+            "the optimistic temp card is on alpha's list while the POST is out")
+        ;; Navigate to beta and let beta's comments settle.
+        (rf/dispatch-sync [:rf.route/handle-url-change "/article/beta"] {:frame f})
+        (settle-comments-ok! f (req-by-id @lowered [:comments/load "beta"]) "beta")
+        ;; THE LATE ARRIVAL. Snapshot beta's comments slice and its whole form
+        ;; — the bug is never the one leaf you looked at.
+        (let [com-before  (comments-slice* f)
+              form-before (comment-form* f)]
+          (settle-ok! f (:on-success post) {:comment (saved-comment "saved-a" "Posted on alpha")})
+          (is (= {:slug "beta"} (route-params* f)) "the route still says beta")
+          (is (= com-before (comments-slice* f))
+              "a late alpha submit SUCCESS changes nothing on beta's comments
+               slice — alpha's saved comment is not spliced into beta's list")
+          (is (= form-before (comment-form* f))
+              "…and nothing on beta's comment form: the draft, errors and
+               lifecycle the reader has on screen all stand"))))))
+
+(defn- comment-submit-cross-slug-late-failure-is-refused-test []
+  (with-held-comment-fx :realworld.test/comment-submit-cross-slug-fail
+    (fn [f lowered]
+      (rf/dispatch-sync [:rf.route/handle-url-change "/article/alpha"] {:frame f})
+      (settle-comments-ok! f (req-by-id @lowered [:comments/load "alpha"]) "alpha")
+      (rf/dispatch-sync [:comment-form/edit-field :body "Posted on alpha"] {:frame f})
+      (rf/dispatch-sync [:comment-form/submit] {:frame f})
+      (let [post (req-by-method+url @lowered :post "/articles/alpha/comments")]
+        (rf/dispatch-sync [:rf.route/handle-url-change "/article/beta"] {:frame f})
+        (settle-comments-ok! f (req-by-id @lowered [:comments/load "beta"]) "beta")
+        ;; Beta's reader is part-way through their own comment.
+        (rf/dispatch-sync [:comment-form/edit-field :body "Typing on beta"] {:frame f})
+        (let [com-before  (comments-slice* f)
+              form-before (comment-form* f)]
+          (settle-fail! f (:on-failure post))
+          (is (= com-before (comments-slice* f))
+              "a late alpha submit FAILURE cannot touch beta's comments slice")
+          (is (= form-before (comment-form* f))
+              "…nor beta's form")
+          (is (nil? (rf/compute-sub [:comment-form/submit-error] (rf/frame-state-value f)))
+              "alpha's error is NOT bannered over beta's comment form")
+          (is (= "Typing on beta"
+                 (:body (rf/compute-sub [:comment-form/draft] (rf/frame-state-value f))))
+              "beta's half-typed draft survives alpha's failure"))))))
+
+(defn- comment-delete-cross-slug-late-rollback-is-refused-test []
+  (with-held-comment-fx :realworld.test/comment-delete-cross-slug
+    (fn [f lowered]
+      ;; Alpha loads with its one comment, and the reader deletes it. The
+      ;; DELETE is held open; the card is already off the screen.
+      (rf/dispatch-sync [:rf.route/handle-url-change "/article/alpha"] {:frame f})
+      (settle-comments-ok! f (req-by-id @lowered [:comments/load "alpha"]) "alpha")
+      (rf/dispatch-sync [:comment/delete "c-alpha"] {:frame f})
+      (let [del (req-by-method+url @lowered :delete "/articles/alpha/comments/c-alpha")]
+        (is (some? del) "alpha's DELETE went out")
+        (is (= :comment/delete-rollback (first (:on-failure del)))
+            "the rollback target is the DELETE's failure branch")
+        (is (= "alpha" (second (:on-failure del)))
+            "…and it carries the slug it was deleting from, ahead of the
+             captured prior")
+        (is (empty? (rf/compute-sub [:comments/data] (rf/frame-state-value f)))
+            "the optimistic delete took the card off alpha's list")
+        ;; Navigate to beta; beta loads its own single comment.
+        (rf/dispatch-sync [:rf.route/handle-url-change "/article/beta"] {:frame f})
+        (settle-comments-ok! f (req-by-id @lowered [:comments/load "beta"]) "beta")
+        (let [com-before (comments-slice* f)]
+          (settle-fail! f (:on-failure del))
+          (is (= com-before (comments-slice* f))
+              "a late alpha DELETE failure changes nothing on beta's slice")
+          (is (= ["First on beta"]
+                 (mapv :body (rf/compute-sub [:comments/data] (rf/frame-state-value f))))
+              "alpha's comment is NOT re-inserted into beta's list — the
+               rollback would otherwise fabricate a comment beta never had"))))))
+
+(defn- comment-mutation-gates-are-not-vacuous-test []
+  ;; The controls: on the CURRENT slug every one of the three settles still
+  ;; does its ordinary optimistic job. A gate that swallowed them all would
+  ;; pass the three cross-slug tests above and break the app.
+  (with-held-comment-fx :realworld.test/comment-same-slug
+    (fn [f lowered]
+      (rf/dispatch-sync [:rf.route/handle-url-change "/article/alpha"] {:frame f})
+      (settle-comments-ok! f (req-by-id @lowered [:comments/load "alpha"]) "alpha")
+
+      ;; (1) SUCCESS on the current slug reconciles: the temp card becomes the
+      ;; saved comment IN PLACE, and the form resets.
+      (rf/dispatch-sync [:comment-form/edit-field :body "Mine"] {:frame f})
+      (rf/dispatch-sync [:comment-form/submit] {:frame f})
+      (let [post (req-by-method+url @lowered :post "/articles/alpha/comments")]
+        (is (true? (rf/compute-sub [:comment-form/submitting?] (rf/frame-state-value f)))
+            "the form is submitting while the POST is out")
+        (settle-ok! f (:on-success post) {:comment (saved-comment "saved-a" "Mine")})
+        (is (= ["First on alpha" "Mine"]
+               (mapv :body (rf/compute-sub [:comments/data] (rf/frame-state-value f))))
+            "the saved comment replaced the temp card IN PLACE, keeping order")
+        (is (= ["c-alpha" "saved-a"]
+               (mapv :id (rf/compute-sub [:comments/data] (rf/frame-state-value f))))
+            "…by id, so the temp card is gone rather than merely relabelled")
+        (is (= "" (:body (rf/compute-sub [:comment-form/draft] (rf/frame-state-value f))))
+            "…and the form reset, so the reader can post again")
+        (is (false? (rf/compute-sub [:comment-form/submitting?] (rf/frame-state-value f)))
+            "…no longer submitting"))
+
+      ;; (2) FAILURE on the current slug rolls the temp card back out and
+      ;; surfaces the message.
+      (rf/dispatch-sync [:comment-form/edit-field :body "Doomed"] {:frame f})
+      (rf/dispatch-sync [:comment-form/submit] {:frame f})
+      (let [post2 (last (filter #(= :post (get-in % [:request :method])) @lowered))]
+        (is (= 3 (count (rf/compute-sub [:comments/data] (rf/frame-state-value f))))
+            "the second temp card is on the list optimistically")
+        (settle-fail! f (:on-failure post2))
+        (is (= ["c-alpha" "saved-a"]
+               (mapv :id (rf/compute-sub [:comments/data] (rf/frame-state-value f))))
+            "the failed post's temp card is rolled back out")
+        (is (some? (rf/compute-sub [:comment-form/submit-error] (rf/frame-state-value f)))
+            "…and the transport error is surfaced on the form it belongs to")
+        (is (false? (rf/compute-sub [:comment-form/submitting?] (rf/frame-state-value f)))
+            "…with the form released"))
+
+      ;; (3) A DELETE failure on the current slug still restores the comment.
+      (rf/dispatch-sync [:comment/delete "saved-a"] {:frame f})
+      (is (= ["c-alpha"] (mapv :id (rf/compute-sub [:comments/data] (rf/frame-state-value f))))
+          "the optimistic delete removed it")
+      (let [del (req-by-method+url @lowered :delete "/articles/alpha/comments/saved-a")]
+        (settle-fail! f (:on-failure del))
+        (is (= ["c-alpha" "saved-a"]
+               (mapv :id (rf/compute-sub [:comments/data] (rf/frame-state-value f))))
+            "the rollback restored the comment at its original index — the
+             gate correlates, it does not swallow every reply")))))
+
+(defn- comment-form-is-released-on-slug-change-test []
+  ;; THE STRAND CONTROL. Refusing a cross-slug settle is only safe because
+  ;; navigation has already released the form. Without the reset in
+  ;; :comments/load the form would arrive on beta still :submitting, and a
+  ;; :submitting form disables both the textarea and the Post button — so
+  ;; beta could never be commented on again.
+  (with-held-comment-fx :realworld.test/comment-form-release
+    (fn [f lowered]
+      (rf/dispatch-sync [:rf.route/handle-url-change "/article/alpha"] {:frame f})
+      (settle-comments-ok! f (req-by-id @lowered [:comments/load "alpha"]) "alpha")
+      (rf/dispatch-sync [:comment-form/edit-field :body "Half-written on alpha"] {:frame f})
+      (rf/dispatch-sync [:comment-form/submit] {:frame f})
+      (let [post (req-by-method+url @lowered :post "/articles/alpha/comments")]
+        (is (true? (rf/compute-sub [:comment-form/submitting?] (rf/frame-state-value f)))
+            "alpha's form is mid-submit, its controls disabled")
+        ;; Navigate away with the POST still out.
+        (rf/dispatch-sync [:rf.route/handle-url-change "/article/beta"] {:frame f})
+        (is (false? (rf/compute-sub [:comment-form/submitting?] (rf/frame-state-value f)))
+            "beta's form is USABLE on arrival — a new article identity resets
+             the form, so alpha's in-flight submit cannot lock beta out")
+        (is (= "" (:body (rf/compute-sub [:comment-form/draft] (rf/frame-state-value f))))
+            "…and alpha's half-written draft did not follow the reader over")
+        (settle-comments-ok! f (req-by-id @lowered [:comments/load "beta"]) "beta")
+        ;; Alpha's settle arrives late and is refused — and the form beta is
+        ;; holding stays exactly as usable as it was.
+        (settle-ok! f (:on-success post) {:comment (saved-comment "saved-a" "Half-written on alpha")})
+        (is (false? (rf/compute-sub [:comment-form/submitting?] (rf/frame-state-value f)))
+            "the refused settle leaves beta's form released, not stranded")
+        ;; And beta can genuinely post its own comment afterwards.
+        (rf/dispatch-sync [:comment-form/edit-field :body "Beta's own"] {:frame f})
+        (rf/dispatch-sync [:comment-form/submit] {:frame f})
+        (let [beta-post (req-by-method+url @lowered :post "/articles/beta/comments")]
+          (is (some? beta-post) "beta's own comment POST goes out")
+          (settle-ok! f (:on-success beta-post) {:comment (saved-comment "saved-b" "Beta's own")})
+          (is (= ["c-beta" "saved-b"]
+                 (mapv :id (rf/compute-sub [:comments/data] (rf/frame-state-value f))))
+              "…and lands on beta's own list"))))))
+
+(defn- comment-form-survives-same-slug-refresh-test []
+  ;; The other side of the reset: a SAME-slug re-load is a refresh, not a new
+  ;; identity, so it must not eat what the reader is part-way through typing.
+  (with-held-comment-fx :realworld.test/comment-form-refresh
+    (fn [f lowered]
+      (rf/dispatch-sync [:rf.route/handle-url-change "/article/alpha"] {:frame f})
+      (settle-comments-ok! f (req-by-id @lowered [:comments/load "alpha"]) "alpha")
+      (rf/dispatch-sync [:comment-form/edit-field :body "Still typing"] {:frame f})
+      (rf/dispatch-sync [:comments/load] {:frame f})
+      (is (= "Still typing"
+             (:body (rf/compute-sub [:comment-form/draft] (rf/frame-state-value f))))
+          "a same-slug comments refresh leaves the in-progress draft alone"))))
+
+(deftest realworld-comment-mutations-cross-slug
+  (testing "a LATE alpha comment-submit SUCCESS cannot reset beta's form or
+            splice alpha's saved comment into beta's list (rf2-84iek)"
+    (comment-submit-cross-slug-late-settle-is-refused-test))
+  (testing "a LATE alpha comment-submit FAILURE cannot banner beta's form or
+            disturb beta's half-typed draft (rf2-84iek)"
+    (comment-submit-cross-slug-late-failure-is-refused-test))
+  (testing "a LATE alpha DELETE failure cannot re-insert alpha's comment into
+            beta's list (rf2-84iek)"
+    (comment-delete-cross-slug-late-rollback-is-refused-test))
+  (testing "on the CURRENT slug all three settles still do their ordinary
+            optimistic job — the gates' non-vacuity control (rf2-84iek)"
+    (comment-mutation-gates-are-not-vacuous-test))
+  (testing "a new article identity releases the comment form, so refusing a
+            cross-slug settle cannot strand beta mid-submit (rf2-84iek)"
+    (comment-form-is-released-on-slug-change-test))
+  (testing "…while a same-slug refresh leaves an in-progress draft alone
+            (rf2-84iek)"
+    (comment-form-survives-same-slug-refresh-test)))
 
 ;; ============================================================================
 ;; favorites / comments / feed / profile — optimistic-success + follow-author +


### PR DESCRIPTION
## The bug

PR #8845 (rf2-iy3d6) correlated the article/comments **reads** to the route that
requested them, adding the `[:comments :slug]` fact and `reply-for-current-slug?`.
The optimistic comment **writes** in the same file stayed slug-free and mutated the
one shared `[:comments :data]` / `[:comment-form]` unconditionally:

- `:comment-form/submit` read the current slug for the POST path but emitted
  `:on-success [:comment-form/submit-success temp-id]` /
  `:on-failure [:comment-form/submit-error temp-id]`. A reply from alpha arriving
  after navigation to beta reset beta's draft on success, or bannered alpha's error
  over beta's form on failure.
- `:comment/delete` sent `:on-failure [:comment/delete-rollback prior]`. If alpha's
  DELETE failed after beta had loaded, the rollback spliced **alpha's** comment into
  **beta's** list — fabricating a comment beta never had.

These carry no shared cross-route request id, and the per-slug `:request-id`s are
deliberately distinct, so managed HTTP's same-id supersede never fires between them.
Correlation is the app's boundary.

## The fix

Carry the issuing slug in the three settle targets and gate each on the existing
`reply-for-current-slug?`. `:comment/delete-success` writes nothing, so it needs
neither slug nor gate.

**Dropping those writes is only safe because of the other half.** `[:comments :data]`
is route-owned already — `:comments/load` resets it on a slug change — but
`[:comment-form]` is a boot-time singleton that `:comment-form/initialise` never
revisits, so it rode across the navigation still `:status :submitting`. Both the
textarea and the Post button are `:disabled submitting?`, so gating **alone** would
have left beta's comment form permanently locked — a worse bug than the one being
fixed. So `:comments/load` now resets the form whenever it takes on a new article
identity, and leaves it alone on a same-slug refresh.

What each path owes its route when its reply arrives late:

| path | verdict | why nothing is stranded |
| --- | --- | --- |
| `:comment-form/submit-success` | drop the whole write | the temp card went with the slice on the slug change; the comment really is saved, and returning re-reads it |
| `:comment-form/submit-error` | drop the whole write | the temp card is already gone, and the slug-change reset already put the form back to `:idle` |
| `:comment/delete-rollback` | drop the whole write | alpha's list was reset on the way out, and the server still holds the comment (the DELETE failed) |

## The commentary

The block comment #8845 added claimed *every* reply target carried its slug and
*every* terminal handler gated its write — true only of the two reads, so the file
asserted the invariant it violated. It now names exactly which five settles are
correlated, names the two deliberate non-members (`:comment/delete-success`, which
writes nothing; and the article social controls, which are ungated and out of scope
with no reproduced defect), and states plainly that the gate correlates *route
identity*, not request identity.

## Tests

Six cases in the existing production-source CLJS suite
(`implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs`): the three
cross-slug refusals; a **non-vacuity control** proving all three settles still do
their ordinary optimistic job on the current slug; the **strand control** pinning that
beta's form arrives usable and can post its own comment; and a same-slug-refresh
control pinning that a refresh does not eat an in-progress draft. The existing
stale-index rollback test moves to the new arity.

No framework change, no new abstraction, no CI job, no browser spec.
