### PR TITLE
docs(method): a correction overshoots into the inverse; test it against the same evidence

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -583,13 +583,19 @@ compatible with a stopped worker and with healthy foreground work alike, so it i
 Re-reading the same four clocks cannot break the tie, however long the freeze runs: an hour of it is
 the same non-signal as a minute of it.
 
-Measured, twice: on the first occasion five workers were reported dormant and four then completed
-alive with full reports, one answering the ping directly to say it had been on final hygiene, while
-the fifth was never explained either way; the diagnosis was retracted in full, including a second
-claim — that messaging was inoperative — which was *slow* converted into *broken*. It recurred the
-same day on a sixth worker whose clocks were frozen for over an hour and which completed normally.
-**Five of six alive is the sourced count; treat it as a warning against the dormancy reading, not as
-a licence for its inverse.**
+Measured, twice: on the first occasion five workers were reported dormant; **three completed alive
+with full reports**, one answering the ping directly to say it had been on final hygiene, and **two
+were never explained either way**. The diagnosis was retracted in full, including a second claim —
+that messaging was inoperative — which was *slow* converted into *broken*. It recurred the same day
+on a sixth worker whose clocks were frozen for over an hour and which completed normally.
+
+**Name those outcomes rather than reducing them to a ratio, because the ratio has already been got
+wrong twice.** A ratio invites you to round the unexplained cases into whichever side you are
+arguing for, and the first attempt also counted a **live control** — a worker that was moving
+throughout, and was the comparison the measurement rested on — among the completions. Four alive,
+two unexplained, one control that was never in question: **treat that as a warning against the
+dormancy reading, not as a licence for its inverse**, and note that the two unexplained workers are
+precisely why the reading is ambiguous rather than merely mistaken.
 
 **So prefer the DIRECT signal where your tooling offers one** — a live progress line, a status the
 supervisor maintains — over any number of indirect clocks, and **treat the four clocks as the fallback

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1435,6 +1435,26 @@ Watch specifically for:
 Report one or two lines unless you find real drift. If you find drift, fix the document or the command
 file — do not just note it.
 
+**But the repair is the step most likely to need repairing, and it fails in one particular way: a
+correction tends to overshoot into the INVERSE of the claim it replaces.** A wrong sentence is
+usually wrong by asserting too much, and the evidence that exposes it feels like evidence for the
+opposite — so the fix arrives with the confidence the original had, pointing the other way, and
+reads as *more* reliable because it was written in response to being caught. Two in one session,
+both in this loop's own output: *"those workers are dormant"*, refuted, became *"frozen clocks are
+the signature of a run about to report"* when the supported claim was that the reading is ambiguous;
+and a containment scan demoted from a verdict to triage kept a clause saying it *"settles the common
+case"*, two sentences from the words *"triage, not a verdict"*. Both were caught by an outside
+reader, not by the loop that wrote them.
+
+**The discharging test is one question, and it costs nothing: would the evidence that falsified the
+old claim also falsify the new one?** If it would, the new claim is not established — it is the old
+error re-pointed. Workers completing alive falsifies *dormant*; it does not establish *about to
+report*, because a stopped worker produces the same reading. Where the honest answer is that the
+observation supports neither side, **say so plainly and let the guidance rest on the asymmetric cost
+of the two errors instead** — that is a real reason to wait, and it survives the next counterexample,
+which a re-pointed claim does not. Being wrong twice about the same sentence is the ordinary case
+here, and this loop is where the second round is supposed to be caught.
+
 **Where the project arms a mayor-side commit guard, the mayor's own repair goes through a
 mayor-occupied worktree** — the guard refuses the mayor checkout for every non-tracker surface,
 these documents included, and that refusal is the guard working, not an exemption to negotiate.

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -929,9 +929,12 @@ and both readings went wrong in a single day here, in opposite directions.
    healthy foreground work looks like, and exactly what a stopped worker looks like.** It cannot
    identify either, and no amount of re-reading the same four clocks converts it into evidence; a
    freeze that has run an hour is still the same non-signal it was in the first minute. Measured twice
