### PR TITLE
fix(story): decide share/address-bar query ownership on decoded key names

### DIFF
--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -91,6 +91,26 @@
   #?(:clj  (java.net.URLEncoder/encode (str s) "UTF-8")
      :cljs (js/encodeURIComponent (str s))))
 
+(defn- ^:no-doc url-decode
+  "Percent-decode one query-component `s` the way `URLSearchParams` does,
+  or nil when `s` is not decodable at all (a lone `%`, a truncated
+  escape). Nil rather than a throw or a passthrough because the only
+  caller is an ownership TEST: an undecodable fragment is by definition
+  not one of Story's plain-ASCII keys, so it must fall through and be
+  preserved verbatim (rf2-b7je1 audit) — never dropped, and never
+  allowed to abort the merge.
+
+  `+` is a space in a query component, so both hosts must treat it as
+  one: `java.net.URLDecoder` already does, and the CLJS arm folds it to
+  `%20` before `decodeURIComponent`, which does not. Without that the
+  two hosts could classify the same URL differently, and the JVM tests
+  would stop being evidence about the browser."
+  [s]
+  #?(:clj  (try (java.net.URLDecoder/decode (str s) "UTF-8")
+                (catch Exception _ nil))
+     :cljs (try (js/decodeURIComponent (str/replace (str s) "+" "%20"))
+                (catch :default _ nil))))
+
 (defn- ^:no-doc kw->str
   "Render a keyword as a stable string `prefix:name` or `name`. Used so
   the URL params don't carry the `:` colon prefix Clojure keywords
@@ -382,14 +402,23 @@
     [(or url "") nil]))
 
 (defn- ^:no-doc query-param-key
-  "Key half of an already-encoded `k=v` query fragment — the text
-  before the first `=`, or the whole fragment when it carries none.
-  Compared in encoded form: every Story-owned key is plain ASCII, so
-  its encoded spelling is its literal name."
+  "DECODED key half of an encoded `k=v` query fragment — the text before
+  the first `=` (or the whole fragment when it carries none), run
+  through `url-decode`. Returns nil for a key half that does not decode.
+
+  Decoded, not raw (rf2-b7je1 audit): the consumer of this query is
+  `URLSearchParams`, which compares key NAMES after percent-decoding, so
+  `%76ariant=` IS `variant=` to the browser. Matching raw text instead
+  leaves such a spelling standing, the generated `variant=` is appended
+  after it, and `.get` — first-value — hands the hydrator the stale one.
+  Only the key half is decoded; the value half and the fragment's own
+  bytes are never rewritten, so unrelated and malformed entries survive
+  verbatim and in order."
   [fragment]
-  (if-let [idx (str/index-of fragment "=")]
-    (subs fragment 0 idx)
-    fragment))
+  (url-decode
+    (if-let [idx (str/index-of fragment "=")]
+      (subs fragment 0 idx)
+      fragment)))
 
 (defn apply-story-params
   "Rewrite `base-url`'s query so the Story vocabulary reads exactly the
@@ -421,12 +450,21 @@
   only what is emitted leaves a stale `modes=` standing when the caller
   requests no modes at all.
 
+  Ownership is decided on the DECODED key name, because that is the
+  comparison `URLSearchParams` makes (rf2-b7je1 audit). A base-url
+  spelling a Story key with escapes — `%76ariant=`, which is a perfectly
+  valid way to write `variant=` — is the same key to the browser, so
+  matching raw text would preserve it, append the generated `variant=`
+  behind it, and hand the hydrator the stale value through `.get`.
+  Nothing else is normalised: kept fragments are re-emitted byte-for-byte
+  in their original order, escapes and all.
+
   Pure data → data; JVM + CLJS-portable."
   [base-url params]
   (let [[path fragment] (split-fragment base-url)
         qidx            (str/index-of path "?")
         bare            (if qidx (subs path 0 qidx) path)
-        owned           (into #{} (map (comp url-encode name)) story-query-keys)
+        owned           (into #{} (map name) story-query-keys)
         kept            (when qidx
                           (->> (str/split (subs path (inc qidx)) #"&" -1)
                                (remove #(contains? owned (query-param-key %)))))

--- a/tools/story/test/re_frame/story/ui/url_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/url_state_cljs_test.cljs
@@ -112,6 +112,79 @@
       (is (str/ends-with? url "#/stories")
           "the hash route survives, after the query"))))
 
+;; ---- rf2-b7je1: the LIVE address bar owns escaped key spellings ---------
+;;
+;; Unifying the two writers on `share/apply-story-params` carried the
+;; share builder's last ownership hole onto the address bar: ownership was
+;; matched on raw key text, while the `URLSearchParams` this shell reads
+;; with compares DECODED names. A `location.search` spelling a Story key
+;; with escapes therefore survived a state-driven push, the generated
+;; value was appended behind it, and the next reload's `.get` —
+;; first-value — restored the stale cell. Asserted against the real
+;; browser API, on the address-bar writer specifically: the repair is in
+;; the shared helper, so this and the share-builder pin move together.
+
+(deftest url-from-state-clears-escaped-story-keys-through-urlsearchparams
+  (testing "rf2-b7je1 audit — `%76ariant=` IS `variant=` to the browser, so
+            a state-driven push must clear it rather than append behind it;
+            read back through the API the next mount will actually use"
+    (let [url (us/url-from-state
+                {:selected-variant :story.new/b}
+                {:pathname "/p/"
+                 :search   "?%76ariant=story.old%2Fa&embed=1"
+                 :hash     "#/stories"})
+          usp (js/URLSearchParams.
+                (second (str/split (first (str/split url #"#" 2)) #"\?" 2)))]
+      (is (= "story.new/b" (.get usp "variant"))
+          "the reload reads the cell this state asked for, not the stale one")
+      (is (= 1 (count (.getAll usp "variant")))
+          "exactly one variant value — the escaped one is gone, not outranked")
+      (is (= "1" (.get usp "embed"))
+          "embed=1 survives — chrome state Story does not own")
+      (is (= "/p/?embed=1&variant=story.new%2Fb#/stories" url)
+          "and the composed string is exactly that, in order"))))
+
+(deftest url-from-state-clears-every-escaped-story-key-cljs
+  (testing "rf2-b7je1 audit — the whole vocabulary spelled with escapes.
+            Derived from `share/story-query-keys`, so a key added to the
+            vocabulary is covered without editing this test."
+    (let [escape #(str "%" (.toUpperCase (.toString (.charCodeAt % 0) 16))
+                       (subs % 1))
+          stale  {"variant"    "story.old%2Fa"
+                  "workspace"  "story.old%2Fws"
+                  "mode-tab"   "docs"
+                  "modes"      "Mode.app%2Fstale"
+                  "viewport"   "tablet"
+                  "background" "dark"
+                  "tag-filter" "stale"
+                  "overrides"  "%7B%3Afoo%201%7D"
+                  "substrate"  "uix"}
+          search (str "?"
+                      (str/join "&" (map #(str (escape (name %))
+                                               "="
+                                               (get stale (name %)))
+                                         share/story-query-keys))
+                      "&from=index&embed=1")
+          url    (us/url-from-state
+                   {:selected-variant :story.new/b}
+                   {:pathname "/p/" :search search :hash "#/stories"})
+          usp    (js/URLSearchParams.
+                   (second (str/split (first (str/split url #"#" 2)) #"\?" 2)))]
+      (is (= (set (map name share/story-query-keys)) (set (keys stale)))
+          "the fixture carries a stale value for every key in the vocabulary")
+      (is (= "story.new/b" (.get usp "variant"))
+          "URLSearchParams.get returns the variant this state asked for")
+      (is (= 1 (count (.getAll usp "variant")))
+          "exactly one variant value")
+      (doseq [k (map name share/story-query-keys)
+              :when (not= k "variant")]
+        (is (zero? (count (.getAll usp k)))
+            (str "URLSearchParams sees no stale " k "= at all")))
+      (is (= "index" (.get usp "from")) "unrelated from= survives")
+      (is (= "1" (.get usp "embed")) "unrelated embed= survives")
+      (is (= "/p/?from=index&embed=1&variant=story.new%2Fb#/stories" url)
+          "every escaped Story key is cleared; both unowned params survive"))))
+
 (deftest url-from-state-consumes-a-browser-shaped-location
   (testing "rf2-gee8n — `current-location-shape` snapshots the browser's own
             {pathname, search, hash} triple off `window.location`. Drive the

--- a/tools/story/test/re_frame/story/ui/url_state_test.cljc
+++ b/tools/story/test/re_frame/story/ui/url_state_test.cljc
@@ -192,6 +192,74 @@
                {:pathname pathname :search search :hash hash}))
           "same base + same cell ⇒ same URL from either writer"))))
 
+;; ---- rf2-b7je1: the address bar owns ESCAPED spellings too --------------
+;;
+;; Unifying the two writers on `share/apply-story-params` carried the
+;; share builder's remaining ownership hole onto the LIVE address bar:
+;; ownership was matched on raw key text while `URLSearchParams` compares
+;; DECODED names, so a `location.search` spelling a Story key with escapes
+;; survived and the generated value was appended behind it. `.get` is
+;; first-value, so the next reload restored the stale cell — the very
+;; thing sharing one merge was supposed to make impossible. The pin is on
+;; the address-bar writer specifically: the repair lives in the shared
+;; helper, so this and the share-builder half must move together or not
+;; at all.
+
+(deftest url-from-state-clears-percent-encoded-story-keys
+  (testing "rf2-b7je1 audit — `%76ariant=` IS `variant=` to the browser, so
+            a state-driven push must clear it rather than append behind it"
+    (is (= "/p/?embed=1&variant=story.new%2Fb#/stories"
+           (us/url-from-state
+             {:selected-variant :story.new/b}
+             {:pathname "/p/"
+              :search   "?%76ariant=story.old%2Fa&embed=1"
+              :hash     "#/stories"}))
+        "the escaped stale key is gone; unowned embed=1 survives, in order")))
+
+(deftest url-from-state-clears-every-escaped-story-key
+  (testing "rf2-b7je1 audit — the whole vocabulary, spelled with escapes:
+            every Story key goes, both unowned params stay. Derived from
+            `share/story-query-keys` so a key added to the vocabulary is
+            covered here without editing this test."
+    (let [escape #(str "%" (format "%02X" (int (first %))) (subs % 1))
+          stale  {"variant"    "story.old%2Fa"
+                  "workspace"  "story.old%2Fws"
+                  "mode-tab"   "docs"
+                  "modes"      "Mode.app%2Fstale"
+                  "viewport"   "tablet"
+                  "background" "dark"
+                  "tag-filter" "stale"
+                  "overrides"  "%7B%3Afoo%201%7D"
+                  "substrate"  "uix"}
+          search (str "?"
+                      (str/join "&" (map #(str (escape (name %))
+                                               "="
+                                               (get stale (name %)))
+                                         share/story-query-keys))
+                      "&from=index&embed=1")]
+      (is (= (set (map name share/story-query-keys)) (set (keys stale)))
+          "the fixture carries a stale value for every key in the vocabulary")
+      (is (= "/p/?from=index&embed=1&variant=story.new%2Fb#/stories"
+             (us/url-from-state
+               {:selected-variant :story.new/b}
+               {:pathname "/p/" :search search :hash "#/stories"}))
+          "every escaped Story key is cleared; both unowned params survive"))))
+
+(deftest url-from-state-and-share-builder-agree-on-escaped-keys
+  (testing "rf2-b7je1 audit — one merge, one boundary: the fix must not
+            have taught only one of the two writers about escaped keys"
+    (let [pathname "/counter-with-stories/"
+          search   "?%76ariant=story.old%2Fa&embed=1&%73ubstrate=uix"
+          hash     "#/stories"]
+      (is (= (share/variant-share-url
+               :story.new/b
+               (str pathname search hash)
+               {:substrate :reagent})
+             (us/url-from-state
+               {:selected-variant :story.new/b :substrate :reagent}
+               {:pathname pathname :search search :hash hash}))
+          "same base + same cell ⇒ same URL from either writer"))))
+
 ;; ---- url-relevant-slots-changed? ----------------------------------------
 
 (deftest url-relevant-slots-changed-detects-variant-change

--- a/tools/story/test/re_frame/story_share_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_share_cljs_test.cljs
@@ -117,6 +117,121 @@
       (is (= "1" (.get usp "embed")) "unrelated embed= survives")
       (is (str/ends-with? url "#/stories") "the hash route survives"))))
 
+;; ---- rf2-b7je1 (audit reopen 2): ownership compares DECODED key names ----
+;;
+;; This is the arm that matters, because the disagreement is with a real
+;; browser API rather than with an emulation of one. Ownership was
+;; matched on the fragment's RAW key text; `URLSearchParams` compares key
+;; names after percent-decoding. So `%76ariant=` — a valid spelling of
+;; `variant=` — was a different string to the builder and the SAME key to
+;; the browser: the stale entry survived, the generated one was appended
+;; behind it, and `.get` (first-value) handed the hydrator the stale
+;; value. Asserted through `js/URLSearchParams` itself, so the pin cannot
+;; drift from what the shell will actually read.
+
+(defn- escape-first-char
+  "Spell `k` with its leading character percent-encoded — \"variant\" →
+  \"%76ariant\". Browser-equivalent to `k`, and sharing no prefix with
+  it, so a raw-text ownership test cannot match it."
+  [k]
+  (str "%"
+       (.toUpperCase (.toString (.charCodeAt k 0) 16))
+       (subs k 1)))
+
+(defn- search-of
+  "The query-string portion of `url` — between `?` and any `#`."
+  [url]
+  (second (str/split (first (str/split url #"#" 2)) #"\?" 2)))
+
+(deftest escaped-story-keys-are-the-same-keys-to-urlsearchparams
+  (testing "rf2-b7je1 — the fixture below is only a regression if the real
+            URLSearchParams reads the escaped spellings as the owned keys.
+            Pin that against the browser API before relying on it."
+    (doseq [k (map name share/story-query-keys)]
+      (let [esc (escape-first-char k)
+            usp (js/URLSearchParams. (str esc "=x"))]
+        (is (not= esc k)
+            (str k " is genuinely respelled, so raw matching cannot see it"))
+        (is (= "x" (.get usp k))
+            (str "URLSearchParams reads " esc " as the key " k))))))
+
+(deftest variant-share-url-owns-percent-encoded-keys-cljs
+  (testing "rf2-b7je1 audit — a base-url spelling every Story key with an
+            escape is carrying those keys as far as the browser is
+            concerned. Read the result back through the REAL
+            URLSearchParams the hydrator uses: one value for each key this
+            call emits, none at all for the ones it omits, unrelated
+            params untouched."
+    (let [stale  {"variant"    "story.old%2Fa"
+                  "workspace"  "story.old%2Fws"
+                  "mode-tab"   "docs"
+                  "modes"      "Mode.app%2Fstale"
+                  "viewport"   "tablet"
+                  "background" "dark"
+                  "tag-filter" "stale"
+                  "overrides"  "%7B%3Afoo%201%7D"
+                  "substrate"  "uix"}
+          base   (str "https://example.test/?"
+                      (str/join "&" (map #(str (escape-first-char (name %))
+                                               "="
+                                               (get stale (name %)))
+                                         share/story-query-keys))
+                      "&from=index&embed=1#/stories")
+          url    (share/variant-share-url
+                   :story.new/b
+                   base
+                   {:active-modes [:Mode.app/dark]})
+          usp    (js/URLSearchParams. (search-of url))]
+      (is (= (set (map name share/story-query-keys)) (set (keys stale)))
+          "the fixture carries a stale value for every key in the vocabulary")
+      (is (= "story.new/b" (.get usp "variant"))
+          "URLSearchParams.get returns the requested variant, not the stale one")
+      (is (= "Mode.app/dark" (.get usp "modes"))
+          "URLSearchParams.get returns the requested modes")
+      (is (= 1 (count (.getAll usp "variant")))
+          "exactly one variant value the browser can see")
+      (is (= 1 (count (.getAll usp "modes")))
+          "exactly one modes value the browser can see")
+      (doseq [k (map name share/story-query-keys)
+              :when (not (#{"variant" "modes"} k))]
+        (is (zero? (count (.getAll usp k)))
+            (str "URLSearchParams sees no stale " k "= at all")))
+      (let [parsed (share/parse-params
+                     (into {} (map (fn [k] [k (.get usp k)]))
+                           (map name share/story-query-keys)))]
+        (is (= :story.new/b (:variant-id parsed))
+            "the hydrator's own read path recovers the requested variant")
+        (is (= [:Mode.app/dark] (:active-modes parsed))
+            "and the requested modes")
+        (doseq [slot [:workspace-id :mode-tab :viewport :background
+                      :tag-filter :cell-overrides :substrate]]
+          (is (nil? (get parsed slot))
+              (str "parse-params restores no stale " slot))))
+      (is (= "index" (.get usp "from")) "unrelated from= survives")
+      (is (= "1" (.get usp "embed")) "unrelated embed= survives")
+      (is (str/ends-with? url "#/stories") "the hash route survives"))))
+
+(deftest undecodable-and-unowned-keys-survive-cljs
+  (testing "rf2-b7je1 audit — decoding is an ownership TEST, not a rewrite.
+            A key half js/decodeURIComponent throws on is preserved
+            byte-for-byte, and `mode+tab` reads as `mode tab` to the
+            browser, so it is not Story's `mode-tab` and must stay."
+    (let [url (share/variant-share-url
+                :story.new/b
+                "https://example.test/?%zz=keepme&100%=raw&mode+tab=notmine&from=index"
+                nil)
+          usp (js/URLSearchParams. (search-of url))]
+      (is (str/starts-with?
+            url
+            "https://example.test/?%zz=keepme&100%=raw&mode+tab=notmine&from=index&variant=")
+          "every undecodable / unowned entry survives verbatim and in order")
+      (is (= 1 (count (.getAll usp "variant")))
+          "the generated variant= is still the only one")
+      (is (= "notmine" (.get usp "mode tab"))
+          "the browser reads mode+tab as `mode tab` — not Story's key")
+      (is (zero? (count (.getAll usp "mode-tab")))
+          "and nothing of Story's was cleared on its account"))))
+
 (deftest parse-share-url-params-cljs
   (testing "CLJS parser reconstructs the share URL tokens used by the shell hydrator"
     (is (= :story.counter/loaded

--- a/tools/story/test/re_frame/story_share_test.clj
+++ b/tools/story/test/re_frame/story_share_test.clj
@@ -252,6 +252,118 @@
       (is (str/ends-with? url "#/stories")
           "the hash route survives, after the query"))))
 
+;; ---- rf2-b7je1 (audit reopen 2): ownership compares DECODED key names ----
+;;
+;; The clear set was matched against the fragment's RAW key text. The
+;; consumer is `URLSearchParams`, which compares key names after percent-
+;; decoding, so `%76ariant=` — a valid spelling of `variant=` — is the
+;; SAME key to the browser and a different string to the builder. The
+;; stale entry therefore survived, the generated `variant=` was appended
+;; behind it, and `.get` (first-value) handed the hydrator the stale
+;; value: the original bug, reached through the key half instead of the
+;; value half.
+
+(defn- escape-first-char
+  "Spell `k` with its leading character percent-encoded — `\"variant\"` →
+  `\"%76ariant\"`. A valid, browser-equivalent spelling of the same key
+  that shares no prefix with the literal name, so a raw-text ownership
+  test cannot match it."
+  [k]
+  (str "%" (format "%02X" (int (first k))) (subs k 1)))
+
+(defn- decoded-key-count
+  "How many query fragments of `url` carry key `k` once the key half is
+  percent-decoded — i.e. how many values `URLSearchParams.getAll` would
+  report for `k`."
+  [url k]
+  (->> (str/split (or (query-part url) "") #"&")
+       (filter #(= k (java.net.URLDecoder/decode
+                       (first (str/split % #"=" 2)) "UTF-8")))
+       count))
+
+(def ^:private escaped-stale-base-url
+  "Base URL carrying a stale value for every Story key, each key spelled
+  with its first character percent-encoded, plus two unrelated params
+  and a hash route."
+  (str "https://example.test/?"
+       (str/join "&" (map #(str (escape-first-char (name %))
+                                "="
+                                (get stale-story-params (name %)))
+                          share/story-query-keys))
+       "&from=index&embed=1#/stories"))
+
+(deftest escaped-story-keys-are-the-same-keys-to-the-browser
+  (testing "rf2-b7je1 — the fixture is only a regression if the escaped
+            spellings really are the owned keys after decoding; pin that
+            before asserting anything about them"
+    (doseq [k (map name share/story-query-keys)]
+      (let [esc (escape-first-char k)]
+        (is (not= esc k)
+            (str k " is genuinely respelled, so raw matching cannot see it"))
+        (is (= k (java.net.URLDecoder/decode esc "UTF-8"))
+            (str esc " decodes to " k))))))
+
+(deftest variant-share-url-owns-percent-encoded-key-spellings
+  (testing "rf2-b7je1 audit — a base-url spelling the Story keys with
+            escapes (%76ariant=) is carrying those keys as far as the
+            browser is concerned. The builder must clear them, leaving one
+            effective value per owned key, while unrelated params, their
+            order, and the hash route survive."
+    (let [url    (share/variant-share-url
+                   :story.new/b
+                   escaped-stale-base-url
+                   {:active-modes [:Mode.app/dark]})
+          getter (first-value-getter url)
+          parsed (share/parse-params getter)]
+      (is (= 1 (decoded-key-count url "variant"))
+          "exactly one variant= the browser can see — the requested one")
+      (is (= 1 (decoded-key-count url "modes"))
+          "exactly one modes= the browser can see — the requested one")
+      (doseq [k (map name share/story-query-keys)
+              :when (not (#{"variant" "modes"} k))]
+        (is (zero? (decoded-key-count url k))
+            (str "stale escaped " k "= is cleared, not merely outranked")))
+      (is (= "story.new/b" (get getter "variant"))
+          "browser first-value read sees the requested variant")
+      (is (= "Mode.app/dark" (get getter "modes"))
+          "browser first-value read sees the requested modes")
+      (is (= :story.new/b (:variant-id parsed))
+          "parse-params reconstructs the requested variant")
+      (is (= [:Mode.app/dark] (:active-modes parsed))
+          "parse-params reconstructs the requested modes")
+      (doseq [slot [:workspace-id :mode-tab :viewport :background
+                    :tag-filter :cell-overrides :substrate]]
+        (is (nil? (get parsed slot))
+            (str "parse-params restores no stale " slot)))
+      (is (= "index" (get getter "from"))
+          "unrelated from= survives with its value")
+      (is (= "1" (get getter "embed"))
+          "unrelated embed= survives — chrome state, never Story's")
+      (is (str/starts-with? url "https://example.test/?from=index&embed=1&variant=")
+          "unrelated entries keep their order ahead of the generated params")
+      (is (str/ends-with? url "#/stories")
+          "the hash route survives, after the query"))))
+
+(deftest apply-story-params-preserves-undecodable-and-unowned-keys
+  (testing "rf2-b7je1 audit — decoding is an ownership TEST, never a
+            rewrite. A key half that does not decode at all falls through
+            and is preserved byte-for-byte; so is a key that decodes to
+            something Story does not own. `mode+tab` is the sharp case:
+            `+` is a space in a query component, so the browser reads it
+            as `mode tab`, which is NOT `mode-tab`."
+    (let [url (share/variant-share-url
+                :story.new/b
+                "https://example.test/?%zz=keepme&100%=raw&mode+tab=notmine&from=index"
+                nil)]
+      (is (str/starts-with?
+            url
+            "https://example.test/?%zz=keepme&100%=raw&mode+tab=notmine&from=index&variant=")
+          "every undecodable / unowned entry survives verbatim and in order")
+      (is (= 1 (decoded-key-count url "variant"))
+          "the generated variant= is still the only one")
+      (is (zero? (decoded-key-count url "mode-tab"))
+          "mode+tab is not mode-tab, so nothing of Story's was cleared"))))
+
 (deftest variant-share-url-inserts-query-before-hash-route
   (testing "hash-routed Story links keep query params in location.search"
     (let [url (share/variant-share-url

--- a/tools/story/test/re_frame/story_share_test.clj
+++ b/tools/story/test/re_frame/story_share_test.clj
@@ -274,11 +274,13 @@
 (defn- decoded-key-count
   "How many query fragments of `url` carry key `k` once the key half is
   percent-decoded — i.e. how many values `URLSearchParams.getAll` would
-  report for `k`."
+  report for `k`. An undecodable key half counts for no key at all, the
+  same fall-through the builder applies to it."
   [url k]
   (->> (str/split (or (query-part url) "") #"&")
-       (filter #(= k (java.net.URLDecoder/decode
-                       (first (str/split % #"=" 2)) "UTF-8")))
+       (filter #(= k (try (java.net.URLDecoder/decode
+                            (first (str/split % #"=" 2)) "UTF-8")
+                          (catch IllegalArgumentException _ nil))))
        count))
 
 (def ^:private escaped-stale-base-url


### PR DESCRIPTION
Closes the third and last ownership hole on the Story share URL (rf2-b7je1).

## The defect

`share/apply-story-params` matched its owned-key set against the **raw key
text** of each existing query fragment. The consumer is `URLSearchParams`,
which compares key names **after percent-decoding** — so `%76ariant=`, a
perfectly valid spelling of `variant=`, was a different string to the builder
and the *same key* to the browser. The stale entry survived the clear, the
generated `variant=` was appended behind it, and `.get` (first-value) handed
the hydrator the stale value.

Because PR #8884 unified the share builder and the address-bar writer on this
one helper, the same defect reached **live state-driven URL writes**. Measured
through the real `url-from-state` before the fix:

```
search:  ?%76ariant=story.old%2Fa&embed=1
state:   :story.new/b
result:  /p/?%76ariant=story.old%2Fa&embed=1&variant=story.new%2Fb#/stories
```

Real `URLSearchParams` over that: `getAll("variant")` is
`["story.old/a", "story.new/b"]`, `get("variant")` is `"story.old/a"`. The next
reload restores the stale cell.

## The repair

The ownership test now decodes **the key half only**, via a new tolerant
`url-decode` beside `url-encode`:

- Values, unrelated entries and their order are untouched — kept fragments are
  re-emitted byte-for-byte, escapes and all. Decoding is an ownership *test*,
  never a rewrite.
- A key half that does not decode at all (a lone `%`, a truncated escape)
  yields nil, falls through, and is preserved verbatim rather than dropped or
  allowed to abort the merge.
- `+` is folded to a space on both hosts, so JVM and CLJS classify the same URL
  identically and `URLSearchParams` agrees with both. `mode+tab` reads as
  `mode tab`, which is *not* Story's `mode-tab`, so it is correctly preserved.

The repair stays in the shared helper: still exactly one merge path and one
ownership boundary, so neither writer can drift from the other. No API
redesign — `variant-share-url`'s signature, the codec and the public surface
are untouched, and `story-query-keys` is unchanged.

No spec change: `tools/story/spec/005-SOTA-Features.md` §Share URL already
states the invariant this restores.

## Coverage

Six fixtures across both hosts, all **derived from `share/story-query-keys`**
so a key added to the vocabulary is covered without editing them:

| Host | Share builder | Address bar |
| --- | --- | --- |
| JVM | `variant-share-url-owns-percent-encoded-key-spellings` | `url-from-state-clears-percent-encoded-story-keys`, `url-from-state-clears-every-escaped-story-key` |
| CLJS (real `URLSearchParams`) | `variant-share-url-owns-percent-encoded-keys-cljs` | `url-from-state-clears-escaped-story-keys-through-urlsearchparams`, `url-from-state-clears-every-escaped-story-key-cljs` |

Plus `apply-story-params-preserves-undecodable-and-unowned-keys` (JVM) and
`undecodable-and-unowned-keys-survive-cljs`, pinning that malformed and
unowned entries survive byte-for-byte; and two guards that pin the *fixtures*
against the browser before anything relies on them
(`escaped-story-keys-are-the-same-keys-to-the-browser`, and its CLJS sibling
which asserts against `js/URLSearchParams` itself).

`url-from-state-and-share-builder-agree-on-escaped-keys` pins that the fix
reached both writers rather than one.

## Evidence

Runner-captured exits (`echo $?` in the same shell as the redirect), on the
final rebased base:

| Gate | Exit | Result |
| --- | --- | --- |
| JVM focused (share + url-state) | 0 | 99 tests / 264 assertions |
| JVM full `tools/story` | 0 | 1887 tests / 6939 assertions |
| JVM full `tools/story-mcp` | 0 | 279 tests / 1476 assertions |
| CLJS `node-test` compile | 0 | 1869 files, 0 warnings |
| CLJS focused (share + url-state) | 0 | 23 tests / 173 assertions |
| CLJS full consolidated suite | 0 | 11131 tests / 55032 assertions |

**Control** — the property removed on ONE line (`url-decode` → `identity` in
`query-param-key`, i.e. exactly the pre-repair raw comparison), red on **both**
host arms:

| Arm | Exit | Failures |
| --- | --- | --- |
| JVM focused | 1 | 23, all in the three new fixtures; counts unchanged at 99/264 |
| CLJS focused | 1 | 34, all in the three new CLJS fixtures; counts unchanged at 23/173 |

Counts unchanged in both means no crashed namespace and no truncated lane. The
CLJS arm **recompiled 111 files** between plant and run, so the runtime
demonstrably observed the plant rather than serving a stale bundle. Restore
verified by `git` blob hash against the committed object, not by reading a
diff, and both arms re-run green afterwards.

Every pre-existing merge test — `variant-share-url-merges-existing-query`,
`variant-share-url-replaces-stale-owned-keys`,
`variant-share-url-clears-stale-omitted-keys`,
`url-from-state-preserves-unowned-query-params`,
`url-from-state-clears-every-stale-story-key` — stayed **green through both the
red and the green runs**, which is what shows this EXTENDS the earlier repairs
rather than replacing or defanging them. (Decoding widens the owned-key match
and never narrows it, so no existing assertion changed meaning.)

## Gate nomination

The diff is confined to `tools/story/**` — five files, no markdown, no `spec/`,
no `implementation/` runtime code, no workflows. `scripts/check_doc_slugs.py`
and `scripts/check_readme_links.py` have no path in this diff to inspect, so
neither is nominated.

rf2-b7je1
