### PR TITLE
fix(machines): bind the SSR hydration reconcile to one frame incarnation (rf2-jqvgp)

### DIFF
--- a/implementation/machines/src/re_frame/machines/hydrate.cljc
+++ b/implementation/machines/src/re_frame/machines/hydrate.cljc
@@ -274,25 +274,54 @@
   epoch restore keeps its opposite contract — `:machines/on-frame-restored!`
   cancels and never re-arms, and shares no callback with this seam.
 
+  ## One incarnation for the whole reconcile
+
+  Both phases emit callback-bearing traces —
+  `:rf.machine.timer/cancelled` in phase 1 and again from each arm's
+  leading `:on-supersede` in phase 2 — and a listener on either can
+  `destroy-frame!` this frame and publish a same-id successor B. The
+  declarations being reconciled are A's: they were enumerated from the
+  runtime-db A held. Installing them into B would be host work derived
+  from a frame that no longer exists, which is the same class of leak the
+  cancel half exists to close, arriving from the other direction.
+
+  So the reconcile captures the owning incarnation ONCE, before either
+  phase, and every callback-bearing step is fenced by that ONE predicate
+  (rf2-jqvgp): the cancel batch short-circuits on it, the arm loop
+  rechecks it before each declaration, and each arm carries it down into
+  `schedule-after-timer!` in place of a fresh capture. Per-step capture
+  is what fails here, and it fails silently: each step alone is correct
+  about the owner it captured, and B — a live frame with the right id —
+  accepts the work without complaint. The loop is explicit rather than a
+  `doseq` for exactly that recheck.
+
   Returns nil; the only observables are the timer table, one
   `:rf.machine.timer/scheduled` trace per armed declaration, and one
   `:rf.machine.timer/cancelled` trace per released one."
   [frame-id]
   (when (and frame-id
              (not= :server (or (:platform (frame/frame-meta frame-id)) :client)))
-    (let [snapshots (get-in (frame/frame-runtime-db-value frame-id)
-                            (paths/snapshot-path))
-          live      (live-declarations snapshots)]
+    ;; Captured BEFORE anything callback-bearing runs, so it names the
+    ;; incarnation whose runtime-db the declarations below are read from.
+    (let [owner-gone? (timer/successor-published?-fn frame-id)
+          snapshots   (get-in (frame/frame-runtime-db-value frame-id)
+                              (paths/snapshot-path))
+          live        (live-declarations snapshots)]
       ;; PHASE 1 — release the host work the replacement snapshots dropped.
       ;; Before the arm, so a declaration that survives is superseded by its
       ;; own re-arm rather than cancelled and re-created.
       (timer/cancel-timers-absent-from!
         frame-id
         (into #{} (map (juxt :actor-id :invoke-id :delay-key)) live)
-        (set (keys snapshots)))
-      ;; PHASE 2 — arm / supersede the live set.
-      (doseq [decl live]
-        (timer/rearm-hydrated-after-timer!
-          frame-id (:actor-id decl) (:invoke-id decl) (:state decl)
-          (:delay-key decl) (:epoch decl) (:snapshot decl)))))
+        (set (keys snapshots))
+        owner-gone?)
+      ;; PHASE 2 — arm / supersede the live set, while the frame is still the
+      ;; one these declarations were enumerated from.
+      (loop [decls live]
+        (when (and (seq decls) (not (owner-gone?)))
+          (let [decl (first decls)]
+            (timer/rearm-hydrated-after-timer!
+              frame-id (:actor-id decl) (:invoke-id decl) (:state decl)
+              (:delay-key decl) (:epoch decl) (:snapshot decl) owner-gone?))
+          (recur (rest decls))))))
   nil)

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -307,7 +307,7 @@
                    (some? sub-vec)      (assoc :rf.sub/id      (first sub-vec)
                                                :rf.sub/query-v (vec sub-vec))))))
 