-   in one day, on five workers and then on a sixth: **five of those six completed alive** — the
-   remaining one was never explained — and on the second occasion the supervisor's own one-line
-   progress string named the phase outright while the four clocks said otherwise. Where no direct
+   in one day: five workers were called dormant and **three of them completed alive, two were never
+   explained either way**; a sixth, recorded later as another instance, also completed. **Do not count
+   a live control among them** — one moving worker was the control for that measurement, and folding
+   it into the numerator is how this count was first written down wrong. On the second occasion the
+   supervisor's own one-line progress string named the phase outright while the four clocks said
+   otherwise. Where no direct
    status exists, declare a window and re-read rather than acting: not because waiting resolves the
    ambiguity, but because the two errors are priced differently — waiting costs a tick, and acting
    costs a duplicate worker in a live worktree.


### PR DESCRIPTION
Retrospective on the method, from a full session as acting mayor.

**Most of what I would have written is already there.** I went looking for four things and found
three of them documented, in some cases better than I would have put them: the audit-reopen
lifecycle and its convergence chains (§5 — *"expect chains … two or three rounds converge"*), the
finding-is-a-claim framing and the licence to refuse (§4), and the whole of §6's drift taxonomy —
stale constants, unsatisfiable quantifiers, diverged blocks, hazards without their discriminating
test. Adding any of it again would have been the *"same drift one level down"* this file already
warns about. The README is accurate, in the operator's voice, and needed nothing.

## The one gap, and it is in this loop's own output

§6 tells you to find drift and fix it. It says nothing about how the **fix** fails — and the fix has
a characteristic failure that cost two rounds in one session, both times on text this loop had just
written.

**A correction overshoots into the inverse of the claim it replaces.** A wrong sentence is usually
wrong by asserting too much, and the evidence that exposes it feels like evidence for the opposite.
So the repair arrives carrying the original's confidence, pointed the other way — and reads as *more*
trustworthy, because it was written in response to being caught.

Both instances were mine, and both were caught by an outside reader rather than by the loop that
wrote them:

- *"Those workers are dormant"* was refuted by five of six completing alive. The repair said frozen
  clocks are **"the signature of a run about to report"** — on pages that had just finished
  explaining that a stopped worker and a healthy one produce *identical* readings. A pattern shared
  by two states identifies neither. The supported claim was that the reading is ambiguous.
- A containment scan was correctly demoted from verdict to triage, and the repair kept a clause
  saying it **"settles the common case"** — two sentences from the words *"triage, not a verdict."*

## The test, which costs nothing

**Would the evidence that falsified the old claim also falsify the new one?** If it would, the new
claim is not established; it is the old error re-pointed. Workers completing alive falsifies
*dormant* — it does not establish *about to report*, because a stopped worker reads the same.

And where the honest answer is that the observation supports neither side, say so and let the
guidance rest on **the asymmetric cost of the two errors** instead. That is a real reason to wait,
and it survives the next counterexample, which a re-pointed claim does not.

Twenty lines, one section, no deletions. Nothing else in the method changes.

## Quality gates

| Gate | Exit | Result |
|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | clean |
| `scripts/check_readme_links.py --ci` | **0** | clean |
| `python -m mkdocs build --strict` | **0** | clean |
| `check_doc_slugs.py` **sabotage** | **1** | `BROKEN ANCHOR: docs\the-mayor-method\loops.md:1439 -> loops.md#planted-retro-zzz` |
| `check_doc_slugs.py` restored | **0** | clean |

Exit codes captured from the runner on one command line. Restore verified by git **blob** hash
against the committed object — `a2fc25b7363f60951e401a348d87c8b804e9555c` on both sides. Merge-base
diff is +20/−0, so there is nothing to revert.

**One incident worth recording, because it happened while verifying this very change.** My first
fixed-string probe of the new text returned **0** — not because the text was missing, but because the
phrase wraps across two lines, and the search is line-oriented. That is the hazard documented under
*a search that returns ZERO is not a check that passed*, and it bit one paragraph after I finished
writing about overclaiming. I re-probed both ways (line-oriented and flattened, 1 and 1) and chose a
single-line anchor for the plant, which is what that rule prescribes.

**Bare `mkdocs` returns 127 in Git Bash on this checkout** — no verdict, not a pass. Run as
`python -m mkdocs`.

## What no gate covers

`mkdocs build --strict` does not gate heading anchors (MkDocs grades them at INFO; `--strict`
promotes only WARNING), so `check_doc_slugs.py` is the sole anchor gate here. Nothing validates prose
or rendering. No table, heading or fenced block is touched, and this change adds no permanent link —
the anchor above existed only as the plant.