### PR TITLE
fix(machines): give durable state the last word over the transient spawn-order cache (rf2-1vlyg)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -740,8 +740,9 @@
   `:fixed-actor-id` re-spawn, a different parent) carries different — or
   no — ownership stamps, so a STALE slot can never destroy it: exact
   incarnation identity is respected. A snapshot-less-but-live edge (the
-  back-to-back spawn-then-destroy window where only the spawn-order signal
-  is up) has no stamps to contradict the slot, so it counts as owned —
+  back-to-back spawn-then-destroy window, where `old-db` predates the
+  snapshot swap and `actor-live?` resolves the actor off the LIVE
+  runtime-db instead) has no stamps to contradict the slot, so it counts as owned —
   the tracked destroy retains its pre-existing behaviour there."
   [runtime-db actor-id parent-id invoke-id]
   (let [snap (when runtime-db (get-in runtime-db (paths/snapshot-path actor-id)))]

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -112,31 +112,51 @@
     {:owner-gone? (fn [] (not (continue?)))
      :owner-token (frame/current-event-owner-token)}))
 
+(defn- snapshot-present?
+  "True iff `runtime-db` carries a machine snapshot at `actor-id`. A nil
+  `runtime-db` (unknown / destroyed frame) carries nothing."
+  [runtime-db actor-id]
+  (and (some? runtime-db)
+       (contains? (get-in runtime-db (paths/snapshot-path)) actor-id)))
+
 (defn- actor-live?
   "The silent-idempotent liveness probe, shared by the
   keyword/tracked destroy paths (`destroy-machine-fx` /
   `destroy-tracked!`) and the per-actor
   `destroy-single-actor!` path. An actor with a resolved
-  `actor-id` is live iff ANY of the following survive:
+  `actor-id` is live iff EITHER of the following survives:
 
     - **Registrar entry present** at `actor-id`. Normal spawned actors resolve
       lazily without a per-instance entry, but teardown still recognises and
       clears a stale or externally installed entry.
     - **Snapshot present** at `[:rf.runtime/machines :snapshots actor-id]`
-      (covers the mid-drain handler-replaced window + hand-crafted call
-      sites).
-    - **Spawn-order entry present** for `actor-id` in the per-frame
-      spawn-order channel. `spawn-order/record!` runs unconditionally on
-      spawn and `spawn-order/forget!` unconditionally on destroy, so the
-      entry's presence/absence is the most reliable \"alive-or-gone\" bit —
-      notably it covers the back-to-back spawn-then-destroy in the same
-      `:fx` vector, where the snapshot swap may not yet have landed.
+      in `runtime-db` — or, when `runtime-db` does not carry it, in the
+      frame's LIVE runtime-db. The second read is gated on a hit in the
+      transient `spawn-order` cache, which is what makes it cheap: only an
+      id a spawn committed in this process can be in the stale-read window
+      at all.
 
-  A truly-already-destroyed actor has all three gone — the unified
-  teardown projection, registrar cleanup, and `spawn-order/forget!`
-  run atomically per `destroy-single-actor!` / `destroy-resolved!` /
-  `finalize-machine`. See Spec 005 §Destroy is silent-idempotent
-  for the normative paragraph.
+  The `runtime-db` argument is often a drain-time `old-db`, captured when
+  the `:rf.machine/destroy` effect entered. A spawn and a destroy
+  back-to-back in one `:fx` vector therefore present an actor that IS
+  live and yet absent from that value — the window the third clause used
+  to cover by trusting the cache outright.
+
+  Trusting it outright was wrong (rf2-1vlyg audit): no production
+  runtime-state install clears the cache, so after a `restore-epoch!` /
+  `replace-frame-state!` that rewinds PAST a spawn, a cache entry names an
+  actor the installed durable value DISCARDED. The bare-cache clause
+  reported such an actor live and ran a full teardown — trace, `:exit`
+  cascade and all — for something no longer in the frame, in violation of
+  Spec 005 §Destroy is silent-idempotent. Re-reading the LIVE runtime-db
+  covers the stale-`old-db` window exactly (`spawn-order/record!` runs
+  only after `install-spawn!` commits, so a cached id whose actor is live
+  always has a live snapshot) while giving durable state the last word.
+
+  A truly-already-destroyed actor has both signals gone — the unified
+  teardown projection and registrar cleanup run atomically per
+  `destroy-single-actor!` / `destroy-resolved!` / `finalize-machine`.
+  See Spec 005 §Destroy is silent-idempotent for the normative paragraph.
 
   This is the ONE liveness probe every destroy shape consults
   (rf2-s2bsmw). The tracked form pairs it with the exact-incarnation
@@ -145,9 +165,9 @@
   [frame-id actor-id runtime-db]
   (and actor-id
        (or (some? (registrar/lookup :event actor-id))
-           (and (some? runtime-db)
-                (contains? (get-in runtime-db (paths/snapshot-path)) actor-id))
-           (some #(= actor-id %) (spawn-order/frame-order frame-id)))))
+           (snapshot-present? runtime-db actor-id)
+           (and (some #(= actor-id %) (spawn-order/frame-order frame-id))
+                (snapshot-present? (frame/frame-runtime-db-value frame-id) actor-id)))))
 
 (defn- teardown-live-actor!
   "The shared ordered teardown pipeline for a LIVE actor (the caller has

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
@@ -38,10 +38,18 @@
   teardown projection in the swap that dissocs it. Reversing that vector
   IS the reverse-creation walk, and because it rides the durable
   runtime-db value it survives every supported round trip —
-  `replace-runtime-db!`, `restore-epoch!`, SSR hydration — with no restore
-  callback. The process-side `re-frame.machines.spawn-order` atom is a
-  transient cache of the same order (Spec 002 §Durable vs transient) and
-  is NOT consulted for ordering here.
+  `replace-frame-state!`, `restore-epoch!`, SSR hydration — with no restore
+  callback.
+
+  The process-side `re-frame.machines.spawn-order` atom is a transient
+  cache (Spec 002 §Durable vs transient) and this walk does not consult it
+  at all — neither for ORDER nor for MEMBERSHIP. No runtime-state install
+  clears it, so after a restore that rewinds PAST a spawn it names an actor
+  the installed durable value discarded; unioning it into the membership
+  reaped that dead actor, and — the durable segment walking first — placed
+  it AFTER the older actor durable state kept, inverting the reverse-creation
+  order this walk exists to honour (rf2-1vlyg audit). What the frame holds
+  is what its runtime-db says it holds.
 
   rf2-1vlyg — this used to be the other way round. The atom was the
   authority, and a restored actor absent from it was ranked by parsing the
@@ -183,11 +191,10 @@
          because the vector is durable runtime-db state rather than
          process-side bookkeeping (rf2-1vlyg).
       b. UNSEQUENCED spawned actors — snapshots carrying
-         `:rf/machine-type`, or ids recorded in the transient cache, that
-         the durable vector does not name. Only a directly-assoc'd
-         fixture / hand-built payload reaches here. Walked in
-         `unsequenced-order`: deterministic, with no reverse-creation
-         claim, because nothing ever sequenced them.
+         `:rf/machine-type` that the durable vector does not name. Only a
+         directly-assoc'd fixture / hand-built payload reaches here.
+         Walked in `unsequenced-order`: deterministic, with no
+         reverse-creation claim, because nothing ever sequenced them.
       c. Singleton stragglers — snapshots with no `:rf/machine-type`
          (registered via `reg-machine`, seeded directly). Runtime-db iteration
          order — there is no reverse-creation contract for singletons.
@@ -223,25 +230,29 @@
           newest-first (reverse durable)
           ;; Spawned actors the durable order does not name. A spawn always
           ;; records itself, so this is the directly-assoc'd fixture /
-          ;; hand-built payload case only. The transient cache is unioned in
-          ;; so an actor recorded there but already gone from runtime-db is
-          ;; still reaped, exactly as before.
-          unsequenced  (->> (concat (keys snapshots)
-                                    (spawn-order/frame-order frame-id))
+          ;; hand-built payload case only.
+          ;;
+          ;; Membership comes from the DURABLE snapshots alone. The transient
+          ;; `spawn-order` cache used to be unioned in here, which reaped
+          ;; actors the frame no longer holds: no runtime-state install clears
+          ;; that cache, so after a `restore-epoch!` / `replace-frame-state!`
+          ;; that rewinds PAST a spawn it still names the discarded actor —
+          ;; and because the durable segment walks first, the discarded NEWER
+          ;; actor was torn down AFTER the older one durable state kept,
+          ;; inverting the very reverse-creation order this walk exists to
+          ;; honour (rf2-1vlyg audit). A cache-only id has no snapshot, no
+          ;; durable order entry and no state to tear down; it is not a live
+          ;; actor of this frame.
+          unsequenced  (->> (keys snapshots)
                             (remove durable-set)
                             distinct
                             ;; Partition on the durable `:rf/machine-type`
                             ;; discriminator: a spawned snapshot MUST get the
                             ;; full teardown (registrar cleanup / system-id
                             ;; release / timer cancel / snapshot dissoc), while
-                            ;; a singleton keeps the exit-only path below. An
-                            ;; id present only in the transient cache has no
-                            ;; snapshot to classify and is treated as spawned —
-                            ;; it is one only a spawn could have recorded.
+                            ;; a singleton keeps the exit-only path below.
                             (group-by (fn [actor-id]
-                                        (if-let [snapshot (get snapshots actor-id)]
-                                          (spawned-snapshot? snapshot)
-                                          true))))
+                                        (spawned-snapshot? (get snapshots actor-id)))))
           singleton-stragglers (get unsequenced false)
           unsequenced-spawned  (unsequenced-order (get unsequenced true))]
       ;; (a) Durably sequenced spawned actors: full destroy, newest first.

