### PR TITLE
fix(flows): settle ahead of the continuations the same handler queued (rf2-kh73v)

### DIFF
--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -1281,7 +1281,11 @@
 ;; `request-flow-settle!` / `do-fx`). It drains inside the same
 ;; run-to-completion pass, runs the ordinary chain — so the framework's
 ;; `flows-after-interceptor` transforms the pending `:db` exactly as it does for
-;; any other event — and settles both arms before the dispatch returns.
+;; any other event — and settles both arms before the dispatch returns. It is
+;; enqueued at the HEAD of the frame's queue (`router/insert-envelope`, keyed on
+;; the `:rf.flow/settle?` envelope flag), so it drains ahead of the
+;; continuations the registering/clearing handler queued with its own
+;; `:dispatch` effects and they read the settled `app-db`.
 ;;
 ;; This is the framework performing, once, the follow-up no-op dispatch the
 ;; contract used to make every application hand-write.

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -752,6 +752,12 @@
                    `:dispatch` never does.
     :source-detail optional; rides onto the `:rf.event/dispatched` trace (e.g.
                    `{:ms n}` for the delayed path — rf2-5qp4g).
+    :rf.flow/settle?
+                   optional; `true` marks the child as the framework-private
+                   flow settle, which the router head-inserts ahead of the
+                   continuations the same handler queued (Spec 013
+                   §Sequencing). Set by `settle-flows-if-requested!` and by
+                   nothing else — it is not a general priority lever.
     :rf.cofx       optional recordable causal-envelope coeffect map merged
                    verbatim onto the child dispatch. `build-envelope` preserves
                    a supplied `:rf.cofx` (extra owner-qualified keys kept) and
@@ -763,10 +769,12 @@
   child's completion carrier through the SAME seam that preserves every
   reserved-dispatch guarantee, adding ONLY its `:rf.cofx` exact-attempt
   coordinate fact — never a second effect duplicating the semantics."
