### PR TITLE
docs(method): a finished change is not a strand, and publishing it is not salvage

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1068,6 +1068,39 @@ and both readings went wrong in a single day here, in opposite directions.
    the probe read *running* five minutes in; all six were resumed on that reading, none
    redispatched, and every one kept its context.
 
+**A finished change is not a strand, and publishing it is not salvage.** Everything above prices one
+action — redispatch — and prices it to favour waiting, correctly, because acting on a wrong *no task*
+destroys a live run. A second action sits beside it and is priced the other way. Where a change is
+already green at the band and its published head matches its branch tip, the only step left is the
+publish flag its author sets last, and taking that step costs nothing if the author was alive after
+all: it wakes to find its work landed, which is what it was trying to do. Verify the change against
+§1 yourself, publish it, retire the agent — and do **not** reopen its items or redispatch, which are
+the moves that carry the cost step 3 is written around. **Read the whole of §1 for it**: the case
+looks finished, which is exactly when a clause gets waived.
+
+**What makes that reading available is a signal none of the four clocks carries: the tracker's own
+record that the worker CLOSED its items.** It is the mirror of the claim signal above — a positive
+act by the agent, landing outside the tree where no file clock can see it — and it is the one thing
+separating this case from the false signature above, because a worker on its third local gate attempt
+has not reached its close step. **It proves the worker REACHED that step, not that nothing remains**,
+so it does not convert green-and-draft into *finished*; the four parts still observe no agent, and the
+warning above stands unchanged. It only makes the finished reading *available* where those four leave
+it ambiguous, and it is checkable in one call.
+
+**The residual risk is one thing and worth naming: an author who had found a further problem and not
+yet pushed the fix.** A closed item says the work was declared done, not that nothing was learned
+after — the third-gate-attempt worker above would present this way too. What bounds it is that you
+merge the PUBLISHED head, which CI graded, so the loss is a fix that was never pushed rather than a
+regression you introduced; the remedy is an ordinary follow-up change, not a destroyed run. That is
+the whole of the asymmetry with step 3, and it is why the pricing inverts.
+
+Measured twice in one day, on two unrelated workers: each had closed every item it held, each had a
+change green at the band with its published head matching, and each had sat two hours and one hour
+past its last write. Both were genuinely past their work — their final lines were *"cleaning up my
+gate artefacts"* and *"now opening the draft PR"*, the second re-attempting a step it had already
+completed. Waiting had bought nothing on either, and one of them was fencing an unrelated item that
+could not dispatch until it merged.
+
 **Never build a commit from someone else's uncommitted work.** Only that worker knows whether it forms
 a coherent change.
 


### PR DESCRIPTION
## What

`loops.md` §4's stranded sweep prices exactly one action — **redispatch** — and prices it to favour waiting, correctly: acting on a wrong *no task* destroys a live run. A second action sits beside it and inverts that pricing, and the section had no case for it.

Where a change is already green at the band and its published head matches its branch tip, the only step left is the publish flag its author sets last. Taking that step costs nothing if the author was alive after all — it wakes to find its work landed, which is what it was trying to do.

## What licenses the reading

A signal none of the four clocks carries: **the tracker's record that the worker CLOSED its items.** It is the mirror of the claim signal the section already names — a positive act by the agent, landing outside the tree where no file-activity clock can see it.

It is what separates this case from the four-part false signature the section already records (*green at the band, clean worktree, tip minutes old, still a draft* — a worker presenting exactly so was on its third local gate attempt). A worker on its third attempt has not reached its close step.

**The existing warning is left standing, deliberately.** The addition does not claim green-and-draft means finished. It says the close record proves the worker *reached* that step, not that nothing remains — it makes the finished reading *available* where the four clocks leave it ambiguous, and no more.

## Residual risk, named rather than glossed

An author who had found a further problem and not yet pushed the fix would present this way too. It is bounded by merging the **published** head, which CI graded: the loss is a fix that was never pushed rather than a regression introduced, and the remedy is a follow-up change rather than a destroyed run. That asymmetry with step 3 is why the pricing inverts, and it is stated in the text.

## Evidence

Measured twice in one day on two unrelated workers. Each had closed every item it held, each had a change green at the band with its published head matching, and each had sat two hours and one hour past its last write. Both were genuinely past their work — final lines *"cleaning up my gate artefacts"* and *"now opening the draft PR"*, the second re-attempting a step it had already completed. Waiting bought nothing on either, and one was fencing an unrelated item that could not dispatch until it merged.

## Gates

`scripts/check_doc_slugs.py` — **captured exit 0**. It is silent on success, so the tree-read proof is a planted fault: a broken anchor inserted into the new text returned **captured exit 1**, `BROKEN ANCHOR: docs\the-mayor-method\loops.md:1071 -> #rf2-planted-fault-anchor`. That fault existed only in this worktree, so a run that had wandered into a sibling's would have come back green. Restore verified by git **blob** hash against the committed object (`122994abd7…`, identical before and after), not by reading a diff; gate re-run green afterwards.

Anchor match count read as 1 before planting. Edit committed before planting. No fenced blocks and no new links in the change, so the fence-blind-spot limit does not apply here. Merge-base diff (`origin/main...HEAD`) is 33 insertions, 0 deletions — nothing reverted.