### PR TITLE
fix(story): Story's macro source stamp absolutises via core's canonical helper (rf2-3xq1v)

### DIFF
--- a/tools/story/src/re_frame/story/macros.clj
+++ b/tools/story/src/re_frame/story/macros.clj
@@ -24,11 +24,11 @@
   the `:source` key — tools / 10x / IDE jump-to-source consume this via
   `(story/handler-meta kind id)`.
 
-  `:file` resolution prefers `(:file (meta &form))` over `*file*` —
-  see `coords-form` for the rationale. The short version:
-  the CLJS analyzer never binds Clojure's `*file*` during macro
-  expansion, so reading it returns `\"NO_SOURCE_PATH\"`; the reader-
-  attached `:file` on the form's metadata is the portable answer.
+  Both the picking rule and the `:file` ABSOLUTISATION are core's:
+  `coords-form` delegates wholesale to
+  `re-frame.source-coords/coords-form`, the same stamp every
+  `re-frame.core` `reg-*` macro emits. See `coords-form` for what that
+  buys and why Story must not re-derive it.
 
   ## Form-B `:variants` desugaring
 
@@ -36,51 +36,75 @@
   and, if present, emits N independent `reg-variant*` calls as siblings
   of the parent `reg-story*` call. Per `001-Authoring.md` §Registration macros this preserves
   hot-reload-by-variant: each variant is a separate top-level form so
