### PR TITLE
fix(core): name the reachable var in reg-machine*'s :where; test(ssr): platform-tag the multi-root hydration fixture (rf2-uuqek, rf2-umi1w)

### DIFF
--- a/implementation/core/src/re_frame/core_machines.cljc
+++ b/implementation/core/src/re_frame/core_machines.cljc
@@ -134,16 +134,18 @@
   `:rf/machine?` / `:rf/machine` keys are stamped by the registration home and
   MUST NOT appear in `opts`."
   ([machine-id machine]
-   (reg-machine-impl 'rf/reg-machine* machine-id machine))
+   (reg-machine-impl 'rf.machines/reg-machine* machine-id machine))
   ([machine-id opts machine]
-   (reg-machine-impl 'rf/reg-machine* machine-id opts machine)))
+   (reg-machine-impl 'rf.machines/reg-machine* machine-id opts machine)))
 
 (defn reg-machine
   "Fn-form delegate the `re-frame.core/reg-machine` macro routes through
   when the spec form is not stamped (no per-element source-coords). The
   separation from `reg-machine*` keeps `:where` symbols faithful to the
-  user-facing surface — `rf/reg-machine` raises with `:where
-  'rf/reg-machine`, `rf/reg-machine*` raises with `:where 'rf/reg-machine*`.
+  surface the caller can actually REACH — `rf/reg-machine` raises with
+  `:where 'rf/reg-machine`, and `reg-machine*`, which is NOT a facade
+  export (`:facade? false`; reach it through `re-frame.machines`), raises
+  with `:where 'rf.machines/reg-machine*`.
 
   Callers should NOT invoke this directly — use `rf/reg-machine`
   (macro) or `rf.machines/reg-machine*` (plain fn). It is public only because

--- a/implementation/ssr/test/re_frame/ssr/multi_root_hydration_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/multi_root_hydration_cljs_test.cljc
@@ -65,10 +65,17 @@
 (defn- fresh-frame!
   "A `:client`-platform frame under an id no other test in this shared
   process has used. Frames are not torn down between tests here, so a
-  reused id would carry a prior test's app-db into this one."
+  reused id would carry a prior test's app-db into this one.
+
+  `make-frame` opts are FLAT — `:platform` sits alongside `:id`. A nested
+  `{:config {:platform :client}}` stores `:config {:config {…}}` and the
+  frame is never platform-tagged at all; every test below would still pass,
+  because the runtime falls back to the host-wide platform marker, which on
+  CLJS is already `:client`. `the-fixture-frames-are-actually-platform-tagged`
+  is what keeps that accident from coming back."
   []
   (let [fid (keyword "rf.multiroot" (str "f" (swap! frame-counter inc)))]
-    (rf/make-frame {:id fid :config {:platform :client}})
+    (rf/make-frame {:id fid :platform :client})
     fid))
 
 (defn- payload-for
@@ -96,6 +103,19 @@
    :root-id                :page/shop
    :view-id                :app/shop-root
    :phase                  :server})
+
+;; ---------------------------------------------------------------------------
+;; The fixture's own tag, asserted so it cannot lapse
+;; ---------------------------------------------------------------------------
+
+(deftest the-fixture-frames-are-actually-platform-tagged
+  (testing "`fresh-frame!` asks for `:platform :client` and the frame CARRIES
+            it. Read through `frame-meta`, the canonical `:rf/frame-meta`
+            shape, which flattens the frame's OWN config and does not fall
+            back to the host-wide platform marker — so this discriminates a
+            tagged frame from an untagged one, where the hydration tests
+            below cannot: they would pass either way on CLJS."
+    (is (= :client (:platform (rf/frame-meta (fresh-frame!)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; THE RED-BEFORE, kept permanently executable


### PR DESCRIPTION
Two small, independent corrections, one commit each.

## rf2-umi1w — the SSR hydration fixture was never platform-tagged

`rf/make-frame` opts are FLAT, but `fresh-frame!` in
`implementation/ssr/test/re_frame/ssr/multi_root_hydration_cljs_test.cljc`
passed `{:id fid :config {:platform :client}}`, which stores `:config {:config
{…}}`. The frames were never platform-tagged at all.

**Premise verified at source.** `make-frame`'s docstring is explicit that
`:platform` is one of the top-level record-config keys ("EVERY OTHER key is
RECORD-CONFIG … `:fx-overrides`, `:platform`, `:ssr`, `:doc` …"), and the
nesting was still present at tip.

It was harmless only by accident: the runtime resolves a frame's platform as
`(or (-> rec :config :platform) (interop/active-platform))`, and the host-wide
marker is already `:client` on CLJS. The cost is that nothing discriminated — a
JVM platform assertion added here would have passed for the wrong reason, and so
would a regression that broke platform tagging outright.

The opts are flattened, and one assertion reads the tag back through
`frame-meta`. That accessor is `(merge (:config f) (:lifecycle f) {:id (:id f)})`
— it flattens the frame's OWN config and does **not** fall back to the host-wide
marker, which is exactly what makes it discriminating where the hydration tests
are not.

Test-only. The hydration contract is untouched.

A sibling fixture, `machine_after_rearm_cljs_test.cljc`, was corrected the same
way and carries the same warning in its docstring; this brings the multi-root
fixture into line with it.

## rf2-uuqek — the `:where` symbol named an unreachable var

`reg-machine*` emitted `:where 'rf/reg-machine*`, but `reg-machine*` is
`:facade? false` in `spec/api-manifest.edn` (row: `{:namespace
"re-frame.machines", :var "reg-machine*", … :facade? false …}`) and `core.cljc`
states outright that it is not a facade export. The `:where` symbol exists to
tell a programmer where to look, and this one named a var that does not exist on
the namespace the message implies — worse than an unhelpful message, because the
reader goes to the namespace, finds nothing, and concludes their build is broken.

It now emits `rf.machines/reg-machine*`. The docstring that described the old
emission is corrected **in the same commit**: it was TRUE about what the code
emitted, so it goes false the moment the emission changes.

The sibling `reg-machine` is deliberately **left alone** — it emits
`'rf/reg-machine`, which is correct, because that macro IS a real facade export
(`:facade? true` on `re-frame.core`).

### Line numbers re-derived at tip
`PR #8912` moved lines in this file, so all five were re-derived rather than
trusted: emissions at **137/139**, the docstring at **144–146**, the sibling at
**157/159** — all matching. After the edit the docstring block grows by two
lines, so the untouched sibling now sits at 159/161.

### Test pins
Searched for the literal both line-oriented and whitespace-flattened across the
repo. **No test pins `rf/reg-machine*`'s `:where`**, so nothing had to move. The
two `:where` pins that do exist are on the *sibling*
(`machines/test/re_frame/late_bind_missing_test.clj` and
`machine_pure_error_contract_test.clj`), which this PR does not touch — and
`late_bind_missing_test.clj` says in prose that it covers `reg-machine` only.

The two searches disagreed in a way worth recording: line-oriented found 3 sites,
flattened found 4, because line 146 carries two occurrences. Reconciled by
counting occurrences per line rather than counting lines.

## Quality gates

All re-run on the final rebased base (`cdb9652c0f`). Exit codes captured with
the redirect and the echo on one command line, and quoted from the captured file
rather than from any harness-reported status.

| Gate | Covers | Result | Captured exit |
|---|---|---|---|
| `clojure -M:test` — `implementation/ssr` | rf2-umi1w | 610 tests / 2991 assertions, 0 failures, 0 errors | **0** |
| `clojure -M:test` — `implementation/core` | rf2-uuqek | 2174 tests / 11130 assertions, 0 failures, 0 errors | **0** |
| `clojure -M:test` — `implementation/machines` | rf2-uuqek transitive seam | 1220 tests / 4289 assertions, 0 failures, 0 errors | **0** |
| CLJS consolidated `node-test` — compile | both | 1874 files, 0 warnings | **0** |
| CLJS consolidated `node-test` — run | both | 11150 tests / 55135 assertions, 0 failures, 0 errors | **0** |

The CLJS lane prints its config path, and it named this worker's own worktree —
that is the worktree check for that gate.

### Controls

**rf2-umi1w — the plant discriminated.** Restoring the nested `:config` turned
the new assertion red on its own: captured exit **1**, exactly **1 failure**,
`actual: (not (= :client nil))` — the platform read as `nil`, which is the
"never platform-tagged at all" defect stated directly. Test and assertion totals
were unchanged from the clean run (608/2965 at the time), so no namespace was
skipped or crashed. Restored and verified by git **blob** hash against the
committed object (line endings are translated in this checkout, so a byte digest
of the working file would not be sound).

**rf2-uuqek — two controls, because the specified one cannot bite.** Reverting
the symbol on line 137 came back **green** (captured exit 0). That is not a
broken control; it is the measured explanation for how the defect survived, and
it agrees with the pin search above: nothing anywhere pins this symbol.

Since a green run proves nothing about which tree was read, a second, *covered*
fault was planted at a line adjacent to the edit — the sibling's `'rf/reg-machine`
replaced with a sentinel. The machines gate went red naming it:
`actual: (not (= rf/reg-machine rf/BOGUS-SENTINEL-UUQEK))`, captured exit **1**,
1 failure, totals otherwise unchanged. The sentinel existed only in this
worktree, so a run that had wandered into another checkout would have come back
green. That establishes both that the gate read the right tree and that this
file's `:where` mechanism is genuinely under test — which is also the direct
evidence for leaving the sibling alone.

Both files restored and verified by blob hash (MATCH in each case).

## Notes for the reviewer

The core JVM suite takes **~8m50s**, which sits just under the 10-minute harness
ceiling; three runs were killed at the ceiling while a peer's `shadow-cljs`
compile was competing for the machine, each leaving a zero-byte log and no exit
file. Those were treated as *no verdict*, not as passes, and the gate was re-run
to completion. Worth knowing for anyone timing this suite locally.

## Incidental finding — not fixed here

The same nested-`:config` mistake is live at four more sites, all outside this
item's stated scope and left alone deliberately rather than swept up:

- `implementation/ssr/test/re_frame/ssr/failed_root_isolation_cljs_test.cljc` (lines 89 and 298)
- `implementation/ssr/test/re_frame/ssr/failed_root_isolation_dom_cljs_test.cljs` (line 45)
- `implementation/ssr/test/re_frame/ssr/multi_root_hydration_dom_cljs_test.cljs` (line 42)

Each is harmless today for the same reason this one was, and each is
non-discriminating in the same way. The last is the DOM sibling of this very
fixture. Flagged for a bead rather than actioned, since a general sweep was
explicitly not wanted.
