### PR TITLE
test(ssr): platform-tag the remaining SSR fixture frames (rf2-33lfn)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr/failed_root_isolation_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/failed_root_isolation_cljs_test.cljc
@@ -83,10 +83,19 @@
 (defn- fresh-frame!
   "A `:client`-platform frame under an id no other test in this shared
   process has used. Frames are not torn down between tests, so a reused
-  id would carry a prior test's app-db into this one."
+  id would carry a prior test's app-db into this one.
+
+  `make-frame` opts are FLAT — `:platform` sits alongside `:id`. A nested
+  `{:config {:platform :client}}` stores `:config {:config {…}}` and the
+  frame is never platform-tagged at all; every test below would still pass,
+  because the runtime resolves the platform as
+  `(or (-> rec :config :platform) (interop/active-platform))` and the
+  host-wide marker is already `:client` on CLJS.
+  `the-fixture-frames-are-actually-platform-tagged` is what keeps that
+  accident from coming back."
   []
   (let [fid (keyword "rf.isolation" (str "f" (swap! frame-counter inc)))]
-    (rf/make-frame {:id fid :config {:platform :client}})
+    (rf/make-frame {:id fid :platform :client})
     fid))
 
 (defn- payload-for
@@ -203,6 +212,19 @@
       (assert-isolated! (ssr/hydrate-page! specs) frames fail-idx
                         (str label " @" fail-idx)))))
 
+;; ---------------------------------------------------------------------------
+;; The fixture's own tag, asserted so it cannot lapse
+;; ---------------------------------------------------------------------------
+
+(deftest the-fixture-frames-are-actually-platform-tagged
+  (testing "`fresh-frame!` asks for `:platform :client` and the frame CARRIES
+            it. Read through `frame-meta`, the canonical `:rf/frame-meta`
+            shape, which flattens the frame's OWN config and does not fall
+            back to the host-wide platform marker — so this discriminates a
+            tagged frame from an untagged one, where the isolation tests
+            below cannot: they would pass either way on CLJS."
+    (is (= :client (:platform (rf/frame-meta (fresh-frame!)))))))
+
 (deftest a-root-whose-manifest-is-not-from-the-schema-family-fails-alone
   (testing "preflight step 1 kills one root; the page hydrates and runs"
     (run-arm! "manifest" manifest-lever)))
@@ -294,8 +316,10 @@
           (str "MEASURED: the seed did not land (the frame was not live), "
                "so the claim was released. Without the release this reads "
                "the claim record, and the assertion below fails."))
