### PR TITLE
fix(routing): url-decode preserves literal UTF-16 code units (rf2-k2d2t)

### DIFF
--- a/implementation/routing/src/re_frame/routing/url.cljc
+++ b/implementation/routing/src/re_frame/routing/url.cljc
@@ -158,36 +158,20 @@
   (clojure.string/join "/" (map url-encode (clojure.string/split (str s) #"/"))))
 
 #?(:clj
-   (defn- percent-escape-non-ascii
-     "Percent-escape every non-ASCII CHARACTER of `s` as its UTF-8 bytes,
-     leaving ASCII — existing `%XX` escapes included — untouched. The
-     result is pure ASCII, so `URLDecoder` under ISO-8859-1 recovers the
-     exact byte sequence the string denotes.
+   (defn- hex-nibble
+     "The value of the ASCII hex digit whose code unit is `n`, or -1 when
+     `n` is not one.
 
-     A literal (unescaped) non-ASCII character is legal input: both hosts
-     pass it through today (`decodeURIComponent(\"café\")` is `\"café\"`),
-     so escaping it here is what keeps that passthrough intact once the
-     bytes go through a STRICT decoder.
-
-     Runs are escaped whole, not character by character, so a surrogate
-     PAIR encodes as the one astral code point it spells rather than as
-     two unpaired halves.
-
-     Folding a literal into an ADJACENT escape run cannot change the
-     verdict in either direction. A literal character's UTF-8 encoding
-     always begins with a LEAD byte (`C2`–`F4`), never a continuation
-     byte, so it can never complete a truncated escape run that
-     `decodeURIComponent` would have rejected (`%C3é` throws on both
-     hosts); and the concatenation of two individually valid UTF-8
-     sequences is itself valid, so it can never spoil a run the browser
-     accepts (`%41é` is `\"Aé\"` on both)."
-     ^String [^String s]
-     (clojure.string/replace
-       s
-       #"[^\x00-\x7F]+"
-       (fn [^String run]
-         (apply str (map #(format "%%%02X" (bit-and (int %) 0xFF))
-                         (.getBytes run java.nio.charset.StandardCharsets/UTF_8)))))))
+     Deliberately NOT `Character/digit` (nor `Integer/parseInt`, which
+     defers to it): those also accept non-ASCII digit characters — the
+     Arabic-Indic `٦`, say — which `decodeURIComponent` refuses. The
+     escape grammar is ASCII-only, so the reader must be too."
+     ^long [^long n]
+     (cond
+       (and (<= (int \0) n) (<= n (int \9))) (- n (int \0))
+       (and (<= (int \a) n) (<= n (int \f))) (+ 10 (- n (int \a)))
+       (and (<= (int \A) n) (<= n (int \F))) (+ 10 (- n (int \A)))
+       :else -1)))
 
 #?(:clj
    (defn- strict-utf8-decode
@@ -215,26 +199,102 @@
          (.decode (java.nio.ByteBuffer/wrap bs))
          (.toString))))
 
