### PR TITLE
test(views): witness the adapter-switch head cache from a post-init componentized slot (rf2-oz7wr)

### DIFF
--- a/implementation/core/test/re_frame/views_adapter_switch_head_cljs_test.cljs
+++ b/implementation/core/test/re_frame/views_adapter_switch_head_cljs_test.cljs
@@ -1,0 +1,242 @@
+(ns re-frame.views-adapter-switch-head-cljs-test
+  "rf2-oz7wr — the head cache across an ADAPTER SWITCH.
+
+  `views/view-head` derives `(rf/view id)` from (registration × installed
+  substrate) and memoises it, because both substrate hooks it consults are
+  routed and the canonical boot order registers views before `rf/init!`.
+  The registrar slot is deliberately NOT rewritten on a re-derivation
+  (`registrar/register!` emits `:rf.registry/handler-replaced` on every call,
+  so re-registering at lookup would publish a phantom hot-reload), so the
+  cache must recognise its own registration by an IMMUTABLE token — the exact
+  object the slot still holds — rather than by whatever the latest derivation
+  produced.
+
+  The defect this file pins, in the shape the audit recorded it:
+
+    A post-init registration under substrate A1 composes wrapper W into
+    componentized head H1; the slot stores H1 and the cache stores
+    {W, H1, A1}. After dispose/install A2 the FIRST lookup correctly misses,
+    derives H2, overwrites the cache with {W, H2, A2} and returns H2 —
+    leaving the slot at H1. On the SECOND lookup the slot's H1 is identical
+    to neither W nor the cache's now-current H2, so `view-head` classified
+    its own registration as FOREIGN and handed back the stale H1. Switching
+    a componentizing substrate for a non-componentizing one failed the same
+    way: W once, then the old A1-marked H1.
+
+  Every pre-existing row starts from an UNCOMPONENTIZED registrar seed (the
+  boot-order rows register with no adapter installed, so the slot holds the
+  bare wrapper and the misclassification cannot arise). These rows start from
+  a post-init COMPONENTIZED slot, which is what makes them able to see it.
+
+  What each row is for:
+
+    - `post-init-componentized-head-survives-*` — the audit's exact shape.
+      Two consecutive lookups after a componentizing → componentizing switch;
+      the second must still answer A2's head, not the stale H1.
+    - `switch-to-a-non-componentizing-substrate-*` — the UIx → Reagent half
+      of the same defect. The re-derivation reuses the registration's own
+      wrapper, so both lookups must answer W and neither may answer H1.
+    - `foreign-view-slot-*` / `foreign-re-registration-*` — the pass-through
+      the repair must NOT trade away. A `:view` slot this ns did not build is
+      handed back exactly as stored, including when a stale cache entry for
+      that id still describes an earlier views-composed registration. These
+      two rows never reach the re-derivation branch, so they are also the
+      NON-VACUITY CONTROL: when the token handling is broken they stay GREEN
+      while the two rows above go red, which is what makes that red
+      attributable to the seam under test rather than to the harness.
+
+  Substrate-agnostic by construction: the adapters are inert maps and the
+  `:adapter/componentize-view` impls are marked forwarding shells modelled on
+  `spine/make-componentize-view`, routed through the real
+  `substrate-adapter/route-hook!`. Nothing here mounts, so this is a headless
+  node row — the property under test is WHICH OBJECT a lookup returns, not
+  rendered output.
+
+  ns ends in `-cljs-test` so shadow-cljs's `:node-test` build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [goog.object :as gobj]
+            [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views :as views]))
+
+;; ---- inert test substrates -------------------------------------------------
+;;
+;; `:kind` is `:custom`, so `substrate-adapter/same-adapter?` routes these by
+;; OBJECT IDENTITY (a canonical `:rf.adapter/*` kind would route by token and
+;; conflate copies). Three distinct maps ⇒ three distinct substrates for both
+;; hook routing and the head cache's adapter half.
+
+(def ^:private adapter-a1 {:kind :custom :rf.test/substrate :a1})
+(def ^:private adapter-a2 {:kind :custom :rf.test/substrate :a2})
+(def ^:private adapter-plain {:kind :custom :rf.test/substrate :plain})
+
+(def ^:private marker-prop "rf2Oz7wrShellMarker")
+
+(defn- shell-marker
+  "Which test substrate componentized `x`, or nil when nothing did.
+  Reads through `goog.object/get` rather than `aget` so a `MetaFn` (an IFn
+  OBJECT, which is exactly what an un-componentized head is) answers nil
+  instead of throwing."
+  [x]
+  (when (some? x) (gobj/get x marker-prop)))
+
+(defn- make-componentize-view
+  "An `:adapter/componentize-view` impl in the shape
+  `spine/make-componentize-view` publishes — a forwarding shell built fresh
+  per derivation — stamped with `marker` so a returned head names the
+  substrate that produced it."
+  [marker]
+  (fn componentize-view [_id _metadata wrapped]
+    (let [shell (fn view-component [& args] (apply wrapped args))]
+      (gobj/set shell marker-prop marker)
+      shell)))
+
+;; Routed, not `set-fn!`'d: routing is the production mechanism, and it keeps
+;; these impls inert for every other namespace in the shared node bundle —
+;; each fires only while ITS map is the installed adapter and otherwise chains
+;; on. `adapter-plain` deliberately publishes nothing, so under it the chain
+;; reaches its nil fallback and `apply-adapter-componentize-view` keeps the
+;; wrapper as the head (the Reagent shape).
+(defonce ^:private routed-componentize-hooks
+  (do (adapter/route-hook! adapter-a1 :adapter/componentize-view
+                           (make-componentize-view :a1))
+      (adapter/route-hook! adapter-a2 :adapter/componentize-view
+                           (make-componentize-view :a2))
+      true))
+
+(defn- render-fn [& _args] [:div "row"])
+
+(defn- switch-adapter! [next-adapter]
+  (adapter/dispose-adapter!)
+  (adapter/install-adapter! next-adapter))
+
+(defn- slot-handler [id]
+  (:handler-fn (registrar/lookup :view id)))
+
+;; ---- fixture ---------------------------------------------------------------
+;; The runtime fixture rolls the registrar back around each test (so the view
+;; ids registered below never leak into the shared bundle) and disposes any
+;; installed adapter on the way in; no `:adapter` is supplied because each row
+;; installs and switches its own. The cold-adapter tail leaves the slot in a
+;; never-installed state for whatever namespace runs next.
+
+(use-fixtures :each
+  (let [reset-runtime (test-support/make-reset-runtime-fixture {})]
+    (fn [t]
+      (reset-runtime
+        (fn []
+          (try
+            (t)
+            (finally
+              (adapter/dispose-adapter!)
+              (adapter/reset-lifecycle-state-for-tests!))))))))
+
+;; ---- the audit's shape: componentizing → componentizing --------------------
+
+(deftest post-init-componentized-head-survives-an-adapter-switch
+  (testing "two consecutive lookups after a switch both answer the NEW substrate's head (rf2-oz7wr)"
+    (adapter/install-adapter! adapter-a1)
+    (let [h1 (views/reg-view* ::switch-row {} render-fn)]
+      ;; Premises. Without these the row could silently decay into the
+      ;; boot-order shape, where the slot holds the uncomponentized seed and
+      ;; the misclassification cannot occur at all.
+      (is (= :a1 (shell-marker h1))
+          "precondition: registering AFTER install produced A1's componentized head H1")
+      (is (identical? h1 (slot-handler ::switch-row))
+          "precondition: the registrar slot holds the COMPONENTIZED head H1")
+      (is (identical? h1 (rf/view ::switch-row))
+          "precondition: while A1 is installed the lookup is a cache hit on H1")
+
+      (switch-adapter! adapter-a2)
+      (is (identical? h1 (slot-handler ::switch-row))
+          "precondition: the switch deliberately leaves the registrar slot at H1")
+
+      (let [first-lookup  (rf/view ::switch-row)
+            second-lookup (rf/view ::switch-row)]
+        (is (= :a2 (shell-marker first-lookup))
+            "the first lookup re-derives the head against A2")
+        (is (not (identical? h1 first-lookup))
+            "the first lookup is not the A1-era head")
+
+        ;; The regression. Pre-fix this answered H1: the slot's H1 matched
+        ;; neither the re-derived wrapper nor the cache's now-current H2, so
+        ;; the entry was classified foreign and the slot was served raw.
+        (is (= :a2 (shell-marker second-lookup))
+            "the SECOND consecutive lookup still answers A2's head, not the stale A1 head")
+        (is (not (identical? h1 second-lookup))
+            "the second lookup is not the stale registrar head H1")
+        (is (identical? first-lookup second-lookup)
+            "identity is stable within an adapter generation, so React reconciles one component type")
+        (is (identical? first-lookup (rf/view ::switch-row))
+            "and stays stable on every further lookup")))))
+
+;; ---- the same defect, componentizing → NON-componentizing ------------------
+
+(deftest switch-to-a-non-componentizing-substrate-does-not-fall-back
+  (testing "a componentizing → non-componentizing switch answers the wrapper on BOTH lookups (rf2-oz7wr)"
+    (adapter/install-adapter! adapter-a1)
+    (let [h1 (views/reg-view* ::to-plain-row {} render-fn)]
+      (is (= :a1 (shell-marker h1))
+          "precondition: the registrar slot holds A1's componentized head H1")
+
+      (switch-adapter! adapter-plain)
+      (is (identical? h1 (slot-handler ::to-plain-row))
+          "precondition: the switch leaves the registrar slot at H1")
+
+      (let [first-lookup  (rf/view ::to-plain-row)
+            second-lookup (rf/view ::to-plain-row)]
+        (is (nil? (shell-marker first-lookup))
+            "the substrate publishes no componentize hook, so the head is the wrapper W")
+        (is (not (identical? h1 first-lookup))
+            "the first lookup is not the A1-marked head")
+
+        ;; Pre-fix this answered H1 — an A1-marked shell served to a substrate
+        ;; that has no idea what that marker means.
+        (is (nil? (shell-marker second-lookup))
+            "the SECOND consecutive lookup is still W, not the A1-marked head")
+        (is (not (identical? h1 second-lookup))
+            "the second lookup is not the stale registrar head H1")
+        (is (identical? first-lookup second-lookup)
+            "identity is stable within the new adapter generation")))))
+
+;; ---- foreign-slot pass-through (and the harness control) -------------------
+
+(deftest foreign-view-slot-passes-through-untouched-across-a-switch
+  (testing "a :view slot this ns did not build is handed back exactly as stored"
+    (adapter/install-adapter! adapter-a1)
+    (let [foreign (fn foreign-view [& _args] [:div "foreign"])]
+      (registrar/register! :view ::foreign-row {:handler-fn foreign})
+      (is (identical? foreign (rf/view ::foreign-row))
+          "a hand-rolled registration is never componentized")
+      (is (identical? foreign (rf/view ::foreign-row))
+          "and the second consecutive lookup answers the same object")
+
+      (switch-adapter! adapter-a2)
+      (is (identical? foreign (rf/view ::foreign-row))
+          "an adapter switch does not adopt a slot this ns did not build")
+      (is (identical? foreign (rf/view ::foreign-row))
+          "and the second lookup after the switch answers it too")
+      (is (nil? (shell-marker (rf/view ::foreign-row)))
+          "nothing stamped a substrate shell onto the foreign handler"))))
+
+(deftest foreign-re-registration-over-a-composed-slot-passes-through
+  (testing "a hand-rolled register! that REPLACES a composed slot wins over the stale cache entry"
+    (adapter/install-adapter! adapter-a1)
+    (let [h1      (views/reg-view* ::hijacked-row {} render-fn)
+          foreign (fn foreign-view [& _args] [:div "foreign"])]
+      (is (= :a1 (shell-marker h1))
+          "precondition: the cache entry for this id describes a views-composed registration")
+      ;; The cache still holds {W, H1, A1} for this id; the slot no longer does.
+      (registrar/register! :view ::hijacked-row {:handler-fn foreign})
+
+      (switch-adapter! adapter-a2)
+      (is (identical? foreign (rf/view ::hijacked-row))
+          "the replaced slot is served raw, not re-derived from the superseded registration")
+      (is (identical? foreign (rf/view ::hijacked-row))
+          "and the second consecutive lookup answers the same object")
+      (is (nil? (shell-marker (rf/view ::hijacked-row)))
+          "no substrate shell was stamped onto the foreign handler")
+      (is (not (identical? h1 (rf/view ::hijacked-row)))
+          "and the superseded head H1 is never resurrected"))))


