### PR TITLE
fix(realworld-http): gate the article delete SUCCESS on the issuing slug (rf2-amhpk)

### DIFF
--- a/examples/real-apps/realworld_http/comments.cljs
+++ b/examples/real-apps/realworld_http/comments.cljs
@@ -65,9 +65,9 @@
 ;; (never blank a loaded page on a refresh), but a slug CHANGE resets the
 ;; slice, so alpha's article is never renderable under `/article/beta`.
 ;;
-;; The rule is now universal in this file: EVERY settle that writes
+;; The rule is now universal in this file: EVERY settle that touches
 ;; route-owned state carries the slug it was requested for and asks this
-;; question before writing. Nine do —
+;; question before acting. Ten do —
 ;;
 ;;   - the three route-driven READS: `:article/load`'s reply hat,
 ;;     `:comments/loaded`, `:comments/load-failed` (rf2-iy3d6);
@@ -76,19 +76,29 @@
 ;;     the one shared `[:comments :data]` / `[:comment-form]`, so alpha's late
 ;;     POST failure would otherwise banner beta's form and alpha's failed
 ;;     DELETE would re-insert alpha's comment into beta's list (rf2-84iek);
-;;   - the three article SOCIAL settles further down:
+;;   - the four article SOCIAL settles further down:
 ;;     `:article/author-follow-synced`, `:article/author-follow-rollback`,
-;;     `:article/delete-failed`. These fire from a button press rather than
-;;     from the route's own load, but they write `[:article ...]`, which the
-;;     route owns just the same. Measured, not merely suspected: a late
-;;     follow FAILURE restored ALPHA's prior flag onto beta's author, so
-;;     beta's Follow button read the opposite of the truth, and a late follow
-;;     SUCCESS was worse still — it replaced beta's author map wholesale, so
-;;     the byline name, the avatar and the profile link all became alpha's
-;;     author. A late failed DELETE bannered alpha's error across beta's page
-;;     (rf2-amhpk).
+;;     `:article/delete-failed`, `:article/delete-success`. These fire from a
+;;     button press rather than from the route's own load, but what they touch
+;;     — `[:article ...]` and the route itself — the active article owns just
+;;     the same. Measured, not merely suspected: a late follow FAILURE restored
+;;     ALPHA's prior flag onto beta's author, so beta's Follow button read the
+;;     opposite of the truth, and a late follow SUCCESS was worse still — it
+;;     replaced beta's author map wholesale, so the byline name, the avatar and
+;;     the profile link all became alpha's author. A late failed DELETE
+;;     bannered alpha's error across beta's page (rf2-amhpk).
 ;;
-;; Why a gate ALONE is enough for all nine, where the comment form also needed
+;; `:article/delete-success` is the one member that writes NO db, and it is
+;; here anyway. It navigates home, and NAVIGATION IS STATE — the most visible
+;; state the active article owns. Delete alpha, walk to beta before the server
+;; answers, and an ungated success yanks the reader off the article they chose
+;; and out to the home page. That is the same ownership violation as the eight
+;; above; "writes no `:db`" is a fact about the mechanism, not about who owns
+;; the outcome. The strand question gets the same answer as the rest: the
+;; server deletion succeeded regardless, beta is a fine place to be, and
+;; returning to alpha later fails and reloads like any other missing article.
+;;
+;; Why a gate ALONE is enough for all ten, where the comment form also needed
 ;; a reset: everything gated here lives in a slice that `:article/load` or
 ;; `:comments/load` REBUILDS on a slug change, so the navigation has already
 ;; released it and refusing a stale settle strands nothing. `[:comment-form]`
@@ -99,16 +109,12 @@
 ;; identity, and the Follow button carries no pending or disabled state to get
 ;; stuck in.
 ;;
-;; Two deliberate NON-members, so nobody reads the list as "everything in
-;; this file is correlated". Both write no state at all, so there is nothing
-;; to correlate:
-;;
-;;   - `:comment/delete-success` exists only to give `:on-success` a target.
-;;   - `:article/delete-success` navigates home and touches no db. A late one
-;;     would still take a reader who has since moved to another article home
-;;     — but that is a product question about a delete the reader themselves
-;;     asked for, not a cross-route write, so it is named here rather than
-;;     changed.
+;; One deliberate NON-member, so nobody reads the list as "everything in this
+;; file is correlated": `:comment/delete-success` exists only to give
+;; `:on-success` a target. It writes nothing and does nothing, so there is
+;; nothing to correlate. Note what the test is — not "writes no db", which
+;; `:article/delete-success` also satisfies while very much needing the gate,
+;; but "produces no outcome the route owns".
 ;;
 ;; The gate correlates ROUTE IDENTITY, not request identity: it asks which
 ;; slug the screen is on, so alpha → beta → alpha readmits an alpha reply
