### PR TITLE
fix(machines): record raised-event transitions in the macrostep cascade (rf2-nb8nj)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -714,8 +714,19 @@
       ;; entry (shallowest-first + initial-descent), each step with its
       ;; `:kind` / `:state` / `:region` / `:action` / `:data-delta`, plus a
       ;; `:microstep` step (carrying nested `:steps`) per `:always`
-      ;; iteration, with per-region structure for parallel machines. This is
-      ;; the contract Xray's epoch panel renders. It rides under
+      ;; iteration, with per-region structure for parallel machines.
+      ;;
+      ;; rf2-nb8nj — plus one `:raised-transition` step per HANDLED dequeue
+      ;; off the internal-event queue, in FIFO order, carrying that internal
+      ;; `:event` and its own nested `:steps`. The walk therefore spans the
+      ;; WHOLE macrostep: every hop between `:before` and `:after` is
+      ;; explained, and a raised transition's rows are NESTED rather than
+      ;; laid alongside the external event's, so a consumer reading the
+      ;; top-level steps reads the dispatched event's geometry and nothing
+      ;; else. `:microsteps` above stays the `:always`-iteration count — it
+      ;; is not a step count and does not include raised dequeues.
+      ;;
+      ;; This is the contract Xray's epoch panel renders. It rides under
       ;; the same handler-scope `:sensitive?` stamp as `:before` / `:after`
       ;; (per Spec 005 §Privacy), so a sensitive machine's cascade
       ;; `:data-delta`s are scrubbed at egress alongside the snapshot slots.

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -1343,7 +1343,44 @@
                 (if (result/fail? step)
                   step
                   (result/with-ok [snap2 fx2] step
-                    (let [[new-raises real-fx] (split-raises fx2)]
+                    (let [[new-raises real-fx] (split-raises fx2)
+                          ;; rf2-nb8nj — group the rebroadcast's rows under ONE
+                          ;; `:kind :raised-transition` boundary instead of
+                          ;; flattening them straight into the accumulator.
+                          ;; The geometry always survived here, but with no
+                          ;; boundary and no trigger event its exit / action /
+                          ;; entry rows were indistinguishable from the EXTERNAL
+                          ;; event's — which is worse than losing them, because
+                          ;; Xray's `handled-regions-from-cascade` treats any
+                          ;; non-`:microstep` row's `:region` as evidence that
+                          ;; the region handled the DISPATCHED event. A region
+                          ;; that declined the external event and moved only on
+                          ;; the raise was therefore misattributed and lit a
+                          ;; phantom event edge.
+                          ;;
+                          ;; Identical shape and gate to the flat/compound drain
+                          ;; (`transition/drain-to-fixed-point`) — one schema-
+                          ;; approved wrapper across both engines, so a consumer
+                          ;; traverses one thing. `:region` is nil: a raise is
+                          ;; re-broadcast across EVERY region, so the boundary
+                          ;; belongs to no single one; the nested `:steps` keep
+                          ;; their own per-region stamps. `:from` / `:to` are the
+                          ;; whole composite region-MAPs, matching the parallel
+                          ;; trace's `:before` / `:after` shape.
+                          ;;
+                          ;; The synthetic `[:rf.machine/done <path>]` region
+                          ;; completion signal enters this same queue, so it is
+                          ;; represented by the same mechanism — no parallel
+                          ;; done-state dialect.
+                          acc-casc' (if (result/handled? step)
+                                      (conj acc-casc
+                                            {:kind   :raised-transition
+                                             :region nil
+                                             :event  ev
+                                             :from   (:state cur-snap)
+                                             :to     (:state snap2)
+                                             :steps  (result/cascade step)})
+                                      acc-casc)]
                       (recur snap2
                              m'
                              ;; FIFO: drop the just-processed
@@ -1353,7 +1390,7 @@
                              (into acc-fx real-fx)
                              (inc depth)
                              (+ acc-micro (result/microsteps step))
-                             (into acc-casc (result/cascade step))
+                             acc-casc'
                              (conj visited (:state snap2)))))))))))))))
 
 ;; ---- parallel done-state / `:on-done` signal ------------------------------

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -4127,7 +4127,55 @@
                           ;; Split the deferred result's fx into the surfaced
                           ;; raised events (append to the BACK, behind pending
                           ;; siblings — FIFO) and the real do-fx-bound fx.
-                          (let [{new-raises :raises real-fx :rest} (split-raise-fx fx2)]
+                          (let [{new-raises :raises real-fx :rest} (split-raise-fx fx2)
+                                ;; rf2-nb8nj — append one
+                                ;; `:kind :raised-transition` boundary carrying
+                                ;; the nested result's OWN cascade, so the
+                                ;; macrostep record stays lossless. Previously
+                                ;; this `recur` passed `cascade` unchanged, which
+                                ;; DISCARDED the raised transition's exit /
+                                ;; action / entry rows outright: the outer trace
+                                ;; could report `:before :idle` / `:after :done`
+                                ;; while its `:cascade` explained only
+                                ;; `:idle → :working`.
+                                ;;
+                                ;; The wrapper mirrors the `:microstep` step's
+                                ;; shape (`:region` / `:from` / `:to` / `:steps`)
+                                ;; and swaps the microstep INDEX for the
+                                ;; triggering internal `:event` — one nested
+                                ;; boundary rather than a second trace protocol.
+                                ;; `:steps` is the nested call's whole cascade,
+                                ;; so an `:always` transition the raise ENABLED
+                                ;; settles inside this boundary (attributed to
+                                ;; the internal event that enabled it) rather
+                                ;; than at top level.
+                                ;;
+                                ;; Gated on the nested Result's `::handled?`:
+                                ;; an IGNORED or GUARD-BLOCKED raise selected no
+                                ;; transition, so it must fabricate no
+                                ;; handled-transition wrapper (its cascade is
+                                ;; empty either way — the gate is what makes the
+                                ;; absence intentional rather than incidental).
+                                ;; A HANDLED targetless raise still records its
+                                ;; boundary, with `:from` equal to `:to`.
+                                ;;
+                                ;; The runtime's synthetic
+                                ;; `[:rf.machine/done <path>]` completion signal
+                                ;; is itself a `[:raise …]` fx (`done-raise-fx`),
+                                ;; so it rides THIS boundary too — no separate
+                                ;; done-state dialect.
+                                ;;
+                                ;; `::microsteps` is untouched: it stays the
+                                ;; `:always`-iteration count, not a step count.
+                                cascade' (if (result/handled? step-result)
+                                           (conj cascade
+                                                 {:kind   :raised-transition
+                                                  :region (:rf/region m)
+                                                  :event  ev
+                                                  :from   (:state snap)
+                                                  :to     (:state snap2)
+                                                  :steps  (result/cascade step-result)})
+                                           cascade)]
                             (recur snap2
                                    ;; Thread the augmented machine forward so the
                                    ;; generated facts from THIS raise's ensure are
@@ -4141,7 +4189,7 @@
                                    always-depth
                                    (inc raise-depth)
                                    (conj visited (:state snap2))
-                                   cascade)))))))
+                                   cascade')))))))
 
                 ;; ---- (3) quiescent — commit -------------------------------
                 ;;

--- a/implementation/machines/test/re_frame/machine_cascade_instrumentation_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_cascade_instrumentation_cljs_test.cljc
@@ -298,6 +298,284 @@
       (is (some #(= :win (:action %)) (:steps microstep))
           "the eventless transition's :win action is explainable inside the microstep"))))
 
