### PR TITLE
docs(method): git cherry's + is absence of proof, not proof of unmerged work

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1240,13 +1240,30 @@ rather than on liveness, which is why that paragraph is the cross-reference here
 something to restate.
 
 **The test is patch-equivalence**, which asks what each commit *does* rather than which object it
-is: an equivalent patch already upstream means the work is contained, and anything with no upstream
-equivalent is genuinely new. In the dominant toolchain that is `cherry`, which marks the two answers
-`-` and `+`. It protects in both directions at once, which is what earns it over either half of a
-rule that only ever fails safe one way. Measured here across 63 worktrees: 60 branches read one to
-three commits ahead of the trunk, 58 of those fully merged and one carrying three genuinely new
-commits. Deleting on ancestry would have kept all 58 forever; deleting on the ahead count alone
-would have destroyed those three.
+is: an equivalent patch already upstream means the work is contained. In the dominant toolchain that
+is `cherry`, which marks the two answers `-` and `+`. It earns its place over either half of a rule
+that only ever fails safe one way. Measured here across 63 worktrees: 60 branches read one to three
+commits ahead of the trunk, 58 of those fully merged and one carrying three genuinely new commits.
+Deleting on ancestry would have kept all 58 forever; deleting on the ahead count alone would have
+destroyed those three.
+
+**But its two answers are not equally strong, and reading them as symmetric is the error this
+paragraph exists to stop.** `-` is proof of containment. `+` is only the ABSENCE of proof — not
+evidence that the commit carries unmerged work. A patch identity is computed over the diff
+*including its context lines*, so a sibling change landing in neighbouring lines of the same file
+changes your commit's context, changes its identity, and leaves work that is fully present upstream
+reading `+`. Measured here: a branch whose change had already MERGED still showed one `+` commit; every
+line that commit added was present at the trunk's tip, character for character. The sibling that moved
+the context was another change to the same file.
+
+**So the rule is safe and its reading is not.** Deleting only on `-` never destroys anything, which
+is why the criterion stands unchanged — but a mayor who reads `+` as *this branch has unmerged work*
+will hunt for work that landed weeks ago, and a branch list read as a backlog is a list of phantoms.
+**The discriminating test is cheap and settles it in one step: take the lines that commit ADDED and
+look for them at the tip.** All present means the content landed and only the context moved; any
+absent means the work is genuinely outstanding. Do that before you conclude a branch is carrying
+something, and never the other way round — the cost of the two errors is not symmetric either, since
+believing `+` costs you a search, while believing a wrongly-derived `-` costs you the work.
 
 **Key destructive operations on identity, never on a name.** Branch names repeat across sessions and
 prefix-match each other. A search for `head:feature-x` also returns the change for `feature-x2`, and


### PR DESCRIPTION
Found by the method-reread loop, checking a rule I had been *enforcing* — this session's hygiene pass ran branch deletion on patch-equivalence, exactly as the Branches section prescribes.

The criterion is right and is unchanged by this PR. What was wrong is the sentence describing what its two answers mean.

The section claimed patch-equivalence "protects in both directions at once", and that "anything with no upstream equivalent is genuinely new". The second half does not hold. A patch identity is computed over the diff **including its context lines**, so a sibling change landing in neighbouring lines of the same file changes your commit's context, changes its identity, and leaves work that is fully present upstream reading `+`.

**Measured during the hygiene pass that prompted this.** A branch whose change had already MERGED still showed one `+` commit. Every line that commit added was present at the trunk's tip, character for character — the sibling that had moved the context was another change to the same file. Read as the section described it, that branch "carried genuinely new work"; it carried none.

The asymmetry matters because the two answers are not equally strong: `-` is proof of containment, `+` is only the *absence* of proof. The rule stays safe either way — deleting only on `-` never destroys anything, which is why the criterion needed no change — but a mayor who reads `+` as *this branch has unmerged work* hunts for work that landed weeks ago, and a branch list read as a backlog is a list of phantoms.

Added with it the one-step discriminating test, which is the thing the section was missing rather than the claim it got wrong: take the lines the commit ADDED and look for them at the tip. All present means only the context moved; any absent means the work is genuinely outstanding. And the direction to run it in — before concluding a branch carries something, never before deleting — because believing `+` costs a search while believing a wrongly-derived `-` costs the work.

## Quality gates

- `python scripts/check_doc_slugs.py` — **exit 0**. `docs/` is inside its roots, so it is the gate for this path.
  - **Control:** the gate is silent on success, so its green was proven by a planted broken link target at a line this change edits → **exit 1**, naming `docs\the-mayor-method\loops.md:1262 -> ./no-such-file-cherry-control.md`. That fault existed only in this worktree, so the red also proves the gate read this tree. Anchor match count read as **1** before planting.
  - **Restore verified by git blob hash**, not by reading a diff: working file `711e41895975df6cc5c4264795487fa6c03b3d16` == the committed object. Gate re-run after restore: **exit 0**. Committed before planting so the restore was well-defined.
- `mkdocs build --strict` — **not nominated, and it would not be the gate.** `mkdocs.yml`'s `exclude_docs` keeps `docs/the-mayor-method/` out of the built site, and `--strict` grades missing anchors at INFO regardless.
- **By hand:** no headings, anchors or tables changed. The new prose sits inside the existing section; the one added link is the planted control, removed.

One file, `docs/the-mayor-method/loops.md`. No code, tests or workflow files touched.
