### PR TITLE
fix(testbed-support): the launch shim's capability probe runs for a column-only coordinate (rf2-1i1ec)

### DIFF
--- a/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
+++ b/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
@@ -161,10 +161,24 @@
        "var f=process.argv[1];"
        "var line=process.argv[2]||undefined;var col=process.argv[3]||undefined;"
        "var e=process.argv[4]||undefined;"
-       ;; Only a coordinate-bearing launch has anything to lose.
-       "if(line){"
+       ;; Only a coordinate-bearing launch has anything to lose — and a
+       ;; COLUMN ALONE is a coordinate. `build-file-spec` normalises a
+       ;; column with no line to `path:1:<column>`, so a `column=7` request
+       ;; asks the launcher for 1:7 and can lose it exactly as a line-bearing
+       ;; one can. Gating this probe on `line` alone let every column-only
+       ;; auto-detect launch past the capability check entirely, so a
+       ;; position-blind binary could strip `:1:7`, exit 0 and win a 200 that
+       ;; suppressed the coordinate-preserving fallback (rf2-1i1ec audit).
+       ;;
+       ;; The normalisation is repeated here rather than derived from the
+       ;; file spec: `line||1` is the same rule `build-file-spec` applies, and
+       ;; the two must agree or the probe answers about a different
+       ;; coordinate than the one being launched. `get-args.js` switches on
+       ;; the command BASENAME only, so the substituted values never change
+       ;; the fall-through verdict — they only have to be present.
+       "if(line||col){"
        "var ed=guess(e)[0];"
