### PR TITLE
docs(method): the added-line scan is triage, not a containment verdict

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1292,11 +1292,32 @@ the context was another change to the same file.
 **So the rule is safe and its reading is not.** Deleting only on `-` never destroys anything, which
 is why the criterion stands unchanged — but a mayor who reads `+` as *this branch has unmerged work*
 will hunt for work that landed weeks ago, and a branch list read as a backlog is a list of phantoms.
-**The discriminating test is cheap and settles it in one step: take the lines that commit ADDED and
-look for them at the tip.** All present means the content landed and only the context moved; any
-absent means the work is genuinely outstanding. Do that before you conclude a branch is carrying
-something, and never the other way round — the cost of the two errors is not symmetric either, since
-believing `+` costs you a search, while believing a wrongly-derived `-` costs you the work.
+The cheap triage is to take the lines that commit ADDED and look for them at the tip: where they are
+all there, the likeliest reading by far is that the content landed and only the context moved. Run it
+first, because it is seconds and it settles the common case.
+
+**But it is triage, not a verdict, and it is wrong in BOTH directions — which is the correction this
+paragraph carries.** A line search has no notion of path, location, multiplicity or order, and it
+cannot see a deletion at all. So *all present* is satisfied by lines that exist somewhere at the tip
+while this branch's actual change is wholly absent — the more generic the added lines, the more
+certain that is, and a commit whose substance is a deletion or a replacement scans clean having been
+inspected for nothing. And *any absent* is equally weak in reverse: upstream can carry the same work
+through a rename, a reformat or a follow-on rewrite, so the change is fully present and the exact
+line is not. **To CONCLUDE either way, compare the commit's whole patch against the tip at the paths
+it touches, deletions included** — a three-way comparison from the branch's parent is enough, and it
+is the only thing here that answers the question actually asked.
+
+**This matters even though the rule already forbids deleting on it.** The damage from a wrong
+*landed* reading is not a lost branch — it is a mayor who stops looking, files nothing, and leaves
+real unmerged work sitting under a name that now reads as residue. The cost of the two errors stays
+asymmetric, which is why the conservative half survives untouched: believing `+` costs you a search,
+while believing a wrongly-derived `-` costs you the work.
+
+**And note the shape of the mistake, because it recurs wherever an instrument is cheap.** This
+document already warns that [a search returning ZERO is not a check that
+passed](dispatch-prompt-template.md#quality-gates--how-a-gate-is-run); the inversion is the same
+defect and reads even better, because a scan returning EVERYTHING looks like corroboration rather
+than like silence. Ask what the instrument compared, not what it answered.
 
 **Key destructive operations on identity, never on a name.** Branch names repeat across sessions and
 prefix-match each other. A search for `head:feature-x` also returns the change for `feature-x2`, and


### PR DESCRIPTION
Closes rf2-4228y.

Audit of PR #8901 (which corrected `git cherry`'s asymmetry) found that its replacement paragraph
overclaimed in turn. That paragraph presented "take the lines the commit ADDED and look for them at
the tip" as a *discriminating test* that *settles it in one step*, with both readings stated as
verdicts: all present → the content landed, any absent → genuinely outstanding.

Both are false, and the audit named the mechanisms. A line search has no notion of path, location,
multiplicity or order and cannot see a deletion at all, so *all present* is satisfied by lines
existing somewhere at the tip while the branch's actual change is absent — and a commit whose
substance is a deletion or replacement scans clean having been inspected for nothing. In reverse,
upstream can carry the same work through a rename, a reformat or a follow-on rewrite, so the change
is fully present and the exact added line is not.

## What changed

One paragraph in `docs/the-mayor-method/loops.md`, under **Branches**:

- The scan is demoted to **triage** — still worth running first, because it is seconds and it settles
  the common case — and is no longer described as discriminating or as settling anything.
- Both failure directions are stated with their mechanisms.
- The conclusion is named: compare the commit's whole patch against the tip at the paths it touches,
  deletions included; a three-way comparison from the branch's parent suffices.
- Why it matters even though the rule already forbids deleting on it: the damage from a wrong
  *landed* reading is a mayor who stops looking and leaves real unmerged work under a name that now
  reads as residue.
- One sentence tying it to the existing "a search returning ZERO is not a check that passed" rule —
  this is that defect inverted, and a scan returning EVERYTHING reads as corroboration rather than
  as silence.

The conservative deletion criterion is **unchanged**: delete only on `-`. The cost asymmetry
sentence is preserved.

`mayor-hygiene.md` is untouched, per the item's scope fence.

## Quality gates

| Gate | Exit | Result |
|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | clean |
| `scripts/check_readme_links.py --ci` | **0** | clean |
| `python -m mkdocs build --strict` | **0** | built in 29.76s |
| `check_doc_slugs.py` **sabotage** | **1** | `BROKEN ANCHOR: docs\the-mayor-method\loops.md:1318 -> ...#quality-gates--how-a-gate-is-runZZZ` |
| `check_doc_slugs.py` restored | **0** | clean |

All exit codes captured from the runner on one command line, not read from harness status. The plant
went into the one **prose** anchor this change adds (match count checked at 1 beforehand); restore
verified by git **blob** hash against the committed object — `a17fd117468931ec83c16507cee9d58bd53a4065`
on both sides. All three gates re-run on the final rebased base.

**Bare `mkdocs` returns 127 in Git Bash on this checkout** — that is no verdict, not a pass. Run as
`python -m mkdocs`.

## What no gate covers

`mkdocs build --strict` does not gate heading anchors at all (MkDocs grades them at INFO and
`--strict` promotes only WARNING), so `check_doc_slugs.py` is the sole anchor gate for this page —
which is why the sabotage went there. Nothing validates the prose itself, its tables or its
rendering. No table is touched, no fenced block is added or edited, so the guide-samples digest gate
is untouched. The merge-base diff was read for reverts: 5 deleted lines, all of them the tail of the
paragraph this change replaces.