-  save-and-reload only invalidates the changed slot.")
+  save-and-reload only invalidates the changed slot."
+  (:require [re-frame.source-coords :as source-coords]))
 
 ;; ---- source-coord helper -------------------------------------------------
 
 (defn coords-form
-  "Construct the literal map that the macro expansion will assign to
-  `re-frame.story.registrar/*pending-coords*`. `form-meta` is the value
-  of `(meta &form)` from the calling macro; `file` is `*file*` from the
-  macro's compile environment; `ns-sym` is the consumer's namespace
-  symbol.
+  "Construct the compile-time coord MAP LITERAL that the macro expansion
+  assigns to `re-frame.story.registrar/*pending-coords*`. `form-meta` is
+  the value of `(meta &form)` from the calling macro; `file` is `*file*`
+  from the macro's compile environment; `ns-sym` is the consumer's
+  namespace symbol.
 
-  Returns a compile-time Clojure form (a `cond->` expression) that
-  evaluates to the map at runtime. Mirrors
-  `re-frame.core/reg-event`'s coord-capture pattern.
+  Delegates wholesale to `re-frame.source-coords/coords-form` — the
+  canonical stamp every `re-frame.core` `reg-*` macro emits. Story
+  authors a separate macro pipeline, but the coordinate it stamps is the
+  same artefact core stamps and is read back by the same consumers
+  (`re-frame.source-coords.editor-uri`, the Story / Xray open-in-editor
+  chips, the Pair MCP source surface), so the derivation belongs in one
+  place. Three properties come with that reuse, and Story previously
+  carried only the first:
 
-  ## :file resolution
+  1. **`:file` picking.** `(:file form-meta)` wins over `*file*`, and the
+     `\"NO_SOURCE_PATH\"` sentinel is rejected from either source (with
+     `:file` omitted outright when both resolve to it — better no `:file`
+     than a poison value that defeats jump-to-source). This is rf2-ulxi:
+     `cljs.analyzer/macroexpand-1*` binds `*cljs-file*`, not Clojure's
+     `*file*`, so under CLJS `*file*` retains the JVM compiler's
+     `\"NO_SOURCE_PATH\"` default while tools.reader HAS stamped `{:file
+     ...}` onto every collection form's metadata. Form-meta is the answer
+     that survives both compilation hosts.
 
-  `:file` comes from `(:file form-meta)` first — the CLJS analyzer reads
-  source files via `tools.reader/indexing-push-back-reader` with the
-  filename argument set, and tools.reader stamps `{:file ...}` on every
-  collection-form's metadata. Falling back to `*file*` covers the JVM
-  compilation path where `clojure.lang.Compiler` binds `*file*` itself
-  but the reader does NOT attach `:file` to form metadata.
+  2. **`:file` absolutisation, at MACRO-EXPANSION time** (rf2-wvsxg).
+     Both shadow-cljs and the JVM compiler put only the
+     CLASSPATH-RELATIVE portion of the source file in `:file` —
+     `counter_with_stories/stories.cljs`, never the on-disk path — and
+     which source root resolved it is invisible to every consumer.
+     `re-frame.source-coords/absolutise-file` resolves it through the
+     context class-loader on the JVM side of the expansion and bakes the
+     absolute path into the emitted literal.
 
-  Reading `*file*` alone is wrong for CLJS because `cljs.analyzer/
-  macroexpand-1*` binds `*cljs-file*` (not Clojure's `*file*`) during
-  macro expansion — so `*file*` retains whatever the JVM compiler last
-  set it to, which is `\"NO_SOURCE_PATH\"` on a fresh classloader. The
-  form-meta path is the portable answer because the reader-attached
-  `:file` survives across both compilation hosts.
+     This is not optional polish for Story. The open-in-editor client
+     PREFERS the dev-server endpoint and FALLS BACK to an `editor://`
+     URI on any non-2xx — including the 422 the endpoint answers when
+     `launch-editor` declines a coordinate-bearing request. With a
+     relative `:file` that fallback ships
+     `windsurf://file/counter_with_stories/stories.cljs:196:3`, which no
+     editor's scheme handler can resolve, and the chip silently misses.
 
-  Also rejects the `\"NO_SOURCE_PATH\"` sentinel from either source — if
-  *both* sources resolve to the sentinel, omit `:file` entirely (better
-  no `:file` than a poison value that defeats jump-to-source)."
+     Note where the resolution happens: ONCE, in Clojure, while the macro
+     expands. The CLJS runtime only ever sees a baked literal string.
+     Story does NOT discover a source root in the browser — the
+     repository's browser-side checkout-root pipeline was retired
+     precisely because the endpoint plus this compile-time stamp make it
+     redundant, and nothing here reintroduces it. Hosts that need a root
+     at runtime (static exports, non-shadow hosts, in-jar sources whose
+     classpath probe finds no `file:` URL) still set the public
+     `:rf.story/project-root` knob, which `editor-uri/compose-path`
+     applies only to a `:file` that is still relative.
+
+  3. **Expansion-time literal, not an emitted runtime `cond->`**
+     (rf2-i3dvj evaluation-order transparency): the returned value is a
+     map, not a form that builds one.
+
+  Story registrations are dev-only — every expansion sits under
+  `(when re-frame.story.config/enabled? ...)` and elides under
+  `:advanced` — so there is no production coord-form counterpart to pick
+  between here the way core's `reg-*` macros must."
   [form-meta file ns-sym]
-  (let [meta-file  (:file form-meta)
-        no-source? #(or (nil? %) (= "NO_SOURCE_PATH" %))
-        chosen     (cond
-                     (not (no-source? meta-file)) meta-file
-                     (not (no-source? file))      file
-                     :else                        nil)]
-    `(cond-> {:ns '~ns-sym}
-       ~chosen              (assoc :file ~chosen)
-       ~(:line form-meta)   (assoc :line ~(:line form-meta))
-       ~(:column form-meta) (assoc :column ~(:column form-meta)))))
+  (source-coords/coords-form form-meta file ns-sym))
 
 (defn variant-id-for
   "Build the variant id from a story id and a variant-name key.

--- a/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
@@ -14,11 +14,17 @@
     reg-fx produce a resolved URI through the same denylist seam the
     chip uses (Xray-parity port).
   - rf2-ox357n — the positive allowlist was removed; only the
-    `javascript:` / `data:` / `vbscript:` denylist gates the chip now."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+    `javascript:` / `data:` / `vbscript:` denylist gates the chip now.
+  - rf2-3xq1v — a REAL Story registration, macro-stamped by this very
+    compile, survives a 422 endpoint decline with a URI the editor can
+    actually resolve. See the block at the foot of this file."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.source-coords.editor-uri :as editor-uri]
             [re-frame.source-coords.open-endpoint :as open-endpoint]
             [re-frame.source-store :as source-store]
+            [re-frame.story :as story]
             [re-frame.story.config :as config]
             [re-frame.story.ui.open-in-editor :as open-in-editor]
             [re-frame.substrate.plain-atom :as plain-atom])
@@ -794,3 +800,141 @@
             "no dev server → URI fallback navigates exactly as before")
         (finally
           (open-endpoint/set-launcher! prev))))))
+
+;; ---- rf2-3xq1v — a real Story coordinate through a 422 decline -----------
+;;
+;; Every URI assertion above is written against a HAND-TYPED coord
+;; (`{:file "src/x.cljs" ...}`), which is the right shape for pinning the
+;; URI grammar and the wrong shape for pinning what Story's macro pipeline
+;; actually stamps. The rf2-3xq1v defect lived exactly in that gap: the
+;; grammar was fine, the coordinate feeding it was classpath-relative.
+;;
+;; `re-frame.story.macros/coords-form` now delegates to
+;; `re-frame.source-coords/coords-form`, which absolutises `:file` through
+;; the context class-loader ON THE JVM, AT MACROEXPANSION. So the
+;; registration below is the assertion's own fixture in the strictest
+;; sense: THIS compile stamped it, from THIS file, and what the compile
+;; baked into the bundle is what the block reads back.
+;;
+;; The scenario is the audit's: the endpoint is PREFERRED and declines
+;; with 422 (what `re-frame.testbed.open-in-editor-server` answers when
+;; `launch-editor` cannot carry a coordinate to the configured editor), no
+;; `:rf.story/project-root` is configured (the state every repository dev
+;; testbed is in since the browser-side checkout-root pipeline was
+;; retired), and the client falls back to the `windsurf://` URI. Before
+;; the fix that URI was `windsurf://file/counter_with_stories/stories.cljs
+;; :196:3` — relative, unresolvable, a chip that silently misses.
+;;
+;; The real client seam runs: `fetch-launcher!` unmodified over a stubbed
+;; `globalThis.fetch`, Story's own `open-coord!` (so `resolve-uri` and the
+;; navigator seam are in the path too). Only the promise is captured, so
+;; the async test can await the decision.
+
+(def ^:private real-fetch
+  "The platform `fetch`, captured at load. A stub left installed would
+  answer for every later namespace in the shared `:node-test` build — a
+  leak a green suite hides rather than reports — so the test asserts the
+  global is `identical?` to this again afterwards."
+  (.-fetch js/globalThis))
+
+(defn- strip-uri-position
+  "`windsurf://file/<path>:<line>:<column>` → `<path>`."
+  [uri]
+  (-> uri
+      (subs (count "windsurf://file/"))
+      (str/replace #":\d+:\d+$" "")))
+
+(deftest endpoint-422-falls-back-to-an-absolute-uri-for-a-real-story-coord
+  (testing "rf2-3xq1v — a real `story/reg-story` coordinate, stamped by this
+            compile, reaches the editor through the 422 fallback as an
+            ABSOLUTE path"
+    (story/reg-story :story.source-coords.cljs-pin
+      {:doc "rf2-3xq1v fixture — this form's own coordinate is the subject."})
+    (let [coord (:source (story/handler-meta :story :story.source-coords.cljs-pin))]
+      (is (some? coord) "the registration carries a :source coord at all")
+      (is (some? (:file coord)) "and that coord carries a :file")
+      (is (editor-uri/absolute-path? (:file coord))
+          (str "the macro must bake an ABSOLUTE :file at expansion — got "
+               (pr-str (:file coord))))
+      (is (str/ends-with? (str/replace (:file coord) "\\" "/")
+                          "re_frame/story_open_in_editor_cljs_test.cljs")
+          "and it must still end in the classpath-relative tail it started as")
+      (config/set-editor! :windsurf)
+      (config/set-project-root! nil)
+      (async done
+        ;; The navigator stub is installed for the whole ASYNC duration, not
+        ;; just the synchronous call: `fetch-launcher!` runs `fallback!` in a
+        ;; promise callback, so a `with-stub-navigator` scope would already
+        ;; have restored `default-navigator!` — which reaches for `js/window`
+        ;; and blows up under node. Worse, `fetch-launcher!`'s own `.catch`
+        ;; would then run `fallback!` a SECOND time on that throw.
+        (let [[nav calls]  (capturing-navigator)
+              pending      (atom nil)
+              orig-fetch   (.-fetch js/globalThis)
+              prev-nav     (open-in-editor/set-navigator! nav)
+              prev-launch  (open-endpoint/set-launcher!
+                             (fn [url fallback!]
+                               ;; The REAL launcher; the atom only lets the
+                               ;; async test await the decision.
+                               (reset! pending
+                                       (open-endpoint/fetch-launcher! url fallback!))))
+              restore!     (fn []
+                             (set! (.-fetch js/globalThis) orig-fetch)
+                             (open-endpoint/set-launcher! prev-launch)
+                             (open-in-editor/set-navigator! prev-nav)
+                             (config/set-editor! :vscode))]
+          (set! (.-fetch js/globalThis)
+                (fn [_url _opts]
+                  (js/Promise.resolve #js {:ok false :status 422})))
+          (open-in-editor/open-coord! coord)
+          ;; Bind the launcher's promise to a LOCAL before threading. A
+          ;; multi-step form in the `->` head (an `or`, say) is lowered by the
+          ;; compiler to an awaited async IIFE — the rf2-i3dvj shape — and the
+          ;; await unwraps the promise to the `nil` `fetch-launcher!`'s own
+          ;; `.then` returns, leaving `.then` to be called on null.
+          (let [p @pending]
+            (if (nil? p)
+              (do (restore!)
+                  (is false "the launcher seam was never reached — the endpoint
+                             is supposed to be PREFERRED, so `fetch-launcher!`
+                             must have run")
+                  (done))
+              (-> p
+                  (.then (fn [_]
+                           (restore!)
+                           (is (= 1 (count @calls))
+                               "the 422 decline ran the URI fallback exactly once")
+                           (let [uri  (first @calls)
+                                 path (strip-uri-position uri)]
+                             (is (str/starts-with? uri "windsurf://file/")
+                                 "the fallback is the historic editor:// URI path")
+                             (is (editor-uri/absolute-path? path)
+                                 (str "the URI the editor receives must name an "
+                                      "ABSOLUTE path — got " (pr-str path)))
+                             (is (not (str/starts-with? path "re_frame/"))
+                                 "the pre-fix shape — a bare classpath-relative
+                                  path in the URI — is what no editor could open"))
+                           (is (identical? real-fetch (.-fetch js/globalThis))
+                               "the fetch stub was not left installed")
+                           (done)))
+                  (.catch (fn [err]
+                            (restore!)
+                            (is false (str "the 422 fallback path threw: " err))
+                            (done)))))))))))
+
+(deftest project-root-knob-is-inert-over-an-absolutised-story-coord
+  (testing "rf2-3xq1v — the public `:rf.story/project-root` option is KEPT for
+            external / static / non-shadow hosts, and stays inert over a
+            coordinate the macro already absolutised: `compose-path` passes an
+            absolute `:file` through rather than double-prefixing it"
+    (story/reg-story :story.source-coords.cljs-root-pin
+      {:doc "rf2-3xq1v fixture — same coordinate, two project-root settings."})
+    (let [coord (:source (story/handler-meta :story :story.source-coords.cljs-root-pin))]
+      (config/set-editor! :windsurf)
+      (config/set-project-root! nil)
+      (let [bare (open-in-editor/resolve-uri coord)]
+        (config/set-project-root! "/some/external/root")
+        (is (= bare (open-in-editor/resolve-uri coord))
+            "an absolute :file is not re-rooted by the knob")
+        (config/set-project-root! nil)
+        (config/set-editor! :vscode)))))

--- a/tools/story/test/re_frame/story_source_coords_test.clj
+++ b/tools/story/test/re_frame/story_source_coords_test.clj
@@ -1,42 +1,102 @@
 (ns re-frame.story-source-coords-test
-  "Regression test for rf2-ulxi — `:rf.assert/*` events surfaced from
-  `:script` sequences were emitting source-coords with `:file
-  \"NO_SOURCE_PATH\"`. Root cause: `coords-form` read `*file*` at
-  macro-expansion time, but the CLJS analyzer never binds Clojure's
-  `*file*` during macro expansion (it binds `cljs.analyzer/*cljs-file*`
-  instead), so `*file*` retained the JVM compiler's default
-  `\"NO_SOURCE_PATH\"` sentinel.
+  "Regression net for the source-coord Story's nine `reg-*` macros stamp.
 
-  The fix prefers `(:file (meta &form))` — the CLJS analyzer reads
-  source files via tools.reader's `indexing-push-back-reader` which
-  attaches `{:file ...}` to every collection-form's metadata, so the
-  form-meta path is the portable answer across both compilation hosts.
+  Two defects live here, and they are the two halves of one coordinate.
 
-  This test is JVM-only because the macro helpers live in `.clj` (only
-  visible from JVM). The CLJS path is exercised transitively: a
-  `(meta &form)` with `:file \"some/file.cljs\"` is what the analyzer
-  hands the macro on CLJS, and we assert that value lands in the
-  emitted coords map.
+  ## rf2-ulxi — WHICH file string gets picked
 
-  Failure mode on `main` (pre-fix): `coords-form` ignored `(:file
-  form-meta)` entirely and used the `file` arg (`*file*`) — which the
-  caller in `re-frame.story.cljc` passes as `*file*`. With `*file*` set
-  to `\"NO_SOURCE_PATH\"`, the emitted coords map carries
-  `:file \"NO_SOURCE_PATH\"`. The test below binds the `file` arg to
-  the sentinel and asserts the form-meta wins."
-  (:require [clojure.test :refer [deftest is testing]]
+  `:rf.assert/*` events surfaced from `:script` sequences were emitting
+  source-coords with `:file \"NO_SOURCE_PATH\"`. Root cause: `coords-form`
+  read `*file*` at macro-expansion time, but the CLJS analyzer never binds
+  Clojure's `*file*` during macro expansion (it binds
+  `cljs.analyzer/*cljs-file*` instead), so `*file*` retained the JVM
+  compiler's default sentinel.
+
+  The fix prefers `(:file (meta &form))` — the CLJS analyzer reads source
+  files via tools.reader's `indexing-push-back-reader`, which attaches
+  `{:file ...}` to every collection-form's metadata, so the form-meta path
+  is the portable answer across both compilation hosts.
+
+  ## rf2-3xq1v — whether that string is USABLE
+
+  Picking the right string is not enough: both compilation hosts hand the
+  macro only the CLASSPATH-RELATIVE portion of the path
+  (`counter_with_stories/stories.cljs`, never the on-disk location). The
+  browser-side checkout-root pipeline that used to supply the missing root
+  was retired once the dev-server endpoint could resolve a relative
+  coordinate itself — but the endpoint is only the PREFERRED path. On any
+  non-2xx the open-in-editor client falls back to an `editor://` URI, and
+  a 422 is exactly what the endpoint answers when `launch-editor` declines
+  a coordinate-bearing request. With a relative `:file` and no project-root
+  configured, that fallback ships
+  `windsurf://file/counter_with_stories/stories.cljs:196:3` — a path no
+  editor's scheme handler can resolve, and a chip that silently misses.
+
+  Story's macro pipeline is separate from core's, so it did not inherit
+  core's compile-time absolutisation (rf2-wvsxg) when core grew it.
+  `re-frame.story.macros/coords-form` now delegates to
+  `re-frame.source-coords/coords-form` outright, which resolves the
+  classpath-relative `:file` through the context class-loader ON THE JVM,
+  AT MACROEXPANSION, and bakes the absolute path into the emitted literal.
+  Nothing resolves anything in the browser.
+
+  ## Why the pins below are shape assertions, not literals
+
+  The absolutised path is the BUILDING MACHINE's path, so every assertion
+  here is computed — `absolute-path?`, an on-disk existence check, and a
+  suffix match against the classpath-relative tail. A literal expected path
+  would pin one developer's checkout.
+
+  JVM-only: the macro helpers live in `.clj`, visible only from the JVM.
+  The CLJS half — a real registration compiled by shadow-cljs, driven
+  through the 422 decline into the URI fallback — is
+  `re-frame.story-open-in-editor-cljs-test`
+  §`endpoint-422-falls-back-to-an-absolute-uri-for-a-real-story-coord`."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.source-coords.editor-uri :as editor-uri]
+            [re-frame.story :as story]
             [re-frame.story.macros :as macros]))
 
-;; ---- helper -----------------------------------------------------------------
+;; ---- helpers ----------------------------------------------------------------
 
 (defn- eval-coords-form
-  "Evaluate the syntax-quoted form `coords-form` returns. The form is a
-  `(cond-> {:ns 'sym} <truthy-test> (assoc ...))` expression — `eval`
-  in this ns produces the runtime map the macro expansion would build."
+  "Evaluate what `coords-form` returns. Since rf2-3xq1v that is a MAP
+  LITERAL built at expansion time (rf2-i3dvj evaluation-order
+  transparency) rather than a `cond->` form — but its `:ns` slot holds a
+  `(quote sym)` form, so `eval` is still how the test reads back the map
+  the macro expansion would bind."
   [form-meta file ns-sym]
   (eval (macros/coords-form form-meta file ns-sym)))
 
-;; ---- the regression --------------------------------------------------------
+;; A real Story source file that IS on this JVM gate's classpath, so the
+;; classpath probe inside `absolutise-file` has something to resolve.
+;; `counter_with_stories/stories.cljs` — the coordinate the rf2-3xq1v audit
+;; measured — resolves under the shadow-cljs compile (`tools/story/testbeds`
+;; is a source path there) but not under `clojure -M:test`, whose classpath
+;; is `src` + `test`. Absolutisation degrades to a pass-through for an
+;; unresolvable path by design, so pinning that literal here would assert
+;; nothing at all. The CLJS half of this net exercises a real testbed-shaped
+;; registration under the real toolchain.
+(def ^:private on-classpath-story-file
+  "re_frame/story/macros.clj")
+
+(defn- assert-absolute-and-real!
+  "Shared shape assertions for an absolutised `:file`: absolute per the
+  same predicate `editor-uri/compose-path` uses, present on disk, and
+  still ending in the classpath-relative tail it started as."
+  [path tail because]
+  (is (editor-uri/absolute-path? path)
+      (str because " — :file must be ABSOLUTE, got " (pr-str path)))
+  (is (str/ends-with? (str/replace path "\\" "/") tail)
+      (str because " — the absolutised path must still end in the "
+           "classpath-relative tail " (pr-str tail)))
+  (is (.exists (io/file path))
+      (str because " — the absolutised path must name a file that "
+           "exists on disk (a rename must fail loudly here)")))
+
+;; ---- rf2-ulxi: which string gets picked ------------------------------------
 
 (deftest file-prefers-form-meta-over-bound-file
   (testing "rf2-ulxi: when (meta &form) carries :file, that wins over the
@@ -44,31 +104,48 @@
             unbound (or stuck at NO_SOURCE_PATH) but the reader has
             attached :file to the form's metadata"
     (let [coords (eval-coords-form
-                   {:line 196 :column 3 :file "counter_with_stories/stories.cljs"}
+                   {:line 196 :column 3 :file on-classpath-story-file}
                    "NO_SOURCE_PATH"                ; the CLJS macro-expansion default
-                   'counter-with-stories.stories)]
-      (is (= "counter_with_stories/stories.cljs" (:file coords))
-          ":file must come from the form-meta, not the NO_SOURCE_PATH sentinel")
+                   're-frame.story.macros)]
       (is (not= "NO_SOURCE_PATH" (:file coords))
           ":file must NOT be the cljs.analyzer NO_SOURCE_PATH sentinel")
+      (assert-absolute-and-real!
+        (:file coords) on-classpath-story-file
+        "rf2-3xq1v: form-meta :file is picked AND absolutised")
       (is (= 196 (:line coords)) ":line still captured")
       (is (= 3 (:column coords)) ":column still captured")
-      (is (= 'counter-with-stories.stories (:ns coords))
+      (is (= 're-frame.story.macros (:ns coords))
           ":ns still captured"))))
 
 (deftest file-falls-back-to-bound-file-when-form-meta-missing
   (testing "JVM compilation: (meta &form) has no :file (clojure.lang.LispReader
             only attaches :line/:column), so coords-form falls back to the
-            *file* arg the macro captured"
+            *file* arg the macro captured — and absolutises THAT too"
     (let [coords (eval-coords-form
                    {:line 42 :column 1}            ; JVM reader — no :file
-                   "src/my/ns.clj"
-                   'my.ns)]
-      (is (= "src/my/ns.clj" (:file coords))
-          ":file falls back to the bound *file* on JVM")
+                   on-classpath-story-file
+                   're-frame.story.macros)]
+      (assert-absolute-and-real!
+        (:file coords) on-classpath-story-file
+        "rf2-3xq1v: the *file* fallback is absolutised on the same path")
       (is (= 42 (:line coords)))
       (is (= 1  (:column coords)))
-      (is (= 'my.ns (:ns coords))))))
+      (is (= 're-frame.story.macros (:ns coords))))))
+
+(deftest unresolvable-file-passes-through-unchanged
+  (testing "rf2-3xq1v: absolutisation is a RESOLUTION, not a string join —
+            a path the class-loader cannot find (an in-jar source, a
+            synthetic coord, a REPL eval) degrades to the input unchanged
+            rather than being prefixed with a guessed root. This is the
+            case the public :rf.story/project-root knob still serves, and
+            it is why that knob was deliberately kept."
+    (let [coords (eval-coords-form
+                   {:line 7 :column 2 :file "no/such/story_file.cljs"}
+                   "NO_SOURCE_PATH"
+                   'some.ns)]
+      (is (= "no/such/story_file.cljs" (:file coords))
+          "unresolvable :file ships verbatim — no fabricated absolute path")
+      (is (not (editor-uri/absolute-path? (:file coords)))))))
 
 (deftest file-omitted-when-both-sources-are-sentinel
   (testing "rf2-ulxi: if BOTH (meta &form) :file and *file* resolve to
@@ -99,7 +176,7 @@
             the *pending-coords* binding form — covers the actual macro
             path Story uses for variants whose :script sequences emit
             :rf.assert/* events"
-    (let [form-meta {:line 42 :column 3 :file "stories.cljs"}
+    (let [form-meta {:line 42 :column 3 :file on-classpath-story-file}
           expansion (macros/gen-reg-call
                       form-meta
                       "NO_SOURCE_PATH"             ; simulate CLJS *file*
@@ -108,16 +185,89 @@
                       :my.app/variant
                       {:doc "x"})
           ;; The expansion is `(when ... (binding [*pending-coords*
-          ;; (cond-> ...)] ...))`. The coords map literal lives inside
-          ;; the binding form — pull it out and evaluate to inspect.
-          ;; Structure: (when _ (binding [_ <coords-form>] _))
+          ;; <coords-map>] ...))`. Pull the literal out of the binding
+          ;; vector and evaluate it (its `:ns` slot is a `(quote ...)`).
+          ;; Structure: (when _ (binding [_ <coords>] _))
           binding-form (-> expansion (nth 2))      ; (binding [...] ...)
-          coords-form  (-> binding-form second second)  ; the (cond-> ...) form
-          coords       (eval coords-form)]
-      (is (= "stories.cljs" (:file coords))
-          "the :file in the emitted *pending-coords* binding comes from form-meta")
+          coords       (eval (-> binding-form second second))]
       (is (not= "NO_SOURCE_PATH" (:file coords))
           "NO_SOURCE_PATH must not leak into the coords map")
+      (assert-absolute-and-real!
+        (:file coords) on-classpath-story-file
+        "rf2-3xq1v: the emitted *pending-coords* literal carries the
+         absolutised path, not the classpath-relative one")
       (is (= 42 (:line coords)))
       (is (= 3  (:column coords)))
       (is (= 'my.app.stories (:ns coords))))))
+
+;; ---- rf2-3xq1v: a REAL Story registration, pinned absolute -----------------
+;;
+;; Everything above drives `coords-form` directly. This drives the actual
+;; `story/reg-story` macro at a real source location in a real Story
+;; artefact file, and reads the coordinate back off the registrar the way
+;; every consumer does — `(story/handler-meta :story id)` → `:source`.
+;; The file this registration sits in IS on the gate's classpath, so the
+;; class-loader probe has a genuine resolution to make.
+
+(deftest a-real-story-registration-stamps-an-absolute-file
+  (testing "rf2-3xq1v: a registration written the way a Story author writes
+            one carries an ABSOLUTE :file in its :source slot. Before the
+            fix this was `re_frame/story_source_coords_test.clj` — the
+            classpath-relative tail on its own."
+    (story/reg-story :story.source-coords.absolute-pin
+      {:doc "rf2-3xq1v fixture — the coordinate under test IS this form's."})
+    (let [coord (:source (story/handler-meta :story :story.source-coords.absolute-pin))]
+      (is (some? coord) "the registration carries a :source coord at all")
+      (assert-absolute-and-real!
+        (:file coord) "re_frame/story_source_coords_test.clj"
+        "rf2-3xq1v: a real Story registration's :file")
+      (is (pos-int? (:line coord)) ":line is captured from the real form")
+      (is (pos-int? (:column coord)) ":column is captured from the real form")
+      (is (= 're-frame.story-source-coords-test (:ns coord))
+          ":ns names the registering namespace"))))
+
+;; ---- rf2-3xq1v: the 422 → URI fallback, with that coordinate ---------------
+;;
+;; `re-frame.source-coords.open-endpoint/fetch-launcher!` invokes the
+;; caller's `fallback!` thunk on ANY non-2xx, and 422 is the status
+;; `re-frame.testbed.open-in-editor-server` answers when launch-editor
+;; declines a coordinate-bearing request (the Windsurf case the audit
+;; measured). The fallback resolves the coord through
+;; `editor-uri/editor-uri` with whatever `:project-root` the host set —
+;; nil for a repository dev testbed, since the browser-side checkout-root
+;; pipeline is gone. That composition is `.cljc` and pure, so the shape the
+;; fallback ships is pinnable here; the CLJS half drives the same coordinate
+;; through the real client seam.
+
+(deftest declined-endpoint-falls-back-to-a-resolvable-uri
+  (testing "rf2-3xq1v: with NO project-root configured — the state every
+            repository dev testbed is in since the checkout-root pipeline
+            was retired — the URI the 422 fallback ships for a real Story
+            coordinate names an absolute path the editor can open"
+    (story/reg-story :story.source-coords.fallback-pin
+      {:doc "rf2-3xq1v fixture — this form's coordinate feeds the URI below."})
+    (let [coord (:source (story/handler-meta :story :story.source-coords.fallback-pin))
+          ;; Exactly what `open-in-editor/resolve-uri` builds when
+          ;; `config/get-project-root` returns nil.
+          uri   (editor-uri/editor-uri :windsurf coord {:project-root nil})]
+      (is (str/starts-with? uri "windsurf://file/")
+          "the fallback is the historic editor:// URI path, unchanged")
+      (let [path (-> uri
+                     (subs (count "windsurf://file/"))
+                     (str/replace #":\d+:\d+$" ""))]
+        (assert-absolute-and-real!
+          path "re_frame/story_source_coords_test.clj"
+          "rf2-3xq1v: the URI the declined endpoint falls back to")
+        (is (not= "re_frame/story_source_coords_test.clj" path)
+            "the pre-fix shape — a bare classpath-relative path in the URI —
+             is exactly what the editor could not resolve"))))
+  (testing "rf2-3xq1v: an explicitly configured :rf.story/project-root does
+            NOT double-prefix an already-absolute coord. The knob is kept
+            for external / static / non-shadow hosts, and it stays inert
+            over a coordinate the macro already absolutised."
+    (let [coord (:source (story/handler-meta :story :story.source-coords.fallback-pin))
+          bare  (editor-uri/editor-uri :windsurf coord {:project-root nil})
+          rooted (editor-uri/editor-uri :windsurf coord
+                                        {:project-root "/some/external/root"})]
+      (is (= bare rooted)
+          "an absolute :file passes through compose-path untouched"))))


### PR DESCRIPTION
Completes rf2-3xq1v, reopened by the audit of PR #8890.

## What the audit found

PR #8890 retired the browser-side checkout-root pipeline on the grounds that the dev-server endpoint resolves relative source coordinates at runtime. That premise holds for core registrations, whose canonical source-coord helper already absolutises `:file` at macro-expansion (rf2-wvsxg). It did **not** hold for Story, which authors a separate macro pipeline: `re-frame.story.macros/coords-form` emitted the reader's `:file` verbatim, and `story_source_coords_test.clj` PINNED that relative spelling — the defect's own regression test.

The endpoint is only PREFERRED. On any non-2xx the open-in-editor client falls back to an `editor://` URI, and 422 is exactly what `re-frame.testbed.open-in-editor-server` answers when `launch-editor` cannot carry a coordinate to the configured editor (the Windsurf case PR #8880 fixed). With a relative `:file` and no project-root, that fallback shipped `windsurf://file/counter_with_stories/stories.cljs:196:3` — a path no editor's scheme handler can resolve, and a chip that silently misses.

## The change

`coords-form` now delegates wholesale to `re-frame.source-coords/coords-form`, the same stamp every `re-frame.core` reg-* macro emits. Story gains two properties it was re-deriving or missing:

- **`:file` absolutisation at MACROEXPANSION** (rf2-wvsxg), through the context class-loader on the JVM side of the expansion. Not a browser-side mechanism: resolution happens once, in Clojure, and the CLJS runtime only ever sees a baked literal string. Nothing here reintroduces the pipeline #8890 removed.
- **An expansion-time map literal** rather than an emitted runtime `cond->` (rf2-i3dvj evaluation-order transparency).

The rf2-ulxi `:file` picking rule (form-meta over `*file*`, `NO_SOURCE_PATH` rejected, `:file` omitted when both sources are the sentinel) is unchanged — it moves from Story's copy to core's original.

## Preserved, deliberately

- **The endpoint-first removal PR #8890 landed.** No replacement root plumbing, no new config layer, no Closure define, no launcher export.
- **The public `:rf.story/project-root` / `:rf.xray/project-root` knob**, for external / static / non-shadow hosts. Two tests pin that it stays inert over an already-absolute coord (`compose-path` passes an absolute `:file` through rather than double-prefixing), and one pins that an unresolvable path — an in-jar source, a synthetic coord — still ships verbatim rather than being joined to a guessed root. That degradation is the case the knob serves, and it is why the knob is kept.

## Tests

`story_source_coords_test.clj`'s relative pin is replaced, not deleted:

- `a-real-story-registration-stamps-an-absolute-file` drives the real `story/reg-story` macro at a real source location and reads the coordinate back off the registrar the way every consumer does. Assertions are computed — absolute per `editor-uri/absolute-path?`, present on disk, still ending in the classpath-relative tail — so nothing pins one machine's checkout.
- `declined-endpoint-falls-back-to-a-resolvable-uri` feeds that coordinate through the 422 fallback's URI composition with no project-root set.
- `unresolvable-file-passes-through-unchanged` pins the degradation path.

The CLJS half is the audit's scenario end to end. `endpoint-422-falls-back-to-an-absolute-uri-for-a-real-story-coord` registers a story that THIS compile stamps, then drives Story's own `open-coord!` with `fetch-launcher!` unmodified over a `globalThis.fetch` stubbed to 422, and asserts the `windsurf://` URI the navigator receives names an absolute path. The fetch stub is asserted restored, so it cannot answer for later namespaces in the shared `:node-test` build.

`counter_with_stories/stories.cljs` — the literal the audit measured — is *not* re-pinned in the JVM gate and the test says why: it resolves under the shadow-cljs compile (`tools/story/testbeds` is a source path there) but not under `clojure -M:test`, whose classpath is `src` + `test`, so absolutisation would degrade to a pass-through and the pin would assert nothing.

## Quality gates

Every exit code below was captured with the redirect and the `echo` on one command line, and is the runner's own status — not a harness report.

| Gate | Result | Exit |
| --- | --- | --- |
| `clojure -M:test` in `tools/story` | 1890 tests / 6960 assertions, 0 failures, 0 errors | **0** |
| `clojure -M:test` in `tools/story-mcp` | 279 tests / 1476 assertions, 0 failures, 0 errors | **0** |
| `npm run test:cljs` (consolidated `:node-test`) | 11151 tests / 55144 assertions, 0 failures, 0 errors | **0** |

All three were re-run on the final rebased base, after the rebase past 15 landings. No sibling landed in `tools/story/**` or `implementation/core/src/re_frame/source_coords*` in that interval, and the merge-base diff (`main...HEAD`) is these three files only — nothing this branch would revert.

The CLJS lane prints its config path, and that line names this worker worktree; the two JVM lanes are silent, and the planted-fault control below is what discriminates them.

Not nominated, and why: the diff is `tools/story/**` — no markdown, no `spec/`, no workflows — so `check_doc_slugs.py` and `check_readme_links.py` have no path here, and `mkdocs build --strict` is not a candidate at all (`docs_dir` is `docs`, so `tools/` was never in the built site).

## The control

`coords-form`'s single delegating line was reverted to emit the picked `:file` without absolutisation — the exact defect, keeping the rf2-ulxi picking rule intact so the discrimination is the absolutisation property alone.

- **JVM, planted:** 8 tests / 40 assertions, **12 failures, 0 errors, exit 1** — the same 40 assertions as the green run, so nothing was skipped. The message names what was planted: `:file must be ABSOLUTE, got "re_frame/story_source_coords_test.clj"`. The three picking-rule tests (`unresolvable-file-passes-through-unchanged`, and both sentinel/omission cases) stayed green.
- **CLJS, planted:** 11150 tests, **4 failures, exit 1**, all four in the two new rf2-3xq1v deftests. The log carries the audit's measured failure verbatim: `navigating to: windsurf://file/re_frame/story_open_in_editor_cljs_test.cljs:851:5` — relative, unresolvable. On the green run the same line reads as an absolute path.

**The compile demonstrably re-ran under the plant**, which a source-level hash alone cannot show for a macro-emitted value. Two independent signals: shadow reported `1873 files, 97 compiled` under the plant against `1873 files, 2 compiled` on the preceding incremental green run; and the *running bundle's* emitted `:file` changed from absolute to relative, which can only come from a fresh macroexpansion.

Restore verified by git **blob** hash against the committed object (line endings are translated in this checkout, so a byte digest of the working file would not be sound): working file and `HEAD:tools/story/src/re_frame/story/macros.clj` both hash to `f3a359b4dfea4c4625406af2f1ccf4012be9ae88`, and the tree is clean.
