### PR TITLE
fix(machines): re-arm active :after timers on SSR hydration (rf2-jqvgp)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -445,6 +445,10 @@
     :producer-ns 're-frame.machines
     :design-bead "rf2-u5kmf8"
     :description "Epoch-restore host-transient quiesce for machine `:after` timers. Consulted by `re-frame.epoch.tool-pair/perform-restore!` AFTER a successful install: releases the restored frame's in-flight `:after` host-clock handles (the orphaned async host work the unwound epochs spawned — NOT frame-state) so a leaked wall-clock timer never fires against the restored state. Emits one `:rf.machine.timer/cancelled :reason :on-restore` per entry. The restore counterpart of `:machines/on-frame-destroyed!` (Managed-Effects §SSR, preload, hydration, and restore: \"epoch restore MUST NOT revive host work\")."}
+   {:key         :machines/rearm-after-hydration!
+    :producer-ns 're-frame.machines
+    :design-bead "rf2-jqvgp"
+    :description "SSR-hydration host-work RECONSTRUCTION for machine `:after` timers — the client-side counterpart of the server-side wire projection `:machines/project-ssr-runtime-db`, and the deliberate OPPOSITE of `:machines/on-frame-restored!`. The server suppresses `:after` timers (Spec 005 §SSR mode) and the wire carries only durable snapshot facts, so a machine hydrated in an `:after`-bearing state arrived with the right `:state` / `:data` / `:rf/after-epoch` and NO live timer. Consulted by `re-frame.ssr.hydrate/hydrate-event-handler*` as a PRESENCE gate (absent hook → no machines artefact → no re-arm fx emitted); the `:rf.machine/hydrate-rearm` fx it gates runs this same body AFTER the payload runtime-db has committed, walking the hydrated snapshots' ACTIVE configuration (flat/compound ancestors + leaf, each parallel region's active path, and the root-owned parallel `:after`) and arming one client timer per live declaration at the epoch the snapshot already carries. Re-runs NO entry / action / raise / spawn and writes no snapshot — the whole point is host work without replayed history (Spec 011 §`:after` is no-op under SSR: \"`:after` timers begin running on the client\"). Restore keeps CANCELLING; only hydration arms."}
    {:key         :machines/teardown-on-frame-destroy!
     :producer-ns 're-frame.machines
     :design-bead "rf2-vsigt"

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -46,6 +46,7 @@
             [re-frame.image-assembly :as image-assembly]
             [re-frame.late-bind :as late-bind]
             [re-frame.machines.data-validation :as data-validation]
+            [re-frame.machines.hydrate :as machines-hydrate]
             [re-frame.machines.lifecycle-fx.destroy :as destroy]
             [re-frame.machines.lifecycle-fx.frame-destroy :as frame-destroy]
             [re-frame.machines.lifecycle-fx.join :as join]
@@ -342,6 +343,25 @@
   {:doc "Machine-internal: cancel a previously-scheduled `:after` timer. Per Spec 005 §Timed transitions. Not for direct application use."}
   after-cancel-fx)
 
