### PR TITLE
fix(realworld-http): keep the article's social writes owned by the route that issued them (rf2-amhpk)

### DIFF
--- a/examples/real-apps/realworld_http/comments.cljs
+++ b/examples/real-apps/realworld_http/comments.cljs
@@ -10,12 +10,12 @@
    - `:comment-form` in the plain form slice shape.
    - Route-driven loads that read the current slug off the runtime-db
      coeffect at `[:rf.runtime/routing :current :params :slug]`.
-   - Route-keyed reads AND comment mutations that stay owned by the route
-     identity: each slice records the slug it is loading, the comment
-     reads and writes carry the slug they were requested for, and a settle
-     that no longer belongs to the screen is refused (see
-     `reply-for-current-slug?` below — the same correlation law
-     article_editor.cljs spells for the editor).
+   - Everything that writes this page's state staying owned by the route
+     identity — the reads, the comment mutations, and the article's own
+     social buttons alike: each slice records the slug it is loading, every
+     settle carries the slug it was requested for, and one that no longer
+     belongs to the screen is refused (see `reply-for-current-slug?` below —
+     the same correlation law article_editor.cljs spells for the editor).
    - Optimistic post / delete flows that roll back through nothing fancier
      than ordinary events."
   (:require [clojure.string :as str]
@@ -65,25 +65,50 @@
 ;; (never blank a loaded page on a refresh), but a slug CHANGE resets the
 ;; slice, so alpha's article is never renderable under `/article/beta`.
 ;;
-;; EXACTLY these carry the slug and gate on it — the two route-driven READS
-;; (`:article/load`'s reply hat, `:comments/loaded` / `:comments/load-failed`)
-;; and the three comment MUTATION settles (`:comment-form/submit-success`,
-;; `:comment-form/submit-error`, `:comment/delete-rollback`). The mutations
-;; need it just as badly as the reads: they land on the one shared
-;; `[:comments :data]` / `[:comment-form]`, so alpha's late POST failure
-;; would otherwise banner beta's form and alpha's failed DELETE would
-;; re-insert alpha's comment into beta's list (rf2-84iek).
+;; The rule is now universal in this file: EVERY settle that writes
+;; route-owned state carries the slug it was requested for and asks this
+;; question before writing. Nine do —
+;;
+;;   - the three route-driven READS: `:article/load`'s reply hat,
+;;     `:comments/loaded`, `:comments/load-failed` (rf2-iy3d6);
+;;   - the three comment MUTATION settles: `:comment-form/submit-success`,
+;;     `:comment-form/submit-error`, `:comment/delete-rollback`. They land on
+;;     the one shared `[:comments :data]` / `[:comment-form]`, so alpha's late
+;;     POST failure would otherwise banner beta's form and alpha's failed
+;;     DELETE would re-insert alpha's comment into beta's list (rf2-84iek);
+;;   - the three article SOCIAL settles further down:
+;;     `:article/author-follow-synced`, `:article/author-follow-rollback`,
+;;     `:article/delete-failed`. These fire from a button press rather than
+;;     from the route's own load, but they write `[:article ...]`, which the
+;;     route owns just the same. Measured, not merely suspected: a late
+;;     follow FAILURE restored ALPHA's prior flag onto beta's author, so
+;;     beta's Follow button read the opposite of the truth, and a late follow
+;;     SUCCESS was worse still — it replaced beta's author map wholesale, so
+;;     the byline name, the avatar and the profile link all became alpha's
+;;     author. A late failed DELETE bannered alpha's error across beta's page
+;;     (rf2-amhpk).
+;;
+;; Why a gate ALONE is enough for all nine, where the comment form also needed
+;; a reset: everything gated here lives in a slice that `:article/load` or
+;; `:comments/load` REBUILDS on a slug change, so the navigation has already
+;; released it and refusing a stale settle strands nothing. `[:comment-form]`
+;; was the one exception — a boot-time singleton nothing revisited, which rode
+;; across the navigation still `:submitting` — which is why rf2-84iek had to
+;; pair its gate with a reset in `:comments/load`. The article's author and
+;; error are not in that position: `[:article]` is reset wholesale on a new
+;; identity, and the Follow button carries no pending or disabled state to get
+;; stuck in.
 ;;
 ;; Two deliberate NON-members, so nobody reads the list as "everything in
-;; this file is correlated":
+;; this file is correlated". Both write no state at all, so there is nothing
+;; to correlate:
 ;;
-;;   - `:comment/delete-success` writes nothing at all (it exists to give
-;;     `:on-success` a target), so it needs neither the slug nor the gate.
-;;   - The article SOCIAL controls further down — `:article/author-follow-
-;;     synced` / `-rollback`, `:article/delete-failed` — are NOT gated. They
-;;     write `[:article :data ...]` from a button press rather than from the
-;;     route's own load, and no cross-route defect has been reproduced
-;;     against them; they are out of rf2-84iek's scope, not covered by it.
+;;   - `:comment/delete-success` exists only to give `:on-success` a target.
+;;   - `:article/delete-success` navigates home and touches no db. A late one
+;;     would still take a reader who has since moved to another article home
+;;     — but that is a product question about a delete the reader themselves
+;;     asked for, not a cross-route write, so it is named here rather than
+;;     changed.
 ;;
 ;; The gate correlates ROUTE IDENTITY, not request identity: it asks which
 ;; slug the screen is on, so alpha → beta → alpha readmits an alpha reply
@@ -481,19 +506,29 @@
 ;; (`[:article :data :author]`), which is a different slice from
 ;; profile.cljs's `:profile/follow` (that one drives the profile-page banner).
 ;; Same gesture, two homes.
+;;
+;; These are button-driven rather than route-driven, but they write the
+;; ROUTE-OWNED `[:article ...]` slice, so their settles carry the slug they
+;; were issued on and gate on it exactly as the loads do — see THE CORRELATION
+;; GATE above for what went wrong before they did (rf2-amhpk).
 
 (rf/reg-event :article/toggle-follow-author
   {:doc "Flip following-the-author on or off optimistically, then send the
          POST/DELETE to /profiles/:username/follow; restore the old flag if it
          fails. Auth-gated (same reasoning as :article/toggle-favorite): a
          logged-out click goes to login instead of firing a tokenless write the
-         real Conduit backend would just 401 anyway."
+         real Conduit backend would just 401 anyway.
+
+         Both reply targets CARRY THE SLUG THE FLIP WAS ISSUED ON — the slice's
+         own `[:article :slug]`, the same identity the reads correlate against
+         — because they write `[:article :data :author]` and the route owns it."
    :rf.http/decode-schemas [schema/ProfileResponse]}
   (fn [{:keys [db]} _]
     (if (nil? (get-in db [:auth :user]))
       {:fx [[:dispatch [:rf.route/navigate {:to :realworld.auth/login}]]]}
-      (let [author    (get-in db [:article :data :author])
-            username  (:username author)
+      (let [slug       (get-in db [:article :slug])
+            author     (get-in db [:article :data :author])
+            username   (:username author)
             following? (:following author)]
         (if (nil? username)
           {}
@@ -502,18 +537,30 @@
                  (rh/request {:method     (if following? :delete :post)
                               :path       (str "/profiles/" username "/follow")
                               :decode     schema/ProfileResponse
-                              :on-success [:article/author-follow-synced]
-                              :on-failure [:article/author-follow-rollback following?]})]]})))))
+                              :on-success [:article/author-follow-synced slug]
+                              :on-failure [:article/author-follow-rollback slug following?]})]]})))))
 
 (rf/reg-event :article/author-follow-synced
-  (fn [{:keys [db]} [_ {:keys [value]}]]
-    {:db (if-let [profile (:profile value)]
-      (assoc-in db [:article :data :author] profile)
-      db)}))
+  {:doc "The follow POST/DELETE's `:on-success`, carrying the slug the flip was
+         issued on. Correlation-gated, and this is the write that most needs
+         it: it re-seeds the WHOLE author map, so a late reply for the article
+         the reader has left would put alpha's author — name, avatar and
+         profile link included — on beta's byline."}
+  (fn [{:keys [db]} [_ slug {:keys [value]}]]
+    (when (reply-for-current-slug? db :article slug)
+      {:db (if-let [profile (:profile value)]
+             (assoc-in db [:article :data :author] profile)
+             db)})))
 
 (rf/reg-event :article/author-follow-rollback
-  (fn [{:keys [db]} [_ previous-following _failure-payload]]
-    {:db (assoc-in db [:article :data :author :following] previous-following)}))
+  {:doc "The follow POST/DELETE's `:on-failure`, correlated exactly as
+         `:article/author-follow-synced` is. Refusing a stale rollback strands
+         nothing: the optimistic flip it would undo went with the slice when
+         `:article/load` reset it for the new slug, and coming back to the
+         article re-reads the true flag from the server."}
+  (fn [{:keys [db]} [_ slug previous-following _failure-payload]]
+    (when (reply-for-current-slug? db :article slug)
+      {:db (assoc-in db [:article :data :author :following] previous-following)})))
 
 (rf/reg-event :article/delete
   {:doc "Delete the current article, straight from the DETAIL page (authors
@@ -529,15 +576,22 @@
                             :path       (article-path slug)
                             :decode     :auto
                             :on-success [:article/delete-success]
-                            :on-failure [:article/delete-failed]})]]}))))
+                            :on-failure [:article/delete-failed slug]})]]}))))
 
 (rf/reg-event :article/delete-success
+  {:doc "Writes no db at all, so it needs neither the slug nor the gate — see
+         the NON-members note in THE CORRELATION GATE above."}
   (fn [_ _]
     {:fx [[:dispatch [:rf.route/navigate {:to :realworld/home}]]]}))
 
 (rf/reg-event :article/delete-failed
-  (fn [{:keys [db]} [_ {:keys [error]}]]
-    {:db (assoc-in db [:article :error] (rh/failure->message error))}))
+  {:doc "The DELETE's `:on-failure`, carrying the slug it was issued for.
+         Correlation-gated: `[:article :error]` sits on screen until the next
+         load, so an ungated late failure banners alpha's error across whatever
+         article the reader has moved on to."}
+  (fn [{:keys [db]} [_ slug {:keys [error]}]]
+    (when (reply-for-current-slug? db :article slug)
+      {:db (assoc-in db [:article :error] (rh/failure->message error))})))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -2405,6 +2405,176 @@
     (comment-form-survives-same-slug-refresh-test)))
 
 ;; ============================================================================
