### PR TITLE
docs(machines): the query-API comment names rf.machines/machine-by-system-id (rf2-lzrza)

### DIFF
--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -164,10 +164,11 @@
 ;; Three thin lookup fns over the existing event registry and the
 ;; runtime-owned `[:rf.runtime/machines :system-ids]` reverse index — derived views, not a
 ;; new registry kind. `(rf.machines/machines)` filters event handlers whose
-;; registration metadata carries `:rf/machine? true`; `(rf.machines/machine-meta
-;; id)` returns the registered machine's spec map; `(rf/machine-by-
-;; system-id sid)` resolves the spawned-machine id currently bound to
-;; `sid` in the active frame's `[:rf.runtime/machines :system-ids]` reverse index.
+;; registration metadata carries `:rf/machine? true`;
+;; `(rf.machines/machine-meta id)` returns the registered machine's spec map;
+;; `(rf.machines/machine-by-system-id sid)` resolves the spawned-machine id
+;; currently bound to `sid` in the active frame's
+;; `[:rf.runtime/machines :system-ids]` reverse index.
 ;;
 ;; These query fns live on the public artefact surface (not a level
 ;; below) since they're how Spec 005 §Querying machines is reached.


### PR DESCRIPTION
Closes rf2-lzrza.

## What survived, and why nothing saw it

The prefix sweep (PR #8912) moved every published `rf/<helper>` machines
spelling to the canonical `rf.machines/` alias. One site survived, in
`implementation/machines/src/re_frame/machines.cljc`, because the token was
broken across a line **and** across a Clojure comment leader:

```
;; id)` returns the registered machine's spec map; `(rf/machine-by-
;; system-id sid)` resolves the spawned-machine id currently bound to
```

The literal on disk is `rf/machine-by-` + newline + `;; ` + `system-id`. No
line-oriented search can see it at all — not with a better pattern, because a
line is the wrong unit. The sweep's own whitespace-spanning census missed it
too, for the reason set out below.

Its two siblings in the same paragraph had already been corrected, so a reader
met three references to one namespace with one of them naming a namespace the
var is not on. `spec/api-manifest.edn` row 220 carries `machine-by-system-id`
on `re-frame.machines` with `:facade? false`, and `re-frame.core` re-exports no
such var — so the old spelling was wrong, not merely non-canonical.

## The change

Reflowed the query-API comment block so all three references read
`rf.machines/…` and none is split at a line boundary.
`(rf.machines/machine-meta id)` was already spelled correctly but was broken at
the same kind of boundary — that is the blind spot rather than the error, and
leaving it split would leave the next census the same hole to fall into.

Comment-only. No API, behaviour or code change.

## The census — the actual deliverable

A census that still cannot see this site proves nothing, so the instrument was
rebuilt and exercised against something it should find before any zero was
believed.

**Two passes, because neither result is a superset of the other.**

* **LINE** — each physical line searched on its own (what ripgrep sees).
* **FLAT** — per file, each line's comment leader is stripped (`;` `//` `#`
  `*` `>`, applied repeatedly so `> ;; ` nests), the lines are joined with a
  single space, and the pattern tolerates whitespace at the `/` and at **every**
  hyphen.

That last clause is the point. Stripping the leader and joining still leaves a
**space** between `by-` and `system-id`, so a flattened search for the fixed
literal `rf/machine-by-system-id` still reports a clean zero. The pattern is
therefore built from the var name with `\s*-\s*` at each hyphen rather than
being a fixed string. A line-end hyphen, a break at the `/`, and a break at a
non-final hyphen are all covered.

The class is the 23 vars read from `spec/api-manifest.edn` at the tip being
censused, not a hardcoded list.

**Two instrument faults were found and fixed by the control, not by inspection:**

1. The first draft's character class ended `…'-` and then had `:/` appended,
   turning `'-:` into a **range** (0x27–0x3A) that swallowed `(`, `)`, `,` and
   every digit. `(rf/machines)` was excluded by its own opening paren and the
   whole census read a clean zero — with the control reading zero too, which is
   the only reason it was caught.
2. The report **crashed mid-listing** on a non-cp1252 character, truncating the
   output and under-reporting.

**Control fixture** (outside the repo, never committed) carries six positive
shapes and four negatives. Both before and after the fix it reads: LINE 2 hits,
FLAT 6 hits, all four negatives correctly rejected — `:rf/machine?` (reserved
metadata key), `[:rf.runtime/machines …]`, the already-canonical spelling, and
`rf/machines-and-more`. Four of the six positives are visible **only** to the
flattened pass.