+;; ---- raised (internal) events appear as their own cascade boundary --------
+;;
+;; rf2-nb8nj — a same-macrostep raised event selects a REAL transition whose
+;; exit/action/entry geometry belongs to THAT event, not to the dispatched
+;; one. Before this fix the flat/compound drain discarded those rows outright
+;; (the loop recurred with the cascade unchanged) and the parallel parent
+;; queue flattened them in with no boundary, so the cascade could say
+;; `:idle -> :done` while explaining only `:idle -> :working`.
+;;
+;; The record is one nested `:kind :raised-transition` wrapper per HANDLED
+;; dequeue, in actual FIFO order, carrying the internal `:event`, its
+;; `:from`/`:to`, and the nested ordered `:steps`.
+
+(defn- raised-steps
+  "The `:kind :raised-transition` wrappers off a cascade, in cascade order."
+  [cascade]
+  (filterv #(= :raised-transition (:kind %)) cascade))
+
+(defn- reg-settle! []
+  ;; The item's own reproduction: external `:go` moves :idle -> :working and
+  ;; its action raises [:settle]; :working handles :settle with :target :done
+  ;; plus entry/exit actions.
+  (rf/reg-machine :casc/settle
+    {:initial :idle
+     :data    {:trail []}
+     :actions {:start   (fn [{d :data}]
+                          {:data (update d :trail (fnil conj []) :action:go)
+                           :fx   [[:raise [:settle]]]})
+               :settled (trail-action :action:settle)
+               :exit-working (trail-action :exit:working)
+               :enter-done   (trail-action :entry:done)}
+     :states  {:idle    {:on {:go {:target :working :action :start}}}
+               :working {:exit :exit-working
+                         :on   {:settle {:target :done :action :settled}}}
+               :done    {:entry :enter-done}}}))
+
+(deftest raised-event-transition-is-recorded-as-its-own-cascade-boundary
+  (testing "external :go raises [:settle], which moves :working -> :done in the
+   SAME macrostep. The committed snapshot is :done (raise FIFO semantics
+   already worked), and the single :rf.machine/transition cascade explains the
+   WHOLE walk: the :go geometry, then one :raised-transition wrapper carrying
+   the raised event and its own ordered exit/action/entry steps"
+    (reg-settle!)
+    (rf/dispatch-sync [:casc/settle [:rf.machine/start]])
+    (let [evs     (record-traces!
+                    (fn [] (rf/dispatch-sync [:casc/settle [:go]])))
+          tr      (the-transition evs)
+          cascade (cascade-of evs)
+          raised  (raised-steps cascade)]
+      ;; Premise: the FOLD is already correct — only the record was lossy.
+      (is (= :done (:state (mtest/snapshot :casc/settle)))
+          "the committed snapshot is :done — FIFO raise semantics")
+      (is (= :idle (get-in tr [:tags :before :state])))
+      (is (= :done (get-in tr [:tags :after :state]))
+          "the headline trace spans the WHOLE macrostep")
+
+      ;; The external event's own geometry stays the headline, un-nested.
+      (let [outer (remove #(= :raised-transition (:kind %)) cascade)]
+        (is (= [:exit :action :entry] (mapv :kind outer))
+            "the external :go transition's own exit/action/entry stay at top level")
+        (is (= [nil :start nil] (mapv :action outer))
+            "the top-level rows are the :go transition's, not the raise's"))
+
+      ;; The raised event's rows are neither discarded nor flattened.
+      (is (= 1 (count raised))
+          "exactly one :raised-transition wrapper (RED before rf2-nb8nj: the
+           flat drain recurred with the cascade unchanged, so this was 0)")
+      (let [w (first raised)]
+        (is (= [:settle] (:event w)) "the wrapper names the internal event")
+        (is (= :working (:from w)) "from-state is where the raise was dequeued")
+        (is (= :done    (:to w))   "to-state is where the raised transition landed")
+        (is (nil? (:region w))     "flat/compound machines carry :region nil")
+        (is (vector? (:steps w))   "the wrapper carries its own nested steps")
+        (is (= [:exit :action :entry] (mapv :kind (:steps w)))
+            "the raised transition's own LCA walk rides INSIDE the wrapper")
+        (is (= [:exit-working :settled :enter-done] (mapv :action (:steps w)))
+            "exit :working -> :settled @ LCA -> entry :done"))
+
+      ;; The wrapper sits AFTER the external rows — execution order.
+      (is (= :raised-transition (:kind (last cascade)))
+          "the raised boundary is appended in execution order")
+
+      ;; Trail oracle: the flattened action order the cascade must explain.
+      (is (= [:action:go :exit:working :action:settle :entry:done]
+             (get-in @(rf/subscribe [:rf/machine :casc/settle]) [:data :trail]))
+          "trail oracle for the whole macrostep"))))
+
+(deftest raised-wrappers-follow-actual-fifo-dequeue-order
+  (testing "two raises emitted by one action are dequeued FIFO, and the
+   cascade's :raised-transition wrappers appear in that same order"
+    (rf/reg-machine :casc/fifo
+      {:initial :a
+       :actions {:fan-out (fn [_] {:fx [[:raise [:first]] [:raise [:second]]]})
+                 :noop    (fn [_] {})}
+       :states  {:a {:on {:go {:target :b :action :fan-out}}}
+                 :b {:on {:first {:target :c :action :noop}}}
+                 :c {:on {:second {:target :d :action :noop}}}
+                 :d {}}})
+    (rf/dispatch-sync [:casc/fifo [:rf.machine/start]])
+    (let [evs    (record-traces!
+                   (fn [] (rf/dispatch-sync [:casc/fifo [:go]])))
+          raised (raised-steps (cascade-of evs))]
+      (is (= :d (:state (mtest/snapshot :casc/fifo))))
+      (is (= [[:first] [:second]] (mapv :event raised))
+          "wrappers are ordered by actual FIFO dequeue order")
+      (is (= [[:b :c] [:c :d]] (mapv (juxt :from :to) raised))
+          "each wrapper's from/to is its own hop, not the macrostep's span"))))
+
+(deftest always-enabled-by-a-raised-transition-rides-inside-its-wrapper
+  (testing "an :always transition enabled by a raised transition settles
+   INSIDE that raise's nested cascade, so the microstep is attributed to the
+   internal event that enabled it rather than to the dispatched event"
+    (rf/reg-machine :casc/raise-always
+      {:initial :a
+       :data    {:n 0}
+       :actions {:kick  (fn [_] {:fx [[:raise [:tick]]]})
+                 :count (fn [{d :data}] {:data {:n (inc (:n d))}})
+                 :win   (fn [{d :data}] {:data (assoc d :won true)})}
+       :states  {:a {:on {:go {:target :b :action :kick}}}
+                 :b {:on {:tick {:target :c :action :count}}}
+                 :c {:always [{:target :d :action :win}]}
+                 :d {}}})
+    (rf/dispatch-sync [:casc/raise-always [:rf.machine/start]])
+    (let [evs     (record-traces!
+                    (fn [] (rf/dispatch-sync [:casc/raise-always [:go]])))
+          cascade (cascade-of evs)
+          raised  (raised-steps cascade)
+          w       (first raised)]
+      (is (= :d (:state (mtest/snapshot :casc/raise-always))))
+      (is (= 1 (count raised)))
+      (is (empty? (filterv #(= :microstep (:kind %)) cascade))
+          "the :always did NOT settle at top level — it was enabled by the raise")
+      (let [nested-micro (filterv #(= :microstep (:kind %)) (:steps w))]
+        (is (= 1 (count nested-micro))
+            "the :always microstep rides inside the raised boundary")
+        (is (= :c (:from (first nested-micro))))
+        (is (= :d (:to   (first nested-micro))))
+        (is (some #(= :win (:action %)) (:steps (first nested-micro)))
+            "the eventless transition's action is explainable inside the nest")))))
+
+(deftest ignored-and-guard-blocked-raises-fabricate-no-wrapper
+  (testing "a raised event no state handles, and a raised event whose only
+   candidate is guard-blocked, each contribute NO :raised-transition wrapper —
+   an unhandled internal event is not a transition"
+    (rf/reg-machine :casc/ignored
+      {:initial :a
+       :data    {:open? false}
+       :guards  {:open? (fn [{d :data}] (:open? d))}
+       :actions {:raise-unknown (fn [_] {:fx [[:raise [:nobody-handles-this]]]})
+                 :raise-guarded (fn [_] {:fx [[:raise [:blocked]]]})
+                 :noop          (fn [_] {})}
+       :states  {:a {:on {:go      {:target :b :action :raise-unknown}
+                          :guarded {:target :b :action :raise-guarded}}}
+                 :b {:on {:blocked {:guard :open? :target :c :action :noop}}}
+                 :c {}}})
+    (rf/dispatch-sync [:casc/ignored [:rf.machine/start]])
+    (let [evs (record-traces!
+                (fn [] (rf/dispatch-sync [:casc/ignored [:go]])))]
+      (is (= :b (:state (mtest/snapshot :casc/ignored))))
+      (is (empty? (raised-steps (cascade-of evs)))
+          "an IGNORED raised event fabricates no handled-transition wrapper"))
+    ;; reset to :a is not needed — re-register a fresh machine for the guard leg
+    (rf/reg-machine :casc/guarded
+      {:initial :a
+       :data    {:open? false}
+       :guards  {:open? (fn [{d :data}] (:open? d))}
+       :actions {:kick (fn [_] {:fx [[:raise [:blocked]]]})
+                 :noop (fn [_] {})}
+       :states  {:a {:on {:go {:target :b :action :kick}}}
+                 :b {:on {:blocked {:guard :open? :target :c :action :noop}}}
+                 :c {}}})
+    (rf/dispatch-sync [:casc/guarded [:rf.machine/start]])
+    (let [evs (record-traces!
+                (fn [] (rf/dispatch-sync [:casc/guarded [:go]])))]
+      (is (= :b (:state (mtest/snapshot :casc/guarded)))
+          "the guard blocked the raised transition — the machine rests at :b")
+      (is (empty? (raised-steps (cascade-of evs)))
+          "a GUARD-BLOCKED raised event fabricates no handled-transition wrapper"))))
+
+(deftest targetless-raised-transition-records-its-action-boundary
+  (testing "a handled raised transition with NO :target still records its
+   boundary — the wrapper is present with :from equal to :to and the action
+   step nested inside it"
+    (rf/reg-machine :casc/targetless
+      {:initial :a
+       :data    {:hits 0}
+       :actions {:kick (fn [_] {:fx [[:raise [:ping]]]})
+                 :bump (fn [{d :data}] {:data {:hits (inc (:hits d))}})}
+       :states  {:a {:on {:go {:target :b :action :kick}}}
+                 :b {:on {:ping {:action :bump}}}}})
+    (rf/dispatch-sync [:casc/targetless [:rf.machine/start]])
+    (let [evs    (record-traces!
+                   (fn [] (rf/dispatch-sync [:casc/targetless [:go]])))
+          raised (raised-steps (cascade-of evs))
+          w      (first raised)]
+      (is (= 1 (count raised))
+          "a targetless HANDLED raise still records its boundary")
+      (is (= [:ping] (:event w)))
+      (is (= (:from w) (:to w))
+          ":from equals :to for an internal (targetless) raised transition")
+      (is (= [:action] (mapv :kind (:steps w)))
+          "action-only — no exit/entry boundary")
+      (is (= [:bump] (mapv :action (:steps w)))))))
+
+(deftest synthetic-done-state-signal-uses-the-same-raised-boundary
+  (testing "the runtime's synthetic [:rf.machine/done <path>] completion event
+   is raised through the SAME internal-event queue, so it is recorded by the
+   SAME mechanism — one :raised-transition wrapper, no special dialect"
+    (rf/reg-machine :casc/done
+      {:initial :work
+       :data    {}
+       :actions {:finish (fn [{d :data}] {:data (assoc d :finished true)})}
+       :states  {:work {:initial :step
+                        :on      {:rf.machine/done {:target :wrapped :action :finish}}
+                        :states  {:step {:on {:go {:target :end}}}
+                                  :end  {:final? true}}}
+                 :wrapped {}}})
+    (rf/dispatch-sync [:casc/done [:rf.machine/start]])
+    (let [evs    (record-traces!
+                   (fn [] (rf/dispatch-sync [:casc/done [:go]])))
+          raised (raised-steps (cascade-of evs))
+          w      (first raised)]
+      (is (= :wrapped (:state (mtest/snapshot :casc/done)))
+          "the done signal advanced the enclosing compound")
+      (is (= 1 (count raised))
+          "the synthetic done signal rides the same raised-transition boundary")
+      (is (= :rf.machine/done (first (:event w)))
+          "the wrapper names the synthetic completion event")
+      (is (some #(= :finish (:action %)) (:steps w))
+          "the done-driven transition's action is explainable inside the wrapper"))))
+
+;; ---- root-parallel: raised rebroadcast is GROUPED, not flattened ----------
+
+(deftest parallel-raised-rebroadcast-is-grouped-under-its-internal-event
+  (testing "a raised event re-broadcast across a parallel root's regions
+   contributes its rows INSIDE one :raised-transition wrapper, so they are no
+   longer indistinguishable from the external event's rows. Before rf2-nb8nj
+   the parallel parent queue flattened them straight into the accumulator,
+   which made Xray read them as evidence that :b's region handled :go."
+    (rf/reg-machine :casc/par
+      {:type :parallel
+       :data {:trail []}
+       :regions
+       {:left  {:initial :l0
+                :states  {:l0 {:on {:go {:target :l1 :action :left-go}}}
+                          :l1 {}}}
+        :right {:initial :r0
+                :states  {:r0 {:on {:settle {:target :r1 :action :right-settle}}}
+                          :r1 {}}}}
+       :actions {:left-go      (fn [{d :data}]
+                                 {:data (update d :trail (fnil conj []) :action:left-go)
+                                  :fx   [[:raise [:settle]]]})
+                 :right-settle (trail-action :action:right-settle)}})
+    (rf/dispatch-sync [:casc/par [:rf.machine/start]])
+    (let [evs     (record-traces!
+                    (fn [] (rf/dispatch-sync [:casc/par [:go]])))
+          cascade (cascade-of evs)
+          raised  (raised-steps cascade)
+          w       (first raised)]
+      (is (= {:left :l1 :right :r1} (:state (mtest/snapshot :casc/par)))
+          "both regions moved — :go in :left, the raised :settle in :right")
+      (is (= 1 (count raised))
+          "the rebroadcast contributes ONE boundary (RED before rf2-nb8nj:
+           its rows were flattened into the accumulator with no boundary)")
+      (is (= [:settle] (:event w)))
+      (is (some #(= :right-settle (:action %)) (:steps w))
+          ":right's raised-transition rows ride inside the wrapper")
+
+      ;; The misattribution the item names: the top-level (non-wrapper,
+      ;; non-microstep) rows must name ONLY the region that handled :go.
+      (let [outer-regions (into #{}
+                                (comp (remove #(#{:microstep :raised-transition} (:kind %)))
+                                      (keep :region))
+                                cascade)]
+        (is (= #{:left} outer-regions)
+            ":right must NOT appear at top level — it declined :go and moved
+             only on the raised :settle (RED before rf2-nb8nj: #{:left :right})")))))
+
 ;; ---- privacy / size: no source-literal or large-payload leak --------------
 
 (deftest cascade-carries-only-deltas-not-whole-data

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -633,11 +633,12 @@ Both traces flow through the standard trace bus, so `*handler-scope*` auto-stamp
 
 The per-action `:rf.machine/action-ran` stream above lets a tool *reconstruct* what ran, but only by re-walking the LCA geometry to know which state each action belonged to and in what cascade order. The macrostep's headline `:rf.machine/transition` trace therefore **also carries a structured `:cascade` field** — the engine emits, in a single trace, the ordered step sequence that explains *how* the transition reached its after-state. One trace, one place for tooling to read; this is the contract Xray's epoch panel renders, and it **removes the need for app-level `:data :trail` workarounds**.
 
-`:cascade` is a **vector of self-describing step maps in execution order**, following the ordering [§Entry/exit cascading along the LCA](#entryexit-cascading-along-the-lca) already defines — **exit deepest-first → transition `:action` at the LCA → entry shallowest-first + initial-descent**, then one step per `:always`/eventless microstep:
+`:cascade` is a **vector of self-describing step maps in execution order**, following the ordering [§Entry/exit cascading along the LCA](#entryexit-cascading-along-the-lca) already defines — **exit deepest-first → transition `:action` at the LCA → entry shallowest-first + initial-descent**, then one step per `:always`/eventless microstep and one per handled raised internal event:
 
 ```clojure
 ;; one cascade step (the structural shape the consumer reads)
-{:kind   :exit | :action | :entry | :microstep   ;; the structural boundary
+{:kind   :exit | :action | :entry                ;; the structural boundary
+         | :microstep | :raised-transition        ;;   (the two nesting kinds)
  :state  [:running :conditioning :heating]        ;; state-path exited/entered;
                                                    ;;   the transition's decl-path for :action
  :region :climate | nil                            ;; parallel region (nil for flat/compound)
@@ -664,16 +665,39 @@ The per-action `:rf.machine/action-ran` stream above lets a tool *reconstruct* w
  :from            :asking
  :to              :winner
  :steps           [ …exit/action/entry step maps for the eventless transition… ]}
+
+;; a :raised-transition step is the SAME nesting shape for a same-macrostep
+;; internal event: it swaps the microstep INDEX for the triggering :event
+{:kind   :raised-transition
+ :region nil                                     ;; nil on the parallel parent queue —
+                                                 ;;   a raise re-broadcasts across EVERY
+                                                 ;;   region, so the boundary belongs to
+                                                 ;;   none of them; the nested :steps keep
+                                                 ;;   their own per-region stamps
+ :event  [:settle]                               ;; the internal event vector, verbatim
+ :from   :working                                ;; state where the raise was DEQUEUED
+ :to     :done                                   ;;   and where its transition landed
+                                                 ;;   (equal for a targetless raise;
+                                                 ;;    whole region-MAPs on a parallel root,
+                                                 ;;    matching :before / :after)
+ :steps  [ …exit/action/entry (+ nested :microstep) maps for the raised transition… ]}
 ```
 
 Key properties:
 
-- **Complete configuration walk.** Every state exited and entered is recorded — *including* boundaries with no declared `:exit`/`:entry` action (`:action nil`, empty `:data-delta`) — so the geometry is explainable without the spec. (An app-level `:data :trail` only captured *action-bearing* boundaries; the cascade is a superset.)
-- **`:kind` is structural, not the action driver phase.** It is the closed set `:exit / :action / :entry / :microstep`. The orthogonal driver phase (`:transition` / `:always` / `:after-action` / `:initial-entry` / `:destroy-exit`) is what the per-action `:rf.machine/action-ran` emit stamps under `:phase`; the two dimensions never smear (see the `action-ran` `:phase` set above).
+- **Complete configuration walk.** Every state exited and entered is recorded — *including* boundaries with no declared `:exit`/`:entry` action (`:action nil`, empty `:data-delta`) — so the geometry is explainable without the spec. (An app-level `:data :trail` only captured *action-bearing* boundaries; the cascade is a superset.) **The walk spans the WHOLE macrostep**, so it covers every state change between the trace's `:before` and `:after` — including the ones a same-macrostep raised internal event selected, which are the subject of the `:raised-transition` property below.
+- **`:kind` is structural, not the action driver phase.** It is the closed set `:exit / :action / :entry / :microstep / :raised-transition`. The orthogonal driver phase (`:transition` / `:always` / `:after-action` / `:initial-entry` / `:destroy-exit`) is what the per-action `:rf.machine/action-ran` emit stamps under `:phase`; the two dimensions never smear (see the `action-ran` `:phase` set above).
 - **`:data-delta` is the minimal per-step contribution** — only the `:data` keys that step's action *changed*, never the whole (possibly large) `:data` map. This keeps the cascade small and side-steps a large-payload leak.
 - **`:source` is an additive, history-only field.** An `:entry` step produced by a `:type :history` restore carries `:source :recorded` (the owning compound's last-active configuration was replayed) or `:source :default` (no recording existed yet, so the leaf came from the history node's `:default-target` / the compound's `:initial`), matching the `:rf.machine.history/restored` event's `:source` (see [§History states](#history-states-type-history--shallow--deep--default-target)). The key is **absent on every non-history step** — a consumer treats its absence as "ordinary cascade entry".
 - **Per-region structure for parallel machines.** Each step carries its `:region`; the cascade is the per-region step sequences concatenated in region declaration order, so a consumer can group by `:region`. Flat / compound machines carry `:region nil`.
 - **`:always` microsteps are explainable.** Each eventless macrostep iteration appends a `:microstep` step carrying its own nested `:steps` — so "all the steps" = the entry/exit cascade **plus** the microstep stream, rather than a bare count. This composes with the per-microstep `:rf.machine.microstep/transition` stream (the latter stays the per-microstep marker; `:cascade` is the macrostep-level structured rollup).
+- **Raised internal events are explainable, and attributed.** Each **handled** dequeue off the internal-event queue (per [§Drain semantics](#drain-semantics)) appends one `:raised-transition` step, in actual FIFO dequeue order, carrying the internal `:event` plus that transition's own nested `:steps`. Two properties follow, and both are contracts a consumer may rely on:
+  - **Nothing is lost.** The cascade explains every hop between `:before` and `:after`, so a macrostep whose external event raised `[:settle]` cannot report `:idle → :done` while explaining only `:idle → :working`.
+  - **Nothing is misattributed.** The raised transition's exit/action/entry rows sit *inside* the wrapper, never alongside the external event's, so a consumer reading the top-level steps is reading the dispatched event's own geometry and nothing else. This is what lets a tool tell "this region handled the dispatched event" from "this region declined it and moved on the rebroadcast raise" — on a parallel root a raise is re-broadcast across **every** region, so the two are otherwise indistinguishable.
+
+  An `:always` transition **enabled by** a raised transition settles inside that wrapper's `:steps` rather than at top level, which places it under the internal event that enabled it. An **ignored or guard-blocked** raised event selects no transition and therefore contributes **no** step — the record never fabricates a transition that did not fire. A **handled targetless** raise still records its boundary, with `:from` equal to `:to`. The runtime's synthetic `[:rf.machine/done <path>]` completion signal (per [§Final states](#final-states-final--on-done--output-key)) is raised through this same queue and so rides this same step — there is no separate done-state shape, and no parallel-only dialect.
+
+  `:microsteps` on the trace is unaffected: it remains the count of **`:always` iterations**, not a count of cascade steps.
 - **Bootstrap composition.** When one handler call both bootstraps the machine *and* processes a user event (the same call the `:before`/`:after` slots span), the initial-entry cascade's `:entry` steps prepend the event-driven steps, matching the macrostep the trace reports.
 
 The privacy story rides the same machine-declared `:data` redaction as `:before` / `:after` (see [§Privacy — redacting machine `:data` at trace egress](#privacy--redacting-machine-data-at-trace-egress)). The field is observability via `trace/emit!` (production-elided through the standard `interop/debug-enabled?` gate), never production app-db, so it adds no new elision concern beyond the existing trace payload.

--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -970,12 +970,22 @@ became `(before, settled, event)` — the aggregate edge that does not exist.
 `direct-event-target` now takes the first of the `:microstep` **and**
 `:raised-transition` boundaries (`macrostep-boundary-steps`), which is the
 state the dispatched event committed either way. Each raised hop then lights
-its **own** edge under its **own** internal event id, and an `:always`
-transition the raise **enabled** settles inside that wrapper's `:steps`, so
-its edge is matched from there rather than at top level. The dispatched event
+its **own** edge under its **own** internal event id. The dispatched event
 and the internal event therefore appear as **distinct causal steps**. With no
 raised events the derivation is a no-op, exactly as the `:microsteps 0` case
 is.
+
+The direct-target rule then applies **once more, one level down**, because a
+wrapper's `:to` is where the raise's whole sub-macrostep ended: the nested
+`machine-transition-single` settles the raised target's own `:always` before
+returning, so an `:always` transition the raise **enabled** rides the
+wrapper's `:steps` rather than the top level. A raised hop's own edge is
+therefore matched against the first **nested** microstep's `:from` — its
+direct target — falling back to the wrapper's `:to` when the raise enabled no
+`:always`; the nested microsteps then light their own `:always` edges. Without
+that second application a raise whose target settles onward matches
+`(dequeue-state, settled-state, raised-event)`, which is the same phantom
+aggregate one level down.
 
 **Parallel — a raise-only region was counted as event-handled.** This one was
 worse than a miss, because it lit an edge that never fired. A raise is

--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -945,6 +945,62 @@ machines-viz edge-ids the live chart mints (agreement by construction).
 [`017-Test-Coverage-Matrix.md`](017-Test-Coverage-Matrix.md) §Parallel
 `:always`-round BROWSER proof.
 
+### Raised-internal-event fired-edge highlight (rf2-nb8nj)
+
+A same-macrostep **raised** internal event (`{:fx [[:raise [:settle]]]}`, and
+the runtime's synthetic `[:rf.machine/done <path>]` completion signal, which
+is the same fx) can select a real transition and move the machine on before
+the macrostep commits. It is the third continuation shape alongside the
+dispatched event and the parent-owned `:always` rounds, and until rf2-nb8nj
+the trace could not describe it: the flat/compound drain **discarded** the
+raised transition's cascade rows outright, and the parallel parent queue
+**flattened** them into the accumulator with no boundary and no trigger event.
+Spec 005 §The structured transition cascade now defines one
+`:kind :raised-transition` step per **handled** dequeue, in FIFO order,
+carrying that internal `:event` and its own nested `:steps`.
+
+Both consumer defects this fixes were **silent** — each produced a
+well-formed highlight rather than an error.
+
+**Single-active — the dispatched event's edge lit nothing.** This is the
+rf2-8i1tg3 failure reached by the other route. A macrostep whose event raised
+an internal event but ran no `:always` had **no cascade boundary at all**, so
+`direct-event-target` fell through to the settled `:after` and the match
+became `(before, settled, event)` — the aggregate edge that does not exist.
+`direct-event-target` now takes the first of the `:microstep` **and**
+`:raised-transition` boundaries (`macrostep-boundary-steps`), which is the
+state the dispatched event committed either way. Each raised hop then lights
+its **own** edge under its **own** internal event id, and an `:always`
+transition the raise **enabled** settles inside that wrapper's `:steps`, so
+its edge is matched from there rather than at top level. The dispatched event
+and the internal event therefore appear as **distinct causal steps**. With no
+raised events the derivation is a no-op, exactly as the `:microsteps 0` case
+is.
+
+**Parallel — a raise-only region was counted as event-handled.** This one was
+worse than a miss, because it lit an edge that never fired. A raise is
+re-broadcast across **every** region, so a region that DECLINED the external
+event can still move on it; with the rebroadcast's rows flattened in
+unmarked, `handled-regions-from-cascade` read that region's `:exit` /
+`:action` / `:entry` rows as evidence it had handled the **dispatched** event
+and minted a phantom edge for it. That set now excludes `:raised-transition`
+steps for the same reason it already excludes `:microstep` steps — the rows
+that must not count are now identifiable, which is precisely what the runtime
+change supplies. The raised hops light separately off `raised-region-hops`,
+which reads each region's own `(from, to)` out of the wrapper's composite
+region-MAP `:from` / `:to` and matches under the internal event id through
+the same region-local → region-`:on` → root-`:on` fallback the event branch
+uses; a region that handled the raise with a targetless/self transition
+(before == after, but present in the wrapper's nested `:steps`) lights its
+self/internal edge. A region's event target resolves from its first
+continuation boundary — a round if one ran, else its first raised hop, since
+`:always` is preferred before the next raise is dequeued.
+
+An **ignored or guard-blocked** raise contributes no wrapper at all, so it
+mints no edge — the record never fabricates a transition that did not fire.
+The returned ids remain the EXACT canonical machines-viz edge-ids the live
+chart mints (agreement by construction).
+
 ### Guard-blocked edge highlight on the topology chart (rf2-fzrzlw)
 
 A guard-blocked no-op (above) emits NO `:rf.machine/transition`, so the chart's

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
@@ -347,18 +347,52 @@
   [cascade]
   (filterv #(= :microstep (:kind %)) cascade))
 
+(defn- raised-cascade-steps
+  "rf2-nb8nj — the `:kind :raised-transition` steps off a transition trace's
+  `:cascade`, in FIFO dequeue order. Both engines append ONE such wrapper per
+  HANDLED internal-event dequeue — `{:kind :raised-transition :event <vec>
+  :from <state> :to <state> :region <r-or-nil> :steps [...]}` — so a
+  same-macrostep raise that moved the machine on is explained in the same
+  trace as the dispatched event instead of being discarded (flat/compound) or
+  flattened in with the external rows (root-parallel).
+
+  `:from`/`:to` are the RAW before/after `:state` values: a keyword or path
+  vector for a single-active machine, a whole composite region-MAP for a
+  root-parallel one. The runtime's synthetic `[:rf.machine/done <path>]`
+  completion signal rides this same wrapper — it is a `[:raise …]` fx like
+  any other, so there is no separate done-state shape to special-case. Empty
+  when the macrostep handled no internal event."
+  [cascade]
+  (filterv #(= :raised-transition (:kind %)) cascade))
+
+(defn- macrostep-boundary-steps
+  "rf2-nb8nj — every step that marks where the DISPATCHED event's own
+  transition ended and same-macrostep continuation began: the `:always`
+  microsteps AND the raised-event wrappers, in cascade (execution) order.
+  Both carry `:from`/`:to`, which is all `direct-event-target` needs."
+  [cascade]
+  (filterv #(#{:microstep :raised-transition} (:kind %)) cascade))
+
 (defn- direct-event-target
-  "rf2-8i1tg3 — the state the DISPATCHED event's own (non-`:always`)
-  transition landed in, as opposed to `to-path-from-trace`'s `:after`,
-  which is the FINAL state once every subsequent `:always` microstep
-  has also settled. When `microsteps` ran (`(seq microsteps)` true),
-  that direct target is the FIRST microstep's `:from` — the state the
-  event-driven transition committed before the `:always` loop took
-  over. With no microsteps, the event-driven transition's target IS
-  the settled `:after`, so `to-path-from-trace` already reads it."
-  [ev microsteps]
-  (if (seq microsteps)
-    (normalise-path (:from (first microsteps)))
+  "rf2-8i1tg3 / rf2-nb8nj — the state the DISPATCHED event's own transition
+  landed in, as opposed to `to-path-from-trace`'s `:after`, which is the
+  FINAL state once every subsequent same-macrostep step has also settled.
+  When `boundaries` ran (`(seq boundaries)` true), that direct target is the
+  FIRST boundary's `:from` — the state the event-driven transition committed
+  before the settle loop took over. With no boundaries, the event-driven
+  transition's target IS the settled `:after`, so `to-path-from-trace`
+  already reads it.
+
+  rf2-nb8nj — a RAISED-event wrapper is as much a boundary as an `:always`
+  microstep, and it was the un-handled case: a macrostep whose event raised
+  an internal event but ran no `:always` had NO boundary at all, so this
+  returned the post-raise settled state and the dispatched event's edge was
+  matched as `(before, settled, event)` — an aggregate edge that does not
+  exist. That lit nothing, the same silent miss rf2-8i1tg3 fixed for
+  `:always`, reached by the other route."
+  [ev boundaries]
+  (if (seq boundaries)
+    (normalise-path (:from (first boundaries)))
     (to-path-from-trace ev)))
 
 (defn- handled-regions-from-cascade
@@ -381,13 +415,63 @@
   counting them would mark it event-handled and mint a PHANTOM event edge. Event
   handling is derived from the non-microstep (`:exit` / `:action` / `:entry`)
   steps alone; the round edges light off the standalone round evidence
-  (`microstep-region-rounds`), not this set. Returns the set of non-nil
-  `:region`s present in the non-microstep cascade steps."
+  (`microstep-region-rounds`), not this set.
+
+  rf2-nb8nj — `:kind :raised-transition` steps are EXCLUDED for the SAME
+  reason, and this is the exclusion the runtime previously made impossible.
+  A raised internal event is re-broadcast across EVERY region, so a region
+  that DECLINED the external event can still move on the raise. Before
+  rf2-nb8nj the parallel parent queue flattened the rebroadcast's rows
+  straight into the accumulator with no boundary and no trigger event, so
+  those `:exit`/`:action`/`:entry` rows were indistinguishable from the
+  external event's — this set counted the raise-only region as having handled
+  the DISPATCHED event and minted a phantom event edge for it. The runtime
+  now nests those rows under a wrapper carrying their own `:event`, so
+  removing the wrapper removes exactly the misattributed rows; the raised
+  hops light their own edges off `raised-region-hops` instead. Returns the
+  set of non-nil `:region`s present in the remaining cascade steps."
   [cascade]
   (into #{}
-        (comp (remove #(= :microstep (:kind %)))
+        (comp (remove #(#{:microstep :raised-transition} (:kind %)))
               (keep :region))
         cascade))
+
+(defn- raised-region-hops
+  "rf2-nb8nj — per-region hops taken under a RAISED internal event, read off
+  a root-parallel macrostep's `:raised-transition` wrappers:
+  `region -> [{:from :to :event} …]` in FIFO dequeue order.
+
+  A parallel wrapper's `:from`/`:to` are the whole composite region-MAPs (the
+  same shape as the trace's `:before`/`:after`), so each region's own hop is
+  the pair of values under its key. `:event` is the internal event's id
+  keyword — the head of the wrapper's `:event` vector — which is what
+  `chart.layout` mints the region's edge under, so these light as the
+  INTERNAL event's edges rather than the dispatched one's.
+
+  A region is included when it MOVED under the raise, or when it stayed put
+  but contributed rows to the wrapper's nested `:steps` (a real self/internal
+  transition selected by the raised event). A region that simply declined the
+  raise contributes nothing. Returns `{}` for a cascade with no wrappers, or
+  for a single-active machine (whose wrapper `:from`/`:to` are not maps)."
+  [cascade]
+  (reduce
+    (fn [acc {:keys [from to event steps]}]
+      (if-not (and (map? from) (map? to))
+        acc
+        (let [handled (into #{} (keep :region) steps)
+              ev-id   (if (vector? event) (first event) event)]
+          (reduce-kv
+            (fn [acc* region region-from]
+              (let [region-to (get to region)]
+                (if (or (not= region-from region-to)
+                        (contains? handled region))
+                  (update acc* region (fnil conj [])
+                          {:from region-from :to region-to :event ev-id})
+                  acc*)))
+            acc
+            from))))
+    {}
+    (raised-cascade-steps cascade)))
 
 (defn- region-local-fired-ids
   "rf2-8ncxrf — fired-edge ids for ONE region that CHANGED state (its
@@ -632,19 +716,60 @@
   that DECLINED the event but later took an `:always` round (its first round's
   `:from` equals its pre-event state, and it is ABSENT from the non-microstep
   event cascade) gains NO phantom event edge — only its round edges light.
+
+  rf2-nb8nj — RAISED internal events, the third continuation shape alongside
+  the event and the parent-owned rounds. `region->raised` (from
+  `raised-region-hops`) carries each region's hops under a same-macrostep
+  raise, with the INTERNAL event's own id. Two things follow. The settled
+  `after` is no more the EVENT's target here than it is under rounds, so a
+  region moved by a raise resolves its event target from its first
+  continuation boundary — a round if one ran, else its first raised hop.
+  And each raised hop lights its OWN edge under its OWN event, through the
+  same region-local → region-`:on` → root-`:on` fallback the event branch
+  uses, so the dispatched event and the internal event show as distinct
+  causal steps rather than one aggregate. A region that moved ONLY on the
+  raise is ABSENT from `handled-regions` (the wrapper is excluded there), so
+  it mints no phantom edge for the dispatched event.
   Returns a seq of ids."
-  [edges before-map after-map event* handled-regions region->rounds]
+  [edges before-map after-map event* handled-regions region->rounds region->raised]
   (when event*
     (mapcat
       (fn [[region region-before]]
         (let [region-after (get after-map region)
               rounds       (get region->rounds region)
-              ;; rf2-bvwv4q — with parent-owned rounds the macrostep `:after`
-              ;; is the FINAL settled state; the state the EVENT committed is
-              ;; the FIRST round's `:from`. With no rounds it IS `:after`.
-              event-target (if (seq rounds) (:from (first rounds)) region-after)
+              raised       (get region->raised region)
+              ;; rf2-bvwv4q / rf2-nb8nj — with parent-owned rounds or raised
+              ;; hops the macrostep `:after` is the FINAL settled state; the
+              ;; state the EVENT committed is the FIRST continuation
+              ;; boundary's `:from`. `:always` is preferred before the next
+              ;; raise is dequeued, so a round — when one ran — is the earlier
+              ;; boundary. With neither, the event's target IS `:after`.
+              event-target (cond
+                             (seq rounds) (:from (first rounds))
+                             (seq raised) (:from (first raised))
+                             :else        region-after)
               from*        (normalise-path region-before)
               ev-to*       (normalise-path event-target)
+              ;; rf2-nb8nj — each raised hop's OWN regional edge, matched
+              ;; under the INTERNAL event id. A hop that moved the region
+              ;; takes the same three-way fallback as the event branch; a
+              ;; handled-but-unchanged hop lights the self/internal edge.
+              raised-ids   (mapcat
+                             (fn [{:keys [from to event]}]
+                               (let [h-from (normalise-path from)
+                                     h-to   (normalise-path to)]
+                                 (if (not= from to)
+                                   (or (seq (region-local-fired-ids
+                                              edges region h-from h-to event))
+                                       (seq (region-machine-on-fired-ids
+                                              edges region h-to event))
+                                       (region-root-on-fired-ids
+                                         edges region h-to event))
+                                   (or (seq (region-self-internal-fired-ids
+                                              edges region h-from event))
+                                       (region-machine-internal-fired-ids
+                                         edges region event)))))
+                             raised)
               ;; rf2-bvwv4q — each parent-owned round's OWN regional edge
               ;; (`:event :always`, region-scoped). Lit directly off the round
               ;; evidence so an ACTIONLESS `:always` round still highlights.
@@ -690,7 +815,8 @@
                   (region-machine-internal-fired-ids edges region event*))
 
               :else nil)
-            always-ids)))
+            always-ids
+            raised-ids)))
       before-map)))
 
 (defn extract-fired-edge-ids
@@ -781,31 +907,59 @@
                  ;; evidence (rf2-bvwv4q) so every region that moved (on the
                  ;; event, via the root `:on`, or on an `:always` round) OR was
                  ;; handled-unchanged lights its edge.
-                 (parallel-transition-fired-ids
-                   edges
-                   (if (map? before-raw) before-raw {})
-                   (if (map? after-raw) after-raw {})
-                   event*
-                   (handled-regions-from-cascade (cascade-from-trace ev))
-                   region->rounds)
+                 (let [cascade (cascade-from-trace ev)]
+                   (parallel-transition-fired-ids
+                     edges
+                     (if (map? before-raw) before-raw {})
+                     (if (map? after-raw) after-raw {})
+                     event*
+                     (handled-regions-from-cascade cascade)
+                     region->rounds
+                     (raised-region-hops cascade)))
                  ;; Single-active (flat / compound): the existing
                  ;; (from, to, event) match + machine-level fallback —
                  ;; PLUS (rf2-8i1tg3) the direct event-driven target
-                 ;; (not the post-`:always` settled state) and every
-                 ;; `:always` microstep's own edge.
-                 (let [from*      (from-path-from-trace ev)
-                       microsteps (microstep-cascade-steps (cascade-from-trace ev))
-                       to*        (direct-event-target ev microsteps)]
+                 ;; (not the post-settle state) and every `:always`
+                 ;; microstep's own edge — PLUS (rf2-nb8nj) every
+                 ;; same-macrostep RAISED transition's own edge, matched
+                 ;; under the internal event that selected it, and the
+                 ;; `:always` microsteps nested inside those raises.
+                 (let [cascade    (cascade-from-trace ev)
+                       microsteps (microstep-cascade-steps cascade)
+                       raised     (raised-cascade-steps cascade)
+                       from*      (from-path-from-trace ev)
+                       to*        (direct-event-target
+                                    ev (macrostep-boundary-steps cascade))
+                       ;; `:always` hops light under the synthetic `:always`
+                       ;; event id `chart.layout` mints eventless edges with
+                       ;; (rf2-oy49f1); a raised hop lights under its own
+                       ;; internal event id.
+                       always-ids (fn [steps]
+                                    (mapcat
+                                      (fn [{step-from :from step-to :to}]
+                                        (single-transition-fired-ids
+                                          edges
+                                          (normalise-path step-from)
+                                          (normalise-path step-to)
+                                          :always))
+                                      steps))]
                    (when (and from* to* event*)
                      (concat
                        (single-transition-fired-ids edges from* to* event*)
-                       (mapcat (fn [{step-from :from step-to :to}]
-                                 (single-transition-fired-ids
-                                   edges
-                                   (normalise-path step-from)
-                                   (normalise-path step-to)
-                                   :always))
-                               microsteps))))))))
+                       (always-ids microsteps)
+                       (mapcat
+                         (fn [{r-from :from r-to :to r-event :event r-steps :steps}]
+                           (let [ev-id (if (vector? r-event) (first r-event) r-event)]
+                             (concat
+                               (single-transition-fired-ids
+                                 edges
+                                 (normalise-path r-from)
+                                 (normalise-path r-to)
+                                 ev-id)
+                               ;; an `:always` the raise ENABLED settles
+                               ;; inside the wrapper — light its edge too.
+                               (always-ids (microstep-cascade-steps r-steps)))))
+                         raised))))))))
          set)))
 
 ;; ---- guard-blocked-edge ids (rf2-fzrzlw) --------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
@@ -949,16 +949,30 @@
                        (always-ids microsteps)
                        (mapcat
                          (fn [{r-from :from r-to :to r-event :event r-steps :steps}]
-                           (let [ev-id (if (vector? r-event) (first r-event) r-event)]
+                           (let [ev-id  (if (vector? r-event) (first r-event) r-event)
+                                 nested (microstep-cascade-steps r-steps)
+                                 ;; The wrapper's `:to` is where the raise's
+                                 ;; WHOLE sub-macrostep ended — the nested
+                                 ;; `machine-transition-single` settles the
+                                 ;; raised target's own `:always` before
+                                 ;; returning. So the raised event's OWN edge
+                                 ;; is matched against its DIRECT target, the
+                                 ;; first nested microstep's `:from`, exactly
+                                 ;; as `direct-event-target` does one level up;
+                                 ;; with no nested `:always` the wrapper's
+                                 ;; `:to` already IS that target.
+                                 r-to*  (if (seq nested)
+                                          (:from (first nested))
+                                          r-to)]
                              (concat
                                (single-transition-fired-ids
                                  edges
                                  (normalise-path r-from)
-                                 (normalise-path r-to)
+                                 (normalise-path r-to*)
                                  ev-id)
                                ;; an `:always` the raise ENABLED settles
                                ;; inside the wrapper — light its edge too.
-                               (always-ids (microstep-cascade-steps r-steps)))))
+                               (always-ids nested))))
                          raised))))))))
          set)))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
@@ -1695,3 +1695,188 @@
                        def events :hvac/controller)]
       (is (= #{climate-id} fired)
           "the changed climate region still lights without a cascade"))))
+
+;; ---- rf2-nb8nj — RAISED (internal) events are their own causal step ------
+;;
+;; The runtime now records one `:kind :raised-transition` wrapper per HANDLED
+;; internal-event dequeue, carrying that event and its own from/to/steps.
+;; Two consumer obligations follow: the dispatched event and the internal
+;; event must light as DISTINCT edges, and a parallel region that moved ONLY
+;; on the raise must no longer read as having handled the dispatched event.
+
+(defn- raise-chain-definition
+  "`:go` is event-driven (:idle -> :working) and its action raises [:settle];
+  `:working` handles `:settle` straight through to `:done`. The runtime
+  settles the raise BEFORE the outer `:rf.machine/transition` commits, so the
+  trace's `:after` is `:done` — never the event-driven `:working` target.
+  The `:always` analogue of this fixture is `always-microstep-definition`."
+  []
+  {:initial :idle
+   :states  {:idle    {:on {:go :working}}
+             :working {:on {:settle :done}}
+             :done    {:final? true}}})
+
+(deftest extract-fired-edge-ids-raised-transition-lights-direct-and-raised-edges
+  (testing "rf2-nb8nj — a macrostep whose event RAISED an internal event
+            lights BOTH the dispatched event's own edge (:idle -> :working)
+            AND the raised event's own edge (:working -> :done), each under
+            its OWN event id — NOT the (from, FINAL-settled, event) triple
+            that matches no declared edge. Before rf2-nb8nj this macrostep
+            carried no cascade boundary at all, so the derivation searched
+            for a phantom :idle -> :done :go edge and lit NOTHING."
+    (let [def       (raise-chain-definition)
+          go-id     (canonical-edge-id def [:idle]    [:working] :go)
+          settle-id (canonical-edge-id def [:working] [:done]    :settle)
+          events    [{:operation  :rf.machine/transition
+                      :tags       {:machine-id :cart}
+                      :from       [:idle]
+                      :to         [:done]
+                      :event      :go
+                      :microsteps 0
+                      :cascade    [{:kind :exit   :state [:idle]    :region nil}
+                                   {:kind :action :state [:idle]    :region nil}
+                                   {:kind :entry  :state [:working] :region nil}
+                                   {:kind   :raised-transition
+                                    :region nil
+                                    :event  [:settle]
+                                    :from   [:working]
+                                    :to     [:done]
+                                    :steps  [{:kind :exit  :state [:working] :region nil}
+                                             {:kind :entry :state [:done]    :region nil}]}]}]
+          fired     (trace-state/extract-fired-edge-ids def events :cart)]
+      (is (string? go-id))
+      (is (string? settle-id))
+      (is (not= go-id settle-id))
+      (is (nil? (canonical-edge-id def [:idle] [:done] :go))
+          "no :idle->:done :go edge is declared — the aggregate match was a phantom")
+      (is (= #{go-id settle-id} fired)
+          "the dispatched event and the internal event light as DISTINCT edges"))))
+
+(deftest extract-fired-edge-ids-always-nested-inside-a-raise-still-lights
+  (testing "rf2-nb8nj — an :always transition ENABLED by a raised transition
+            settles INSIDE that raise's nested :steps, not at top level. Its
+            edge must still light, attributed to the internal event's hop."
+    (let [def       {:initial :idle
+                     :states  {:idle     {:on {:go :working}}
+                               :working  {:on {:settle :checking}}
+                               :checking {:always :done}
+                               :done     {:final? true}}}
+          go-id     (canonical-edge-id def [:idle]     [:working]  :go)
+          settle-id (canonical-edge-id def [:working]  [:checking] :settle)
+          always-id (canonical-edge-id def [:checking] [:done]     :always)
+          events    [{:operation :rf.machine/transition
+                      :tags      {:machine-id :cart}
+                      :from      [:idle]
+                      :to        [:done]
+                      :event     :go
+                      :cascade   [{:kind :entry :state [:working] :region nil}
+                                  {:kind   :raised-transition
+                                   :region nil
+                                   :event  [:settle]
+                                   :from   [:working]
+                                   :to     [:done]
+                                   :steps  [{:kind :entry :state [:checking] :region nil}
+                                            {:kind            :microstep
+                                             :microstep-index 0
+                                             :from            [:checking]
+                                             :to              [:done]
+                                             :steps           []}]}]}]
+          fired     (trace-state/extract-fired-edge-ids def events :cart)]
+      (is (every? string? [go-id settle-id always-id]))
+      (is (= #{go-id settle-id always-id} fired)
+          "the nested :always microstep's edge lights alongside its enclosing raise"))))
+
+(deftest extract-fired-edge-ids-no-raised-transitions-unaffected
+  (testing "rf2-nb8nj regression guard — a macrostep with no raised events is
+            unaffected by the raised-boundary derivation (falls through to the
+            pre-existing to-path-from-trace read)"
+    (let [def         (toy-definition)
+          populate-id (canonical-edge-id def [:empty] [:populated] :populate)
+          events      [{:operation :rf.machine/transition
+                        :tags      {:machine-id :cart}
+                        :from      [:empty]
+                        :to        [:populated]
+                        :event     :populate
+                        :cascade   [{:kind :entry :state [:populated] :region nil}]}]
+          fired       (trace-state/extract-fired-edge-ids def events :cart)]
+      (is (= #{populate-id} fired)))))
+
+(deftest fired-ids-parallel-raise-only-region-is-not-event-handled
+  (testing "rf2-nb8nj — :left handles :go and raises [:settle]; :right
+            DECLINES :go and moves only on the rebroadcast raise. The raised
+            rows now ride a :raised-transition wrapper, so :right is NOT in
+            handled-regions and mints NO phantom :go edge — it lights its own
+            :settle edge instead. Before rf2-nb8nj the parallel parent queue
+            flattened those rows in with no boundary, so :right read as having
+            handled :go."
+    (let [def       {:type :parallel
+                     :regions {:left  {:initial :l0
+                                       :states  {:l0 {:on {:go :l1}}
+                                                 :l1 {}}}
+                               :right {:initial :r0
+                                       :states  {:r0 {:on {:settle :r1}}
+                                                 :r1 {}}}}}
+          projected (:edges (chart-layout/project-definition def))
+          left-go   (region-edge-id projected :left  [:l0] [:l1] :go)
+          right-set (region-edge-id projected :right [:r0] [:r1] :settle)
+          events    [{:operation :rf.machine/transition
+                      :tags {:actor-id :par/raise
+                             :before {:state {:left :l0 :right :r0}}
+                             :after  {:state {:left :l1 :right :r1}}
+                             :event  [:go]
+                             :cascade
+                             [{:kind :exit   :region :left :state [:l0]}
+                              {:kind :action :region :left :state [:l0]}
+                              {:kind :entry  :region :left :state [:l1]}
+                              {:kind   :raised-transition
+                               :region nil
+                               :event  [:settle]
+                               :from   {:left :l1 :right :r0}
+                               :to     {:left :l1 :right :r1}
+                               :steps  [{:kind :exit  :region :right :state [:r0]}
+                                        {:kind :entry :region :right :state [:r1]}]}]}}]
+          fired     (trace-state/extract-fired-edge-ids def events :par/raise)]
+      (is (every? string? [left-go right-set]))
+      (is (nil? (region-edge-id projected :right [:r0] [:r1] :go))
+          "no :go edge is declared in :right — a phantom would have to invent one")
+      (is (= #{left-go right-set} fired)
+          ":left lights its :go edge and :right lights its RAISED :settle edge"))))
+
+(deftest fired-ids-parallel-raise-handled-unchanged-region-lights-self-edge
+  (testing "rf2-nb8nj — a region that handles the RAISED event with a
+            targetless/self transition (before == after) still lights its
+            self/internal edge off the wrapper's nested :steps, rather than
+            being read as resting"
+    (let [def        {:type :parallel
+                      :regions {:left  {:initial :l0
+                                        :states  {:l0 {:on {:go :l1}}
+                                                  :l1 {}}}
+                                :right {:initial :r0
+                                        :states  {:r0 {:on {:settle {:action :note}}}}}}}
+          projected  (:edges (chart-layout/project-definition def))
+          left-go    (region-edge-id projected :left [:l0] [:l1] :go)
+          right-self (->> projected
+                          (some (fn [e]
+                                  (when (and (:internal? e)
+                                             (= :settle (:event e))
+                                             (= (chart-layout/region-scoped-id :right [:r0])
+                                                (:source e)))
+                                    (:id e)))))
+          events     [{:operation :rf.machine/transition
+                       :tags {:actor-id :par/raise2
+                              :before {:state {:left :l0 :right :r0}}
+                              :after  {:state {:left :l1 :right :r0}}
+                              :event  [:go]
+                              :cascade
+                              [{:kind :entry :region :left :state [:l1]}
+                               {:kind   :raised-transition
+                                :region nil
+                                :event  [:settle]
+                                :from   {:left :l1 :right :r0}
+                                :to     {:left :l1 :right :r0}
+                                :steps  [{:kind :action :region :right :state [] :action :note}]}]}}]
+          fired      (trace-state/extract-fired-edge-ids def events :par/raise2)]
+      (is (string? left-go))
+      (is (string? right-self) "the :right :settle self/internal edge exists")
+      (is (= #{left-go right-self} fired)
+          "the raised self/internal transition lights, attributed to :settle"))))


### PR DESCRIPTION
Closes rf2-nb8nj.

## The defect

The structured `:cascade` on `:rf.machine/transition` is meant to be the one lossless explanation of how a macrostep reached its final state. It was not lossless for raised (internal) events, and the two engines lost it differently.

- **Flat/compound** (`transition.cljc`, `drain-to-fixed-point`): after handling a dequeued raise the loop recurred with `cascade` unchanged, so the raised transition's rows were **discarded entirely**. The trace could report `:before :idle` / `:after :done` while its cascade explained only `:idle -> :working`.
- **Root-parallel** (`parallel.cljc`, `drain-parent-queue`): the rebroadcast's cascade *was* appended, but with no boundary and no trigger event. That is worse than losing it: a raise is re-broadcast across **every** region, so Xray's `handled-regions-from-cascade` — which treats any non-`:microstep` row's `:region` as evidence that region handled the **dispatched** event — read a raise-only region as event-handled and lit a **phantom edge** for it.

Both failures were silent. The entire pre-existing machines suite passes with the rows lost, which is why this survived to be filed.

## The fix

Both engines now append one `:kind :raised-transition` step per **handled** dequeue, in actual FIFO order:

    {:kind   :raised-transition
     :region nil
     :event  [:settle]
     :from   :working
     :to     :done
     :steps  [ ...the nested exit/action/entry and :always steps... ]}

It mirrors the existing `:microstep` step's shape (`:region` / `:from` / `:to` / `:steps`), swapping the microstep index for the triggering `:event` — one nested boundary, not a second trace protocol. One shape across both engines.

- An **ignored or guard-blocked** raise contributes nothing (gated on the nested Result's `::handled?`), so no fictional transition is fabricated. A **handled targetless** raise still records its boundary, `:from` equal to `:to`.
- An `:always` transition the raise **enabled** settles inside the wrapper's `:steps`, attributing it to the internal event that enabled it.
- The synthetic `[:rf.machine/done <path>]` signal is itself a `[:raise ...]` fx, so it rides the same step — no done-state dialect, no parallel-only dialect.
- `:microsteps` is untouched: still the `:always`-iteration count.

`:source` is **deliberately omitted** from the wrapper. The item's example spelling included `:source :raise`, but the cascade's `:source` key is documented in Spec 005 as history-only (`:recorded` / `:default`), and every step reaching this arm comes off the same `:raise` queue — so the field would be constant and would contradict the existing "present ONLY on an `:entry` step" contract. `:kind` plus `:event` already carry it. (The item calls the spelling "a recommendation, not a request for aliases".)

## The state/effect fold is unchanged

Established three ways:

1. **Structurally.** The only changed value flowing into either loop is the cascade accumulator. Every other `recur` argument — snapshot, machine, fx, pending queue, depth counters, `visited` — is byte-identical; the whole non-comment diff of both engine files is the two `let` bindings and the two argument renames.
2. **By census.** All 24 `result/cascade` reader sites across `implementation/` and `tools/` either re-stamp via `with-cascade`, feed the trace emit in `registration.cljc`, or are tests. None flows into a snapshot or an fx vector. (`transition.cljc`'s `commit-snapshot ... cascade` reads the *transition-geometry* local, a different binding from `cascade-steps`.)
3. **Empirically.** The pre-existing suites — which pin snapshot values, `:data`, effect order, raise FIFO, eventless-before-next-raise ordering, atomic rollback and dispatch behaviour — are identically green before and after.

## Xray

`trace_state.cljs` learns the wrapper:

- `handled-regions-from-cascade` excludes `:raised-transition` for the same reason it already excludes `:microstep` — this is the misattribution fix, and it is only expressible because the runtime now marks those rows.
- `direct-event-target` takes the first boundary of **either** kind. A macrostep that raised but ran no `:always` previously had no boundary at all, so it fell through to the settled `:after` and matched a phantom aggregate edge — the rf2-8i1tg3 miss reached by the other route.
- Each raised hop lights its **own** edge under its **own** internal event id, matched against its **direct** target (the first *nested* microstep's `:from`) — the same rule applied one level down, because a wrapper's `:to` is where the raise's whole sub-macrostep ended.
- `raised-region-hops` resolves per-region hops out of a parallel wrapper's composite region-MAP `:from`/`:to`.

**`tools/xray/spec/*` DID change**, per the standing rule: `003-Machine-Inspector.md` gains a "Raised-internal-event fired-edge highlight (rf2-nb8nj)" section beside its `:always`-microstep and parallel-round siblings, which document this exact derivation. `tools/xray/spec/API.md` is untouched (open PR #8921 owns it).

`panels/epoch/projection.cljc` is deliberately **not** touched: `structured-cascade-body` was retired by rf2-akvfe, so nothing renders those cascade steps any more and `cascade-regions` / `cascade-step-count` survive only as harness test oracles. No fixture there raises, so nothing changes.

## Spec

`spec/005-StateMachines.md` §The structured transition cascade: the closed `:kind` vocabulary gains `:raised-transition` (the change is not expressible without it), the step-shape fence gains the wrapper, and the "Complete configuration walk" property now states that the walk spans the whole macrostep, with a new key-property bullet covering losslessness and attribution.

## Quality gates

| Gate | Result | Captured exit |
|---|---|---|
| `clojure -M:test` (`implementation/machines`) | 1227 tests / 4332 assertions, 0 failures, 0 errors | **0** |
| `npm run test:cljs` (consolidated `node-test`; covers the machines `.cljc` tests **and** the Xray `trace_state` tests) | 11164 tests / 55221 assertions, 0 failures, 0 errors | **0** |
| `python scripts/check_doc_slugs.py` | pass | **0** |
| `python scripts/check_readme_links.py --ci` | pass | **0** |

All four re-run on the final rebased base (20 commits landed during the work; no file this PR touches was touched on trunk).

**Gate provenance.** The CLJS lane printed a `shadow-cljs - config:` line naming this worktree's `implementation/shadow-cljs.edn` — it read this checkout. `check_doc_slugs.py` is silent on success, so it was proved to bite by a planted fault: one broken anchor in **prose** at a line already being edited returned exit **1** naming `spec/005-StateMachines.md:698` and the exact planted anchor. Restore verified by git blob hash (`3cb0e18206d803b5ad6e8aeeddec87be00e8c012`, matched).

**Coverage limit, stated rather than implied.** Both doc gates share an extractor that strips fenced code blocks, so the `:raised-transition` step shape added to the `spec/005-StateMachines.md` clojure fence is **invisible to both** — their exit 0 says nothing about it. Hand-checked instead: delimiters balanced within the block (curly 5/5, square 5/5, round 9/9), the union pseudo-syntax follows the block's own pre-existing convention (`:region :climate | nil`), the new map's shape and comment alignment match the `:microstep` block above it, and **no markdown table was touched anywhere in the diff** (the one pipe-leading diff line is the `:kind` union's continuation inside that fence, not a table row). `mkdocs build --strict` is **not** nominated: `docs_dir` is `docs`, so `spec/` and `tools/` were never in the built site and it would return a green that inspected nothing.

## The control

Reverting the two engine hunks **and** the `trace_state.cljs` consumer, keeping every test:

- **30 failures, all 30 in the 10 new deftests.** All 11,150 other tests — the whole pre-existing machines suite and the whole pre-existing Xray suite — stayed **green**.
- Red: `raised-event-transition-is-recorded-as-its-own-cascade-boundary` (8), `always-enabled-by-a-raised-transition-rides-inside-its-wrapper` (5), `targetless-raised-transition-records-its-action-boundary` (4), `parallel-raised-rebroadcast-is-grouped-under-its-internal-event` (4), `synthetic-done-state-signal-uses-the-same-raised-boundary` (3), `raised-wrappers-follow-actual-fifo-dequeue-order` (2), and one each in `fired-ids-parallel-raise-only-region-is-not-event-handled`, `fired-ids-parallel-raise-handled-unchanged-region-lights-self-edge`, `extract-fired-edge-ids-raised-transition-lights-direct-and-raised-edges`, `extract-fired-edge-ids-always-nested-inside-a-raise-still-lights`.
- Green **by design** under the control: `ignored-and-guard-blocked-raises-fabricate-no-wrapper` and `extract-fired-edge-ids-no-raised-transitions-unaffected` — both assert an **absence**, which holds on either side. They guard the fix from over-reaching rather than demonstrating the gap.

The parallel misattribution was measured directly: the control run reported the handled-region set as both regions where only one had handled the dispatched event.

Restore after the control verified by git blob hash on all three source files.
