### PR TITLE
docs(method): put the re-draft rule where the fix dispatch actually happens

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -570,19 +570,26 @@ ready mark, or message them. What gets read instead is a worker that has stopped
 unmoved, worktree clean, everything pushed, a direct message unanswered for half an hour, and a draft
 sitting exactly at band with nothing non-terminal and nothing failing.
 
-**Every signal in that list is also what a worker in its FINAL MINUTES looks like, and that is the
-likelier explanation.** A worker finishing up — running one last foreground gate, deleting gate logs,
-unlinking a shared-dependency link, tidying a scratch directory — writes outside the worktree and
-outside version control, and is too busy to answer. So the tip does not move, the fetch clock does not
-move, the write clock does not move, and the message goes unanswered. **The four indirect signals do
-not fail independently here; they fail together, for one cause.** Frozen-across-three-readings feels
-like the most damning pattern available and is in fact the signature of a run about to report.
+**Every signal in that list is also what a worker in its FINAL MINUTES looks like.** A worker
+finishing up — running one last foreground gate, deleting gate logs, unlinking a shared-dependency
+link, tidying a scratch directory — writes outside the worktree and outside version control, and is
+too busy to answer. So the tip does not move, the fetch clock does not move, the write clock does not
+move, and the message goes unanswered. **The four indirect signals do not fail independently here;
+they fail together, for one cause.**
+
+**Which makes the frozen reading AMBIGUOUS, and that is the whole finding — not that it means the
+opposite.** Frozen-across-three-readings feels like the most damning pattern available, and it is
+compatible with a stopped worker and with healthy foreground work alike, so it identifies neither.
+Re-reading the same four clocks cannot break the tie, however long the freeze runs: an hour of it is
+the same non-signal as a minute of it.
 
 Measured, twice: on the first occasion five workers were reported dormant and four then completed
-alive with full reports, one answering the ping directly to say it had been on final hygiene; the
-diagnosis was retracted in full, including a second claim — that messaging was inoperative — which
-was *slow* converted into *broken*. It recurred the same day on a sixth worker whose clocks were
-frozen for over an hour and which completed normally.
+alive with full reports, one answering the ping directly to say it had been on final hygiene, while
+the fifth was never explained either way; the diagnosis was retracted in full, including a second
+claim — that messaging was inoperative — which was *slow* converted into *broken*. It recurred the
+same day on a sixth worker whose clocks were frozen for over an hour and which completed normally.
+**Five of six alive is the sourced count; treat it as a warning against the dormancy reading, not as
+a licence for its inverse.**
 
 **So prefer the DIRECT signal where your tooling offers one** — a live progress line, a status the
 supervisor maintains — over any number of indirect clocks, and **treat the four clocks as the fallback

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -379,6 +379,13 @@ candidate. Once you have established the failure is the change's own and not the
 not — dispatch a fix worker onto the **existing** branch that runs the **actual** failing
 gate, not a proxy that already passed.
 
