### PR TITLE
fix(ssr): Form-2 inner arity selection models the compiled CLJS dispatch (rf2-mocn3)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -378,48 +378,95 @@
                   :element el}})))
 
 #?(:clj
-   (defn- accepts-arity?
-     "Does the compiled fn `f` accept an invocation of EXACTLY `k` arguments?
+   (defn- declared-fixed-arities
+     "The set of FIXED arities the compiled fn `f` declares.
 
      Read off the class, not discovered by calling: a Clojure fn compiles to
-     a class declaring one `invoke` method per FIXED arity, and a variadic fn
-     additionally extends `clojure.lang.RestFn`, whose `getRequiredArity`
-     gives the number of params before the `&`. Both halves are needed —
-     `(fn [& xs] …)` declares NO `invoke` method, and `(fn [a & xs] …)`
-     accepts any arity from ONE up, so \"variadic\" must never be read as
-     \"accepts zero\".
+     a class declaring one `invoke` method per fixed arity. A purely variadic
+     `(fn [& xs] …)` declares NONE, so this returns `#{}` for it — the
+     variadic tail is `variadic-required-arity`'s business, and the two must
+     stay separate so \"accepts any arity\" is never read as \"accepts zero\".
 
      Only ever called on a `fn?` value (`resolve-component-head` guards),
      which matters: a Var is `ifn?` but not `fn?`, and `clojure.lang.Var`
      declares `invoke` for arities 0–21 regardless of what it holds, so
      inspecting one would answer yes to everything."
-     [f k]
-     (boolean
-       (or (some (fn [^java.lang.reflect.Method m]
-                   (and (= "invoke" (.getName m))
-                        (= k (alength (.getParameterTypes m)))))
-                 (.getDeclaredMethods (class f)))
-           (and (instance? clojure.lang.RestFn f)
-                (>= k (.getRequiredArity ^clojure.lang.RestFn f)))))))
+     [f]
+     (into #{}
+           (keep (fn [^java.lang.reflect.Method m]
+                   (when (= "invoke" (.getName m))
+                     (alength (.getParameterTypes m)))))
+           (.getDeclaredMethods (class f)))))
+
+#?(:clj
+   (defn- variadic-required-arity
+     "The number of params before the `&` when `f` is VARIADIC, else `nil`.
+     A variadic fn extends `clojure.lang.RestFn`, whose `getRequiredArity`
+     gives that count: `(fn [& xs] …)` reports 0, `(fn [a & xs] …)` reports 1."
+     [f]
+     (when (instance? clojure.lang.RestFn f)
+       (.getRequiredArity ^clojure.lang.RestFn f))))
 
 #?(:clj
    (defn- form-2-invocation-arity
-     "How many of the component's `n` args to pass `inner`: `n` itself when
-     `inner` accepts them all, else the LONGEST accepted prefix (zero
-     included), else `nil` when `inner` declares no arity at or below `n`."
+     "How many of the component's `n` args to hand `inner` — modelling what
+     the SAME `inner`, compiled by ClojureScript, would accept — or `nil` when
+     CLJS would reject the call too and the JVM should simply pass all `n` and
+     let its own `ArityException` report the real call.
+
+     rf2-mocn3 (audit) — this used to walk every declared arity downward and
+     take the longest accepted prefix, which is NOT what a compiled CLJS fn
+     does. Only a fn with a SINGLE fixed arity and no variadic tail compiles
+     to a bare JavaScript function, and only a bare JavaScript function drops
+     extra arguments. Anything with more than one arm compiles to a dispatcher
+     that switches on `arguments.length` and throws `Invalid arity: n` when no
+     arm matches. Measured on node against `cljs.core/apply`, which is exactly
+     what the `:cljs` branch of `invoke-form-2-render-fn` calls:
+
+       (fn [x] …)                  at 3 args  → returns (extra args dropped)
+       (fn ([x] …) ([x y] …))      at 3 args  → throws `Invalid arity: 3`
+       (fn ([] …) ([x] …))         at 2 args  → throws `Invalid arity: 2`
+
+     The prefix walk selected 2 and 1 for those last two and rendered happily,
+     so a shared `.cljc` Form-2 component could render on the server and blow
+     up on hydration — the precise parity this helper exists to hold.
+
+     So the three selection rules mirror the three shapes the dispatcher has:
+
+       1. an EXACT fixed arm for `n`               → `n`
+       2. a variadic arm whose required count is
+          satisfied by `n`                         → `n` (the whole arg list)
+       3. exactly ONE fixed arity, no variadic
+          tail, shorter than `n`                   → that arity (truncate)
+
+     Rule 3 is deliberately narrow, and widening it would be a DIFFERENT
+     behaviour wearing this name. Nothing here ever SUPPLIES missing args:
+     CLJS does pass `undefined` for them, but fabricating `nil` props on the
+     server is the kind of silent divergence this helper exists to prevent, so
+     an inner that declares only arities above `n` falls through to `nil`."
      [inner n]
-     (first (filter #(accepts-arity? inner %) (range n -1 -1)))))
+     (let [fixed    (declared-fixed-arities inner)
+           required (variadic-required-arity inner)]
+       (cond
+         (contains? fixed n)            n
+         (and required (>= n required)) n
+         (and (nil? required)
+              (= 1 (count fixed))
+              (< (first fixed) n))      (first fixed)
+         :else                          nil))))
 
 (defn- invoke-form-2-render-fn
-  "Invoke a Form-2 inner render fn with `args`, tolerating an inner that
-  declares FEWER params than the component was passed. The idiomatic
+  "Invoke a Form-2 inner render fn with `args`, on the JVM under the SAME
+  arity rules the compiled CLJS `inner` would follow. The idiomatic
   Reagent/UIx Form-2 inner either takes the SAME args as the outer
   (`(fn [x] …)`), ignores them and closes over the outer's (`(fn [] …)`), or
   — just as validly — takes a non-zero PREFIX of them (`(fn [kept] …)` under
-  an `(fn [kept ignored] …)` outer). On CLJS all three are equivalent, since
-  JS arity leniency drops extra args, so `(apply inner args)` renders them
-  all. The JVM is strict, so this helper emulates that leniency by CHOOSING
-  the call shape.
+  an `(fn [kept ignored] …)` outer). Those all compile to a bare JavaScript
+  function, which drops extra arguments, so the client renders them; the JVM
+  is strict, so this helper picks the call shape rather than being told it.
+  What it must NOT do is be MORE permissive than the client, which is why
+  `form-2-invocation-arity` models the compiled dispatcher rather than
+  helpfully finding some arity that works.
 
   rf2-mocn3 — it used to DISCOVER the shape instead, with
   `(try (apply inner args) (catch ArityException _ (inner)))`, and that is
@@ -433,13 +480,12 @@
   so a prefix-taking inner was rejected on the server while rendering fine in
   the browser.
 
-  So: select from the inner's DECLARED arities (`accepts-arity?`), then
-  invoke exactly once. No user code runs inside a catch here, and anything
-  the render throws propagates unchanged. When the inner declares no
-  compatible arity at all there is no shape to choose — CLJS has no
-  equivalent of supplying missing args, so widening is not on the table —
-  and `(apply inner args)` lets the inner's own `ArityException` report the
-  real call rather than a fabricated zero-arity retry."
+  So: select the shape from the inner's DECLARED arities
+  (`form-2-invocation-arity`), then invoke exactly once. No user code runs
+  inside a catch here, and anything the render throws propagates unchanged.
+  When there is no shape CLJS would accept either, `(apply inner args)` lets
+  the inner's own `ArityException` report the real call rather than a
+  fabricated retry — the server fails where the client fails."
   [inner args]
   #?(:clj  (let [k (form-2-invocation-arity inner (count args))]
              (apply inner (if k (take k args) args)))