-       "var a=ed?getArgs(ed,'F',line,col||1):null;"
+       "var a=ed?getArgs(ed,'F',line||1,col||1):null;"
        "if(a&&a.length===1&&a[0]==='F'){"
        "process.stderr.write('" position-unsupported-error "\\n');"
        "process.exit(" position-unsupported-exit ");}}"

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -1180,7 +1180,32 @@
               (let [{:keys [ok message]} (oies/launch! f nil nil "nonexistent-dir/Brackets")]
                 (is (false? ok))
                 (is (not= oies/position-unsupported-error message)
-                    "the empty coordinate argv tokens read as absent")))))))))
+                    "the empty coordinate argv tokens read as absent")))
+
+            ;; A COLUMN with no line is the coordinate shape every probe above
+            ;; misses: they all pass 27 AND 9. `build-file-spec` normalises it
+            ;; to `path:1:<column>`, and `position-would-be-dropped?` already
+            ;; calls it a coordinate — but the shim gated its probe on the
+            ;; LINE argv token alone, which is empty here, so the whole
+            ;; capability check was skipped and a position-blind binary could
+            ;; strip `:1:7`, exit 0 and win a 200 (rf2-1i1ec audit).
+            (testing "COLUMN-ONLY, position-blind: refused on the same terms
+                      as a line-bearing launch. The argv line token is empty,
+                      so this is precisely the request the old `if(line)` gate
+                      waved through"
+              (is (= {:ok false :message oies/position-unsupported-error}
+                     (oies/launch! f nil 7 "nonexistent-dir/Brackets"))
+                  "a column alone is a coordinate the launcher can lose"))
+
+            (testing "COLUMN-ONLY POSITIVE CONTROL — the same column-only
+                      request to a position-CAPABLE command still reaches a
+                      real launch attempt. It fails (the binary does not
+                      exist) but NOT as the decline, so widening the gate did
+                      not turn column-only into a blanket refusal"
+              (let [{:keys [ok message]} (oies/launch! f nil 7 "nonexistent-dir/zed")]
+                (is (false? ok) "the nonexistent binary could not be launched")
+                (is (not= oies/position-unsupported-error message)
+                    "…and it was a launch failure, not a capability refusal")))))))))
 
 (deftest endpoint-turns-a-launch-time-decline-into-the-same-422
   (testing "the wiring that makes the shim's refusal user-visible: a
@@ -1205,4 +1230,26 @@
         (is (not (<= 200 (:status resp) 299))
             "non-2xx is what runs the client's coordinate-preserving fallback")
         (is (re-find #"\"error\":\"editor-position-unsupported\"" (:body resp))
-            "the same token the declared-vocabulary decline emits")))))
+            "the same token the declared-vocabulary decline emits"))))
+
+  (testing "the same mapping for a COLUMN-ONLY request, which is the shape
+            that used to bypass the shim's probe altogether: `column=7` with
+            no `line` and no `editor`. The coordinate at stake is the
+            normalised 1:7 the endpoint would have handed the launcher, and
+            the client's URI fallback is what carries it"
+    (is (= "/abs/src/app.cljs:1:7"
+           (#'oies/build-file-spec "/abs/src/app.cljs" nil 7))
+        "column-only normalises to line 1 — a real coordinate, not an absent
+         one, which is why the shim must probe for it")
+    (with-redefs [oies/launch! (fn [& _]
+                                 {:ok false
+                                  :message oies/position-unsupported-error})]
+      (let [resp (oies/handle
+                   {:uri            oies/endpoint-path
+                    :request-method :post
+                    :query-string   "file=fake_ns/core.cljs&column=7"
+                    :headers        {"host" "localhost:8031"}})]
+        (is (= 422 (:status resp))
+            "a 200 here would claim 1:7 reached an editor that never got it")
+        (is (re-find #"\"error\":\"editor-position-unsupported\"" (:body resp))
+            "one contract for the client, whatever shape the coordinate had")))))


### PR DESCRIPTION
Reopened by the PR #8910 audit. The capability probe that PR added is the right narrow repair, but it could not see the endpoint's own column-only coordinate.

## The defect

`launch!` passes `line` and `column` as separate argv tokens so the shim can tell whether a coordinate is at stake *before* handing the file spec to `launch-editor`. An absent value is an empty token. The shim then gated the whole probe on the **line** token alone:

```js
var line=process.argv[2]||undefined;var col=process.argv[3]||undefined;
if(line){                                   // ← column-only never gets here
```

So `launch! f nil 7 nil` builds the correct file spec `f:1:7`, passes argv tokens `""` and `"7"`, and the shim skips capability checking entirely. On the no-hint / custom auto-detect route — the only route this probe covers — a position-blind binary (`Brackets` on every platform, `Cursor.exe` on Windows) could then strip `:1:7`, exit 0, and win a 200 that suppressed the coordinate-preserving `editor://` fallback.

Reproduced against the installed dependency before touching anything:

```
LINE+COL   Brackets -> {:ok false, :message "editor-position-unsupported"}   ← declined
COL-ONLY   Brackets -> {:ok false, :message "launch-editor: (code 1)."}      ← NOT declined
NO-COORD   Brackets -> {:ok false, :message "launch-editor: (code 1)."}
file-spec col-only  -> /abs/a.cljs:1:7
```

The column-only row is a launch *attempt* — it failed only because that binary does not exist. With a real Brackets on the box it exits 0 and the endpoint answers 200.

## Why the shim was the wrong half, not the README

Both surrounding contracts already treated a bare column as a coordinate, and the shim was the single surface disagreeing:

- `build-file-spec` normalises a column with no line to `path:1:<column>` — it has a dedicated test.
- `position-would-be-dropped?` already fires on `(nil, 9)`, with an existing assertion reading *"a column alone is a coordinate (build-file-spec supplies line 1)"*.

The two statements the audit called contradicted were checked at source and **both are correct as written** — neither needed changing:

- `README.md`: *"A 200 from this endpoint means the whole source coordinate reached an editor, not merely that a process exited."*
- `README.md`: *"A request carrying no line or column is never declined: there is nothing to lose, and classpath resolution is worth having."* — i.e. only a request with **neither** is exempt, so a column-only request was always in scope for the decline.

No markdown is touched by this PR.

## The repair

Probe when **either** token is present, and substitute line 1 when only a column is — `build-file-spec`'s own rule, so the probe asks about the same coordinate that will actually be launched:

```js
if(line||col){
var ed=guess(e)[0];
var a=ed?getArgs(ed,'F',line||1,col||1):null;
```

`get-args.js` switches on the command **basename** only, so the substituted values never change the fall-through verdict; they only have to be present. No editor registry, no launcher redesign, no change to the supported vocabulary or to `commands-without-position-support`.

## Tests

Every pre-existing real-node auto-detect probe passes line 27 **and** column 9, so none could reach this path. Added:

- a real-node **column-only refusal** against a position-blind command (`launch! f nil 7 "nonexistent-dir/Brackets"`);
- a real-node **position-capable control** on the same coordinate (`…/zed`) proving the widened gate did not turn column-only into a blanket refusal;
- the endpoint's **422 mapping** for a column-only request with no `editor` param, alongside the `:1:7` the fallback carries.

## Quality gates

| Gate | Captured exit | Result |
|---|---|---|
| `clojure -M:test` in `tools/testbed-support` (with `launch-editor` installed) | **0** | 42 tests / 260 assertions, 0 failures, 0 errors |
| same, re-run after restoring the sabotage | **0** | 42 tests / 260 assertions, 0 failures, 0 errors |
| same, dependency absent (CI's shape) | **0** | 42 tests / 229 assertions, 0 failures, 0 errors |
| **Control** — `if(line\|\|col)` reverted to `if(line)` | **1** | 42 tests / 260 assertions, **1 failure** |

Exit codes were captured with the redirect and `echo $?` on one command line and are quoted from the `.exit` file, not from any harness report.

`check_doc_slugs.py` and `check_readme_links.py --ci` are not nominated: no markdown is touched. `mkdocs build --strict` is not a candidate either — `docs_dir` is `docs`, so `tools/` was never in the built site. The changed-surface classifier was run on the two changed paths and returns `tools_jvm_testbed_support=true`, `cljs_node_test=true`, `cljs_browser=true`; it returns zero surfaces on a control path in no arm, so it is not answering vacuously. Both changed files are `.clj`, which no CLJS build in this tree can load, so the two CLJS lanes cover unchanged sources.

### Control detail — exactly one assertion red

Reverting only the gate left the lane at 42 tests / 260 assertions with a single failure, in `launch-declines-when-the-resolved-editor-would-drop-the-position`:

```
expected: (= {:ok false, :message oies/position-unsupported-error}
             (oies/launch! f nil 7 "nonexistent-dir/Brackets"))
  actual: (not (= {:ok false, :message "editor-position-unsupported"}
                  {:ok false, :message "launch-editor: (code 1)."}))
```

The actual value is the unrepaired launch attempt, at the exact spot the decline was due. **All 254 pre-existing assertions stayed green under the control** — which is why this gap survived #8910 — as did the 5 other assertions this PR adds (the `zed` control passes either way by design, and the 422-mapping assertions stub `launch!` and test the mapping rather than the probe). A plant that reddened the lane broadly would not have demonstrated the gap. Test and assertion totals held at 42/260 under sabotage, so nothing was dropped. Source restored and verified by git **blob** hash against the committed object (`f323d905a256ade88c6f53718d2c68474e9c0fd3` before the plant, `41078c8475bf273d734287688ef85b382d562aa3` planted, back to `f323d905a256ade88c6f53718d2c68474e9c0fd3` after) rather than by reading a diff.

### One honest caveat about CI

The CI job `jvm-tools-testbed-support` runs `clojure -M:test` with **no `npm ci` step**, so `launch-editor-installed?` is false there and the node-backed tests — including the new refusal — self-skip. CI will therefore report **42 tests / 229 assertions**, not 260. The 31-assertion delta between the two runs above is the measurement that shows the real-node block actually executed locally against the installed `launch-editor@2.14.1`; the exit code alone would not distinguish a run from a skip. That skipping is a pre-existing property of the lane, not something this PR introduces.

Closes rf2-1i1ec.