-      ;; The frame comes back — a legitimate SPA teardown/rebuild.
-      (rf/make-frame {:id fid :config {:platform :client}})
+      ;; The frame comes back — a legitimate SPA teardown/rebuild. Flat
+      ;; opts, exactly as `fresh-frame!` builds it: the rebuilt frame must
+      ;; carry the same `:client` tag the original did.
+      (rf/make-frame {:id fid :platform :client})
       (boot/hydrate! {:frame fid :payload (payload-for {:count 7})
                       :root-id :page/b})
       (is (hydrated? fid)

--- a/implementation/ssr/test/re_frame/ssr/failed_root_isolation_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/failed_root_isolation_dom_cljs_test.cljs
@@ -40,10 +40,36 @@
 
 (def ^:private frame-counter (atom 0))
 
-(defn- fresh-frame! []
+(defn- fresh-frame!
+  "A `:client`-platform frame under an id no other test in this shared
+  process has used.
+
+  `make-frame` opts are FLAT — `:platform` sits alongside `:id`. A nested
+  `{:config {:platform :client}}` stores `:config {:config {…}}` and the
+  frame is never platform-tagged at all; every test below would still pass,
+  because the runtime resolves the platform as
+  `(or (-> rec :config :platform) (interop/active-platform))` and the
+  host-wide marker is already `:client` on CLJS.
+  `the-fixture-frames-are-actually-platform-tagged` is what keeps that
+  accident from coming back."
+  []
   (let [fid (keyword "rf.isolation.dom" (str "f" (swap! frame-counter inc)))]
-    (rf/make-frame {:id fid :config {:platform :client}})
+    (rf/make-frame {:id fid :platform :client})
     fid))
+
+(deftest the-fixture-frames-are-actually-platform-tagged
+  (testing "`fresh-frame!` asks for `:platform :client` and the frame CARRIES
+            it. Read through `frame-meta`, the canonical `:rf/frame-meta`
+            shape, which flattens the frame's OWN config and does not fall
+            back to the host-wide platform marker — so this discriminates a
+            tagged frame from an untagged one, where the DOM tests below
+            cannot: they would pass either way on CLJS.
+
+            Deliberately NOT gated on `(browser?)`. Building a frame and
+            reading its tag needs no `js/document`, so this one assertion
+            runs under `:node-test` as well as in the browser — the only
+            test in this namespace that is not vacuous under node."
+    (is (= :client (:platform (rf/frame-meta (fresh-frame!)))))))
 
 (defn- payload-for [db]
   (payload-policy/build-payload nil db "server-hash-1" {}))

--- a/implementation/ssr/test/re_frame/ssr/multi_root_hydration_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/multi_root_hydration_dom_cljs_test.cljs
@@ -37,10 +37,36 @@
 
 (def ^:private frame-counter (atom 0))
 
-(defn- fresh-frame! []
+(defn- fresh-frame!
+  "A `:client`-platform frame under an id no other test in this shared
+  process has used.
+
+  `make-frame` opts are FLAT — `:platform` sits alongside `:id`. A nested
+  `{:config {:platform :client}}` stores `:config {:config {…}}` and the
+  frame is never platform-tagged at all; every test below would still pass,
+  because the runtime resolves the platform as
+  `(or (-> rec :config :platform) (interop/active-platform))` and the
+  host-wide marker is already `:client` on CLJS.
+  `the-fixture-frames-are-actually-platform-tagged` is what keeps that
+  accident from coming back."
+  []
   (let [fid (keyword "rf.multiroot.dom" (str "f" (swap! frame-counter inc)))]
-    (rf/make-frame {:id fid :config {:platform :client}})
+    (rf/make-frame {:id fid :platform :client})
     fid))
+
+(deftest the-fixture-frames-are-actually-platform-tagged
+  (testing "`fresh-frame!` asks for `:platform :client` and the frame CARRIES
+            it. Read through `frame-meta`, the canonical `:rf/frame-meta`
+            shape, which flattens the frame's OWN config and does not fall
+            back to the host-wide platform marker — so this discriminates a
+            tagged frame from an untagged one, where the DOM tests below
+            cannot: they would pass either way on CLJS.
+
+            Deliberately NOT gated on `(browser?)`. Building a frame and
+            reading its tag needs no `js/document`, so this one assertion
+            runs under `:node-test` as well as in the browser — the only
+            test in this namespace that is not vacuous under node."
+    (is (= :client (:platform (rf/frame-meta (fresh-frame!)))))))
 
 (defn- payload-for [db]
   (payload-policy/build-payload nil db "server-hash-1" {}))


### PR DESCRIPTION
Completes the sweep `rf2-umi1w` started. That bead fixed one fixture and
deliberately did not sweep the rest; this is the rest.

## The defect

`rf/make-frame` opts are FLAT. Four call sites across three SSR fixtures
passed `{:id fid :config {:platform :client}}`, which stores `:config
{:config {…}}` — so those frames were **never platform-tagged at all**.

It was harmless only by accident: the runtime resolves a frame's platform
through `fx/platform-for-frame-record` as `(or (-> rec :config :platform)
(interop/active-platform))`, and the host-wide marker is already `:client`
on CLJS. Each fixture got the platform it meant without ever asking for it,
and nothing in these files discriminated a tagged frame from an untagged
one.

## Premise verification (each checked at source, not taken from the bead)

- **`make-frame` opts are flat.** `implementation/core/src/re_frame/core.cljc`
  §`make-frame` docstring: *"EVERY OTHER key is RECORD-CONFIG, honoured in
  the same call: `:initial-events` …, `:fx-overrides`, `:platform`, `:ssr`,
  `:doc`, `:preset`, `:tags` …"*. So `:platform` is a top-level opt and a
  passed `:config` key is itself just record-config.
- **`frame-meta` is discriminating.** `implementation/core/src/re_frame/frame.cljc`
  §`frame-meta` is `(merge (:config f) (:lifecycle f) {:id (:id f)})` — it
  flattens the frame's OWN config and never consults the host-wide marker.
  Exported on the facade as `rf/frame-meta`.
- **The fallback that hid it.** `implementation/core/src/re_frame/fx.cljc`
  §`platform-for-frame-record` is `(or (-> frame-record :config :platform)
  (interop/active-platform))`, shared by the router's `:fx` walk and
  `cofx/active-platform-for-frame`.

## Roster — re-derived at tip, not taken from the bead's count

The bead named "four more fixtures". At tip the shape is **4 call sites
across 3 files**; the bead's own list is the same 4 sites, and its line
numbers still hold. The fifth site, in
`multi_root_hydration_cljs_test.cljc`, was already fixed by `rf2-umi1w` and
is untouched here.

| File | Sites |
|---|---|
| `implementation/ssr/test/re_frame/ssr/failed_root_isolation_cljs_test.cljc` | 2 (`fresh-frame!`, and the SPA teardown/rebuild inside `a-root-whose-seed-does-not-land-releases-its-claim`) |
| `implementation/ssr/test/re_frame/ssr/failed_root_isolation_dom_cljs_test.cljs` | 1 |
| `implementation/ssr/test/re_frame/ssr/multi_root_hydration_dom_cljs_test.cljs` | 1 |

**Census method — run twice, because neither pass is a superset of the
other.** The target is a nested map literal that can break across lines, and
a line-oriented search is blind to that. Pass 1 was line-oriented over
`implementation/ssr/test/`; pass 2 re-read every file with whitespace
collapsed to single spaces and matched `make-frame … :config {` across the
collapsed text. Both returned the same 4 code sites (plus docstring prose in
the two already-fixed fixtures, which is not a call site). Both passes were
exercised against a control sharing the target's shape — a `make-frame` call
with `:config` and its brace split across a line boundary. The line-oriented
pass returned **zero** on that control (confirming the blind spot is real,
not hypothetical) while the collapsed pass found it. Post-fix, both passes
return zero.

## What the fix is

Flatten the four opts maps, and add one assertion per fixture reading the
tag back through `rf/frame-meta`.

The two `_dom_cljs_test.cljs` assertions are deliberately **not** gated on
`(browser?)`. Building a frame and reading its tag needs no `js/document`,
so unlike the DOM tests around them they actually execute under `:node-test`
(whose `cljs-test$` ns-regexp matches these namespaces, and `ssr/test` is on
its source paths) rather than being vacuous there.

## Gate, and why green alone is not the evidence

`npm run test:cljs` from `implementation/` — the `:node-test` build, which
covers all three files. Captured exit code **0**; 11175 tests, 55288
assertions, 0 failures, 0 errors. The run's own config line names this
branch's checkout.

**A green suite proves only that nothing broke — it is precisely the
evidence that failed here, since the fixtures were green throughout while
completely untagged.** The tagging itself was proved by restoring the nested
form in `failed_root_isolation_cljs_test.cljc`, recompiling, and re-running:

```
FAIL in (the-fixture-frames-are-actually-platform-tagged)
expected: (= :client (:platform (rf/frame-meta (fresh-frame!))))
  actual: (not (= :client nil))

Ran 15 tests containing 124 assertions.
1 failures, 0 errors.
```

Captured exit code 1. Two things follow. First, the untagged frame really
does read `:platform nil` through `frame-meta`, and the flat form really
does make it `:client` — the assertion discriminates rather than restating
the host default. Second, and this is the defect measured directly: **the
other 14 tests in that namespace passed unchanged**. Only the new assertion
noticed. The plant was then reverted and the revert verified by comparing
the file's blob hash against the committed object (identical), not by
reading a diff.

## Scope

Test-only, `implementation/ssr/test/` — no change to `make-frame` or to the
SSR runtime. The flat-opts contract is documented clearly in `make-frame`'s
own docstring, so no API-clarity bead was filed.

`check_doc_slugs.py`, `check_readme_links.py --ci` and `mkdocs build
--strict` are out of scope for this diff.