--- a/implementation/ssr/test/re_frame/ssr/form2_arity_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/form2_arity_cljs_test.cljc
@@ -1,0 +1,132 @@
+(ns re-frame.ssr.form2-arity-cljs-test
+  "rf2-mocn3 (audit) — the CROSS-HOST arity contract for a Form-2 inner
+  render fn, as a single table asserted on BOTH hosts.
+
+  The whole reason `re-frame.ssr.emit/invoke-form-2-render-fn` selects an
+  arity at all is that a shared `.cljc` Form-2 component must resolve the
+  same way on the JVM server and in the browser. A JVM-only proof cannot
+  see the defect this namespace exists to pin, because the defect IS a
+  disagreement between the hosts: the JVM helper used to walk the inner's
+  declared arities downward and take the longest accepted PREFIX, which is
+  not what a compiled ClojureScript fn does.
+
+    - A fn with a SINGLE fixed arity and no variadic tail compiles to a bare
+      JavaScript function. JS drops extra arguments, so it renders.
+    - Anything with more than one arm compiles to a dispatcher that switches
+      on `arguments.length` and throws `Invalid arity: n` when no arm matches.
+
+  So `(fn ([x] …) ([x y] …))` applied to three args, and `(fn ([] …) ([x] …))`
+  applied to two, are REJECTED on the client while the prefix walk selected
+  arity 2 and arity 1 for them and rendered happily. A component like that
+  server-rendered fine and blew up on hydration.
+
+  Every row below therefore asserts the SAME expectation on both hosts —
+  either exact rendered bytes or `::arity-rejected`. That is the contract:
+  not \"the JVM is lenient\", but \"the JVM agrees with CLJS\".
+
+  Runs on BOTH hosts (`.cljc`, `-cljs-test` ns): `clojure -M:test` from
+  `implementation/ssr` (JVM) and `npm run test:cljs` (node). The streaming
+  consumer of the same shared resolver is asserted alongside the sync one in
+  the JVM-only `re-frame.ssr-emit-test`."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.ssr.emit :as emit]))
+
+;; ---------------------------------------------------------------------------
+;; Outcome helper
+;; ---------------------------------------------------------------------------
+
+(defn- arity-rejection?
+  "Is `e` the host's own refusal to invoke a fn at the requested arity?
+
+  Deliberately host-specific and deliberately NARROW. The JVM raises
+  `clojure.lang.ArityException`; the CLJS multi-arity dispatcher raises a
+  plain `js/Error` whose message is `Invalid arity: n`. Anything else — a
+  malformed-hiccup `ExceptionInfo`, a NullPointerException from a typo in a
+  fixture — must NOT read as the expected rejection, which is why `outcome`
+  rethrows what this rejects."
+  [e]
+  #?(:clj  (instance? clojure.lang.ArityException e)
+     :cljs (and (instance? js/Error e)
+                (string? (.-message e))
+                (str/includes? (.-message e) "Invalid arity"))))
+
+(defn- outcome
+  "Render `el` through the sync emitter; return the HTML, or
+  `::arity-rejected` when the HOST refused the inner's invocation arity.
+  Any other throwable propagates — a row must never pass on the wrong
+  failure."
+  [el]
+  (try
+    (emit/emit-element el)
+    (catch #?(:clj Throwable :cljs :default) e
+      (if (arity-rejection? e)
+        ::arity-rejected
+        (throw e)))))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures — Form-2 components whose OUTER is variadic (it is not under
+;; test) and whose INNER carries the arity shape each row exercises.
+;; ---------------------------------------------------------------------------
+
+(defn- form-2
+  "A Form-2 component: a variadic outer returning `inner`."
+  [inner]
+  (fn [& _] inner))
+
+(def ^:private single      (form-2 (fn [x] [:p (str "single|" x)])))
+(def ^:private multi-1-2   (form-2 (fn ([x]   [:p (str "m1|" x)])
+                                        ([x y] [:p (str "m2|" x "|" y)]))))
+(def ^:private multi-0-1   (form-2 (fn ([]  [:p "m0"])
+                                        ([x] [:p (str "m1|" x)]))))
+(def ^:private var-only    (form-2 (fn [& xs] [:p (str "v|" (str/join "," xs))])))
+(def ^:private mixed-1-var (form-2 (fn ([a] [:p (str "mx1|" a)])
+                                        ([a b & r]
+                                         [:p (str "mxv|" a "|" b "|"
+                                                  (str/join "," r))]))))
+
+;; ---------------------------------------------------------------------------
+;; The table
+;; ---------------------------------------------------------------------------
+
+(deftest form-2-inner-arity-selection-agrees-across-hosts
+  (testing "rf2-mocn3 — a SINGLE-fixed-arity inner is the only lenient shape:
+            it compiles to a bare JS function, so extra args are dropped"
+    (is (= "<p>single|a</p>" (outcome [single "a" "b" "c"]))
+        "an inner taking a PREFIX of the outer's args renders on both hosts")
+    (is (= "<p>single|a</p>" (outcome [single "a"]))
+        "the same inner at its exact arity renders on both hosts"))
+
+  (testing "rf2-mocn3 — a MULTI-arity inner dispatches on the argument count
+            and REJECTS a count no arm declares. This is the audit finding:
+            the JVM used to select the longest prefix and render"
+    ;; Compiled CLJS: `Invalid arity: 3`. The old JVM walk chose arity 2 and
+    ;; returned `<p>m2|a|b</p>` — a server render the client cannot reproduce.
+    (is (= ::arity-rejected (outcome [multi-1-2 "a" "b" "c"]))
+        "a 1-or-2-arity inner handed 3 args is refused on both hosts")
+    ;; Compiled CLJS: `Invalid arity: 2`. The old JVM walk chose arity 1.
+    (is (= ::arity-rejected (outcome [multi-0-1 "a" "b"]))
+        "a 0-or-1-arity inner handed 2 args is refused on both hosts"))
+
+  (testing "rf2-mocn3 — non-vacuity: the SAME multi-arity inners still render
+            through every arm they DO declare, so the rows above pin the
+            rejection and not a blanket refusal of multi-arity inners"
+    (is (= "<p>m2|a|b</p>" (outcome [multi-1-2 "a" "b"]))
+        "the exact 2-arity arm is selected")
+    (is (= "<p>m1|a</p>" (outcome [multi-1-2 "a"]))
+        "the exact 1-arity arm is selected")
+    (is (= "<p>m1|a</p>" (outcome [multi-0-1 "a"]))
+        "the exact 1-arity arm is selected")
+    (is (= "<p>m0</p>" (outcome [multi-0-1]))
+        "the exact 0-arity arm is selected"))
+
+  (testing "rf2-mocn3 — a satisfied VARIADIC arm receives the whole arg list,
+            never a truncated prefix and never a fabricated zero-arity call"
+    (is (= "<p>v|a,b,c</p>" (outcome [var-only "a" "b" "c"]))
+        "a purely variadic inner is handed every arg")
+    (is (= "<p>v|</p>" (outcome [var-only]))
+        "a purely variadic inner handed nothing renders its empty case")
+    (is (= "<p>mxv|a|b|c</p>" (outcome [mixed-1-var "a" "b" "c"]))
+        "a fixed+variadic inner routes an over-fixed count to the variadic arm")
+    (is (= "<p>mx1|a</p>" (outcome [mixed-1-var "a"]))
+        "the same inner routes an exactly-matching count to its fixed arm")))

