### PR TITLE
fix(routing): refuse unpaired surrogates in url-encode on the JVM (rf2-j3tud)

### DIFF
--- a/implementation/routing/src/re_frame/routing/url.cljc
+++ b/implementation/routing/src/re_frame/routing/url.cljc
@@ -33,6 +33,61 @@
 ;; literal '/' between captured segments, so the splat encoder runs
 ;; per-segment.
 
+#?(:clj
+   (defn- reject-unpaired-surrogates!
+     "Throw when `s` contains an UNPAIRED surrogate code unit; return `s`
+     otherwise. This is `encodeURIComponent`'s own validity rule,
+     transplanted to the JVM.
+
+     A code point above U+FFFF is carried in a Java/JavaScript string as a
+     SURROGATE PAIR — a high unit in U+D800–U+DBFF followed by a low unit
+     in U+DC00–U+DFFF. Either half standing alone spells no code point at
+     all, so it has no UTF-8 encoding. The two hosts disagreed about what
+     to do with one:
+
+     - `encodeURIComponent` throws `URIError: URI malformed`.
+     - Java's UTF-8 encoder SUBSTITUTES, and `URLEncoder` runs it under
+       the default (REPLACE) malformed-input action, so a lone surrogate
+       silently became the byte `0x3F` — a literal `?` — and came back as
+       `%3F`. A lone high surrogate, a lone low surrogate and `a`+U+D800+`b`
+       encoded as `%3F`, `%3F` and `a%3Fb` (rf2-j3tud).
+
+     `%3F` is exactly what a legitimate literal `?` encodes to, so the
+     substitution is not merely lossy — it ALIASES malformed route data
+     onto a valid component that decodes back to a different string.
+     Under SSR the href/canonical-link/cache-key carried that alias while
+     the browser refused the same address outright, which is the
+     host-dependent emission this namespace exists to rule out.
+
+     WHAT THIS DOES NOT REJECT. The scan looks only at the surrogate
+     range, so every input that is already valid on both hosts stays
+     valid: ASCII, every non-surrogate BMP character (`é`, `日`), and a
+     well-formed surrogate PAIR, which still encodes to its astral code
+     point's UTF-8 bytes (U+1F600 → `%F0%9F%98%80`). Over-rejecting
+     legitimate input would trade this bug for a worse one — the JVM
+     would then refuse addresses the browser happily emits."
+     ^String [^String s]
+     (let [n (.length s)]
+       (loop [i 0]
+         (if (<= n i)
+           s
+           (let [c (.charAt s i)]
+             (cond
+               (Character/isHighSurrogate c)
+               (if (and (< (inc i) n)
+                        (Character/isLowSurrogate (.charAt s (inc i))))
+                 (recur (+ i 2))
+                 (throw (IllegalArgumentException.
+                          (format "URI malformed: unpaired high surrogate U+%04X at index %d"
+                                  (int c) i))))
+
+               (Character/isLowSurrogate c)
+               (throw (IllegalArgumentException.
+                        (format "URI malformed: unpaired low surrogate U+%04X at index %d"
+                                (int c) i)))
+
+               :else (recur (inc i)))))))))
+
 (defn url-encode
   "Encode a single component (named param or query value) with
   `encodeURIComponent` semantics on BOTH hosts.
@@ -40,7 +95,7 @@
   HOST-SYMMETRIC: identical route data produces one canonical URL byte
   string on JVM (SSR) and CLJS (browser). CLJS calls
   `encodeURIComponent` directly; the JVM arm emulates it on top of
-  `java.net.URLEncoder`, which needs TWO corrections rather than one:
+  `java.net.URLEncoder`, which needs THREE corrections rather than one:
 
   1. `URLEncoder` is the `application/x-www-form-urlencoded` encoder, so
      it emits `+` for a space where `encodeURIComponent` emits `%20`.
@@ -51,6 +106,11 @@
      divergent, so a legitimate slug like `draft~1` emitted
      `/articles/draft%7E1` from SSR and `/articles/draft~1` from the
      hydrated client (rf2-j3tud).
+  3. `URLEncoder` encodes an UNPAIRED SURROGATE rather than refusing it,
+     substituting `%3F` where `encodeURIComponent` throws `URIError`.
+     `reject-unpaired-surrogates!` above supplies the missing refusal;
+     its docstring carries the reasoning, including why `%3F` is the
+     worst possible substitution here.
 
   Both spellings decode to the same route, but that is weaker than the
   invariant Spec 012 §Bidirectional URL ↔ params actually promises:
@@ -67,9 +127,16 @@
   The five unescapes are unambiguous: every `%XX` in `URLEncoder` output
   is one it generated, so a `%21` in that output can only have come from
   a literal `!`. A literal `%` in the input is already `%25`, and no
-  `%25`-prefixed run can spell one of these escapes."
+  `%25`-prefixed run can spell one of these escapes.
+
+  The surrogate check runs BEFORE `URLEncoder`, not after: once the
+  substitution has happened its `%3F` is indistinguishable from the one
+  a real `?` produces, so the only place the two can still be told apart
+  is the input string."
   [s]
-  #?(:clj  (-> (java.net.URLEncoder/encode (str s) "UTF-8")
+  #?(:clj  (-> (str s)
+               (reject-unpaired-surrogates!)
+               (java.net.URLEncoder/encode "UTF-8")
                (.replace "+" "%20")
                (.replace "%21" "!")
                (.replace "%27" "'")
@@ -80,7 +147,13 @@
 
 (defn url-encode-splat
   "Encode a splat value — multi-segment, preserves literal '/'.
-  Each segment is encoded individually."
+  Each segment is encoded individually.
+
+  Composing `url-encode` per chunk is what makes the boundary inherit:
+  the mark set, the escaped controls and the unpaired-surrogate refusal
+  all arrive per segment. Splitting on `/` cannot manufacture a fresh
+  unpaired surrogate either — U+002F is outside the surrogate range, so
+  no split point ever falls between the halves of a pair."
   [s]
   (clojure.string/join "/" (map url-encode (clojure.string/split (str s) #"/"))))
 

--- a/implementation/routing/test/re_frame/routing_url_encoding_parity_cljs_test.cljc
+++ b/implementation/routing/test/re_frame/routing_url_encoding_parity_cljs_test.cljc
@@ -31,11 +31,21 @@
   itself. An encoder that changed on one host only cannot also rewrite
   what it is compared against.
 
+  THE UNESCAPED SET WAS ONLY HALF OF IT. `encodeURIComponent` also
+  REFUSES input it cannot encode — an unpaired surrogate — and the JVM
+  arm silently substituted `%3F` there instead, so the same address
+  emitted a URL from SSR that the browser threw on. That half is pinned
+  in its own section below and is the reason this suite grew a
+  fail-loud table alongside its literal-output ones.
+
   Reverting the JVM arm to `URLEncoder` plus the `+`→`%20` swap alone
   turns the JVM half of this namespace red on the boundary set, the
-  production `route-url` case and the round-trip, while the
-  escaped-character controls stay green — proving those controls are not
-  what carries the suite."
+  production `route-url` case and the round-trip; removing the
+  unpaired-surrogate guard turns the fail-loud table and the surrogate
+  prism red. In BOTH sabotages every valid-input control — the escaped
+  characters, the literal `?`, the well-formed surrogate pair — stays
+  green, which is what proves the controls are not what carries the
+  suite."
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
@@ -114,6 +124,130 @@
     (is (= "my%20file/50%25.txt" (url/url-encode-splat "my file/50%.txt"))
         "the controls still escape per chunk")))
 
+;; ---- unpaired surrogates: the fail-LOUD half of the boundary -------------
+;;
+;; `encodeURIComponent` is not only a mapping, it is also a REFUSAL: a
+;; code unit in U+D800–U+DFFF that is not half of a well-formed pair
+;; spells no code point, has no UTF-8 encoding, and raises `URIError`.
+;; Java's UTF-8 encoder SUBSTITUTES instead, and `URLEncoder` runs it
+;; under the default REPLACE action, so the JVM arm emitted `%3F` — the
+;; encoding of a literal `?`. Malformed route data was therefore ALIASED
+;; onto a valid component that decodes back to a different string, and it
+;; reached the SSR href / canonical link / cache key while the browser
+;; refused the very same address (rf2-j3tud, audit of PR #8873).
+;;
+;; Every input below is built from NUMERIC code units rather than written
+;; as a character literal. A lone surrogate does not survive every editor,
+;; shell or file re-encoding intact, and a mangled one would quietly turn
+;; these rows into assertions about some other string; `code-units` plus
+;; the instrument control below is what keeps that honest.
+
+(defn- code-units
+  "Build a string from raw UTF-16 code-unit values. Host-symmetric: a
+  Java `String` and a JavaScript string are both UTF-16 code-unit
+  sequences, so the same integers name the same string on both."
+  [codes]
+  (apply str (map (fn [c] #?(:clj  (str (char c))
+                             :cljs (js/String.fromCharCode c)))
+                  codes)))
+
+(defn- code-unit-at
+  "The numeric UTF-16 code unit at index `i` of `s`."
+  [s i]
+  #?(:clj  (int (.charAt ^String s i))
+     :cljs (.charCodeAt s i)))
+
+(def ^:private unpaired-surrogates
+  "Code-unit sequences `encodeURIComponent` REFUSES. One row per shape so
+  a failure names the exact offender."
+  [[[0xD800]               "lone HIGH surrogate — the JVM emitted %3F"]
+   [[0xDFFF]               "lone LOW surrogate — the JVM emitted %3F"]
+   [[0x0061 0xD800 0x0062] "a lone high surrogate EMBEDDED between ASCII — the JVM emitted a%3Fb"]
+   [[0xD800 0x0078]        "a high surrogate followed by ASCII instead of its low partner"]
+   [[0x0078 0xDC00]        "a low surrogate preceded by ASCII instead of its high partner"]
+   [[0xDFFF 0xD800]        "a REVERSED pair — low then high is two orphans, not a pair"]
+   [[0xD83D 0x0062]        "the high half of a REAL pair (U+1F600), orphaned by its partner"]
+   [[0xDE00]               "the low half of that same real pair, standing alone"]])
+
+(def ^:private well-formed-code-unit-strings
+  "Inputs that MUST still encode, with their literal expected output.
+  These are the controls: the refusal table above cannot be satisfied by
+  making `url-encode` throw more freely, because every one of these would
+  start throwing if it did."
+  [[[0xD83D 0xDE00]  "%F0%9F%98%80" "a WELL-FORMED surrogate pair — U+1F600, four UTF-8 bytes. The guard inspects pairing, not the surrogate range"]
+   [[0xDBFF 0xDFFF]  "%F4%8F%BF%BF" "the LAST well-formed pair — U+10FFFF, the top of Unicode"]
+   [[0xD800 0xDC00]  "%F0%90%80%80" "the FIRST well-formed pair — U+10000, built from two units each of which the table above refuses on its own"]
+   [[0x003F]         "%3F"          "a LITERAL question mark — the exact output the JVM used to alias every lone surrogate onto, so it must still be reachable by legitimate input"]
+   [[0x00E9]         "%C3%A9"       "é — an ordinary non-ASCII BMP character"]
+   [[0x65E5]         "%E6%97%A5"    "日 — a three-byte BMP character"]
+   [[0xFFFD]         "%EF%BF%BD"    "a real U+FFFD — the character just BELOW the surrogate-adjacent range, and the near-miss the decoder side turns on"]
+   [[0x0061 0x0062]  "ab"           "plain ASCII"]])
+
+(deftest code-unit-helper-builds-the-strings-these-tables-claim
+  (testing "the instrument control: assert on NUMBERS, so a file
+            re-encoding that mangled a surrogate into U+FFFD (or into a
+            `?`) makes this red rather than quietly rewriting the
+            subject of every row below"
+    (let [high (code-units [0xD800])]
+      (is (= 1 (count high)) "a lone high surrogate is ONE code unit")
+      (is (= 0xD800 (code-unit-at high 0)) "and it really is D800"))
+    (let [low (code-units [0xDFFF])]
+      (is (= 1 (count low)) "a lone low surrogate is ONE code unit")
+      (is (= 0xDFFF (code-unit-at low 0)) "and it really is DFFF"))
+    (let [pair (code-units [0xD83D 0xDE00])]
+      (is (= 2 (count pair)) "U+1F600 is TWO code units in UTF-16")
+      (is (= 0xD83D (code-unit-at pair 0)) "high half")
+      (is (= 0xDE00 (code-unit-at pair 1)) "low half"))
+    (is (= 0x003F (code-unit-at (code-units [0x003F]) 0))
+        "the literal `?` control is a real question mark, not a
+         substituted surrogate")))
+
+(deftest url-encode-refuses-unpaired-surrogates-on-both-hosts
+  (testing "an unpaired surrogate is REFUSED, not substituted. CLJS
+            throws `URIError`; the JVM used to return %3F and now throws
+            too (rf2-j3tud)"
+    (doseq [[codes why] unpaired-surrogates]
+      (is (thrown? #?(:clj Throwable :cljs :default)
+                   (url/url-encode (code-units codes)))
+          why)))
+  (testing "the aliasing itself, stated directly: whatever `url-encode`
+            does with a lone surrogate, it must not be what it does with
+            a literal `?` — those two inputs are different strings"
+    (is (= "%3F" (url/url-encode (code-units [0x003F])))
+        "a literal `?` still encodes to %3F on both hosts")
+    (is (thrown? #?(:clj Throwable :cljs :default)
+                 (url/url-encode (code-units [0xD800])))
+        "while the lone surrogate that used to produce the SAME bytes is
+         now refused on both hosts")))
+
+(deftest url-encode-still-encodes-every-well-formed-string-on-both-hosts
+  (testing "the controls: valid input must NOT be refused, so the table
+            above cannot pass by throwing on everything. A surrogate PAIR
+            is legitimate input and still encodes to its astral code
+            point's UTF-8 bytes"
+    (doseq [[codes expected why] well-formed-code-unit-strings]
+      (is (= expected (url/url-encode (code-units codes))) why)))
+  (testing "the whole ASCII mark set and the escaped controls are
+            untouched by the surrogate guard"
+    (is (= "!'()~*-._" (url/url-encode "!'()~*-._")))
+    (is (= "a%20b%26c" (url/url-encode "a b&c")))))
+
+(deftest url-encode-splat-refuses-unpaired-surrogates-per-chunk
+  (testing "the splat encoder composes `url-encode` per chunk, so the
+            refusal arrives per segment — it used to emit `a/%3F`"
+    (is (thrown? #?(:clj Throwable :cljs :default)
+                 (url/url-encode-splat (str "a/" (code-units [0xD800]))))
+        "a lone surrogate in a LATER segment still fails the whole call")
+    (is (thrown? #?(:clj Throwable :cljs :default)
+                 (url/url-encode-splat (str (code-units [0xDFFF]) "/b")))
+        "and in the FIRST segment"))
+  (testing "the control: a well-formed pair is NOT split apart by the
+            per-segment encoding — U+002F is outside the surrogate range,
+            so no split point can fall between the halves of a pair"
+    (is (= "a/%F0%9F%98%80/b"
+           (url/url-encode-splat (str "a/" (code-units [0xD83D 0xDE00]) "/b")))
+        "the pair survives the split and encodes as one astral code point")))
+
 ;; ---- production route-url: one canonical URL on both hosts ---------------
 
 (deftest route-url-emits-one-canonical-url-across-hosts
@@ -167,3 +301,57 @@
             "the punctuation-bearing query key AND value both recover")
         (is (= frag (:fragment parsed))
             "the fragment recovers byte-exactly")))))
+
+(deftest route-url-refuses-unpaired-surrogates-in-every-position-on-both-hosts
+  (testing "the production prism, not a re-derivation: an unpaired
+            surrogate anywhere in the address fails the whole call on
+            both hosts. The JVM used to emit a URL here — with %3F
+            standing in for the surrogate — while the browser threw, so
+            the SSR href, the canonical head link and the cache key
+            carried a spelling the client could not produce (rf2-j3tud)"
+    (rf/reg-route :parity/surrogate {:params [:map [:slug :string]]} "/p/:slug")
+    (let [high (code-units [0xD800])
+          low  (code-units [0xDFFF])]
+      (is (thrown? #?(:clj Throwable :cljs :default)
+                   (routing/route-url {:to :parity/surrogate :params {:slug high}}))
+          "path param — the JVM used to emit /p/%3F")
+      (is (thrown? #?(:clj Throwable :cljs :default)
+                   (routing/route-url {:to     :parity/surrogate
+                                       :params {:slug "ok"}
+                                       :query  {"q" low}}))
+          "query VALUE — the JVM used to emit /p/ok?q=%3F")
+      (is (thrown? #?(:clj Throwable :cljs :default)
+                   (routing/route-url {:to     :parity/surrogate
+                                       :params {:slug "ok"}
+                                       :query  {high "v"}}))
+          "query KEY")
+      (is (thrown? #?(:clj Throwable :cljs :default)
+                   (routing/route-url {:to       :parity/surrogate
+                                       :params   {:slug "ok"}
+                                       :fragment high}))
+          "fragment")
+      (is (thrown? #?(:clj Throwable :cljs :default)
+                   (routing/route-url {:to     :parity/surrogate
+                                       :params {:slug (str "draft" high "1")}}))
+          "embedded mid-slug, where a substituting encoder is least visible")))
+  (testing "the control: the SAME route emits one canonical URL for an
+            astral code point, so the assertions above cannot pass by
+            breaking the prism. A surrogate PAIR is legitimate route data"
+    (rf/reg-route :parity/surrogate2 {:params [:map [:slug :string]]} "/p/:slug")
+    (let [emoji (code-units [0xD83D 0xDE00])
+          built (routing/route-url {:to :parity/surrogate2 :params {:slug emoji}})]
+      (is (= "/p/%F0%9F%98%80" built)
+          "the literal canonical URL, identical on JVM and CLJS")
+      (let [parsed (routing/match-url built)]
+        (is (some? parsed) "it is not a malformed-URL route-miss")
+        (is (= emoji (get-in parsed [:params :slug]))
+            "and round-trips back to the same string")
+        (is (= [0xD83D 0xDE00]
+               (let [s (get-in parsed [:params :slug])]
+                 [(code-unit-at s 0) (code-unit-at s 1)]))
+            "asserted as CODE UNITS, so a U+FFFD substitution anywhere in
+             the round trip cannot read as a pass")))
+    (let [built (routing/route-url {:to :parity/surrogate2 :params {:slug "?"}})]
+      (is (= "/p/%3F" built)
+          "and a literal `?` still emits %3F — the alias target stays
+           reachable by the legitimate input that owns it"))))


### PR DESCRIPTION
## What

`re-frame.routing.url/url-encode` promises `encodeURIComponent` semantics on both hosts. PR #8873 closed the mapping half of that promise (the five ASCII marks `!` `'` `(` `)` `~`). This closes the half the audit of that PR reopened rf2-j3tud for: `encodeURIComponent` is also a **refusal**.

A UTF-16 code unit in U+D800–U+DFFF that is not half of a well-formed pair spells no code point and has no UTF-8 encoding, so `encodeURIComponent` throws `URIError`. Java's UTF-8 encoder **substitutes**, and `java.net.URLEncoder` runs it under the default REPLACE malformed-input action, so the JVM arm emitted `%3F` — the encoding of a literal `?`.

Measured against production `url-encode` before this change (JVM left, node's `encodeURIComponent` right, inputs built from numeric code units and outputs printed as code units, not glyphs):

| input (code units) | JVM before | JVM after | `encodeURIComponent` |
|---|---|---|---|
| `U+D800` | `%3F` | throws | throws `URIError` |
| `U+DFFF` | `%3F` | throws | throws `URIError` |
| `a U+D800 b` | `a%3Fb` | throws | throws `URIError` |
| `U+DFFF U+D800` | `%3F%3F` | throws | throws `URIError` |
| `U+D83D U+DE00` (U+1F600) | `%F0%9F%98%80` | `%F0%9F%98%80` | `%F0%9F%98%80` |
| `U+00E9` | `%C3%A9` | `%C3%A9` | `%C3%A9` |
| `U+003F` (literal `?`) | `%3F` | `%3F` | `%3F` |

`%3F` is exactly what a legitimate `?` encodes to, so the substitution did not merely lose information — it **aliased** malformed route data onto a valid component that decodes back to a different string. Under SSR that alias reached `route-link`'s `:href`, the canonical head link and the cache key while the hydrating client threw on the same address.

Through the production prism, before this change: `route-url {:to :probe :params {:slug U+D800}}` returned `/p/%3F` on the JVM and threw in the browser. It now throws on both, in all four positions (path param, query key, query value, fragment).

## How

`reject-unpaired-surrogates!` scans the input **before** `URLEncoder` sees it, because once the substitution has happened its `%3F` is indistinguishable from the one a real `?` produces — the input string is the only place the two can still be told apart.

The scan looks only at **pairing** within the surrogate range, so everything that was already valid on both hosts stays valid: ASCII, every non-surrogate BMP character, and well-formed surrogate **pairs**, which still encode to their astral code point's UTF-8 bytes. Over-rejecting would have traded this bug for a worse one — the JVM refusing addresses the browser happily emits.

`url-encode-splat` composes `url-encode` per chunk and inherits the refusal. U+002F is outside the surrogate range, so no split point can fall between the halves of a pair.

CLJS is normative and **unchanged**: it IS `encodeURIComponent`, the de-facto reference Spec 012 names, and the JVM arm is explicitly labelled the emulation. An incomplete emulation is a conformance bug in the emulator, so no spec edit is owed — the same disposition #8873 and rf2-k2d2t (#8882) took.

## Scope

Confined to `implementation/routing/**`. `implementation/http/**` is untouched: `re-frame.http.encoding/url-encode` merely shares a name — it imports `java.net.URLEncoder` directly and requires nothing from routing.

## Tests

Extends the existing shared CLJC parity suite `routing_url_encoding_parity_cljs_test.cljc` (one table per host, asserted identically on both against literal expectations, so a one-host change cannot rewrite what it is compared against):

- an **instrument control** asserting the code-unit helper really builds a lone D800 / DFFF and a two-unit U+1F600 — assertions on numbers, so a file re-encoding that mangled a surrogate into U+FFFD or `?` goes red rather than quietly changing the subject of every row;
- a **refusal table** over eight unpaired shapes: lone high, lone low, embedded between ASCII, high-then-ASCII, ASCII-then-low, a reversed pair, and each half of a real U+1F600 pair standing alone;
- a **valid-input control table**: three well-formed pairs (U+10000, U+1F600, U+10FFFF), `é`, `日`, a real U+FFFD, plain ASCII, and a **literal `?`** — the alias target, which must stay reachable by the legitimate input that owns it;
- per-chunk splat coverage, with a control that a pair survives the split;
- the production `route-url` prism refusing an unpaired surrogate in path param, query key, query value, fragment and mid-slug, with an astral-pair control asserting the literal canonical URL `/p/%F0%9F%98%80` and a `match-url` round trip checked **as code units**.

## Gates

Both hosts are load-bearing — this is a `.cljc` artefact and the whole point is host parity. Runner's own captured exit codes:

| gate | captured exit | result |
|---|---|---|
| JVM `clojure -M:test` in `implementation/routing` | 0 | 547 tests / 3320 assertions |
| CLJS `scripts/compile-node-test.cjs node-test` | 0 | 1869 files, 0 warnings |
| CLJS `node out/node-test.js` | 0 | 11120 tests / 54895 assertions |
| `clj-kondo --fail-level error --lint implementation/routing` | 0 | 0 errors |

No markdown changed, so neither doc-link gate is nominated.

## Sabotage

Removing the guard from the JVM arm reds the fail-closed assertions **only** — every valid-input control stays green. Planting a wrong expectation in the shared table reds the CLJS run, proving the `.cljc` table really executes on both hosts. Numbers in the thread.