--- a/implementation/machines/src/re_frame/machines/spawn_order.cljc
+++ b/implementation/machines/src/re_frame/machines/spawn_order.cljc
@@ -22,18 +22,47 @@
   survives `replace-runtime-db!`, epoch restore, and SSR hydration, which
   is precisely what the transient channel below does not.
 
-  **The process-side `spawn-order` atom is a transient CACHE of the same
-  order, never the authority** (rf2-1vlyg). It is runtime bookkeeping in
-  the Spec 002 §Durable vs transient sense: it has no observer contract,
-  is not serialised, and is empty after any state round trip. Destroy
-  keeps consulting it as a liveness bit (`destroy/actor-live?` — it is
-  set on spawn and cleared on destroy regardless of whether a runtime-db
-  swap landed), but frame destroy takes its ORDER from the durable vector
-  alone. Before rf2-1vlyg, frame destroy fell back to parsing the `#<n>`
-  suffix of a restored actor-id when this atom was empty; that suffix is a
-  per-id-prefix sequence and cannot order actors of different machine
-  types, so the fallback emitted a confident wrong order. The durable
-  vector replaced it.
+  **The process-side `spawn-order` atom is a transient CACHE, never the
+  authority** (rf2-1vlyg). It is runtime bookkeeping in the Spec 002
+  §Durable vs transient sense: no observer contract, not serialised, and
+  absent in any fresh process. Before rf2-1vlyg, frame destroy fell back
+  to parsing the `#<n>` suffix of a restored actor-id when this atom was
+  empty; that suffix is a per-id-prefix sequence and cannot order actors
+  of different machine types, so the fallback emitted a confident wrong
+  order. The durable vector replaced it.
+
+  ## What a cache entry means, and what it does not
+
+  An entry says **a spawn COMMITTED in this process** — `record!` runs
+  only after `install-spawn!` reports `:committed`, so by the time an id
+  is in here its snapshot and its durable order entry have landed. It
+  never says the actor is **still** in the frame's durable state.
+
+  The gap is not hypothetical, and it is worse than emptiness. An
+  in-process runtime-state install — `restore-epoch!`,
+  `replace-frame-state!`, a captured-value runtime-db revert — replaces
+  the durable value and touches nothing process-side; no production path
+  clears this atom (`:machines/on-frame-restored!` cancels `:after`
+  timers and nothing else). An install that rewinds PAST a spawn
+  therefore leaves the discarded actor named here while durable state has
+  dropped it: the cache is not merely stale, it is WRONG about liveness.
+
+  **So every consumer confirms against the LIVE runtime-db before
+  believing an entry.** `frame-destroy/teardown-on-frame-destroy!` takes
+  its whole membership from the durable snapshots plus the durable order
+  and never unions this atom in; `destroy/actor-live?` re-reads the live
+  runtime-db before trusting a cache hit. Enforcing the invariant where
+  the cache is READ — rather than reconciling it at each install site —
+  is what makes it hold for install paths that fire no hook at all
+  (`replace-frame-state!` fires none) and for paths not yet written.
+
+  That leaves the cache exactly ONE job, which no durable read can do:
+  compensating for a runtime-db argument that is a STALE drain-time read.
+  A `:rf.machine/destroy` effect carries the `old-db` captured at the
+  start of its drain, so a spawn and a destroy back-to-back in one `:fx`
+  vector present an actor that is genuinely live but absent from that
+  value. A cache hit tells `actor-live?` to go and look at the live
+  container instead of trusting `old-db`'s silence.
 
   Shape (both channels): a vector used as an append-only stack, the
   transient one keyed by frame — `{<frame-id> [<actor-id-1> …]}`. Spawn
