### PR TITLE
fix(testbed-support): decline auto-detected launches that would drop the coordinate (rf2-1i1ec)

### DIFF
--- a/tools/testbed-support/README.md
+++ b/tools/testbed-support/README.md
@@ -74,13 +74,33 @@ into a browser bundle.
 
 A 200 from this endpoint means the whole source coordinate reached an editor,
 not merely that a process exited. `launch-editor` encodes a position per editor
-binary and has no case for `windsurf`, so it would launch Windsurf with the
-bare file and still exit 0. A coordinate-bearing `editor=windsurf` request is
-therefore declined with 422 `editor-position-unsupported` before Node is
-spawned, and the browser's `windsurf://file/<path>:<line>:<column>` fallback —
-which does carry the position — opens the file at the right place. A Windsurf
-request with no line or column is served normally. Every other editor in the
-vocabulary is unaffected.
+binary and falls through to a bare-file launch for binaries it has no case for
+— which still exits 0. A coordinate-bearing request that would take that
+fall-through is declined with 422 `editor-position-unsupported`, and the
+browser's `editor://` fallback — which does carry the position — opens the file
+at the right place instead.
+
+Two routes answer that question, because the endpoint does not always choose
+the binary:
+
+- **A named editor.** `editor=windsurf` maps to a command the pinned
+  `launch-editor` has no `get-args.js` case for, so it is declined before Node
+  is spawned. The browser then navigates
+  `windsurf://file/<path>:<line>:<column>`.
+- **No editor at all.** The client sends no `editor` parameter for a nil
+  preference or a `{:custom …}` one, which puts `launch-editor` on auto-detect:
+  it picks a binary from the running process list, and that list reaches
+  editors with no position case (Brackets on every platform; on Windows also
+  `Cursor.exe`, whose capitalised process name the lowercase `cursor` case does
+  not match). The launch shim therefore asks `get-args.js` itself what it would
+  emit before launching, and declines the same way if the coordinate would be
+  dropped. A nil preference then falls back to the default `vscode://` scheme,
+  and a `{:custom …}` preference to its own template — which auto-detect had
+  been ignoring.
+
+A request carrying no line or column is never declined: there is nothing to
+lose, and classpath resolution is worth having. Editors whose position
+`launch-editor` does encode are unaffected and keep preferring the endpoint.
 
 ## Wiring
 

--- a/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
+++ b/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
@@ -49,7 +49,13 @@
   everything else. At the pinned 2.14.1 — which is also the newest published
   release — it has no `windsurf` case, so Windsurf alone in this endpoint's
   vocabulary loses the coordinate. Drop an entry here when a pinned release
-  starts encoding that editor's position; the contract test comes with it."
+  starts encoding that editor's position; the contract test comes with it.
+
+  Covers the commands this endpoint NAMES, and only those — it is the cheap
+  half, letting a hint we already know about be declined without spawning
+  Node at all. The binary auto-detect picks is decided inside the dependency,
+  so `launch-shim` asks `get-args.js` itself; that probe is the general
+  answer and this set is a fast path in front of it."
   #{"windsurf"})
 
 (defn position-would-be-dropped?
@@ -58,10 +64,29 @@
   A request carrying no coordinate loses nothing by going through the
   endpoint, and the endpoint's classpath resolution is real value the
   client-side `editor://` URI fallback cannot supply — so only a
-  coordinate-BEARING request to a position-blind command is declined."
+  coordinate-BEARING request to a position-blind command is declined.
+
+  Answers only for a command this endpoint NAMED. A nil `command` is
+  launch-editor's auto-detect, whose binary is chosen inside the dependency
+  from the running process list — unknowable here, so the same capability
+  question is asked at launch time by `launch-shim` instead. Both routes
+  answer with `position-unsupported-error`."
   [command line column]
   (boolean (and (or line column)
                 (contains? commands-without-position-support command))))
