### PR TITLE
docs(method): a reopen is a signal not a verdict; the export check reads the export

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -42,17 +42,27 @@ The order is what makes it accurate. Each step is a check the next depends on.
    re-enumerate a bead's children before concluding a decision is absent. Every one of
    those binds the mayor writing the brief exactly as it binds the worker reading it.
 
-   **And one cheap query tells you when skipping the walk is guaranteed to burn a dispatch:
+   **And one cheap query tells you which items are most likely to punish skipping the walk:
    has this item ever been CLOSED and reopened?** The rule above is unconditional, which is
    why it gets skipped — an unconditional instruction competes with every other unconditional
-   instruction. This is the case where skipping it is not a gamble but a certainty. A reopened
-   item's description is stale *by construction*: it describes the defect as originally found,
-   the work that closed it has shipped, and the live instruction is whatever note reopened it.
-   Nothing about the rendered item says so — the description still reads as a current bug
-   report, because it once was one. Measured across one session: three briefs written from
-   descriptions whose work had already merged, and **all three items showed a closed-to-open
-   transition in their status history while the control, never closed, showed none**. Ask the
-   tracker for the item's status over time rather than its status now.
+   instruction. A closed-to-open transition is the strongest cheap signal there is that the
+   description is no longer the live instruction: it was written about the defect as originally
+   found, and something later disagreed enough to reopen the item. Nothing about the rendered
+   item says so — the description still reads as a current bug report, because it once was one.
+   Measured across one session: three briefs written from descriptions whose work had already
+   merged, and **all three items showed a closed-to-open transition in their status history
+   while the control, never closed, showed none**. Ask the tracker for the item's status over
+   time rather than its status now.
+
+   **It is a signal to do the walk, though, not a substitute for it, and the two ways of
+   over-reading it are worth naming because both are natural.** *Closed* does not mean
+   *shipped* — a project whose items close when a change is opened for review will have closed
+   items whose work is still unmerged, so "the closing work has landed" is an inference about
+   this project's conventions rather than a fact about the transition. And a reopening does not
+   always supersede: an item reopened because the same defect REGRESSED has a description that is
+   accurate, and treating it as stale sends the worker looking for a newer instruction that does
+   not exist. **What decides currency is the history and the tree**, which is what the rule above
+   already says; the query tells you where that reading is most likely to change your brief.
 
    **The three consequences differ, and only the first is obvious.** The dispatch may re-do
    finished work; it may point a worker at a defect that no longer exists, whose deliverable is

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -567,11 +567,22 @@ from version-control history* — which looks like recovery — silently reverts
 since that revision. **Treat a coordinator timeout as contention until something else proves
 corruption.** The one export observed apparently hung here had in fact completed.
 
-**Verify it without touching the store at all**: compare the committed export against the working
-copy by size or line count, and check the working tree is clean. Equal and clean means consistent
-and nothing is owed, at zero cost to the resource under load — it answered in a second what
-re-running could not answer in three minutes. And ask the store for one thing per command while
-saturated: two queries chained in one invocation time out where each alone returns.
+**Take a first look that does not touch the store at all**: compare the committed export against the
+working copy by size or line count, and check the working tree is clean. That costs the resource
+under load nothing, and it answered in a second what re-running could not answer in three minutes.
+And ask the store for one thing per command while saturated: two queries chained in one invocation
+time out where each alone returns.
+
+**But be exact about what that look establishes, because it is easy to promote and the promotion is
+this document's own measured fault.** It reads the EXPORT and the working tree — never the database.
+So it cannot tell you that a mutation which timed out committed, that the store holds nothing newer
+than the file, or that the store is healthy. A clean tree proves only that the tracked export matches
+the revision. **And equal counts are not equality**: one project's checkpoint passed its row-count
+floor at 1,938 against 1,938 and silently dropped three items and reverted two newer statuses,
+because the two sides had substituted one-for-one. Size is a smoke test against truncation, which is
+what it was built for. Once the contention clears, verify the store against the export the way the
+project's own checkpoint does — by stable id, modification time and status — before saying anything
+is consistent or that nothing is owed.
 
 **A queued measurement window makes an otherwise-free slot not free.** The drain clause in
 the filter list does not reach this case — it lifts only once the exclusive items are all


