### PR TITLE
test(http): pin the delivered supersede reply to issuance 2 and drop the timed quiescence window (rf2-o9e15)

### DIFF
--- a/implementation/http/test/re_frame/http_reply_lowering_test.clj
+++ b/implementation/http/test/re_frame/http_reply_lowering_test.clj
@@ -29,6 +29,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.http.managed :as http-managed]
+            [re-frame.http.registry :as registry]
             [re-frame.http.reply :as http-reply]
             [re-frame.http.test-support]
             [re-frame.late-bind :as late-bind]
@@ -530,12 +531,51 @@
 ;; Group 3 — supersession suppresses the prior request's app target.
 ;; ===========================================================================
 
+;; WHY THESE TESTS CARRY NO TIMED WAIT (rf2-o9e15, and its PR #8889 audit).
+;;
+;; Both server responses are byte-identical, so "one reply, :status :ok" is
+;; satisfied just as well by a broken path that delivers the SUPERSEDED
+;; issuance and loses the superseding one. The three devices below make the
+;; claim these tests advertise — *the one delivered reply is request #2's, and
+;; there is never a second* — provable rather than merely probable, and none of
+;; them is a clock:
+;;
+;;   (1) ISSUANCE IDENTITY. `:rf.reply/work-id` is
+;;       `[:rf.work/http logical-id issuance attempt]` (reply.cljc `work-id`),
+;;       and `registry/next-issuance!` bumps `issuance` on each fresh request
+;;       under one `:request-id`. So issuance 1 vs 2 is exactly what the two
+;;       otherwise-identical replies differ by, and asserting the delivered
+;;       reply's work-id is `[:rf.work/http :search 2 1]` is what pins WHICH
+;;       one arrived. `reset-issuance-counters-for-test!` makes those literals
+;;       independent of what else ran first in this JVM.
+;;
+;;   (2) THE SUPERSEDE IS AN ORDERING, NOT A RACE. Asserted while both
+;;       exchanges are still HELD: the `:search` in-flight slot already holds
+;;       issuance 2. `registry/supersede!` cleared #1 out of it and fired #1's
+;;       abort-fn INLINE, during the second `dispatch-sync`'s fx phase. That
+;;       abort-fn wins #1's once-only `:finalised?` CAS and routes through
+;;       `dispatch-aborted!`, where `:request-id-superseded` is a
+;;       reply-SUPPRESSING reason (transport.cljc `reply-suppressing-abort-
+;;       reasons`) — no app dispatch, and the won CAS makes #1's later
+;;       transport completion bail at `already-replied?`. There is therefore no
+;;       later moment at which a second reply could originate; a timed window
+;;       was allowing for one that cannot exist.
+;;
+;;   (3) A QUEUE BARRIER, NOT A SLEEP. `dispatch-sync` seeds at the FRONT of
+;;       the frame's FIFO queue and then runs the drain loop to fixed point
+;;       (router.cljc `drain-block!`), so every envelope enqueued before it has
+;;       been PROCESSED by the time it returns. Dispatching `:search/quiesce`
+;;       after the surviving reply lands therefore observes any wrongly
+;;       dispatched #1 reply, where the previous `Thread/sleep 200` only
+;;       established that none had arrived within 200 ms.
+
 (deftest supersede-suppresses-prior-app-reply
   (testing "a same-:request-id supersede suppresses the FIRST request's :on-failure app target"
     ;; A held server keeps request #1 in flight; issuing request #2 with the
     ;; same :request-id supersedes #1. Per Spec 014 §`:request-id` (internal)
     ;; the superseded request's reply is trace-only — its app target MUST NOT
     ;; fire. #2 completes normally and IS delivered.
+    (registry/reset-issuance-counters-for-test!)
     (let [release (java.util.concurrent.CountDownLatch. 1)
           replied (java.util.concurrent.CountDownLatch. 1)
           srv     (start-held-server! release)
@@ -548,6 +588,7 @@
             ;; here rather than sampling a clock for it (rf2-o9e15).
             (.countDown replied)
             {:db db}))
+        (rf/reg-event :search/quiesce (fn [{:keys [db]} _] {:db db}))
         (rf/reg-event :search/go
           (fn [_ _]
             {:fx [[:rf.http/managed
@@ -561,23 +602,39 @@
         ;; supersede — see `start-held-server!`.
         (rf/dispatch-sync [:search/go])
         (rf/dispatch-sync [:search/go])
+        ;; Device (2) — read while BOTH exchanges are still held, so this is an
+        ;; ordering fact, not a sampled one: #1 has already been cleared out of
+        ;; the `:search` slot and issuance 2 owns it.
+        (let [live (registry/lookup-in-flight :search)]
+          (is (some? live) "the superseding request #2 is the live in-flight request")
+          (is (= [:rf.work/http :search 2 1] (http-reply/work-id live))
+              "the surviving in-flight request is issuance 2; issuance 1 was superseded out of the slot during the second dispatch-sync"))
         ;; Release both exchanges, then wait on the reply handler's own latch.
         (.countDown release)
         (is (.await replied 30 java.util.concurrent.TimeUnit/SECONDS)
             "the surviving request's app reply was delivered")
-        (Thread/sleep 200) ;; quiescence window for any (wrongly) delivered #1 reply
+        ;; Device (3) — a FIFO drain barrier in place of a timed quiescence
+        ;; window: everything enqueued before this call has been processed by
+        ;; the time it returns.
+        (rf/dispatch-sync [:search/quiesce])
         ;; The superseded request #1's app target is NOT dispatched: exactly
         ;; one delivered reply (request #2's), never the supersede of #1.
         (is (= 1 (count @replies))
             "only the surviving request's reply is delivered; the superseded one is suppressed")
         (is (= :ok (:status (first @replies)))
             "the surviving reply is request #2's canonical :status :ok success")
+        ;; Device (1) — the two server responses are identical, so the work-id
+        ;; is the ONLY thing distinguishing "delivered #2" from "delivered #1
+        ;; and lost #2". Both satisfy the two assertions above.
+        (is (= [:rf.work/http :search 2 1] (:rf.reply/work-id (first @replies)))
+            "the delivered reply belongs to the SUPERSEDING issuance (2), not the superseded issuance 1")
         (finally
           (.countDown release)
           (stop-server! srv))))))
 
 (deftest supersede-distinct-work-ids-and-canonical-stale-trace
   (testing "rf2-azcmd3 — superseded + superseding attempts have DISTINCT :work/id, and the superseded one records a canonical :status :stale / :rf.reply/work-status :suppressed reply-envelope trace with carried/current correlation; only the new app reply fires"
+    (registry/reset-issuance-counters-for-test!)
     (let [release (java.util.concurrent.CountDownLatch. 1)
           replied (java.util.concurrent.CountDownLatch. 1)
           srv     (start-held-server! release)
@@ -591,6 +648,7 @@
             (swap! replies conj payload)
             (.countDown replied)
             {:db db}))
+        (rf/reg-event :search/quiesce (fn [{:keys [db]} _] {:db db}))
         (rf/reg-event :search/go
           (fn [_ _]
             {:fx [[:rf.http/managed
@@ -642,6 +700,13 @@
                       (:work/id (:rf.reply/current tags))))
             ;; The canonical join key reads the carried (superseded) work-id.
             (is (= [:rf.work/http :search 1 1] (:rf.reply/work-id tags)))))
+        ;; Device (2) — read while BOTH exchanges are still held: the supersede
+        ;; already cleared issuance 1 out of the `:search` slot and issuance 2
+        ;; owns it, so #1's suppression is settled BEFORE anything is released.
+        (let [live (registry/lookup-in-flight :search)]
+          (is (some? live) "the superseding request #2 is the live in-flight request")
+          (is (= [:rf.work/http :search 2 1] (http-reply/work-id live))
+              "the surviving in-flight request is issuance 2; issuance 1 was superseded out of the slot during the second dispatch-sync"))
         ;; The surviving request's APP REPLY is the one genuinely async step
         ;; (transport reply → reply lowering → app dispatch), and it publishes
         ;; its own completion: the reply handler counts the latch down. So this
@@ -652,10 +717,22 @@
         (.countDown release)
         (is (.await replied 30 java.util.concurrent.TimeUnit/SECONDS)
             "the surviving request's app reply was delivered")
-        (Thread/sleep 200) ;; quiescence window for any (wrongly) delivered #1 reply
+        ;; Device (3) — a FIFO drain barrier in place of a timed quiescence
+        ;; window: everything enqueued before this call has been processed by
+        ;; the time it returns, so a wrongly delivered #1 reply is OBSERVED
+        ;; rather than merely not-yet-arrived.
+        (rf/dispatch-sync [:search/quiesce])
         ;; Exactly one DELIVERED app reply — request #2's; #1 suppressed.
         (is (= 1 (count @replies))
             "only the surviving request's app reply is delivered")
+        (is (= :ok (:status (first @replies)))
+            "the surviving reply is request #2's canonical :status :ok success")
+        ;; Device (1) — both server responses are identical, so the work-id is
+        ;; the only fact distinguishing "delivered issuance 2" from "delivered
+        ;; issuance 1 and lost issuance 2"; the count and :status assertions
+        ;; above are satisfied by both.
+        (is (= [:rf.work/http :search 2 1] (:rf.reply/work-id (first @replies)))
+            "the delivered reply belongs to the SUPERSEDING issuance (2), not the superseded issuance 1")
         (finally
           (.countDown release)
           (trace/unregister-listener! lid)


### PR DESCRIPTION
Closes rf2-o9e15 (reopened by the PR #8889 audit).

PR #8889 removed the original flake by holding the test server so the supersede
became a property of the ordering rather than of machine speed. The audit
reopened the item because the regression still did not prove the one delivered
app reply belonged to the **superseding** issuance: both server responses are
byte-identical, and both tests asserted only reply count 1 and `:status :ok`, so
a broken path that delivered issuance 1 while losing issuance 2 passed. The
closing `Thread/sleep 200` was likewise only a 200 ms window for the absence of
a second delivery.

This is the minimal completion the audit asked for. The held-server harness is
unchanged, no production source is touched, no new abstraction is introduced,
and no assertion is weakened.

## What changed

Three devices in `supersede-suppresses-prior-app-reply` and
`supersede-distinct-work-ids-and-canonical-stale-trace`, none of them a clock.

**(1) Issuance identity — the delivered reply is pinned.** `:rf.reply/work-id`
is `[:rf.work/http logical-id issuance attempt]` (`reply.cljc` `work-id`), and
`registry/next-issuance!` bumps `issuance` on each fresh request under one
`:request-id`. Issuance is therefore exactly what the two otherwise-identical
replies differ by, and both tests now assert the delivered reply's work-id is
`[:rf.work/http :search 2 1]`.

`registry/reset-issuance-counters-for-test!` (an existing test-only helper,
already used in `http_managed_test.clj`) now runs at the top of each test, so
that literal does not depend on what else ran first in the JVM. The counter is
process-global and `http_managed_test.clj` also uses `:request-id :search`; the
literal held only because eviction happened to clear it. That is precisely the
latent load-order dependency a single full-suite lane cannot see.

**(2) The supersede is an ordering, asserted while both exchanges are still
HELD.** The `:search` in-flight slot already holds issuance 2, so
`registry/supersede!` cleared issuance 1 out of it and fired its abort-fn
*inline*, during the second `dispatch-sync`'s fx phase. That abort-fn wins the
request's once-only `:finalised?` CAS and routes through `dispatch-aborted!`,
where `:request-id-superseded` is a reply-suppressing reason
(`transport.cljc` `reply-suppressing-abort-reasons`) — no app dispatch, and the
won CAS makes issuance 1's later transport completion bail at
`already-replied?`. There is no later moment at which a second reply could
originate, which is what the timed window was allowing for.

**(3) A FIFO drain barrier replaces `Thread/sleep 200`.** `dispatch-sync` seeds
at the front of the frame's queue and then runs the drain loop to fixed point
(`router.cljc` `drain-block!`), so every envelope enqueued before it has been
*processed* by the time it returns. A wrongly delivered reply is observed rather
than merely not-yet-arrived.

Group 3 also gains a `:status :ok` assertion on the delivered reply in the
second test, which previously asserted only the count.

## Quality gates

All exit codes captured with the redirect and the exit-code echo on one command
line, in one shell, and quoted from the `.exit` file rather than from any
harness report. Everything below is on the final rebased base (`163aefb4c4`,
merge base `3cc654e45c`).

| Gate | Command | Exit | Result |
| --- | --- | ---: | --- |
| Full suite (= CI `jvm-http`) | `clojure -M:test` from `implementation/http` | **0** | 508 tests, 3890 assertions, 0 failures, 0 errors |
| Solo namespace, run 1 | `clojure -M:test -n re-frame.http-reply-lowering-test` | **0** | 25 tests, 144 assertions |
| Solo namespace, run 2 | same | **0** | 25 tests, 144 assertions |
| Solo namespace, run 3 | same | **0** | 25 tests, 144 assertions |
| Solo namespace, run 4 | same | **0** | 25 tests, 144 assertions |
| Solo namespace, run 5 | same | **0** | 25 tests, 144 assertions |

The namespace was run **solo** as well as in the full suite deliberately. CI's
`jvm-http` job runs only a bare full-suite `clojure -M:test`, so a full-suite
ordering can supply a load-order dependency the namespace does not declare —
which is exactly the hazard device (1)'s counter reset addresses. Assertion
counts are identical solo and in-suite (144 of the suite's 3890), and stable
across all five consecutive solo runs, which is part of the determinism evidence
rather than decoration: one green run cannot distinguish deterministic from
lucky. Baseline before this change was 137 solo / 3883 full; the seven new
assertions account for the whole delta.

No markdown, no `spec/`, no production source and no workflow file is touched,
so neither `check_doc_slugs.py` nor `check_readme_links.py` has a path in this
diff and neither is nominated.

### The control

The audit's defect is that the *old* assertions pass when the wrong issuance is
delivered, so a plant that reds everything would only show the test runs. The
discriminating plant makes the harness genuinely deliver issuance **1**: a
single `registry/reset-issuance-counters-for-test!` inserted *between* the two
`dispatch-sync` calls in `supersede-suppresses-prior-app-reply`, so the
superseding request is re-minted as issuance 1. The supersede still happens (it
keys on `:request-id`, not issuance), exactly one reply is still delivered, and
it is still `:status :ok` — but its work-id is now issuance 1's, which is the
broken path the audit described.

Under the plant, exit **1**, 25 tests / 144 assertions, **2 failures, 0 errors**
— the same assertion count as the clean run, so no namespace was crashed out.

**RED (both new, both in `supersede-suppresses-prior-app-reply`):**

- `the surviving in-flight request is issuance 2; issuance 1 was superseded out of the slot during the second dispatch-sync` — device (2). Actual `[:rf.work/http :search 1 1]`.
- `the delivered reply belongs to the SUPERSEDING issuance (2), not the superseded issuance 1` — device (1). Actual `[:rf.work/http :search 1 1]`.

**GREEN under the same plant — the assertions that existed before this PR:**

- `only the surviving request's reply is delivered; the superseded one is suppressed` (reply count 1)
- `the surviving reply is request #2's canonical :status :ok success`
- `the superseding request #2 is the live in-flight request`
- the whole of `supersede-distinct-work-ids-and-canonical-stale-trace`, including its stale-trace carried/current work-id assertions

That green-beside-red is the point: the count-and-status pair the tests
previously rested on is satisfied by a reply from the wrong issuance, and the
new work-id assertion is what convicts it.

The red also establishes that the gate read this branch's checkout — the fault
exists only here, so a run that had wandered elsewhere would have come back
green. The first plant attempt was placed *after* both `dispatch-sync` calls,
where both issuances had already been minted; it was inert and the run came back
green. That green was treated as a reason to stop and diagnose rather than to
proceed, the plant was moved between the two dispatches, and the control then
bit. Restores after every plant were verified by git **blob** hash against the
committed object (`e27fd9f7aa3b14dd8011e275d1314bef137e50a5`), not by reading a
diff — line endings are translated in this checkout, so a byte digest of the
working file would not be sound.

### Audit literal

The audit quoted the expected work-id as `[:rf.work/http :search 2 1]`. Read
from the code rather than from the note — `reply.cljc` `work-id` builds
`[:rf.work/http logical-id (or issuance 1) (or attempt 1)]` with `logical-id`
the caller's `:request-id`, here `:search`; the superseding request is the
second issuance under that id, and neither request retries — the literal is
correct as written.