@@ -566,7 +572,11 @@
   {:doc "Delete the current article, straight from the DETAIL page (authors
          only). No retry — it's destructive and it's one click. On success we
          head home. (The editor has its own Delete path too, in
-         article_editor.cljs; both lead to the same place.)"}
+         article_editor.cljs; both lead to the same place.)
+
+         BOTH reply targets carry the slug the delete was issued on — the
+         failure because it banners an error, the success because it NAVIGATES.
+         See THE CORRELATION GATE above."}
   (fn [{:keys [db]} _]
     (let [slug (get-in db [:article :data :slug])]
       (if (nil? slug)
@@ -575,14 +585,22 @@
                (rh/request {:method     :delete
                             :path       (article-path slug)
                             :decode     :auto
-                            :on-success [:article/delete-success]
+                            :on-success [:article/delete-success slug]
                             :on-failure [:article/delete-failed slug]})]]}))))
 
 (rf/reg-event :article/delete-success
-  {:doc "Writes no db at all, so it needs neither the slug nor the gate — see
-         the NON-members note in THE CORRELATION GATE above."}
-  (fn [_ _]
-    {:fx [[:dispatch [:rf.route/navigate {:to :realworld/home}]]]}))
+  {:doc "The DELETE's `:on-success`, carrying the slug it was issued for.
+         Correlation-gated like the rest — this one writes no db, but it
+         NAVIGATES, and the route is the most visible state the active article
+         owns. Delete alpha, walk to beta while the server thinks about it, and
+         an ungated success takes the reader away from the article they chose.
+
+         Refusing strands nothing: the server deletion succeeded either way,
+         beta is a perfectly good place to be, and coming back to alpha later
+         just fails and reloads like any other missing article."}
+  (fn [{:keys [db]} [_ slug _reply]]
+    (when (reply-for-current-slug? db :article slug)
+      {:fx [[:dispatch [:rf.route/navigate {:to :realworld/home}]]]})))
 
 (rf/reg-event :article/delete-failed
   {:doc "The DELETE's `:on-failure`, carrying the slug it was issued for.

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -2428,14 +2428,23 @@
 ;; DELETE banners its error on `[:article :error]`, where beta's page shows it
 ;; until the next load.
 ;;
+;; `:article/delete-success` is the fourth, and it was excluded from the first
+;; pass because it writes no db at all. It navigates, and navigation is the
+;; route's own state — the most visible state there is. Delete alpha, walk to
+;; beta before the server answers, and the late success took beta's reader home
+;; and threw away the route they had chosen. Refusing it strands nothing: the
+;; deletion succeeded on the server either way, so there is no retry to lose
+;; and nothing left half-done.
+;;
 ;; The fix is the gate alone, with NO reset half — the difference from
 ;; rf2-84iek that matters. `[:comment-form]` was a boot-time singleton that
 ;; rode across the navigation still `:submitting`, so gating it without a
 ;; reset would have locked beta's form; `[:article]` is rebuilt wholesale by
-;; `:article/load` on a slug change and the Follow button carries no pending
-;; state, so the navigation has already released everything a refused settle
-;; would have touched. `beta-slice-is-rebuilt` below is what pins that, and it
-;; is why refusing strands nothing.
+;; `:article/load` on a slug change, and neither the Follow button nor the
+;; Delete button carries any pending or disabled state, so the navigation has
+;; already released everything a refused settle would have touched.
+;; `beta-slice-is-rebuilt` below is what pins that, and it is why refusing
+;; strands nothing.
 ;;
 ;; These reuse `with-held-comment-fx` — the shared held-request harness for
 ;; the article page, comment-flavoured only in its name.
@@ -2526,6 +2535,60 @@
         (is (nil? (:error (article-slice* f)))
             "a LATE alpha DELETE failure does not banner its error over beta's page (rf2-amhpk)")))))
 