+
+(def position-unsupported-error
+  "The single client-visible error token for a launch declined because the
+  coordinate would not have survived it — emitted by BOTH capability routes
+  (the declared-vocabulary check above and the launch-time probe in
+  `launch-shim`), so the browser sees one contract rather than two."
+  "editor-position-unsupported")
+
+(def position-unsupported-exit
+  "The shim's exit code for a launch DECLINED by its capability probe.
+  Distinct from 1 (a launch that was attempted and failed) so `launch!` can
+  tell a refusal from a failure without scraping stderr."
+  3)
 
 ;; Core owns classpath URL decoding; this endpoint adds runtime cwd fallback.
 
@@ -102,9 +127,47 @@
 ;; spec and optional editor binary are passed as separate argv tokens.
 
 (def ^:private launch-shim
-  ;; Exit nonzero from launch-editor's callback so the JVM sees failures.
+  ;; Runs launch-editor's OWN capability question before launching, then exits
+  ;; nonzero from its callback so the JVM sees failures.
+  ;;
+  ;; `commands-without-position-support` can only answer for a command this
+  ;; endpoint NAMED. When no `editor` hint is sent — the client omits it for a
+  ;; nil preference and for `{:custom …}` — `guessEditor` picks the binary from
+  ;; the running process list, and that list reaches editors `get-args.js` has
+  ;; no case for: `Brackets.exe` on all three platforms, and on Windows
+  ;; `Cursor.exe` too (the registry stores the capitalised process name while
+  ;; the switch matches lowercase `cursor`). Either would launch the bare file,
+  ;; exit 0, and make this endpoint answer 200 to a coordinate-bearing request
+  ;; (rf2-1i1ec audit).
+  ;;
+  ;; So the probe asks the dependency instead of predicting it: resolve the
+  ;; editor with the same `guessEditor` the launch will use, then ask
+  ;; `getArgumentsForPosition` what it would emit for a sentinel filename.
+  ;; `get-args.js` interpolates the position into every case it encodes and
+  ;; falls through to `return [fileName]` for the rest, so an argv that is the
+  ;; sentinel ALONE is exactly the documented drop — no editor list here to
+  ;; keep in step with the dependency, and a future release that learns an
+  ;; editor's position syntax lifts the decline with no edit.
+  ;;
+  ;; Auto-detect is therefore scanned twice on this path (once here, once
+  ;; inside `launchEditor`). The resolved binary cannot be handed back as
+  ;; `specifiedEditor` to save the second scan — launch-editor shell-parses
+  ;; that argument, which would split a Windows path at its spaces.
   (str "var l=require('launch-editor');"
-       "var f=process.argv[1];var e=process.argv[2]||undefined;"
+       "var guess=require('launch-editor/guess');"
+       "var getArgs=require('launch-editor/get-args');"
+       ;; argv: <file-spec> <line> <column> [<editor hint>] — the optional
+       ;; hint is last so the coordinate tokens sit at fixed positions.
+       "var f=process.argv[1];"
+       "var line=process.argv[2]||undefined;var col=process.argv[3]||undefined;"
+       "var e=process.argv[4]||undefined;"
+       ;; Only a coordinate-bearing launch has anything to lose.
+       "if(line){"
+       "var ed=guess(e)[0];"
+       "var a=ed?getArgs(ed,'F',line,col||1):null;"
+       "if(a&&a.length===1&&a[0]==='F'){"
+       "process.stderr.write('" position-unsupported-error "\\n');"
+       "process.exit(" position-unsupported-exit ");}}"
        "l(f,e,function(file,msg){"
        "process.stderr.write('launch-editor: '+(msg||'no editor found')+'\\n');"
        "process.exit(1);});"))
@@ -178,12 +241,20 @@
   thread. OS pipes are bounded, so a child that fills an undrained pipe blocks
   on the write and never reaches `process.exit` — the parent would then time
   out waiting for an exit its own undrained pipe prevents (rf2-j538f7.21). A