-  [frame-id parent-envelope event {:keys [source ms source-detail] rf-cofx :rf.cofx}]
+  [frame-id parent-envelope event
+   {:keys [source ms source-detail] rf-cofx :rf.cofx flow-settle? :rf.flow/settle?}]
   (let [opts (cond-> (assoc (child-dispatch-opts frame-id parent-envelope) :source source)
                (some? source-detail) (assoc :source-detail source-detail)
-               (some? rf-cofx)       (assoc :rf.cofx rf-cofx))]
+               (some? rf-cofx)       (assoc :rf.cofx rf-cofx)
+               (true? flow-settle?)  (assoc :rf.flow/settle? true))]
     (if (number? ms)
       (arm-dispatch-later! frame-id ms event opts)
       ;; Sticky hook (rf2-f72pd) — `:router/dispatch!` is published once at
@@ -822,11 +830,27 @@
   queued it, and `:source` is a CLOSED enum (Spec 002 §Routing) — a new member
   would be a Spec 002 change this does not need.
 
-  Back of the queue, not front. Run-to-completion means the whole queue drains
-  before the originating dispatch returns either way, so both placements settle
-  within the boundary the contract promises; the back is the one that settles
-  ONCE over everything the cascade did, rather than settling early and leaving
-  the cascade's own later writes to the next event.
+  HEAD of the queue, not back — it carries `:rf.flow/settle? true`, which
+  `router/insert-envelope` reads to place it ahead of everything already
+  queued. Run-to-completion drains the whole queue before the originating
+  dispatch returns either way, so both placements satisfy the settle BOUNDARY
+  Spec 013 §Sequencing states; what the back placement does not satisfy is
+  composition with ordinary follow-up work. A `:dispatch` effect from the same
+  handler is appended DURING the walk, so a back-inserted settle sits behind it
+  in FIFO order: the continuation then runs against the pre-registration /
+  pre-clear `app-db`, cannot read a newly registered flow's output, reads a
+  cleared flow's stale one, and can persist that wrong decision into `app-db`
+  where the later settle — which repairs only the derived slot — will not undo
+  it.
+
+  Settling early costs nothing, which is the half worth stating because the
+  earlier back-of-queue rationale assumed otherwise: the flow transform runs on
+  EVERY event, so each continuation settles its OWN writes on its OWN drain.
+  There was never a need for one late settle to cover the whole cascade.
+
+  At most one settle per walk, enqueued here at the very end of it, so a plain
+  head-push has no siblings to reverse (unlike the machine-internal splice,
+  which is called once per sibling and therefore preserves a boundary).
 
   The event id is written here as a LITERAL rather than read from
   `re-frame.events/settle-flows-event-id`, which defines it: `re-frame.events`
@@ -840,7 +864,8 @@
   (when (some-> *flow-settle-requested* deref)
     (child-dispatch! frame-id parent-envelope
                      [:rf/settle-flows]
-                     {:source :fx-dispatch}))
+                     {:source            :fx-dispatch
+                      :rf.flow/settle?  true}))
   nil)
 
 (def ^:private reserved-fx-handlers
@@ -948,7 +973,11 @@
    ;; walk enqueues ONE `[:rf/settle-flows]` on this frame
    ;; (`settle-flows-if-requested!`). Run-to-completion drains it inside
    ;; the same pass, so both arms have settled by the time the dispatch
-   ;; returns.
+   ;; returns — and it goes to the HEAD of the queue, so it settles ahead
+   ;; of any continuation this same handler queued with a `:dispatch`
+   ;; effect rather than behind it. Otherwise those continuations read the
+   ;; pre-registration / pre-clear `app-db` and can persist a decision the
+   ;; later settle would not undo.
    ;;
    ;; Note what this does NOT do, because it is what the ordering was
    ;; protecting. It does NOT re-run the flow transform after `:fx`, and

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -361,6 +361,15 @@
         ;; ordering guarantee — NOT a trace concern — so the flag is
         ;; carried unconditionally (never gated on interop/debug-enabled?).
         machine-internal?  (true? (:rf.machine/internal? opts))
+        ;; Spec 013 §Sequencing: the framework-private flow settle, stamped by
+        ;; `fx/settle-flows-if-requested!` on the ONE child dispatch a completed
+        ;; `:fx` walk makes when it registered or cleared a flow. `insert-envelope`
+        ;; reads it to place the settle at the HEAD of the queue, ahead of the
+        ;; continuations that same handler queued — so those continuations read
+        ;; the settled `app-db` rather than the pre-registration / pre-clear one.
+        ;; A runtime ordering guarantee like `:rf.machine/internal?`, so carried
+        ;; on the same terms: unconditionally, never gated on debug-enabled?.
+        flow-settle?       (true? (:rf.flow/settle? opts))
         ;; EP-0017 §6 / slice-B.8: the per-call cofx MINT POLICY
         ;; — the most-specific binding point. A Tool-Pair replay supplies
         ;; `:strict` (so an incomplete record fails loudly rather than minting
@@ -441,6 +450,9 @@
       ;; Carry the machine-internal continuation flag onto
       ;; the envelope so `dispatch!` can front-of-queue insert it.
       machine-internal?  (assoc :rf.machine/internal? true)
+      ;; Spec 013 §Sequencing: carry the flow-settle ordering flag onto the
+      ;; envelope so `insert-envelope` can head-insert it.
+      flow-settle?       (assoc :rf.flow/settle? true)
       ;; EP-0017 §6 / slice-B.8: carry the per-call cofx mint
       ;; policy onto the envelope only when supplied, so `assemble-initial-ctx`
       ;; reads it (per-call wins over the frame config). Absent ⇒ the key is
@@ -3946,7 +3958,7 @@
             (swap! router assoc :scheduled? false :in-drain? nil))
           (throw t))))))
 