A loose variant that drops the `:` and `'` boundaries was also run, to prove
nothing hides behind them: it returns 71 flat hits, essentially all
`:rf/machines` / `:rf/machine-meta` **keyword** forms (reserved app-db slots and
metadata keys), plus one line-broken `[:rf/machines :login/flow …]` app-db path
in `tools/story/test/story_browser_scenarios.cjs`. None is a var reference, so
the strict boundary is doing real classification rather than hiding work.

### Before / after

| pass | before | after |
| --- | --- | --- |
| LINE-oriented | 3 | 3 |
| FLAT (leaders + newlines represented) | **4** | 3 |
| seen only by FLAT | `machines.cljc` `machine-by-system-id` | none |

The one hit the flattened pass could see and the line pass could not is exactly
the target site. After the fix both passes agree at 3, and those 3 are the
deliberate exclusions.

### Deliberate exclusions — re-derived, unchanged at 3

1. `implementation/scripts/api-manifest/test/re_frame/api_manifest/doc_api_check_test.clj:44`
   — live fixture in `live-manifest-var-resolves-anywhere`, asserting
   doc-api-check's cross-namespace bare-name latitude.
2. `implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_guide_check.clj:94`
   — the comment explaining that latitude and why `docs/core/api/**` is excluded.
3. `implementation/core/src/re_frame/core_machines.cljc:146` — prose describing
   the literal `:where` symbol the code really emits (`'rf/reg-machine*`, emitted
   at lines 137/139).

All three are genuine and were read, not assumed. Not touched by this PR;
`core_machines.cljc` in particular is left alone.

## Quality gates

| gate | result | captured exit |
| --- | --- | --- |
| `clojure -M:test` (`implementation/machines`), final base | 1233 tests / 4379 assertions, 0 failures, 0 errors | **0** |
| same, **sabotage** | 1 failure, same 1233/4379 — bounded, no cascade | **1** |
| `clj-kondo --lint` on the changed file, final base | 0 errors, 0 warnings | **0** |
| same, **sabotage** | `Unresolved symbol: this-var-does-not-exist` | **2** |
| census control fixture, final base | LINE 2 / FLAT 6, negatives rejected | 0 |
| census whole tree, final base | LINE 3 / FLAT 3, flat-only none | 0 |

Every exit code above is the runner's own, captured with the redirect and the
`echo $?` on one command line — not a harness report.

**Worktree-read proof: planted fault.** Neither gate prints its root, so the
proof is the red. The fault existed only in this checkout, so a run that had
wandered into a sibling's would have come back green. Both restores were
verified by **git blob hash** against the committed object (identical before and
after), not by reading a diff. The plant used a mid-line anchor and its match
count was read as exactly 1 before each run, so a CRLF-translated line ending
could not silently no-op it.

**Gates deliberately not nominated, having been checked rather than assumed:**

* `check_doc_slugs.py` / `check_readme_links.py` / `mkdocs build --strict` — the
  change is a comment in a `.cljc` file. No markdown.
* **doc-api-check and doc-guide-check do not cover this file.** Both resolve
  only `*.md` files (`markdown-files` / `require-markdown-files`) and neither
  ever opens a `.clj`/`.cljc`/`.cljs` source file. Worth stating because two of
  the three deliberate exclusions live inside those checkers, which makes it look
  as though they read this class of reference — they read it in markdown only.

### Coverage limit, stated plainly

**Nothing in this repo validates comment content in a `.cljc` file.** No gate
asserts that a comment names a resolvable var, which is precisely how this class
drifted far enough to need a sweep. The green suite says the change compiles,
not that it is right.

The corrected spelling was therefore **hand-checked**: `(ns re-frame.machines …)`
is the namespace; `machine-by-system-id` is defined on it; `spec/api-manifest.edn`
row 220 pins `re-frame.machines` / `machine-by-system-id` / `:facade? false`;
`spec/Conventions.md` line 205 pins `[re-frame.machines :as rf.machines]` as the
canonical alias; and `re-frame.core` carries no re-export of the var.

## Notes for the merge

The branch was rebased once mid-flight; a `fix(machines)` landed in the interval
and the gates were re-run on the final base — the counts moved 1226/4336 →
1233/4379, so the re-run measured a genuinely different tree rather than
reconfirming the old one. The merge-base diff (`origin/main...HEAD`) is one file,
5 insertions / 4 deletions, reverting nothing.