--- a/implementation/ssr/test/re_frame/ssr_emit_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_emit_test.clj
@@ -1068,3 +1068,90 @@
           "streaming passed the variadic inner the complete arg sequence")
       (is (= 1 @calls)
           "streaming invoked the variadic inner exactly once"))))
+
+;; ===========================================================================
+;; rf2-mocn3 (audit) — the selection must not be MORE permissive than CLJS
+;;
+;; The first repair replaced exception-driven probing with a walk down the
+;; inner's declared arities, taking the longest accepted PREFIX. That is not
+;; what a compiled ClojureScript fn does. Only a fn with a SINGLE fixed arity
+;; and no variadic tail compiles to a bare JavaScript function, and only a
+;; bare JavaScript function drops extra arguments; anything with more than one
+;; arm compiles to a dispatcher that switches on `arguments.length` and throws
+;; `Invalid arity: n`. Measured on node (see the cross-host table in
+;; `re-frame.ssr.form2-arity-cljs-test`):
+;;
+;;   (fn [x] …)               at 3 args → returns
+;;   (fn ([x] …) ([x y] …))   at 3 args → throws `Invalid arity: 3`
+;;   (fn ([] …) ([x] …))      at 2 args → throws `Invalid arity: 2`
+;;
+;; The prefix walk selected arity 2 and arity 1 for those last two and
+;; rendered, so a shared `.cljc` Form-2 component rendered on the server and
+;; failed on hydration — the exact parity the repair exists to hold.
+;;
+;; The cross-host table proves the AGREEMENT on both hosts through the sync
+;; emitter. What is here is the second public consumer: streaming shares one
+;; resolver with sync, so every row asserts through BOTH.
+;; ===========================================================================
+
+(deftest emit-form-2-multi-arity-inner-refuses-what-cljs-refuses
+  (testing "rf2-mocn3 — a multi-arity inner handed a count no arm declares is
+            REFUSED on both server paths, as the client refuses it, rather
+            than silently rendering some shorter arm's output"
+    ;; The audit's two shapes verbatim. Under the prefix walk the first
+    ;; rendered `<p>m2|a|b</p>` and the second `<p>m1|a</p>`.
+    (let [multi-1-2 (fn [& _] (fn ([x]   [:p (str "m1|" x)])
+                                  ([x y] [:p (str "m2|" x "|" y)])))
+          multi-0-1 (fn [& _] (fn ([]  [:p "m0"])
+                                  ([x] [:p (str "m1|" x)])))]
+      (is (thrown? clojure.lang.ArityException
+                   (emit/emit-element [multi-1-2 "a" "b" "c"]))
+          "sync emit refuses a 1-or-2-arity inner handed 3 args")
+      (is (thrown? clojure.lang.ArityException
+                   (streaming/render-shell [multi-1-2 "a" "b" "c"]))
+          "streaming refuses a 1-or-2-arity inner handed 3 args")
+      (is (thrown? clojure.lang.ArityException
+                   (emit/emit-element [multi-0-1 "a" "b"]))
+          "sync emit refuses a 0-or-1-arity inner handed 2 args")
+      (is (thrown? clojure.lang.ArityException
+                   (streaming/render-shell [multi-0-1 "a" "b"]))
+          "streaming refuses a 0-or-1-arity inner handed 2 args")
+
+      ;; NON-VACUITY. The same two inners must still render through every arm
+      ;; they DO declare — otherwise the rows above would be satisfied by a
+      ;; blanket refusal of multi-arity inners, which is a different (and
+      ;; worse) behaviour wearing the same green.
+      (is (= "<p>m2|a|b</p>" (emit/emit-element [multi-1-2 "a" "b"]))
+          "sync emit selects the exact 2-arity arm")
+      (is (= "<p>m2|a|b</p>"
+             (:shell-html (streaming/render-shell [multi-1-2 "a" "b"])))
+          "streaming selects the exact 2-arity arm")
+      (is (= "<p>m1|a</p>" (emit/emit-element [multi-1-2 "a"]))
+          "sync emit selects the exact 1-arity arm")
+      (is (= "<p>m1|a</p>"
+             (:shell-html (streaming/render-shell [multi-1-2 "a"])))
+          "streaming selects the exact 1-arity arm")
+      (is (= "<p>m0</p>" (emit/emit-element [multi-0-1]))
+          "sync emit selects the exact 0-arity arm")
+      (is (= "<p>m0</p>" (:shell-html (streaming/render-shell [multi-0-1])))
+          "streaming selects the exact 0-arity arm")))
+
+  (testing "rf2-mocn3 — a fixed+variadic inner routes by the same rules: the
+            exact fixed arm when one matches, otherwise the variadic arm with
+            the WHOLE arg list, on both server paths"
+    ;; `(fn ([a] …) ([a b & r] …))` — fixed arity 1 plus a variadic arm
+    ;; requiring 2. The compiled CLJS dispatcher sends 1 arg to the fixed arm
+    ;; and 3 to the variadic one; so must the JVM. Note the prefix walk would
+    ;; have sent 3 args to the ARITY-1 arm, dropping two props.
+    (let [mixed (fn [& _] (fn ([a] [:p (str "mx1|" a)])
+                              ([a b & r] [:p (str "mxv|" a "|" b "|"
+                                                  (str/join "," r))])))]
+      (is (= "<p>mxv|a|b|c</p>" (emit/emit-element [mixed "a" "b" "c"]))
+          "sync emit hands the satisfied variadic arm every arg")
+      (is (= "<p>mxv|a|b|c</p>"
+             (:shell-html (streaming/render-shell [mixed "a" "b" "c"])))
+          "streaming hands the satisfied variadic arm every arg")
+      (is (= "<p>mx1|a</p>" (emit/emit-element [mixed "a"]))
+          "sync emit prefers the exact fixed arm")
+      (is (= "<p>mx1|a</p>" (:shell-html (streaming/render-shell [mixed "a"])))
+          "streaming prefers the exact fixed arm"))))