-(declare front-insert-machine-internal)
+(declare insert-envelope)
 
 (defn- ensure-drain-scheduled!
   "Enqueue `envelope` into the target incarnation's queue and, when this call is
@@ -3971,11 +3983,7 @@
               (swap! router
                      (fn [state]
                        (-> state
-                           (update :queue
-                                   (fn [queue]
-                                     (if (:rf.machine/internal? envelope)
-                                       (front-insert-machine-internal queue envelope)
-                                       (conj queue envelope))))
+                           (update :queue insert-envelope envelope)
                            (assoc :scheduled? true))))
               {:enqueued? true :schedule? (not scheduled?)})))]
     (when (:schedule? outcome)
@@ -4145,29 +4153,66 @@
   (let [[internal external] (split-with :rf.machine/internal? q)]
     (into interop/empty-queue (concat internal [envelope] external))))
 
-(defn- enqueue-envelope!
-  "Insert `envelope` into the frame's router queue. Per Spec 002, ordinary
-  dispatches go to the BACK (plain FIFO via `conj` on the PersistentQueue).
+(defn- head-insert
+  "Return `q` (a PersistentQueue of envelopes) with `envelope` at its HEAD —
+  dequeued next, ahead of everything already queued.
 
-  Per rf2-j20a7 / Spec 005 §Level 4 — the one exception: a machine-
-  internal continuation envelope (`:rf.machine/internal? true`, stamped
-  by `build-envelope` from the machine-tagged child opts) leap-frogs
-  ahead of any already-queued EXTERNAL events, so the machine settles its
-  macrostep to quiescence before the next external event runs (SCXML
-  'internal before external'). It is spliced in by
-  `front-insert-machine-internal` AFTER any sibling machine-internal
-  envelopes already queued this macrostep, so source order is preserved
-  among siblings (first emitted is dequeued first).
+  PersistentQueue has no native head-push, so the queue is rebuilt. Only the
+  flow settle uses this, and only because it is the one envelope for which
+  `front-insert-machine-internal`'s boundary splice would be wrong: that
+  splice exists to keep SIBLINGS in source order, and the settle has no
+  siblings — the `:fx` walk enqueues at most one, at the very end of the walk
+  (`fx/settle-flows-if-requested!`), so there is nothing for a splice to
+  preserve and nothing a plain head-push can reverse."
+  [q envelope]
+  (into interop/empty-queue (cons envelope q)))
+
+(defn- insert-envelope
+  "Return the frame's router queue with `envelope` inserted at its position.
+  The single ordering rule, read by BOTH enqueue paths (`enqueue-envelope!`
+  and `ensure-drain-scheduled!`) so they cannot drift apart.
+
+  Per Spec 002, ordinary dispatches go to the BACK (plain FIFO via `conj` on
+  the PersistentQueue). Two envelopes jump it, and the order of the clauses
+  below is itself the priority order:
+
+  1. **The flow settle** (`:rf.flow/settle? true`, stamped by
+     `build-envelope` from the opt `fx/settle-flows-if-requested!` passes)
+     goes to the ABSOLUTE HEAD — ahead of machine-internal continuations too.
+     Per Spec 013 §Sequencing the settle repairs `app-db` to agree with the
+     flow registry as the completed `:fx` walk left it, and every event still
+     queued is a CONTINUATION of the handler that mutated that registry. Left
+     at the back (or spliced behind the machine-internal prefix), those
+     continuations run against the pre-registration / pre-clear `app-db` and
+     can persist a wrong decision into `app-db` that the later settle, which
+     repairs only the derived slot, does not undo. Ahead of them, every
+     continuation reads the settled value. Nothing is lost by settling early:
+     the flow transform runs on EVERY event, so a continuation's own writes
+     are settled by its own drain, not by this envelope.
+  2. **A machine-internal continuation** (`:rf.machine/internal? true`, per
+     rf2-j20a7 / Spec 005 §Level 4) leap-frogs ahead of any already-queued
+     EXTERNAL events, so the machine settles its macrostep to quiescence
+     before the next external event runs (SCXML 'internal before external').
+     It is spliced in by `front-insert-machine-internal` AFTER any sibling
+     machine-internal envelopes already queued this macrostep, so source
+     order is preserved among siblings (first emitted is dequeued first).
 
   Front-of-queue changes ORDER ONLY, not granularity: the leap-frogged
   envelope is still a separately-dequeued event with its own epoch (per
   Spec 002 §Drain versus event and Spec 005 §Level 4). `:raise` is a
   different lever — it never reaches this queue (it drains in-memory,
   intra-macrostep, inside the machine handler invocation)."
+  [q envelope]
+  (cond
+    (:rf.flow/settle? envelope)      (head-insert q envelope)
+    (:rf.machine/internal? envelope) (front-insert-machine-internal q envelope)
+    :else                            (conj q envelope)))
+
+(defn- enqueue-envelope!
+  "Insert `envelope` into the frame's router queue at the position
+  `insert-envelope` gives it."
   [router envelope]
-  (if (:rf.machine/internal? envelope)
-    (swap! router update :queue front-insert-machine-internal envelope)
-    (swap! router update :queue conj envelope)))
+  (swap! router update :queue insert-envelope envelope))
 
 ;; Private authority for the synchronous `:on-destroy` event and the
 ;; same-frame child dispatches it intentionally emits. The cascade drains an