### PR DESCRIPTION
## rf2-oz7wr — the regression witness for the adapter-switch head cache

The audit on PR #8919 found the code repair already landed and asked for the one thing
still missing: a test that starts from a **post-init componentized registrar head**,
switches substrates, and performs **two consecutive lookups**. This PR is that witness,
and **no source change was needed** — the witness passed on its first run against tip.

### What was missing, and why every existing row was blind to it

`view-head` derives `(rf/view id)` from (registration × installed substrate) and memoises
it, deliberately leaving the registrar slot alone (`registrar/register!` emits
`:rf.registry/handler-replaced` on every call, so re-registering at lookup would publish a
phantom hot-reload). The entry must therefore recognise its own registration by an
immutable token — the object the slot still holds.

The audit's failure needs a slot holding a **componentized** head:

> A post-init registration under A1 composes wrapper W into head H1; the slot stores H1 and
> the cache stores `{W, H1, A1}`. After dispose/install A2 the first lookup misses, derives
> H2, overwrites the cache with `{W, H2, A2}`, returns H2 and leaves the slot at H1. On the
> second lookup H1 is identical to neither W nor the cache's now-current H2, so `view-head`
> classifies its own registration as foreign and returns the stale H1.

Every pre-existing row starts from the **uncomponentized boot-order seed** — registration
before `rf/init!`, so the slot holds the bare wrapper and the misclassification cannot
arise at all. That is exactly why 757 browser rows and 11k node rows were green over it.