+;; article page — the SOCIAL settles stay owned by the route too (rf2-amhpk)
+;; ============================================================================
+;;
+;; rf2-84iek correlated the comment mutations and left the article's own
+;; social settles alone, naming them in the source as a suspected same-class
+;; defect it had not reproduced. It is the same class, and it does reproduce.
+;;
+;; `:article/toggle-follow-author` flips `[:article :data :author :following]`
+;; optimistically and sends a POST/DELETE whose reply targets carried no slug.
+;; Follow eve on /article/alpha, walk to /article/beta before the reply lands,
+;; and the settle writes into BETA's author:
+;;
+;;   - a late FAILURE (`:article/author-follow-rollback`) restores ALPHA's
+;;     prior flag onto beta's author, so beta's Follow/Unfollow button reads
+;;     the opposite of the truth;
+;;   - a late SUCCESS (`:article/author-follow-synced`) is worse — it
+;;     `assoc-in`s alpha's whole author profile over beta's, so the byline
+;;     name, the avatar and the profile link all become the wrong person's.
+;;
+;; `:article/delete-failed` is the third of the same shape: alpha's failed
+;; DELETE banners its error on `[:article :error]`, where beta's page shows it
+;; until the next load.
+;;
+;; The fix is the gate alone, with NO reset half — the difference from
+;; rf2-84iek that matters. `[:comment-form]` was a boot-time singleton that
+;; rode across the navigation still `:submitting`, so gating it without a
+;; reset would have locked beta's form; `[:article]` is rebuilt wholesale by
+;; `:article/load` on a slug change and the Follow button carries no pending
+;; state, so the navigation has already released everything a refused settle
+;; would have touched. `beta-slice-is-rebuilt` below is what pins that, and it
+;; is why refusing strands nothing.
+;;
+;; These reuse `with-held-comment-fx` — the shared held-request harness for
+;; the article page, comment-flavoured only in its name.
+
+(defn- author* [f] (rf/compute-sub [:article/author] (rf/frame-state-value f)))
+
+(defn- settle-article-with-author!
+  "Settle the held article GET for `slug` with an article whose author is
+   `username` at `following?`. The two slugs in these tests deliberately carry
+   DIFFERENT authors in DIFFERENT follow states, so a write that crosses from
+   one to the other shows up instead of being coincidentally equal."
+  [f lowered slug username following?]
+  (rf/dispatch-sync
+    (conj (:reply-to (req-by-id @lowered [:article/load slug]))
+          {:status :ok
+           :value {:article (assoc (full-article slug (str "Title " slug))
+                                   :author {:username username :bio nil
+                                            :image nil :following following?})}})
+    {:frame f}))
+
+(defn- follow-alpha-then-walk-to-beta!
+  "The shared arrangement: read /article/alpha whose author `eve` is NOT
+   followed, click Follow (optimistic flip, POST held open), then walk to
+   /article/beta whose author `bob` IS followed. Returns the held follow
+   request so the caller can settle it however it likes, far too late."
+  [f lowered]
+  (rf/dispatch-sync [:rf.route/handle-url-change "/article/alpha"] {:frame f})
+  (settle-article-with-author! f lowered "alpha" "eve" false)
+  (is (false? (:following (author* f))) "alpha's author eve starts unfollowed")
+  (rf/dispatch-sync [:article/toggle-follow-author] {:frame f})
+  (is (true? (:following (author* f))) "the flip is optimistic — eve reads followed at once")
+  (let [follow-req (req-by-method+url @lowered :post "/profiles/eve/follow")]
+    (is (some? follow-req) "the follow POST went out and is held open")
+    (rf/dispatch-sync [:rf.route/handle-url-change "/article/beta"] {:frame f})
+    (settle-article-with-author! f lowered "beta" "bob" true)
+    (is (= "bob" (:username (author* f))) "beta's author is bob")
+    (is (true? (:following (author* f))) "…whom the reader does follow")
+    follow-req))
+
+(defn- follow-cross-slug-late-rollback-is-refused-test []
+  (with-held-comment-fx :realworld.test/follow-cross-slug-rollback
+    (fn [f lowered]
+      (let [follow-req (follow-alpha-then-walk-to-beta! f lowered)]
+        ;; The strand control, and the reason a gate needs no reset half here:
+        ;; the navigation already rebuilt the slice, so the optimistic flip a
+        ;; refused rollback would have undone is long gone.
+        (is (= "beta" (:slug (article-slice* f)))
+            "beta-slice-is-rebuilt — :article/load reset [:article] on the slug change")
+        ;; Alpha's follow POST fails, long after the reader left alpha.
+        (rf/dispatch-sync (conj (:on-failure follow-req)
+                                {:status :error :error {:kind :rf.http/http-5xx :status 500}})
+                          {:frame f})
+        (is (= "bob" (:username (author* f)))
+            "a LATE alpha follow FAILURE leaves beta's author alone")
+        (is (true? (:following (author* f)))
+            "…and does not flip beta's Follow button to the wrong state (rf2-amhpk)")))))
+
+(defn- follow-cross-slug-late-sync-is-refused-test []
+  (with-held-comment-fx :realworld.test/follow-cross-slug-sync
+    (fn [f lowered]
+      (let [follow-req (follow-alpha-then-walk-to-beta! f lowered)]
+        ;; Alpha's follow POST SUCCEEDS, long after the reader left alpha. The
+        ;; synced handler re-seeds the whole author map, so an ungated write
+        ;; here swaps beta's byline for alpha's author outright.
+        (rf/dispatch-sync (conj (:on-success follow-req)
+                                {:status :ok
+                                 :value {:profile {:username "eve" :bio "Writer"
+                                                   :image nil :following true}}})
+                          {:frame f})
+        (is (= "bob" (:username (author* f)))
+            "a LATE alpha follow SUCCESS does not replace beta's author with alpha's (rf2-amhpk)")
+        (is (nil? (:bio (author* f)))
+            "…not even partially — alpha's bio never reaches beta's byline")))))
+
+(defn- article-delete-cross-slug-late-failure-is-refused-test []
+  (with-held-comment-fx :realworld.test/article-delete-cross-slug
+    (fn [f lowered]
+      (rf/dispatch-sync [:rf.route/handle-url-change "/article/alpha"] {:frame f})
+      (settle-article-with-author! f lowered "alpha" "alice" false)
+      (rf/dispatch-sync [:article/delete] {:frame f})
+      (let [delete-req (req-by-method+url @lowered :delete "/articles/alpha")]
+        (is (some? delete-req) "the article DELETE went out and is held open")
+        (rf/dispatch-sync [:rf.route/handle-url-change "/article/beta"] {:frame f})
+        (settle-article-with-author! f lowered "beta" "bob" true)
+        (rf/dispatch-sync (conj (:on-failure delete-req)
+                                {:status :error :error {:kind :rf.http/http-5xx :status 500}})
+                          {:frame f})
+        (is (nil? (:error (article-slice* f)))
+            "a LATE alpha DELETE failure does not banner its error over beta's page (rf2-amhpk)")))))
+
+(defn- article-social-gates-are-not-vacuous-test []
+  ;; The control that keeps the three refusals above honest: a gate wired to
+  ;; refuse everything would satisfy all of them and break the app. On the
+  ;; CURRENT slug each settle must still do its ordinary job.
+  (with-held-comment-fx :realworld.test/article-social-not-vacuous
+    (fn [f lowered]
+      (rf/dispatch-sync [:rf.route/handle-url-change "/article/alpha"] {:frame f})
+      (settle-article-with-author! f lowered "alpha" "eve" false)
+      ;; 1. Follow succeeds on the slug it was issued on → author re-seeded
+      ;;    from the server's authoritative profile.
+      (rf/dispatch-sync [:article/toggle-follow-author] {:frame f})
+      (rf/dispatch-sync (conj (:on-success (req-by-method+url @lowered :post "/profiles/eve/follow"))
+                              {:status :ok
+                               :value {:profile {:username "eve" :bio "Writer"
+                                                 :image nil :following true}}})
+                        {:frame f})
+      (is (= "Writer" (:bio (author* f)))
+          ":article/author-follow-synced still re-seeds the author on the current slug")
+      ;; 2. Unfollow fails on the slug it was issued on → prior flag restored.
+      (rf/dispatch-sync [:article/toggle-follow-author] {:frame f})
+      (is (false? (:following (author* f))) "the unfollow flips optimistically")
+      (rf/dispatch-sync (conj (:on-failure (req-by-method+url @lowered :delete "/profiles/eve/follow"))
+                              {:status :error :error {:kind :rf.http/http-4xx :status 422}})
+                        {:frame f})
+      (is (true? (:following (author* f)))
+          ":article/author-follow-rollback still restores the prior flag on the current slug")
+      ;; 3. Delete fails on the slug it was issued on → the error is bannered.
+      (rf/dispatch-sync [:article/delete] {:frame f})
+      (rf/dispatch-sync (conj (:on-failure (req-by-method+url @lowered :delete "/articles/alpha"))
+                              {:status :error :error {:kind :rf.http/http-5xx :status 500}})
+                        {:frame f})
+      (is (some? (:error (article-slice* f)))
+          ":article/delete-failed still surfaces its error on the current slug"))))
+
+(deftest realworld-article-social-cross-slug
+  (testing "a LATE alpha follow FAILURE cannot flip beta's author's Follow
+            button (rf2-amhpk)"
+    (follow-cross-slug-late-rollback-is-refused-test))
+  (testing "a LATE alpha follow SUCCESS cannot replace beta's author with
+            alpha's (rf2-amhpk)"
+    (follow-cross-slug-late-sync-is-refused-test))
+  (testing "a LATE alpha DELETE failure cannot banner its error over beta's
+            page (rf2-amhpk)"
+    (article-delete-cross-slug-late-failure-is-refused-test))
+  (testing "on the CURRENT slug all three settles still do their ordinary job
+            — the gates' non-vacuity control (rf2-amhpk)"
+    (article-social-gates-are-not-vacuous-test)))
+
+;; ============================================================================
 ;; favorites / comments / feed / profile — optimistic-success + follow-author +
 ;; article-delete + blank-comment + feed-load + profile-follow (rf2-rq65wv)
 ;; ============================================================================