-(defn- successor-published?-fn
+(defn successor-published?-fn
   "Build the same-id-successor detection predicate for `frame-id`, captured at
   the cancellation entry BEFORE the callback-bearing `:rf.machine.timer/cancelled`
   trace (rf2-rbxdxa). Returns a 0-arity predicate true once a `destroy-frame!` +
@@ -316,6 +316,16 @@
   incarnation. When the frame is absent at capture (nil token) the predicate is
   `(constantly false)`, so an ordinary cancellation with no successor releases its
   shared `(frame,query-v)` subscription ref fully.
+
+  PUBLIC because one batch spans two namespaces (rf2-jqvgp). Every other
+  multi-step timer operation both captures and consumes its owner inside this
+  file, but the SSR hydration reconcile's two phases are driven from
+  `re-frame.machines.hydrate/rearm-after-timers!` — cancel here, arm here, one
+  enumeration there. That caller captures ONCE with this fn and threads the
+  result into `cancel-timers-absent-from!` and every
+  `rearm-hydrated-after-timer!`, so the whole reconcile is bound to the
+  incarnation that owned the frame when it began rather than to a fresh capture
+  per phase and per iteration.
 
   Precise BY CONSTRUCTION: `frame-incarnation-token` mints a DISTINCT token per
   construction, so the predicate flips only on a genuine A→B incarnation swap,
@@ -488,14 +498,23 @@
   resolution / slot reservation / host arm, so a superseding reschedule installs
   NO A-derived host work (or subscription ref-count) into successor B. An INITIAL
   schedule supersedes an empty slot (no trace, no callback), so the recheck is a
-  no-op pass-through and the arm proceeds normally."
+  no-op pass-through and the arm proceeds normally.
+
+  rf2-jqvgp — an `:owner-gone?` option lets a MULTI-ARM caller supply the
+  incarnation it captured at batch entry instead of this fn capturing a fresh
+  one. A fresh capture is right for a standalone arm, but wrong inside a batch:
+  if an earlier step's cancellation already destroyed A and published same-id B,
+  a re-capture names B as the owner and the A-derived arm proceeds into it. The
+  SSR hydration reconcile is the one such caller."
   [frame-id parent-id invoke-id state delay-key epoch server? snapshot
-   {:keys [emit-scheduled-trace?]}]
+   {:keys [emit-scheduled-trace? owner-gone?]}]
   (let [delay-source (transition/classify-delay-source delay-key)
         k            (after-timer-key parent-id invoke-id delay-key)
         ;; rf2-ijlhj — the owning incarnation, captured BEFORE the callback-bearing
         ;; `:on-supersede` cancel and rechecked before the durable arm below.
-        owner-gone?  (successor-published?-fn frame-id)
+        ;; rf2-jqvgp — a batch caller's own capture wins, so every arm in one
+        ;; batch is fenced by the incarnation that owned the frame at batch entry.
+        owner-gone?  (or owner-gone? (successor-published?-fn frame-id))
         ;; A region `:after`'s `invoke-id` is region-PREFIXED
         ;; (`prefix-region-invoke-id` prepends the region name). Record that
         ;; region name in the entry so `emit-cancelled!` can strip it before
@@ -795,10 +814,19 @@
   (Spec 011 §`:after` is no-op under SSR), and the caller has already
   refused a `:server` frame, so `server?` is passed `false`. Idempotent
   through the ordinary timer-table key — a second hydration supersedes
-  the first arm rather than duplicating it."
-  [frame-id parent-id invoke-id state delay-key epoch snapshot]
+  the first arm rather than duplicating it.
+
+  rf2-jqvgp — `owner-gone?` is the reconcile's ONE captured incarnation,
+  threaded down instead of re-captured here. Each arm's leading
+  `:on-supersede` cancel is callback-bearing, so arm N can be the step that
+  destroys A and publishes same-id B; a re-capture at arm N+1 would name B the
+  owner and install an A-derived timer into it. The caller rechecks the same
+  predicate between iterations, so a lost incarnation stops the whole arm phase
+  rather than only the arm that lost it."
+  [frame-id parent-id invoke-id state delay-key epoch snapshot owner-gone?]
   (schedule-after-timer! frame-id parent-id invoke-id state delay-key epoch
-                         false snapshot {:emit-scheduled-trace? true})
+                         false snapshot {:emit-scheduled-trace? true
+                                         :owner-gone?           owner-gone?})
   nil)
 
 (defn cancel-timers-absent-from!
@@ -839,13 +867,19 @@
   the `[k entry]` pairs, cancels each by its snapshotted attempt token
   (`cancel-snapshotted-entry!`, never re-reading the current occupant), and
   short-circuits once a callback-published same-id successor B has replaced
-  the incarnation captured at entry."
-  [frame-id live-decls present-actors]
-  (let [live        (into #{}
-                          (map (fn [[parent-id invoke-id delay-key]]
-                                 (after-timer-key parent-id invoke-id delay-key)))
-                          live-decls)
-        owner-gone? (successor-published?-fn frame-id)]
+  the incarnation captured at entry.
+
+  rf2-jqvgp — that incarnation is the CALLER'S, passed in rather than captured
+  here, because this batch is only the first half of one operation. Capturing
+  locally left the fence's scope equal to this loop: the caller's arm phase then
+  ran unfenced against whatever incarnation the last cancellation had left
+  behind. `owner-gone?` is now the same predicate the arm phase rechecks, so
+  cancel and arm are bound to one incarnation."
+  [frame-id live-decls present-actors owner-gone?]
+  (let [live (into #{}
+                   (map (fn [[parent-id invoke-id delay-key]]
+                          (after-timer-key parent-id invoke-id delay-key)))
+                   live-decls)]
     (loop [pairs (into []
                        (remove (fn [[k _]] (contains? live k)))
                        (get @after-timers frame-id))]

--- a/implementation/machines/test/re_frame/machine_hydration_reconcile_incarnation_fence_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_hydration_reconcile_incarnation_fence_cljs_test.cljc
@@ -1,0 +1,323 @@
+(ns re-frame.machine-hydration-reconcile-incarnation-fence-cljs-test
+  "rf2-jqvgp (audit of PR #8930) — the SSR hydration reconcile is bound to ONE
+  frame incarnation, across BOTH phases and EVERY iteration.
+
+  `machine_after_hydration_reconcile_cljs_test` pins the reconcile's shape:
+  the cancel half releases what the replacement snapshots dropped, the arm half
+  arms what they keep. Every case it drives runs to completion on a frame that
+  stays put, so the one thing it cannot see is the frame moving underneath the
+  reconcile.
+
+  ## The gap
+
+  Both phases emit CALLBACK-BEARING traces. Phase 1 emits one
+  `:rf.machine.timer/cancelled` per released entry; phase 2 emits another from
+  each arm's leading `:on-supersede` whenever it supersedes a live entry. A
+  listener on either can `destroy-frame!` this frame and publish a same-id
+  successor B — the very sequence `machine_timer_incarnation_fence_cljs_test`
+  pins for the cancellation batches (rf2-ijlhj).
+
+  The declarations being reconciled are A's: they were enumerated once, from
+  the runtime-db A held. Each individual step was already fenced — the cancel
+  batch short-circuits on the owner it captured, and each arm rechecks the
+  owner IT captured before touching anything durable — but nothing bound the
+  two phases, or successive iterations, to the SAME owner:
+
+    - CANCEL → ARM. `cancel-timers-absent-from!` captured its guard inside its
+      own loop and returned nil. A `:cancelled` listener that replaced A with B
+      stopped that loop and nothing else; the caller then walked the old live
+      vector regardless, and each arm captured B as its current owner and
+      installed A-derived work into it.
+    - ARM → ARM. The first live declaration's `:on-supersede` can publish B.
+      That arm aborts correctly on its own captured owner — and the NEXT
+      iteration captures B and arms another A-derived declaration into it.
+
+  The failure is silent by construction: every step is right about the owner it
+  captured, and B is a live frame under the right id, so it accepts the timer,
+  the watcher, the subscription ref-count and the `/scheduled` trace without
+  complaint.
+
+  ## Shape of the controls
+
+  Two mutation teeth, one per direction, each publishing same-id B from the
+  FIRST callback-bearing trace of its phase — then four readings of B: its
+  timer table, the `/scheduled` trace stream, the subscription ref-count, and
+  whether a change in the delay's value reaches a surviving watcher. A table
+  check alone would miss the last two.
+
+  The third test is the control the fence must not break: with no successor
+  published, a multi-live reconcile arms every declaration, so the loop that
+  replaced the `doseq` still runs to completion.
+
+  Both hosts: a `.cljc` named `*-cljs-test`, so it runs under `clojure -M:test`
+  from `implementation/machines` (JVM) and under the node runner
+  (`npm run test:cljs`). Deterministic and single-threaded on both — B is
+  published on the cancellation callback's own stack."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            ;; Loading `re-frame.machines` installs the artefact's late-bind
+            ;; hooks + reserved fxs; under a single-ns run nothing else does.
+            [re-frame.machines]
+            [re-frame.machines.hydrate :as m-hydrate]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines.timer :as timer]
+            [re-frame.subs :as subs]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  mtest/trace-capture-fixture)
+
+;; ---------------------------------------------------------------------------
+;; Fixtures
+;; ---------------------------------------------------------------------------
+
+(def ^:private frame-counter (atom 0))
+
+(defn- fresh-frame!
+  "A frame of the given platform under an id no other test in this shared
+  process has used. `make-frame` opts are FLAT — a nested `{:config {…}}`
+  would store `:config {:config {…}}` and the platform would silently read
+  as the `:client` default."
+  [platform]
+  (let [fid (keyword "rf.hydfence" (str (name platform) (swap! frame-counter inc)))]
+    (rf/make-frame {:id fid :platform platform})
+    fid))
+
+(defn- inner
+  "`frame-id`'s inner `:after` timer table, or `{}` when it holds none."
+  [frame-id]
+  (get @timer/after-timers frame-id {}))
+
+(defn- server-runtime-db
+  "Run every `[machine-id events]` pair on ONE real SERVER frame, assert it
+  armed no host timer, and return the resulting runtime-db value — a genuine
+  server-produced hydration slice rather than a literal, and one holding as
+  many actors as the caller asked for."
+  [runs]
+  (let [sfid (fresh-frame! :server)]
+    (doseq [[machine-id events] runs
+            e                   events]
+      (rf/dispatch-sync [machine-id e] {:frame sfid}))
+    (is (empty? (inner sfid))
+        "precondition: the SERVER armed no `:after` host timer")
+    (frame/frame-runtime-db-value sfid)))
+
+(defn- install!
+  "Replace `frame-id`'s runtime-db with `runtime-db` and run the machines
+  hydration seam — what `:rf/hydrate` does once its runtime-db effect has
+  committed."
+  [frame-id runtime-db]
+  (frame/replace-runtime-db! frame-id runtime-db)
+  (m-hydrate/rearm-after-timers! frame-id))
+
+(defn- republish-frame-once!
+  "Register a `:rf.machine.timer/cancelled` listener under `listener-id` that,
+  on the FIRST cancellation only, destroys `frame-id` and publishes a same-id
+  successor B — the audit's mutation tooth, on the trace's own stack.
+
+  `fired?` records that the seam was actually exercised (a test whose tooth
+  never bit would pass on the broken code); `token-b` receives B's incarnation
+  token so the test can prove B is a genuinely distinct incarnation rather than
+  the same frame under a new name."
+  [listener-id frame-id fired? token-b]
+  (trace-tooling/register-listener!
+    listener-id
+    (fn [ev]
+      (when (and (= :rf.machine.timer/cancelled (:operation ev))
+                 (compare-and-set! fired? false true))
+        (frame/destroy-frame! frame-id)
+        (rf/make-frame {:id frame-id :platform :client})
+        (reset! token-b (frame/frame-incarnation-token frame-id))))))
+
+(defn- assert-successor-took-no-a-work!
+  "The four readings of successor B. A dropped table entry is the obvious one;
+  the other three are what a table check alone cannot see."
+  [frame-id reaction subscribes]
+  (is (empty? (inner frame-id))
+      (str "successor B holds NO timer. Under a per-step capture the arm phase "
+           "reads B as its current owner and installs A-derived host work into "
+           "a frame that never enumerated it."))
+  (is (empty? (mtest/events-of :rf.machine.timer/scheduled))
+      (str "and no `:rf.machine.timer/scheduled` row was emitted for B — a "
+           "hydrated-timer trace naming a frame that hydrated nothing"))
+  (is (zero? @subscribes)
+      (str "and no `(frame, query-v)` subscription hold was taken out in B's "
+           "name — the ref-count an A-derived arm bumps is B's to release"))
+  ;; The watcher is the half a table read cannot reach: an attached one
+  ;; re-enters the timer machinery on the next value change.
+  (mtest/reset-captured!)
+  (reset! reaction 9000)
+  (is (empty? (mtest/events-of :rf.machine.timer/scheduled))
+      "a change in the delay's value re-resolves nothing in B")
+  (is (empty? (mtest/events-of :rf.machine.timer/cancelled))
+      (str "and reaches NOTHING at all — an A-derived arm would have left its "
+           "re-resolution watcher attached to the reaction here")))
+
+;; ---------------------------------------------------------------------------
+;; Machines under test
+;; ---------------------------------------------------------------------------
+
+(def ^:private dyn-machine
+  "A single SUBSCRIPTION-vector `:after`, so an arm into the successor takes a
+  reaction, a change-watcher and a subscription ref-count with it rather than
+  just a bare host handle."
+  {:initial :idle
+   :data    {}
+   :states  {:idle    {:on {:go :waiting}}
+             :waiting {:after {[:hydfence/dyn] {:target :timeout}}}
+             :timeout {}}})
+
+(def ^:private literal-machine
+  "The actor the replacement snapshots DROP — a literal delay, because its only
+  job is to give phase 1 exactly one cancellation to fire the tooth from."
+  {:initial :idle
+   :data    {}
+   :states  {:idle    {:on {:go :waiting}}
+             :waiting {:after {5000 {:target :timeout}}}
+             :timeout {}}})
+
+(def ^:private two-delay-machine
+  "MULTI-LIVE: one active node bearing TWO `:after` declarations, so the arm
+  phase has a second iteration for the first arm's `:on-supersede` callback to
+  land in front of."
+  {:initial :idle
+   :data    {}
+   :states  {:idle      {:on {:go :waiting}}
+             :waiting   {:after {[:hydfence/dyn-a] {:target :timeout}
+                                 [:hydfence/dyn-b] {:target :elsewhere}}}
+             :timeout   {}
+             :elsewhere {}}})
+
+;; ---------------------------------------------------------------------------
+;; Tooth 1 — CANCEL → ARM: a phase-1 cancellation republishes the frame
+;; ---------------------------------------------------------------------------
+
+(deftest a-cancel-phase-callback-that-republishes-the-frame-arms-nothing-into-b
+  (testing "MIXED retained/dropped: the cancellation of the dropped actor
+            destroys frame A and publishes same-id B, and the retained
+            declaration — enumerated from A's runtime-db — must not be armed
+            into B"
+    (rf/reg-machine :hydfence/kept dyn-machine)
+    (rf/reg-machine :hydfence/gone literal-machine)
+    (let [reaction   (atom 2500)
+          subscribes (atom 0)
+          fired?     (atom false)
+          token-b    (atom nil)]
+      (with-redefs [subs/subscribe            (fn ([_q] (swap! subscribes inc) reaction)
+                                                ([_q _o] (swap! subscribes inc) reaction))
+                    subs/unsubscribe          (fn ([_q] nil) ([_f _q] nil))
+                    interop/schedule-after!   (fn [_thunk _ms] ::handle)
+                    interop/cancel-scheduled! (fn [_h] nil)]
+        (let [rt-both (server-runtime-db [[:hydfence/kept [[:go]]]
+                                          [:hydfence/gone [[:go]]]])
+              rt-kept (update-in rt-both [:rf.runtime/machines :snapshots]
+                                 dissoc :hydfence/gone)
+              cfid    (fresh-frame! :client)]
+          (is (some? (get-in rt-kept [:rf.runtime/machines :snapshots :hydfence/kept]))
+              "precondition: the replacement RETAINS one live declaration")
+          (is (nil? (get-in rt-kept [:rf.runtime/machines :snapshots :hydfence/gone]))
+              "precondition: and DROPS the other actor, so phase 1 has exactly
+               one entry to cancel")
+
+          (install! cfid rt-both)
+          (is (= 2 (count (inner cfid)))
+              "precondition: both actors' timers are armed under incarnation A")
+
+          (let [token-a (frame/frame-incarnation-token cfid)]
+            (reset! subscribes 0)
+            (mtest/reset-captured!)
+            (republish-frame-once! ::cancel-phase cfid fired? token-b)
+            (try
+              (install! cfid rt-kept)
+              (finally (trace-tooling/unregister-listener! ::cancel-phase)))
+
+            (is (true? @fired?)
+                "the phase-1 cancellation's listener ran (the seam is exercised)")
+            (is (some? @token-b) "same-id successor B is live after the swap")
+            (is (not (identical? token-a @token-b))
+                "and B is a DISTINCT incarnation from A")
+            (assert-successor-took-no-a-work! cfid reaction subscribes)))))))
+
+;; ---------------------------------------------------------------------------
+;; Tooth 2 — ARM → ARM: the first arm's own supersede republishes the frame
+;; ---------------------------------------------------------------------------
+
+(deftest an-arm-phase-supersede-that-republishes-the-frame-stops-the-later-arms
+  (testing "MULTI-LIVE: an identical re-hydration cancels nothing in phase 1,
+            so the first callback-bearing trace is arm 1's own
+            `:on-supersede`. That arm aborts on its own guard — and the arm
+            AFTER it must not resume against the successor"
+    (rf/reg-machine :hydfence/multi two-delay-machine)
+    (let [reaction   (atom 2500)
+          subscribes (atom 0)
+          fired?     (atom false)
+          token-b    (atom nil)]
+      (with-redefs [subs/subscribe            (fn ([_q] (swap! subscribes inc) reaction)
+                                                ([_q _o] (swap! subscribes inc) reaction))
+                    subs/unsubscribe          (fn ([_q] nil) ([_f _q] nil))
+                    interop/schedule-after!   (fn [_thunk _ms] ::handle)
+                    interop/cancel-scheduled! (fn [_h] nil)]
+        (let [rt   (server-runtime-db [[:hydfence/multi [[:go]]]])
+              cfid (fresh-frame! :client)]
+          (install! cfid rt)
+          (is (= 2 (count (inner cfid)))
+              "precondition: BOTH live declarations are armed, so both arms of
+               the re-hydration supersede a LIVE entry and are callback-bearing")
+
+          (let [token-a (frame/frame-incarnation-token cfid)]
+            (reset! subscribes 0)
+            (mtest/reset-captured!)
+            (republish-frame-once! ::arm-phase cfid fired? token-b)
+            (try
+              (install! cfid rt)
+              (finally (trace-tooling/unregister-listener! ::arm-phase)))
+
+            (is (true? @fired?)
+                "arm 1's `:on-supersede` fired and swapped A→B (seam exercised)")
+            (is (some? @token-b) "same-id successor B is live after the swap")
+            (is (not (identical? token-a @token-b))
+                "and B is a DISTINCT incarnation from A")
+            (assert-successor-took-no-a-work! cfid reaction subscribes)))))))
+
+;; ---------------------------------------------------------------------------
+;; Control — the fence is scoped strictly to owner LOSS
+;; ---------------------------------------------------------------------------
+
+(deftest a-live-owner-reconcile-arms-every-live-declaration
+  (testing "with no successor published, a multi-live reconcile still walks the
+            whole live set — the recheck must not truncate an ordinary
+            hydration the way the `doseq` it replaced never could"
+    (rf/reg-machine :hydfence/live two-delay-machine)
+    (let [reaction   (atom 2500)
+          subscribes (atom 0)]
+      (with-redefs [subs/subscribe            (fn ([_q] (swap! subscribes inc) reaction)
+                                                ([_q _o] (swap! subscribes inc) reaction))
+                    subs/unsubscribe          (fn ([_q] nil) ([_f _q] nil))
+                    interop/schedule-after!   (fn [_thunk _ms] ::handle)
+                    interop/cancel-scheduled! (fn [_h] nil)]
+        (let [rt   (server-runtime-db [[:hydfence/live [[:go]]]])
+              cfid (fresh-frame! :client)]
+          (mtest/reset-captured!)
+          (install! cfid rt)
+          (is (= 2 (count (inner cfid)))
+              "both declarations armed on the first hydration")
+          (is (= 2 (count (mtest/events-of :rf.machine.timer/scheduled)))
+              "one `/scheduled` row apiece")
+
+          (mtest/reset-captured!)
+          (install! cfid rt)
+          (is (= 2 (count (inner cfid)))
+              "and still exactly two handles after an identical re-hydration —
+               each live declaration superseded in place, neither truncated")
+          (is (= 2 (count (mtest/events-of :rf.machine.timer/scheduled)))
+              "both arms ran")
+          (is (= [:on-supersede :on-supersede]
+                 (mapv #(:reason (:tags %))
+                       (mtest/events-of :rf.machine.timer/cancelled)))
+              (str "and each was the ordinary same-key supersede — an arm loop "
+                   "that stopped early would leave the second declaration's "
+                   "prior handle uncancelled and unre-armed")))))))


### PR DESCRIPTION
Second pass on rf2-jqvgp, audit-reopened against its own merged PR #8930.

## What the audit found, verified at source before building

PR #8930 made hydration RECONCILE the host `:after` timer table rather than
merely add to it. Both halves of the reconcile were correct; neither was bound
to a frame incarnation as a batch.

- `hydrate/rearm-after-timers!` computed frame A's live declarations, then
  called `timer/cancel-timers-absent-from!`, which captured its incarnation
  guard **inside its own loop** and returned `nil`. A
  `:rf.machine.timer/cancelled` listener that destroys A and publishes a
  same-id successor B stops that loop — and nothing else. The caller then
  walked the old, A-derived live vector unconditionally, and
  `rearm-hydrated-after-timer!` → `schedule-after-timer!` captured **B** as its
  current owner and installed A-derived timer work into it.
- The same gap ran across the arm loop. The first live declaration's leading
  `:on-supersede` is callback-bearing whenever it supersedes a live entry; its
  own per-entry guard aborts that arm correctly, but the next iteration
  captured B and armed another A declaration into it.

The entry-level token and incarnation fences (rf2-ijlhj / rf2-rbxdxa) are
sound. The batch owner was not threaded across phases or iterations. That was
the whole defect, and it fails silently: every step is right about the owner it
captured, and B is a live frame under the right id, so it accepts the timer,
the watcher, the subscription ref-count and the `/scheduled` trace without
complaint.

## The repair — threading, not a new mechanism

`rearm-after-timers!` captures the owning incarnation **once**, before either
phase, and every callback-bearing step is fenced by that one predicate:

1. `cancel-timers-absent-from!` takes `owner-gone?` as an argument instead of
   capturing locally, so the cancel batch's short-circuit and the arm phase
   share one owner.
2. The arm phase is an explicit `loop` rather than a `doseq`, rechecking
   `owner-gone?` before each declaration.
3. `rearm-hydrated-after-timer!` carries that predicate down into
   `schedule-after-timer!` through a new `:owner-gone?` option, in place of a
   fresh capture per arm.

`successor-published?-fn` becomes public because this is the one timer batch
whose two halves are driven from another namespace; every other multi-step
timer operation still captures and consumes its owner inside `timer.cljc`.

With the owner still live every predicate reads `false`, so the normal
reconcile — cancel the dropped set, arm the live set at the persisted epoch, no
entry or cascade replay, restore semantics untouched, sibling frames untouched
— runs exactly as before. No new trace vocabulary, no public API, no spec or
docs change owed. Diff is `implementation/machines/**` only.

## Regression

New namespace
`implementation/machines/test/re_frame/machine_hydration_reconcile_incarnation_fence_cljs_test.cljc`
(3 deftests). Two mutation teeth, one per direction, each publishing same-id B
from the **first** callback-bearing trace of its phase:

- `a-cancel-phase-callback-that-republishes-the-frame-arms-nothing-into-b` —
  mixed retained/dropped: two actors armed, the replacement drops one, and that
  cancellation's listener destroys A and publishes B. The retained
  subscription-delay declaration was enumerated from A's runtime-db and must
  not reach B.
- `an-arm-phase-supersede-that-republishes-the-frame-stops-the-later-arms` —
  multi-live: one node bearing two `:after` declarations, identical
  re-hydration, so phase 1 cancels nothing and the first callback-bearing trace
  is arm 1's own `:on-supersede`.

Each then reads **four** things off successor B — its timer table, the
`/scheduled` trace stream, the subscription ref-count, and whether a change in
the delay's value reaches a surviving watcher. A table check alone cannot see
the last two.

`a-live-owner-reconcile-arms-every-live-declaration` is the control the fence
must not break: with no successor published, a multi-live reconcile still arms
both declarations and supersedes both in place, so the recheck cannot truncate
an ordinary hydration.

### Sabotage result

The threading reverted at two single-line anchors in `hydrate.cljc` — the arm
loop's recheck removed and `nil` passed in place of the batch owner, which is
exactly the pre-fix per-arm re-capture:

- machines JVM lane **exit 1**, 1236 tests / 4407 assertions — the same totals
  as the clean run, so no namespace was skipped or crashed — with **8
  failures, all in the new namespace**, 4 per tooth, covering the table, the
  `/scheduled` row, the subscription hold and the surviving watcher.
- The watcher failure printed the audit's mechanism verbatim: a
  `:rf.machine.timer/cancelled :reason :on-resolution` fired from a watcher
  that an A-derived arm had attached inside B.
- GREEN under the same plant: every pre-existing machines test, including all
  of `machine_after_hydration_reconcile_cljs_test` and
  `machine_after_hydration_rearm_cljs_test`, and the new namespace's own
  live-owner control.
- The plant was restored by checkout and verified by git **blob** hash against
  the committed object (identical before and after), not by reading a diff.

## Gates

Re-run on the final rebased base; each exit code captured on the same command
line as the redirect, and the CLJS lane's printed shadow-cljs config path names
this branch's own checkout.

| gate | result | captured exit |
| --- | --- | --- |
| machines JVM `clojure -M:test` | 1236 tests / 4407 assertions, 0 failures | 0 |
| CLJS `compile-node-test.cjs node-test` | build completed, 0 warnings | 0 |
| CLJS `node out/node-test.js` | 11174 tests / 55304 assertions, 0 failures | 0 |

The diff is `implementation/machines/**` only — no markdown, no `spec/`, no
workflows — so `check_doc_slugs.py` and `check_readme_links.py --ci` are out of
scope and `mkdocs build --strict` is not a candidate (`docs_dir` is `docs`). CI
owns the full matrix; the browser lanes were not run locally.
