### PR TITLE
fix(ssr): the Form-2 arity contract states the missing-argument divergence instead of promising parity (rf2-mocn3)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -409,10 +409,21 @@
 
 #?(:clj
    (defn- form-2-invocation-arity
-     "How many of the component's `n` args to hand `inner` — modelling what
-     the SAME `inner`, compiled by ClojureScript, would accept — or `nil` when
-     CLJS would reject the call too and the JVM should simply pass all `n` and
-     let its own `ArityException` report the real call.
+     "How many of the component's `n` args to hand `inner` — modelling which
+     arm the SAME `inner`, compiled by ClojureScript, would SELECT — or `nil`
+     when no declared arm fits `n`, in which case the JVM passes all `n` and
+     lets its own `ArityException` report the real call.
+
+     `nil` covers two situations that are NOT the same, and only one of them
+     is host agreement (rf2-mocn3, mayor ruling 2026-09-01):
+
+       • TOO MANY args for every arm of a multi-arm inner — the compiled
+         CLJS dispatcher throws `Invalid arity: n` as well, so both hosts
+         refuse and the shared component is rejected identically.
+       • TOO FEW args — CLJS does NOT refuse. JavaScript binds the missing
+         parameters to `undefined` and the render proceeds. The JVM refuses
+         instead, DELIBERATELY. See `invoke-form-2-render-fn` for the
+         supported contract and why this direction is not emulated.
 
      rf2-mocn3 (audit) — this used to walk every declared arity downward and
      take the longest accepted prefix, which is NOT what a compiled CLJS fn
@@ -440,10 +451,11 @@
           tail, shorter than `n`                   → that arity (truncate)
 
      Rule 3 is deliberately narrow, and widening it would be a DIFFERENT
-     behaviour wearing this name. Nothing here ever SUPPLIES missing args:
-     CLJS does pass `undefined` for them, but fabricating `nil` props on the
-     server is the kind of silent divergence this helper exists to prevent, so
-     an inner that declares only arities above `n` falls through to `nil`."
+     behaviour wearing this name. There is deliberately no fourth rule for
+     TOO FEW args: nothing here ever SUPPLIES an argument the caller did not
+     pass, so an inner that declares only arities above `n` falls through to
+     `nil` and the JVM raises. That is the one place the hosts disagree, and
+     `invoke-form-2-render-fn` states the contract and the reason."
      [inner n]
      (let [fixed    (declared-fixed-arities inner)
            required (variadic-required-arity inner)]
@@ -456,8 +468,10 @@
          :else                          nil))))
 
 (defn- invoke-form-2-render-fn
-  "Invoke a Form-2 inner render fn with `args`, on the JVM under the SAME
-  arity rules the compiled CLJS `inner` would follow. The idiomatic
+  "Invoke a Form-2 inner render fn with `args`, on the JVM under the arity
+  rules the compiled CLJS `inner` would follow for arm SELECTION and for
+  EXCESS arguments — see THE SUPPORTED CONTRACT below for the one direction
+  in which the JVM deliberately does NOT follow them. The idiomatic
   Reagent/UIx Form-2 inner either takes the SAME args as the outer
   (`(fn [x] …)`), ignores them and closes over the outer's (`(fn [] …)`), or
   — just as validly — takes a non-zero PREFIX of them (`(fn [kept] …)` under
@@ -483,9 +497,28 @@
   So: select the shape from the inner's DECLARED arities
   (`form-2-invocation-arity`), then invoke exactly once. No user code runs
   inside a catch here, and anything the render throws propagates unchanged.
-  When there is no shape CLJS would accept either, `(apply inner args)` lets
-  the inner's own `ArityException` report the real call rather than a
-  fabricated retry — the server fails where the client fails."
+  When no declared arm fits, `(apply inner args)` lets the inner's own
+  `ArityException` report the real call rather than a fabricated retry.
+
+  THE SUPPORTED CONTRACT — stated narrowly, because the wide version is
+  false (rf2-mocn3, mayor ruling 2026-09-01). This helper matches compiled
+  CLJS on arity SELECTION (which arm of a multi-arm inner runs, and that a
+  count no arm declares is refused on both hosts) and on EXCESS arguments (a
+  single-fixed-arity inner compiles to a bare JS function, which drops them;
+  the JVM truncates to match). It deliberately DIVERGES in one direction:
+
+    MISSING arguments. Where the caller passes FEWER args than the inner's
+    shortest arm requires, JavaScript binds the absent parameters to
+    `undefined` and CLJS renders; the JVM raises `ArityException` and SSR
+    fails. The server is therefore STRICTER than the client here — a legal
+    shared `.cljc` Form-2 can render in the browser and fail during SSR.
+
+  That is a choice, not an oversight, and the reason is one clause: CLJS
+  supplying `undefined` is an accident of the JavaScript calling convention,
+  and emulating it would ship an author's arity mistake as production HTML
+  with nil props instead of failing where it can be seen. So do NOT \"fix\"
+  this by filling the missing slots with nil. Both cases are pinned on both
+  hosts, divergence included, by `re-frame.ssr.form2-arity-cljs-test`."
   [inner args]
   #?(:clj  (let [k (form-2-invocation-arity inner (count args))]
              (apply inner (if k (take k args) args)))
@@ -498,8 +531,9 @@
 
   A Form-1 component returns hiccup directly. A Form-2 component returns an
   INNER render fn; per Reagent/UIx Form-2 semantics it is invoked once
-  more with the SAME args (arity-tolerantly — see
-  `invoke-form-2-render-fn`) to obtain the hiccup. Resolving Form-2 here
+  more with the SAME args (at the arity its declared arms select, and
+  tolerating EXCESS args only — see `invoke-form-2-render-fn` for the
+  supported contract) to obtain the hiccup. Resolving Form-2 here
   does NOT perturb the structural hash — the hash walks the RAW tree
   (`[component …]`, a raw fn head serialising to one fixed token, hash.cljc),
   identical on server and client, so the resolved output cannot fire a

--- a/implementation/ssr/test/re_frame/ssr/form2_arity_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/form2_arity_cljs_test.cljc
@@ -20,9 +20,24 @@
   arity 2 and arity 1 for them and rendered happily. A component like that
   server-rendered fine and blew up on hydration.
 
-  Every row below therefore asserts the SAME expectation on both hosts —
-  either exact rendered bytes or `::arity-rejected`. That is the contract:
-  not \"the JVM is lenient\", but \"the JVM agrees with CLJS\".
+  Most rows below therefore assert the SAME expectation on both hosts —
+  either exact rendered bytes or `::arity-rejected`.
+
+  TWO ROWS DO NOT, AND THAT IS THE POINT OF THEM (rf2-mocn3, mayor ruling
+  2026-09-01). The hosts agree on arm SELECTION and on EXCESS arguments, and
+  they DIVERGE on MISSING ones: JavaScript binds an absent parameter to
+  `undefined` and CLJS renders, while the JVM raises `ArityException` and SSR
+  fails. That divergence is deliberate — see
+  `re-frame.ssr.emit/invoke-form-2-render-fn`, THE SUPPORTED CONTRACT — so
+  those two rows carry a per-host expectation and record what each host
+  actually does. A table whose stated contract is host agreement has to show
+  where agreement STOPS, or it advertises the same false promise the prose
+  used to.
+
+  So the contract this table pins is not \"the JVM is lenient\", and no
+  longer the flat \"the JVM agrees with CLJS\" it once claimed: it is \"the
+  JVM agrees with CLJS on which arm runs and on extra args, and refuses —
+  loudly, on purpose — where CLJS would silently supply `undefined`\".
 
   Runs on BOTH hosts (`.cljc`, `-cljs-test` ns): `clojure -M:test` from
   `implementation/ssr` (JVM) and `npm run test:cljs` (node). The streaming
@@ -85,6 +100,15 @@
                                          [:p (str "mxv|" a "|" b "|"
                                                   (str/join "," r))]))))
 
