### PR TITLE
ci(pair fixture): arm the shipped-preload test on its remaining local roots (rf2-f9f3p)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -667,8 +667,41 @@ else
     # exactly that trade ("when in doubt, over-classify"), and the alternative
     # — a 29th output existing only to split two fixture jobs apart — buys a
     # few runner-minutes for a permanent widening of the matrix.
+    #
+    # rf2-f9f3p — THE ROSTER IS THE UNION OF BOTH FIXTURES' CLASSPATHS, and
+    # completing the second half is this bead. rf2-bbe91 armed the Pair fixture
+    # for core and the Reagent adapter INCIDENTALLY, because the two fixtures
+    # share those two roots and share this one output. But
+    # `skills/re-frame2-pair/tests/fixture/deps.edn` resolves FIVE in-repo
+    # artefacts, not two — the shipped preload `:require`s `re-frame.epoch`,
+    # `re-frame.schemas` and `re-frame.machines` directly for its
+    # epoch-history/`get-path`/`orient`/list-machines surfaces, which the
+    # wad2fl front-porch shrink demoted off the `re-frame.core` facade — so
+    # three fifths of that job's own in-repo classpath still classified
+    # `skills_structural=false` (measured at rf2-bbe91's tip, for `src/*` and
+    # `deps.edn` alike, against `implementation/core/src/*` and
+    # `implementation/core/deps.edn` as passing controls). An owned-namespace
+    # API or behaviour change in any of the three could therefore break
+    # `re_frame2_pair.pure` or the runtime preload while the only job that
+    # compiles and tests that shipped source was skipped — and a skipped
+    # required job is an accepted result, so nothing went red.
+    #
+    # ONE DISPATCH FOR BOTH FIXTURES rather than a second `case` beside this
+    # one, because they gate the identical output: two rosters setting one
+    # variable is a distinction with no behavioural difference, and the union
+    # is what `skills_structural=true` actually means here. The three added
+    # roots also each already have an arm in the big `case` below (the
+    # per-feature fan-out), so the shadowing argument above applies to them
+    # unchanged — epoch keeps `mcp_conformance`/`mcp_live`, schemas keeps
+    # `template_expensive`, machines keeps the machines-viz and `playground`
+    # lanes. This dispatch only ever SETS the flag; it cannot narrow them.
+    #
+    # The over-fire trade is the same one, and no larger: ssr and hicasso
+    # over-fire `re-frame2-pair-fixture-pure`, epoch/schemas/machines over-fire
+    # `reagent-migration-fixture-cold-start`, and all seven over-fire the cheap
+    # Babashka `skills-structural` job. Still no 29th output.
     case "$file" in
