### PR TITLE
docs(dispatch): give the stale-description hazard its discriminating test

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -41,6 +41,27 @@ The order is what makes it accurate. Each step is a check the next depends on.
    walk adjacent snapshot pairs newest-first to the first text-bearing change, and you
    re-enumerate a bead's children before concluding a decision is absent. Every one of
    those binds the mayor writing the brief exactly as it binds the worker reading it.
+
+   **And one cheap query tells you when skipping the walk is guaranteed to burn a dispatch:
+   has this item ever been CLOSED and reopened?** The rule above is unconditional, which is
+   why it gets skipped — an unconditional instruction competes with every other unconditional
+   instruction. This is the case where skipping it is not a gamble but a certainty. A reopened
+   item's description is stale *by construction*: it describes the defect as originally found,
+   the work that closed it has shipped, and the live instruction is whatever note reopened it.
+   Nothing about the rendered item says so — the description still reads as a current bug
+   report, because it once was one. Measured across one session: three briefs written from
+   descriptions whose work had already merged, and **all three items showed a closed-to-open
+   transition in their status history while the control, never closed, showed none**. Ask the
+   tracker for the item's status over time rather than its status now.
+
+   **The three consequences differ, and only the first is obvious.** The dispatch may re-do
+   finished work; it may point a worker at a defect that no longer exists, whose deliverable is
+   then a refutation; or — the expensive one — it may describe a *smaller* problem than the one
+   the reopening found, so the worker fixes what you asked and the real defect survives with an
+   item now closed over it. The worker's own history walk catches all three, which is why this
+   costs a dispatch rather than a defect. **Do not let that safety net become the plan**: it
+   spends a worker's context re-deriving what one query answers, and the mayor learns nothing,
+   because a brief refuted politely reads much like a brief fulfilled.
 2. **Check every factual claim you are about to write.** Does the symbol resolve?
    Does the file say what you think? Is the count still true? Is the ruling you cite
    *ruled*, or only recommended? A recommendation and a decision read identically in


### PR DESCRIPTION
Found by the method-reread loop, checking a rule I had been *enforcing* — and the first finding was that the rule was already correct and I had simply not followed it.

Step 1 of *Write the brief in this order* already binds the mayor to the tracker-timestamp walk, and says so in as many words: "Every one of those binds the mayor writing the brief exactly as it binds the worker reading it." Step 2 already says to check the tree. I skipped both, three times in one session. That is not document drift, and I nearly stopped there.

What is genuinely missing is smaller and more useful: **the hazard is recorded without its discriminating test.** The instruction is unconditional, which is exactly why it loses — an unconditional instruction competes with every other unconditional instruction, and there is nothing in the rendered item to raise a flag, because a reopened item's description still reads as a current bug report. It once was one.

**The discriminator, measured.** All three items whose briefs went out wrong showed a **closed-to-open transition** in their status history; the control, an item never closed, showed none.

| item | status transitions |
|---|---|
| rf2-1vlyg | closed → open → closed → in_progress → open |
| rf2-8odvg | closed → open → closed → in_progress → open → closed → open → closed |
| rf2-bbe91 | closed → open → closed → in_progress → open |
| rf2-zq34m (control) | open |

Three for three, with a control that discriminates. A reopened item's description is stale *by construction*: it describes the defect as originally found, the work that closed it has shipped, and the live instruction is whatever note reopened it.

The addition also names the three ways the resulting brief goes wrong, because only the first is obvious: re-doing finished work; pointing at a defect that no longer exists, whose deliverable is then a refutation; or — the expensive one — describing a *smaller* problem than the reopening found, so the worker fixes what was asked and the real defect survives under an item now closed over it. The worker's own history walk catches all three, which is why this costs a dispatch rather than a defect, and the text says plainly not to let that safety net become the plan.

**A note on how this nearly went wrong**, since it bears on the method rather than on me. My first probe of the status history read the wrong field and returned "never closed" for all four items — including three I knew had been reopened. It agreed with the control, so nothing looked broken. That is the gate-mechanics block's own warning ("any instrument that can answer *nothing here* gives the same answer when misused") landing on the act of checking a rule about hazards. Exercising it against an input it should flag is what caught it.

## Quality gates

- `python scripts/check_doc_slugs.py` — **exit 0**. `docs/` is inside its roots.
  - **Control:** the gate is silent on success, so its green was proven by a planted broken link target at a line this change edits → **exit 1**, naming `docs\the-mayor-method\dispatch-prompt-template.md:45 -> ./no-such-file-reopened-control.md`. That fault existed only in this worktree, so the red also proves the gate read this tree. Anchor match count read as **1** before planting.
  - **Restore verified by git blob hash**, not by reading a diff: working file `e2c22098294370bd0a7d600842b56a9fb8645e70` == the committed object. Gate re-run after restore: **exit 0**. Committed before planting, so the restore was well-defined.
- `mkdocs build --strict` — **not nominated.** `mkdocs.yml`'s `exclude_docs` keeps `docs/the-mayor-method/` out of the built site, and `--strict` grades missing anchors at INFO regardless.
- **By hand:** prose added inside an existing numbered list item — no headings, anchors or tables changed. The only link introduced was the planted control, removed.

One file, `docs/the-mayor-method/dispatch-prompt-template.md`. No code, tests or workflow files touched.