@@ -120,10 +149,15 @@
 
 (defn frame-order
   "Return `frame-id`'s TRANSIENT spawn-order vector (oldest → newest), or
-  an empty vector when no spawns have been recorded in this process. This
-  is the cache, not the authority — it is empty after any state round
-  trip, so a caller that needs the frame's real creation order reads
-  `durable-order` off the runtime-db instead."
+  an empty vector when no spawns have been recorded in this process.
+
+  This is the cache, not the authority (see the ns docstring). It is empty
+  in a fresh process, and after an in-process runtime-state install it can
+  name actors the installed durable value DISCARDED — so it answers
+  neither \"what order?\" nor \"is this actor live?\" on its own. A caller
+  that needs the frame's real creation order reads `durable-order` off the
+  runtime-db; a caller testing liveness confirms a hit here against the
+  live runtime-db."
   [frame-id]
   (or (get @spawn-order frame-id) []))
 

--- a/implementation/machines/test/re_frame/final_state_spawn_order_forget_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/final_state_spawn_order_forget_cljs_test.cljc
@@ -4,25 +4,36 @@
   exactly like the explicit-destroy path (`destroy/teardown-live-actor!`,
   destroy.cljc step 7).
 
-  `spawn-order/frame-order` is `actor-live?`'s \"most reliable
-  alive-or-gone bit\" (destroy.cljc:83): `record!` runs unconditionally on
-  spawn, `forget!` unconditionally on destroy. If finalize omits the
-  `forget!`, a finished actor STAYS recorded even though its snapshot is
-  dissoc'd — so:
-
-    - a later stale `[:rf.machine/destroy id]` sees it LIVE (spawn-order
-      hit) → `teardown-live-actor!` RE-RUNS → a PHANTOM
-      `:rf.machine/destroyed` trace + a RE-FIRED resource release, violating
-      the silent-idempotent destroy contract (Spec 005 §Destroy is
-      silent-idempotent); and
-    - frame-destroy's spawn-order walk (frame_destroy.cljc segment (b))
-      emits a PHANTOM `:rf.machine.lifecycle/destroyed :parent-frame-destroyed`
-      for the already-finished actor.
+  `record!` runs when a spawn commits and `forget!` when a destroy tears
+  the actor down, so the channel tracks exactly the actors this process
+  spawned and has not yet destroyed. If finalize omits the `forget!`, a
+  finished actor STAYS recorded even though its snapshot is dissoc'd —
+  bookkeeping that names an actor the frame no longer holds.
 
   These JVM+CLJS tests pin: (1) finalize forgets the actor from
   spawn-order; (2) a subsequent stale destroy is a SILENT no-op — no phantom
   destroyed trace, no re-fired release; (3) frame-destroy emits no phantom
   for the finished actor.