### PR DESCRIPTION
Closes rf2-r70kn and rf2-rjqtj. Both are audits of this document's own recent additions, and both
are the same failure: a measured observation restated one layer above its evidence. That pattern is
already named in `dispatch-prompt-template.md` under Shape 6 — *"your published sentences are claims
too"* — which is the argument for fixing both here rather than adding anything new.

## rf2-r70kn — the closed-to-open shortcut (PR #8906)

The shortcut is useful and stays. Its wording was not supported by its evidence: three stale
reopened descriptions plus one never-closed control establish a strong signal, not that skipping the
walk is *guaranteed* to burn a dispatch, and not that a reopened description is stale *by
construction*.

Two inferences went with it, and both are false in ways that matter:

- **Closed does not mean shipped.** A project whose items close when a change is opened for review
  has closed items whose work is still unmerged — true in this repository right now. "The closing
  work has landed" is a claim about local convention, not about the transition.
- **A reopening does not always supersede.** An item reopened because the same defect REGRESSED has
  an accurate description, and calling it stale sends the worker hunting for a newer instruction
  that does not exist.

The paragraph now says what it can support: a closed-to-open transition is the strongest cheap
signal that the description is no longer the live instruction, and it tells you where the
already-required timestamp walk is most likely to change your brief. **History and the tree decide
currency.** No checklist, no script, no tracker field, no new layer — per the item.

Worth noting that this item's own DESCRIPTION is stale (it targets `.claude/commands/mayor-dispatch.md`,
under a directory that no longer exists) while its audit note is live — which is the shortcut working
exactly as the corrected wording describes.

## rf2-rjqtj — the tracker-contention export check (PR #8913)

The remote-tracking-ref rebase guidance in that PR is untouched; the audit calls it correct and
complete. The contention addition overstated its cheap first look, which compares the committed
export against the working copy by size or line count and checks the tree is clean. That reads the
**export and the working tree, never the database**, so it cannot establish that a timed-out
mutation committed, that the store holds nothing newer, or that the store is healthy.

And **equal counts are not equality** — this document's own measured fault. One checkpoint passed its
row-count floor at 1,938 against 1,938 while silently dropping three items and reverting two newer
statuses, because the two sides had substituted one-for-one.

The paragraph keeps contention-until-proven-otherwise and keeps the safe non-destructive first look,
now labelled as evidence about the working export only, with size named as the smoke test against
truncation it was built for. Once contention clears, verification goes through the project's own
checkpoint comparison — stable id, modification time, status — before anything is called consistent.
No sync service, recovery framework or probe.

## Quality gates

| Gate | Exit | Result |
|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | clean |
| `scripts/check_readme_links.py --ci` | **0** | clean |
| `python -m mkdocs build --strict` | **0** | clean |
| `check_doc_slugs.py` **sabotage** | **1** | `BROKEN ANCHOR: docs\the-mayor-method\loops.md:582 -> loops.md#planted-no-such-heading-zzz` |
| `check_doc_slugs.py` restored | **0** | clean |

Exit codes captured from the runner on one command line, not read from harness status. The plant went
into PROSE at a line this change edits (match count checked at 1 beforehand, since a fault inside a
fence is invisible to this gate); restore verified by git **blob** hash against the committed object —
`ed4a0b832723ac2ba5a9833731b467889638f427` on both sides. All three gates re-run after rebasing.

**Bare `mkdocs` returns 127 in Git Bash on this checkout** — no verdict, not a pass. Run as
`python -m mkdocs`.

## What no gate covers

`mkdocs build --strict` does not gate heading anchors at all (MkDocs grades them at INFO and
`--strict` promotes only WARNING), so `check_doc_slugs.py` is the sole anchor gate for these pages.
Nothing validates the prose, tables or rendering. This change adds no link, anchor, heading, table or
fenced block — it is prose only, so the green above says the change broke nothing, not that it is
right. The merge-base diff was read for reverts: 14 deleted lines, all of them the two paragraphs
this change rewrites, and PR #8920's containment text (same file, merged minutes earlier) is present
and untouched — checked explicitly rather than inferred from a clean rebase.