### PR TITLE
docs(method): one rule for a finished draft — stop the agent, then merge

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -610,6 +610,13 @@ it false. Until one of those arrives the change waits, and the honest report say
 stranded and why. That rule is unchanged by the above — what changes is how often you should expect to
 reach for it, which is rarely.
 
+**Where that second one is taken, it is taken FIRST.** Stopping the agent and then merging is
+authorised; merging and then stopping is the same inference with the act appended afterwards, and it
+leaves an identical record — a merged change beside a stopped agent — so nothing later can tell the two
+apart. The coordinator's side of this rule, and the cost of stopping an author who had found further
+work, are under *The stranded sweep* in [`loops.md`](loops.md#the-stranded-sweep); the rule itself is
+one rule and this page states it.
+
 ---
 
 ## Pasting a block

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1068,38 +1068,33 @@ and both readings went wrong in a single day here, in opposite directions.
    the probe read *running* five minutes in; all six were resumed on that reading, none
    redispatched, and every one kept its context.
 
-**A finished change is not a strand, and publishing it is not salvage.** Everything above prices one
-action — redispatch — and prices it to favour waiting, correctly, because acting on a wrong *no task*
-destroys a live run. A second action sits beside it and is priced the other way. Where a change is
-already green at the band and its published head matches its branch tip, the only step left is the
-publish flag its author sets last, and taking that step costs nothing if the author was alive after
-all: it wakes to find its work landed, which is what it was trying to do. Verify the change against
-§1 yourself, publish it, retire the agent — and do **not** reopen its items or redispatch, which are
-the moves that carry the cost step 3 is written around. **Read the whole of §1 for it**: the case
-looks finished, which is exactly when a clause gets waived.
+**A finished change is not a strand — but publishing it is still not yours to infer.** Everything
+above prices redispatch, and prices it to favour waiting because acting on a wrong *no task* destroys
+a live run. A second case sits beside it: a change already green at the band, its published head
+matching its branch tip, needing only the publish flag its author sets last. The pull is to set that
+flag yourself. **Do not reach for a new signal to justify it** — the flag is the interlock precisely
+because a merge command refuses a draft, and an interlock you can talk yourself past is not one.
 
-**What makes that reading available is a signal none of the four clocks carries: the tracker's own
-record that the worker CLOSED its items.** It is the mirror of the claim signal above — a positive
-act by the agent, landing outside the tree where no file clock can see it — and it is the one thing
-separating this case from the false signature above, because a worker on its third local gate attempt
-has not reached its close step. **It proves the worker REACHED that step, not that nothing remains**,
-so it does not convert green-and-draft into *finished*; the four parts still observe no agent, and the
-warning above stands unchanged. It only makes the finished reading *available* where those four leave
-it ambiguous, and it is checkable in one call.
+**Use the authorisation the [dispatch template](dispatch-prompt-template.md#publishing-the-change)
+already names: the operator's decision to STOP that agent, which settles liveness by making it false.**
+Stop it, then merge. That is an act with a definite outcome where every clock above is an inference
+with none, and it needs no new discriminator — a stopped agent cannot be working, so the question the
+four clocks could not answer stops being asked. Verify the change against §1 in full, exactly as for
+any other change, and do not reopen the stopped worker's items or redispatch them.
 
-**The residual risk is one thing and worth naming: an author who had found a further problem and not
-yet pushed the fix.** A closed item says the work was declared done, not that nothing was learned
-after — the third-gate-attempt worker above would present this way too. What bounds it is that you
-merge the PUBLISHED head, which CI graded, so the loss is a fix that was never pushed rather than a
-regression you introduced; the remedy is an ordinary follow-up change, not a destroyed run. That is
-the whole of the asymmetry with step 3, and it is why the pricing inverts.
+**The ORDER is the whole rule, and reversing it looks identical afterwards.** Merging first and
+stopping second reaches the same end state by the forbidden route: the merge rests on an inference and
+the act that would have settled it arrives too late to have authorised anything. Both orders leave a
+merged change and a stopped agent, so the record cannot tell them apart later — which is why this says
+*stop, then merge* rather than *make sure the agent ends up stopped*. Written the day it was got wrong
+twice.
 
-Measured twice in one day, on two unrelated workers: each had closed every item it held, each had a
-change green at the band with its published head matching, and each had sat two hours and one hour
-past its last write. Both were genuinely past their work — their final lines were *"cleaning up my
-gate artefacts"* and *"now opening the draft PR"*, the second re-attempting a step it had already
-completed. Waiting had bought nothing on either, and one of them was fencing an unrelated item that
-could not dispatch until it merged.
+**The residual risk is real and belongs to stopping, not to merging: you may be killing work you
+cannot see.** An author who closed its items and then discovered something further presents exactly
+like one that is finished. What bounds it is that you merge the PUBLISHED head, which CI graded, so the
+loss is an unpushed fix rather than a regression introduced, and the remedy is a follow-up change. That
+is a cost to weigh before stopping — it is not a reason to merge without stopping, which trades a
+bounded loss for an unbounded one.
 
 **Never build a commit from someone else's uncommitted work.** Only that worker knows whether it forms
 a coherent change.


### PR DESCRIPTION
Closes the audit that reopened rf2-ttu8i against PR #8944. Both of its findings are correct and both are fixed by **removing** what #8944 added rather than extending it.

## Finding 1 — #8944 reintroduced two-source drift

The finished-draft exception landed only in `loops.md`. `dispatch-prompt-template.md`'s **Publishing the change** still said never flip the flag on an inference and that the change waits stranded — so the two method pages gave opposite executable instructions. That is precisely the drift the draft interlock exists to prevent.

## Finding 2 — #8944 contradicted itself

It claimed the third-local-gate worker *"separates cleanly because it had not reached its close step"*, then seven lines later named as residual risk that the same worker *"would present this way too"* with closed items. The caveat falsified the claim and the claim was left standing.

## The fix: drop the invented discriminator entirely

`#8944` introduced *closed tracker items* as a new positive signal licensing the mayor to set the publish flag. That was unnecessary — the template already carried a sufficient authorisation:

> the agent's own report, **or the operator's decision to stop that agent, which settles liveness by making it false**

`loops.md` now routes to that instead. A stopped agent cannot be working, so the question the four clocks cannot answer stops being asked, and no new signal is needed. One rule, stated on the template page, deferred to from the loop page.

## What both pages now add: the ORDER

**Stop, then merge.** Merging first and stopping second reaches the same end state by the forbidden route — the merge rests on an inference and the settling act arrives too late to have authorised it. Both orders leave a merged change beside a stopped agent, so **nothing later can tell them apart**, which is why the rule is *stop, then merge* rather than *make sure the agent ends up stopped*.

## Residual risk, reattributed

Restated as the audit asked — an author who closed its items and then discovered further work — and attributed to **stopping**, which is the act that can destroy unpushed work, not to merging. Bounded by merging the published head CI graded: the loss is an unpushed fix, not an introduced regression.

## Note on the bead's third file

`.claude/commands/mayor-merge.md` no longer exists; that directory has been removed. Nothing to change there.

## Gates

| gate | captured exit | tree-read proof |
|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | planted anchor → **exit 1**, `BROKEN ANCHOR: docs\the-mayor-method\loops.md:1078` |
| `python -m mkdocs build --strict` | **0** | planted file link → **exit 1**, `WARNING - Doc file 'the-mayor-method/loops.md' contains a link 'rf2-planted-missing-file.md'` … `Aborted with 1 warnings in strict mode!` |

`exclude_docs` does not hide `the-mayor-method/`, so mkdocs genuinely builds these pages — confirmed by the planted-link red rather than assumed. Run as `python -m mkdocs`; bare `mkdocs` returns 127 here, which is no verdict. Both plants restored and each restore verified by git **blob** hash against the committed object (`e4fbc279a9…`, identical before and after), never by reading a diff; anchor match count read as 1 before planting.

No fenced blocks added, so the guide-samples digest gate is untouched. Merge-base diff (`origin/main...HEAD`) is two files; every deletion is #8944's own replaced text.