-      implementation/core/src/*|implementation/core/deps.edn|implementation/ssr/src/*|implementation/ssr/deps.edn|implementation/hicasso/src/*|implementation/hicasso/deps.edn|implementation/adapters/reagent/src/*|implementation/adapters/reagent/deps.edn)
+      implementation/core/src/*|implementation/core/deps.edn|implementation/ssr/src/*|implementation/ssr/deps.edn|implementation/hicasso/src/*|implementation/hicasso/deps.edn|implementation/adapters/reagent/src/*|implementation/adapters/reagent/deps.edn|implementation/epoch/src/*|implementation/epoch/deps.edn|implementation/schemas/src/*|implementation/schemas/deps.edn|implementation/machines/src/*|implementation/machines/deps.edn)
         skills_structural=true
         ;;
     esac

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -2314,21 +2314,121 @@ for (const file of MIG23_FIXTURE_LOCAL_ROOTS) {
   });
 }
 
-// The negative half. The edge is the fixture's CLASSPATH, not "anything under
-// implementation/", so it must not become a default arm by drift. A `:local/root`
-// contributes the artefact's `:paths` plus its dependency declaration — an
-// artefact's own `test/` tree is not on the fixture's classpath — and the three
-// sibling per-feature artefacts are not on it at all.
+// rf2-f9f3p — the SECOND fixture's half of the same reverse edge.
+// `re-frame2-pair-fixture-pure` is gated solely on `skills_structural` too, so
+// rf2-bbe91 armed it INCIDENTALLY for the two roots the fixtures share (core
+// and the stock Reagent adapter). It shares only two:
+// `skills/re-frame2-pair/tests/fixture/deps.edn` resolves FIVE in-repo
+// artefacts, because the shipped preload `:require`s `re-frame.epoch`,
+// `re-frame.schemas` and `re-frame.machines` directly. Those three classified
+// `skills_structural=false` at rf2-bbe91's tip, for `src/*` and `deps.edn`
+// alike — so the one job that compiles and tests that shipped source was
+// accepted as SKIPPED on a change to three fifths of its own in-repo
+// classpath, and a skipped required job is an accepted result.
+//
+// THE ROSTER IS THE FIXTURE'S OWN `:deps` MAP, all five roots, both entry
+// shapes. The two already covered by rf2-bbe91 are pinned here as well rather
+// than assumed: their coverage is a side effect of the OTHER fixture's roster,
+// so a future narrowing of that roster would silently unarm this job, and
+// nothing else in this file would notice.
+//
+// EVERY PATH IS TRACKED, checked with `git ls-files` rather than transcribed —
+// the same trap rf2-bbe91's own note records, and it bites identically here:
+// these arms are pure path patterns, so a phantom file classifies exactly like
+// a real one and the assertion passes while pinning a route no diff can take.
+// The extensions are again the tell — the three added roots are `.cljc` and the
+// Reagent adapter is `.cljs`.
+const PAIR_FIXTURE_LOCAL_ROOTS = [
+  'implementation/core/src/re_frame/core.cljc',
+  'implementation/core/deps.edn',
+  'implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs',
+  'implementation/adapters/reagent/deps.edn',
+  'implementation/epoch/src/re_frame/epoch.cljc',
+  'implementation/epoch/deps.edn',
+  'implementation/schemas/src/re_frame/schemas.cljc',
+  'implementation/schemas/deps.edn',
+  'implementation/machines/src/re_frame/machines.cljc',
+  'implementation/machines/deps.edn',
+];
+for (const file of PAIR_FIXTURE_LOCAL_ROOTS) {
+  test(`${file} arms skills_structural — Pair fixture reverse edge (rf2-f9f3p)`, () => {
+    assert.equal(
+      classify(file).skills_structural,
+      'true',
+      `${file} is on the re-frame2-pair fixture's :local/root classpath; a change to it must ` +
+        'schedule re-frame2-pair-fixture-pure, the only job that compiles and tests the ' +
+        'shipped preload against the tree it ships beside',
+    );
+  });
+}
+
+// The dispatch only ever SETS `skills_structural`, so it cannot narrow the
+// three newly-armed artefacts' existing routing — each of which owns lanes the
+// other two do not. Pinned per artefact rather than over the intersection,
+// because the intersection is exactly what a refactor into an arm of the big
+// first-match `case` would leave standing while it dropped the rest.
+for (const [file, keys] of [
+  [
+    'implementation/epoch/src/re_frame/epoch.cljc',
+    ['implementation_jvm', 'cljs_node_test', 'cljs_browser', 'examples_compile', 'cljs_prod', 'bundle_isolation', 'mcp_conformance', 'mcp_live'],
+  ],
+  [
+    'implementation/schemas/src/re_frame/schemas.cljc',
+    ['implementation_jvm', 'cljs_node_test', 'cljs_browser', 'examples_compile', 'cljs_prod', 'bundle_isolation', 'template_expensive'],
+  ],
+  [
+    'implementation/machines/src/re_frame/machines.cljc',
+    ['implementation_jvm', 'cljs_node_test', 'cljs_browser', 'examples_compile', 'cljs_prod', 'bundle_isolation', 'tools_jvm_machines_viz', 'tools_cljs_machines_viz', 'playground'],
+  ],
+]) {
+  test(`the Pair reverse edge does not narrow ${file}'s production routing (rf2-f9f3p)`, () => {
+    const result = classify(file);
+    for (const key of keys) {
+      assert.equal(
+        result[key],
+        'true',
+        `${file} must retain ${key}; the Pair fixture reverse edge widens, it never narrows`,
+      );
+    }
+  });
+}
+
+test('re-frame2-pair-fixture-pure is job-level gated on skills_structural (rf2-f9f3p)', () => {
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 're-frame2-pair-fixture-pure');
+  assert.match(block, /needs: detect_changed_surfaces/);
+  assert.match(
+    block,
+    /if: needs\.detect_changed_surfaces\.outputs\.skills_structural == 'true'/,
+  );
+});
+
+// The negative half, now covering BOTH fixtures. The edge is the two fixtures'
+// CLASSPATHS, not "anything under implementation/", so it must not become a
+// default arm by drift. A `:local/root` contributes the artefact's `:paths`
+// plus its dependency declaration — an artefact's own `test/` tree is not on
+// either fixture's classpath — and the sibling per-feature artefacts are on
+// neither.
+//
+// rf2-f9f3p moved one entry: `implementation/schemas/src/re_frame/schemas.cljc`
+// stood here as a negative under rf2-bbe91 and is now a POSITIVE above, because
+// it IS on the Pair fixture's classpath even though it is not on MIG-23's. That
+// is the whole reason this pair of files is one-toucher — the roster and the
+// assertions that pin it cannot be true in separate commits. Its slot is taken
+// by `implementation/schemas/test/*`, which is the sharper boundary anyway: it
+// pins the `src/*`-plus-`deps.edn` scope on a newly-armed artefact, from the
+// side the new arms could most plausibly over-reach.
 for (const file of [
   'implementation/core/test/re_frame/adapter/routing_arity_cljs_test.cljc',
-  'implementation/schemas/src/re_frame/schemas.cljc',
+  'implementation/schemas/test/re_frame/late_bind_missing_test.clj',
+  'implementation/epoch/test/re_frame/epoch_attribution_test.clj',
   'implementation/adapters/uix/src/re_frame/adapter/uix.cljs',
+  'implementation/flows/src/re_frame/flows.cljc',
 ]) {
-  test(`${file} does NOT arm skills_structural (reverse edge stays scoped, rf2-bbe91)`, () => {
+  test(`${file} does NOT arm skills_structural (reverse edge stays scoped, rf2-bbe91 / rf2-f9f3p)`, () => {
     assert.equal(
       classify(file).skills_structural,
       'false',
-      `${file} is not on the MIG-23 fixture's :local/root classpath; it must not queue the ` +
+      `${file} is on neither fixture's :local/root classpath; it must not queue the ` +
         'skills_structural fixture jobs',
     );
   });

--- a/tools/story/test/story_browser_scenarios.cjs
+++ b/tools/story/test/story_browser_scenarios.cjs
@@ -1856,7 +1856,24 @@ module.exports = {
       // detail-source renderer plus the expected/actual fields. The
       // source-coord chip's open-in-editor button text reads "open"
       // alongside the file:line.
-      if (!/at\s+counter_with_stories\/stories\.cljs:\d+/.test(detailText)) {
+      //
+      // rf2-ak6re — match the classpath-relative TAIL, not the whole
+      // `:file`. This assertion originally pinned the leading edge of
+      // the path, which held only while Story's macro stamped the
+      // reader's `:file` verbatim. rf2-3xq1v routed
+      // `re-frame.story.macros/coords-form` through
+      // `re-frame.source-coords/coords-form`, which absolutises at
+      // macro-expansion time (rf2-wvsxg), so the renderer now emits
+      // `at <checkout>/tools/story/testbeds/counter_with_stories/
+      // stories.cljs:438` — an on-disk location whose prefix differs
+      // per machine. The tail is what carries the signal this
+      // scenario exists to check (the coord names the play's own
+      // source file, with a line), and it is stable across hosts;
+      // `[\\/]` accepts the Windows separator, and the leading `\S*`
+      // is optional so a host that cannot resolve a root (in-jar
+      // source, synthetic coord) still passes on the relative
+      // spelling that path ships verbatim.
+      if (!/\bat\s+\S*counter_with_stories[\\/]stories\.cljs:\d+/.test(detailText)) {
         throw new Error(
           `failing-play detail missing source-coord (at <file>:<line>); got: ${detailText.slice(0, 300)}`,
         );


### PR DESCRIPTION
## What

`re-frame2-pair-fixture-pure` is gated solely on `skills_structural`. rf2-bbe91 (PR #8903) armed that output for the four MIG-23 fixture roots, which incidentally armed the Pair fixture for the two roots the fixtures share — core and the stock Reagent adapter. The Pair fixture declares **five**: `skills/re-frame2-pair/tests/fixture/deps.edn` also resolves epoch, schemas and machines as `:local/root`, because the shipped preload `:require`s `re-frame.epoch`, `re-frame.schemas` and `re-frame.machines` directly for surfaces the wad2fl front-porch shrink demoted off the `re-frame.core` facade.

This extends the existing reverse-edge dispatch to the union of both fixtures' classpaths.

## The premise, measured at tip before the change

Probes run through the production classifier, with positive controls of the **same shape** beside the negatives:

| path | `skills_structural` before |
|---|---|
| `implementation/epoch/src/re_frame/epoch.cljc` | `false` |
| `implementation/epoch/deps.edn` | `false` |
| `implementation/schemas/src/re_frame/schemas.cljc` | `false` |
| `implementation/schemas/deps.edn` | `false` |
| `implementation/machines/src/re_frame/machines.cljc` | `false` |
| `implementation/machines/deps.edn` | `false` |
| **control** `implementation/core/src/re_frame/adapter/context.cljs` | `true` |
| **control** `implementation/core/deps.edn` | `true` |
| **control** `implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs` | `true` |
| **control** `implementation/adapters/reagent/deps.edn` | `true` |
| **control (negative)** `README.md` | `false` |

The controls matter because a classifier that never understood the question answers `false` in the same voice as one that considered the path and said no. Both entry shapes (`src/*` and `deps.edn`) are exercised in both directions.

So the one job that compiles and tests that shipped source was accepted as **skipped** on a change to three fifths of its own in-repo classpath — and a skipped required job is an accepted result, so nothing went red.

After the change, all ten Pair roots arm and every prior output is preserved: epoch keeps `mcp_conformance`/`mcp_live`, schemas keeps `template_expensive`, machines keeps `tools_jvm_machines_viz`/`tools_cljs_machines_viz`/`playground`.

## Shape

**One dispatch rather than a second `case` beside it.** The two fixtures gate the identical output, so two rosters setting one variable would be a distinction with no behavioural difference, and the union is what `skills_structural=true` actually means here. The dispatch only ever SETS the flag, so it cannot narrow the three added roots' existing per-feature routing — the same argument rf2-bbe91's own comment makes.

The over-fire trade is the one rf2-bbe91 already chose and no wider: ssr/hicasso over-fire the Pair fixture, epoch/schemas/machines over-fire the MIG-23 fixture, and all seven over-fire the cheap Babashka `skills-structural` job. **No new job, fixture, output or dependency-graph mechanism.**

## Why both halves are one commit

The mirror pinned `implementation/schemas/src/re_frame/schemas.cljc` as a **negative** under the MIG-23 roster. That path is now a **positive** under the Pair one, so the roster and the assertions that pin it cannot be true in separate commits. Its slot goes to `implementation/schemas/test/*`, which is the sharper boundary anyway: it pins the `src/*`-plus-`deps.edn` scope on a newly-armed artefact, from the side the new arms could most plausibly over-reach.

Mirror additions: the ten-path five-root positive roster (every path checked with `git ls-files`, not transcribed — these arms are pure path patterns, so a phantom path classifies exactly like a real one and would pin a route no diff can take); three per-artefact non-narrowing tests; a job-level gating pin for `re-frame2-pair-fixture-pure`; and the negative half widened to five paths covering both fixtures.

## Gate

`implementation/scripts/_changed-surfaces.test.cjs`, run directly with node on the final rebased base: **captured exit 0, 330 tests passed.**

Tree-read proof by planted fault: replacing `implementation/machines/src/*` with a non-matching pattern in the arm this PR edits produced **captured exit 1** with exactly one failure, `implementation/machines/src/re_frame/machines.cljc arms skills_structural — Pair fixture reverse edge (rf2-f9f3p)` — a test that exists only on this branch, so a run against any other checkout would have come back green. Restore verified by comparing the git blob hash against the committed object, not by reading a diff.

No markdown under the doc/README link-gate rosters, so those gates are not nominated. `.github/**` is outside `docs_dir` entirely.

## What this PR's own CI does and does not prove

This diff touches `.github/scripts/report-changed-surfaces.sh`, which hits the `mark_all` arm — so `re-frame2-pair-fixture-pure` will run here, but because *everything* is armed, not because of the new edges. The edges themselves are proven by the mirror, which spawns the real script bytes. The end-to-end confirmation is the next PR that touches only `implementation/{epoch,schemas,machines}/src/**` or their `deps.edn`: that job should now be scheduled where it would previously have been skipped.

## Noted, not changed

`re-frame2-pair-fixture-pure`'s cache key hashes only three of the fixture's five `deps.edn` files (core, reagent, epoch — not schemas or machines), so a schemas/machines dependency bump restores a stale classpath cache. That is a `.github/workflows/test.yml` edit, out of this bead's fence and held by another worker; flagged for the mayor rather than touched here.

Closes rf2-f9f3p.


---

## Second commit: the Story red this PR exposed (rf2-ak6re)

Arming everything is the point of the `mark_all` arm, and on this PR it armed a gate that almost never runs: `Run the FULL Story feature-load gate (direct-runner change, rf2-65ajl)`, which arms only on the five paths in `is_story_full_gate_path`. It came back red. PR #8943, whose diff is disjoint from this one and equally Story-free, went red on the identical step — so the defect belongs to neither PR, and this branch only made it visible.

**Root cause.** `tools/story/test/story_browser_scenarios.cjs` asserted the failing-play detail's source-coord by matching it from its LEADING edge, `at counter_with_stories/stories.cljs:<line>`. That spelling held only while Story's macro emitted the reader's classpath-relative `:file` verbatim. `e1cbd089c4` (rf2-3xq1v, merged 2026-09-01 21:42 AUSEST) routed `re-frame.story.macros/coords-form` through `re-frame.source-coords/coords-form`, which absolutises at macro-expansion time (rf2-wvsxg), so the detail-source renderer now prints an on-disk path whose prefix is per-machine. The coord is present and correct; only its prefix moved. rf2-3xq1v updated the JVM and CLJS pins it knew about and could not reach this one, because nothing ran it.

**Fix.** Match the classpath-relative TAIL — `/\bat\s+\S*counter_with_stories[\/]stories\.cljs:\d+/` — which is what carries the signal the scenario checks (the coord names the play's own source file, with a line) and is stable across hosts. `[\/]` accepts the Windows separator; the leading `\S*` is optional so a host that cannot resolve a root still passes on the relative spelling. Exercised against controls, not only the target: MATCH on the CI absolute, the Windows absolute in both separators, and the legacy relative spelling; NO MATCH on a detail with no coord, one with no line number, and one naming the wrong file. The absoluteness of the coord stays pinned by the JVM/CLJS tests rf2-3xq1v added.

**How long red — bounded.** The step last passed on PR #8794 (`660423bb74`), 2026-08-31 00:42 UTC, the most recent prior PR to touch any arming path. One PR's worth of rot, not a rotten lane.

**Gate.** `npm run test:story-feature-load` in this worktree, against its own `npm ci` install (no shared `node_modules` link): **captured exit 1 before the fix, captured exit 0 after** — same command, same checkout, that one file the only change between them. The red run named this checkout's own paths in both the coord and the stack frame, which is the tree-read proof; the green run is the same command one commit later.

**The classifier is not narrowed.** `git diff origin/main...HEAD` on `report-changed-surfaces.sh` removes one line and replaces it with a strict superset; #8903's four MIG-23 roots survive verbatim. Greening by re-hiding the Story red was explicitly not done.

**Recorded, not fixed.** rf2-3xq1v's three files arm neither Story browser output — not just the full gate. `is_story_xray_runtime_path` guards `tools/{story,xray}/src/**` on extension and so excludes `.clj`, but its two sibling predicates both carry a named `macros.clj` exception (rf2-eyyd2, whose comment says "Same reasoning arms it on the browser predicate below"); the third did not get it. Measured on `origin/main`'s classifier as well as this branch's, with controls in both directions. Completing that is a cost decision on the gate matrix and is left on rf2-ak6re rather than taken here.