@@ -2470,7 +2640,11 @@
       (is (= "Writer" (:bio author))
           ":article/author-follow-synced re-seeds the author from the returned profile"))
     ;; Rollback handler (driven directly): restores the captured prior flag.
-    (rf/dispatch-sync [:article/author-follow-rollback false {:kind :rf.http/http-4xx}] {:frame f})
+    ;; The leading "hello" is the issuing slug the handler now correlates on
+    ;; (rf2-amhpk); the route is /article/hello, so the gate admits it. Pass a
+    ;; different slug and this assertion fails — which is exactly what
+    ;; follow-cross-slug-late-rollback-is-refused-test pins.
+    (rf/dispatch-sync [:article/author-follow-rollback "hello" false {:kind :rf.http/http-4xx}] {:frame f})
     (is (false? (:following (rf/compute-sub [:article/author] (rf/frame-state-value f))))
         ":article/author-follow-rollback restores the captured prior following flag")))
 
@@ -2490,13 +2664,16 @@
     (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
     (rf/dispatch-sync [:rf.route/handle-url-change "/article/hello"] {:frame f})
     (is (= "hello" (:slug (rf/compute-sub [:article/data] (rf/frame-state-value f)))))
+    ;; The failure branch (driven directly), taken FIRST so it runs while the
+    ;; reader is still on /article/hello — the slug it now correlates against
+    ;; (rf2-amhpk). Driving it after the successful delete would leave the
+    ;; assertion hostage to whatever the home route does to `[:article :slug]`.
+    (rf/dispatch-sync [:article/delete-failed "hello" {:error {:kind :rf.http/http-5xx :status 500}}] {:frame f})
+    (is (some? (rf/compute-sub [:article/error] (rf/frame-state-value f)))
+        ":article/delete-failed surfaces a readable error message")
     (rf/dispatch-sync [:article/delete] {:frame f})
     (is (= :realworld/home (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
-        "a successful detail-page delete navigates home")
-    ;; The failure branch (driven directly): a readable error lands on the slice.
-    (rf/dispatch-sync [:article/delete-failed {:error {:kind :rf.http/http-5xx :status 500}}] {:frame f})
-    (is (some? (rf/compute-sub [:article/error] (rf/frame-state-value f)))
-        ":article/delete-failed surfaces a readable error message")))
+        "a successful detail-page delete navigates home")))
 
 (defn- comment-blank-body-test []
   ;; :comment-form/submit with a blank body → client-side validation, no round trip.


### PR DESCRIPTION
## The suspicion reproduced — all three of them

PR #8898 (rf2-84iek) correlated the optimistic comment writes in
`examples/real-apps/realworld_http/comments.cljs` and deliberately left the
article's own social settles alone, naming them in the source as a suspected
same-class defect it had not reproduced. rf2-amhpk asked for a reproduction or
a refutation first. It reproduces, and the success path is worse than the one
that was suspected.

`:article/toggle-follow-author` flips `[:article :data :author :following]`
optimistically and sent a POST/DELETE whose reply targets carried no slug.
Follow eve on `/article/alpha`, walk to `/article/beta` before the reply lands,
and the settle writes into beta. Measured, as four assertions failing on the
pre-fix tree:

| settle | observed on beta |
| --- | --- |
| `:article/author-follow-rollback` (late failure) | beta's author's `:following` flipped `true` → `false`, so the Follow button read the opposite of the truth |
| `:article/author-follow-synced` (late success) | beta's author replaced wholesale — `:username` became `"eve"`, alpha's `:bio` `"Writer"` landed on beta's byline |
| `:article/delete-failed` (late failure) | `"Server error (status 500)."` bannered on `[:article :error]` over beta's page |

The success path is the sharpest: `:article/author-follow-synced` re-seeds the
WHOLE author map, so the byline name, the avatar and the profile link all
become the other article's author.

## Is the follow state route-owned, or does it ride across?

Route-owned, and this is the question the item said would decide the shape of
the fix. `:article/load`'s request hat rebuilds `[:article]` wholesale on a
slug change (`:data nil`, `:error nil`), and the Follow button carries no
pending or disabled state — its label is derived straight from
`(:following author)`.

So **a gate alone is the whole fix here**, and #8898's second half has no
counterpart. There, gating alone would have been a worse bug: `[:comment-form]`
is a boot-time singleton the route never revisits, so it rode across the
navigation still `:submitting` with textarea and Post button disabled, and
refusing alpha's settle would have locked beta's form permanently — hence the
paired reset in `:comments/load`. Nothing here is in that position: the
navigation has already released everything a refused settle would have
touched, and refusing strands nothing (the server holds the truth; returning to
the article re-reads it). That is pinned by a test rather than asserted —
`beta-slice-is-rebuilt` — not reasoned about in a comment.

## The change

Carry the issuing slug (the slice's own `[:article :slug]`, the same identity
the reads correlate against) in all three settle targets, and gate each on the
existing `reply-for-current-slug?`. No new machinery: this is #8898's predicate,
unchanged. `:article/delete-success` writes no db, so it needs neither.

The correlation-gate commentary said the social controls were ungated with no
reproduced defect against them. That is no longer true of the file, so it now
states the rule universally — every settle that writes route-owned state
carries its slug and gates — enumerates all nine, and names the two remaining
non-members as writing no state at all. `:article/delete-success` is newly
named among them: a late one would still take a reader who has moved on to
another article home, but that is a product question about a delete they
themselves asked for rather than a cross-route write, so it is called out in
the source rather than changed.

Census, re-derived rather than quoted: the gate expression
`(when (reply-for-current-slug?` occurred **6** times at the merge base (not the
5 recorded on rf2-84iek — that figure counted the two route-driven read *flows*,
which are three handlers) and occurs **9** times after this change. Two further
`refresh?` bindings use the predicate as a same-slug test rather than as a gate,
unchanged at 2.

`schema.cljs` already described `:slug` as the fact that "gates every
article/comments settle" — prose that was an overstatement before this change
and is now accurate, so it needed no edit.

## Tests

Four cases in the existing production-source CLJS suite
(`realworld_cljs_test.cljs`, `deftest realworld-article-social-cross-slug`):
the three cross-slug refusals, the slice-rebuild strand control, and a
non-vacuity control proving all three settles still do their ordinary job on
the current slug — a gate wired to refuse everything would satisfy the first
three and break the app.

Two pre-existing tests drove these handlers directly and move to the new arity.
`article-detail-delete-test` now drives its failure branch while still on the
article, so the assertion is not left hostage to whatever the home route does
to `[:article :slug]` after the successful delete.

No framework change, no new abstraction, no Playwright spec, no CI job.