+(defn- article-delete-cross-slug-late-success-is-refused-test []
+  ;; The fourth of the shape, and the one the first pass excluded because it
+  ;; writes no db. Navigation is state all the same — the reader's own — and a
+  ;; late alpha success took it away from them.
+  (with-held-comment-fx :realworld.test/article-delete-cross-slug-ok
+    (fn [f lowered]
+      (rf/dispatch-sync [:rf.route/handle-url-change "/article/alpha"] {:frame f})
+      (settle-article-with-author! f lowered "alpha" "alice" false)
+      (rf/dispatch-sync [:article/delete] {:frame f})
+      (let [delete-req (req-by-method+url @lowered :delete "/articles/alpha")]
+        (is (some? delete-req) "the article DELETE went out and is held open")
+        (is (= [:article/delete-success "alpha"] (:on-success delete-req))
+            "the DELETE's SUCCESS target carries the slug it was issued on, not
+             just its failure target")
+        ;; The reader gives up waiting and reads another article.
+        (rf/dispatch-sync [:rf.route/handle-url-change "/article/beta"] {:frame f})
+        (settle-article-with-author! f lowered "beta" "bob" true)
+        ;; The strand control, exactly as for the three writes above: the
+        ;; navigation already rebuilt the slice, and the delete left no pending
+        ;; flag or disabled control behind, so refusing this settle abandons
+        ;; nothing. The server deletion stands; alpha is simply gone.
+        (is (= "beta" (:slug (article-slice* f)))
+            "beta-slice-is-rebuilt — [:article] is beta's before the late settle")
+        ;; Alpha's DELETE succeeds, far too late.
+        (rf/dispatch-sync (conj (:on-success delete-req) {:status :ok :value nil})
+                          {:frame f})
+        (is (= :realworld.article/show
+               (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+            "a LATE alpha DELETE SUCCESS does not yank beta's reader home (rf2-amhpk)")
+        (is (= {:slug "beta"} (route-params* f))
+            "…the reader's own newer route choice is the one that stands")
+        (is (= "beta" (:slug (article-slice* f)))
+            "…and beta's article is still the one on screen")))))
+
+(defn- article-delete-current-slug-still-navigates-home-test []
+  ;; The navigation control for the gate above: refusing a STALE success must
+  ;; not cost the ordinary one. Delete the article you are reading, settle it
+  ;; while you are still reading it, and you go home as before.
+  (with-held-comment-fx :realworld.test/article-delete-current-slug
+    (fn [f lowered]
+      (rf/dispatch-sync [:rf.route/handle-url-change "/article/alpha"] {:frame f})
+      (settle-article-with-author! f lowered "alpha" "alice" false)
+      (rf/dispatch-sync [:article/delete] {:frame f})
+      (let [delete-req (req-by-method+url @lowered :delete "/articles/alpha")]
+        (is (= :realworld.article/show
+               (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+            "still on the article while the DELETE is out")
+        (rf/dispatch-sync (conj (:on-success delete-req) {:status :ok :value nil})
+                          {:frame f})
+        (is (= :realworld/home
+               (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+            ":article/delete-success still navigates home when its own slug is
+             the one on screen — the gate is not vacuous (rf2-amhpk)")))))
+
 (defn- article-social-gates-are-not-vacuous-test []
   ;; The control that keeps the three refusals above honest: a gate wired to
   ;; refuse everything would satisfy all of them and break the app. On the
@@ -2570,6 +2633,12 @@
   (testing "a LATE alpha DELETE failure cannot banner its error over beta's
             page (rf2-amhpk)"
     (article-delete-cross-slug-late-failure-is-refused-test))
+  (testing "a LATE alpha DELETE success cannot navigate beta's reader home
+            (rf2-amhpk)"
+    (article-delete-cross-slug-late-success-is-refused-test))
+  (testing "…while a delete settled on its own slug still goes home — the
+            navigation control (rf2-amhpk)"
+    (article-delete-current-slug-still-navigates-home-test))
   (testing "on the CURRENT slug all three settles still do their ordinary job
             — the gates' non-vacuity control (rf2-amhpk)"
     (article-social-gates-are-not-vacuous-test)))


### PR DESCRIPTION
## What

`:article/delete-success` was the one settle in `examples/real-apps/realworld_http/comments.cljs` left outside the correlation gate. The first pass excluded it on the grounds that it writes no db — true, and beside the point. It **navigates**, and navigation is the active article's state, the most visible state it owns.

## Reproduced first, not pattern-matched

The bead is explicit that this must not be fixed on its resemblance to rf2-84iek. It was reproduced, by running the new test against unmodified source:

- Read `/article/alpha`, press Delete, hold the DELETE open.
- Walk to `/article/beta` before the server answers; beta loads and owns `[:article]`.
- Let alpha's DELETE succeed.

Observed: route id `:realworld/home`, route params `{}`. The reader is thrown to the home page and the route they chose is discarded. Three assertions red, every other assertion in the 55,172-assertion lane green — which is why the existing suite passed with this bug and the audit had to find it by hand.

## The fix

The DELETE's success target now carries the issuing slug, exactly as its failure target already did, and the handler asks the existing `reply-for-current-slug?` before dispatching the navigation. No request epoch, no cancellation scheme, no new abstraction.

## Does refusing strand anything? Checked, not assumed

The bead's description warns that rf2-84iek needed a gate **and** a reset, because `[:comment-form]` was a boot-time singleton that rode across the navigation still `:submitting`, so gating alone left beta's form permanently locked. Verified at source that the article delete is not in that position:

- `:article/delete` writes **no** `:db` at all — it fires the request and nothing else. There is no `:deleting` flag to get stuck in.
- The Delete button (`article-meta`) has no `:disabled` binding and no pending state.
- `[:article]` is rebuilt wholesale by `:article/load`'s request hat on a slug change.
- The server deletion succeeded regardless, so there is no retry to lose. Returning to alpha later fails and reloads like any other missing article.

So a gate alone is correct here, and the navigation control below pins that the gate is not vacuous.

## Tests

Both in `implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs`, in the existing `realworld-article-social-cross-slug` deftest, reusing the existing held-request harness:

- **`article-delete-cross-slug-late-success-is-refused-test`** — the refusal. Also carries the strand control (`beta-slice-is-rebuilt`) in the same shape the three sibling refusals use.
- **`article-delete-current-slug-still-navigates-home-test`** — the navigation control: a delete settled while its own slug is still on screen goes home as before.

Prose in both files updated: the correlation-gate roster in `comments.cljs` goes from nine members to ten, and `:article/delete-success` moves out of the NON-members note — which now states the real test (*produces no outcome the route owns*, not *writes no db*, since `:article/delete-success` satisfies the latter while very much needing the gate).

Out of scope and untouched: `:editor/delete-success` in `article_editor.cljs` is a different slice with its own `still-editing?` law; the bead names `:article/delete-success` only.

## Quality gates

| Gate | Result | Captured exit |
|---|---|---|
| `node scripts/compile-node-test.cjs node-test` (pre-fix, control) | Build completed, 1874 files, 0 warnings | `0` |
| `node out/node-test.js` (pre-fix, control) | 11152 tests / 55172 assertions, **3 failures**, 0 errors | `1` |
| `node scripts/compile-node-test.cjs node-test` (post-fix) | Build completed, 1874 files (5 recompiled), 0 warnings | `0` |
| `node out/node-test.js` (post-fix) | 11152 tests / 55172 assertions, **0 failures, 0 errors** | `0` |
| `node scripts/check-examples-compile.cjs` | all 56 swept builds compiled, zero warnings (`:examples/realworld` among them) | `0` |

Exit codes are the runner's own, captured with `echo $? > <file>` on the same command line as the redirect, then quoted from that file.

**The control is the pre-fix run**, which is stronger than a plant: the tests were written and run against unmodified source before the gate existed. Red under the control, all three in the new test:

- `the DELETE's SUCCESS target carries the slug it was issued on, not just its failure target` — actual `[:article/delete-success]`
- `a LATE alpha DELETE SUCCESS does not yank beta's reader home` — actual `:realworld/home`
- `…the reader's own newer route choice is the one that stands` — actual `{}`

Green under the control: everything else, all 55,169 remaining assertions, including the three db-write gates the audit calls correct (`follow-cross-slug-late-rollback`, `follow-cross-slug-late-sync`, `article-delete-cross-slug-late-failure`), their non-vacuity control, and `article-detail-delete-test`'s existing "a successful detail-page delete navigates home".

Both gates were verified to have read this branch's checkout: each prints `shadow-cljs - config: …/implementation/shadow-cljs.edn` under the worker worktree, and the post-fix compile recompiled 5 files, positive evidence the runtime observed the edit.

Gates not nominated, with reasons: no markdown, no `spec/`, no workflow files in the diff, so `check_doc_slugs.py` and `check_readme_links.py` have nothing in range; `mkdocs build --strict` cannot see either path (`docs_dir` is `docs`). No Playwright spec — examples are test-free by policy (rf2-8cevm) and real regression coverage lives in the CLJS suites, which is why the bead names `realworld_cljs_test.cljs`.

Closes rf2-amhpk.