+
+  Which of the three actually DISCRIMINATE changed under rf2-1vlyg, and it
+  is worth saying rather than leaving a reader to assume. This channel used
+  to be `actor-live?`'s standalone alive-or-gone bit, and frame destroy
+  unioned it into its walk membership — so a stranded entry made (2) emit a
+  phantom `:rf.machine/destroyed` and (3) a phantom
+  `:rf.machine.lifecycle/destroyed :parent-frame-destroyed`. Both consumers
+  now confirm against the LIVE runtime-db first (rf2-1vlyg audit: no
+  runtime-state install clears this cache, so a `restore-epoch!` that
+  rewinds past a spawn leaves it naming a DISCARDED actor, and believing it
+  reaped the dead). A stranded entry can therefore no longer resurrect a
+  dissoc'd actor by itself.
+
+  So (2) and (3) still pin their contracts — an already-finished actor is
+  never re-reaped — but they no longer FAIL on a missing `forget!`;
+  measured by deleting it from `finalize-machine`, which reds (1) and the
+  `frame-order` assertion inside (3) and leaves their trace assertions
+  green. (1), which asserts on `frame-order` directly, is the pin that
+  keeps the `forget!` honest, and it is why this suite still catches
+  rf2-p6fw3q's regression.
 
   Named `*-cljs-test.cljc` so both cognitect.test-runner (JVM, plain-atom)
   and shadow-cljs (CLJS, reagent) discover it."

--- a/implementation/machines/test/re_frame/frame_destroy_cascade_test.clj
+++ b/implementation/machines/test/re_frame/frame_destroy_cascade_test.clj
@@ -295,7 +295,7 @@
 
 ;; ---- restore / hydration: spawned snapshots absent from spawn-order ------
 ;;
-;; Restore / SSR hydration / `replace-runtime-db!` / `restore-epoch!`
+;; Restore / SSR hydration / `replace-frame-state!` / `restore-epoch!`
 ;; repopulate the DURABLE runtime-db snapshots WITHOUT repopulating the
 ;; PROCESS-SIDE (transient) `spawn-order` atom (Spec 002 §Durable vs
 ;; transient: the atom is runtime bookkeeping, not durable state). A restored