+#?(:clj
+   (defn- decode-percent-escapes
+     "`decodeURIComponent`'s own decode loop, transplanted to the JVM.
+
+     One left-to-right walk with a SEGMENTATION SEAM at every literal
+     character. Consecutive `%XX` escapes accumulate into a byte buffer;
+     the moment a non-`%` character arrives (or the string ends) that
+     buffer is flushed through `strict-utf8-decode` and the literal
+     character is appended VERBATIM. So the strict UTF-8 decoder sees
+     exactly the bytes the percent escapes contributed, and nothing else.
+
+     THE SEAM IS THE POINT, and it is the whole of rf2-k2d2t's second
+     half. A Java string, like a JavaScript string, is a sequence of
+     UTF-16 CODE UNITS and may legally hold an UNPAIRED SURROGATE. Such a
+     code unit spells no code point, so it has no UTF-8 encoding at all —
+     and the previous JVM arm reached the byte level by escaping every
+     literal non-ASCII character with `String.getBytes(UTF_8)`, whose
+     REPLACE action silently turned that code unit into the byte `0x3F`,
+     a literal `?`. `decodeURIComponent` never encodes a literal at all:
+     it copies it straight to the output. So a lone U+D800 came back as
+     `?` on the JVM and as the raw code unit in the browser — the same
+     class of host divergence this namespace exists to rule out, and
+     doubly bad because `?` is a legitimate character the lone surrogate
+     was thus ALIASED onto. Copying literals through, rather than
+     round-tripping them via bytes, is what removes the lossy step.
+
+     WHAT THE SEAM DOES NOT WEAKEN. A PERCENT-ENCODED lone surrogate is a
+     different thing entirely and must still fail closed: `%ED%A0%80`
+     puts the bytes `ED A0 80` in the buffer, and UTF-8 has no encoding
+     for a surrogate, so `strict-utf8-decode` reports and the nil
+     sentinel stands. The two rows pull in opposite directions on
+     purpose.
+
+     The seam is also what makes a TRUNCATED escape run fail closed
+     against a following literal: `%C3é` flushes the single byte `C3` on
+     its own, which is malformed, exactly as `decodeURIComponent` throws
+     there. The previous arm reached the same verdict by a different
+     route (`C3` concatenated with `é`'s lead byte is malformed too), so
+     that behaviour is preserved rather than restored.
+
+     Throws `IllegalArgumentException` for a structurally malformed
+     escape (`%`, `%a`, `%zz`) — the same class `URLDecoder` threw, which
+     is what `safe-url-decode`'s sentinel already catches."
+     ^String [^String s]
+     (let [n   (.length s)
+           out (StringBuilder. n)
+           buf (java.io.ByteArrayOutputStream. 8)]
+       (letfn [(flush-escape-run! []
+                 (when (pos? (.size buf))
+                   (.append out (strict-utf8-decode (.toByteArray buf)))
+                   (.reset buf)))]
+         (loop [i 0]
+           (if (<= n i)
+             (do (flush-escape-run!)
+                 (.toString out))
+             (let [c (.charAt s i)]
+               (if (= \% c)
+                 (let [hi (if (< (inc i) n) (hex-nibble (int (.charAt s (inc i)))) -1)
+                       lo (if (< (+ i 2) n) (hex-nibble (int (.charAt s (+ i 2)))) -1)]
+                   (when (or (neg? hi) (neg? lo))
+                     (throw (IllegalArgumentException.
+                              (format "URI malformed: incomplete or non-hex %% escape at index %d" i))))
+                   (.write buf (int (+ (* 16 hi) lo)))
+                   (recur (+ i 3)))
+                 (do (flush-escape-run!)
+                     (.append out c)
+                     (recur (inc i)))))))))))
+
 (defn url-decode
   "Decode a percent-encoded string back to its raw form. Round-trip
   inverse of url-encode.
 
   HOST-SYMMETRIC: on both hosts this IS `decodeURIComponent`. The CLJS
-  arm calls it; the JVM arm emulates it on top of `java.net.URLDecoder`,
-  which needs TWO corrections rather than one:
+  arm calls it; the JVM arm is `decode-percent-escapes` above, which
+  walks the string the way `decodeURIComponent` itself does. Reaching
+  that shape took THREE corrections to `java.net.URLDecoder`, and the
+  third is why `URLDecoder` is no longer in the path at all:
 
   1. `URLDecoder` is the `application/x-www-form-urlencoded` decoder, so
      it turns a bare `+` into a SPACE. `+` must stay a LITERAL `+` on
-     both hosts, in path captures and query values alike, so every bare
-     `+` is pre-escaped to `%2B` before URLDecoder sees it: `+` → `+`,
+     both hosts, in path captures and query values alike: `+` → `+`,
      `%2B` → `+`, `%20` → space, real spaces → space (rf2-9a9ix).
   2. `URLDecoder` decodes bytes with the REPLACE malformed-input action,
      so an INVALID UTF-8 sequence is silently rewritten to U+FFFD and a
-     string comes back; `decodeURIComponent` throws `URIError`. Repairing
-     only (1) left that standing, and it was the worse half: for
+     string comes back; `decodeURIComponent` throws `URIError`. For
      `%C0%80`, `%ED%A0%80`, `%FF` or `%E0%80%80` the JVM returned a
      value and CLJS returned the nil sentinel, so `malformed-url?` read
      FALSE on JVM and TRUE on CLJS (rf2-k2d2t).
+  3. Reaching a strict byte decoder by percent-escaping literal non-ASCII
+     characters — the first repair of (2) — pushed each literal through
+     `String.getBytes(UTF_8)`, whose REPLACE action turns an UNPAIRED
+     SURROGATE code unit into the byte `0x3F`. `decodeURIComponent`
+     copies a literal to the output untouched, so a lone U+D800 came
+     back as `?` on the JVM and as the raw code unit in the browser
+     (rf2-k2d2t again). `decode-percent-escapes` never encodes a literal
+     at all; see its docstring for why the seam is where it is.
 
   The consequence of (2) was a whole-tree Spec 011 mismatch on a
   security-adjacent sink, and the server was the PERMISSIVE side: a
@@ -245,28 +305,21 @@
   URLs, partner integrations with broken escaping\") was not the posture
   the JVM arm actually had.
 
-  So the JVM arm decodes in three stages: pre-escape (bare `+`, then
-  every literal non-ASCII character), then `URLDecoder` under ISO-8859-1
-  — the 1:1 byte↔char charset, which performs the SAME structural
-  validation as before (`%`, `%a`, `%zz` still throw
-  `IllegalArgumentException`) while substituting nothing — and finally a
-  STRICT UTF-8 decode of the recovered bytes.
+  Structural validation is unchanged in substance: `%`, `%a` and `%zz`
+  still throw `IllegalArgumentException`, now from the escape reader
+  rather than from `URLDecoder`. Its hex reader is ASCII-only on purpose
+  (see `hex-nibble`).
 
   Per Spec 012 §Bidirectional URL ↔ params §`+` is a literal:
   `decodeURIComponent` is the de-facto reference, the browser is the
   canonical host, and the JVM matches it. A host-divergent decoder
   yields a different `:params` / `:query` slice for the same URL on JVM
   (SSR) vs CLJS (browser) — the exact Spec 011 hydration-mismatch class
-  the spec names there. Both corrections are conformance repairs to that
-  standing requirement, not new policy; §Route-miss ¶5 already requires
-  malformed percent-encoding to fail the whole match closed."
+  the spec names there. All three corrections are conformance repairs to
+  that standing requirement, not new policy; §Route-miss ¶5 already
+  requires malformed percent-encoding to fail the whole match closed."
   [s]
-  #?(:clj  (-> (str s)
-               (.replace "+" "%2B")
-               (percent-escape-non-ascii)
-               (java.net.URLDecoder/decode "ISO-8859-1")
-               (.getBytes java.nio.charset.StandardCharsets/ISO_8859_1)
-               (strict-utf8-decode))
+  #?(:clj  (decode-percent-escapes (str s))
      :cljs (js/decodeURIComponent (str s))))
 
 (defn safe-url-decode

--- a/implementation/routing/test/re_frame/routing_url_decoding_parity_cljs_test.cljc
+++ b/implementation/routing/test/re_frame/routing_url_decoding_parity_cljs_test.cljc
@@ -50,7 +50,34 @@
   of this namespace red on the invalid-UTF-8 table, on the
   `malformed-url?` positions and on the production `match-url` prism,
   while every valid-input control — `%EF%BF%BD` included — stays green,
-  proving those controls are not what carries the suite."
+  proving those controls are not what carries the suite.
+
+  THE SECOND HALF: LITERAL UTF-16 CODE UNITS. The first strict-decoder
+  fix reached the byte level by percent-escaping every literal non-ASCII
+  character with `String.getBytes(UTF_8)`, which silently REPLACES an
+  unpaired surrogate code unit with the byte `0x3F` — a literal `?`.
+  Java strings, like JavaScript strings, can legally hold one, and
+  `decodeURIComponent` copies a literal to its output untouched rather
+  than encoding it, so a lone U+D800 decoded to `?` on the JVM and to
+  the raw code unit in the browser: the same host divergence again, and
+  aliased onto a legitimate character. The JVM arm now segments the
+  input, strict-decoding only the bytes the percent escapes contribute.
+
+  THOSE TWO ROWS PULL IN OPPOSITE DIRECTIONS AND BOTH ARE ASSERTED HERE.
+  A LITERAL lone surrogate must SURVIVE; a PERCENT-ENCODED one
+  (`%ED%A0%80`) must still be nil, because UTF-8 has no encoding for a
+  surrogate. A fix that merely passed everything through would satisfy
+  the first and break the second, so the valid surrogate PAIR and the
+  escaped-lone-surrogate rows are what keep the seam honest in both
+  directions.
+
+  EVERY SURROGATE CASE IS BUILT FROM NUMERIC CODE UNITS AND ASSERTED AS
+  A VECTOR OF CODE UNITS. An unpaired surrogate cannot be written as a
+  source literal at all (it has no UTF-8 encoding, which is the bug),
+  and on output a lone surrogate, a `?` and a U+FFFD are all mojibake in
+  a terminal and indistinguishable by eye. Comparing rendered strings
+  would answer \"no divergence\" in the same confident voice as a real
+  all-clear."
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
@@ -65,6 +92,34 @@
   (test-support/make-reset-runtime-fixture
     {:adapter substrate/adapter
      :init-fn routing/reset-counters!}))
