### PR TITLE
docs(dispatch): a line-spanning target defeats the matched control too

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -944,6 +944,21 @@ control and missed every punctuation-final hit, so the census read zero on four 
 its control read green. If the target ends in punctuation, carries a backslash, or spans a line,
 the control must too.
 
+**But for the line-spanning case that advice is inert, and it is the one case where a matched
+control actively reassures you.** Most search tools take a LINE as their unit, so a target broken
+across two lines is not merely hard to match — it cannot be seen at all, whatever the pattern. A
+control sharing that shape is invisible in exactly the same way: both come back zero, and the
+check reports a clean pattern over an unsearched target. Every other hazard here is caught by a
+control that bites; this one is caught only by changing the instrument. **Run the search twice —
+once line-oriented, once over the text with whitespace collapsed — because neither result is a
+superset of the other.** Measured four times in one session: a census found one site
+line-oriented and missed four line-broken ones, then found those four flattened and missed the
+first; a second census caught a stale phrase only when flattened; and twice a hand-written probe
+of a wrapped field reported data loss that had not happened. **Wrapped text is the common case,
+not the exotic one** — anything hard-wrapped to a column, which is most prose documents and many
+tracker fields, will break a long enough probe somewhere. So keep a probe short enough to sit
+inside one line, and where the target is genuinely longer, flatten before believing a zero.
+
 **This is not a fact about searching, and reading it as one is how it gets past you.** ANY
 instrument that can answer "nothing here" gives the same answer when misused, and a misused one
 raises no error — so its all-clear is complete, well-formed and plausible. Measured: a


### PR DESCRIPTION
Found by the method-reread loop, testing rules I had been *enforcing*. Two checks passed and one turned up a real hole.

**Passed — the band.** I have asserted a check-count band of 85 all session. Re-derived rather than remembered: **0 new job keys across the last 40 trunk commits**, with the discriminator exercised against a commit known to add one, where it reads **1**. So the zero is a measurement rather than an instrument failure, and the band is unchanged.

**Passed — block divergence.** The boundary and gate blocks I paste still match source.

**The hole.** The zero-is-not-a-check paragraph already lists `spans a line` among the shapes a control must share. For that one shape the advice is **inert**, and it is the only hazard in that paragraph a biting control does not catch.

Most search tools take a LINE as their unit. A target broken across two lines is not merely hard to match — it cannot be seen at all, whatever the pattern. So a control sharing that shape is invisible in exactly the same way: both return zero, and the check reports a clean pattern over a target it never searched. The existing advice tells you to make the control share the target's shape, which here makes the control fail silently *in the same direction* as the target.

The remedy is to change the instrument, not the control: **search twice — once line-oriented, once with whitespace collapsed — because neither result is a superset of the other.**

**Measured four times in one session:**

1. A census found one site line-oriented and missed four line-broken ones; the flattened pass found those four and missed the first. Neither instrument alone sufficed.
2. A second census caught a stale phrase, and a hit in another file, only when flattened.
3. A probe of a wrapped tracker field returned zero on text that was present and correct — reported as data loss that had not happened.
4. Checking *this document* for block divergence, a line I paste into every dispatch returned `0` from a line-oriented grep and `1` flattened.

And once more while writing the fix: **the edit anchor for this very change failed to match on the first attempt**, for exactly this reason. That is why the addition says wrapped text is the common case rather than the exotic one — anything hard-wrapped to a column, which is most prose documents and many tracker fields, breaks a long enough probe somewhere.

## Kept generic

No tool, repository, operating system or person named. "Search", "line-oriented", "whitespace collapsed" and "probe" are the vocabulary the paragraph already uses.

## Quality gates

- `python scripts/check_doc_slugs.py` — **exit 0**. `docs/` is inside its roots.
  - **Control:** the gate is silent on success, so the green was proven by a planted broken link target at a line this change edits → **exit 1**, naming `docs\the-mayor-method\dispatch-prompt-template.md:952 -> ./no-such-file-linespan-control.md`. That fault existed only in this worktree, so the red also proves the gate read this tree. Match count read as **1** before planting.
  - **Restore verified by git blob hash**: working file `e8b335823741245a07f110442aff0c2d3b478f70` == the committed object. Gate re-run after restore: **exit 0**. Committed before planting, so the restore was well-defined.
- `mkdocs build --strict` — **not nominated.** `mkdocs.yml`'s `exclude_docs` keeps `docs/the-mayor-method/` out of the built site, and `--strict` grades missing anchors at INFO regardless.
- **By hand:** prose added inside an existing paragraph — no headings, anchors or tables changed; the one link introduced was the planted control, removed.

One file, `docs/the-mayor-method/dispatch-prompt-template.md`. No code, tests or workflow files touched.