### PR DESCRIPTION
## What

`re-frame.ssr.emit/form-2-invocation-arity` chose the Form-2 inner's call shape by walking every declared fixed arity downward and taking the longest accepted prefix. A compiled ClojureScript fn does not behave that way, so the two hosts disagreed: a shared `.cljc` Form-2 component could render successfully during SSR and throw on the client/hydration path — the precise parity the helper exists to hold.

Only a fn with a **single fixed arity and no variadic tail** compiles to a bare JavaScript function, and only a bare JavaScript function drops extra arguments. Anything with more than one arm compiles to a dispatcher that switches on `arguments.length` and throws `Invalid arity: n` when no arm matches.

Measured on node against `cljs.core/apply` (exactly what the `:cljs` branch calls), and on the JVM against this artefact:

| inner | args | CLJS | JVM before | JVM after |
|---|---|---|---|---|
| `(fn [x] ...)` | 3 | renders | renders | renders |
| `(fn ([x] ...) ([x y] ...))` | 3 | `Invalid arity: 3` | rendered the 2-arm | refuses |
| `(fn ([] ...) ([x] ...))` | 2 | `Invalid arity: 2` | rendered the 1-arm | refuses |
| `(fn ([a] ...) ([a b & r] ...))` | 3 | variadic arm, all args | variadic arm, all args | variadic arm, all args |
| `(fn [& xs] ...)` | 3 | all args | all args | all args |