+;; The two MISSING-argument shapes, per the ruling: a single fixed arity of
+;; two, and a fixed+variadic arm requiring two with no shorter arm to fall
+;; back on. Both are invoked below their required count by the rows that use
+;; them.
+(def ^:private fixed-2   (form-2 (fn [a b] [:p (str "fixed2|" a "|" b)])))
+(def ^:private fixed-var (form-2 (fn [a b & r]
+                                   [:p (str "fv|" a "|" b "|"
+                                            (str/join "," r))])))
+
 ;; ---------------------------------------------------------------------------
 ;; The table
 ;; ---------------------------------------------------------------------------
@@ -130,3 +154,62 @@
         "a fixed+variadic inner routes an over-fixed count to the variadic arm")
     (is (= "<p>mx1|a</p>" (outcome [mixed-1-var "a"]))
         "the same inner routes an exactly-matching count to its fixed arm")))
+
+(deftest form-2-inner-missing-arguments-diverge-across-hosts
+  (testing "rf2-mocn3 (mayor ruling 2026-09-01) — MISSING arguments are the
+            ONE place the hosts disagree, and the rows record what each host
+            actually does rather than a parity the code does not hold.
+            JavaScript binds an absent parameter to `undefined` and the CLJS
+            render proceeds; the JVM raises `ArityException` and SSR fails.
+            The JVM is the STRICTER host here, deliberately — a fabricated
+            nil prop ships an author's arity mistake as production HTML,
+            where a loud server failure shows it. Do not `fix` either side
+            to make these rows agree; that would be the change the ruling
+            refused"
+    ;; Case 1 — a SINGLE fixed arity of two, handed one arg.
+    (is (= #?(:clj ::arity-rejected :cljs "<p>fixed2|a|</p>")
+           (outcome [fixed-2 "a"]))
+        "a single-fixed-arity-2 inner at 1 arg: CLJS renders with the second
+         slot missing; the JVM refuses")
+    ;; Case 2 — a fixed+variadic arm requiring two, handed one arg. CLJS
+    ;; routes to the variadic arm regardless, leaving `b` missing and the
+    ;; rest seq empty.
+    (is (= #?(:clj ::arity-rejected :cljs "<p>fv|a||</p>")
+           (outcome [fixed-var "a"]))
+        "a fixed+variadic inner below its required count: CLJS routes to the
+         variadic arm with the missing slot absent; the JVM refuses"))
+
+  (testing "rf2-mocn3 — non-vacuity: the SAME two inners render identically
+            on both hosts at every count they DO accept, so the rows above
+            pin the missing-argument divergence and not a JVM that has
+            simply stopped rendering these shapes"
+    (is (= "<p>fixed2|a|b</p>" (outcome [fixed-2 "a" "b"]))
+        "the fixed-arity-2 inner at its exact arity agrees across hosts")
+    (is (= "<p>fv|a|b|</p>" (outcome [fixed-var "a" "b"]))
+        "the fixed+variadic inner at exactly its required count agrees")
+    (is (= "<p>fv|a|b|c</p>" (outcome [fixed-var "a" "b" "c"]))
+        "the fixed+variadic inner above its required count agrees, whole
+         arg list handed to the variadic arm"))
+
+  ;; `undefined` is load-bearing in the contract wording and is NOT
+  ;; interchangeable with nil, but the RENDERED BYTES above cannot tell them
+  ;; apart: `(str x)` is "" for both, and `nil?` answers true for both
+  ;; because it compiles to `== null`. `undefined?` is a `===` against
+  ;; `void 0`, which is what discriminates — so pin the slot itself, on the
+  ;; host where the call actually happens.
+  #?(:cljs
+     (testing "rf2-mocn3 — the client's missing slot is genuinely
+               `js/undefined`, not a nil the client fabricated"
+       (let [seen (atom nil)
+             spy  (fn [a b]
+                    (reset! seen {:a-undefined? (undefined? a)
+                                  :b-undefined? (undefined? b)})
+                    [:p "x"])]
+         (apply spy ["a"])
+         (is (false? (:a-undefined? @seen))
+             "the argument that WAS passed is not undefined")
+         (is (true? (:b-undefined? @seen))
+             "the argument that was NOT passed is undefined")
+         (is (false? (undefined? nil))
+             "control: `undefined?` really discriminates — nil is not
+              undefined under it, though `nil?` is true of both")))))

--- a/implementation/ssr/test/re_frame/ssr_emit_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_emit_test.clj
@@ -1089,9 +1089,14 @@
 ;; rendered, so a shared `.cljc` Form-2 component rendered on the server and
 ;; failed on hydration — the exact parity the repair exists to hold.
 ;;
-;; The cross-host table proves the AGREEMENT on both hosts through the sync
-;; emitter. What is here is the second public consumer: streaming shares one
-;; resolver with sync, so every row asserts through BOTH.
+;; The cross-host table runs on both hosts through the sync emitter: it pins
+;; the AGREEMENT above, and — since rf2-mocn3's mayor ruling of 2026-09-01 —
+;; also the one place agreement STOPS. Where an inner is handed FEWER args
+;; than its shortest arm requires, CLJS binds the missing parameters to
+;; `undefined` and renders while the JVM raises; the JVM is stricter there on
+;; purpose (`emit/invoke-form-2-render-fn`, THE SUPPORTED CONTRACT). What is
+;; here is the second public consumer: streaming shares one resolver with
+;; sync, so every row asserts through BOTH.
 ;; ===========================================================================
 
 (deftest emit-form-2-multi-arity-inner-refuses-what-cljs-refuses


### PR DESCRIPTION
## What this changes

`rf2-mocn3` was reopened by the audit of PR #8918: the repaired Form-2 arity
dispatcher matches CLJS for **excess** arguments but knowingly diverges for
**missing** ones, while its public and in-source contract still promised that
it "models what the same compiled CLJS inner accepts" and that "the server
fails where the client fails". That promise is false in one direction, and a
false promise is what makes a legal shared `.cljc` Form-2 look safe.

Per the mayor's ruling of 2026-09-01 the divergence **stays** — CLJS supplying
`undefined` for a missing argument is an accident of the JavaScript calling
convention, and emulating it on the JVM would ship an author's arity mistake
as production HTML with nil props instead of failing where it can be seen. So
the defect repaired here is the **contract text**, plus the two table rows that
were missing.

**No behaviour change.** `emit.cljc`'s edits are docstrings only; single
invocation and unmodified exception propagation are untouched, and there is no
flag, no options map, no renderer abstraction and no public API change.

## The premise, verified at tip before any edit

Re-measured rather than taken from #8918's report. Four probes, two per host.

**Real compiled CLJS** (ClojureScript 1.12.145, node v24.13.0), through
`emit/emit-element` — the same public entry point the cross-host table uses:

| case | result |
|---|---|
| single fixed-arity-2 inner @ 1 arg | renders `<p>fixed2\|a\|</p>` |
| fixed+variadic inner (required 2) @ 1 arg | renders `<p>fv\|a\|\|</p>` (variadic arm, missing slot) |

**JVM**, through the same `emit/emit-element` at tip:

| case | result |
|---|---|
| single fixed-arity-2 inner @ 1 arg | throws `clojure.lang.ArityException` — `Wrong number of args (1) passed to: …` |
| fixed+variadic inner (required 2) @ 1 arg | throws `clojure.lang.ArityException` — `Wrong number of args (1) passed to: …` |

Controls on both hosts at every count the same inners *do* accept rendered
identical bytes, so the probes reached the live Form-2 path rather than
short-circuiting.

**How `undefined` was told apart from nil, and both from a throw.** The
rendered strings cannot do it: `(str x)` is `""` for both `nil` and
`undefined`, and `nil?` answers `true` for both because it compiles to
`== null`. The discriminator is `undefined?`, which is `===` against `void 0`.
A spy fn captured `(undefined? a)` / `(undefined? b)` at the call site: the
passed argument read `false`, the missing one read `true`, and the control
`(undefined? nil)` read `false`. A throw is a third, unambiguous outcome —
the exception class was printed, not inferred from output.

## Deliverables

1. **Both omitted cases pinned on both hosts** in the existing cross-host
   table (`re-frame.ssr.form2-arity-cljs-test`), as rows carrying a **per-host**
   expectation that records what each host actually does, divergence included.
   Three non-vacuity controls assert host *agreement* at every count these same
   two inners do accept, so the divergence rows cannot be satisfied by a JVM
   that has simply stopped rendering these shapes. A CLJS-only block pins that
   the missing slot is genuinely `js/undefined` rather than a fabricated nil —
   the word is load-bearing in the contract and the rendered bytes cannot
   carry it.
2. **Contract wording corrected**, in every place that stated it:
   `form-2-invocation-arity` (its `nil` return covers two situations, and only
   one of them is host agreement), `invoke-form-2-render-fn` (a new **THE
   SUPPORTED CONTRACT** paragraph), `resolve-component-head`, the table's ns
   docstring, and the `ssr_emit_test.clj` section comment. The reason is stated
   in one clause at each site so the next reader does not read the divergence
   as an oversight and "fix" it.
3. **Preserved**: single invocation, unmodified exception propagation.

### The wording, before and after

Before — `invoke-form-2-render-fn`, closing sentence:

> When there is no shape CLJS would accept either, `(apply inner args)` lets
> the inner's own `ArityException` report the real call rather than a
> fabricated retry — **the server fails where the client fails.**

After — the same helper now carries:

> **THE SUPPORTED CONTRACT** … This helper matches compiled CLJS on arity
> SELECTION … and on EXCESS arguments … It deliberately DIVERGES in one
> direction: **MISSING arguments.** … The server is therefore STRICTER than the
> client here — a legal shared `.cljc` Form-2 can render in the browser and
> fail during SSR. That is a choice, not an oversight …

The header of `form-2-invocation-arity` changed the same way: `nil` no longer
means "CLJS would reject the call too", it means "no declared arm fits `n`",
and the two situations that produces are enumerated.

## Scope notes

- **`spec/011-SSR.md` is untouched, and no hot-zone edit is needed.** Checked
  line-oriented and again over the whitespace-flattened text: the spec carries
  no Form-2 arity contract at all (`Form-2`, `form-2`, `inner render`,
  `invoke-form-2` all count 0). The contract lives only in source and tests.
- **Streaming is not re-asserted for these two cases.** `emit-element` and
  `render-shell` share one resolver and that is already pinned by many rows;
  the refusal is pre-existing behaviour now being documented, not new
  behaviour. Adding rows there would have been widening without evidence.
- Nothing widens into the broader leniency class beyond the two cases the
  ruling named.

## Quality gates

Every exit code below was captured with the redirect and the `echo $?` on one
command line, in one shell, and is the number quoted.

| gate | run | captured exit | result |
|---|---|---|---|
| `clojure -M:test` from `implementation/ssr` | final base | **0** | 610 tests / 2995 assertions, 0 failures, 0 errors |
| `npm run test:cljs` (consolidated `node-test`, real CLJS on node) | final base | **0** | 11153 tests / 55172 assertions, 0 failures, 0 errors; compile 1874 files, **0 warnings** |
| `clj-kondo` v2026.04.15, `lint.yml`'s exact `--lint` list and `--fail-level error` | final base | **0** | errors 0, warnings 2081 |

Both suites were re-run **after** the rebase onto `de33d639e7`, not rested on
the pre-rebase green: nine commits landed in the interval, three of them under
`implementation/core/src/re_frame/` which this suite loads.

JVM baseline before this change was 609 tests / 2990 assertions on the same
base; the new deftest adds exactly +1 test and +5 assertions on the JVM and +8
on CLJS (the extra three are the CLJS-only `undefined?` pin).

### Tree-read controls

- **CLJS lane**: prints its config path, and the line named this worktree's
  `implementation/shadow-cljs.edn` on both runs.
- **clj-kondo**: prints no root, so the proof is a planted fault. One
  `str/join` arity error planted at the fixture line this PR adds reddened it
  — captured exit **3**, `errors: 1` at exactly that file and line, warning
  total unchanged at 76 for the scoped surface. Set-differencing the complete
  finding lists of the clean and planted runs moves exactly one line and
  nothing else. The fault existed only in this worktree, so a run that had
  wandered into another checkout would have come back green.

### The row-flip control

The two new rows *record* a divergence rather than asserting a fix, so
"revert the fix and watch it red" does not apply. Instead each row's expected
value was flipped to the other host's behaviour and the run checked for red on
the host it is then wrong about.

| plant | host | captured exit | what reddened |
|---|---|---|---|
| both `:clj` expectations → the CLJS render | JVM | **1** | 2 failures, one per row, at their own lines; `actual: ::arity-rejected` |
| both `:cljs` expectations → `::arity-rejected` | node | **1** | 2 failures, one per row; `actual: "<p>fixed2\|a\|</p>"` and `actual: "<p>fv\|a\|\|</p>"` |

So neither row would pass if its host behaved the other way — which is the
whole question for a row whose content is "these hosts disagree". The node
plant's `actual:` values are also the direct real-CLJS evidence, produced by
the gate itself, that the client renders where the server refuses.

A positive control ran first on the unplanted tree with the same node
namespace selector (captured exit **0**, 2 tests / 20 assertions), so the
selector was known to bite before it was trusted to red.

Every plant was applied and reverted by git **blob** hash against the
committed object (line endings are translated in this checkout, so a byte
digest of the working file is not sound), each restored file verified equal to
blob `74b9009afed5458ac79a1b354816829ba17522c7`. One plant was caught matching
**zero** lines by the pre-run match count — a multi-line anchor defeated by
CRLF — and was re-planted by line index; the run that followed the failed
plant is not counted as a control anywhere above.