@@ -308,11 +308,19 @@
 ;; runs the `:exit` cascade + HTTP abort only and is reserved for restored
 ;; SINGLETON snapshots that carry no `:rf/machine-type`.)
 ;;
-;; These tests model restore by spawning normally, then wiping ONLY the
-;; transient spawn-order atom (`spawn-order/reset-all!`) while leaving the
-;; durable runtime-db snapshots in place — exactly the post-restore /
-;; post-hydration state. Asserting on the durable runtime-db cleanup then
-;; pins that the spawned-straggler path runs full teardown.
+;; The tests in THIS section model an SSR / preload hydration into a FRESH
+;; PROCESS: durable snapshots arrive on the wire and the transient atom was
+;; never populated at all. `spawn-order/reset-all!` reproduces exactly that —
+;; an empty cache beside a full runtime-db.
+;;
+;; It is NOT a model of an IN-PROCESS `restore-epoch!` / `replace-frame-state!`,
+;; and reading it as one is what rf2-1vlyg's first pass got wrong: no
+;; production install path clears the cache (`:machines/on-frame-restored!`
+;; cancels `:after` timers and nothing else), so after an in-process install
+;; the cache is POPULATED and may name actors the installed durable value
+;; discarded. That harder shape has its own section — §in-process runtime-state
+;; install, below — driven through core's real write surface with no reach into
+;; machines internals.
 
 (defn- runtime-snapshots
   "The `[:rf.runtime/machines :snapshots]` map on `frame-id`'s runtime-db."
@@ -567,3 +575,176 @@
           "frame destroy exits only the two survivors, newest-first — the dead actor is not exited a second time")
       (is (nil? (runtime-spawn-order :probedd/auth))
           "the slot is pruned once it empties — no unbounded stale entry survives the frame"))))