--- a/implementation/core/src/re_frame/router/diagnostics.cljc
+++ b/implementation/core/src/re_frame/router/diagnostics.cljc
@@ -126,6 +126,14 @@
                             config's policy, else the router's `:live` default
     :rf.trace/call-site     macro-stamped invocation coord (dev-only)
     :rf.machine/internal?   machine-internal continuation flag (front-queue)
+    :rf.flow/settle?        Spec 013 §Sequencing — marks the ONE
+                            framework-private `[:rf/settle-flows]` child a
+                            completed `:fx` walk dispatches when it registered
+                            or cleared a flow (`fx/settle-flows-if-requested!`).
+                            `insert-envelope` reads it to head-insert the
+                            settle ahead of the continuations that same handler
+                            queued. INTERNAL — not an app-facing opt, and not a
+                            general priority lever
     :step-index             frame-construction setup-step index, stamped by
                             `frame.cljc`'s `run-setup-events!` onto each
                             `:initial-events` dispatch (EP-0027); read by
@@ -142,7 +150,8 @@
                             `:rf.frame/` namespace) — not an app-facing opt."
   #{:frame :fx-overrides :interceptor-overrides :trace-id :source
     :source-detail :origin :rf.cofx :rf.cofx/mint-policy :rf.trace/call-site
-    :rf.machine/internal? :step-index :rf.frame/expected-incarnation})
+    :rf.machine/internal? :rf.flow/settle? :step-index
+    :rf.frame/expected-incarnation})
 
 (def ^:const retired-draft-opt-hints
   "Dispatch-opt keys that named a fact only ever spelled in the spec's own

--- a/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
+++ b/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
@@ -258,8 +258,13 @@
     ;; incarnation token a `capture-frame` op threads through; build-envelope
     ;; reads it and carries it onto the envelope so `dispatch!` / `dispatch-sync!`
     ;; fence the enqueue to the exact captured incarnation.
+    ;; `:rf.flow/settle?` (rf2-kh73v) is the INTERNAL flag on the ONE
+    ;; `[:rf/settle-flows]` child a completed `:fx` walk dispatches after it
+    ;; registered or cleared a flow; build-envelope reads it and carries it onto
+    ;; the envelope so `insert-envelope` head-inserts the settle ahead of the
+    ;; continuations that same handler queued (Spec 013 §Sequencing).
     (is (= #{:frame :fx-overrides :interceptor-overrides :trace-id :source
              :source-detail :origin :rf.cofx :rf.cofx/mint-policy
-             :rf.trace/call-site :rf.machine/internal? :step-index
-             :rf.frame/expected-incarnation}
+             :rf.trace/call-site :rf.machine/internal? :rf.flow/settle?
+             :step-index :rf.frame/expected-incarnation}
            diag/known-dispatch-opts))))

