### PR TITLE
fix(text): three independent text corrections (rf2-0g60h, rf2-v04qh, rf2-jgsl9)

### DIFF
--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -903,8 +903,9 @@
 ;; §`:rf/set-db`. The framework's OWN registration goes through the private
 ;; `registrar/register!` path (see `register-set-db-standard!`), so this guard —
 ;; which fires only on the public `register-event!` entry — does not reject the
-;; framework's own seeding. The set is deliberately narrow (today only
-;; `:rf/set-db`): the OTHER framework `:rf/*` events (`:rf/hydrate`,
+;; framework's own seeding. The set is deliberately narrow (today `:rf/set-db`
+;; and `:rf/settle-flows` — see the def's docstring for why each is in): the
+;; OTHER framework `:rf/*` events (`:rf/hydrate`,
 ;; `:rf.route/url-requested`, `:rf/server-init`, …) are still registered through the
 ;; public `reg-event` by their owning feature artefacts, so they are NOT listed
 ;; here; widening the set is a Spec change.

--- a/skills/re-frame2-implementor/references/cardinal-rules.md
+++ b/skills/re-frame2-implementor/references/cardinal-rules.md
@@ -74,11 +74,12 @@ gh issue list --repo day8/re-frame2 --search "<agent-authored safe keywords>"
    gh issue create \
      --repo day8/re-frame2 \
      --title "spec-gap(EP-NNN): <one-line>" \
-     --body-file '/tmp/re-frame2-issue-7f3a9c.md' \
-     --label spec-gap,from-implementor
+     --body-file '/tmp/re-frame2-issue-7f3a9c.md'
    ```
 
    Single-quote the path. It is agent-authored, so nothing in it needs expanding, and single quotes keep a Windows path's backslashes literal.
+
+   **File it unlabelled — do not add `--label`.** `gh` resolves label names to ids *before* the create mutation, so a single name the target repo does not carry kills the whole call at pre-flight (`could not add label: <name> not found`, exit 1) and the approved body is never filed. A published recipe cannot know which labels `day8/re-frame2` carries on the day it runs, so it names none; a maintainer labels the issue on arrival.
 
 `--body-file` reads the body verbatim from disk, so no shell expansion ever touches the transcript-derived text, and the only `Bash` call is a bare `gh issue create` — exactly what the skill's `allowed-tools` grants.
 
@@ -86,11 +87,11 @@ gh issue list --repo day8/re-frame2 --search "<agent-authored safe keywords>"
 
 - **Never paste evidence-/transcript-derived text into `--title`.** A failure string, a log line, or a suggested title can carry `$(…)`, backticks, `"`, `'`, `\`, or a newline the shell expands the moment the command runs. Engineer approval to file an issue is not approval to execute session-carried shell syntax.
 - **Author the title from a restricted safe alphabet:** letters, digits, spaces, and `- . , / ( ) :` only — no `$`, no backtick, no `"`/`'`, no `\`, no newline, no other shell metacharacter.
-- **Reviewer pass covers the title.** Re-read the assembled `--title` arg in the same pre-emission pass that scans the body for private evidence. The same rule covers any other user-influenced argument (`--label`, `--repo`): keep them agent-authored or from a fixed set, never interpolated from evidence.
+- **Reviewer pass covers the title.** Re-read the assembled `--title` arg in the same pre-emission pass that scans the body for private evidence. The same rule covers any other user-influenced argument (`--repo`, and `--search` above): keep them agent-authored or from a fixed set, never interpolated from evidence.
 
 ## 9. Approval gate before any cross-repo side effect
 
-Filing a GitHub issue against `day8/re-frame2` from inside the engineer's port repo is a cross-repo side effect. **Per-issue approval IS required.** Before the call, show the engineer the full draft — title, target repo, label set, body — and wait for an explicit OK. Invoking the skill is consent to the *workflow*, not consent to each *cross-repo write*. Treat the two as separate gates.
+Filing a GitHub issue against `day8/re-frame2` from inside the engineer's port repo is a cross-repo side effect. **Per-issue approval IS required.** Before the call, show the engineer the full draft — title, target repo, body — and wait for an explicit OK. Invoking the skill is consent to the *workflow*, not consent to each *cross-repo write*. Treat the two as separate gates.
 
 ## 10. Honour the reserved `:rf/*` scheme — with the fixed three-fx unqualified carve-out
 

--- a/skills/re-frame2/patterns/websocket.md
+++ b/skills/re-frame2/patterns/websocket.md
@@ -22,7 +22,7 @@ SSE (`EventSource`) and WebRTC peer connections share the same lifecycle shape �
 | `:spawn` (declarative spawn) | `:active` invokes a `:websocket/socket` child owning the JS `WebSocket`. Exiting `:active` destroys it; re-entering spawns a fresh one. |
 | `:after` (fn-form delay) | Exponential backoff timer in `:reconnecting`, computed at entry from `:retries` and `:base-ms`. |
 | `:always` | Max-retries guard on `:reconnecting` entry; queue-flush guard on `:connected` entry. |
-| Parent-level `:on` | `:ws/closed`, `:ws/fatal`, `:ws/send`, `:ws/rotate-cred` declared once on `:active`, inherited by every leaf. |
+| Parent-level `:on` | `:ws/closed`, `:ws/fatal`, `:ws/disconnect`, `:ws/send`, `:ws/rotate-cred` declared once on `:active`, inherited by every leaf. The first three are the doors *out*: each destroys the socket actor, so each settles `:in-flight` on the way out. |
 | Connection-epoch staleness check | Live socket-actor's `:rf/self-id` is the epoch. Replies carry `:source-socket-id`; `:current-socket?` guard rejects events from a torn-down prior socket. |
 
 ## Credential discipline (load-bearing — read before the snippet)
@@ -48,6 +48,22 @@ The pattern below uses `:cred-ref` as the placeholder; substitute whatever opaqu
 ;; own (which is what makes :current-socket? a safe connection clock).
 (def socket-invoke-id [:active])
 (defn socket-id [data] (get-in data [:rf/spawned socket-invoke-id]))
+
+;; The in-flight half of losing the wire, shared by EVERY door out of :active
+;; (the :ws/closed drop, the clean :ws/disconnect, the :ws/fatal escape hatch).
+;; Each exit destroys the socket actor, so each must settle :in-flight on the
+;; way out: a slot left behind leaks forever, because its timeout carries the
+;; dead socket-id and :current-socket? drops it after teardown. FAIL, never
+;; replay — the server may already have processed the request. Returns an
+;; action result the calling action builds on.
+(defn fail-in-flight [data]
+  {:data (assoc data :in-flight {})
+   :fx   (into [] (keep (fn [[rid {:keys [reply-event]}]]
+                          (when reply-event
+                            [:dispatch (conj reply-event
+                                             {:origin :ws/local :request-id rid
+                                              :ok false :error :ws/connection-lost})])))
+               (:in-flight data))})
 
 (rf/reg-machine :ws/connection
   {:initial :disconnected
@@ -81,7 +97,15 @@ The pattern below uses `:cred-ref` as the placeholder; substitute whatever opaqu
                               {:data (assoc data :url url :cred-ref cred-ref)})
     :rotate-cred     (fn [{data :data [_ new-cred-ref] :event}]
                        {:data (assoc data :cred-ref new-cred-ref)})
-    :bump-retry      (fn [{data :data}] {:data (update data :retries inc)})
+    ;; Three doors out of :active, one shared in-flight settlement. The drop
+    ;; also bumps the retry counter; the fatal door also records the error; the
+    ;; clean door does neither — the app asked for it, so it is not a failure.
+    :on-socket-lost  (fn [{data :data}] (-> (fail-in-flight data)
+                                            (update :data update :retries inc)))
+    :fail-in-flight  (fn [{data :data}] (fail-in-flight data))
+    :on-fatal-error  (fn [{data :data [_ {:keys [error]}] :event}]
+                       (-> (fail-in-flight data)
+                           (update :data assoc :error error)))
     :on-connected
     ;; :entry takes one fn / id, never a vector — consolidate.
     (fn [{data :data}]
@@ -110,8 +134,11 @@ The pattern below uses `:cred-ref` as the placeholder; substitute whatever opaqu
                ;; :data fn takes ONE context-map arg {:keys [snapshot event]}.
                :data       (fn [{snap :snapshot}] {:url      (-> snap :data :url)
                                                    :cred-ref (-> snap :data :cred-ref)})}
-     :on      {:ws/closed      {:target :reconnecting :action :bump-retry}
-               :ws/fatal       {:target :failed}
+     ;; Every door OUT of :active kills the wire, so every one settles
+     ;; :in-flight exactly once on the way out — see the three actions above.
+     :on      {:ws/closed      {:target :reconnecting  :action :on-socket-lost}
+               :ws/fatal       {:target :failed        :action :on-fatal-error}
+               :ws/disconnect  {:target :disconnected  :action :fail-in-flight}
                :ws/send        {:action :enqueue-message}
                :ws/rotate-cred {:action :rotate-cred}}
      :initial :connecting
@@ -190,6 +217,7 @@ The `:connected` `:ws/received` transition vets the frame first — connection e
 - **Routing a refresh bearer through dispatch without classifying its path at its owner.** If a credential genuinely must move via dispatch (e.g. an out-of-band rotation), classify the path where it lands — a durable app-db secret via the writing event's `:sensitive` commit-plane effect, or the transient dispatch payload key in the dispatching handler's registration `:sensitive` metadata — per the privacy seam in [`../references/cross-cutting/privacy-and-elision.md`](../references/cross-cutting/privacy-and-elision.md). (There is **no** handler-meta `{:sensitive? true}` privacy switch; classification is fail-open and does not propagate.)
 - **Reconnect via `setTimeout` from inside fx-handler.** Bypasses the machine, tracing, stale-detection. Use `:after`.
 - **Skipping `:current-socket?` on `:ws/received`.** A slow `:message` from a torn-down socket lands in the new connection's `:in-flight` — wrong-reply at best.
+- **Settling `:in-flight` on only one door out of `:active`.** The `:ws/closed` drop is the door everyone remembers. A clean `:ws/disconnect` and an app-level `:ws/fatal` destroy the socket just as surely, and a slot stranded by `:ws/fatal` survives even a later manual `:ws/connect` out of `:failed` — its timeout carries the dead socket-id, so `:current-socket?` drops it and nothing else ever clears the slot. Route every exit through one shared fail-and-clear rather than repeating the logic per door.
 - **Treating WebSocket as Pattern-AsyncEffect.** A connection that retries, reconnects, and survives across messages is state-machine-shaped.
 - **Skipping schema validation on `:ws/received` payloads.** Inbound socket frames are an untrusted boundary. Validate against the agreed wire schema at the route-message seam before mutating app-db or branching downstream dispatches. See [`../references/fundamentals/schemas.md`](../references/fundamentals/schemas.md) §`validate-at-boundary-interceptor`.
 - **Validating at the app-db ingress only, when the machine mutates on the frame first.** "Before mutating app-db" is not the whole rule if the connection machine clears an `:in-flight` slot the frame names: the ingress refuses the body, app-db is untouched, and the correlation is already spent — the caller waits forever, and nothing on the rejection counter says so. Put the wire contract in the transition guard as well, ahead of the branch.

--- a/spec/Pattern-WebSocket.md
+++ b/spec/Pattern-WebSocket.md
@@ -47,12 +47,13 @@ The canonical states form a hierarchical machine. `:connecting`, `:authenticatin
 :active / :authenticating --:ws/auth-failed-->   :failed
 :active / *             --:ws/closed-->          :reconnecting
 :active / *             --:ws/fatal-->           :failed
+:active / *             --:ws/disconnect-->      :disconnected
 :reconnecting           --:after backoff-->      :active / :connecting
 :reconnecting           --:always max-retries--> :failed
 :failed                 --:ws/connect-->         :active / :connecting
 ```
 
-Per [005 §Transition resolution — deepest-wins with parent fallthrough](005-StateMachines.md#transition-resolution--deepest-wins-with-parent-fallthrough), `:ws/closed` and `:ws/fatal` are declared on `:active` once and inherited by every leaf — every `:connecting`-error, `:authenticating`-error, and `:connected`-error path routes through the same parent-level transition.
+Per [005 §Transition resolution — deepest-wins with parent fallthrough](005-StateMachines.md#transition-resolution--deepest-wins-with-parent-fallthrough), the doors *out* of `:active` — the `:ws/closed` drop, the `:ws/fatal` escape hatch, and the clean `:ws/disconnect` — are declared on `:active` once and inherited by every leaf, so every `:connecting`, `:authenticating`, and `:connected` exit path routes through the same parent-level transition. Each of those doors destroys the socket actor, so **each of them also settles the `:in-flight` request set on the way out** — see §Message correlation for request-reply, item 5.
 
 The connection machine composes the locked substrate:
 
@@ -76,6 +77,31 @@ The connection machine composes the locked substrate:
 ;; idiom (005 §Recording the spawned id user-side), preferred over an :on-spawn
 ;; self-dispatch.
 (defn- socket-id [data] (get-in data [:rf/spawned [:active]]))
+
+;; The in-flight half of losing the wire, shared by EVERY door out of `:active`
+;; that destroys the socket — the guarded `:ws/closed` drop, the clean
+;; `:ws/disconnect`, and the app-level `:ws/fatal` escape hatch. Clear every
+;; `:in-flight` slot and fire each waiting `:reply-event` with the documented
+;; local-failure body. Each of those requests was already on the wire that is
+;; going away, so its reply can never arrive on this connection; left in
+;; `:in-flight` the slot leaks forever — its timeout is stamped with the dead
+;; socket-id, so `:current-socket?` drops that timeout after teardown and
+;; nothing else ever clears the slot. Semantics are FAIL, not replay: the
+;; server may already have processed the request, so a blind re-send risks
+;; double execution. Returns an action result (`:data` + `:fx`) for the calling
+;; action to build on — factoring it out is what keeps the three doors from
+;; drifting apart.
+(defn- fail-in-flight [data]
+  {:data (assoc data :in-flight {})
+   :fx   (into []
+               (keep (fn [[rid {:keys [reply-event]}]]
+                       (when reply-event
+                         [:dispatch (conj reply-event
+                                          {:origin     :ws/local
+                                           :request-id rid
+                                           :ok         false
+                                           :error      :ws/connection-lost})])))
+               (:in-flight data))})
 
 (rf/reg-event :ws/connection
   {:doc "WebSocket connection lifecycle: disconnected → active{:connecting →
@@ -149,25 +175,41 @@ The connection machine composes the locked substrate:
       ;; Heading for :reconnecting, two things happen:
       ;;   1. Bump the retry counter — it drives the :after backoff and the
       ;;      :max-retries-exceeded? guard.
-      ;;   2. FAIL every in-flight request. Each was already on the wire that
-      ;;      just died, so its reply can never arrive on THIS connection; left
-      ;;      in :in-flight it would leak forever (its timeout is stamped with
-      ;;      the now-dead socket-id, so :current-socket? drops that timeout
-      ;;      after we reconnect and the slot never clears). Loss semantics are
-      ;;      FAIL, not replay — the server may already have processed the
-      ;;      request, so a blind re-send risks double execution. Each waiting
-      ;;      :reply-event fires with {:ok false :error :ws/connection-lost} so
-      ;;      the caller learns the outcome instead of hanging forever.
+      ;;   2. FAIL every in-flight request, through the shared `fail-in-flight`
+      ;;      helper above — the same half of the job the clean-disconnect and
+      ;;      fatal doors do. Each waiting :reply-event fires with
+      ;;      {:origin :ws/local :ok false :error :ws/connection-lost} so the
+      ;;      caller learns the outcome instead of hanging forever. See the
+      ;;      helper for the full leak/replay story.
       (fn [{:keys [data]}]
-        {:data (-> data (update :retries inc) (assoc :in-flight {}))
-         :fx   (into []
-                     (keep (fn [[rid {:keys [reply-event]}]]
-                             (when reply-event
-                               [:dispatch (conj reply-event
-                                                {:request-id rid
-                                                 :ok         false
-                                                 :error      :ws/connection-lost})])))
-                     (:in-flight data))})
+        (-> (fail-in-flight data)
+            (update :data update :retries inc)))
+
+      :fail-in-flight
+      ;; The clean door. A :ws/disconnect out of :active destroys the socket
+      ;; just as surely as a drop does, so the SAME invariant applies: every
+      ;; request accepted into :in-flight settles exactly once on the way out.
+      ;; Unlike :on-socket-lost there is no retry bump — the app asked for this
+      ;; disconnect, so it is not a connection failure; only the requests still
+      ;; riding the wire fail, with the same documented body.
+      (fn [{:keys [data]}]
+        (fail-in-flight data))
+
+      :on-fatal-error
+      ;; :ws/fatal is the app-level escape hatch out of :active — the app
+      ;; itself declaring the connection unrecoverable (a protocol violation, a
+      ;; server telling us not to come back) and going straight to :failed
+      ;; without retrying. It leaves :active, so the runtime destroys the
+      ;; socket just as surely as a drop or a clean disconnect does, and
+      ;; recording the error is only HALF the job: without the fail-in-flight
+      ;; half the slot and its waiting :reply-event survive teardown forever,
+      ;; because the scheduled timeout carries the destroyed socket's id and
+      ;; :current-socket? rejects it once the socket is gone. That leak
+      ;; outlives a later manual :ws/connect out of :failed too, so the caller
+      ;; never learns anything. No retry bump: we are giving up, not retrying.
+      (fn [{:keys [data] [_ {:keys [error]}] :event}]
+        (-> (fail-in-flight data)
+            (update :data assoc :error error)))
 
       :send-auth
       ;; Route an :auth message into the live socket actor. NO token in
@@ -295,8 +337,18 @@ The connection machine composes the locked substrate:
        :on    {:ws/closed   {:guard  :current-socket?
                              :target :reconnecting
                              :action :on-socket-lost}
+               ;; The app-level escape hatch. It leaves :active, so it kills
+               ;; the wire — and therefore settles the in-flight set on the way
+               ;; out as well as recording the error (see :on-fatal-error).
                :ws/fatal    {:target :failed
-                             :action :record-error}
+                             :action :on-fatal-error}
+               ;; The clean door out. It kills the wire too, so it settles the
+               ;; in-flight set on the way out (see :fail-in-flight). Every
+               ;; door out of :active reachable from :connected — this one, the
+               ;; guarded :ws/closed drop and :ws/fatal — settles :in-flight
+               ;; exactly once.
+               :ws/disconnect {:target :disconnected
+                               :action :fail-in-flight}
                :ws/send     {:action :enqueue-message}
                :ws/rotate-cred {:action :rotate-cred}
                ;; A request issued before the connection is :connected is
@@ -322,6 +374,11 @@ The connection machine composes the locked substrate:
          ;; straggler :ws/auth-failed must not tear a fresh attempt to :failed.
          :on    {:ws/auth-ok     {:guard  :current-socket?
                                   :target :connected}
+                 ;; This door leaves :active too, but it needs no in-flight
+                 ;; settlement — plain :record-error is correct here, not an
+                 ;; oversight. :register-request is the only writer into
+                 ;; :in-flight and it is bound only on :connected, so reaching
+                 ;; :authenticating means :in-flight is provably empty.
                  :ws/auth-failed {:guard  :current-socket?
                                   :target [:failed]
                                   :action :record-error}}}
@@ -445,7 +502,7 @@ Request-reply protocols carry a correlation id on every request and matching rep
 2. **`:register-request` action** records the in-flight entry — `(:in-flight data)` gains `{request-id {:reply-event ... :timeout-ms ...}}` — forwards the body (with `:request-id` stamped) to the socket actor, and schedules a `:dispatch-later` for the timeout.
 3. **`:ws/received` arrives with `{:body {:type :reply :request-id ... :ok ...}}`.** The `:connected` state's `:trusted-frame?` guard checks the connection epoch **and** the closed wire contract; only then does the handler branch on the vetted `:type`. A `:reply` looks up the in-flight entry, clears the slot, and dispatches the registered reply event with the machine's `:origin :ws/server` stamp added; a `:push` only routes to `[:ws/handle-message body]`. Branch on `:type`, not on the presence of a `:request-id` — the frame's declared kind is part of the contract you just checked, whereas presence-of-a-key is a shape test a widened arm re-opens.
 4. **`:ws/request-timeout` fires** if no reply arrives within the timeout window. The `:clear-request` action removes the in-flight entry; the caller's reply event never fires. (Apps that want to surface "request timed out" to the caller can do so by dispatching a per-feature error event from `:clear-request` instead.)
-5. **Connection loss fails the slot.** When the live socket drops (`:ws/closed` → `:reconnecting`), `:on-socket-lost` fails every still-in-flight request — each `:reply-event` fires with `{:origin :ws/local :ok false :error :ws/connection-lost}` and `:in-flight` is cleared — so no correlation slot leaks across the reconnect and no caller hangs. Loss semantics are FAIL, not silent replay: the server may already have processed the request, so blind re-send risks double execution.
+5. **Losing the wire fails the slot — by every door, not only the drop.** A request accepted into `:in-flight` settles exactly once, and it settles whenever the socket goes away rather than only when it is lost underneath us. Every transition that exits `:active` destroys the socket actor, so all three doors run the shared `fail-in-flight` helper: the guarded `:ws/closed` drop (`:on-socket-lost`, which also bumps the retry counter), the clean `:ws/disconnect` (`:fail-in-flight`), and the app-level `:ws/fatal` escape hatch (`:on-fatal-error`, which also records the error). Each still-in-flight `:reply-event` fires with `{:origin :ws/local :ok false :error :ws/connection-lost}` and `:in-flight` is cleared, so no correlation slot leaks and no caller hangs. Semantics are FAIL, not silent replay: the server may already have processed the request, so blind re-send risks double execution. (`:ws/auth-failed` is the exception that proves the rule — `:register-request` is bound only on `:connected`, so `:in-flight` is provably empty by the time that door can be taken, and plain `:record-error` is correct there.)
 
 **Two producers reach the reply event, so say which is which — with a key the sender cannot set.** A correlated wire reply and a locally minted loss/timeout failure both arrive at the caller's `:reply-event`, and they are different facts: one is the server's claim, the other is the machine's own truth about the connection. Discriminating between them by *shape* hands the choice to the sender, because a hostile server that has seen the wire request id can send back whatever shape the "local failure" arm describes and have its frame recorded as a connection fact the app minted itself. So the machine **stamps** `:origin` — `:ws/server` on the wire body as it hands it on, `:ws/local` on the bodies it mints — and the outcome schema is a closed union dispatching on that stamp. Stamped after receipt, `:origin` is not forgeable from the wire.
 
@@ -515,7 +572,7 @@ This mirrors the rule for any client-only fx: the `:platforms` metadata gates ex
 - **Per-message machine-spawn-and-destroy.** The connection machine is long-lived. Spawning a new machine per outgoing message is structural overkill — use a single connection machine with `:in-flight` correlation tracking instead.
 - **Treating WebSocket as Pattern-AsyncEffect.** A connection that retries, reconnects, and survives across message boundaries is state-machine-shaped. Use this pattern.
 - **Storing the `WebSocket` object in `app-db`.** The JS `WebSocket` is not a value; it cannot serialise; it cannot survive Tool-Pair epoch replay. The `:websocket/socket` actor owns it via a host-side reference; only its id appears in `:data` — under the runtime-maintained `:rf/spawned` slot.
-- **Leaking in-flight requests when the socket drops.** A request already on the wire when the connection is lost can never be answered on that socket; left in `:in-flight` it dangles forever (its timeout is stamped with the dead socket-id, so `:current-socket?` drops the timeout after reconnect and the slot never clears). Fail each on loss — fire its `:reply-event` with `{:origin :ws/local :ok false :error :ws/connection-lost}` and clear `:in-flight` (the worked example's `:on-socket-lost`) — so callers learn the outcome. FAIL, not blind replay: the server may already have processed the request, so re-sending risks double execution.
+- **Leaking in-flight requests on a door out of `:active` — and fixing only the drop.** A request already on the wire when the socket goes away can never be answered on that socket; left in `:in-flight` it dangles forever (its timeout is stamped with the dead socket-id, so `:current-socket?` drops the timeout after teardown and the slot never clears). The obvious version of the bug is missing it on the `:ws/closed` drop. The version that survives review is repairing that one door and leaving the others: a clean `:ws/disconnect` and an app-level `:ws/fatal` destroy the socket just as surely, and a `:ws/fatal` leak outlives even a later manual `:ws/connect` out of `:failed`, so the caller never learns anything. Route **every** exit from `:active` through one shared fail-and-clear — the worked example's `fail-in-flight`, composed by `:on-socket-lost`, `:fail-in-flight` and `:on-fatal-error` — firing each `:reply-event` with `{:origin :ws/local :ok false :error :ws/connection-lost}` and clearing `:in-flight`, so callers learn the outcome. FAIL, not blind replay: the server may already have processed the request, so re-sending risks double execution.
 - **Anchoring the `:spawn` on `:connecting` instead of the `:active` parent.** A socket actor scoped to `:connecting` is destroyed the moment the leaf transitions to `:authenticating` — every dispatch from `:authenticating` and `:connected` then addresses a dead actor. The actor's lifetime must outlive every leaf that dispatches through it; the hierarchical parent is the natural anchor.
 - **Storing a raw bearer / cookie / refresh token in machine `:data`, or dispatching one through the machine.** `:data` is framework-inspectable — app-db snapshots, trace emissions, recorder fixtures, pair tooling — so a credential held there is liable to be serialised somewhere nobody inspects character-by-character. Carry an opaque `:cred-ref` and resolve it to the real bearer inside the socket actor's host closure at authentication time (see §Parameters).
 - **Forgetting to re-thread connection opts on reconnect.** Recording `:url` and `:cred-ref` only in `:disconnected`'s `:ws/connect` handler — and never refreshing them on the `:reconnecting` → `:active` path — means a credential expiry mid-session can never recover. Either store opts in `:data` (where the `:spawn` `:data` fn re-reads them on every `:active` entry — the worked example's approach) or provide an explicit `:ws/rotate-cred` slot at the parent level.


### PR DESCRIPTION
Three small, mutually independent text corrections. They share no file and are one PR only because each is small.

## rf2-0g60h — `spec/Pattern-WebSocket.md` worked example taught the `:ws/fatal` in-flight leak

PR #8872 (rf2-ni0ko) composed `fail-in-flight` onto `:ws/fatal` in `examples/patterns/websocket/connection.cljs`, so every door out of `:active` reachable from `:connected` now settles `:in-flight` exactly once. The spec's worked-example listing was outside that bead's fence and still showed `:ws/fatal {:target :failed :action :record-error}` — the exact shape #8872's witness proves strands every in-flight slot and its waiting `:reply-event`, including across a later manual `:ws/connect` out of `:failed`.

**Nothing in the page was false.** Its stated invariant was drop-scoped (§5 item 5, and the "when the socket drops" pitfall) and the listing agreed with it. This is teaching-drift: a consumer copying the recommended listing inherits a leak the shipped example no longer has. The correction brings the listing level with the example and states the invariant the example now implements, which the page's own `:spawn` bullet already implied ("any transition that exits `:active` destroys the actor").

- one `fail-in-flight` helper, composed by all three doors — `:on-socket-lost` (also bumps retries), `:fail-in-flight` (clean `:ws/disconnect`), new `:on-fatal-error` (also records the error);
- the `:ws/disconnect` row the listing never carried, at the `:active` parent level where the in-flight obligation lives, plus a line in the standard-transitions block;
- why `:ws/auth-failed` correctly keeps plain `:record-error` — `:register-request` is bound only on `:connected`, so `:in-flight` is provably empty by the time that door can be taken;
- the helper mints `:origin :ws/local`, which §5 and the two-producers paragraph already state but the listing omitted.

`skills/re-frame2/patterns/websocket.md` carried the same drift condensed (`:ws/fatal` with no action at all; no `:ws/disconnect` in the parent-level `:on` summary row) and gets the same treatment at its own level of abbreviation, plus one anti-pattern for the door-by-door version of the bug.

Deliberately out: the example also carries `:ws/disconnect` on `:reconnecting` and `:failed`. Those doors carry no in-flight obligation — `:in-flight` was settled on leaving `:active` — so neither listing gains them here. No `rf/machine-` or `rf/make-machine-handler` spelling was touched (the file has exactly one such line, `rf/make-machine-handler` in the worked example, left exactly as it was — rf2-wrzfb holds those).

## rf2-v04qh — implementor filing recipe passed two labels that do not exist

`--label spec-gap,from-implementor` in `skills/re-frame2-implementor/references/cardinal-rules.md` §8. Re-confirmed at source at tip: `day8/re-frame2` carries exactly ten labels and a direct API lookup for each of the two returns 404, while the control lookup for `bug` resolves. `gh` resolves label names to ids *before* the createIssue mutation, so the call dies at pre-flight and the approved body is never filed.

Per the ruling on the bead, option 2 — drop the flag. The sibling migration recipe passes no `--label` and files successfully, so this costs nothing currently being had and forecloses nothing. A short note says why there is no label so the next author does not add one back. §9's approval draft no longer asks the engineer to review a "label set" that cannot exist, and the reviewer-pass bullet cites `--repo` / `--search` instead of a flag the recipe now refuses to pass.

**No gate added**, per the same ruling: a check reaching the live forge on every PR buys a rarely-changing fact at the cost of CI network flakiness.

Census re-run at tip over tracked files, line-level *and* flattened so a line-broken occurrence cannot hide, each control-checked against a known hit. `--label` appears in five files: three are an unrelated bench script's own flag, one is prose in the migration recipe warning against interpolating it, and §8 was the only filing recipe passing it. `spec-gap` survives only as the issue *title* prefix `spec-gap(EP-NNN):` and in prose — neither is a label.

## rf2-jgsl9 — stale comment contradicted a docstring five lines below

`implementation/core/src/re_frame/events.cljc`: the comment above the def said the set is "deliberately narrow (today only `:rf/set-db`)" while the docstring below it and the value itself both read `#{:rf/set-db :rf/settle-flows}` (verified at tip). PR #8893 added the second member and updated the docstring but not the comment. Comment text only — no code, no behaviour, no test change.

## Gates

Exit codes captured on the runner's own command line and quoted in the thread. `scripts/check_doc_slugs.py` covers `spec/` and `skills/`; `scripts/check_readme_links.py --ci` covers the repo-root and beside-source markdown roster.

**What no gate covers, stated plainly:**

- Both doc gates strip fenced code blocks before reading a single link, and the whole of the rf2-0g60h correction — every listing change — lives inside a fence. Their green says nothing about the content of that change. Markdown structure was hand-checked instead: paren/bracket/brace balance of every `clojure` fence in both pages (balanced before and after), table column counts (uniform at 2), and no heading, anchor or link target added, moved or removed.
- Nothing validates comment *content* in a `.cljc` file. rf2-jgsl9's correctness rests on reading `reserved-event-ids`' actual value at tip, which is `#{:rf/set-db :rf/settle-flows}`. That is the honest answer, not a weakness.
- Nothing in CI checks that the filing recipe runs. That is how rf2-v04qh shipped, and the ruling explicitly declines to add a live-forge check for it.
