### PR TITLE
docs(method): the fix dispatch re-drafts; frozen clocks are the signature of a run about to report

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -555,23 +555,47 @@ second worker arrives and nothing in the change records that anyone is inside it
 reads a ready change, the criterion passes, and the merge lands under a live worker — the exact
 failure the flag exists to prevent, arriving by the one path where the flag was never the current
 worker's to set. Measured here; nothing was lost, because the commits that went green were the ones
-that landed, but that was timing rather than protection. So on a fix dispatch the flag is stale by
-construction, and the only record that a second worker is there is the mayor's dispatch ledger.
+that landed, but that was timing rather than protection.
 
-**Stuck-CLOSED — an author goes silent holding a green draft.** Both remedies above assume the author
-answers: wait for the ready mark, or message them. Measured here: three workers registered as
-*running* while idle for over an hour — no writes, tips unmoved, worktrees clean, everything pushed —
-two of them holding drafts, one reading exactly at band with nothing non-terminal and nothing failing.
-Direct messages went unanswered for half an hour. A finished change is then blocked by an interlock
-whose protected party may no longer exist, and the fleet loses the slot as well as the change.
+**The remedy belongs to the DISPATCHER, because the worker cannot supply it.** Telling the fix worker
+to mark the change ready last does nothing when the flag is already ready before it starts, and a rule
+the protected party is unable to execute is not a rule. So converting the change back to draft is part
+of dispatching a fix, done before the worker begins — and **confirm the state took rather than trusting
+the call**, since a host that ignores the request fails silently and leaves exactly the gap you were
+closing. The dispatch ledger is then the record of who is inside it, not the only one.
 