### The witness

`implementation/core/test/re_frame/views_adapter_switch_head_cljs_test.cljs`, four rows:

| row | shape |
| --- | --- |
| `post-init-componentized-head-survives-an-adapter-switch` | the audit's exact shape: componentizing → componentizing, two consecutive lookups, the second must answer A2's head and not the stale H1 |
| `switch-to-a-non-componentizing-substrate-does-not-fall-back` | the UIx → Reagent half: "W once, then the old UIx-marked H1". Both lookups must answer W |
| `foreign-view-slot-passes-through-untouched-across-a-switch` | a hand-rolled `registrar/register!` slot is served raw, before and after a switch |
| `foreign-re-registration-over-a-composed-slot-passes-through` | a hand-rolled `register!` that REPLACES a composed slot wins over the stale cache entry — the pass-through the repair must not trade away |

The first three rows assert their own premises (`:a1`-marked head in the slot; the switch
leaves the slot at H1), so they cannot silently decay into the boot-order shape.

Substrate-agnostic by construction: three inert `:kind :custom` adapter maps (routed by
object identity), with `:adapter/componentize-view` impls modelled on
`spine/make-componentize-view` and published through the real
`substrate-adapter/route-hook!`. Each fires only while its own map is installed and chains
on otherwise, so nothing here is visible to the rest of the shared node bundle.

