### PR TITLE
docs(spec/005): the last bare machines/ call spelling takes the canonical rf.machines alias (rf2-ur6kh)

### DIFF
--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -4097,7 +4097,7 @@ Three test levels fall out naturally from the pure-factory contract on `make-mac
 
 ```clojure
 (let [{:keys [status snapshot fx error]}
-      (machines/machine-transition definition snapshot event)]
+      (rf.machines/machine-transition definition snapshot event)]
   (case status
     :ok    [snapshot fx]                            ;; post-transition snapshot + emitted fx
     :error (throw (ex-info "transition failed" error))))


### PR DESCRIPTION
One line in `spec/005-StateMachines.md`.

## What changed

The Level 1 testing fence in `spec/005-StateMachines.md` carried
`(machines/machine-transition definition snapshot event)`. `spec/Conventions.md`
§Require-alias dialect makes `rf.machines` the canonical alias for
`re-frame.machines` and reserves the bare `:as machines` **for an application's
own namespaces**. It now reads `rf.machines/machine-transition`.

PR #8905 corrected this file's `rf/`-prefixed machines helpers and did not touch
bare-alias ones, which is why the site survived that pass.

## No require clause was added — the document already has one

The bead reads the site as a fence "with no require beside it, so a reader
copying the fence gets an alias that is never introduced". That is right about
the *defect* and it is the reason the bare spelling had to go — but the remedy is
the rename alone, because **this document already introduces the alias once, for
the whole file**, at line 3932:

> Require it under the conventional dotted alias, `[re-frame.machines :as rf.machines]`,
> per Conventions §Require-alias dialect; the `rf.machines/` spellings **below**
> assume exactly that alias.

The corrected line is 168 lines *below* that sentence, so it is covered by it
verbatim. The bare `machines` alias was the thing introduced nowhere; `rf.machines`
is introduced, deliberately and document-scoped.

Two further facts point the same way:

- **44 other `rf.machines/` call spellings already live in this file** (PR #8905's
  work) and **not one of them carries a local require** — line 3932 is the file's
  single, deliberate introduction. A require here alone would contradict that
  design.
- The sibling **Level 2** fence eleven lines below already spells
  `rf.machines/make-machine-handler` bare of any require.

The alias is also mechanical under the Conventions dialect (`re-frame.<leaf>`
takes `rf.<leaf>`), so `rf.machines/` names its own origin in a way the reserved
bare `machines/` cannot.

## Census — re-derived, not inherited

Class: the bare alias token `machines` qualifying a **published
`re-frame.machines` helper**. The helper roster is *derived*, not hardcoded —
the 23 ``### `re-frame.machines/<name>` `` headings of
`docs/api/re-frame.machines.md`. Over all **974 tracked markdown files**, from
one command producing the total and the per-file rows together.

**Before this PR — 24 hits in 7 files:**

| Count | File |
|---:|---|
| 14 | `docs/api/re-frame.machines.md` |
| 4 | `docs/machines/inspecting-machines.md` |
| 2 | `docs/machines/tutorial.md` |
| 1 | `docs/machines/concepts.md` |
| 1 | `spec/008-Testing.md` |
| 1 | `spec/Construction-Prompts.md` |
| 1 | **`spec/005-StateMachines.md`** ← this PR |
| **24** | **7 files** |

**After this PR — 23 hits in 6 files**, `spec/005-StateMachines.md` gone from the
list and every other row unchanged.

### "Last of the class" — correct, but conditional

**23 of those 24 are PR #8912's fence, and #8912 has NOT merged** (state `OPEN`,
head `c50fb15a86`, on `worker/machnames-lzrza`). The bead's census was taken *at
#8912's tip*, so "last of the class" is true **conditional on #8912 landing**; on
`main` today the class is 24 sites, not one. This PR touches only the site outside
that fence, so the two do not conflict, and #8912 remains the one that closes the
class.

### The two traps, handled explicitly

- **The keyword form was excluded deliberately.** A fixed-string search for
  `machines/` matches `:machines/…` as well. A leading `:` sits in the negative
  lookbehind character class, which drops **27** keyword occurrences that are not
  call sites. The same lookbehind (`.` and `-`) excludes `rf.machines/`,
  `re-frame.machines/` and `day8.re-frame2-machines/`.
- **The census ran twice — line-oriented and whitespace-spanning** (whitespace,
  newlines included, tolerated inside the `machines / helper` token), because a
  line-oriented search cannot see a target broken across two lines and a control
  sharing that shape is invisible identically. **Both passes agreed at 24 before
  and 23 after; the delta is empty in both directions.**

A broad tier over bare `machines/<anything>` returned 76 with every off-roster
token listed, so nothing is dropped silently: the extra 53 are file paths
(`machines/transition.cljc`, `machines/parallel.cljc`), MCP op names
(`machines/list`, `machines/describe`) and prose slashes (`machines/routes`,
`machines/routing`) — none of them alias call spellings.

Non-vacuity control on the census itself: the canonical `rf.machines/` spelling
occurs **112** times across tracked markdown, 44 of them in this very file.

Live `:as machines` require aliases in `implementation/` and `tools/` **source**
are untouched, consistent with rf2-qt7au: that is a compile surface across ~124
files, and rf2-qt7au left open whether Conventions should instead be amended to
match it.

## Gate

`spec` is in `scripts/check_doc_slugs.py`'s `DEFAULT_ROOTS` (verified at source,
not by job name), so that is the gate. Run to completion with the exit code
captured on one command line, on the final rebased base: **exit 0**.

**No gate covers the content of this change, and that is stated plainly rather
than papered over.** Neither documentation gate reads inside fenced code blocks —
they share one extractor that strips fences before reading a link — and this edit
is *inside* a fence. `mkdocs build --strict` is not a candidate either:
`mkdocs.yml`'s `docs_dir` is `docs`, so `spec/` is outside it entirely, and
`--strict` promotes WARNING but not the INFO at which MkDocs grades a missing
anchor.

The changed line was therefore **hand-checked**: a one-token symbol rename inside
a `clojure` fence — no link, no anchor, no table, no heading. The fence's
destructuring (`status`, `snapshot`, `fx`, `error`) and its `definition` /
`snapshot` / `event` arguments are untouched, the form still reads as valid
Clojure, and the spelling now matches both the alias line 3932 introduces and the
44 other `rf.machines/` call sites in this file.

The gate was proven **non-vacuous against this worktree** by planting a broken
anchor in *prose* at line 4096 (a fault inside a fence would be invisible to it).
The gate went **red, exit 1**, naming the planted target at the exact file and
line — `BROKEN ANCHOR: spec/005-StateMachines.md:4096` — which also proves it read
this tree and not a sibling's. The plant was then restored and the restore
verified **by git blob hash against the committed object** (`78457e35d2…`, match)
rather than by reading a diff, and the gate re-run green.