-  bounded head of stderr is retained as the failure diagnostic."
+  bounded head of stderr is retained as the failure diagnostic.
+
+  `line` and `column` are ALSO passed as their own argv tokens, not only
+  folded into the file spec: the shim's capability probe has to know whether
+  a coordinate is at stake before it hands the spec to launch-editor, and
+  re-parsing the spec there would duplicate the dependency's own position
+  regex. An absent value is an empty token, which the shim reads as falsy.
+  The optional editor hint stays LAST so those positions are fixed."
   [abs-path line column command]
   (if-not (file-exists? abs-path)
     {:ok false :message "file-not-found"}
     (let [file-spec (build-file-spec abs-path line column)
-          args (cond-> ["node" "-e" launch-shim file-spec]
+          args (cond-> ["node" "-e" launch-shim file-spec
+                        (str line) (str column)]
                  command (conj command))]
       (try
         (let [pb (doto (ProcessBuilder. ^java.util.List args)
@@ -204,8 +275,16 @@
                 {:ok false :message "launch-editor timed out"})
             (let [exit (.exitValue proc)
                   err  (deref err-drain 1000 "")]
-              (if (zero? exit)
-                {:ok true}
+              (cond
+                (zero? exit) {:ok true}
+
+                ;; The shim's capability probe refused BEFORE launching: read
+                ;; the verdict off the exit code rather than off stderr, so the
+                ;; client-visible error is a contract and not a scraped string.
+                (= exit position-unsupported-exit)
+                {:ok false :message position-unsupported-error}
+
+                :else
                 {:ok false
                  :message (or (when (seq err) (str/trim err))
                               (str "launch-editor exited " exit))}))))
@@ -353,10 +432,13 @@
   Query keys are `file` (required), `line`, `column`, and `editor`. Only a
   local POST reaches `launch!`. Invalid input produces JSON 400/403/405
   responses; missing files and launch failures produce 422, as does a
-  coordinate-bearing request for an editor whose `launch-editor` command
-  cannot carry the position (`position-would-be-dropped?`) — every one of
-  those non-2xx answers hands the launch to the client's `editor://` URI
-  fallback, which does carry it."
+  coordinate-bearing request whose editor cannot carry the position — either
+  because this endpoint named a position-blind command
+  (`position-would-be-dropped?`, answered here without spawning Node) or
+  because the binary `launch-editor` picked by auto-detect turned out to be
+  one (`launch-shim`'s probe, answered at launch time). Every one of those
+  non-2xx answers hands the launch to the client's `editor://` URI fallback,
+  which does carry the coordinate."
   [{:keys [uri request-method query-string] :as req}]
   (when (= uri endpoint-path)
     (let [ao (allow-origin req)]
@@ -394,7 +476,7 @@
               ;; decline before spawning so the client's coordinate-preserving
               ;; `editor://` URI fallback gets its turn (rf2-1i1ec).
               (position-would-be-dropped? cmd line column)
-              (json-resp 422 ao {:ok false :error "editor-position-unsupported"})
+              (json-resp 422 ao {:ok false :error position-unsupported-error})
 
               :else
               (let [abs-path (resolve-file file)

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_client_cljs_test.cljs
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_client_cljs_test.cljs
@@ -199,6 +199,82 @@
                    (done)))
           (.catch (fn [err] (is false (str "click! threw: " err)) (done)))))))
 
+;; ---- the no-hint path (rf2-1i1ec audit) ----------------------------------
+;;
+;; `editor->param` sends no `editor=` at all for a nil preference and for
+;; `{:custom …}`, which puts the server on `launch-editor`'s auto-detect —
+;; where the binary is chosen from the running process list and can be one
+;; `get-args.js` has no position case for. The server now declines that too.
+;; What the tests below witness is the half the server cannot: that declining
+;; actually leaves the user better off, because the fallback these two
+;; preferences reach still carries 27:9.
+
+(def ^:private custom-editor
+  "A `{:custom …}` preference, the other shape that sends no `editor=`."
+  {:custom "myeditor://open?f={file}&l={line}&c={column}"})
+
+(deftest no-editor-hint-requests-take-the-auto-detect-path
+  (testing "both preferences the audit names omit `editor=` entirely, so the
+            server auto-detects — this is the request that could return a
+            bare-file 200 before the repair"
+    (is (= (str open-endpoint/endpoint-path
+                "?file=src%2Fapp.cljs&line=27&column=9")
+           (open-endpoint/build-url coord nil))
+        "a nil preference sends the coordinate and no editor")
+    (is (= (str open-endpoint/endpoint-path
+                "?file=src%2Fapp.cljs&line=27&column=9")
+           (open-endpoint/build-url coord custom-editor))
+        "a {:custom …} preference likewise — the template is the client's own
+         business, so the server is told nothing about it")
+    (is (not (re-find #"editor=" (open-endpoint/build-url coord nil)))
+        "control: `editor=` really is absent, not merely differently spelled")
+    (is (re-find #"editor=" (open-endpoint/build-url coord :windsurf))
+        "control the other way: the same assertion FINDS `editor=` when a
+         keyword preference is set, so its absence above is a real difference")))
+
+(deftest declined-no-hint-answer-still-lands-on-the-coordinate
+  (testing "rf2-1i1ec audit — declining the auto-detect path is only a repair
+            if the fallback it hands over to keeps 27:9. For a nil preference
+            that is `editor-uri`'s default scheme; for `{:custom …}` it is the
+            user's own template, which the endpoint's auto-detect ignored
+            entirely. Both carry the coordinate the bare-file launch dropped"
+    (async done
+      (-> (click-each! [{:editor nil            :status 422}
+                        {:editor custom-editor :status 422}])
+          (.then (fn [outcomes]
+                   (is (= 2 (count outcomes)) "both preferences were exercised")
+                   (doseq [{:keys [editor fallbacks]} outcomes]
+                     (is (= 1 fallbacks)
+                         (str editor " → the fallback ran exactly once")))
+                   (let [{:keys [navigated]} (first outcomes)]
+                     (is (= "vscode://file/src/app.cljs:27:9" navigated)
+                         "a nil preference falls back to the default scheme,
+                          line 27 column 9 intact"))
+                   (let [{:keys [navigated]} (second outcomes)]
+                     (is (= "myeditor://open?f=src/app.cljs&l=27&c=9" navigated)
+                         "a {:custom …} preference gets its OWN template with
+                          27 and 9 substituted — declining honours the
+                          configuration the auto-detect launch overrode"))
+                   (is (fetch-restored?) "the fetch stub was not left installed")
+                   (done)))
+          (.catch (fn [err] (is false (str "click! threw: " err)) (done)))))))
+
+(deftest a-2xx-no-hint-answer-suppresses-the-fallback-too
+  (testing "the defect's other half on the auto-detect path: a 200 is final
+            here as well, so a bare-file launch behind it is unrecoverable.
+            This is why the server had to decline rather than let the client
+            decide"
+    (async done
+      (-> (click! {:editor nil :status 200})
+          (.then (fn [{:keys [requested navigated fallbacks]}]
+                   (is (some? requested) "the endpoint was asked")
+                   (is (zero? fallbacks)
+                       "no fallback — nothing downstream could recover 27:9")
+                   (is (nil? navigated))
+                   (is (fetch-restored?) "the fetch stub was not left installed")
+                   (done)))
+          (.catch (fn [err] (is false (str "click! threw: " err)) (done)))))))
+
 (deftest position-carrying-editors-keep-preferring-the-endpoint
   (testing "the repair must not make every editor fall back: for an editor the
             endpoint still serves, a 2xx is final and no URI is navigated —

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -745,8 +745,13 @@
     (is (false? (oies/position-would-be-dropped? "idea" 27 9)))
     (is (false? (oies/position-would-be-dropped? "code-insiders" 27 9)))
     (is (false? (oies/position-would-be-dropped? nil 27 9))
-        "auto-detect is not declined — launch-editor picks the binary and we
-         have made no claim about which")))
+        "this predicate answers for NAMED commands only. nil is auto-detect,
+         whose binary launch-editor chooses from the running process list —
+         so the capability question is asked of the dependency at launch time
+         instead, by launch-shim's probe. That auto-detect route is NOT
+         undeclined: it is covered by
+         launch-declines-when-the-resolved-editor-would-drop-the-position and
+         endpoint-turns-a-launch-time-decline-into-the-same-422 below")))
 
 (deftest endpoint-declines-coordinate-bearing-windsurf-request
   (testing "editor=windsurf with line+column is DECLINED before Node is
@@ -1006,3 +1011,198 @@
           (is (= file (#'editor-uri/compose-path nil file))
               (str tool " composes to itself with no project-root — the
                    composition step the retired pipeline used to feed")))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-1i1ec (audit) — auto-detect is a capability question too
+;; ---------------------------------------------------------------------------
+;;
+;; The declared-vocabulary decline above closes `editor=windsurf`. It cannot
+;; close the path where no `editor` is sent at all — which the client takes
+;; for a nil preference AND for `{:custom …}` — because launch-editor then
+;; picks the binary itself, from the running process list. Its registries
+;; reach editors `get-args.js` has no case for, so that route could still
+;; launch a bare file, exit 0, answer 200, and suppress the coordinate-
+;; preserving URI fallback.
+;;
+;; `launch-shim` therefore asks the dependency rather than predicting it. The
+;; tests below pin that in three places: the dependency really does behave
+;; this way (a probe of the installed package, which also guards the declared
+;; set against drift), the shim really does decline it (real node children,
+;; none of which can open an editor), and a launch-time decline really does
+;; reach the client as the same 422 the declared route emits.
+
+(def ^:private implementation-dir
+  "The directory `shadow-cljs watch` runs the dev server from — and the only
+  one from which `require('launch-editor')` resolves, since `node -e` walks
+  up from the working directory."
+  (delay (io/file @repo-root "implementation")))
+
+(defn ^:private launch-editor-installed?
+  "Whether the pinned `launch-editor` package is present in this checkout.
+  A JVM lane that never ran `npm ci` self-skips rather than failing red."
+  []
+  (.isDirectory (io/file @implementation-dir "node_modules" "launch-editor")))
+
+(defn ^:private with-dev-cwd*
+  "Run `f` with `user.dir` at `implementation/` — `launch!` reads it at
+  request time to set the child's working directory, so this is what makes
+  the shim's `require` resolve exactly as it does under `shadow-cljs watch`."
+  [f]
+  (let [prev (System/getProperty "user.dir")]
+    (try
+      (System/setProperty "user.dir" (.getAbsolutePath ^File @implementation-dir))
+      (f)
+      (finally (System/setProperty "user.dir" prev)))))
+
+(def ^:private dependency-probe-script
+  "Ask the INSTALLED `launch-editor` what it would do — the same two questions
+  `launch-shim` asks, put to the same two modules. Emits `key<TAB><json>` per
+  line. `F` is a sentinel filename: `get-args.js` interpolates the position
+  into every case it encodes and falls through to `return [fileName]` for the
+  rest, so an argv of the sentinel ALONE is exactly the documented drop."
+  (str "var g=require('launch-editor/guess');"
+       "var a=require('launch-editor/get-args');"
+       "function say(k,v){process.stdout.write(k+'\\t'+JSON.stringify(v)+'\\n');}"
+       "['code','code-insiders','cursor','zed','idea','windsurf'].forEach("
+       "function(c){say(c,a(c,'F',27,9));});"
+       ;; The auto-detect class: names that appear in the process registries
+       ;; but not in the get-args switch.
+       "say('brackets',a('Brackets','F',27,9));"
+       "say('win-cursor-exe',a('C:\\\\x\\\\Cursor.exe','F',27,9));"
+       ;; …and the registries that can select them, one per platform.
+       "say('win-process',g.getEditorFromWindowsProcesses("
+       "'C:\\\\Program Files\\\\Brackets\\\\Brackets.exe\\r\\n'));"
+       "say('linux-process',g.getEditorFromLinuxProcesses('Brackets\\n'));"
+       "say('mac-process',g.getEditorFromMacProcesses("
+       "'/Applications/Brackets.app/Contents/MacOS/Brackets'));"))
+
+(defn ^:private run-dependency-probe
+  "Run `dependency-probe-script` under node from `implementation/` and return
+  its `key → raw JSON` map. Values are compared as JSON text: exact, and with
+  no JSON dependency on this artefact's tiny test classpath."
+  []
+  (let [pb   (doto (ProcessBuilder. ^java.util.List ["node" "-e" dependency-probe-script])
+               (.directory ^File @implementation-dir)
+               (.redirectErrorStream false))
+        proc (.start pb)
+        out  (slurp (.getInputStream proc))]
+    (.waitFor proc 30 java.util.concurrent.TimeUnit/SECONDS)
+    (is (zero? (.exitValue proc))
+        (str "the dependency probe itself ran: " (slurp (.getErrorStream proc))))
+    (into {}
+          (for [line  (str/split-lines out)
+                :when (str/includes? line "\t")]
+            (let [[k v] (str/split line #"\t" 2)]
+              [k v])))))
+
+(deftest launch-editor-2-14-1-really-does-drop-these-positions
+  (testing "the installed dependency's own answers — the premise every decline
+            in this namespace rests on, asked of the package rather than
+            asserted from prose"
+    (if-not (and (node-available?) (launch-editor-installed?))
+      (is true "skipped: node or launch-editor not installed")
+      (let [probe (run-dependency-probe)]
+        (testing "the probe returned the keys it was asked for (a silently
+                  empty map must not read as a pass)"
+          (is (= 11 (count probe)) "every probed key came back")
+          (is (contains? probe "windsurf")))
+
+        (testing "every command this endpoint DECLARES position-blind really is
+                  — and no more. This is the drift guard: a launch-editor
+                  release that learns one of these makes it red, which is the
+                  signal to drop the entry from the set"
+          (doseq [cmd oies/commands-without-position-support]
+            (is (= "[\"F\"]" (get probe cmd))
+                (str cmd " is invoked with the bare file — the coordinate is
+                     dropped inside the dependency"))))
+
+        (testing "every OTHER command in the vocabulary carries the position,
+                  so the decline is as narrow as the invariant allows"
+          (doseq [cmd (remove oies/commands-without-position-support
+                              (vals oies/editor-command-by-keyword))]
+            (let [argv (get probe cmd)]
+              (is (some? argv) (str cmd " was probed"))
+              (is (not= "[\"F\"]" argv)
+                  (str cmd " is not a bare-file launch"))
+              (is (str/includes? argv "27")
+                  (str cmd " argv carries the requested line")))))
+
+        (testing "AUTO-DETECT reaches position-blind binaries the declared set
+                  cannot name — the audit's finding. Brackets is in all three
+                  process registries with no get-args case; on Windows so is
+                  Cursor.exe, whose basename the lowercase `cursor` case
+                  does not match"
+          (is (= "[\"F\"]" (get probe "brackets")))
+          (is (= "[\"F\"]" (get probe "win-cursor-exe")))
+          (is (= "\"C:\\\\Program Files\\\\Brackets\\\\Brackets.exe\""
+                 (get probe "win-process"))
+              "the Windows registry selects Brackets from a process list")
+          (is (= "\"brackets\"" (get probe "linux-process")))
+          (is (= "\"brackets\"" (get probe "mac-process"))))))))
+
+(deftest launch-declines-when-the-resolved-editor-would-drop-the-position
+  (testing "the shim's probe runs for real: a coordinate-bearing launch whose
+            resolved editor has no position syntax is refused BEFORE
+            launch-editor is called, and comes back as the same
+            client-visible token the declared route emits.
+
+            Every command below is under a directory that does not exist, so
+            the position-CAPABLE control cannot open anything either — the two
+            cases differ only in the probe's verdict"
+    (if-not (and (node-available?) (launch-editor-installed?))
+      (is true "skipped: node or launch-editor not installed")
+      (let [f (.getAbsolutePath (tmp-existing-file))]
+        (with-dev-cwd*
+          (fn []
+            (testing "a position-blind command the endpoint never names — the
+                      class auto-detect reaches"
+              (is (= {:ok false :message oies/position-unsupported-error}
+                     (oies/launch! f 27 9 "nonexistent-dir/Brackets"))))
+
+            (testing "windsurf reaches the same verdict here too, so the
+                      handler's pre-spawn fast path is an optimisation and not
+                      the only thing standing between it and a false 200"
+              (is (= {:ok false :message oies/position-unsupported-error}
+                     (oies/launch! f 27 9 "windsurf"))))
+
+            (testing "POSITIVE CONTROL — a position-CARRYING command is passed
+                      through to a real launch attempt. It still fails, because
+                      the binary does not exist, but NOT as the decline: the
+                      probe is discriminating, not refusing everything"
+              (let [{:keys [ok message]} (oies/launch! f 27 9 "nonexistent-dir/zed")]
+                (is (false? ok) "the nonexistent binary could not be launched")
+                (is (not= oies/position-unsupported-error message)
+                    "…and it was a launch failure, not a capability refusal")))
+
+            (testing "a coordinate-FREE launch is never refused: there is no
+                      position to lose, so even a position-blind command
+                      reaches the launcher"
+              (let [{:keys [ok message]} (oies/launch! f nil nil "nonexistent-dir/Brackets")]
+                (is (false? ok))
+                (is (not= oies/position-unsupported-error message)
+                    "the empty coordinate argv tokens read as absent")))))))))
+
+(deftest endpoint-turns-a-launch-time-decline-into-the-same-422
+  (testing "the wiring that makes the shim's refusal user-visible: a
+            coordinate-bearing request with NO editor param — what the client
+            sends for a nil preference and for {:custom …} — answers 422
+            `editor-position-unsupported` when the launch declines. Same
+            status and same token as the declared-vocabulary route, so the
+            browser has one contract to honour rather than two.
+
+            `launch!` is stubbed with the verdict the previous test proves the
+            real shim returns; what is under test here is the mapping"
+    (with-redefs [oies/launch! (fn [& _]
+                                 {:ok false
+                                  :message oies/position-unsupported-error})]
+      (let [resp (oies/handle
+                   {:uri            oies/endpoint-path
+                    :request-method :post
+                    :query-string   "file=fake_ns/core.cljs&line=27&column=9"
+                    :headers        {"host" "localhost:8031"}})]
+        (is (= 422 (:status resp))
+            "a 200 here would claim 27:9 reached an editor that never got it")
+        (is (not (<= 200 (:status resp) 299))
+            "non-2xx is what runs the client's coordinate-preserving fallback")
+        (is (re-find #"\"error\":\"editor-position-unsupported\"" (:body resp))
+            "the same token the declared-vocabulary decline emits")))))


### PR DESCRIPTION
Closes the second half of rf2-1i1ec, reopened by the audit of PR #8880.

## What was still wrong

#8880 made `editor=windsurf` decline, and with it the endpoint took on a
promise: a 200 means the whole source coordinate reached an editor. That
promise was still false whenever no editor was named.

`editor->param` in the client sends no `editor=` at all for a nil preference
and for `{:custom …}`, which puts the server on `launch-editor`'s auto-detect.
The binary is then chosen inside the dependency from the running process list,
and that list reaches editors `get-args.js` has no position case for. So a
coordinate-bearing click could still launch a bare file, exit 0, return 200 —
and that 200 suppresses the coordinate-preserving `editor://` fallback.

Verified against the installed package (2.14.1, the newest published release):

| probe | result |
| --- | --- |
| `getArgumentsForPosition('Brackets', 'F', 27, 9)` | `["F"]` |
| `getArgumentsForPosition('C:\x\Cursor.exe', 'F', 27, 9)` | `["F"]` |
| `getEditorFromWindowsProcesses('C:\Program Files\Brackets\Brackets.exe\r\n')` | selects Brackets |
| `getEditorFromLinuxProcesses('Brackets\n')` | `"brackets"` |
| `getEditorFromMacProcesses('/Applications/Brackets.app/…/Brackets')` | `"brackets"` |
| `getArgumentsForPosition('code', 'F', 27, 9)` | `["-r","-g","F:27:9"]` |

Brackets is in all three platform registries. On Windows `Cursor.exe` is too,
and its basename does not match the switch's lowercase `cursor` case — so
auto-detected Cursor loses the coordinate as well.

## The repair

The launch shim asks the dependency rather than predicting it. Before
launching a coordinate-bearing request it resolves the editor with the same
`guessEditor` the launch will use, then asks `getArgumentsForPosition` what it
would emit for a sentinel filename. `get-args.js` interpolates the position
into every case it encodes and falls through to `return [fileName]` for the
rest, so an argv that is the sentinel **alone** is exactly the documented drop.
The shim then exits with a distinct code and `launch!` reports the same
`editor-position-unsupported` token the named-editor route already emits.

There is no editor list here to keep in step with the dependency, and a future
release that learns an editor's position syntax lifts the decline with no edit.
`commands-without-position-support` stays as the cheap half — it lets a hint we
already know about be declined without spawning Node at all.

**Blast radius.** This changes the shared launch path for all editors, in one
direction only: a launch whose resolved editor has no position syntax is
refused instead of reported as success. Every editor `launch-editor` does
encode a position for is untouched and keeps preferring the endpoint, and a
request carrying no line or column is never declined — there is nothing to
lose, and classpath resolution is worth having.

Declining is also the better answer for the two preferences that reach it: a
nil preference falls back to the default `vscode://` scheme with 27:9 intact,
and a `{:custom …}` preference to the user's own template — which the
auto-detect launch had been ignoring entirely.

## Coverage

- `launch-editor-2-14-1-really-does-drop-these-positions` — probes the
  installed package for the table above. Doubles as a drift guard on
  `commands-without-position-support`: a release that learns one of those
  commands makes it red, which is the signal to drop the entry.
- `launch-declines-when-the-resolved-editor-would-drop-the-position` — real
  node children through the real shim. Every command sits under a directory
  that does not exist, so the position-capable positive control cannot open
  anything either; the two cases differ only in the probe's verdict.
- `endpoint-turns-a-launch-time-decline-into-the-same-422` — a
  coordinate-bearing request with no `editor` param answers 422 with the same
  token as the declared route.
- `no-editor-hint-requests-take-the-auto-detect-path`,
  `declined-no-hint-answer-still-lands-on-the-coordinate`,
  `a-2xx-no-hint-answer-suppresses-the-fallback-too` — the client half, driving
  the real `build-url` / `fetch-launcher!` seam.

One existing assertion changed meaning rather than value:
`position-would-be-dropped?` on a nil command still returns `false`, but its
rationale — "auto-detect is not declined" — was the bug. It now says the
predicate answers for named commands only and names the two tests that cover
the auto-detect route.

## Gates

Captured runner exit codes, foreground, on the final rebased base.

- `clojure -M:test` in `tools/testbed-support/` — exit 0, 42 tests / 254
  assertions.
- `npm run test:testbed-support` — exit 0, 16 tests / 62 assertions.
- `scripts/check_readme_links.py --ci` — exit 0. This is the gate for markdown
  beside source; `check_doc_slugs.py` does not reach outside its `docs/`,
  `spec/`, `skills/`, `migration/` and `tools/*/spec` roots.

Controls, each restored and the restore verified by git blob hash against the
committed object:

1. Shim decline branch disabled → JVM exit 1, 2 failures, both in
   `launch-declines-…`, the actual value showing the unrepaired
   `launch-editor: (code 1).` where the decline was due.
2. A bogus entry added to `commands-without-position-support` → JVM exit 1
   with the dependency probe among the failures, so the drift guard is not
   vacuous.
3. A planted expectation in the client suite → CLJS exit 1 naming it.
4. A planted broken link and broken anchor in the touched README section →
   `check_readme_links.py --ci` exit 1 naming both, which is what proves that
   gate covers this path at all (it is silent on success).

Test and assertion totals were unchanged under sabotage (42/254 and 16/62), so
nothing was dropped and the reds are the named assertions.

Confined to `tools/testbed-support/**`. The `launch-editor` version is
untouched.