**Lane: node, not browser.** The property under test is *which object a lookup returns*,
not rendered output, so no `createRoot` commit is required — the cheapest lane that can
observe it. The DOM-mounting half of this bead is already covered by the browser rows PRs
#8874/#8909/#8919 added.

### Quality gates

Captured exit codes (`cmd > log 2>&1; echo $? > exit`, one command line, one shell — the
quoted numbers are the captured ones, not the harness's). All re-run on the final rebased
base `de33d639e7`.

| gate | result | exit |
| --- | --- | --- |
| CLJS `node-test` compile (from `implementation/`) | 1875 files, 1214 compiled, 0 warnings | **0** |
| CLJS `node-test` run (consolidated) | 11156 tests / 55191 assertions, 0 failures, 0 errors | **0** |
| JVM `clojure -M:test` (from `implementation/core`) | 2175 tests / 11138 assertions, 0 failures, 0 errors | **0** |
| focused run of the new ns | 4 tests / 27 assertions, 0 failures | **0** |

The compile lane prints `shadow-cljs - config: …/adapterswitch/implementation/shadow-cljs.edn`
— it read this branch's checkout, not a sibling's.

Not nominated: the diff is one new `.cljs` test file, so `check_doc_slugs.py` and
`check_readme_links.py` have no changed path in their rosters, and `mkdocs build --strict`
has none under `docs_dir`.

### Control — the witness discriminates

The witness passes on the first run, so the red was constructed deliberately rather than
observed. Planted the revert of #8919's token handling at the single line
`:registered handler-fn` in `views.cljs` — keying the re-derived entry on the **new**
derivation's head instead of the immutable object the registrar still holds:

```clojure
(let [next-entry (assoc (compose-view id (:metadata entry) (:render-fn entry) entry)
                        :registered handler-fn)
      next-entry (assoc next-entry :registered (:head next-entry))]   ; ← planted
```

Anchor matched exactly 1 line (checked before the run); source change proved by blob hash
`010bc3f6…` → `ef1275ce…`; 978 files recompiled, so the runtime observed it.

**Sabotage run: exit 1, 7 failures, 0 errors**, all in the two re-derivation rows:

- `the SECOND consecutive lookup still answers A2's head` → `(not (= :a2 :a1))`, and
  `(identical? h1 second-lookup)` was **true** — literally the stale registrar head.
- the non-componentizing row: `first-lookup` was a `MetaFn` (W) and `second-lookup` was the
  A1-marked shell — the audit's "W once, then the old UIx-marked H1", verbatim.

**Both foreign-slot pass-through rows stayed GREEN**, and the run reported the same
4 tests / 27 assertions as the green control, so no namespace was crashed out and the red
is attributable to the seam under test rather than to the harness.

Restored and verified by git **blob** hash against the committed object
(`010bc3f6ebc83d2cfc025cd701043040161f1b25`, both sides); recompiled (978 files) and the
focused run returned to 4 tests / 27 assertions, exit **0**.
