### PR TITLE
docs(method): a remedy inherits what it reads; the tracker is the fourth contention shape

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -339,6 +339,18 @@ familiar fix:
   pass until it lands. **That intermediate state is expected, not a second failure.**
   Both obvious reflexes are wrong — repeating the pull stays ahead, and forcing equality
   discards the very checkpoint the drill exists to protect.
+
+  **Rebase onto the remote-tracking REF, not with a pull.** *Rebase* names an outcome, and
+  the command that first comes to hand for it is a pull carrying a rebase flag — which reads
+  the same shared scratch file this drill just retired for the fast-forward. The argument two
+  paragraphs up applies here unchanged and is easy to miss, because it was made about the
+  step rather than about the remedy for that step's own failure: retiring the reading command
+  in one place and readmitting it in the next is no protection at all. Measured under a
+  saturated fleet: with remote and branch both named, the pull form aborted a second time
+  wearing the contamination message — peers adding worktrees had left several refs in that
+  file — while rebasing onto the ref succeeded immediately on the same tree. **A remedy
+  inherits the hazards of whatever it reads**, so choose it by what it reads, not by what it
+  is called.
 * **A truncated abort, or a ref-level race** — re-fetch and re-read. Do not reach for
   any remedy above.
 
@@ -539,6 +551,27 @@ which would trade a recoverable failure for a permanently slower one; it is that
 continuously* is what makes a fleet-wide kill survivable. Read a worker that has not pushed for
 a long stretch as the exposure it is, and expect the salvage under *The stranded sweep* to be
 wanted for the whole fleet at once rather than for one worker.
+
+**And the fourth shape is the one where YOU are the competitor: the tracker itself.** The
+three above degrade the workers. This one degrades the mayor, because a fleet at the ceiling
+is a fleet reading and writing the item store continuously — every brief's history walk, every
+verdict, every close — and the mayor's own queries queue behind them. Measured at six workers:
+four consecutive coordinator commands exceeded a two-minute ceiling in one cycle, including a
+plain listing and, with some irony, the note recording this observation; all are second-scale
+on an idle fleet.
+
+**What makes it worth writing down is not the slowness but the misreading.** A timeout on the
+item store presents exactly as a corrupt or wedged store, and the reflex remedies are both
+wrong: re-running adds load to the thing that is overloaded, and *restoring the store's export
+from version-control history* — which looks like recovery — silently reverts every item recorded
+since that revision. **Treat a coordinator timeout as contention until something else proves
+corruption.** The one export observed apparently hung here had in fact completed.
+
+**Verify it without touching the store at all**: compare the committed export against the working
+copy by size or line count, and check the working tree is clean. Equal and clean means consistent
+and nothing is owed, at zero cost to the resource under load — it answered in a second what
+re-running could not answer in three minutes. And ask the store for one thing per command while
+saturated: two queries chained in one invocation time out where each alone returns.
 
 **A queued measurement window makes an otherwise-free slot not free.** The drain clause in
 the filter list does not reach this case — it lifts only once the exclusive items are all


### PR DESCRIPTION
Retrospective on acting as mayor at a sustained six-worker ceiling. Two findings, both about the mayor's *own* tooling failing under concurrency — a theme the method currently covers only from the workers' side. Nothing else in the document needed changing.

## 1. A remedy inherits the hazards of whatever it reads

*After each merge* retires the pull for the fast-forward step, and argues it well: a pull picks its target out of a scratch file any concurrent process in the same checkout can rewrite, so "the repair is to retire the command that reads the shared file."

It then prescribes **"Rebase, then push"** for that step's own failure — and does not name the form. The command that first comes to hand for *rebase* is a pull carrying a rebase flag, which reads that same file. So the section retires the reading command in one paragraph and readmits it in the next, and the argument that would have caught it is easy to skip past because it was made about the *step* rather than about the *remedy for that step's failure*.

**Measured this session, under a saturated fleet, with remote and branch both named:** the pull form aborted a second time wearing the contamination message — peers adding worktrees had left several refs in that file — while rebasing onto the remote-tracking ref succeeded immediately on the same tree.

This is not a hypothetical. I read this section carefully, followed it, and hit the trap it warns about — because the trap was described one command earlier than the one I was told to reach for.

## 2. The tracker is a fourth contention shape, and the coordinator is the competitor

*Shape and saturation* names three: contention for **files** (surfaces), for the **machine** (heavyweight gates), and for the **allowance** (shared quota). All three degrade the workers. The fourth degrades the mayor — a fleet at the ceiling reads and writes the item store continuously (every brief's history walk, every verdict, every close), and the coordinator's own queries queue behind them.

**Measured at six workers:** four consecutive coordinator commands exceeded a two-minute ceiling in one cycle, including a plain listing and — with some irony — the note recording this observation. All are second-scale on an idle fleet.

**The slowness is not what makes this worth writing down; the misreading is.** A timeout on the item store presents exactly as a corrupt or wedged store, and both reflex remedies are wrong. Re-running adds load to the thing that is overloaded. And *restoring the store's export from version-control history* — which looks like textbook recovery — silently reverts every item recorded since that revision. The one export that appeared hung here had in fact completed.

So the addition names the discriminating posture (contention until proven otherwise) and the check that settles it **without touching the resource under load**: compare the committed export against the working copy by line count and confirm the tree is clean. Equal and clean means consistent and nothing is owed. That answered in one second what re-running could not answer in three minutes.

## Kept generic

No operating system, repository, tool or person is named. "Item store", "coordinator", "remote-tracking ref" and "shared scratch file" are the vocabulary the surrounding document already uses.

## Quality gates

- `python scripts/check_doc_slugs.py` — **exit 0**. `docs/` is inside its roots.
  - **Control:** the gate is silent on success, so the green was proven by a planted broken link target at a line this change edits → **exit 1**, naming `docs\the-mayor-method\loops.md:353 -> ./no-such-file-coord-control.md`. That fault existed only in this worktree, so the red also proves the gate read this tree. Match count read as **1** before planting.
  - **Restore verified by git blob hash**, not by reading a diff: working file `72ea09902d58e627e0837996f828c8c8245fc025` == the committed object. Gate re-run after restore: **exit 0**. Committed before planting, so the restore was well-defined.
- `mkdocs build --strict` — **not nominated.** `mkdocs.yml`'s `exclude_docs` keeps `docs/the-mayor-method/` out of the built site, and `--strict` grades missing anchors at INFO regardless.
- **By hand:** prose only — no headings, anchors or tables changed; the one link introduced was the planted control, removed.

One file, `docs/the-mayor-method/loops.md`. No code, tests or workflow files touched.