+;; SSR hydration re-arm. Emitted by the `:rf/hydrate` handler (via the
+;; `:machines/rearm-after-hydration!` presence gate) so it runs AFTER the
+;; payload's runtime-db has committed — `commit-frame-effects!` installs
+;; both partitions before `run-fx-effects!` walks `:fx`, which is exactly
+;; the ordering the re-arm needs: it reads the just-installed snapshots.
+;; Deliberately NOT a state-entry replay — see `re-frame.machines.hydrate`.
+(fx/reg-fx :rf.machine/hydrate-rearm
+  {:doc "Machine-internal: reconstruct the host `:after` timer table for the frame's just-hydrated machine snapshots, at each snapshot's existing `:rf/after-epoch` and without replaying entry effects. Per Spec 011 §`:after` is no-op under SSR (\"`:after` timers begin running on the client\"). Not for direct application use."}
+  (fn [{frame-id :frame} _args]
+    (let [;; The cascade envelope frame is the fx-context `:frame`; a nil
+          ;; stamp is an invariant failure (`:rf.error/no-frame-context`),
+          ;; never a synthesised `:rf/default` — the timers would otherwise
+          ;; be armed against a frame nobody hydrated.
+          frame-id (frame/require-frame-stamp!
+                     frame-id :rf.machine/hydrate-rearm
+                     {:where 'rf.machine/hydrate-rearm})]
+      (machines-hydrate/rearm-after-timers! frame-id))
+    nil))
+
 (fx/reg-fx :rf.machine/update-snapshot
   {:doc "Snapshot-level escape hatch. Emit `[:rf.machine/update-snapshot {:rf/machine-id <id> :rf/patch {:data {...}}}]` from a callback's `:fx` vector to touch `:state` / `:meta` / `:data` atomically. Per Spec 005 §Snapshot-level escape hatch."}
   update-snapshot/update-snapshot-fx)
@@ -514,6 +534,19 @@
 ;; statically require the machines artefact.
 (late-bind/set-fn! :machines/on-frame-restored!
                    (fn [frame-id] (timer/cancel-frame-timers-on-restore! frame-id)))
+;; SSR hydration re-arm hook. `re-frame.ssr.hydrate/hydrate-event-handler*`
+;; consults it purely as a PRESENCE gate — an SSR app without the machines
+;; artefact finds it unbound and emits no re-arm fx — and the
+;; `:rf.machine/hydrate-rearm` fx registered above runs this same body with
+;; the committed frame. The counterpart of the SERVER-side projection hook
+;; `:machines/project-ssr-runtime-db`: that one puts the durable snapshot on
+;; the wire, this one rebuilds the host work the snapshot implies but cannot
+;; carry. NOT the epoch-restore hook — `:machines/on-frame-restored!` cancels
+;; and must keep cancelling (Managed-Effects: "epoch restore MUST NOT revive
+;; host work"); hydration arms timers that were never armed at all.
+;; Late-bound so SSR never statically requires the machines artefact.
+(late-bind/set-fn! :machines/rearm-after-hydration!
+                   machines-hydrate/rearm-after-timers!)
 ;; Frame-destroy machine-cascade hook. `frame/destroy-frame!` calls this
 ;; hook BEFORE the sub-cache / adapter teardown so each active machine's
 ;; `:exit` cascade runs against a live container in reverse-creation order

--- a/implementation/machines/src/re_frame/machines/hydrate.cljc
+++ b/implementation/machines/src/re_frame/machines/hydrate.cljc
@@ -1,0 +1,226 @@
+(ns re-frame.machines.hydrate
+  "SSR hydration re-arm for machine `:after` timers — the client-side
+  counterpart of `re-frame.machines.ssr`'s wire projection.
+
+  ## The hole this closes
+
+  Durable machine state and host work are two different things, and only
+  the first one crosses the wire. The server renders a machine's `:state`
+  statically and schedules NO wall-clock timer (Spec 005 §SSR mode; the
+  pure side emits `:rf.machine.timer/skipped-on-server` in place of
+  `/scheduled`). The hydration payload then carries the snapshot — right
+  `:state`, right `:data`, right `:rf/after-epoch` — and the client
+  installs it verbatim. Nothing in that path reconstructs the host-side
+  timer table, so a machine hydrated while sitting in an `:after`-bearing
+  state had the correct durable state and NO live timer: it could sit
+  there forever unless some unrelated external event moved it.
+
+  Spec 011 §`:after` is no-op under SSR names the two admissible
+  handoffs — re-fire entry actions on hydration, or \"treat hydration as a
+  special case that schedules `:after` timers without re-running other
+  entry effects\" — and requires that `:after` timers begin running on the
+  client *per the snapshot's epoch*. This namespace is the second
+  handoff, which is the one that is actually safe: re-running entry would
+  re-arm the timers AND re-fire `:entry` actions, raises and spawns that
+  already happened on the server.
+
+  ## What it does, and what it deliberately does not
+
+  Given a frame whose runtime-db has just been REPLACED by a hydration
+  payload, walk `[:rf.runtime/machines :snapshots]`, resolve each actor's
+  machine spec the same way dispatch does, enumerate the `:after`
+  declarations the snapshot's ACTIVE configuration keeps live, and arm one
+  client timer for each at the epoch already recorded.
+
+  Enumeration is ACTIVE-configuration-shaped, not whole-spec-shaped:
+
+    - flat / compound — every node from the root down to the active leaf
+      (`transition/nodes-along-path`), because a still-active ANCESTOR's
+      `:after` is as live as the leaf's;
+    - parallel — the same walk inside each region's own active path,
+      against the synthetic region-spec so the region's per-region epoch
+      slot and region-prefixed invoke-id are the ones the runtime already
+      uses; plus the ROOT-owned `:after` at decl-path `[]`, which belongs
+      to the machine rather than to any region.
+
+  It runs NO cascade. No `:entry`, no `:exit`, no `:action`, no `:raise`,
+  no `:spawn`, no `:always` — none of the historical effects the server
+  already performed are replayed, and no snapshot is written (the epoch is
+  read, never bumped). The only thing this seam creates is host work.
+
+  ## Remaining duration: the FULL declared delay
+
+  A reconstructed timer is armed for its whole declared delay measured
+  from hydration, not for a remainder. That is not a preference — it is
+  the only reading the durable data supports. The snapshot records the
+  `:after` epoch and nothing else about the timer: Spec 005 §Clock
+  abstraction states outright that `:after` scheduling reads the host
+  clock to schedule but never records the schedule instant, precisely so
+  that firing stays replay-sound as a facts-against-facts epoch check
+  rather than a wall-clock comparison. There is consequently no
+  `scheduled-at` / `due-at` anywhere on the wire to subtract from, and
+  Spec 011 §`:after` is no-op under SSR gives the matching rationale:
+  `:after` timers are state-entry-relative and \"have no semantic meaning
+  until the user is interacting with the page — i.e., until after
+  hydration\". The client's arrival IS the entry, for timing purposes.
+
+  ## Not the epoch-restore path
+
+  Epoch restore is the mirror image and stays that way: it CANCELS the
+  frame's in-flight `:after` handles (`:machines/on-frame-restored!` →
+  `timer/cancel-frame-timers-on-restore!`, one
+  `:rf.machine.timer/cancelled :reason :on-restore` per entry) and never
+  re-arms, because Managed-Effects §SSR, preload, hydration, and restore
+  rules that restore MUST NOT revive host work. The asymmetry is real and
+  intended: restore rewinds a timeline that already ran its host work,
+  while hydration establishes host work that was never armed at all. This
+  namespace is reached only from the `:rf/hydrate` seam and shares no
+  callback with restore.
+
+  Pure / host-agnostic CLJC apart from the one arming call — the walk is a
+  pure function of `[spec snapshot]` and is tested as such."
+  (:require [re-frame.frame :as frame]
+            [re-frame.machines.lifecycle-fx.resolver :as resolver]
+            [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.paths :as paths]
+            [re-frame.machines.timeout :as timeout]
+            [re-frame.machines.timer :as timer]
+            [re-frame.machines.transition :as transition]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn- walkable-state?
+  "True iff `state` is a shape `transition/state-path` can normalise — a
+  leaf keyword or a vector path.
+
+  A snapshot arriving from the wire is deserialised, untrusted data. Per
+  Spec 011 §The `:rf/hydrate` event hydration is best-effort
+  (degraded-but-running), so a snapshot whose `:state` is neither shape is
+  SKIPPED here rather than throwing out of the fx and taking the other
+  actors' timers down with it. Such a snapshot is corrupt for every other
+  machine read too, and the first ordinary dispatch against it raises the
+  named `:rf.error/machine-bad-state-form` with the diagnostic that owns
+  that condition — this seam does not duplicate it."
+  [state]
+  (or (keyword? state) (vector? state)))
+
+(defn- decls-along-path
+  "Every live `:after` declaration on the active `path` of one SCOPE —
+  `machine` is a flat/compound machine spec or a synthetic region-spec.
+
+  Returns a vector of
+  `{:invoke-id <vec> :state <kw> :delay-key <k> :epoch <int>}`, one entry
+  per delay-key per `:after`-bearing node along the path.
+
+  `prefix-fn` maps the in-scope decl-path to the invoke-id the timer table
+  is keyed by: identity-ish (`vec`) for a flat/compound machine, and the
+  region-name prepend for a region — the same shape
+  `parallel/prefix-region-invoke-id` stamps on the region's own
+  `:rf.machine/after-schedule` fxs, so a hydrated timer lands in the slot
+  a subsequent state exit will cancel.
+
+  `:state` is `(last decl-path)` — exactly what `build-after-fx` puts on
+  the `/scheduled` row for an entered node, so the trace pairing is
+  identical whether the timer was entered into or hydrated into."
+  [machine snapshot path prefix-fn]
+  (into []
+        (mapcat (fn [[decl-path node]]
+                  (when-let [after-map (:after node)]
+                    (let [epoch (transition/node-epoch machine snapshot decl-path)]
+                      (map (fn [[delay-key _target]]
+                             {:invoke-id (prefix-fn decl-path)
+                              :state     (last decl-path)
+                              :delay-key delay-key
+                              :epoch     epoch})
+                           after-map)))))
+        (transition/nodes-along-path machine path)))
+
+(defn- root-parallel-decls
+  "The ROOT-owned `:after` declarations of a parallel machine (Spec 005
+  §Root parallel `:after`). The root is not a region, so its epoch lives
+  at the flat slot under decl-path `[]`, its invoke-id is `[]`, and its
+  `:state` is the `:rf/parallel-root` sentinel — matching what
+  `schedule-root-after-fx` / `build-after-fx` emit at machine birth, and
+  what `root-after-match` expects when the timer fires."
+  [spec snapshot]
+  (if-let [after-map (:after spec)]
+    (let [epoch (transition/node-epoch spec snapshot [])]
+      (mapv (fn [[delay-key _target]]
+              {:invoke-id []
+               :state     :rf/parallel-root
+               :delay-key delay-key
+               :epoch     epoch})
+            after-map))
+    []))
+
+(defn active-after-decls
+  "PURE. Enumerate every `:after` declaration one hydrated `snapshot` keeps
+  live under `spec`, as
+  `[{:invoke-id … :state … :delay-key … :epoch …} …]`.
+
+  `spec` is desugared first (`timeout/desugar-timeouts` — idempotent, and
+  a no-rebuild fast path for the timeout-free common case) so an authored
+  `:timeout` / `:on-timeout` is enumerated through the `:after` it lowers
+  onto, exactly as the transition engine sees it.
+
+  Returns `[]` for a snapshot with no active `:after` — a machine sitting
+  in an ordinary state hydrates with no timers, which is the whole
+  correctness point of enumerating the ACTIVE configuration rather than
+  the spec."
+  [spec snapshot]
+  (let [spec (timeout/desugar-timeouts spec)
+        st   (:state snapshot)]
+    (cond
+      (parallel/parallel? spec)
+      ;; A parallel snapshot's `:state` is a region-name → region-state
+      ;; map. Walk each region's own active path against the synthetic
+      ;; region-spec (which carries `:rf/region`, so `node-epoch` reads the
+      ;; per-region epoch slot), then add the root-owned declarations.
+      (into (root-parallel-decls spec snapshot)
+            (mapcat (fn [[region-name region-state]]
+                      (when (and (contains? (:regions spec) region-name)
+                                 (walkable-state? region-state))
+                        (decls-along-path (parallel/region-machine spec region-name)
+                                          snapshot
+                                          (transition/state-path region-state)
+                                          #(vec (cons region-name %))))))
+            (when (map? st) st))
+
+      (walkable-state? st)
+      (decls-along-path spec snapshot (transition/state-path st) vec)
+
+      :else [])))
+
+(defn rearm-after-timers!
+  "Reconstruct the host-side `:after` timer table for `frame-id` from the
+  machine snapshots its runtime-db currently holds. The body behind the
+  `:machines/rearm-after-hydration!` late-bind hook and the
+  `:rf.machine/hydrate-rearm` fx; called ONLY after a valid `:rf/hydrate`
+  has committed the payload's runtime-db.
+
+  Refuses a `:server` frame — the frame's own `:platform` config resolved
+  the way `registration/prepare-machine-ctx` resolves it, so this seam and
+  `build-after-fx`'s server-skip can never disagree about which platform a
+  frame is. A frame with no `:platform` config is a client (the machines
+  default), so an ordinary JVM test frame re-arms.
+
+  Idempotent by the ordinary timer-table key: a second install over the
+  same snapshots supersedes the first arm (one `:on-supersede` cancel,
+  one fresh arm) rather than leaving two handles on one declaration.
+
+  Returns nil; the only observable is the timer table plus one
+  `:rf.machine.timer/scheduled` trace per armed declaration."
+  [frame-id]
+  (when (and frame-id
+             (not= :server (or (:platform (frame/frame-meta frame-id)) :client)))
+    (let [snapshots (get-in (frame/frame-runtime-db-value frame-id)
+                            (paths/snapshot-path))]
+      (doseq [[actor-id snapshot] snapshots
+              :when (map? snapshot)
+              :let  [spec (resolver/spec-from-id-or-snapshot actor-id snapshot)]
+              :when (map? spec)
+              decl  (active-after-decls spec snapshot)]
+        (timer/rearm-hydrated-after-timer!
+          frame-id actor-id (:invoke-id decl) (:state decl)
+          (:delay-key decl) (:epoch decl) snapshot))))
+  nil)

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -768,6 +768,39 @@
                             {:emit-scheduled-trace? false})
     nil))
 
+(defn rearm-hydrated-after-timer!
+  "Arm ONE `:after` timer for a node the hydrated snapshot says is ALREADY
+  active. The SSR hydration re-arm seam
+  (`re-frame.machines.hydrate/rearm-after-timers!`) is the only caller.
+
+  This is deliberately NOT a second scheduling mechanism: it is the
+  ordinary `schedule-after-timer!` arm with two differences that both
+  follow from hydration not being a state ENTRY.
+
+    - The `epoch` is the one the hydrated snapshot ALREADY carries; it is
+      never bumped. Entry bumps (`commit-snapshot`'s `bump-after-epochs`)
+      because a re-entry must invalidate the prior visit's in-flight
+      timer; hydration re-establishes host work for a visit that already
+      happened, so bumping would strand the very snapshot being restored.
+    - The `/scheduled` trace is emitted HERE rather than by the pure side.
+      No transition ran, so `build-after-fx` never fired — without this
+      the reconstructed timer would arm untraced (and emitting a
+      state-entry cascade to get the trace would replay the server's
+      entry effects, the worse bug). The row is the ORDINARY
+      `:rf.machine.timer/scheduled` shape, so the existing
+      scheduled→fired / →cancelled pairing on `(actor-id, state, epoch)`
+      holds for a hydrated timer exactly as for an entered one.
+
+  Never server-armed: hydration re-arm runs on the client by contract
+  (Spec 011 §`:after` is no-op under SSR), and the caller has already
+  refused a `:server` frame, so `server?` is passed `false`. Idempotent
+  through the ordinary timer-table key — a second hydration supersedes
+  the first arm rather than duplicating it."
+  [frame-id parent-id invoke-id state delay-key epoch snapshot]
+  (schedule-after-timer! frame-id parent-id invoke-id state delay-key epoch
+                         false snapshot {:emit-scheduled-trace? true})
+  nil)
+
 (defn after-cancel-fx
   "fx handler for `:rf.machine/after-cancel`. Emitted on exit from an
   :after-bearing state node to release the host-clock timer handles and

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -627,9 +627,15 @@
   [machine path]
   (grammar/node-at (:states machine) path))
 
-(defn- nodes-along-path
+(defn nodes-along-path
   "Return [[prefix-path node] ...] from root down to leaf. Skips nodes
-  that don't resolve (defensive)."
+  that don't resolve (defensive).
+
+  Public because the SSR hydration re-arm
+  (`re-frame.machines.hydrate`) needs the SAME root→leaf enumeration the
+  cascade uses: a hydrated snapshot's active path may carry `:after` on
+  an ancestor as well as on the leaf, and every one of them is a live
+  declaration whose client timer must be reconstructed."
   [machine path]
   (loop [m   (:states machine)
          p   path
@@ -877,13 +883,19 @@
     [:data :rf/after-epoch-by-region rn]
     [:data :rf/after-epoch]))
 
-(defn- node-epoch
+(defn node-epoch
   "Read the per-node `:after` epoch for the scheduling node at `decl-path`
   from `snapshot`. Absent nodes read as 0 (a node never entered has no
   in-flight timer; a carried epoch of 0 against an absent node is the
   bootstrap-then-stale shape). `decl-path` is the absolute state path the
   `:after` was declared at (for a region, the path WITHIN the region —
-  matching the `:rf/invoke-id` the timer carries)."
+  matching the `:rf/invoke-id` the timer carries).
+
+  Public because the SSR hydration re-arm
+  (`re-frame.machines.hydrate`) must arm each reconstructed timer at the
+  epoch the hydrated snapshot ALREADY carries — reading it through this
+  one accessor is what keeps the flat / per-region slot rule from being
+  restated (and drifting) at the hydration seam."
   [machine snapshot decl-path]
   (or (get-in snapshot (conj (after-epoch-path machine) (vec decl-path))) 0))
 

--- a/implementation/machines/test/re_frame/machine_after_hydration_rearm_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_after_hydration_rearm_cljs_test.cljc
@@ -1,0 +1,441 @@
+(ns re-frame.machine-after-hydration-rearm-cljs-test
+  "rf2-jqvgp — a machine hydrated in an `:after`-bearing state gets its
+  client timer back.
+
+  The server suppresses `:after` wall-clock timers (Spec 005 §SSR mode)
+  and a host-clock handle cannot ride the wire, so the hydration payload
+  carries a snapshot with the right `:state`, `:data` and
+  `:rf/after-epoch` and NOTHING that schedules. Before this fix the client
+  installed exactly that and stopped: correct durable state, no live
+  timer, and a machine that could sit in a timed state forever unless some
+  unrelated external event moved it. Spec 011 §`:after` is no-op under SSR
+  requires the opposite — \"`:after` timers begin running on the client
+  (per the snapshot's epoch)\".
+
+  ## These tests FIRE the timer
+
+  Every positive case here captures the host-clock thunk
+  (`with-redefs` on `interop/schedule-after!`, the pattern
+  `after_fire_reap_cljs_test` established) and INVOKES it, then asserts the
+  machine actually transitioned. Asserting that the timer table is
+  non-empty would have passed for the whole life of this defect had the
+  table been populated with anything inert; only the fire proves the
+  reconstructed timer is wired to the epoch, the decl-path and the
+  transition.
+
+  ## The server half is measured, not assumed
+
+  The snapshots hydrated here are produced by running the machine on a
+  real `:platform :server` frame, and each test asserts that frame armed
+  NOTHING. So the fixture cannot drift into hydrating a snapshot the
+  server would never have produced, and the server-skip contract is
+  re-measured on every run.
+
+  Both hosts: a `.cljc` named `*-cljs-test`, so it runs under
+  `clojure -M:test` from `implementation/machines` (JVM) and under the
+  node runner (`npm run test:cljs`). The defect is a CLIENT host-runtime
+  defect, so the CLJS arm is the load-bearing one."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            ;; Loading `re-frame.machines` installs the artefact's late-bind
+            ;; hooks + reserved fxs; under a single-ns run nothing else does.
+            [re-frame.machines]
+            [re-frame.machines.hydrate :as m-hydrate]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines.timer :as timer]
+            [re-frame.subs :as subs]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  mtest/trace-capture-fixture)
+
+;; ---------------------------------------------------------------------------
+;; Fixtures
+;; ---------------------------------------------------------------------------
+
+(def ^:private frame-counter (atom 0))
+
+(defn- fresh-frame!
+  "A frame of the given platform under an id no other test in this shared
+  process has used. `:platform` is what both `build-after-fx`'s server-skip
+  and the hydration re-arm's own refusal read, so it is the one axis these
+  tests vary."
+  [platform]
+  (let [fid (keyword "rf.hydrearm" (str (name platform) (swap! frame-counter inc)))]
+    ;; `make-frame` opts are FLAT — everything but `:id` lands under the
+    ;; record's `:config`, which is what `frame-meta` merges. Nesting a
+    ;; `{:config {…}}` map here would store `:config {:config {…}}` and the
+    ;; platform would silently read as the `:client` default, making the
+    ;; server-side negative controls pass for the wrong reason.
+    (rf/make-frame {:id fid :platform platform})
+    fid))
+
+(defn- inner
+  "`frame-id`'s inner `:after` timer table, or `{}` when it holds none."
+  [frame-id]
+  (get @timer/after-timers frame-id {}))
+
+(defn- server-runtime-db
+  "Run `machine` on a real SERVER frame through `events`, assert it armed
+  no host timer, and return the resulting runtime-db value — a genuine
+  server-produced hydration slice, not a hand-written literal."
+  [machine-id machine events]
+  (let [sfid (fresh-frame! :server)]
+    (doseq [e events]
+      (rf/dispatch-sync [machine-id e] {:frame sfid}))
+    (is (empty? (inner sfid))
+        "precondition: the SERVER armed no `:after` host timer")
+    (frame/frame-runtime-db-value sfid)))
+
+(defn- fire!
+  "Run a captured host-clock thunk to completion.
+
+  The thunk dispatches the synthetic
+  `[:rf.machine.timer/after-elapsed <delay-key> <epoch> <decl-path>]`
+  through the REAL async router (`:router/dispatch!`), whose drain is
+  scheduled on `interop/next-tick` — a background executor on the JVM and
+  a macrotask in CLJS, so a bare call would race every assertion after it.
+  Collapsing `next-tick` to an inline call for the duration is the
+  established seam (`core/test/re_frame/drain_test.clj`,
+  `cofx_envelope_test.clj`): the whole routing path still runs, including
+  the per-decl-path epoch stale-gate that a wrongly-armed timer would
+  fail. Nothing here re-implements the timer's own event, which is
+  precisely the part under test."
+  [thunk]
+  (with-redefs [interop/next-tick (fn [f] (f) nil)]
+    (thunk)))
+
+(defn- hydrate-into!
+  "Install `runtime-db` on a fresh CLIENT frame and run the re-arm seam —
+  the machines half of what `:rf/hydrate` does once its runtime-db effect
+  has committed. Returns the frame id."
+  [runtime-db]
+  (let [cfid (fresh-frame! :client)]
+    (frame/replace-runtime-db! cfid runtime-db)
+    (m-hydrate/rearm-after-timers! cfid)
+    cfid))
+
+;; ---------------------------------------------------------------------------
+;; Machines under test
+;; ---------------------------------------------------------------------------
+
+(def ^:private flat-machine
+  "`:waiting` carries a 5s `:after`. Its `:entry` bumps `:entries`, which is
+  the entry-replay control: the server runs it once, and a hydration that
+  re-fired entry would run it twice."
+  {:initial :idle
+   :data    {:entries 0}
+   :actions {:bump-entries (fn [{data :data}]
+                             {:data (update data :entries inc)})}
+   :states  {:idle    {:on {:go :waiting}}
+             :waiting {:entry :bump-entries
+                       :after {5000 {:target :timeout}}}
+             :timeout {}}})
+
+(def ^:private compound-machine
+  "An ancestor AND its active leaf both declare `:after`. Entry only ever
+  schedules NEWLY-entered nodes, so nothing but an ACTIVE-configuration
+  walk reconstructs both."
+  {:initial :idle
+   :data    {}
+   :states  {:idle {:on {:go [:outer :inner]}}
+             :outer {:initial :inner
+                     :after   {9000 {:target :outer-fired}}
+                     :states  {:inner {:after {4000 {:target :inner-fired}}}
+                               :inner-fired {}}}
+             :outer-fired {}}})
+
+(def ^:private parallel-machine
+  "Two regions, one of them `:after`-bearing, plus a ROOT-owned `:after`
+  (decl-path `[]`, epoch at the flat slot, `:rf/parallel-root` state)."
+  {:type    :parallel
+   :data    {}
+   :after   {7000 {:target [:left :left-done]}}
+   :regions {:left  {:initial :idle
+                     :states  {:idle {:on {:go :ticking}}
+                               :ticking {:after {3000 {:target :left-done}}}
+                               :left-done {}}}
+             :right {:initial :steady
+                     :states  {:steady {}}}}})
+
+;; ---------------------------------------------------------------------------
+;; The core proof: hydration arms a timer that FIRES
+;; ---------------------------------------------------------------------------
+
+(deftest hydrated-after-timer-is-armed-at-the-persisted-epoch-and-fires
+  (testing "a machine hydrated while sitting in an `:after`-bearing state
+            gets exactly one client timer, armed at the epoch the SNAPSHOT
+            carries, whose expiry performs the declared transition"
+    (rf/reg-machine :hyd/flat flat-machine)
+    (let [thunks (atom [])
+          arms   (atom [])
+          rt     (server-runtime-db :hyd/flat flat-machine [[:go]])
+          snap   (get-in rt [:rf.runtime/machines :snapshots :hyd/flat])
+          epoch  (get-in snap [:data :rf/after-epoch [:waiting]])]
+      (is (= :waiting (:state snap))
+          "precondition: the server settled in the `:after`-bearing state")
+      (is (and (integer? epoch) (pos? epoch))
+          "precondition: the durable per-decl-path epoch rode the snapshot")
+
+      (let [cfid (with-redefs [interop/schedule-after!
+                              (fn [thunk ms]
+                                (swap! thunks conj thunk)
+                                (swap! arms conj ms)
+                                ::handle)]
+                   (hydrate-into! rt))
+            table (inner cfid)]
+
+        (is (= 1 (count table))
+            "hydration armed EXACTLY one timer for the one live `:after`")
+        (let [[k entry] (first table)]
+          (is (= {:parent :hyd/flat :spawn [:waiting] :delay 5000} k)
+              "keyed by the owning actor + the `:after`'s decl-path + delay")
+          (is (= epoch (:epoch entry))
+              (str "armed at the epoch the hydrated snapshot ALREADY carried "
+                   "— re-arm must not bump, or the very snapshot being "
+                   "restored would go stale against its own timer"))
+          (is (= :waiting (:state entry)))
+          (is (= :literal (:delay-source entry))))
+
+        (is (= [5000] @arms)
+            (str "armed for the FULL declared delay measured from hydration. "
+                 "Nothing durable records a schedule instant — Spec 005 "
+                 "§Clock abstraction keeps `:after` replay-sound precisely by "
+                 "NOT recording one — so there is no remainder to compute."))
+
+        ;; THE FIRE. Not "a table is populated" — the reconstructed timer
+        ;; must actually drive the transition.
+        (is (= :waiting (mtest/machine-state cfid :hyd/flat))
+            "precondition: still waiting before the clock runs out")
+        (fire! (first @thunks))
+        (is (= :timeout (mtest/machine-state cfid :hyd/flat))
+            (str "the hydrated timer FIRED and performed the declared "
+                 "`:after` transition. This is the whole bug: before the fix "
+                 "no timer existed, so this state was terminal in practice."))))))
+
+(deftest hydration-does-not-replay-entry
+  (testing "re-arming reconstructs host work only — the server's `:entry`
+            action is NOT run a second time"
+    (rf/reg-machine :hyd/noreplay flat-machine)
+    (let [rt   (server-runtime-db :hyd/noreplay flat-machine [[:go]])
+          snap (get-in rt [:rf.runtime/machines :snapshots :hyd/noreplay])]
+      (is (= 1 (get-in snap [:data :entries]))
+          "precondition: the server ran `:entry` exactly once")
+      (let [cfid (with-redefs [interop/schedule-after!
+                              (fn [_thunk _ms] ::handle)]
+                   (hydrate-into! rt))]
+        (is (= 1 (:entries (mtest/machine-data cfid :hyd/noreplay)))
+            (str "still 1. Re-running entry would have re-armed the timers "
+                 "AND re-fired every entry effect the server already "
+                 "performed — a different and worse bug than the one fixed."))
+        (is (= :waiting (mtest/machine-state cfid :hyd/noreplay))
+            "and the durable state is untouched by the re-arm")))))
+
+(deftest hydration-re-arm-is-idempotent
+  (testing "a second re-arm over the same snapshots supersedes rather than
+            duplicating — one live handle per declaration, always"
+    (rf/reg-machine :hyd/idem flat-machine)
+    (let [rt (server-runtime-db :hyd/idem flat-machine [[:go]])]
+      (with-redefs [interop/schedule-after! (fn [_thunk _ms] ::handle)]
+        (let [cfid (hydrate-into! rt)]
+          (is (= 1 (count (inner cfid))))
+          (m-hydrate/rearm-after-timers! cfid)
+          (is (= 1 (count (inner cfid)))
+              "still one entry — the ordinary timer-table key superseded"))))))
+
+;; ---------------------------------------------------------------------------
+;; Hierarchy: an active ANCESTOR's `:after` is as live as the leaf's
+;; ---------------------------------------------------------------------------
+
+(deftest hydration-re-arms-every-node-on-a-compound-active-path
+  (testing "both the active leaf's `:after` and its still-active ancestor's
+            are reconstructed, each at its OWN per-decl-path epoch"
+    (rf/reg-machine :hyd/compound compound-machine)
+    (let [thunks (atom {})
+          rt     (server-runtime-db :hyd/compound compound-machine [[:go]])
+          snap   (get-in rt [:rf.runtime/machines :snapshots :hyd/compound])]
+      (is (= [:outer :inner] (:state snap))
+          "precondition: the server settled on the compound leaf")
+      (let [cfid  (with-redefs [interop/schedule-after!
+                               (fn [thunk ms] (swap! thunks assoc ms thunk) ::handle)]
+                    (hydrate-into! rt))
+            table (inner cfid)]
+        (is (= #{{:parent :hyd/compound :spawn [:outer]        :delay 9000}
+                 {:parent :hyd/compound :spawn [:outer :inner] :delay 4000}}
+                (set (keys table)))
+            (str "BOTH scheduling nodes on the active path. Entry only "
+                 "schedules newly-entered nodes, so an enumeration keyed on "
+                 "the leaf alone would silently drop the ancestor's timer."))
+        (doseq [[k entry] table]
+          (is (= (get-in snap [:data :rf/after-epoch (:spawn k)]) (:epoch entry))
+              (str "each node armed at its OWN durable epoch: " (:spawn k))))
+
+        ;; Fire the ANCESTOR's timer — the one an entry-shaped fix misses.
+        (fire! (get @thunks 9000))
+        (is (= :outer-fired (mtest/machine-state cfid :hyd/compound))
+            "the hydrated ANCESTOR timer fired and transitioned")))))
+
+;; ---------------------------------------------------------------------------
+;; Parallel: per-region active paths + the root-owned `:after`
+;; ---------------------------------------------------------------------------
+
+(deftest hydration-re-arms-region-and-root-parallel-afters
+  (testing "a root-parallel machine hydrates with its region's active
+            `:after` AND its root-owned `:after` both live"
+    (rf/reg-machine :hyd/par parallel-machine)
+    (let [thunks (atom {})
+          rt     (server-runtime-db :hyd/par parallel-machine [[:go]])
+          snap   (get-in rt [:rf.runtime/machines :snapshots :hyd/par])]
+      (is (= :ticking (get-in snap [:state :left]))
+          "precondition: the `:after`-bearing region is on its timed state")
+      (let [cfid  (with-redefs [interop/schedule-after!
+                               (fn [thunk ms] (swap! thunks assoc ms thunk) ::handle)]
+                    (hydrate-into! rt))
+            table (inner cfid)]
+        (is (= #{{:parent :hyd/par :spawn [:left :ticking] :delay 3000}
+                 {:parent :hyd/par :spawn []              :delay 7000}}
+                (set (keys table)))
+            (str "the region `:after` under its REGION-PREFIXED invoke-id, "
+                 "and the root-owned `:after` at the empty decl-path"))
+
+        (let [region-entry (get table {:parent :hyd/par :spawn [:left :ticking] :delay 3000})
+              root-entry   (get table {:parent :hyd/par :spawn [] :delay 7000})]
+          (is (= (get-in snap [:data :rf/after-epoch-by-region :left [:ticking]])
+                 (:epoch region-entry))
+              "the region timer reads the PER-REGION epoch slot")
+          (is (= :left (:region region-entry))
+              "and records its region so the cancelled row's work-id matches")
+          (is (= (get-in snap [:data :rf/after-epoch []]) (:epoch root-entry))
+              "the root timer reads the FLAT slot at decl-path []")
+          (is (= :rf/parallel-root (:state root-entry))
+              "root sentinel, matching what birth-time scheduling stamps"))
+
+        (fire! (get @thunks 3000))
+        (is (= :left-done (get-in (mtest/snapshot cfid :hyd/par) [:state :left]))
+            "the hydrated REGION timer fired and moved that region alone")
+        (is (= :steady (get-in (mtest/snapshot cfid :hyd/par) [:state :right])
+               )
+            "and left its sibling region untouched")))))
+
+;; ---------------------------------------------------------------------------
+;; Dynamic delays resolve on the client
+;; ---------------------------------------------------------------------------
+
+(deftest hydration-resolves-a-dynamic-delay-on-the-client
+  (testing "a subscription-vector delay is resolved through the ordinary
+            scheduling path at hydration time, and its watcher is attached
+            and released like any other"
+    (let [reaction (atom 2500)
+          m        {:initial :idle
+                    :data    {}
+                    :states  {:idle    {:on {:go :waiting}}
+                              :waiting {:after {[:t/dyn] {:target :fired}}}
+                              :fired   {}}}
+          armed    (atom [])
+          thunk    (atom nil)]
+      (rf/reg-sub :t/dyn (fn [_db _] @reaction))
+      (rf/reg-machine :hyd/dyn m)
+      (with-redefs [subs/subscribe   (fn ([_q] reaction) ([_q _o] reaction))
+                    subs/unsubscribe (fn ([_] nil) ([_ _] nil))
+                    interop/schedule-after! (fn [t ms]
+                                              (reset! thunk t)
+                                              (swap! armed conj ms)
+                                              ::handle)]
+        (let [rt    (server-runtime-db :hyd/dyn m [[:go]])
+              cfid  (hydrate-into! rt)
+              table (inner cfid)]
+          (is (= 1 (count table)))
+          (let [[k entry] (first table)]
+            (is (= [:t/dyn] (:delay k)))
+            (is (= :sub (:delay-source entry)))
+            (is (= 2500 (:resolved-ms entry))
+                "resolved on the CLIENT — the server never resolved it")
+            (is (some? (:reaction entry)) "the dynamic-delay reaction is held")
+            (is (some? (:sub-watcher-key entry))
+                "and its re-resolution watcher is attached"))
+          (is (= [2500] @armed))
+          (fire! @thunk)
+          (is (= :fired (mtest/machine-state cfid :hyd/dyn))
+              "the client-resolved dynamic delay fired the transition")
+          (is (empty? (inner cfid))
+              "and the spent one-shot reaped its entry, releasing the watch"))))))
+
+;; ---------------------------------------------------------------------------
+;; Negative controls
+;; ---------------------------------------------------------------------------
+
+(deftest a-snapshot-with-no-active-after-arms-nothing
+  (testing "hydrating a machine that is NOT in an `:after`-bearing state
+            arms no timers — the walk is over the ACTIVE configuration, not
+            over the spec"
+    (rf/reg-machine :hyd/none flat-machine)
+    ;; Birth only: `:idle` declares no `:after`, and `:waiting`'s
+    ;; declaration is inert while nothing occupies it.
+    (let [rt (server-runtime-db :hyd/none flat-machine [[:noop]])]
+      (is (= :idle (get-in rt [:rf.runtime/machines :snapshots :hyd/none :state]))
+          "precondition: parked on the `:after`-free initial state")
+      (with-redefs [interop/schedule-after! (fn [_t _ms] ::handle)]
+        (let [cfid (hydrate-into! rt)]
+          (is (empty? (inner cfid))
+              "no live declaration, so nothing armed"))))))
+
+(deftest a-server-side-hydrate-arms-nothing
+  (testing "the re-arm refuses a `:platform :server` frame — an isomorphic
+            loopback or server-side `:rf/hydrate` must not start host clocks"
+    (rf/reg-machine :hyd/srv flat-machine)
+    (let [rt (server-runtime-db :hyd/srv flat-machine [[:go]])]
+      (with-redefs [interop/schedule-after! (fn [_t _ms] ::handle)]
+        (let [sfid (fresh-frame! :server)]
+          (frame/replace-runtime-db! sfid rt)
+          (m-hydrate/rearm-after-timers! sfid)
+          (is (empty? (inner sfid))
+              (str "same refusal `build-after-fx` applies, read off the same "
+                   "frame `:platform` — the two cannot disagree")))))))
+
+(deftest an-unresolvable-snapshot-arms-nothing
+  (testing "a snapshot whose machine type resolves to nothing is skipped,
+            and does not stop its siblings from re-arming"
+    (rf/reg-machine :hyd/mixed flat-machine)
+    (let [rt      (server-runtime-db :hyd/mixed flat-machine [[:go]])
+          ;; A wire-shaped snapshot for an actor no registration backs.
+          poisoned (assoc-in rt [:rf.runtime/machines :snapshots :hyd/ghost]
+                             {:state :waiting :data {} :rf/machine-type :hyd/never-registered})]
+      (with-redefs [interop/schedule-after! (fn [_t _ms] ::handle)]
+        (let [cfid (hydrate-into! poisoned)]
+          (is (= #{{:parent :hyd/mixed :spawn [:waiting] :delay 5000}}
+                 (set (keys (inner cfid))))
+              (str "the resolvable actor re-armed; the unresolvable one "
+                   "contributed nothing and took nothing down with it")))))))
+
+;; ---------------------------------------------------------------------------
+;; The trace a hydrated timer leaves
+;; ---------------------------------------------------------------------------
+
+(deftest a-hydrated-timer-emits-one-ordinary-scheduled-trace
+  (testing "the reconstructed timer emits ONE normal
+            `:rf.machine.timer/scheduled` row — not a state-entry replay,
+            and not nothing"
+    (rf/reg-machine :hyd/trace flat-machine)
+    (let [rt (server-runtime-db :hyd/trace flat-machine [[:go]])]
+      (mtest/reset-captured!)
+      (with-redefs [interop/schedule-after! (fn [_t _ms] ::handle)]
+        (let [cfid  (hydrate-into! rt)
+              ;; A trace event carries its payload under `:tags`, not at the
+              ;; top level (the shape `after_test` reads).
+              rows  (filterv #(= :hyd/trace (:actor-id (:tags %)))
+                             (mtest/events-of :rf.machine.timer/scheduled))
+              epoch (get-in rt [:rf.runtime/machines :snapshots :hyd/trace
+                                :data :rf/after-epoch [:waiting]])]
+          (is (= 1 (count rows)) "exactly one scheduled row")
+          (let [row (:tags (first rows))]
+            (is (= :waiting (:state row)))
+            (is (= 5000 (:delay row)))
+            (is (= :literal (:delay-source row)))
+            (is (= epoch (:epoch row))
+                "carrying the persisted epoch, so scheduled→fired pairs")
+            (is (= cfid (:frame row))))
+          (is (empty? (mtest/events-of :rf.machine.timer/skipped-on-server))
+              "and no server-skip row: this arm happened on a client"))))))

--- a/implementation/ssr/src/re_frame/ssr/hydrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hydrate.cljc
@@ -295,6 +295,12 @@
   ;; 016 §SSR and hydration — Resources recomputes its reverse indexes from
   ;; entries, orphans SSR owners, surfaces clock skew). Absent hook leaves
   ;; the runtime-db unchanged (no resources artefact loaded).
+  ;;
+  ;; That hook reconciles the installed VALUE. Its counterpart for HOST work
+  ;; is the `:machines/rearm-after-hydration!` gate on the `:fx` vector
+  ;; below (rf2-jqvgp): machine `:after` timers are suppressed server-side
+  ;; and cannot ride the wire, so the machines artefact re-arms them from
+  ;; the hydrated snapshots once the runtime-db has committed.
   [db runtime-db frame payload new-db]
   (let [version       (:rf/version payload)
         schema-digest (:rf/schema-digest payload)
@@ -358,7 +364,42 @@
                    (conj [:rf.ssr/check-version       version])
 
                    (and client? schema-digest)
-                   (conj [:rf.ssr/check-schema-digest schema-digest]))}
+                   (conj [:rf.ssr/check-schema-digest schema-digest])
+
+                   ;; LATE-BOUND cross-subsystem hydration RE-ARM (rf2-jqvgp).
+                   ;; The `:resources/hydrate-runtime-db` hook below is PURE —
+                   ;; it reshapes the runtime-db value being installed. Machines
+                   ;; needs the other half: HOST work. A machine hydrated in an
+                   ;; `:after`-bearing state carries the right `:state` / `:data`
+                   ;; / `:rf/after-epoch` and no live timer, because the server
+                   ;; suppressed timer scheduling (Spec 005 §SSR mode) and a
+                   ;; wall-clock handle is not serialisable. Spec 011 §`:after`
+                   ;; is no-op under SSR requires those timers to begin running
+                   ;; on the client against the preserved epoch, so the machines
+                   ;; artefact re-arms them — WITHOUT re-running entry actions,
+                   ;; raises or spawns the server already performed.
+                   ;;
+                   ;; An EFFECT rather than a hook call inside the handler,
+                   ;; because arming host clocks is not something a pure handler
+                   ;; may do and because the walk must read the runtime-db AFTER
+                   ;; it commits: `commit-frame-effects!` installs both
+                   ;; partitions before `run-fx-effects!` walks this vector.
+                   ;;
+                   ;; Gated three ways, each of which independently means "no
+                   ;; timers": `client?` (a server-side / isomorphic-loopback
+                   ;; hydrate arms nothing, same gate the two `:rf.ssr/check-*`
+                   ;; fxs use), `payload-rt` (only a server-settled runtime-db
+                   ;; slice needs reconstructing — a client-only payload's
+                   ;; machines are already running their own timers), and the
+                   ;; hook's presence (an SSR app without the machines artefact
+                   ;; emits nothing, so `:rf.machine/hydrate-rearm` is never
+                   ;; requested from a runtime that has no handler for it).
+                   ;; The rejected paths — malformed payload, wrong frame-id —
+                   ;; return before this handler and so arm nothing either.
+                   (and client?
+                        (some? payload-rt)
+                        (some? (late-bind/get-fn :machines/rearm-after-hydration!)))
+                   (conj [:rf.machine/hydrate-rearm {}]))}
       ;; Install the runtime-db partition when EITHER a server-settled
       ;; runtime-db slice rode the payload OR hydration metadata was produced.
       ;; The metadata merges on top of the payload slice (server-hash/version

--- a/implementation/ssr/test/re_frame/ssr/machine_after_rearm_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/machine_after_rearm_cljs_test.cljc
@@ -1,0 +1,207 @@
+(ns re-frame.ssr.machine-after-rearm-cljs-test
+  "rf2-jqvgp — the `:rf/hydrate` SEAM re-arms machine `:after` timers.
+
+  `machine_after_hydration_rearm_cljs_test` (machines artefact) pins the
+  walk and the arming. This namespace pins the WIRING: that a real
+  server-rendered payload, dispatched through the real `:rf/hydrate`
+  event, ends with a live client timer — and that the three ways the seam
+  is supposed to arm NOTHING all hold.
+
+  Nothing here is hand-written wire shape. The snapshot is produced by
+  running the machine on a `:platform :server` frame, projected by
+  `payload-policy/project-runtime-db` (the shipped projector, machines
+  hook and all) and assembled by `payload-policy/build-payload` (the
+  shipped assembler), so the test tracks the real payload rather than a
+  literal that can drift away from it.
+
+  ## It fires the timer
+
+  The positive case captures the host-clock thunk and INVOKES it, then
+  asserts the machine transitioned. A timer table with an entry in it
+  proves nothing about whether the entry is wired to anything.
+
+  Both hosts: a `.cljc` named `*-cljs-test`, so it runs under
+  `clojure -M:test` from `implementation/ssr` (JVM) and under the node
+  runner (`npm run test:cljs`). Handlers and machines are registered
+  INSIDE each test body under per-test ids — in the shared node process a
+  sibling namespace's `registrar/clear-all!` wipes ns-load-time
+  registrations, which would silently turn a dispatch into a no-op."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            ;; Loading the machines artefact publishes the
+            ;; `:machines/rearm-after-hydration!` hook the hydrate handler
+            ;; gates on, and registers `:rf.machine/hydrate-rearm`.
+            [re-frame.machines]
+            [re-frame.machines.timer :as timer]
+            [re-frame.router :as router]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.payload-policy :as payload-policy]))
+
+(use-fixtures :once (fn [f] (rf/init! ssr/adapter) (f)))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures
+;; ---------------------------------------------------------------------------
+
+(def ^:private counter (atom 0))
+
+(defn- fresh-frame!
+  "A frame of the given platform under an id no other test in this shared
+  process has used. `make-frame` opts are FLAT — a nested `{:config {…}}`
+  would store `:config {:config {…}}` and the platform would silently read
+  as the default."
+  [platform]
+  (let [fid (keyword "rf.ssrrearm" (str (name platform) (swap! counter inc)))]
+    (rf/make-frame {:id fid :platform platform})
+    fid))
+
+(defn- inner
+  "`frame-id`'s inner `:after` timer table, or `{}` when it holds none."
+  [frame-id]
+  (get @timer/after-timers frame-id {}))
+
+(defn- fire!
+  "Run a captured host-clock thunk to completion. The thunk dispatches the
+  synthetic `:rf.machine.timer/after-elapsed` event through the REAL async
+  router, whose drain is scheduled on `interop/next-tick`; collapsing that
+  to an inline call is the established seam for observing an async drain
+  deterministically on both hosts."
+  [thunk]
+  (with-redefs [interop/next-tick (fn [f] (f) nil)]
+    (thunk)))
+
+(def ^:private waiting-machine
+  {:initial :idle
+   :data    {:entries 0}
+   :actions {:bump (fn [{data :data}] {:data (update data :entries inc)})}
+   :states  {:idle    {:on {:go :waiting}}
+             :waiting {:entry :bump
+                       :after {5000 {:target :timeout}}}
+             :timeout {}}})
+
+(defn- server-render!
+  "Register `machine-id`, run it into its `:after`-bearing state on a real
+  SERVER frame, and return the SHIPPED hydration payload for that frame.
+  Asserts the server armed nothing on the way through, so the payload can
+  never be one the server would not actually have produced."
+  [machine-id]
+  (rf/reg-machine machine-id waiting-machine)
+  (let [sfid (fresh-frame! :server)]
+    (rf/dispatch-sync [machine-id [:go]] {:frame sfid})
+    (is (empty? (inner sfid))
+        "precondition: the SERVER armed no `:after` host timer")
+    (payload-policy/build-payload
+      nil
+      (rf/app-db-value sfid)
+      "server-hash-1"
+      {:runtime-db (payload-policy/project-runtime-db
+                     (frame/frame-runtime-db-value sfid) sfid)})))
+
+;; ---------------------------------------------------------------------------
+;; The seam works end to end
+;; ---------------------------------------------------------------------------
+
+(deftest rf-hydrate-re-arms-the-machines-after-timer-and-it-fires
+  (testing "dispatching `:rf/hydrate` with a server-produced payload leaves
+            the client frame holding a live `:after` timer whose expiry
+            performs the declared transition"
+    (let [payload (server-render! :ssrrearm/one)
+          snap    (get-in payload [:rf/runtime-db :rf.runtime/machines
+                                   :snapshots :ssrrearm/one])
+          epoch   (get-in snap [:data :rf/after-epoch [:waiting]])
+          thunks  (atom [])
+          armed   (atom [])
+          cfid    (fresh-frame! :client)]
+      (is (= :waiting (:state snap))
+          "precondition: the `:after`-bearing state rode the wire")
+      (is (and (integer? epoch) (pos? epoch))
+          "precondition: so did the per-decl-path epoch")
+      (is (empty? (inner cfid)) "precondition: the client holds no timers yet")
+
+      (with-redefs [interop/schedule-after! (fn [t ms]
+                                             (swap! thunks conj t)
+                                             (swap! armed conj ms)
+                                             ::handle)]
+        (router/dispatch-sync! [:rf/hydrate payload] {:frame cfid}))
+
+      (let [table (inner cfid)]
+        (is (= 1 (count table))
+            (str "the `:rf/hydrate` seam armed exactly one timer. Before "
+                 "rf2-jqvgp this was 0 and the machine was stuck in "
+                 ":waiting for the life of the page."))
+        (is (= {:parent :ssrrearm/one :spawn [:waiting] :delay 5000}
+               (ffirst table)))
+        (is (= epoch (:epoch (val (first table))))
+            "armed at the epoch the PAYLOAD carried — hydration must not bump")
+        (is (= [5000] @armed)
+            "for the FULL declared delay; nothing on the wire records a
+             schedule instant to compute a remainder from"))
+
+      (is (= :waiting (get-in (frame/frame-runtime-db-value cfid)
+                              [:rf.runtime/machines :snapshots :ssrrearm/one :state])))
+      (fire! (first @thunks))
+      (is (= :timeout (get-in (frame/frame-runtime-db-value cfid)
+                              [:rf.runtime/machines :snapshots :ssrrearm/one :state]))
+          "the hydrated timer FIRED and drove the declared transition")
+      (is (= 1 (get-in (frame/frame-runtime-db-value cfid)
+                       [:rf.runtime/machines :snapshots :ssrrearm/one :data :entries]))
+          (str "and `:entry` still ran exactly once — the server's. The re-arm "
+               "reconstructs host work; it does not replay history.")))))
+
+;; ---------------------------------------------------------------------------
+;; The three ways it arms nothing
+;; ---------------------------------------------------------------------------
+
+(deftest a-server-side-hydrate-arms-nothing
+  (testing "hydrating onto a `:platform :server` frame — the isomorphic
+            loopback / test-harness shape — starts no host clocks"
+    (let [payload (server-render! :ssrrearm/srv)
+          target  (fresh-frame! :server)]
+      (with-redefs [interop/schedule-after! (fn [_t _ms] ::handle)]
+        (router/dispatch-sync! [:rf/hydrate payload] {:frame target}))
+      (is (= :waiting (get-in (frame/frame-runtime-db-value target)
+                              [:rf.runtime/machines :snapshots :ssrrearm/srv :state]))
+          "the payload DID install — so the empty table below is the gate
+           working, not the hydration failing")
+      (is (empty? (inner target))
+          "no timers on a server-side hydrate"))))
+
+(deftest a-rejected-payload-arms-nothing
+  (testing "a payload the handler fails CLOSED on installs nothing and
+            therefore arms nothing"
+    (let [good (server-render! :ssrrearm/rej)
+          cfid (fresh-frame! :client)]
+      (with-redefs [interop/schedule-after! (fn [_t _ms] ::handle)]
+        ;; (a) malformed — a present-but-non-map `:rf/app-db` slice.
+        (router/dispatch-sync! [:rf/hydrate (assoc good :rf/app-db "not-a-map")]
+                               {:frame cfid})
+        (is (empty? (inner cfid)) "malformed payload: rejected, nothing armed")
+        (is (nil? (get-in (frame/frame-runtime-db-value cfid)
+                          [:rf.runtime/machines :snapshots :ssrrearm/rej]))
+            "and nothing installed either — the rejection is total")
+
+        ;; (b) wrong frame — a payload stamped for a DIFFERENT frame id.
+        (router/dispatch-sync! [:rf/hydrate (assoc good :rf/frame-id :ssrrearm/somewhere-else)]
+                               {:frame cfid})
+        (is (empty? (inner cfid)) "wrong-frame payload: rejected, nothing armed")
+
+        ;; CONTROL — the same payload, unmangled, on the same frame DOES arm.
+        ;; Without this the two assertions above would pass for a payload
+        ;; that could never arm anything in the first place.
+        (router/dispatch-sync! [:rf/hydrate good] {:frame cfid})
+        (is (= 1 (count (inner cfid)))
+            "control: the well-formed payload arms, so the rejections above
+             are about the rejection and not about the payload")))))
+
+(deftest a-payload-with-no-runtime-db-slice-arms-nothing
+  (testing "a client-only payload (no `:rf/runtime-db`) requests no re-arm —
+            there is no server-settled machine state to reconstruct from"
+    (let [good (server-render! :ssrrearm/nort)
+          cfid (fresh-frame! :client)]
+      (with-redefs [interop/schedule-after! (fn [_t _ms] ::handle)]
+        (router/dispatch-sync! [:rf/hydrate (dissoc good :rf/runtime-db)]
+                               {:frame cfid}))
+      (is (empty? (inner cfid))
+          "no runtime-db slice, no re-arm"))))


### PR DESCRIPTION
Closes rf2-jqvgp (P1).

## The defect

The server intentionally suppresses machine wall-clock timers (Spec 005 §SSR mode) and a host-clock handle cannot ride the wire. The client hydration path installed the serialized runtime-db snapshot and stopped there — it reconstructed no timer table and re-ran no machine entry. A machine hydrated while sitting in an `:after`-bearing state therefore had the right `:state`, `:data` and `:rf/after-epoch` and **no live timer**, and could sit there forever unless some unrelated external event moved it.

This contradicted [Spec 011 §`:after` is no-op under SSR](https://github.com/day8/re-frame2/blob/main/spec/011-SSR.md) ("`:after` timers begin running on the client (per the snapshot's epoch)"), [Spec 005 §SSR mode](https://github.com/day8/re-frame2/blob/main/spec/005-StateMachines.md), and `docs/machines/automatic-transitions.md` ("The client re-arms timers after hydration"). **No spec or doc wording changed in this PR — the prose was already correct and the code was the deviation.**

## The fix

A hydration-only re-arm seam, `re-frame.machines.hydrate`:

- Walks the just-installed snapshots' **active configuration**, not the spec — every node from root to leaf on a flat/compound path (a still-active *ancestor*'s `:after` is as live as the leaf's, and entry only ever schedules newly-entered nodes), each parallel region's own active path against its synthetic region-spec, and the root-owned parallel `:after` at decl-path `[]`.
- Arms one client timer per live declaration through the ordinary `schedule-after-timer!` path, at the epoch the snapshot **already carries** — never bumped.
- Runs **no cascade**: no `:entry`, `:action`, `:raise`, `:spawn` or `:always` is replayed, and no snapshot is written. Re-running entry would have re-armed the timers *and* re-fired the server's entry effects — a different and worse bug.
- Idempotent through the ordinary timer-table key: a second install supersedes rather than duplicating.

Wired as the late-bound `:machines/rearm-after-hydration!` hook plus the `:rf.machine/hydrate-rearm` fx that `hydrate-event-handler*` conjoins onto `:fx`. An fx rather than an in-handler hook call because arming host clocks is not something a pure handler may do, and because the walk must read the runtime-db *after* it commits — `commit-frame-effects!` installs both partitions before `run-fx-effects!` walks `:fx`.

Gated three ways, each independently meaning "no timers": a client platform, a server-settled `:rf/runtime-db` slice, and the hook's presence (an SSR app without the machines artefact requests nothing). The rejected paths — malformed payload, wrong frame-id — return before the handler and arm nothing either.

## Remaining duration on re-arm: the FULL declared delay

Not a preference — the only reading the durable data supports. Spec 005 §Clock abstraction states outright that `:after` scheduling reads the host clock to schedule but **never records the schedule instant**, precisely so firing stays replay-sound as a facts-against-facts epoch check rather than a wall-clock comparison. There is consequently no `scheduled-at` / `due-at` anywhere in the bounded payload to subtract from. Spec 011 gives the matching rationale: `:after` timers are state-entry-relative and "have no semantic meaning until the user is interacting with the page — i.e., until after hydration". The client's arrival is the entry, for timing purposes. The choice is stated in the namespace docstring, in the late-bind directory entry, and asserted (`armed == [5000]`) in both test namespaces.

## Epoch restore does NOT share the hole

Checked at source rather than assumed. `:machines/on-frame-restored!` → `timer/cancel-frame-timers-on-restore!` **cancels** the restored frame's in-flight handles, one `:rf.machine.timer/cancelled :reason :on-restore` per entry, and deliberately does not re-arm — Managed-Effects §SSR, preload, hydration, and restore rules that "epoch restore MUST NOT revive host work". That is correct behaviour under a different contract, not the same defect: restore rewinds a timeline whose host work already ran, while hydration establishes host work that was never armed at all. The asymmetry is now documented in both directions (the new hook's directory entry and the `hydrate` namespace docstring both name restore as the deliberate opposite). Restore is untouched by this PR and its existing coverage is unchanged.

## Evidence: the timers FIRE

Both new namespaces capture the host-clock thunk and **invoke** it, then assert the machine transitioned. A structural "the table is non-empty" assertion would have passed throughout this defect's life had the table been populated with anything inert.

- `implementation/machines/test/re_frame/machine_after_hydration_rearm_cljs_test.cljc` — 10 tests: flat fire, no entry replay, idempotence, compound ancestor+leaf (fires the *ancestor* timer, the one an entry-shaped fix misses), region + root-parallel (fires the region timer and checks the sibling region is untouched), dynamic sub-vec delay resolved on the client and reaped on fire, plus negative controls (no active `:after`, server frame, unresolvable snapshot) and the `/scheduled` trace shape.
- `implementation/ssr/test/re_frame/ssr/machine_after_rearm_cljs_test.cljc` — 4 tests through the real `:rf/hydrate` event, on a payload built by the shipped projector + assembler: fire end to end, server-side hydrate arms nothing, rejected (malformed / wrong-frame) payloads arm nothing *with a control proving the same payload does arm*, and a client-only payload arms nothing.

Every snapshot hydrated in these tests is produced by running the machine on a real `:platform :server` frame, and each helper asserts that frame armed nothing — so the fixtures cannot drift into hydrating a snapshot the server would never produce, and the server-skip contract is re-measured on every run.

**Red-before, measured:** neutralising `rearm-after-timers!` takes the machines namespace to 28 failures / 4 errors, the errors being "no thunk was ever captured" — i.e. nothing armed, which is the defect. Restored and verified by git blob hash.

## Notes for review

- No new trace id and no new error id: hydrated timers emit the ordinary `:rf.machine.timer/scheduled` row, so the existing scheduled→fired / →cancelled pairing on `(actor-id, state, epoch)` holds for a hydrated timer exactly as for an entered one.
- `transition/nodes-along-path` and `transition/node-epoch` become public (no behaviour change) so the hydration walk reuses the cascade's own enumeration and the flat/per-region epoch-slot rule rather than restating them.
- No public var added to the `re-frame.machines` facade, so the public-API manifest is unchanged.
- `implementation/core/src/re_frame/late_bind/directory.cljc` gains the new hook's inventory row, which `late_bind_drift_test` requires.
- Markdown gates: no markdown changed in this PR.
- Adjacent and untouched: rf2-nb8nj (machines tracing / macrostep cascade) — this change runs no cascade at all; rf2-mocn3 (SSR Form-2 arity fallback) — the only SSR file touched is the hydration seam itself.