The two middle rows are the defect, and they are the audit's probe verbatim.

## How

Selection now mirrors the three shapes the compiled dispatcher has:

1. an exact fixed arm for `n` → `n`
2. a variadic arm whose required count is satisfied by `n` → `n` (the whole arg list)
3. exactly one fixed arity, no variadic tail, shorter than `n` → that arity (truncate)

otherwise there is no shape CLJS would accept either, and `(apply inner args)` lets the JVM's own `ArityException` report the real call.

Rule 3 is deliberately narrow — it models what the compiled runtime does, and widening it would be a different behaviour wearing the same name. Nothing here supplies missing args: CLJS does pass `undefined` for them (measured: a single-arity-2 inner at 1 arg, and a variadic arm below its required count, both return on CLJS and raise on the JVM), but fabricating `nil` props on the server is the silent divergence this helper exists to prevent, so those stay refused on the JVM.

`accepts-arity?` is replaced by `declared-fixed-arities` + `variadic-required-arity`, which carry forward the two things the old docstring was right to insist on: the reflection is only ever applied to a `fn?` value, because `clojure.lang.Var` declares `invoke` for 0–21 regardless of what it holds; and a variadic tail is never read as "accepts zero".

The single invocation and the unmodified propagation of anything the render throws — what the previous repair established — are unchanged. No renderer abstraction, no new protocol, no spec edit: this is a JVM implementation bug against semantics Spec 011 already promises.