+
+;; ---- code-unit instruments ----------------------------------------------
+;;
+;; A UTF-16 code unit is the unit of both a Java string and a JavaScript
+;; string, and it is the unit this suite's surrogate half is about. Both
+;; helpers below are index-based on purpose: `count`/`.length` and
+;; `.charAt`/`.charCodeAt` agree on both hosts that the index runs over
+;; CODE UNITS, whereas iterating a JS string with `Array.from` or `for
+;; ... of` walks CODE POINTS and silently collapses a surrogate pair to
+;; one element. A census run through the wrong instrument reports "no
+;; divergence" exactly as convincingly as a real one.
+
+(defn- code-units
+  "`s` as a vector of its UTF-16 code units; nil passes through so the
+  fail-closed sentinel stays distinguishable from an empty decode."
+  [s]
+  (when (some? s)
+    (mapv (fn [i]
+            #?(:clj  (int (.charAt ^String s i))
+               :cljs (.charCodeAt s i)))
+          (range (count s)))))
+
+(defn- from-code-units
+  "A string built from literal UTF-16 code units. The only way to write
+  an UNPAIRED surrogate: it has no UTF-8 encoding, so it cannot appear
+  as a character literal in this (UTF-8) source file."
+  [& ns]
+  (apply str (map char ns)))
 
 ;; ---- the UTF-8 validity boundary ----------------------------------------
 ;;