--- a/implementation/flows/test/re_frame/flows_settle_ordering_test.clj
+++ b/implementation/flows/test/re_frame/flows_settle_ordering_test.clj
@@ -1,0 +1,118 @@
+(ns re-frame.flows-settle-ordering-test
+  "Spec 013 §Sequencing — the settle runs BEFORE the continuations the same
+  handler queued (rf2-kh73v, audit of PR #8893).
+
+  `re-frame.flows-settle-on-dispatch-test` pins the settle BOUNDARY: the
+  derived slot is correct by the time the originating dispatch returns. That
+  is necessary and not sufficient. The settle used to be appended to the BACK
+  of the frame's router queue, so a `:dispatch` effect emitted by the SAME
+  handler was already ahead of it in FIFO order. Those child handlers ran
+  inside the originating run-to-completion pass while `app-db` still reflected
+  the pre-registration / pre-clear state — so a continuation after a register
+  could not read the new output, and a continuation after a clear read the
+  stale one. Each could persist a wrong decision into `app-db` that the later
+  settle, repairing only the derived slot, would not undo.
+
+  The two deftests below are exactly that shape: one handler emitting a
+  lifecycle effect AND a `:dispatch`, where the dispatched handler reads the
+  derived slot and records what it saw. They are the CONTROL for the ordering
+  fix — under the back-of-queue settle they read `nil` (register arm) and the
+  stale value (clear arm), while every other flows test stays green, which is
+  why this had to be found by hand rather than by the existing lane."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; Loading `re-frame.flows` is what publishes the `:flows/reg-flow`
+            ;; / `:flows/clear-flow` late-bind hooks. Without it the reserved fx
+            ;; find no hook and NO-OP silently, which reads exactly like the
+            ;; lagging runtime — every assertion below goes red for the wrong
+            ;; reason. Required for effect, not for a var.
+            [re-frame.flows]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private sum-flow
+  "1 + 2 = 3 at `[:derived]` — the audit probe's own shape."
+  [:sum
+   {:inputs      [[:wizard :foo] [:wizard :bar]]
+    :output-path [:derived]}
+   (fn [foo bar] (+ foo bar))])
+
+(deftest settle-precedes-continuations-queued-by-the-registering-handler
+  (testing "a :dispatch emitted alongside :rf.fx/reg-flow reads the flow's
+            output, not the pre-registration app-db"
+    (rf/reg-event :init (fn [_ _] {:db {:wizard {:foo 1 :bar 2}}}))
+    ;; The continuation. It reads the derived slot and PERSISTS what it saw —
+    ;; the durable wrong decision the later settle cannot undo.
+    (rf/reg-event :read-after-register
+      (fn [{:keys [db]} _]
+        {:db (assoc db :seen-after-register (:derived db))}))
+    (rf/reg-event :enter
+      (fn [_ _]
+        {:fx [[:rf.fx/reg-flow sum-flow]
+              [:dispatch [:read-after-register]]]}))
+
+    (rf/dispatch-sync [:init])
+    (rf/dispatch-sync [:enter])
+
+    (let [db (rf/app-db-value :rf/default)]
+      (is (= 3 (:derived db))
+          (str "precondition — the settle boundary itself still holds. Row " db))
+      ;; THE CONTROL, register arm. Red under the back-of-queue settle:
+      ;; `{:seen-after-register nil, :derived 3}`.
+      (is (= 3 (:seen-after-register db))
+          (str "the continuation ran AFTER the settle and read the new output. Row " db)))))
+
+(deftest settle-precedes-continuations-queued-by-the-clearing-handler
+  (testing "a :dispatch emitted alongside :rf.fx/clear-flow reads the vacated
+            slot, not the flow's stale output"
+    (rf/reg-event :init (fn [_ _] {:db {:wizard {:foo 1 :bar 2}}}))
+    (rf/reg-event :enter (fn [_ _] {:fx [[:rf.fx/reg-flow sum-flow]]}))
+    (rf/reg-event :read-after-clear
+      (fn [{:keys [db]} _]
+        {:db (assoc db :seen-after-clear (:derived db))}))
+    (rf/reg-event :leave
+      (fn [_ _]
+        {:fx [[:rf.fx/clear-flow :sum]
+              [:dispatch [:read-after-clear]]]}))
+
+    (rf/dispatch-sync [:init])
+    (rf/dispatch-sync [:enter])
+    (is (= 3 (:derived (rf/app-db-value :rf/default)))
+        "precondition — the flow is registered and its output materialised")
+
+    (rf/dispatch-sync [:leave])
+
+    (let [db (rf/app-db-value :rf/default)]
+      (is (not (contains? db :derived))
+          (str "precondition — the settle boundary itself still holds. Row " db))
+      ;; THE CONTROL, clear arm. Red under the back-of-queue settle:
+      ;; `{:seen-after-clear 3}` with `:derived` already removed.
+      (is (nil? (:seen-after-clear db))
+          (str "the continuation ran AFTER the settle and read the vacated slot. Row " db)))))
+
+(deftest settle-precedes-a-whole-run-of-queued-continuations
+  (testing "one settle, ahead of EVERY continuation the handler queued, and the
+            continuations keep their own source order"
+    (let [seen (atom [])]
+      (rf/reg-event :init (fn [_ _] {:db {:wizard {:foo 1 :bar 2}}}))
+      (rf/reg-event :read-a
+        (fn [{:keys [db]} _] (swap! seen conj [:a (:derived db)]) nil))
+      (rf/reg-event :read-b
+        (fn [{:keys [db]} _] (swap! seen conj [:b (:derived db)]) nil))
+      (rf/reg-event :enter
+        (fn [_ _]
+          {:fx [[:dispatch [:read-a]]
+                [:rf.fx/reg-flow sum-flow]
+                [:dispatch [:read-b]]]}))
+
+      (rf/dispatch-sync [:init])
+      (rf/dispatch-sync [:enter])
+
+      ;; Both continuations see the settled value — including `:read-a`, queued
+      ;; BEFORE the lifecycle effect ran. The settle is enqueued once, at the
+      ;; end of the walk, ahead of the whole queued run.
+      (is (= [[:a 3] [:b 3]] @seen)
+          (str "settled value in both, source order preserved. Row " @seen)))))


### PR DESCRIPTION
Audit follow-up on PR #8893 (rf2-kh73v, reopened).

## The gap

PR #8893 made `:rf.fx/reg-flow` / `:rf.fx/clear-flow` settle on the dispatching frame by having the completed `:fx` walk enqueue one framework-private `[:rf/settle-flows]`. It went to the **back** of the frame's router queue, so a `:dispatch` effect emitted by that same handler — appended *during* the walk — sat ahead of it in FIFO order.

Those child handlers therefore ran inside the originating run-to-completion pass against the pre-registration / pre-clear `app-db`. A continuation after a register could not read the new output; one after a clear read the stale one. Either can persist that wrong decision into `app-db`, where the later settle — which repairs only the derived slot — does not undo it.

Reproduced at tip before any change, with the audit's own values:

| probe | `app-db` after the dispatch |
|---|---|
| `reg-flow` + `[:dispatch [:read-after-register]]` | `{:wizard {:foo 1, :bar 2}, :seen-after-register nil, :derived 3}` |
| `clear-flow` + `[:dispatch [:read-after-clear]]` | `{:wizard {:foo 1, :bar 2}, :seen-after-clear 3}` (`:derived` already removed) |

## The change

The settle now carries `:rf.flow/settle?` on its envelope and the router **head-inserts** it, ahead of everything already queued. It stays one ordinary internal event, on the same frame, with no public knob.

- `fx.cljc` — `settle-flows-if-requested!` passes `:rf.flow/settle? true` through the existing `child-dispatch!` seam.
- `router.cljc` — `build-envelope` carries the flag; the queue-ordering rule moves into one `insert-envelope` (settle → head, machine-internal → boundary splice, else `conj`). The two enqueue sites (`enqueue-envelope!` and `ensure-drain-scheduled!`) each carried their own copy of that rule; both now read the one function.
- `router/diagnostics.cljc` — `:rf.flow/settle?` joins `known-dispatch-opts`, so the internal opt does not trip the no-silent-swallow `:rf.warning/unknown-dispatch-opt`.

**Why head-insert rather than the existing boundary splice.** `front-insert-machine-internal` splices *after* the machine-internal prefix, because it is called once per sibling and must keep siblings in source order. The settle has no siblings — at most one per `:fx` walk, enqueued at the very end of it — so there is nothing for a splice to preserve, and splicing behind the machine-internal prefix would leave the machine case broken (machine continuations are "already queued continuations" too). Running the settle synchronously inside `do-fx` was the third option and is worse on both counts the audit protects: it would re-enter the drain outside run-to-completion and put the settle's `:derive` failures back inside the registering event.

**Settling early costs nothing**, which the old back-of-queue rationale assumed otherwise: the flow transform runs on *every* event, so each continuation settles its own writes on its own drain. There was never a need for one late settle to cover the whole cascade.

Preserved untouched: one `app-db` install per event, and the existing `:rf.error/flow-eval-exception` failure path.

## Spec

No spec change. Spec 013 §Sequencing already states the contract as the settle **boundary** and says applications must not depend on the settling event's id, its trace presence, **or its position in the queue** — this moves the position, inside that contract. `:rf.flow/*` is the rostered flows sub-namespace in `spec/Conventions.md`, so the new envelope flag needs no roster row (`:rf.machine/internal?`, its neighbour, has none either).

## Quality gates

| gate | result | captured exit |
|---|---|---|
| JVM `clojure -M:test` in `implementation/flows` | 250 tests, 6102 assertions, 0 failures | **0** |
| JVM `clojure -M:test` in `implementation/core` | 2174 tests, 11130 assertions, 0 failures | **0** |
| CLJS `npm run test:cljs` (consolidated `node-test`) from `implementation` | 11149 tests, 55134 assertions, 0 failures | **0** |

All three re-run on the final base after rebasing onto current `origin/main` (trunk's only source movement in the interval was under `implementation/ssr/`, zero overlap with this diff). No markdown changed, so neither doc-link gate is nominated.

### Control

Reverting the ordering — the settle's `:rf.flow/settle?` flag set false, so the envelope falls back to `conj` (the pre-change back-of-queue behaviour) — took the **full flows lane** to captured exit **1** with **exactly 3 failures across the same 250 tests / 6102 assertions**:

- RED: `settle-precedes-continuations-queued-by-the-registering-handler` (the `:seen-after-register` assertion)
- RED: `settle-precedes-continuations-queued-by-the-clearing-handler` (the `:seen-after-clear` assertion)
- RED: `settle-precedes-a-whole-run-of-queued-continuations` (`[[:a nil] [:b 3]]` for `[[:a 3] [:b 3]]`)
- GREEN: every one of the 247 pre-existing flows tests, including all three of `flows_settle_on_dispatch_test`'s settle-boundary tests, and the three preconditions inside the new tests themselves

That asymmetry is the point: the pre-existing lane passes under the buggy ordering, which is why the audit had to find this by hand. Namespace and assertion counts are identical between the control and the green run, so nothing was skipped.

The CLJS lane prints its config path and it named this checkout. The core JVM lane prints no root, so it was discriminated by a planted unresolved symbol in `router.cljc`, which took it to captured exit 1 naming the plant. Both plants restored and verified by git **blob** hash against the committed object (line endings are translated in this checkout).