## Tests

- **`re-frame.ssr.form2-arity-cljs-test`** (new `.cljc`, cross-host) — one table of twelve rows asserting the SAME expectation on both hosts, either exact rendered bytes or `::arity-rejected`. A JVM-only proof cannot see this defect at all, because the defect IS a disagreement between the hosts. The rejection helper is narrow and host-specific (`ArityException` on the JVM, an `Invalid arity` `js/Error` on CLJS); anything else propagates, so a row can never pass on the wrong failure.
- **`emit-form-2-multi-arity-inner-refuses-what-cljs-refuses`** (JVM, beside the existing Form-2 block) — the second public consumer. `emit/emit-element` and `streaming/render-shell` share one resolver, so every row asserts through both. Includes the fixed+variadic routing rows.
- Non-vacuity is built in: the same multi-arity inners must still render through every arm they DO declare, so the rejection rows cannot be satisfied by a blanket refusal of multi-arity inners.

## Gates — captured exit codes on the final rebased base

| gate | host | captured exit | result |
|---|---|---|---|
| `clojure -M:test` from `implementation/ssr` | JVM | **0** | 605 tests / 2969 assertions, 0 failures, 0 errors |
| `npm run test:cljs` (`:node-test`) | real CLJS (node) | **0** | 11127 tests / 54980 assertions, 0 failures, 0 errors |
| `clj-kondo` v2026.04.15, `lint.yml`'s exact `--lint` list + `--fail-level error` | — | **0** | errors 0, warnings 2078 (unchanged) |