-**Do not answer that by flipping the flag on an inference.** *It looks done* is the proxy the reaping
-rules refuse one surface over, and every reason the paragraph above rejects a per-merge liveness check
-still holds. What differs is scope: this is a rare exception path — one otherwise-mergeable draft whose
-author has stopped — rather than a test on every merge. Settle it the way reaping is settled, by a read
-rather than an inference: the agent's own report, or the operator's decision to stop that agent, which
-settles liveness by making it false. Until one of those arrives the change waits, and the honest report
-says a finished change is stranded and why.
+**Stuck-CLOSED — an author appears to go silent holding a green draft. Read this one carefully,
+because the reading is usually wrong.** The remedies above assume the author answers: wait for the
+ready mark, or message them. What gets read instead is a worker that has stopped — no writes, tip
+unmoved, worktree clean, everything pushed, a direct message unanswered for half an hour, and a draft
+sitting exactly at band with nothing non-terminal and nothing failing.
+
+**Every signal in that list is also what a worker in its FINAL MINUTES looks like, and that is the
+likelier explanation.** A worker finishing up — running one last foreground gate, deleting gate logs,
+unlinking a shared-dependency link, tidying a scratch directory — writes outside the worktree and
+outside version control, and is too busy to answer. So the tip does not move, the fetch clock does not
+move, the write clock does not move, and the message goes unanswered. **The four indirect signals do
+not fail independently here; they fail together, for one cause.** Frozen-across-three-readings feels
+like the most damning pattern available and is in fact the signature of a run about to report.
+
+Measured, twice: on the first occasion five workers were reported dormant and four then completed
+alive with full reports, one answering the ping directly to say it had been on final hygiene; the
+diagnosis was retracted in full, including a second claim — that messaging was inoperative — which
+was *slow* converted into *broken*. It recurred the same day on a sixth worker whose clocks were
+frozen for over an hour and which completed normally.
+
+**So prefer the DIRECT signal where your tooling offers one** — a live progress line, a status the
+supervisor maintains — over any number of indirect clocks, and **treat the four clocks as the fallback
+they are.** If you have only the clocks, declare a window and re-read rather than acting; the error is
+cheap in exactly one direction.
+
+**And do not answer any of it by flipping the flag on an inference.** *It looks done* is the proxy the
+reaping rules refuse one surface over, and every reason the paragraph above rejects a per-merge
+liveness check still holds. Settle it the way reaping is settled, by a read rather than an inference:
+the agent's own report, or the operator's decision to stop that agent, which settles liveness by making
+it false. Until one of those arrives the change waits, and the honest report says a finished change is
+stranded and why. That rule is unchanged by the above — what changes is how often you should expect to
+reach for it, which is rarely.
 
 ---
 

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -62,6 +62,15 @@ a draft, so the interlock costs this loop nothing to remember. See
 [*Publishing the change*](dispatch-prompt-template.md#publishing-the-change) in
 `dispatch-prompt-template.md`.
 
+**With one exception this loop DOES have to remember, because it is the loop that creates
+it.** The flag protects whoever is inside the change, and it is set by whoever finished
+last — so a fix dispatch onto an EXISTING ready change inherits a flag its original author
+set, and nothing in the change records that somebody is inside it now. The interlock is then
+already open before the second worker starts. **So converting that change back to draft is
+part of dispatching the fix, not part of the fix**: do it yourself, before the worker begins,
+and confirm the state took rather than assuming the call did. The fix worker marks it ready
+last, exactly as any other worker does.
+
 Resolve the head first — the branch name **and** the head revision — because
 clauses 4 and 5 are both keyed to it.
 
@@ -902,6 +911,19 @@ and both readings went wrong in a single day here, in opposite directions.
    dispatch are exactly when you need it, because the first thing every brief tells a worker to do is
    read. Its absence proves nothing — not every dispatch claims — which is why the sweep starts from
    the worktrees in the first place.
+
+   **And if your tooling maintains a live status for a running agent, read THAT before any of these.**
+   Every signal in this step is indirect — it infers a worker from the traces it leaves — and they
+   share a blind spot wide enough to matter: a worker in its **final minutes**, running a last gate and
+   then tidying scratch files and shared-dependency links, works outside the worktree and outside
+   version control and is too busy to answer. Tip, fetch clock, write clock and a direct message then
+   read as dead *together*, for one cause, which is why corroborating one with another does not help
+   here. **Frozen on every clock across several readings is the signature of a run about to report**,
+   not of a dead one. Measured twice in one day, on five workers and then on a sixth: every one
+   completed alive, and on the second occasion the supervisor's own one-line progress string named the
+   phase outright while the four clocks said otherwise. Where no direct status exists, declare a window
+   and re-read rather than acting — waiting costs a tick, and acting costs a duplicate worker in a live
+   worktree.
 
    **That clock says "no activity" in four voices and you can only tell them apart with a control.**
    Besides the reading worker and the poller treated just below, a path that resolves to nothing


### PR DESCRIPTION
Closes rf2-m7sto.

That item was filed by the mayor reporting workers registered as running while idle. **The diagnosis
was retracted the same day** — four of the five completed alive with full reports, one answering the
ping to say it had been on final hygiene — but the retraction never reached the documents, which still
present it as a measured failure. An audit caught that and reopened the item with a bounded completion.
This is it.

## Three changes

**1. The stuck-CLOSED "measurement" is recast, not deleted.** What actually happened is more useful than
the false version: every one of the four indirect signals — tip revision, fetch clock, write clock, an
unanswered message — reads exactly the same for a worker in its FINAL MINUTES as for a dead one, because
tidying gate logs, scratch files and shared-dependency links happens outside the worktree and outside
version control. They do not fail independently; they fail **together, for one cause**, which is why
corroborating one with another does not help. Frozen on every clock across several readings is the
signature of a run about to report.

Measured twice in one day: five workers, then a sixth whose clocks were frozen for over an hour and which
completed normally. On the second occasion the supervisor's own progress line named the phase outright
while the four clocks said otherwise — so the guidance is now **prefer a direct status where the tooling
has one**, and where it does not, declare a window and re-read.

The conservative rule for a genuinely silent author is **unchanged**: never flip the flag on an inference;
settle it by the agent's own report or the operator's decision to stop it. What changes is how often you
should expect to reach for it, which is rarely.

**2. The stale-OPEN half gets an action that the responsible party can actually perform.** It correctly
described a fix dispatch inheriting a ready flag set by the previous author, then left the remedy to the
worker — which cannot work, because the flag is already ready before that worker starts. Re-drafting the
change is now part of **dispatching** the fix, done before work begins, with the state confirmed rather
than the call assumed.

**3. `loops.md`'s contradictory sibling is corrected.** It said the interlock "costs this loop nothing to
remember", which is true for an ordinary dispatch and false for the one case the merge loop itself creates.
That exception is now stated where the claim is made.

`loops.md` §4 needed no correction on the main point — it already says a still tip is the *expected*
reading for a healthy worker inside a long gate — so the addition there is only the missing priority:
read a direct status before any indirect clock.

## Quality gates

| Gate | Exit | Result |
|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | clean |
| `scripts/check_readme_links.py --ci` | **0** | clean |
| `python -m mkdocs build --strict` | **0** | clean |
| `check_doc_slugs.py` **sabotage** | **1** | `BROKEN ANCHOR: docs\the-mayor-method\loops.md:921 -> loops.md#planted-draftlock-zzz` |
| `check_doc_slugs.py` restored | **0** | clean |

Exit codes captured from the runner on one command line, not read from harness status. The plant went into
PROSE at a line this change adds (match count checked at 1 beforehand, since a fault inside a fence is
invisible to this gate); restore verified by git **blob** hash against the committed object —
`cfe4fde8c70871fa9ef7fe229e131587a5d95e9f` on both sides. All three gates re-run after rebasing.

**Bare `mkdocs` returns 127 in Git Bash on this checkout** — no verdict, not a pass. Run as `python -m mkdocs`.

## What no gate covers

`mkdocs build --strict` does not gate heading anchors (MkDocs grades them at INFO; `--strict` promotes only
WARNING), so `check_doc_slugs.py` is the sole anchor gate for these pages. Nothing validates prose, tables or
rendering. This change adds no link, anchor, heading, table or fenced block, so the green above says it broke
nothing rather than that it is right. Merge-base diff read for reverts: 15 deleted lines, all of them prose
this change rewrites, and the text merged by #8920 and #8922 into the same two files is present and untouched
— checked explicitly rather than inferred from a clean rebase.

No scope beyond the item: no liveness dashboard, no per-merge activity sweep.