### PR TITLE
fix(spec): a live-socket timeout fires the caller's reply-event (rf2-i3og0)

### DIFF
--- a/spec/Pattern-WebSocket.md
+++ b/spec/Pattern-WebSocket.md
@@ -78,6 +78,20 @@ The connection machine composes the locked substrate:
 ;; self-dispatch.
 (defn- socket-id [data] (get-in data [:rf/spawned [:active]]))
 
+;; The body the machine hands a waiting `:reply-event` when IT — not the server
+;; — decides a request is over: the wire went away, or the deadline elapsed.
+;; `:origin :ws/local` is the machine's own stamp, and it is what makes this
+;; outcome distinguishable from server bytes at the callback. A frame off the
+;; network cannot reach this shape, because the machine assoc's `:origin` after
+;; receipt rather than reading it off the frame. Both local producers — the
+;; lost wire and the elapsed deadline — mint through here, so the two cannot
+;; drift into two different failure shapes.
+(defn- local-failure [request-id error]
+  {:origin     :ws/local
+   :request-id request-id
+   :ok         false
+   :error      error})
+
 ;; The in-flight half of losing the wire, shared by EVERY door out of `:active`
 ;; that destroys the socket — the guarded `:ws/closed` drop, the clean
 ;; `:ws/disconnect`, and the app-level `:ws/fatal` escape hatch. Clear every
@@ -97,10 +111,7 @@ The connection machine composes the locked substrate:
                (keep (fn [[rid {:keys [reply-event]}]]
                        (when reply-event
                          [:dispatch (conj reply-event
-                                          {:origin     :ws/local
-                                           :request-id rid
-                                           :ok         false
-                                           :error      :ws/connection-lost})])))
+                                          (local-failure rid :ws/connection-lost))])))
                (:in-flight data))})
 
 (rf/reg-event :ws/connection
@@ -275,8 +286,23 @@ The connection machine composes the locked substrate:
                             :source-socket-id (socket-id data)}]]}]]})
 
       :clear-request
+      ;; A request's deadline fired — a `:ws/request-timeout` that passed
+      ;; `:current-socket?`, so the socket is still live but the reply never
+      ;; came. FAIL the request, don't just forget it: clear the in-flight slot
+      ;; AND fire the waiting `:reply-event` with an explicit timeout body, so a
+      ;; request that times out on a live socket learns its outcome instead of
+      ;; hanging forever. This is `fail-in-flight`'s per-request twin — same
+      ;; local-failure shape, scoped to the single request whose timer elapsed
+      ;; rather than the whole in-flight set. (A request registered without a
+      ;; `:reply` has a nil `:reply-event`, so the dispatch is guarded.)
       (fn [{:keys [data] [_ {:keys [request-id]}] :event}]
-        {:data (update data :in-flight dissoc request-id)})
+        (let [{:keys [reply-event]} (get-in data [:in-flight request-id])]
+          {:data (update data :in-flight dissoc request-id)
+           :fx   (cond-> []
+                   reply-event (conj [:dispatch
+                                      (conj reply-event
+                                            (local-failure request-id
+                                                           :ws/timeout))]))}))
 
       :record-and-reset
       ;; Compound action — record fresh opts AND reset the retry counter.
@@ -501,7 +527,7 @@ Request-reply protocols carry a correlation id on every request and matching rep
 1. **Caller dispatches `[:ws/connection [:ws/request {:request-id ..., :body ..., :reply [::handler ...], :timeout-ms 10000}]]`.**
 2. **`:register-request` action** records the in-flight entry — `(:in-flight data)` gains `{request-id {:reply-event ... :timeout-ms ...}}` — forwards the body (with `:request-id` stamped) to the socket actor, and schedules a `:dispatch-later` for the timeout.
 3. **`:ws/received` arrives with `{:body {:type :reply :request-id ... :ok ...}}`.** The `:connected` state's `:trusted-frame?` guard checks the connection epoch **and** the closed wire contract; only then does the handler branch on the vetted `:type`. A `:reply` looks up the in-flight entry, clears the slot, and dispatches the registered reply event with the machine's `:origin :ws/server` stamp added; a `:push` only routes to `[:ws/handle-message body]`. Branch on `:type`, not on the presence of a `:request-id` — the frame's declared kind is part of the contract you just checked, whereas presence-of-a-key is a shape test a widened arm re-opens.