JVM baseline before the change was 603 tests / 2943 assertions; the new rows add exactly +2 tests / +26 assertions (14 from the JVM deftest, 12 from the cross-host table).

### Sabotage controls

- Restoring the prefix walk in `form-2-invocation-arity`: JVM exit **1**, 6 failures — both cross-host rejection rows and all four JVM multi-arity rejection rows (sync and streaming). Namespace/assertion counts unchanged (605/2969), so the plant failed rows rather than crashing a lane.
- Restoring the ORIGINAL exception-driven probing in `invoke-form-2-render-fn`: JVM exit **1**, 10 failures + 2 errors — every one of the previous repair's defect-detecting rows goes red (`emit-renders-form-2-partial-arity-inner`, both `emit-form-2-inner-body-arity-exception-propagates-once` blocks, `emit-form-2-variadic-inner-body-failure-is-not-swallowed`). This change did not defang them.
- Real-CLJS tree-read control: an expectation flipped in the new `.cljc` reds the node run at that exact line and reports `actual: ... ::arity-rejected` — the CLJS runtime genuinely refuses the multi-arity call.
- clj-kondo tree-read control: one planted `str/join` arity error reds the gate (exit 3, errors 1) at exactly that line, warnings unchanged at 2078.

Every plant was applied and reverted by git blob hash, each restored file verified equal to its committed object.