@@ -81,7 +136,10 @@
    ["%FF"       "invalid lead byte — FF can never begin a UTF-8 sequence"]
    ["%E0%80%80" "overlong — a three-byte encoding of a code point that needs one"]
    ["%C3"       "truncated — a two-byte lead with no continuation byte"]
-   ["%80"       "bare continuation byte — 80 with no lead"]])
+   ["%80"       "bare continuation byte — 80 with no lead"]
+   ["%ED%BF%BF" "lone LOW surrogate U+DFFF, escaped — the other half of the range"]
+   ["%ED%A0%BD%ED%B8%80"
+    "CESU-8: U+1F600's two surrogate halves escaped INDIVIDUALLY rather than as the astral code point. Each half is a surrogate, so each is refused — a pair is only a pair in UTF-16"]])
 
 (def ^:private valid-decodes
   "Inputs that MUST still decode, with their literal expected output.
@@ -151,6 +209,84 @@
     (is (nil? (url/safe-url-decode "%E2%82é"))
         "same, with a two-byte truncation")))
 
+;; ---- literal UTF-16 code units: the surrogate seam ------------------------
+;;
+;; Everything above is about the BYTES a percent escape contributes.
+;; This section is about the CODE UNITS a literal contributes, which the
+;; decoder must never route through a byte encoder at all.
+
+(def ^:private literal-code-unit-passthrough
+  "Inputs carrying LITERAL (unescaped) UTF-16 code units, with the exact
+  code-unit vector `decodeURIComponent` returns for each. Every
+  expectation is a literal vector measured against native
+  `decodeURIComponent`, never derived from `url-decode` itself — a
+  decoder that changed on one host only must not be able to rewrite what
+  it is compared against."
+  [[[0xD800]                 [55296]
+    "LONE HIGH surrogate — no UTF-8 encoding exists, so the previous JVM arm's String.getBytes(UTF_8) substituted 0x3F and it decoded to `?`"]
+   [[0xDFFF]                 [57343]
+    "LONE LOW surrogate — the other half of the range, same substitution"]
+   [[97 0xD800 98]           [97 55296 98]
+    "EMBEDDED lone surrogate — `a`, U+D800, `b`; the JVM returned [97 63 98]"]
+   [[0xD83D 0xDE00]          [55357 56832]
+    "THE PAIR CONTROL: a WELL-FORMED surrogate pair (U+1F600) must survive as its two code units. This is what stops the fix from being `pass everything through` — it was already correct, and must stay correct"]
+   [[0xDFFF 0xD800]          [57343 55296]
+    "a low unit followed by a high unit — adjacent but REVERSED, so still two unpaired halves rather than a pair"]])
+
+(deftest url-decode-preserves-literal-utf16-code-units-on-both-hosts
+  (testing "a literal code unit is COPIED to the output, never encoded.
+            `decodeURIComponent` only ever decodes the bytes percent
+            escapes contribute; routing a literal through a UTF-8 encoder
+            to reach the strict decoder replaced an unpaired surrogate
+            with `?` on the JVM (rf2-k2d2t)"
+    (doseq [[in-units expected-units why] literal-code-unit-passthrough]
+      (is (= expected-units
+             (code-units (url/safe-url-decode (apply from-code-units in-units))))
+          why)))
+
+  (testing "a literal lone surrogate ADJACENT to a valid escape run: the
+            seam keeps them apart, so neither corrupts the other"
+    (is (= [55296 233]
+           (code-units (url/safe-url-decode (str (from-code-units 0xD800) "%C3%A9"))))
+        "literal U+D800 then %C3%A9 — the escape still decodes to é")
+    (is (= [233 55296]
+           (code-units (url/safe-url-decode (str "%C3%A9" (from-code-units 0xD800)))))
+        "and in the other order")
+    (is (= [65 55296]
+           (code-units (url/safe-url-decode (str "%41" (from-code-units 0xD800)))))
+        "an ASCII escape beside one, too"))
+
+  (testing "THE COUNTERWEIGHT. A PERCENT-ENCODED lone surrogate must
+            still fail closed: UTF-8 has no encoding for a surrogate, so
+            those bytes are malformed however they arrived. A fix that
+            preserved literals by weakening the escaped-byte check would
+            red here"
+    (is (nil? (url/safe-url-decode "%ED%A0%80"))
+        "escaped lone HIGH surrogate stays nil")
+    (is (nil? (url/safe-url-decode "%ED%BF%BF"))
+        "escaped lone LOW surrogate stays nil")
+    (is (nil? (url/safe-url-decode "%ED%A0%BD%ED%B8%80"))
+        "and CESU-8 — U+1F600's halves escaped individually — stays nil")
+    (is (= [55357 56832] (code-units (url/safe-url-decode "%F0%9F%98%80")))
+        "while the SAME code point escaped properly, as one four-byte
+         UTF-8 sequence, decodes to the same pair the literal control
+         carries — so the three rows above are refusing the encoding, not
+         the code point")
+    (is (nil? (url/safe-url-decode (str "%C3" (from-code-units 0xD800))))
+        "a TRUNCATED escape run flushed against a literal surrogate is
+         still malformed — the seam does not rescue it"))
+
+  (testing "`malformed-url?` agrees across hosts for a literal code unit
+            in a path segment. It reads FALSE on both — a lone surrogate
+            is not malformed PERCENT-ENCODING — where the escaped form
+            reads TRUE on both"
+    (is (false? (routing/malformed-url? (str "/p/" (from-code-units 0xD800))))
+        "literal lone surrogate in a path segment: decodable on both hosts")
+    (is (false? (routing/malformed-url? (str "/p/x?q=" (from-code-units 0xDFFF))))
+        "and in a query value")
+    (is (true? (routing/malformed-url? "/p/%ED%A0%80"))
+        "while the percent-encoded form is malformed on both hosts")))
+
 ;; ---- the public predicate, in all four URL positions ---------------------
 
 (deftest malformed-url?-agrees-across-hosts-in-every-url-position
@@ -212,7 +348,12 @@
             value containing a REAL U+FFFD, which `url-encode` emits as
             %EF%BF%BD and the strict decoder must read back"
     (rf/reg-route :decode-parity/round {:params [:map [:slug :string]]} "/r/:slug")
-    (doseq [slug ["café" "日本" "a�b" "it's~a(test)!" "50% done"]]
+    (doseq [slug ["café" "日本" "a�b" "it's~a(test)!" "50% done"
+                  ;; a WELL-FORMED surrogate pair, built from code units:
+                  ;; `url-encode` emits it as the astral code point's
+                  ;; four UTF-8 bytes and the segmenting decoder must
+                  ;; read those back as the same two code units.
+                  (from-code-units 0xD83D 0xDE00)]]
       (let [built  (routing/route-url {:to :decode-parity/round :params {:slug slug}})
             parsed (routing/match-url built)]
         (is (some? parsed)


### PR DESCRIPTION
Closes rf2-k2d2t (the residual its PR #8882 audit reopened it for).

## The defect

PR #8882 made `re-frame.routing.url/url-decode` fail closed on invalid
percent-encoded UTF-8 on both hosts. It reached the byte level by
percent-escaping every literal non-ASCII character with
`String.getBytes(UTF_8)`, whose REPLACE action silently turns an
**unpaired surrogate code unit** into the byte `0x3F` — a literal `?`.
A Java string, like a JavaScript string, may legally hold one, and
`decodeURIComponent` never encodes a literal at all: it copies it to the
output untouched.

Verified at the current tip before any edit, against production
`safe-url-decode` on the JVM and native `decodeURIComponent` in node.
Inputs built from numeric code units, outputs read as vectors of code
units — a lone surrogate, a `?` and a U+FFFD are all mojibake in a
terminal and indistinguishable by eye.

| input (code units) | JVM before | node `decodeURIComponent` |
|---|---|---|
| `[D800]` lone high | `[63]` | `[55296]` |
| `[DFFF]` lone low | `[63]` | `[57343]` |
| `[61 D800 62]` = `a` + U+D800 + `b` | `[97 63 98]` | `[97 55296 98]` |
| `[D83D DE00]` valid PAIR | `[55357 56832]` | `[55357 56832]` (agreed) |
| `%ED%A0%80` escaped lone | nil | nil (agreed) |

So the JVM both diverged from the browser and **aliased malformed UTF-16
onto a legitimate question mark** — the same shape of defect rf2-j3tud
fixed on the encode side, where `%3F` was the substitution.

## The fix

The JVM arm is now one left-to-right walk with a **segmentation seam at
every literal character**. Consecutive `%XX` escapes accumulate into a
byte buffer; the moment a non-`%` character arrives (or the string ends)
that buffer is flushed through the strict UTF-8 decoder and the literal
character is appended verbatim. That is `decodeURIComponent`'s own decode
loop, so `java.net.URLDecoder` leaves the path entirely — and with it the
`+`-preescape and the non-ASCII escaping stage, which existed only to
feed it. The net diff removes one helper and the three-stage pipeline and
adds one.

Structural validation is unchanged in substance: `%`, `%a` and `%zz`
still throw `IllegalArgumentException`, now from the escape reader. Its
hex reader is ASCII-only on purpose — `Character/digit` (and
`Integer/parseInt`, which defers to it) accepts Arabic-Indic digits that
`decodeURIComponent` refuses.

The CLJS arm is untouched and remains normative. No caller changed; no
public API changed. `implementation/http` is unrelated — its
`url-encode` merely shares the name.

**The counterweight holds.** A *percent-encoded* lone surrogate must
still fail closed, because UTF-8 has no encoding for a surrogate however
those bytes arrived: `%ED%A0%80`, `%ED%BF%BF` and CESU-8
`%ED%A0%BD%ED%B8%80` are all nil on both hosts, while the same code point
escaped properly as one four-byte sequence (`%F0%9F%98%80`) decodes to
the pair. Those two rows pull in opposite directions and both are pinned.

## No spec edit owed

Checked rather than assumed, and `spec/012-Routing.md` / `spec/011-SSR.md`
are untouched. Spec 012 already names `decodeURIComponent` as the
reference and the browser as the canonical host; the JVM arm is
explicitly the emulation. An incomplete emulation is a conformance bug in
the emulator — the same disposition PR #8873, PR #8882 and PR #8908
reached.

## Tests

`implementation/routing/test/re_frame/routing_url_decoding_parity_cljs_test.cljc`
— the existing shared `.cljc` suite — gains the four controls the audit
named (lone-high, lone-low, embedded-lone, valid PAIR) plus the
reversed-halves case, three literal/escape adjacency rows, the escaped
counterweights, the CESU-8 row, `malformed-url?` over a literal code
unit, and a surrogate-pair slug in the `route-url` to `match-url`
round trip. Every surrogate case is built from numeric code units and
asserted as a vector of code units, against literal expected values
measured from native `decodeURIComponent` — never derived from
`url-decode` itself.

## Quality gates

All re-run on the final base after rebasing onto `28b3e3e604`
(16 landings on from the first pass). Exit codes captured on one command
line and quoted from the captured `.exit` file, not from harness-reported
status.

| gate | captured exit | result |
|---|---|---|
| JVM `clojure -M:test` in `implementation/routing` | 0 | 548 tests / 3340 assertions, 0 failures |
| CLJS `compile-node-test.cjs node-test` | 0 | 1873 files, 0 warnings |
| CLJS `node out/node-test.js` | 0 | 11149 tests / 55142 assertions, 0 failures |
| `clj-kondo --fail-level error` over routing src + the suite | 0 | 0 errors |

The CLJS lane was discriminated by its printed root: shadow-cljs named
this worker checkout's own `shadow-cljs.edn`. No markdown, `spec/` or
workflow file changed, so neither doc-link gate has a path here and
neither is nominated.

## Controls — two plants, each redding exactly one direction

The whole risk in this change is coupling the two directions together, so
each was sabotaged separately. Every plant's anchor match count was read
as 1 before the run, and every restore verified by **git blob hash**
against the committed object (line endings are translated in this
checkout, so a byte digest of the working file would not be sound).

**A — the seam removed** (one line: the literal branch round-trips each
character through `getBytes(UTF_8)`, restoring the replacing encoder).
Blob `16399d8f` to `bea02e6c`, restored and re-verified back to
`16399d8f`. Captured exit 1, **8 failures**, counts 548 / 3340 identical
to the green run so no namespace crashed and no lane truncated. All 8 are
literal-code-unit rows — lone-high `[55296]` read `[63]`, lone-low
`[57343]` read `[63]`, embedded `[97 55296 98]` read `[97 63 98]`, the
pair, the reversed halves and the three adjacency rows. **ZERO mention
any percent-encoded row**: the fail-closed table, the `%EF%BF%BD`
near-miss control and every escaped-surrogate counterweight stayed green.

**B — the escaped-byte check weakened** (one line:
`CodingErrorAction/REPORT` to `REPLACE`). Blob `16399d8f` to `6fb2c013`,
restored and re-verified back to `16399d8f`. Captured exit 1, **26
failures**, counts again 548 / 3340. Every one is a fail-closed
assertion — the invalid-UTF-8 table, the `malformed-url?` positions, the
production `match-url` prism, and the escaped-surrogate counterweights.
**ZERO literal-passthrough rows redded** (0 failures at that table's
line).

A and B are the same suite redding in opposite directions under opposite
plants, which is what proves the literal seam and the escaped-byte check
are independent rather than two names for one property.

**C — a wrong expected value in the SHARED table** (`[97 55296 98]`
changed to `[97 12345 98]`). Blob `2b229131` to `2d53893a`, restored and
re-verified back to `2b229131`. Run on the **CLJS** lane: captured exit
1, exactly 1 failure, reporting the CLJS host's own output as
`[97 55296 98]`. Three proofs at once — the new rows genuinely execute on
the CLJS host and not only on the JVM; the host-parity claim is measured
from inside the suite rather than asserted; and `code-units` really walks
code units there (three elements for a three-code-unit string, where
`Array.from` would have collapsed a pair). Counts 11127 / 54988 identical
to that run's green baseline.
