### PR TITLE
ci(surfaces): retire stale skills_structural caveats; arm the MIG-23 fixture's reverse edge; narrow the security tier

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -618,6 +618,52 @@ else
         ;;
     esac
 
+    # rf2-bbe91 (audit reopen of PR #8868) — the REVERSE edge into the MIG-23
+    # SSR cold-start fixture. `reagent-migration-fixture-cold-start` is gated
+    # solely on `skills_structural`, and before this dispatch that output was
+    # armed only from the skill trees themselves. So the fixture fired on a
+    # change to the RECIPE but never on a change to the SUBSTRATE it pins the
+    # recipe against — a core adapter-lifecycle, SSR, Hicasso server-render or
+    # Reagent adapter change skipped the only cross-artefact witness that the
+    # documented cold start still works, which is the very regression the
+    # fixture exists to catch. A skipped job is an accepted result, so the
+    # aggregator could not notice.
+    #
+    # The roster is the fixture's own declared classpath —
+    # `skills/reagent-migration/tests/fixture/deps.edn` resolves exactly these
+    # four artefacts as `:local/root`, and the job's cache key hashes the same
+    # four `deps.edn` files. `src/*` + `deps.edn` rather than the whole tree
+    # because a `:local/root` contributes the artefact's `:paths` and its
+    # dependency declaration and nothing else: an artefact's own `test/` tree is
+    # not on this fixture's classpath and cannot change what it compiles.
+    #
+    # ITS OWN DISPATCH RATHER THAN FOUR ARMS OF THE BIG `case` BELOW, for the
+    # reason rf2-65ajl gives just under this: a POSIX `case` takes the FIRST
+    # match, and all four of these trees already have arms there
+    # (`implementation/core/*`, `implementation/adapters/*`, the per-feature
+    # fan-out that carries `implementation/ssr/*`, and `implementation/
+    # hicasso/*`). An arm placed above them would SHADOW those arms and
+    # silently narrow four artefacts' coverage to one output; placed below, it
+    # would never match. A dispatch consulted for every file can do neither —
+    # it only ever SETS `skills_structural`, so it cannot narrow anything.
+    #
+    # THE FAN-OUT IS DELIBERATE AND WIDER THAN THE ONE JOB, which is worth
+    # stating because `skills_structural` gates three things. Firing it here
+    # also schedules `re-frame2-pair-fixture-pure`, and that is CORRECT for
+    # two of the four: `skills/re-frame2-pair/tests/fixture/deps.edn` declares
+    # core and the Reagent adapter as `:local/root` too, so it carries the
+    # identical unarmed reverse dependency and this closes it as well. For ssr
+    # and hicasso it over-fires that job, and it over-fires the cheap Babashka
+    # `skills-structural` job for all four. TESTING.md's routing rule prefers
+    # exactly that trade ("when in doubt, over-classify"), and the alternative
+    # — a 29th output existing only to split two fixture jobs apart — buys a
+    # few runner-minutes for a permanent widening of the matrix.
+    case "$file" in
+      implementation/core/src/*|implementation/core/deps.edn|implementation/ssr/src/*|implementation/ssr/deps.edn|implementation/hicasso/src/*|implementation/hicasso/deps.edn|implementation/adapters/reagent/src/*|implementation/adapters/reagent/deps.edn)
+        skills_structural=true
+        ;;
+    esac
+
     # rf2-65ajl — its own dispatch rather than an arm of the big `case` below,
     # for the reason a POSIX `case` takes the FIRST match: the full gate's
     # roster straddles two trees that already have arms there

--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -571,7 +571,16 @@ else
     # below, not this list — `testbeds/*` is deliberately NOT here, because a
     # first-match `case` would then swallow the extension narrowing.
     case "$file" in
-      examples/*|implementation/adapters/*|implementation/epoch/*|implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/resources/*|implementation/security/*|implementation/deps.edn|implementation/shadow-cljs.edn|implementation/package.json|implementation/package-lock.json|implementation/scripts/check-examples-compile.cjs)
+      # rf2-qxg24 — `implementation/security/*` is NOT here. It is a src-less
+      # test partition (`:paths []`, `:deps {}`, no `src/` tree, no published
+      # artefact), so nothing under it can appear in a compiled example
+      # closure: the all-examples compiler has no edge to a test-only tree.
+      # It was added to this arm by 5bb3cd9cd1 as a side effect — that commit
+      # wanted `implementation_jvm` + `cljs_node_test` and reached for a
+      # generic feature arm that happened to set five outputs — and the toll
+      # was real: security-only commit d1fa5ff493 made the ~10-minute
+      # all-examples job its critical path.
+      examples/*|implementation/adapters/*|implementation/epoch/*|implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/resources/*|implementation/deps.edn|implementation/shadow-cljs.edn|implementation/package.json|implementation/package-lock.json|implementation/scripts/check-examples-compile.cjs)
         examples_compile=true
         ;;
       # rf2-in6c4 — top-level testbed CLJS sources. The extensions are the
@@ -1047,7 +1056,18 @@ else
         # files a change is most likely to be in.
         ssr_node=true
         ;;
-      implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/resources/*|implementation/security/*|implementation/deps.edn)
+      # rf2-qxg24 — `implementation/security/*` LEFT this arm for the src-less
+      # tier below. This arm is the PRODUCTION per-feature fan-out: every other
+      # tree in it publishes a Maven artefact whose source rides a shipped
+      # bundle, which is what earns `cljs_browser` + `cljs_prod` +
+      # `bundle_isolation`. The security partition publishes nothing. Its
+      # namespaces are all `-security-cljs-test`, and `:browser-test` selects
+      # only `*-dom-cljs-test`, so the browser lane cannot observe an edit to
+      # it; the production and bundle-isolation builds do not require the test
+      # tree at all. Its JVM job and its consolidated `:node-test` inclusion
+      # are unchanged — those are the two lanes that DO run these tests, and
+      # the tier below sets exactly them.
+      implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/resources/*|implementation/deps.edn)
         # rf2-8jz9t — adapter_testbed_smokes NOT fired here. Per-feature
         # artefact changes are covered by their own JVM + CLJS unit
         # suites (implementation_jvm, cljs_browser, cljs_prod) and by
@@ -1276,7 +1296,21 @@ else
         # suite is the cheaper error, and TESTING.md says to prefer it.
         migration_hicasso_codemod=true
         ;;
-      implementation/reply-conformance/*|implementation/derivation-conformance/*|implementation/event-conformance/*)
+      implementation/reply-conformance/*|implementation/derivation-conformance/*|implementation/event-conformance/*|implementation/security/*)
+        # rf2-qxg24 — `implementation/security/*` JOINED this arm, closing a
+        # contradiction the file carried with itself. The comment below already
+        # named the security tier as the PRECEDENT for omitting the browser /
+        # production / bundle gates, while two earlier, executable arms put
+        # security in the production fan-out and the examples-compile roster
+        # and thereby armed all four. Prose lost to code, silently, for as long
+        # as nobody classified a security path and read the output. All four
+        # source-less tiers now take the same route, which is what the prose
+        # said all along.
+        #
+        # The four tiers are alike in the way that matters here: `:paths []`,
+        # `:deps {}`, no `src/` tree, no Maven artefact — test surfaces on the
+        # root test classpath and nothing else.
+        #
         # rf2-dxndhc — the three EP cross-conformance tiers
         # (reply-conformance / derivation-conformance / event-conformance)
         # are src-less `.cljc` TEST surfaces on the root test classpath

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5820,8 +5820,15 @@ jobs:
   # Node. The fixture has no package-lock.json (dev-only, deps pinned exactly in
   # package.json), so `npm install` — not `npm ci` — bootstraps shadow-cljs.
   #
-  # GATED ON `skills_structural`, which `skills/reagent-migration/*` arms
-  # (rf2-g1m2q) — so a diff confined to the skill tree schedules this job.
+  # GATED ON `skills_structural`, which two directions arm. The skill tree
+  # itself (`skills/reagent-migration/*`, rf2-g1m2q) covers a change to the
+  # RECIPE. The fixture's four `:local/root` artefacts — core, ssr, hicasso and
+  # the stock Reagent adapter, at `src/*` + `deps.edn` — cover a change to the
+  # SUBSTRATE the recipe is pinned against (rf2-bbe91). Without that second
+  # edge this job was skipped on exactly the adapter-lifecycle, SSR or
+  # server-render change it exists to witness, and a skipped job is an accepted
+  # result, so the aggregator could not tell. Both directions are pinned in
+  # `implementation/scripts/_changed-surfaces.test.cjs`.
   # ---------------------------------------------------------------------------
   reagent-migration-fixture-cold-start:
     name: reagent-migration MIG-23 SSR cold-start node-test (rf2-vpdrf)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5710,10 +5710,12 @@ jobs:
       # *_test.clj, as the setup step above does, so a future pair-retro test is
       # gated automatically rather than waiting on another wiring PR.
       #
-      # Same `skills_structural` caveat as reagent-migration-fixture-cold-start
-      # below: the classifier has no arm for `skills/re-frame2-pair-retro/**`
-      # and no default arm, so a diff confined to that tree classifies to
-      # nothing and this step does not run. rf2-g1m2q owns widening it.
+      # `skills/re-frame2-pair-retro/*` arms `skills_structural` in
+      # `.github/scripts/report-changed-surfaces.sh` (rf2-g1m2q), so a diff
+      # confined to this tree does schedule this step. The arm is pinned from
+      # both sides in `implementation/scripts/_changed-surfaces.test.cjs`
+      # (SKILLS_STRUCTURAL_ONLY_FILES) — including the `-retro` / `pair/`
+      # prefix boundary, which is why the tree needs an arm of its own.
       - name: Run re-frame2-pair-retro structural tests
         working-directory: skills/re-frame2-pair-retro
         run: |
@@ -5818,18 +5820,8 @@ jobs:
   # Node. The fixture has no package-lock.json (dev-only, deps pinned exactly in
   # package.json), so `npm install` — not `npm ci` — bootstraps shadow-cljs.
   #
-  # GATED ON `skills_structural`, WHICH DOES NOT YET FIRE FOR THIS TREE
-  # (rf2-g1m2q). `.github/scripts/report-changed-surfaces.sh` arms that output
-  # from four case arms — `skills/re-frame2-pair/{tests/fixture,preload}/*`,
-  # `skills/re-frame2-pair/*|skills/shared/*`, `skills/re-frame2-setup/*` — and
-  # the main `case` has no default arm, so a diff confined to
-  # `skills/reagent-migration/**` classifies to NOTHING and this job is skipped
-  # on the very change it exists to gate. Widening the arm means touching that
-  # script AND its pinned mirror `implementation/scripts/_changed-surfaces.
-  # test.cjs`, the one-toucher-by-construction pair, which was held by another
-  # lane when this landed; rf2-g1m2q owns it. The wiring is still the right half
-  # to land first: it is what makes the arm worth widening, and the job already
-  # fires on a `--all` run and on any other `skills_structural` path.
+  # GATED ON `skills_structural`, which `skills/reagent-migration/*` arms
+  # (rf2-g1m2q) — so a diff confined to the skill tree schedules this job.
   # ---------------------------------------------------------------------------
   reagent-migration-fixture-cold-start:
     name: reagent-migration MIG-23 SSR cold-start node-test (rf2-vpdrf)

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -2269,6 +2269,98 @@ for (const file of SKILLS_STRUCTURAL_ONLY_FILES) {
   });
 }
 
+// rf2-bbe91 (audit reopen of PR #8868) — the REVERSE edge into the MIG-23 SSR
+// cold-start fixture. rf2-g1m2q above armed `skills_structural` from the SKILL
+// trees, which fires `reagent-migration-fixture-cold-start` on a change to the
+// RECIPE. It left the other direction open: the fixture pins the recipe against
+// four in-repo artefacts it resolves as `:local/root`, and a change to any of
+// THOSE classified `skills_structural=false`, so the only cross-artefact
+// cold-start witness was skipped on exactly the substrate change that could
+// break it. A skipped job is an accepted result, so the aggregator stayed green.
+//
+// The roster below IS `skills/reagent-migration/tests/fixture/deps.edn`'s
+// `:deps` map, and the same four `deps.edn` files the job's cache key hashes.
+//
+// EVERY PATH HERE IS TRACKED, checked with `git ls-files`, not transcribed from
+// prose. The extensions are the trap: the Hicasso server door and the stock
+// Reagent adapter are `.cljs`, not `.cljc`, and the reopening audit's own note
+// spelled both `.cljc`. Nothing would have caught it — these arms are pure path
+// patterns, so a phantom file classifies identically to a real one and the
+// assertion passes while pinning a route no diff can ever take. That is the
+// same defect rf2-qxg24 removes from the examples_compile fixture list in this
+// file, and it is why the negative half below uses tracked paths too.
+const MIG23_FIXTURE_LOCAL_ROOTS = [
+  'implementation/core/src/re_frame/core.cljc',
+  'implementation/ssr/src/re_frame/ssr.cljc',
+  'implementation/hicasso/src/re_frame/hicasso/server.cljs',
+  'implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs',
+];
+for (const file of MIG23_FIXTURE_LOCAL_ROOTS) {
+  test(`${file} arms skills_structural — MIG-23 cold-start reverse edge (rf2-bbe91)`, () => {
+    const result = classify(file);
+    assert.equal(
+      result.skills_structural,
+      'true',
+      `${file} is on the MIG-23 cold-start fixture's :local/root classpath; a change to it ` +
+        'must schedule reagent-migration-fixture-cold-start, the only cross-artefact witness ' +
+        'that the documented SSR cold start still works',
+    );
+  });
+}
+
+// The negative half. The edge is the fixture's CLASSPATH, not "anything under
+// implementation/", so it must not become a default arm by drift. A `:local/root`
+// contributes the artefact's `:paths` plus its dependency declaration — an
+// artefact's own `test/` tree is not on the fixture's classpath — and the three
+// sibling per-feature artefacts are not on it at all.
+for (const file of [
+  'implementation/core/test/re_frame/adapter/routing_arity_cljs_test.cljc',
+  'implementation/schemas/src/re_frame/schemas.cljc',
+  'implementation/adapters/uix/src/re_frame/adapter/uix.cljs',
+]) {
+  test(`${file} does NOT arm skills_structural (reverse edge stays scoped, rf2-bbe91)`, () => {
+    assert.equal(
+      classify(file).skills_structural,
+      'false',
+      `${file} is not on the MIG-23 fixture's :local/root classpath; it must not queue the ` +
+        'skills_structural fixture jobs',
+    );
+  });
+}
+
+// The dispatch only ever SETS `skills_structural`, so it cannot narrow the four
+// artefacts' existing routing. Pinned because a future refactor into an arm of
+// the big first-match `case` WOULD narrow it, silently and in exactly one
+// direction — the failure the dispatch's own comment exists to prevent.
+test('the MIG-23 reverse edge does not narrow core/ssr/reagent production routing (rf2-bbe91)', () => {
+  for (const file of [
+    'implementation/core/src/re_frame/core.cljc',
+    'implementation/ssr/src/re_frame/ssr.cljc',
+    'implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs',
+  ]) {
+    const result = classify(file);
+    for (const key of ['implementation_jvm', 'cljs_node_test', 'cljs_browser', 'cljs_prod', 'bundle_isolation']) {
+      assert.equal(
+        result[key],
+        'true',
+        `${file} must retain ${key}; the cold-start reverse edge widens, it never narrows`,
+      );
+    }
+  }
+});
+
+test('reagent-migration-fixture-cold-start is job-level gated on skills_structural (rf2-bbe91)', () => {
+  const block = jobBlock(
+    fs.readFileSync(WORKFLOW, 'utf8'),
+    'reagent-migration-fixture-cold-start',
+  );
+  assert.match(block, /needs: detect_changed_surfaces/);
+  assert.match(
+    block,
+    /if: needs\.detect_changed_surfaces\.outputs\.skills_structural == 'true'/,
+  );
+});
+
 test('cljs-browser job is job-level gated on cljs_browser (browser consumer, rf2-11yjq)', () => {
   const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'cljs-browser');
   assert.match(block, /needs: detect_changed_surfaces/);

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -2053,7 +2053,13 @@ test('example compilation has a dedicated changed-surface output (rf2-gzavkm)', 
     'implementation/ssr/src/re_frame/ssr.cljc',
     'implementation/ssr-ring/src/re_frame/ssr/ring.clj',
     'implementation/resources/src/re_frame/resources.cljc',
-    'implementation/security/src/re_frame/security.cljc',
+    // rf2-qxg24 — `implementation/security/src/re_frame/security.cljc` is GONE
+    // from this list. It never existed: the security partition is deliberately
+    // src-less, so this row asserted that an imaginary file could change a
+    // compiled example closure. It passed anyway, and would have gone on
+    // passing forever, because these arms are pure path patterns — a phantom
+    // path classifies exactly like a real one. The tier's real routing is
+    // pinned below, from tracked paths.
     'implementation/scripts/check-examples-compile.cjs',
     'tools/story/src/re_frame/story.cljs',
     'tools/xray/src/day8/re_frame2_xray/preload.cljs',
@@ -3514,6 +3520,100 @@ test('a src-less conformance tier does NOT widen production bundles (no bundle_i
   assert.equal(result.bundle_isolation, 'false');
   assert.equal(result.cljs_browser, 'false');
   assert.equal(result.cljs_prod, 'false');
+});
+
+// rf2-qxg24 — the security tier is the FOURTH source-less partition and now
+// takes the same route as the three above. It had been the stated precedent for
+// that route since rf2-dxndhc while two earlier executable arms classified it
+// as a shipped production feature, arming `cljs_browser`, `cljs_prod`,
+// `bundle_isolation` and `examples_compile` on every security-only edit.
+//
+// NONE of those four gates can observe an edit here. `implementation/security`
+// is `:paths []` / `:deps {}` with no `src/` tree and no published artefact;
+// `:browser-test` selects only `*-dom-cljs-test` namespaces and every namespace
+// in this tree is `-security-cljs-test`; the production and bundle-isolation
+// builds do not require the test tree; and the all-examples compiler has no
+// edge to it. The toll was not theoretical — security-only commit d1fa5ff493
+// made the ~10-minute all-examples job its critical path.
+//
+// Paths are TRACKED files, checked with `git ls-files`. That is the whole point
+// of this bead: the row this replaces asserted from
+// `implementation/security/src/re_frame/security.cljc`, which has never
+// existed.
+const SECURITY_TIER_FILES = [
+  'implementation/security/deps.edn',
+  'implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc',
+  'implementation/security/test/re_frame/security/schema_redaction_security_cljs_test.cljc',
+  'implementation/security/test/re_frame/security/gen.cljc',
+];
+for (const file of SECURITY_TIER_FILES) {
+  test(`${file} arms implementation_jvm + cljs_node_test ONLY (src-less security tier, rf2-qxg24)`, () => {
+    const result = classify(file);
+    assert.equal(
+      result.implementation_jvm,
+      'true',
+      'a security-tier change must still run the jvm-security suite (its own :test alias)',
+    );
+    assert.equal(
+      result.cljs_node_test,
+      'true',
+      'a security-tier change must still run the consolidated :node-test build',
+    );
+    // The four gates this bead removes, locked so the broad production arm
+    // cannot silently return.
+    for (const key of ['examples_compile', 'cljs_browser', 'cljs_prod', 'bundle_isolation']) {
+      assert.equal(
+        result[key],
+        'false',
+        `${file} is a source-less test partition; ${key} cannot observe it and must not be armed`,
+      );
+    }
+  });
+}
+
+test('jvm-security remains gated on implementation_jvm and in the aggregator (rf2-qxg24 criterion 4)', () => {
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  const block = jobBlock(workflow, 'jvm-security');
+  assert.match(block, /needs: detect_changed_surfaces/);
+  assert.match(
+    block,
+    /if: needs\.detect_changed_surfaces\.outputs\.implementation_jvm == 'true'/,
+  );
+  assert.match(
+    block,
+    /implementation\/security/,
+    'jvm-security must still run from implementation/security',
+  );
+  assert.match(
+    jobBlock(workflow, 'all-required-passed'),
+    /- jvm-security\r?\n/,
+    'narrowing the security tier must not drop its required JVM job from the aggregator',
+  );
+});
+
+test('narrowing the security tier leaves the production per-feature fan-out intact (rf2-qxg24 criterion 5)', () => {
+  // The arms security LEFT still route every src-bearing artefact exactly as
+  // before. This is the regression that matters: the edit removed one entry
+  // from two shared patterns, and a fat-fingered pattern would take a sibling
+  // with it — silently, since fewer gates always passes.
+  for (const file of [
+    'implementation/schemas/src/re_frame/schemas.cljc',
+    'implementation/machines/src/re_frame/machines.cljc',
+    'implementation/routing/src/re_frame/routing.cljc',
+    'implementation/flows/src/re_frame/flows.cljc',
+    'implementation/http/src/re_frame/http.cljc',
+    'implementation/ssr/src/re_frame/ssr.cljc',
+    'implementation/resources/src/re_frame/resources.cljc',
+  ]) {
+    const result = classify(file);
+    for (const key of ['implementation_jvm', 'cljs_node_test', 'cljs_browser', 'cljs_prod', 'bundle_isolation', 'examples_compile']) {
+      assert.equal(
+        result[key],
+        'true',
+        `${file} is a src-bearing published artefact; it must retain ${key}`,
+      );
+    }
+  }
 });
 
 test('jvm-resources is job-level gated on implementation_jvm (rf2-dxndhc)', () => {


### PR DESCRIPTION
Three items, clustered because they share the two one-toucher surfaces
(`.github/workflows/test.yml` and the classifier pair) that cannot be edited
concurrently. One commit each.

## rf2-yasvj — retire the stale `skills_structural` caveats

PR #8876 (rf2-g1m2q) armed `skills_structural` for `skills/re-frame2-pair-retro/*`
and `skills/reagent-migration/*`. **Verified on the trunk this branch is based on**
before deleting anything — the caveats were true until that landed, so the fence
mattered. Two in-place comments in `test.yml` still said the output "does not yet
fire for this tree" and named rf2-g1m2q as the owner of a widening that has landed.

Replaced rather than deleted, so each site now says which arm schedules it and points
at the executable pin. Deleting a caveat can delete the only thing pinning the
behaviour it described; here it does not — `SKILLS_STRUCTURAL_ONLY_FILES` in the
classifier mirror pins both arms, including the `-retro` / `pair/` prefix boundary
that is the reason the retro tree needs an arm of its own.

Census run two ways, because the target text is line-broken across YAML comment
markers: a line-level search and a newline-flattened one. Each was exercised against
a control it should find — the flattened pass alone found `for this tree (rf2-g1m2q)`
and a `no default arm` hit in `spec/Pattern-WebSocket.md` that the line-level pass
could not see. `test.yml` was the only file carrying stale text; the `g1m2q`
references in the classifier and its mirror are the fix's own provenance and are
correct.

## rf2-bbe91 — arm the MIG-23 cold-start fixture from its own classpath

**The bead was reopened by audit; the wiring it originally asked for already merged
as PR #8868.** The live scope is the reverse dependency that wiring left open.

`reagent-migration-fixture-cold-start` is gated solely on `skills_structural`, and
that output was armed only from the skill trees. So the fixture fired on a change to
the **recipe** but never on a change to the **substrate** it pins the recipe against:
the four artefacts it resolves as `:local/root` all classified
`skills_structural=false`. A skipped job is an accepted result, so the aggregator
could not tell.

Added as its own dispatch ahead of the big first-match `case`, for the reason
rf2-65ajl gives beside it: all four trees already have arms there, so an arm above
them would shadow and silently narrow four artefacts to one output, and an arm below
would never match. Scoped to `src/*` + `deps.edn` — what a `:local/root` actually
contributes; an artefact's own `test/` tree is not on the fixture's classpath.

The fan-out is wider than the one job and deliberately so: it also schedules
`re-frame2-pair-fixture-pure`, which is **correct** for core and reagent (that fixture
declares the same two local roots and carries the identical unarmed reverse
dependency), and over-fires for ssr and hicasso alongside the cheap Babashka
`skills-structural` job. TESTING.md's routing rule prefers that trade over a 29th
output existing only to split two fixture jobs apart.

**Three phantom paths caught and corrected.** The reopening audit spelled the Hicasso
server door and the Reagent adapter `.cljc`; both are `.cljs`. A fourth, in my own
first draft of the negative pins, was a core test path that does not exist. Nothing
would have caught any of them — these arms are pure path patterns, so a phantom
classifies identically to a real one and pins a route no diff can ever take. Every
pinned path is now checked against `git ls-files`. This is the same defect rf2-qxg24
removes below.

## rf2-qxg24 — route the security tier as the source-less partition it is

`implementation/security` is `:paths []` / `:deps {}`, no `src/` tree, no published
artefact. The classifier armed `cljs_browser`, `cljs_prod`, `bundle_isolation` and
`examples_compile` on every security-only edit, and none of those four can observe
one: `:browser-test` selects only `*-dom-cljs-test` while every namespace here is
`-security-cljs-test`, the production and bundle-isolation builds do not require the
test tree, and the all-examples compiler has no edge to it.

Drift from recorded intent, not a coverage trade. 5bb3cd9cd1 added the path to fire
`implementation_jvm` + `cljs_node_test` but reached for a generic feature arm setting
five outputs; the later src-less arm then named security as the **precedent** for
omitting those gates. The file contradicted itself, prose against code, and prose
lost. Security-only commit d1fa5ff493 made the ~10-minute all-examples job its
critical path.

Also removes the phantom `implementation/security/src/re_frame/security.cljc` from the
`examples_compile` fixture list — a row asserting that an imaginary file could change a
compiled example closure, passing for exactly the reason above.

Scope held: `jvm-security`, the local JVM roster entry, the shadow `:node-test` root
and `npm run test:security` are unchanged and untouched. `test.yml`'s `pull_request`
trigger is untouched and remains unfiltered.

## Classifier transcript (post-rebase, all four source-less tiers plus controls)

| path | jvm | node | browser | prod | bundle | examples | skills_struct |
|---|---|---|---|---|---|---|---|
| `implementation/security/deps.edn` | T | T | F | F | F | F | F |
| `implementation/security/test/.../mcp_egress_security_cljs_test.cljc` | T | T | F | F | F | F | F |
| `implementation/reply-conformance/test/.../reply_vocabulary_...cljc` | T | T | F | F | F | F | F |
| `implementation/derivation-conformance/test/.../derivation_algebra_...cljc` | T | T | F | F | F | F | F |
| `implementation/event-conformance/test/.../event_model_...cljc` | T | T | F | F | F | F | F |
| `implementation/schemas/src/re_frame/schemas.cljc` (src-bearing control) | T | T | T | T | T | T | F |
| `implementation/core/src/re_frame/core.cljc` | T | T | T | T | T | F | **T** |
| `implementation/ssr/src/re_frame/ssr.cljc` | T | T | T | T | T | T | **T** |
| `implementation/hicasso/src/re_frame/hicasso/server.cljs` | F | T | T | F | F | F | **T** |
| `implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs` | T | T | T | T | T | T | **T** |

Narrowing is confined to the security partition: across 18 probes covering all four
source-less tiers, all seven src-bearing per-feature artefacts, core, the Reagent
adapter, examples and the two root build files, the full 28-output before/after diff
is **four lines, all on the two security paths**. The bbe91 dispatch's own diff is
**four lines, all `skills_structural=false` becoming `true`** — it sets, never clears.

## Gates (captured exit codes, all re-run on the final base after rebase)

| gate | exit |
|---|---|
| `node --test implementation/scripts/_changed-surfaces.test.cjs` | **0** — 314 passed (299 before this PR; +15 new) |
| `scripts/check_gate_scheduling.py --verbose` | **0** — 33 gate commands, 29 scheduled, 0 unowned holes |
| `scripts/check_workflow_yaml.py` | **0** — 11 workflow files |
| `scripts/check_workflow_job_timeouts.py` | **0** — 114 jobs capped |
| `scripts/check_jvm_lane_rosters.py` | **0** — 31 rostered artefacts, bijection holds |
| `scripts/check_test_lane_bijection.py` | **0** — 1520 test-defining files, 45 lanes |
| `npm install` + `npm run test:cold-start` in the fixture | **0** — 1 test, 12 assertions |
| `bash -n` + `sh -n` on the classifier | **0** |

`shellcheck` is not installed on this machine, so the `.github/scripts/*.sh` shellcheck
in `portability.yml` is the gate for that; `bash -n` and `sh -n` are the local
substitute and both pass.

## Controls — that each gate read this tree, and that each is non-vacuous

A wiring change is where a green gate proves least, so each gate was made to go red.

- **The fixture is a real witness.** Renamed the `:document` key in
  `implementation/hicasso/src/re_frame/hicasso/server.cljs` — one of the four
  `:local/root` artefacts this PR now arms — and `npm run test:cold-start` returned
  **exit 1, 2 failures** (`expected: (string? (:document r1))`). Restored, re-run
  **exit 0**, assertion count unchanged at 12 both times, so the plant was scoped to
  the suite rather than crashing namespaces. That is the whole case for the reverse
  edge in one measurement: before this PR that same edit classified
  `skills_structural=false` and the job would not have run at all.
- **The security pins genuinely lock the negatives.** Reverted the defect — put
  `implementation/security/*` back into the `examples_compile` arm — and the mirror
  suite returned **exit 1 with 4 failures** naming `examples_compile cannot observe
  it`. Restored, **exit 0**, 314 passed.
- **The timeouts gate reads this tree.** Dropped `timeout-minutes` from the cold-start
  job; **exit 1** naming `reagent-migration-fixture-cold-start`. Restored, **exit 0**.
- Every restore verified by **git blob hash** against the committed object, not by
  reading a diff.
- The mirror suite's log names this worktree's own path, and the test-count deltas
  (299, then 308, then 314) are themselves discriminating: those tests exist only
  here. The fixture's compile log likewise names this checkout's `implementation/`
  paths.

## Not verified locally

Whether the runner provisions and schedules the jobs as written — this PR's own CI run
answers that. Note `test.yml` is in the classifier's `mark_all` arm, so this PR arms
every surface and runs the full matrix.