-4. **`:ws/request-timeout` fires** if no reply arrives within the timeout window. The `:clear-request` action removes the in-flight entry; the caller's reply event never fires. (Apps that want to surface "request timed out" to the caller can do so by dispatching a per-feature error event from `:clear-request` instead.)
+4. **`:ws/request-timeout` fires** if no reply arrives within the timeout window. The `:clear-request` action removes the in-flight entry **and fires the caller's `:reply-event`** with `{:origin :ws/local :ok false :error :ws/timeout}` — the per-request twin of the loss body in item 5, minted through the same `local-failure` helper. A timeout is a terminal outcome, so the caller must learn it: clearing the slot silently would leave a request that timed out on a *live* socket waiting forever, with no reply and no timer left to fire. The socket is still up, so this is the one door where nothing else will ever settle the slot.
 5. **Losing the wire fails the slot — by every door, not only the drop.** A request accepted into `:in-flight` settles exactly once, and it settles whenever the socket goes away rather than only when it is lost underneath us. Every transition that exits `:active` destroys the socket actor, so all three doors run the shared `fail-in-flight` helper: the guarded `:ws/closed` drop (`:on-socket-lost`, which also bumps the retry counter), the clean `:ws/disconnect` (`:fail-in-flight`), and the app-level `:ws/fatal` escape hatch (`:on-fatal-error`, which also records the error). Each still-in-flight `:reply-event` fires with `{:origin :ws/local :ok false :error :ws/connection-lost}` and `:in-flight` is cleared, so no correlation slot leaks and no caller hangs. Semantics are FAIL, not silent replay: the server may already have processed the request, so blind re-send risks double execution. (`:ws/auth-failed` is the exception that proves the rule — `:register-request` is bound only on `:connected`, so `:in-flight` is provably empty by the time that door can be taken, and plain `:record-error` is correct there.)
 
 **Two producers reach the reply event, so say which is which — with a key the sender cannot set.** A correlated wire reply and a locally minted loss/timeout failure both arrive at the caller's `:reply-event`, and they are different facts: one is the server's claim, the other is the machine's own truth about the connection. Discriminating between them by *shape* hands the choice to the sender, because a hostile server that has seen the wire request id can send back whatever shape the "local failure" arm describes and have its frame recorded as a connection fact the app minted itself. So the machine **stamps** `:origin` — `:ws/server` on the wire body as it hands it on, `:ws/local` on the bodies it mints — and the outcome schema is a closed union dispatching on that stamp. Stamped after receipt, `:origin` is not forgeable from the wire.


### PR DESCRIPTION
Closes rf2-i3og0 — **partially**. Half 1 is implemented; **Half 2 is stopped and reported**, because its premise does not survive a source check. Details below.

## Half 1 — implemented: a live-socket timeout fires the caller's reply-event

`spec/Pattern-WebSocket.md` contradicted itself on the timeout door, and the wrong side was the worked example a reader copies.

**Item 4, as it stood (verbatim):**

> 4. **`:ws/request-timeout` fires** if no reply arrives within the timeout window. The `:clear-request` action removes the in-flight entry; the caller's reply event never fires. (Apps that want to surface "request timed out" to the caller can do so by dispatching a per-feature error event from `:clear-request` instead.)

**The contradicting passage, two paragraphs later (verbatim, unchanged by this PR):**

> **Two producers reach the reply event, so say which is which — with a key the sender cannot set.** A correlated wire reply and a locally minted loss/timeout failure both arrive at the caller's `:reply-event` …

The canonical runnable example already agreed with the *second* passage: `examples/patterns/websocket/connection.cljs`'s `action-clear-request` reads `:reply-event`, clears the slot, and dispatches a machine-stamped `:ws/timeout` failure. rf2-b2jpr's acceptance requires a live-socket timeout as an explicit terminal outcome, and `websocket_cljs_test.cljs` already asserts that body. So item 4 and the worked action were the stale side, and copying the worked machine restored the caller-hang the example had removed.

Changes, all in `spec/Pattern-WebSocket.md`:

- **`:clear-request`** now looks up the `:reply-event`, clears the slot, and dispatches the timeout failure — guarded for a request registered without a `:reply`, matching the runnable example.
- **Item 4** states that the reply-event fires, and why a silent clear strands the caller: the socket is still live, so this is the one door where nothing else will ever settle the slot.
- **`local-failure` helper factored out** (as `connection.cljs` already does) so the two local producers — lost wire and elapsed deadline — mint through one shape. The inline duplicate literal is what let the two sides drift apart in the first place.

**The reply shape is unchanged** — this is the app-level correlation body, not an envelope migration. See Half 2.

## Half 2 — STOPPED: the premise does not hold, and the drift runs the other way

The ruling asks that the bespoke `{:origin :ws/local :ok false :error …}` outcome be replaced by the uniform reply envelope across seven files, citing `skills/re-frame2/patterns/websocket.md:200`. That paragraph does say what the ruling quotes. But it is the drift, not the rule — three normative sources and one deliberate prior ruling say the opposite:

1. **`spec/Managed-Effects.md:281`** — the envelope contract's own owning spec: *"A WebSocket connection is a long-lived synchronous surface rather than a one-shot async request, so **property 9 (the uniform async-reply envelope) is exempt** — the eight synchronous properties are the ones the pattern is graded on."*
2. **`spec/Pattern-WebSocket.md:8`** (this page's own header blockquote) — same exemption, stated independently.
3. **`spec/Pattern-WebSocket.md:511`** — a normative note: *"This correlation shape is APP-LEVEL — NOT the uniform reply envelope. … re-frame2 does **not** ship a managed WebSocket, so there is no `:rf/reply-to` target, `:status` taxonomy, `:work/id` correlation, or `:completed-at` metadata on a per-message reply here … the recommended worked shape is the app-level `:in-flight` map."*
4. **Commit `6fb1223396` (2026-06-17, rf2-eygytk)** — *"pin the WebSocket request/reply path as app-level, outside EP-0011"*. This exact finding was raised then ("could read as a second, competing reply vocabulary alongside the EP-0011 uniform reply envelope") and resolved the other way, on a recorded Mike ruling that re-frame2 ships no managed WebSocket. It states plainly: *"Rewriting it to `:rf/reply-to` + reply-map would contradict the spec."*
5. **A canary test was planted by that commit and is live at tip** — `implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs:1150-1159`, five assertions that the reply carries none of `:rf/reply-to`, `:status`, `:work/id`, `:work/kind`, `:completed-at`, commented *"a canary if a future ruling ever folds this into the envelope"*.

**Timeline settles which side drifted.** The skill's uniform-envelope sentence entered on **2026-06-11** (`208c7e281d`, a general "surface the EP-0011 uniform reply envelope in managed-async guidance" sweep). The pinning fix landed **2026-06-17**, six days later, and corrected the spec, the example and the test — **but never reached the skill**. Today's PR #8907 carried the stale sentence through unchanged. So `skills/…/websocket.md:200` is residue from a sweep that a later, bead-tracked, Mike-ruled correction superseded everywhere else.

**Why this stops rather than proceeds.** Implementing Half 2 as ruled would require editing `spec/Managed-Effects.md` to withdraw the property-9 exemption — outside this PR's fence, and the brief's explicit STOP condition ("if you conclude the envelope contract itself needs a change, STOP and report"). It would also reverse a recorded Mike ruling and turn the five canary assertions red — the canary firing exactly as its author intended.

**The item's own acceptance criteria already sanctions the other resolution:** *"…either the uniform managed envelope **or an explicitly justified pattern-local contract**."* Sources 1–3 above are precisely that explicit justification, already written.

**Recommendation (not actioned here — mayor's call):** the real defect Half 2 identified is genuine — a page stating a rule its own examples violate. The minimal repair is to correct `skills/re-frame2/patterns/websocket.md:200` to cite the app-level boundary the spec establishes, leaving all six other files alone. That is a one-file, one-paragraph change to the skill. It reverses the ruling's stated direction, so it is not taken unilaterally.

## Quality gates

Each exit code captured on the same command line as the redirect, in one shell, and quoted from the captured `.exit` file — not from a harness report.

| Gate | Result | Captured exit |
|---|---|---|
| `python scripts/check_doc_slugs.py` (covers `spec/`) | pass | **0** |
| `python scripts/check_readme_links.py --ci` | pass | **0** |
| `clojure -M:test -n re-frame.pattern-smoke-test` (`implementation/core`) — 6 tests, 56 assertions, 0 failures, 0 errors | pass | **0** |
| Fenced-block balance check (hand tool, 6 Clojure fences across the 3 doc surfaces) | pass | **0** |
| **Control:** `check_doc_slugs.py` with one broken anchor planted in prose | **red as required** | **1** |
| **Control:** balance checker with one bracket removed | **red as required** | **1** |

### Gates deliberately not run, with reasons

- **CLJS consolidated `node-test`** and **`test:examples-compile`** were nominated on the assumption this PR would edit `websocket_cljs_test.cljs` and the `examples/patterns/websocket/**` sources. Half 2 stopped, so **the diff is one markdown file under `spec/`** — no CLJS source, no test, no example changed. Neither gate reads anything in this diff. I checked for a digest gate that pins the spec's fenced blocks (the `docs/core/freehand/` hazard) and there is none for `spec/`; `implementation/core/test/re_frame/pattern_smoke_test.clj` references Pattern-WebSocket but re-implements the machine inline rather than hashing the page, and it passes above.
- **`mkdocs build --strict`** is not a candidate: `docs_dir` is `docs`, so `spec/` was never in the built site.

### Controls, and exactly what they prove

- **Doc gate.** Blob hash of the committed file before the plant: `51d2dca6b18047f0d688cb6f3bfa6049076e5413`. Planted one broken in-prose anchor at a line already edited by this PR; the working file's blob hash moved to `493d4dff75b48d57bdd05fd2187d90e5c0f860e4`, proving the plant applied rather than silently no-opping. The gate returned **exit 1**, naming the file and line and the planted anchor. Restored; the working file's blob hash is `51d2dca6…` again, byte-identical to the committed object. The fault existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green — the red is the discrimination.
- **Balance checker.** Exercised once against an input it should flag (one closing bracket removed from `local-failure`'s arglist): **exit 1**, naming the fence and the block-line. Its green on the real files therefore means something. The control copy was a scratch file, never the tracked one.
- **Census instrument.** The seven-file scope was re-derived at tip **twice, by different instruments** — line-oriented (`git grep -F`) and whitespace-flattened — because a map literal spanning two lines is invisible to a line-oriented search whatever the pattern. Both returned the identical membership. Non-zero on every probe, so no silent "no matches".

## Hand-checked inside fences (the gates cannot see this)

Both doc gates strip fenced code blocks before reading a link, so their green says nothing about the substance of this change — which is almost entirely inside fences. Checked by hand:

- **Paren/bracket/brace balance** across all 6 Clojure fences in the three doc surfaces — tool above, with a control proving it bites. New `local-failure` defn and the rewritten `:clear-request` both balance.
- **The forms read as valid Clojure.** `:clear-request`'s `(let [{:keys [reply-event]} (get-in data [:in-flight request-id])] …)` destructures the in-flight entry before `:data` dissocs it, so the lookup is against the pre-clear map — same ordering as `connection.cljs`. `(cond-> [] reply-event (conj …))` yields `[]` when `:reply-event` is nil, matching the guarded-dispatch idiom the page already uses in `fail-in-flight`'s `keep`.
- **`local-failure` arity and call sites agree** — `[request-id error]`, called as `(local-failure rid :ws/connection-lost)` and `(local-failure request-id :ws/timeout)`. Both 2-arity.
- **Shape parity with the runnable example** — the spec's `local-failure` now emits the same four keys in the same order as `connection.cljs:120-132`.
- **No table column counts changed** — this PR edits no table.
- **Anchors** — the one link in the new prose is inline `code`, not a link; no new cross-references were introduced, and none were removed.

## Scope re-derived at tip

The ruling's seven-file list was re-measured at tip and is **exact — delta zero** in membership, not just count: `spec/Pattern-WebSocket.md`, `skills/re-frame2/patterns/websocket.md`, `examples/patterns/websocket/{connection,schema,messages}.cljs`, `examples/patterns/websocket/README.md`, `implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs`. Of those, **this PR touches one**, because Half 1 turned out to be a spec-only correction — the example, the test and the README were already on the correct side of the contradiction.