+
+;; ---- in-process runtime-state install: the transient cache goes stale -----
+;;
+;; An IN-PROCESS whole/partial runtime-state install — `restore-epoch!`,
+;; `replace-frame-state!`, a captured-value `swap-runtime-db!` revert — replaces
+;; the durable runtime-db and touches NOTHING process-side. No production path
+;; clears the frame's transient spawn-order cache: `:machines/on-frame-restored!`
+;; cancels `:after` timers and nothing else. So an install that rewinds PAST a
+;; spawn leaves the discarded actor named in the cache while durable state has
+;; dropped it — the cache is not merely EMPTY after a round trip (the
+;; fresh-process shape above), it is WRONG.
+;;
+;; The invariant that settles it (rf2-1vlyg): a cache entry is evidence that a
+;; spawn once COMMITTED IN THIS PROCESS, never evidence that the actor is still
+;; in the frame's durable state. Both consumers confirm against the live
+;; runtime-db before believing it — frame destroy takes its whole membership
+;; from the durable snapshots + durable order, and the destroy liveness probe
+;; re-reads the live runtime-db before trusting a cache hit. That holds for
+;; EVERY install path, including those that fire no hook at all, which is why it
+;; is enforced where the cache is READ rather than at each install site.
+;;
+;; These tests drive the loss boundary through `frame/replace-frame-state!` —
+;; core's ONE frame-state write surface, and the very fn
+;; `epoch/perform-restore!` calls to install a restored epoch. No test below
+;; resets a machines internal by hand.
+
+(defn- reg-staged-probe-machines!
+  "Two child TYPES under DIFFERENT id-prefixes, each appending its stamped
+  `:rf/self-id` to `exit-log` from its active state's `:exit`, plus a boot
+  machine that spawns them on SEPARATE events (and can destroy the second).
+  Staging the two spawns apart is what lets a test capture a frame-state
+  BETWEEN them — the value a `restore-epoch!` rewinds to."
+  [exit-log]
+  (let [child (fn [] {:initial :running
+                      :data    {}
+                      :states  {:running
+                                {:exit (fn [{data :data}]
+                                         (swap! exit-log conj (:rf/self-id data))
+                                         {})}}})
+        spawn (fn [t] [:rf.machine/spawn {:machine-id t :id-prefix t}])]
+    (rf/reg-machine :stage/a (child))
+    (rf/reg-machine :stage/b (child))
+    (rf/reg-machine :stage/boot
+                    {:initial :idle
+                     :data    {}
+                     :states  {:idle {:on {:spawn-a {:action (fn [_] {:fx [(spawn :stage/a)]})}
+                                           :spawn-b {:action (fn [_] {:fx [(spawn :stage/b)]})}
+                                           :drop-b  {:action (fn [_]
+                                                               {:fx [[:rf.machine/destroy :stage/b#1]]})}}}}})))
+
+(defn- collect-traces!
+  "Run `body-fn` with a trace listener attached; return the collected
+  envelopes."
+  [body-fn]
+  (let [traces (atom [])
+        cb-key (gensym ::destroy-cascade-cb)]
+    (rf/register-listener! :trace cb-key (fn [ev] (swap! traces conj ev)))
+    (try (body-fn) (finally (rf/unregister-listener! :trace cb-key)))
+    @traces))
+
+(defn- destroyed-actor-ids
+  "The `:actor-id` tags of every `operation` trace in `traces`, in emission
+  order, narrowed to `of-interest`."
+  [traces operation of-interest]
+  (->> traces
+       (filter #(= operation (:operation %)))
+       (map #(:actor-id (:tags %)))
+       (filterv of-interest)))
+
+(deftest restore-past-a-spawn-does-not-reap-the-discarded-actor
+  (testing "an in-process frame-state install that rewinds PAST a spawn leaves the discarded actor in the transient cache; frame destroy must reap only what durable state still carries"
+    (rf/make-frame {:id :stage/auth :doc "in-process restore frame"})
+    (let [exit-log (atom [])]
+      (reg-staged-probe-machines! exit-log)
+      (rf/dispatch-sync [:stage/boot [:spawn-a]] {:frame :stage/auth})
+      ;; The value `restore-epoch!` would reinstall — captured while ONLY
+      ;; :stage/a#1 is live.
+      (let [captured (rf/frame-state-value :stage/auth)]
+        (is (= [:stage/a#1] (runtime-spawn-order :stage/auth))
+            "the durable order carries a#1 at capture time (non-vacuity control)")
+        (rf/dispatch-sync [:stage/boot [:spawn-b]] {:frame :stage/auth})
+        (is (= [:stage/a#1 :stage/b#1] (runtime-spawn-order :stage/auth))
+            "b#1 is recorded NEWER than a#1 in the durable order (non-vacuity control)")
+        (is (= [:stage/a#1 :stage/b#1] (spawn-order/frame-order :stage/auth))
+            "the transient cache carries both (non-vacuity control)")
+        ;; --- the loss boundary: a whole frame-state install through core's
+        ;; ONE write surface, the same fn epoch/perform-restore! calls.
+        (frame/replace-frame-state! :stage/auth captured)
+        (is (= [:stage/a#1] (runtime-spawn-order :stage/auth))
+            "the durable order rewound past b#1")
+        (is (nil? (get (runtime-snapshots :stage/auth) :stage/b#1))
+            "b#1's snapshot is gone from durable state — the install DISCARDED that actor")
+        (is (= [:stage/a#1 :stage/b#1] (spawn-order/frame-order :stage/auth))
+            (str "the transient cache still names the discarded b#1 — no production "
+                 "install path clears it. This is the CONDITION under test, not a "
+                 "defect the fix papers over by clearing it."))
+        ;; --- the discriminator ---
+        (let [traces (collect-traces! #(rf/destroy-frame! :stage/auth))]
+          (is (= [:stage/a#1]
+                 (destroyed-actor-ids traces :rf.machine.lifecycle/destroyed
+                                      #{:stage/a#1 :stage/b#1}))
+              (str "only the actor durable state still carries is reaped. Unioning the "
+                   "stale transient cache into the walk reaps :stage/b#1 as well — and "
+                   "since the durable segment goes FIRST, it places the discarded newer "
+                   "b#1 AFTER the older a#1, inverting the reverse-creation discipline "
+                   "Spec 005 §Cross-Spec Interactions §1 pins."))
+          (is (= [:stage/a#1] (filterv #{:stage/a#1 :stage/b#1} @exit-log))
+              "only a#1's :exit cascade ran"))))))
+
+(deftest explicit-destroy-of-a-restore-discarded-actor-is-silent
+  (testing "after an install that rewinds past its spawn, an explicit :rf.machine/destroy of the discarded actor is the silent-idempotent no-op Spec 005 pins — a stale cache entry alone must not report it live"
+    (rf/make-frame {:id :stagex/auth :doc "silent-destroy-after-restore frame"})
+    (let [exit-log (atom [])]
+      (reg-staged-probe-machines! exit-log)
+      (rf/dispatch-sync [:stage/boot [:spawn-a]] {:frame :stagex/auth})
+      (let [captured (rf/frame-state-value :stagex/auth)]
+        (rf/dispatch-sync [:stage/boot [:spawn-b]] {:frame :stagex/auth})
+        (is (some? (get (runtime-snapshots :stagex/auth) :stage/b#1))
+            "b#1 is live before the install (non-vacuity control)")
+        (frame/replace-frame-state! :stagex/auth captured)
+        (is (nil? (get (runtime-snapshots :stagex/auth) :stage/b#1))
+            "b#1 was discarded by the install")
+        (is (some? (some #{:stage/b#1} (spawn-order/frame-order :stagex/auth)))
+            "the stale cache entry for b#1 survives the install (the condition under test)")
+        (reset! exit-log [])
+        (let [traces (collect-traces!
+                       #(rf/dispatch-sync [:stage/boot [:drop-b]] {:frame :stagex/auth}))]
+          (is (= [] (destroyed-actor-ids traces :rf.machine/destroyed #{:stage/b#1}))
+              (str "no :rf.machine/destroyed for an actor durable state no longer carries. "
+                   "Spec 005 §Destroy is silent-idempotent: an already-gone actor emits no "
+                   "trace, runs no teardown and raises no error."))
+          (is (= [] @exit-log)
+              "and no :exit cascade ran for the discarded actor"))))))
+
+(deftest mixed-prefix-order-survives-a-real-frame-state-reinstall
+  (testing "the DURABLE vector, not the transient cache, carries reverse-creation teardown through a genuine in-process frame-state reinstall"
+    (rf/make-frame {:id :probere/auth :doc "reinstall ordering frame"})
+    (let [exit-log (atom [])]
+      (reg-probe-machines! exit-log)
+      (rf/reg-machine :probere/boot
+                      {:initial :idle
+                       :data    {}
+                       :states  {:idle {:on {:drop-all
+                                             {:action (fn [_]
+                                                        {:fx [[:rf.machine/destroy :probe/a#1]
+                                                              [:rf.machine/destroy :probe/a#2]
+                                                              [:rf.machine/destroy :probe/b#1]]})}}}}})
+      (rf/dispatch-sync [:probe/boot [:spawn-mixed]] {:frame :probere/auth})
+      (let [captured (rf/frame-state-value :probere/auth)]
+        (is (= [:probe/a#1 :probe/a#2 :probe/b#1] (runtime-spawn-order :probere/auth))
+            "the durable order is recorded at capture time (non-vacuity control)")
+        ;; Empty the transient cache the ORDINARY way — three explicit
+        ;; destroys, each running `spawn-order/forget!`. No internals reset.
+        (rf/dispatch-sync [:probere/boot [:drop-all]] {:frame :probere/auth})
+        (is (= [] (spawn-order/frame-order :probere/auth))
+            "the transient cache is empty after the destroys (non-vacuity control)")
+        (is (nil? (runtime-spawn-order :probere/auth))
+            "and the durable slot is pruned once it empties")
+        (reset! exit-log [])
+        ;; Reinstall the captured frame-state — the whole-value install
+        ;; `restore-epoch!` performs. Only the DURABLE order comes back.
+        (frame/replace-frame-state! :probere/auth captured)
+        (is (= [:probe/a#1 :probe/a#2 :probe/b#1] (runtime-spawn-order :probere/auth))
+            "the durable order rode the install back in")
+        (is (= [] (spawn-order/frame-order :probere/auth))
+            (str "the transient cache is STILL empty — no install path repopulates it, "
+                 "so the walk below has nothing but the durable vector to read"))
+        (rf/destroy-frame! :probere/auth)
+        (is (= [:probe/b#1 :probe/a#2 :probe/a#1]
+               (filterv #{:probe/a#1 :probe/a#2 :probe/b#1} @exit-log))
+            (str "exact reverse creation order, read off the reinstalled durable vector. "
+                 "Descending-suffix sorting — the pre-rf2-1vlyg fallback — yields "
+                 "[:probe/a#2 :probe/a#1 :probe/b#1]."))))))


### PR DESCRIPTION
## rf2-1vlyg (audit reopen of PR #8870)

PR #8870 made the DURABLE `[:rf.runtime/machines :spawn-order]` vector the ordering
authority. The audit reopened the bead because the process-side cache could still
contradict durable state about **liveness**, and that turned #8870's segment ordering
into a new violation of the very invariant it fixed.

### The defect, reproduced

No production runtime-state install clears the frame's transient spawn-order cache —
`:machines/on-frame-restored!` cancels `:after` timers and nothing else, and
`replace-frame-state!` fires no hook at all. So an in-process `restore-epoch!` /
`replace-frame-state!` that rewinds PAST a spawn leaves the discarded actor named in
the cache while durable state has dropped it.

Measured on the pre-fix tree, driving the loss boundary through
`frame/replace-frame-state!` (core's one frame-state write surface, the fn
`epoch/perform-restore!` itself calls):

- frame destroy reaped `[:stage/a#1 :stage/b#1]` — the discarded NEWER `b#1` torn down
  AFTER the older `a#1` the durable order kept, inverting the reverse-creation
  discipline Spec 005 §Cross-Spec Interactions §1 pins;
- an explicit `:rf.machine/destroy` of the discarded `b#1` emitted
  `:rf.machine/destroyed` instead of the silent-idempotent no-op Spec 005 pins.

### The repair

A cache entry means **a spawn COMMITTED in this process**; it never means the actor is
still in the frame's durable state. Both consumers now confirm against the live
runtime-db:

- `teardown-on-frame-destroy!` takes its whole walk membership from the durable
  snapshots plus the durable order and does not read the cache at all;
- `actor-live?` re-reads the LIVE runtime-db before trusting a cache hit. That covers
  the one thing the cache is genuinely for — a drain-time `old-db` too stale to carry a
  just-spawned actor, the back-to-back spawn-then-destroy window — while leaving
  durable state the last word. `spawn-order/record!` runs only after `install-spawn!`
  commits, so a cached id whose actor is live always has a live snapshot; the live read
  covers that window exactly.

Enforced where the cache is READ rather than reconciled at each install site, which is
the audit's second disjunct and the stronger one: it holds for every install path,
including `replace-frame-state!` (no hook) and SSR hydration, and for paths not yet
written. The durable vector remains the ordering authority. No compatibility layer.

### Tests

Three new regressions in `frame_destroy_cascade_test.clj`, all driven through
`frame/replace-frame-state!` with **no reach into machines internals** (the audit's
specific complaint about #8870's `spawn-order/reset-all!` model):

- `restore-past-a-spawn-does-not-reap-the-discarded-actor`
- `explicit-destroy-of-a-restore-discarded-actor-is-silent`
- `mixed-prefix-order-survives-a-real-frame-state-reinstall` — the mixed-prefix
  reverse-creation order through a genuine reinstall with the cache emptied by
  ORDINARY destroys, the faithful replacement for the `reset-all!` model

Each carries non-vacuity controls asserting the pre-install live set, the durable
order, and that the cache really is stale afterwards.

The existing `reset-all!` tests stay — they model a FRESH-PROCESS SSR/preload
hydration, which is a real shape. Their section comment no longer claims they model
the in-process restore; that mis-reading is what #8870 got wrong.

### Scope

Machines artefact + its tests only. No `spec/` change: Spec 005 states the
reverse-creation REQUIREMENT, which was correct all along; the false claims were in
implementation docstrings and are repaired here. The reserved-slot bookkeeping for the
durable sibling already landed under rf2-pg5w6 (PR #8881) and is unaffected — no new
runtime-db key.

### Gates (captured exit codes, both hosts — the diff is `.cljc`)

Re-run on the FINAL rebased base:

| gate | captured exit | result |
| --- | --- | --- |
| `clojure -M:test` from `implementation/machines` (test.yml `jvm-machines`) | `0` | 1210 tests, 4231 assertions |
| `scripts/compile-node-test.cjs node-test` (the consolidated cljs job's build) | `0` | 1869 files, 0 warnings |
| `node out/node-test.js` | `0` | 11114 tests, 54835 assertions |

No markdown changed, so neither `check_doc_slugs.py` nor `check_readme_links.py --ci`
has a surface here.

**Control — both halves of the fix reverted at once** (the cache union restored in
`frame_destroy.cljc`, the bare cache clause restored in `actor-live?`): captured exit
`1`, exactly two failures, byte-for-byte the pre-fix behaviour —
`[:stage/a#1 :stage/b#1]` where `[:stage/a#1]` is due, and `[:stage/b#1]` where `[]` is
due. Namespace and assertion counts identical to the green run (15 tests / 75
assertions), so the plant stopped nothing; every non-vacuity control (pre-install live
set, durable order, stale cache) stayed green. That red is also the proof each gate read
this worktree — the fault existed nowhere else. Restore verified by git **blob** hash
against the committed objects.

**Defang check.** rf2-p6fw3q's `final_state_spawn_order_forget_cljs_test` consumed the
state this change alters, so its `forget!` was deleted from `finalize-machine` to see
whether the suite still discriminates. It does: captured exit `1`, reddening test (1)
and the `frame-order` assertion inside test (3). Their downstream TRACE assertions now
stay green — an honest loss of redundancy, since durable state governs those outcomes —
and the suite header now says exactly which of its three tests discriminate rather than
leaving the old, now-false mechanism claim standing.