+**If that change is already marked ready, convert it back to draft first, and confirm the state
+took.** The flag is set by whoever finished last, so a fix dispatch inherits one the previous
+author set and the interlock is open before the second worker starts — [the exception the
+criterion names](#the-criterion), and the only one this loop has to remember, because this loop
+is what creates it. It belongs here rather than in the brief: the worker cannot set a flag that
+is already ready, and by the time it could, the merge has landed underneath it.
+
 **But a red on a change still published as a DRAFT belongs to its author, for as long as that
 author is alive.** The draft flag means the worker has not finished, and a worker briefed to push as
 it goes will publish reds by design: one here deleted a gate's witness in its first commit and the

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -925,12 +925,16 @@ and both readings went wrong in a single day here, in opposite directions.
    then tidying scratch files and shared-dependency links, works outside the worktree and outside
    version control and is too busy to answer. Tip, fetch clock, write clock and a direct message then
    read as dead *together*, for one cause, which is why corroborating one with another does not help
-   here. **Frozen on every clock across several readings is the signature of a run about to report**,
-   not of a dead one. Measured twice in one day, on five workers and then on a sixth: every one
-   completed alive, and on the second occasion the supervisor's own one-line progress string named the
-   phase outright while the four clocks said otherwise. Where no direct status exists, declare a window
-   and re-read rather than acting — waiting costs a tick, and acting costs a duplicate worker in a live
-   worktree.
+   here. **So frozen on every clock, across any number of readings, is AMBIGUOUS — it is exactly what
+   healthy foreground work looks like, and exactly what a stopped worker looks like.** It cannot
+   identify either, and no amount of re-reading the same four clocks converts it into evidence; a
+   freeze that has run an hour is still the same non-signal it was in the first minute. Measured twice
+   in one day, on five workers and then on a sixth: **five of those six completed alive** — the
+   remaining one was never explained — and on the second occasion the supervisor's own one-line
+   progress string named the phase outright while the four clocks said otherwise. Where no direct
+   status exists, declare a window and re-read rather than acting: not because waiting resolves the
+   ambiguity, but because the two errors are priced differently — waiting costs a tick, and acting
+   costs a duplicate worker in a live worktree.
 
    **That clock says "no activity" in four voices and you can only tell them apart with a control.**
    Besides the reading worker and the poller treated just below, a path that resolves to nothing
@@ -1333,8 +1337,8 @@ the context was another change to the same file.
 is why the criterion stands unchanged — but a mayor who reads `+` as *this branch has unmerged work*
 will hunt for work that landed weeks ago, and a branch list read as a backlog is a list of phantoms.
 The cheap triage is to take the lines that commit ADDED and look for them at the tip: where they are
-all there, the likeliest reading by far is that the content landed and only the context moved. Run it
-first, because it is seconds and it settles the common case.
+all there, the likeliest reading is that the content landed and only the context moved. Run it first
+because it costs seconds and tells you where to point the real check — never because it finishes one.
 
 **But it is triage, not a verdict, and it is wrong in BOTH directions — which is the correction this
 paragraph carries.** A line search has no notion of path, location, multiplicity or order, and it


### PR DESCRIPTION
Two method corrections plus the placement fix that opened this PR. Closes rf2-4228y and rf2-m7sto.

## 1. Placement — where the re-draft rule is read

PR #8925 established that re-drafting an already-ready change is part of **dispatching** a fix, since
the worker cannot set a flag that is already set. It put that rule in §1's criterion discussion, which
a mayor reads when deciding whether to **merge**. The fix dispatch is actually performed from *"When a
change is not green"*, which says "dispatch a fix worker onto the existing branch" twice and carried
nothing about the flag. Right rule, wrong place — the same shape as rf2-r70kn. Seven lines at the point
of action, pointing back rather than restating.

## 2. rf2-m7sto — frozen clocks are ambiguous, not a signature

Audit of PR #8925, and it is correct. That PR replaced one unsupported inference with its inverse: both
pages said a stopped worker and a healthy one in final hygiene produce *identical* frozen observations,
and then called that pattern "the signature of a run about to report." **A pattern explicitly shared by
two states identifies neither.** "About to" is also unsupported by hour-long freezes.

Both pages now say the reading is **ambiguous** — compatible with a stopped worker and with healthy
foreground work alike — and that re-reading the same four clocks cannot break the tie however long the
freeze runs. Direct-status-first and the declare-a-window rule are preserved, but the window is now
justified honestly: not because waiting resolves the ambiguity, but because the two errors are priced
differently.

**The two pages also disagreed on my own evidence**, which the audit caught: one said four of five plus
a sixth, the other said all five plus the sixth. The sourced count is **five of six alive, the remaining
one never explained**, and both pages now state exactly that, with the explicit note that it is a warning
against the dormancy reading rather than a licence for its inverse.

## 3. rf2-4228y — triage points, it does not settle

Audit of PR #8920, also correct. That PR labelled the added-line scan triage and explained both false
directions, but the preceding sentence still said to run it first "because it settles the common case" —
contradicting "triage, not a verdict" two sentences later, and being the behavioural instruction most
likely to stop a mayor before the whole-patch comparison. It now says the scan costs seconds and tells
you where to point the real check, **never** that it finishes one. The full-patch conclusion and the
delete-only-on-`-` rule are unchanged.

## Quality gates

| Gate | Exit | Result |
|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | clean |
| `scripts/check_readme_links.py --ci` | **0** | clean |
| `python -m mkdocs build --strict` | **0** | clean |
| `check_doc_slugs.py` **sabotage** | **1** | `BROKEN ANCHOR: docs\the-mayor-method\loops.md:385 -> #the-criterion-planted-zzz` |
| `check_doc_slugs.py` restored | **0** | clean |

Exit codes captured from the runner on one command line. The sabotage broke the one cross-reference
anchor this change adds — the gate's real subject here. Match count read as 1 beforehand, and the plant
was anchored on `](#the-criterion)` rather than the link text, because that text wraps across two lines
and a line-oriented match would have found nothing. Restore verified by git **blob** hash against the
committed object, `c3c961620034215a85eebc6c50c7ca9b8f741b83` on both sides.

Two checks after the edits, since prose is what changed: a fixed-string search confirms neither
overclaiming phrase survives on either page (0 and 0), and the outcome count now appears exactly once
per page rather than in two different forms.

**Bare `mkdocs` returns 127 in Git Bash on this checkout** — no verdict, not a pass. Run as `python -m mkdocs`.

## What no gate covers

`mkdocs build --strict` does not gate heading anchors (MkDocs grades them at INFO; `--strict` promotes
only WARNING), so `check_doc_slugs.py` is the sole anchor gate for these pages. Nothing validates prose,
tables or rendering — the two fixed-string checks above are hand-verification, not a gate. No table,
heading or fenced block is touched. Merge-base diff read for reverts: 19 deleted lines, all of them
prose this change rewrites.