### PR TITLE
feat(mcp-conformance): name the profile in every terminal verdict (rf2-a9l6e)

### DIFF
--- a/implementation/scripts/_mcp-conformance-install-policy.test.cjs
+++ b/implementation/scripts/_mcp-conformance-install-policy.test.cjs
@@ -3,8 +3,22 @@
 'use strict';
 
 /*
- * Reproducible-install policy gate for `test-mcp-conformance.cjs`
- * (rf2-vtp2er).
+ * Policy gate for `test-mcp-conformance.cjs` — two concerns, one file.
+ *
+ *   A. Reproducible-install policy (rf2-vtp2er), below.
+ *   B. Profile SELECTION (rf2-a9l6e): default vs `--live` vs `--help` vs an
+ *      unknown option, and the verdict text each one renders. These are
+ *      pure-function assertions against the runner's exported
+ *      `parseArgs` / `planRun` / `renderReport` / `helpText`, so the suite
+ *      launches no Clojure, no shadow-cljs, no Chromium, and neither MCP
+ *      server — the runner only spawns under `require.main === module`,
+ *      which this section pins.
+ *
+ * They share a file rather than splitting because both pin the SAME script
+ * and both are static/pure; a second `_*.test.cjs` would only duplicate the
+ * fixture.
+ *
+ * --- A. Reproducible-install policy (rf2-vtp2er) ---
  *
  * `npm run test:mcp-conformance` must be a (near-)pure verification
  * command: it must not silently re-mutate dependency state on every run,
@@ -235,6 +249,223 @@ test('LIVE: lockfile-backed tool packages the runner installs have a present, dr
     'expected at least one lockfile-backed tool package (mcp-conformance) ' +
       'to be exercised by this gate.',
   );
+});
+
+// ---------------------------------------------------------------------
+// B. Profile selection + verdict honesty (rf2-a9l6e).
+//
+// Requiring the runner is itself part of the contract: it must expose its
+// selection/rendering as pure functions and spawn NOTHING at module load.
+// If that regressed, this `require` would start installing npm packages and
+// booting servers, and the suite would not finish.
+const runner = require('./test-mcp-conformance.cjs');
+
+test('the runner only spawns under require.main === module', () => {
+  assert.match(
+    RUNNER_CODE,
+    /require\.main\s*===\s*module/,
+    'expected the run loop to be guarded by `require.main === module` so ' +
+      'the profile-selection tests can require the runner without launching ' +
+      'Clojure, shadow-cljs, Chromium, or either MCP server (rf2-a9l6e).',
+  );
+});
+
+test('default selection: no flag selects the default profile', () => {
+  assert.deepEqual(runner.parseArgs([]), {
+    help: false,
+    profile: runner.PROFILE_DEFAULT,
+    error: null,
+  });
+});
+
+test('--live selects the live profile', () => {
+  assert.deepEqual(runner.parseArgs(['--live']), {
+    help: false,
+    profile: runner.PROFILE_LIVE,
+    error: null,
+  });
+});
+
+test('--help / -h select help, and help is side-effect-free text', () => {
+  for (const flag of ['--help', '-h']) {
+    const parsed = runner.parseArgs([flag]);
+    assert.equal(parsed.help, true, `${flag} must select help`);
+    assert.equal(parsed.error, null, `${flag} must not be a usage error`);
+  }
+  const help = runner.helpText();
+  // Both modes, the cost boundary, the prerequisites, which mode proves
+  // live runtime behaviour, and the narrower meaning of the conformance
+  // package's own `npm test` (acceptance 3).
+  for (const needle of [
+    runner.ROOT_COMMAND,
+    runner.LIVE_COMMAND,
+    'default (medium)',
+    '--live (expensive)',
+    'PREREQUISITES',
+    'PROFILE THAT PROVES LIVE RUNTIME SEMANTICS',
+    'NARROWER NEIGHBOUR',
+    'EXIT CODES',
+  ]) {
+    assert.ok(
+      help.includes(needle),
+      `--help output must mention ${JSON.stringify(needle)}.`,
+    );
+  }
+});
+
+test('an unknown option is a usage error naming the option, with no profile', () => {
+  const parsed = runner.parseArgs(['--liv']);
+  assert.equal(parsed.profile, null, 'a usage error must select no profile');
+  assert.equal(parsed.help, false);
+  assert.match(
+    String(parsed.error),
+    /unknown option `--liv`/,
+    'the usage error must name the offending option.',
+  );
+  // The usage exit code must not collide with the gate codes (1 = gate /
+  // inner-conformance failure, 2 = hermetic orchestration/cleanup failure).
+  assert.notEqual(runner.EXIT_USAGE, 0);
+  assert.notEqual(runner.EXIT_USAGE, 1);
+  assert.notEqual(runner.EXIT_USAGE, 2);
+});
+
+test('the live gate is ABSENT from the default plan and PRESENT in the live plan', () => {
+  const dflt = runner.planRun(runner.PROFILE_DEFAULT);
+  const live = runner.planRun(runner.PROFILE_LIVE);
+  assert.equal(dflt.gates.length, runner.DEFAULT_GATES.length);
+  assert.equal(live.gates.length, runner.DEFAULT_GATES.length + 1);
+  assert.ok(
+    !dflt.gates.includes(runner.LIVE_GATE),
+    'the default profile must not plan the hermetic live gate.',
+  );
+  assert.equal(
+    live.gates[live.gates.length - 1],
+    runner.LIVE_GATE,
+    'the live profile must append the hermetic live gate last.',
+  );
+  // Both profiles share the same prerequisites; --live adds a gate, not a
+  // second orchestrator.
+  assert.deepEqual(dflt.prep, live.prep);
+});
+
+test('the live gate delegates to the EXISTING hermetic entry point (no second roster)', () => {
+  const conformancePkg = JSON.parse(
+    fs.readFileSync(path.join(TOOLS, 'mcp-conformance', 'package.json'), 'utf8'),
+  );
+  const script = conformancePkg.scripts['test:re-frame2-pair-live-hermetic-suite'];
+  assert.ok(
+    script,
+    'tools/mcp-conformance/package.json must keep the ' +
+      'test:re-frame2-pair-live-hermetic-suite script the --live profile delegates to.',
+  );
+  assert.ok(
+    script.includes(runner.LIVE_GATE.args[0]),
+    `the --live gate runs ${runner.LIVE_GATE.args[0]}, which must be the same ` +
+      `entry point as the package script (${script}).`,
+  );
+  assert.equal(runner.LIVE_GATE.node, true, 'the live gate spawns under node');
+  // The live row count comes from the one live roster, never a copy.
+  assert.match(
+    RUNNER_CODE,
+    /require\([\s\S]{0,120}?live-test-inventory\.cjs['"]/,
+    'the runner must read LIVE_TESTS from ' +
+      'tools/mcp-conformance/scripts/live-test-inventory.cjs rather than ' +
+      'listing live rows itself (rf2-a9l6e acceptance 6).',
+  );
+});
+
+// A green that cannot be told apart from a skip is the defect rf2-a9l6e
+// exists to close, so the verdict text is pinned as tightly as the plan.
+function reportFor(profile, fail = null) {
+  const { gates } = runner.planRun(profile);
+  const results = gates.map((g) => ({ name: g.name, status: 0 }));
+  if (!fail) {
+    return runner.renderReport({ profile, gates, results, firstFailure: null });
+  }
+  return runner.renderReport({
+    profile,
+    gates,
+    // Fail-fast: the failing step's row, and nothing after it.
+    results: results
+      .slice(0, fail.index)
+      .concat([{ name: gates[fail.index].name, status: fail.status }]),
+    firstFailure: {
+      step: gates[fail.index].name,
+      status: fail.status,
+      signal: null,
+    },
+  });
+}
+
+test('the default-profile verdict names its profile and marks the live suite NOT RUN', () => {
+  const report = reportFor(runner.PROFILE_DEFAULT);
+  assert.match(
+    report,
+    /MCP-CONFORMANCE DEFAULT PROFILE GREEN — 6\/6 gates, hermetic live Pair suite NOT RUN/,
+  );
+  assert.ok(
+    report.includes('[NOT RUN ]'),
+    'the default summary must carry an explicit NOT RUN row for the hermetic suite.',
+  );
+  assert.ok(
+    report.includes(runner.LIVE_COMMAND),
+    'the default summary must print the exact --live invocation beside it.',
+  );
+});
+
+test('no unqualified all-green sentence survives anywhere in the runner', () => {
+  // The old sentinel. Renaming it is only worth anything if it cannot come
+  // back — pin the source AND the rendered default-profile report.
+  const forbidden = 'ALL MCP-CONFORMANCE GATES GREEN';
+  // RUNNER_CODE, not RUNNER_SRC: the header comment legitimately QUOTES the
+  // retired sentinel to explain why it went. Comments are stripped so the
+  // pin matches executable source only.
+  assert.ok(
+    !RUNNER_CODE.includes(forbidden),
+    `test-mcp-conformance.cjs must not emit "${forbidden}": it cannot be ` +
+      'told apart from a run whose live layer was skipped (rf2-a9l6e).',
+  );
+  const report = reportFor(runner.PROFILE_DEFAULT);
+  assert.ok(!report.includes(forbidden));
+  // Control: the pin is a real substring test, not a pattern that can only
+  // ever answer "no match" — the same shape IS found where it exists.
+  assert.ok(reportFor(runner.PROFILE_DEFAULT).includes('PROFILE GREEN'));
+});
+
+test('the live-profile verdict names its profile and carries no NOT RUN row', () => {
+  const report = reportFor(runner.PROFILE_LIVE);
+  assert.match(
+    report,
+    /MCP-CONFORMANCE LIVE PROFILE GREEN — 7\/7 gates, hermetic live Pair suite INCLUDED/,
+  );
+  assert.ok(
+    !report.includes('NOT RUN'),
+    'the live profile ran the hermetic suite — nothing may be marked NOT RUN.',
+  );
+  assert.ok(
+    report.includes(runner.LIVE_GATE.name),
+    'the live summary must show the hermetic gate as one of its rows.',
+  );
+});
+
+test('a failing gate renders a profile-named FAILED verdict in both profiles', () => {
+  const dflt = reportFor(runner.PROFILE_DEFAULT, { index: 2, status: 1 });
+  assert.match(dflt, /MCP-CONFORMANCE DEFAULT PROFILE FAILED — .* exited 1/);
+  assert.ok(!dflt.includes('PROFILE GREEN'));
+  assert.ok(
+    dflt.includes('halted by an earlier failure'),
+    'gates the fail-fast never reached must be labelled halted, never passed.',
+  );
+
+  // The hermetic suite's own 1-vs-2 distinction must survive to the verdict:
+  // 2 is an orchestration/cleanup failure, not an inner conformance failure.
+  const liveGates = runner.planRun(runner.PROFILE_LIVE).gates;
+  const live = reportFor(runner.PROFILE_LIVE, {
+    index: liveGates.indexOf(runner.LIVE_GATE),
+    status: 2,
+  });
+  assert.match(live, /MCP-CONFORMANCE LIVE PROFILE FAILED — .* exited 2/);
+  assert.ok(!live.includes('PROFILE GREEN'));
 });
 
 run();

--- a/implementation/scripts/test-mcp-conformance.cjs
+++ b/implementation/scripts/test-mcp-conformance.cjs
@@ -1,16 +1,28 @@
 #!/usr/bin/env node
 /*
- * Single MCP-conformance entry-point for operator pairs (rf2-gt4pf).
+ * Single MCP-conformance entry-point for operator pairs (rf2-gt4pf,
+ * rf2-a9l6e).
  *
- * Chains the six MCP-conformance gates that PR CI runs as separate jobs
- * (`.github/workflows/test.yml`):
+ * ONE command, TWO explicit profiles. Every terminal verdict this script
+ * prints names the profile that actually ran, because the two profiles do
+ * not prove the same thing and a bare "green" cannot be told apart from a
+ * skip (rf2-a9l6e).
  *
- *   1. JVM tools/story-mcp         (`clojure -M:test`)
- *   2. Node tools/story-mcp        stdio roundtrip (rf2-h8z5l)
- *   3. Node tools/re-frame2-pair-mcp  shadow-cljs :server-test
- *   4. MCP conformance tools/re-frame2-pair-mcp  (SDK Client driver, rf2-cum40)
- *   5. MCP conformance tools/story-mcp           (SDK Client driver, rf2-cum40)
- *   6. MCP conformance wire-vocab  (rf2-j2z7o + rf2-6m8tq + rf2-zvv65)
+ *   default  (medium)     the six MCP-conformance gates PR CI runs as
+ *                         separate jobs in `.github/workflows/test.yml`:
+ *
+ *     1. JVM tools/story-mcp         (`clojure -M:test`)
+ *     2. Node tools/story-mcp        stdio roundtrip (rf2-h8z5l)
+ *     3. Node tools/re-frame2-pair-mcp  shadow-cljs :server-test
+ *     4. MCP conformance tools/re-frame2-pair-mcp  (SDK Client driver, rf2-cum40)
+ *     5. MCP conformance tools/story-mcp           (SDK Client driver, rf2-cum40)
+ *     6. MCP conformance wire-vocab  (rf2-j2z7o + rf2-6m8tq + rf2-zvv65)
+ *
+ *   --live   (expensive)  the same six gates, then the EXISTING hermetic
+ *                         live Pair suite
+ *                         (`tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs`,
+ *                         the `test:re-frame2-pair-live-hermetic-suite`
+ *                         entry point) as gate 7.
  *
  * Gates #4 + #5 ride on `tools/mcp-conformance/npm test`, which dispatches
  * via `tools/mcp-conformance/scripts/test-all.cjs`. That orchestrator's
@@ -23,28 +35,38 @@
  * before invoking the conformance suite — matching what
  * `mcp-conformance-re-frame2-pair` does in CI.
  *
+ * WHY THE PROFILE MUST BE NAMED. Under the default profile the child
+ * orchestrator correctly marks its live-* rows `SKIP` (no
+ * `SHADOW_CLJS_NREPL_PORT`, so no live runtime is proven). This runner used
+ * to collapse that whole child run to one status row and end with an
+ * unqualified `ALL MCP-CONFORMANCE GATES GREEN`, which reads as full MCP
+ * compatibility when the live layer was never exercised. The default
+ * profile now ends on a verdict that says so, and prints the exact `--live`
+ * invocation beside a `NOT RUN` row for the hermetic suite.
+ *
+ * The live roster is NOT re-listed here: `LIVE_TESTS` from
+ * `tools/mcp-conformance/scripts/live-test-inventory.cjs` is the one owner
+ * (the hermetic runner derives its own `INNER_TESTS` from the same module),
+ * and this script only reads its length for the help/verdict text.
+ *
  * Fail-fast: the first non-zero exit code halts the run and the
  * orchestrator forwards it verbatim, so the parent shell sees exactly
- * which gate failed. The summary at the end attributes pass/fail per
- * gate one-glance, matching the shape of
+ * which gate failed — and so the hermetic suite's own exit-code
+ * distinction survives (`1` inner live-conformance failure, `2`
+ * orchestration/cleanup failure where the teardown could not be proven
+ * clean). The summary at the end attributes pass/fail per gate
+ * one-glance, matching the shape of
  * `tools/mcp-conformance/scripts/test-all.cjs`.
  *
- * Out of scope per Mike's minimum-scope direction (rf2-gt4pf):
+ * Out of scope per Mike's minimum-scope direction (rf2-gt4pf), unchanged by
+ * rf2-a9l6e:
  *   - Formal runner ns (this is a Node operator-side ergonomic, not a
  *     CI gate — CI keeps the six split jobs for differential surface
  *     attribution)
  *   - Rich output formatting / unified report
  *   - Incremental `--changed-only` mode
- *
- * The hermetic live conformance gate (which boots shadow-cljs + Playwright
- * Chromium against `skills/re-frame2-pair/tests/fixture/` and runs the
- * SKIP-gated live probes against it — its `INNER_TESTS` array in
- * `tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs`
- * is the authoritative list) is intentionally NOT chained here. That gate
- * lives in CI's `mcp-conformance-re-frame2-pair` job and burns ~2 min of
- * wall-clock on a cold-cache run. Operators who want it run
- * `cd tools/mcp-conformance && npm run test:re-frame2-pair-live-hermetic-suite`
- * directly.
+ *   - A general profile engine: there are exactly two profiles, and the
+ *     live one is a single extra step delegating to an existing runner.
  */
 'use strict';
 
@@ -61,13 +83,114 @@ const PAIR_MCP = path.join(TOOLS, 're-frame2-pair-mcp');
 const CONFORMANCE = path.join(TOOLS, 'mcp-conformance');
 const WIRE_VOCAB = path.join(CONFORMANCE, 'wire-vocab');
 
+// The single live roster. Both `tools/mcp-conformance/scripts/test-all.cjs`
+// and the hermetic runner derive their live rows from this module; we read
+// it only to say how many rows the live profile covers, so there is no
+// second inventory to drift (rf2-a9l6e).
+const { LIVE_TESTS } = require(
+  path.join(CONFORMANCE, 'scripts', 'live-test-inventory.cjs'),
+);
+
+// The copyable repository-root invocations. `implementation/package.json`
+// owns the script name; `--prefix` is what makes it runnable from the repo
+// root without a second package-level alias.
+const ROOT_COMMAND = 'npm --prefix implementation run test:mcp-conformance';
+const LIVE_COMMAND = ROOT_COMMAND + ' -- --live';
+
+const PROFILE_DEFAULT = 'default';
+const PROFILE_LIVE = 'live';
+
+const PROFILES = {
+  [PROFILE_DEFAULT]: { cost: 'medium' },
+  [PROFILE_LIVE]: { cost: 'expensive' },
+};
+
+// A usage error is not a gate result: nothing ran, so it must not reuse the
+// gate exit codes (1 = a gate/inner-conformance failure, 2 = hermetic
+// orchestration/cleanup failure). 64 is the conventional EX_USAGE.
+const EXIT_USAGE = 64;
+
 // ---------------------------------------------------------------------
-// Exec-safety: no `shell: true`, no bare-name spawns (rf2-1irs7).
+// Profile selection. Pure, side-effect-free, and resolved BEFORE anything
+// installs, compiles, or boots a server — `--help` and an unknown option
+// must never mutate dependency state (rf2-a9l6e).
+function parseArgs(argv) {
+  let profile = PROFILE_DEFAULT;
+  let help = false;
+  for (const arg of argv) {
+    if (arg === '--help' || arg === '-h') {
+      help = true;
+      continue;
+    }
+    if (arg === '--live') {
+      profile = PROFILE_LIVE;
+      continue;
+    }
+    return { help: false, profile: null, error: `unknown option \`${arg}\`` };
+  }
+  return { help, profile, error: null };
+}
+
+function helpText() {
+  return `test:mcp-conformance — MCP compatibility profiles for re-frame2's MCP servers
+
+USAGE (from the repository root)
+  ${ROOT_COMMAND}
+  ${LIVE_COMMAND}
+  ${ROOT_COMMAND} -- --help
+
+PROFILES
+  default (medium)
+    Six gates: the story-mcp JVM suite, the story-mcp stdio roundtrip, the
+    re-frame2-pair-mcp shadow-cljs :server-test suite, the SDK-client
+    conformance inventory for BOTH servers (degraded pair end-to-end + story
+    end-to-end + flag gates), and the wire-vocab JVM suite. Proves MCP
+    handshake, tool catalogue, descriptor and result-envelope behaviour.
+    It does NOT prove live runtime behaviour: with no nREPL port the
+    live-re-frame2-pair-* rows report SKIP.
+
+  --live (expensive)
+    The six default gates, then the hermetic live Pair suite
+    (tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs).
+    That suite boots the pair fixture under shadow-cljs, launches Chromium,
+    supplies the nREPL port, and runs all ${LIVE_TESTS.length} live rows registered in
+    tools/mcp-conformance/scripts/live-test-inventory.cjs. THIS IS THE ONLY
+    PROFILE THAT PROVES LIVE RUNTIME SEMANTICS. It certifies green only when
+    every live row reaches its own success sentinel and the hermetic teardown
+    grades clean. Budget a couple of extra minutes on a warm cache, more when
+    the fixture's dependencies or the CLJS build are cold.
+
+PREREQUISITES
+  Both profiles: node + npm, \`clojure\` on PATH and a JVM (gates 1 and 6).
+  --live also needs Playwright's Chromium and a free port for nREPL.
+  Node dependencies are installed by this runner: \`npm ci\` where the tool
+  package commits a lockfile, a skip-if-present \`npm install\` where it does
+  not (rf2-vtp2er) — so a repeat run does not re-mutate dependency state.
+
+EXIT CODES
+  0   the SELECTED profile passed (the verdict line names which one)
+  1   a gate failed; under --live, an inner live-conformance failure
+  2   under --live, a hermetic orchestration/cleanup failure — the inner
+      contract may have passed but the teardown could not be proven clean,
+      so the run is not certified
+  ${EXIT_USAGE}  usage error (unknown option); nothing ran
+
+NARROWER NEIGHBOUR
+  \`npm test\` inside tools/mcp-conformance is NOT either profile. It is the
+  Node conformance inventory alone — exec-safety and runner unit gates, the
+  SDK-driven end-to-end workflows, and the flag gates — with the live rows
+  reporting SKIP. It runs neither JVM suite and never boots the hermetic
+  live suite. Per-suite diagnostic recipes: tools/mcp-conformance/README.md.
+`;
+}
+
+// ---------------------------------------------------------------------
+// Exec-safety: no shell dispatch, no bare-name spawns (rf2-1irs7).
 //
 // The original form spawned every step with
 // `spawnSync(bareCommandString, { shell: true, cwd })`. On Windows that
-// is the rf2-33vvc command-hijack accident class: `shell: true` + a
-// bare exe name (`npm`/`npx`/`clojure`) + a repo-controlled `cwd`
+// is the rf2-33vvc command-hijack accident class: a shell-enabled spawn +
+// a bare exe name (`npm`/`npx`/`clojure`) + a repo-controlled `cwd`
 // resolves against the cwd ahead of PATH, so a checkout that ever
 // carried a `npm.cmd` / `npx.cmd` / `clojure.cmd` in one of these dirs
 // (a fixture dir, anywhere in PATHEXT order) would silently execute it.
@@ -76,45 +199,52 @@ const WIRE_VOCAB = path.join(CONFORMANCE, 'wire-vocab');
 // sites (`tools/mcp-conformance/test/end-to-end-story.cjs`,
 // `scripts/run-live-...-hermetic.cjs`): resolve each tool name to a
 // single trusted absolute path OUTSIDE the workspace via
-// `resolveTrustedExe`, then spawn with an args ARRAY and NO shell. We
+// `resolveTrustedExe`, then spawn with an args ARRAY and no shell. We
 // reuse that exact primitive here rather than hand-roll a second one.
-//
+const { resolveTrustedExe } = require(
+  path.join(CONFORMANCE, 'lib', 'exec-safety.cjs'),
+);
+
 // `cross-spawn` (the slice's own spawn helper) is the cross-platform
 // piece: given the trusted absolute path `resolveTrustedExe` returns —
 // on Windows that is typically the extensionless `npm`/`npx` shim under
 // the Node install dir, NOT the `.cmd` — Node's built-in `spawnSync`
-// with `shell: false` fails (ENOENT on the shim; EINVAL on a `.cmd`
-// since the CVE-2024-27980 fix). `cross-spawn` reads the shebang /
-// dispatches the `.cmd` correctly without re-introducing the shell, so
-// `resolveTrustedExe` + `cross-spawn` is the only combination that is
-// both hardened and cross-platform (Windows / macOS / Linux).
+// with no shell fails (ENOENT on the shim; EINVAL on a `.cmd` since the
+// CVE-2024-27980 fix). `cross-spawn` reads the shebang / dispatches the
+// `.cmd` correctly without re-introducing a shell, so `resolveTrustedExe`
+// + `cross-spawn` is the only combination that is both hardened and
+// cross-platform (Windows / macOS / Linux).
 // rf2-ocfiq — `cross-spawn` is an `implementation/` devDependency added
-// by rf2-1irs7. It is required at module-load (before any STEP runs), so
-// a STALE `implementation/node_modules` (one that predates the 1irs7
-// install — e.g. an operator who pulled the change but didn't re-run
-// `npm install`) would otherwise crash here with a raw loader stack
+// by rf2-1irs7. A STALE `implementation/node_modules` (one that predates
+// the 1irs7 install — e.g. an operator who pulled the change but didn't
+// re-run `npm install`) would otherwise crash with a raw loader stack
 // (`Error: Cannot find module 'cross-spawn'`) that gives NO hint the fix
 // is a one-time `npm install`. The script's own prep STEPS install deps
 // for the TOOLS packages, not for `implementation/` itself, so they
 // can't cover this. Fail LOUD with an actionable hint instead.
-let crossSpawn;
-try {
-  crossSpawn = require('cross-spawn');
-} catch (err) {
-  if (err && err.code === 'MODULE_NOT_FOUND') {
-    process.stderr.write(
-      "\ntest:mcp-conformance: 'cross-spawn' is not installed.\n" +
-        '  This entry-point requires the implementation/ devDependencies.\n' +
-        '  Fix: run `npm install` in implementation/ first ' +
-        '(rf2-1irs7 added cross-spawn as a devDependency).\n\n',
-    );
-    process.exit(1);
+// rf2-a9l6e — loaded lazily, on the first spawn only, so `--help` and the
+// unknown-option refusal answer correctly on a checkout whose
+// implementation/node_modules is absent, and so the profile-selection
+// regression test can require this module without touching npm state.
+let crossSpawn = null;
+function loadCrossSpawn() {
+  if (crossSpawn) return crossSpawn;
+  try {
+    crossSpawn = require('cross-spawn');
+  } catch (err) {
+    if (err && err.code === 'MODULE_NOT_FOUND') {
+      process.stderr.write(
+        "\ntest:mcp-conformance: 'cross-spawn' is not installed.\n" +
+          '  This entry-point requires the implementation/ devDependencies.\n' +
+          '  Fix: run `npm install` in implementation/ first ' +
+          '(rf2-1irs7 added cross-spawn as a devDependency).\n\n',
+      );
+      process.exit(1);
+    }
+    throw err;
   }
-  throw err;
+  return crossSpawn;
 }
-const { resolveTrustedExe } = require(
-  path.join(CONFORMANCE, 'lib', 'exec-safety.cjs'),
-);
 
 // Cache one resolution per tool name; the lookup walks PATH + PATHEXT
 // and is identical for every step that uses the same tool.
@@ -183,8 +313,8 @@ function resolveInstallStep(step) {
   return { ...step, exe: 'npm', args: ['install'], skip: false };
 }
 
-const STEPS = [
-  // ---- prep ----
+// ---- prerequisites (not gates: excluded from the gate summary) ----
+const PREP_STEPS = [
   {
     name: 'install tools/re-frame2-pair-mcp deps',
     install: true,
@@ -204,70 +334,164 @@ const STEPS = [
     cwd: CONFORMANCE,
     prep: true,
   },
+];
 
-  // ---- the six gates ----
+// ---- the six default-profile gates, run as five steps ----
+// Names carry NO `[n/6]` prefix: the position and the total are rendered at
+// print time from the PLANNED gate list, so the live profile reads `[7/7]`
+// rather than claiming six gates while running seven. `covers` is how many
+// of CI's split gates a step accounts for — one each, except the
+// conformance orchestrator, which is CI gates 4 AND 5 in a single pass.
+const DEFAULT_GATES = [
   {
-    name: '[1/6] JVM tools/story-mcp (clojure -M:test)',
+    name: 'JVM tools/story-mcp (clojure -M:test)',
     exe: 'clojure',
     args: ['-M:test'],
     cwd: STORY_MCP,
   },
   {
-    name: '[2/6] Node tools/story-mcp stdio roundtrip (rf2-h8z5l)',
+    name: 'Node tools/story-mcp stdio roundtrip (rf2-h8z5l)',
     node: true,
     args: ['test/stdio-roundtrip.js'],
     cwd: STORY_MCP,
   },
   {
-    name: '[3/6] Node tools/re-frame2-pair-mcp (shadow-cljs :server-test)',
+    name: 'Node tools/re-frame2-pair-mcp (shadow-cljs :server-test)',
     exe: 'npm',
     args: ['test'],
     cwd: PAIR_MCP,
   },
   {
-    name: '[4+5/6] MCP conformance tools/re-frame2-pair-mcp + tools/story-mcp (rf2-cum40)',
+    name: 'MCP conformance tools/re-frame2-pair-mcp + tools/story-mcp (rf2-cum40)',
     node: true,
     args: ['scripts/test-all.cjs'],
     cwd: CONFORMANCE,
+    covers: 2,
     // tools/mcp-conformance/npm test == node scripts/test-all.cjs;
-    // it covers BOTH gates [4] (re-frame2-pair-mcp end-to-end + live-*
-    // SKIPs) and [5] (story-mcp end-to-end + flag-gates) in one
-    // orchestrator pass, alongside the exec-safety unit tests. The
-    // upstream orchestrator already prints its own per-test summary
-    // (see `tools/mcp-conformance/scripts/test-all.cjs`), so we don't
+    // it covers BOTH the re-frame2-pair-mcp end-to-end + live-* SKIP rows
+    // and the story-mcp end-to-end + flag-gates in one orchestrator pass,
+    // alongside the exec-safety unit tests. The upstream orchestrator
+    // already prints its own per-test summary (see
+    // `tools/mcp-conformance/scripts/test-all.cjs`), so we don't
     // artificially split its output.
   },
   {
-    name: '[6/6] MCP conformance wire-vocab (rf2-j2z7o + rf2-6m8tq + rf2-zvv65)',
+    name: 'MCP conformance wire-vocab (rf2-j2z7o + rf2-6m8tq + rf2-zvv65)',
     exe: 'clojure',
     args: ['-M:test'],
     cwd: WIRE_VOCAB,
   },
 ];
 
-function banner(line) {
-  const sep = '─'.repeat(72);
-  process.stdout.write('\n' + sep + '\n' + line + '\n' + sep + '\n');
+// ---- the one extra gate the --live profile adds ----
+// It is a plain delegation to the EXISTING hermetic entry point (the
+// `test:re-frame2-pair-live-hermetic-suite` script of
+// tools/mcp-conformance/package.json), spawned under `process.execPath`
+// so its exit code — 1 inner, 2 orchestration/cleanup — reaches the
+// parent shell verbatim.
+const LIVE_GATE = {
+  name:
+    'hermetic live Pair conformance suite (shadow-cljs fixture + Chromium; ' +
+    `${LIVE_TESTS.length} live rows)`,
+  node: true,
+  args: ['scripts/run-re-frame2-pair-live-hermetic-suite.cjs'],
+  cwd: CONFORMANCE,
+  live: true,
+};
+
+// The whole of "profile" as a mechanism: which gate list runs.
+function planRun(profile) {
+  const gates =
+    profile === PROFILE_LIVE ? [...DEFAULT_GATES, LIVE_GATE] : [...DEFAULT_GATES];
+  return { profile, prep: PREP_STEPS, gates };
 }
 
-const results = [];
-let firstFailure = null;
+// CI splits the default profile into SIX jobs but one step covers two of
+// them, so the `[n/N]` label counts CI gates rather than spawns: the fourth
+// step reads `[4+5/6]`, and the live profile's extra step is `[7/7]`.
+function gateCount(gates) {
+  return gates.reduce((sum, gate) => sum + (gate.covers || 1), 0);
+}
 
-for (const rawStep of STEPS) {
-  // Install steps resolve their concrete command (npm ci / npm install /
-  // skip) from the live on-disk lockfile + node_modules state (rf2-vtp2er).
-  const step = rawStep.install ? resolveInstallStep(rawStep) : rawStep;
+function gatePositions(gates) {
+  let next = 1;
+  return gates.map((gate) => {
+    const span = gate.covers || 1;
+    const label = Array.from({ length: span }, (_, k) => next + k).join('+');
+    next += span;
+    return label;
+  });
+}
 
-  if (step.skip) {
-    banner(
-      '▷ ' + step.name +
-        '\n  cwd: ' + step.cwd +
-        '\n  SKIPPED: node_modules already present and no committed ' +
-        'lockfile to install against (reproducible-verify; rf2-vtp2er).',
+const SEP = '─'.repeat(72);
+
+function banner(line) {
+  process.stdout.write('\n' + SEP + '\n' + line + '\n' + SEP + '\n');
+}
+
+// The terminal verdict. EVERY branch names the profile that ran, so a
+// green can never be mistaken for the other profile's green, nor for a
+// skip (rf2-a9l6e).
+function verdict(profile, gates, firstFailure) {
+  const total = gateCount(gates);
+  if (firstFailure) {
+    const signal = firstFailure.signal ? ` (signal ${firstFailure.signal})` : '';
+    return (
+      `MCP-CONFORMANCE ${profile.toUpperCase()} PROFILE FAILED — ` +
+      `${firstFailure.step} exited ${firstFailure.status}${signal}`
     );
-    continue;
   }
+  if (profile === PROFILE_LIVE) {
+    return (
+      `MCP-CONFORMANCE LIVE PROFILE GREEN — ${total}/${total} gates, ` +
+      `hermetic live Pair suite INCLUDED (${LIVE_TESTS.length} live rows)`
+    );
+  }
+  return (
+    `MCP-CONFORMANCE DEFAULT PROFILE GREEN — ${total}/${total} gates, ` +
+    'hermetic live Pair suite NOT RUN'
+  );
+}
 
+// The summary block, verdict included. Pure: takes the planned gates and
+// whatever results the run produced, returns the text. The default
+// profile always carries an explicit NOT RUN row for the hermetic suite
+// with the exact opt-in command beside it.
+function renderReport({ profile, gates, results, firstFailure }) {
+  const total = gateCount(gates);
+  const positions = gatePositions(gates);
+  const lines = [
+    '',
+    SEP,
+    `test:mcp-conformance summary — profile: ${profile} (${PROFILES[profile].cost})`,
+    SEP,
+  ];
+  gates.forEach((gate, i) => {
+    const label = `[${positions[i]}/${total}] ${gate.name}`;
+    const result = results[i];
+    if (!result) {
+      lines.push(`  [NOT RUN ] ${label} (halted by an earlier failure)`);
+      return;
+    }
+    lines.push(
+      `  [${result.status === 0 ? 'OK      ' : 'FAIL    '}] ${label} (exit=${result.status})`,
+    );
+  });
+  if (profile === PROFILE_DEFAULT) {
+    lines.push(`  [NOT RUN ] ${LIVE_GATE.name}`);
+    lines.push('             — not part of the default profile. Opt in with:');
+    lines.push(`             ${LIVE_COMMAND}`);
+  }
+  lines.push('');
+  lines.push(verdict(profile, gates, firstFailure));
+  if (!firstFailure && profile === PROFILE_DEFAULT) {
+    lines.push(`  Live runtime behaviour is unproven here. Run: ${LIVE_COMMAND}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function runStep(step) {
   // Resolve the executable up-front: `node` steps use the absolute
   // `process.execPath`; native-tool steps resolve their bare name to a
   // trusted absolute path outside the workspace (rf2-1irs7 / rf2-33vvc).
@@ -278,42 +502,107 @@ for (const rawStep of STEPS) {
       '\n  exe: ' + exe +
       '\n  args: ' + step.args.join(' '),
   );
-  // `cross-spawn` + args ARRAY + NO `shell`: the resolved absolute path
+  // `cross-spawn` + args ARRAY + no shell: the resolved absolute path
   // is the only thing the OS interprets, so a workspace-local
   // `npm.cmd` / `npx.cmd` / `clojure.cmd` can no longer hijack the
   // invocation (rf2-1irs7). cross-spawn handles the Windows `.cmd` /
-  // extensionless-shim dispatch that built-in `spawnSync` can't under
-  // `shell: false`.
-  const child = crossSpawn.sync(exe, step.args, {
+  // extensionless-shim dispatch that built-in `spawnSync` can't without
+  // one.
+  return loadCrossSpawn().sync(exe, step.args, {
     cwd: step.cwd,
     stdio: 'inherit',
     env: process.env,
   });
-  const status = child.status === null ? 'signal:' + child.signal : child.status;
-  // Don't include prep steps in the gate-summary (they're not gates, they're prerequisites).
-  if (!step.prep) {
-    results.push({ name: step.name, status });
-  }
-  if (child.status !== 0 && firstFailure === null) {
-    firstFailure = { step: step.name, status: child.status, signal: child.signal };
-    break;
-  }
 }
 
-banner('test:mcp-conformance summary');
-for (const r of results) {
-  const tick = r.status === 0 ? 'OK  ' : 'FAIL';
-  process.stdout.write(`  [${tick}] ${r.name} (exit=${r.status})\n`);
-}
+function main(argv) {
+  const selection = parseArgs(argv);
 
-if (firstFailure) {
-  process.stdout.write(
-    `\nFAIL: ${firstFailure.step} exited ${firstFailure.status}` +
-      (firstFailure.signal ? ' (signal ' + firstFailure.signal + ')' : '') +
-      '\n',
+  if (selection.error) {
+    // Before ANY install, compile, or server boot.
+    process.stderr.write(
+      `\ntest:mcp-conformance: ${selection.error} — nothing ran.\n` +
+        `  Profiles: (no flag) = default/medium, \`--live\` = live/expensive.\n` +
+        `  See \`${ROOT_COMMAND} -- --help\`.\n\n`,
+    );
+    return EXIT_USAGE;
+  }
+
+  if (selection.help) {
+    process.stdout.write(helpText());
+    return 0;
+  }
+
+  const { profile, prep, gates } = planRun(selection.profile);
+  banner(
+    `test:mcp-conformance — profile: ${profile} (${PROFILES[profile].cost})` +
+      `\n  gates: ${gateCount(gates)} (in ${gates.length} steps)` +
+      (profile === PROFILE_DEFAULT
+        ? `\n  hermetic live Pair suite: NOT RUN (opt in: ${LIVE_COMMAND})`
+        : `\n  hermetic live Pair suite: INCLUDED (${LIVE_TESTS.length} live rows)`),
   );
-  process.exit(firstFailure.status === null ? 1 : firstFailure.status);
+
+  const results = [];
+  let firstFailure = null;
+
+  for (const rawStep of [...prep, ...gates]) {
+    // Install steps resolve their concrete command (npm ci / npm install /
+    // skip) from the live on-disk lockfile + node_modules state (rf2-vtp2er).
+    const step = rawStep.install ? resolveInstallStep(rawStep) : rawStep;
+
+    if (step.skip) {
+      banner(
+        '▷ ' + step.name +
+          '\n  cwd: ' + step.cwd +
+          '\n  SKIPPED: node_modules already present and no committed ' +
+          'lockfile to install against (reproducible-verify; rf2-vtp2er).',
+      );
+      continue;
+    }
+
+    const child = runStep(step);
+    const status = child.status === null ? 'signal:' + child.signal : child.status;
+    // Prep steps are prerequisites, not gates — keep them out of the
+    // gate summary so the `[n/N]` positions stay honest.
+    if (!step.prep) {
+      results.push({ name: step.name, status });
+    }
+    if (child.status !== 0) {
+      firstFailure = {
+        step: step.name,
+        status: child.status,
+        signal: child.signal,
+      };
+      break;
+    }
+  }
+
+  process.stdout.write(renderReport({ profile, gates, results, firstFailure }));
+
+  if (firstFailure) {
+    // Forward the child's own code so the hermetic suite's 1-vs-2
+    // distinction survives to the parent shell.
+    return firstFailure.status === null ? 1 : firstFailure.status;
+  }
+  return 0;
 }
 
-process.stdout.write('\nALL MCP-CONFORMANCE GATES GREEN\n');
-process.exit(0);
+module.exports = {
+  parseArgs,
+  planRun,
+  helpText,
+  renderReport,
+  verdict,
+  gateCount,
+  PROFILE_DEFAULT,
+  PROFILE_LIVE,
+  ROOT_COMMAND,
+  LIVE_COMMAND,
+  EXIT_USAGE,
+  DEFAULT_GATES,
+  LIVE_GATE,
+};
+
+if (require.main === module) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -110,10 +110,52 @@ loaded names.
 
 ## Running the gates
 
-Install this artefact's Node dependencies first:
+### Start here: the two repository-root commands
+
+One command runs MCP compatibility, in one of two explicit profiles. Both
+run from the repository root and install what they need themselves.
 
 ```bash
-npm install
+# default profile — medium cost, no browser
+npm --prefix implementation run test:mcp-conformance
+
+# live profile — expensive; adds the hermetic live Pair suite
+npm --prefix implementation run test:mcp-conformance -- --live
+```
+
+Each run ends on a verdict that names the profile it ran, so a green can
+never be mistaken for one whose live layer was skipped. Adding `-- --help`
+prints both profiles, their prerequisites, their relative cost and their
+exit codes, and exits before installing, compiling, or booting anything.
+
+| Layer | `default` | `--live` |
+| --- | --- | --- |
+| story-mcp JVM suite | included | included |
+| story-mcp stdio roundtrip | included | included |
+| re-frame2-pair-mcp `:server-test` | included | included |
+| SDK end-to-end: degraded pair, story, flag gates | included | included |
+| wire-vocabulary JVM suite | included | included |
+| live pair rows (`test/live-re-frame2-pair-*.cjs`) | `SKIP` | run, sentinel-graded |
+| hermetic shadow-cljs + Chromium orchestration | omitted | run, cleanup-graded |
+
+Exit codes carry through from the hermetic runner: `1` is a conformance
+failure, `2` is an orchestration or cleanup failure where the teardown could
+not be proven clean.
+
+`npm test` in this package is narrower than either profile: it is the Node
+inventory alone — no JVM suite, no hermetic live suite — with the live rows
+reporting `SKIP`.
+
+### Focused diagnostic recipes
+
+The commands below run one layer at a time, for diagnosing a failure the
+profiles above have already found.
+
+Install this artefact's Node dependencies first, lockfile-exact — the same
+install the repository-level runner performs:
+
+```bash
+npm ci
 ```
 
 The focused, server-free Node gate is:
@@ -155,7 +197,9 @@ clojure -M:test
 
 `npm test` runs the authoritative Node inventory sequentially and fails
 fast. Live rows report `SKIP` unless a port is supplied; the hermetic
-command above is the gate that requires them to execute.
+command above is the gate that requires them to execute, and
+`test:mcp-conformance -- --live` is the repository-level command that
+chains it.
 
 ## Inventory ownership
 


### PR DESCRIPTION
## What

`npm --prefix implementation run test:mcp-conformance` is now the one documented
front door for MCP compatibility, and **every terminal verdict it prints names the
profile that actually ran** (rf2-a9l6e).

The defect it closes: the default run correctly leaves the hermetic live Pair
suite out — an intentional cost boundary, not a missing test — and then ended on
`ALL MCP-CONFORMANCE GATES GREEN`, a sentence indistinguishable from a run whose
live layer had been exercised. One level down the child orchestrator already says
`SKIP` for those rows; the outer runner threw that distinction away.

## Two profiles, one runner

| | `default` (medium) | `--live` (expensive) |
| --- | --- | --- |
| six PR-time gates (story JVM, story stdio, pair `:server-test`, SDK conformance for both servers, wire-vocab) | run | run |
| hermetic live Pair suite (shadow-cljs fixture + Chromium, 6 live rows) | **NOT RUN**, with the exact opt-in command printed beside it | run, sentinel- and cleanup-graded |

- `--live` is a single extra step delegating to the **existing**
  `test:re-frame2-pair-live-hermetic-suite` entry point. Its exit codes reach the
  parent shell verbatim, so `1` (inner conformance) and `2` (orchestration/cleanup
  could not be proven clean) stay distinct.
- `--help` prints both profiles, prerequisites, cost boundary, exit codes and the
  narrower meaning of `tools/mcp-conformance`'s own `npm test`. It exits 0 **before
  any install, compile or server boot** — verified on a checkout with no
  `node_modules` at all.
- An unknown option exits `64` (EX_USAGE, deliberately not colliding with the gate
  codes) having mutated nothing.
- Gate positions are rendered from the planned list, so the fourth step reads
  `[4+5/6]` (it covers two CI jobs in one pass) and the live step reads `[7/7]`.

## No new machinery

`LIVE_TESTS` is read from `scripts/live-test-inventory.cjs` — the one live roster,
the same module the hermetic runner derives `INNER_TESTS` from. No second
inventory, no report format, no CI job, no workflow file touched, no change to
`implementation/package.json` or `TESTING.md`.

## Regression coverage

Selection and verdict rendering are pure exported functions
(`parseArgs` / `planRun` / `renderReport` / `helpText`), and the runner only spawns
under `require.main === module`. `implementation/scripts/_mcp-conformance-install-policy.test.cjs`
— the suite that already pinned this runner — gains eleven tests covering default,
`--live`, `--help`/`-h`, unknown-option, the live gate's absence/presence in the
planned summary, agreement with the conformance package's own hermetic script
name, and the exact verdict text in all four terminal branches. None of them
launches Clojure, shadow-cljs, Chromium, or either MCP server.

## Verification

Both profiles were run end to end from the repository root, exactly as the README
now documents them. Exit codes are the numbers captured by the invoking shell.

**Default profile** — `npm --prefix implementation run test:mcp-conformance`,
captured exit **0**:

```
test:mcp-conformance summary — profile: default (medium)
────────────────────────────────────────────────────────────────────────
  [OK      ] [1/6] JVM tools/story-mcp (clojure -M:test) (exit=0)
  [OK      ] [2/6] Node tools/story-mcp stdio roundtrip (rf2-h8z5l) (exit=0)
  [OK      ] [3/6] Node tools/re-frame2-pair-mcp (shadow-cljs :server-test) (exit=0)
  [OK      ] [4+5/6] MCP conformance tools/re-frame2-pair-mcp + tools/story-mcp (rf2-cum40) (exit=0)
  [OK      ] [6/6] MCP conformance wire-vocab (rf2-j2z7o + rf2-6m8tq + rf2-zvv65) (exit=0)
  [NOT RUN ] hermetic live Pair conformance suite (shadow-cljs fixture + Chromium; 6 live rows)
             — not part of the default profile. Opt in with:
             npm --prefix implementation run test:mcp-conformance -- --live

MCP-CONFORMANCE DEFAULT PROFILE GREEN — 6/6 gates, hermetic live Pair suite NOT RUN
  Live runtime behaviour is unproven here. Run: npm --prefix implementation run test:mcp-conformance -- --live
```

**Live profile** — `npm --prefix implementation run test:mcp-conformance -- --live`,
captured exit **0**. The hermetic suite really ran (`RE-FRAME2-PAIR-MCP live
hermetic conformance passed (6 inner tests).`), which it emits only after every
inner row reaches its sentinel and the teardown grades clean:

```
test:mcp-conformance summary — profile: live (expensive)
────────────────────────────────────────────────────────────────────────
  [OK      ] [1/7] JVM tools/story-mcp (clojure -M:test) (exit=0)
  [OK      ] [2/7] Node tools/story-mcp stdio roundtrip (rf2-h8z5l) (exit=0)
  [OK      ] [3/7] Node tools/re-frame2-pair-mcp (shadow-cljs :server-test) (exit=0)
  [OK      ] [4+5/7] MCP conformance tools/re-frame2-pair-mcp + tools/story-mcp (rf2-cum40) (exit=0)
  [OK      ] [6/7] MCP conformance wire-vocab (rf2-j2z7o + rf2-6m8tq + rf2-zvv65) (exit=0)
  [OK      ] [7/7] hermetic live Pair conformance suite (shadow-cljs fixture + Chromium; 6 live rows) (exit=0)

MCP-CONFORMANCE LIVE PROFILE GREEN — 7/7 gates, hermetic live Pair suite INCLUDED (6 live rows)
```

The two verdicts are the whole point: neither can be read as the other, and the
default one says out loud what it did not prove.

Other captured exits: policy suite **0** (16/16), `_script-spawn-policy.test.cjs`
**0** (141/141), `check_readme_links.py --ci` **0**, `check_gate_scheduling.py`
**0** (33 gate commands, no orphans).

`--help`: captured exit **0**, on a checkout with no `node_modules` anywhere —
nothing was installed. `-- --liv`: captured exit **64**, and the three tool
`node_modules` directories were still absent afterwards.

Gates run, and why these:

- **The runner itself**, both profiles — it is what changed.
- `implementation/scripts/_mcp-conformance-install-policy.test.cjs` — the runner's
  own policy suite (install reproducibility + the new profile selection).
- `implementation/scripts/_script-spawn-policy.test.cjs` — the other suite that
  pins this file; the runner keeps its `resolveTrustedExe` + `cross-spawn` posture.
- `scripts/check_readme_links.py --ci` — nominated **by path**: the changed
  `tools/mcp-conformance/README.md` is a README beside source, outside
  `check_doc_slugs.py`'s roots. (`mkdocs build --strict` is not a candidate at all:
  `docs_dir` is `docs`, so `tools/` was never in the site build.)
- `scripts/check_gate_scheduling.py` — the runner is a declared gate command there.

Controls, because a green from a gate that read the wrong tree is worth nothing:

- **The policy suite discriminates.** Its first run against this branch came back
  **red (captured exit 1)**, naming four failures at line numbers in this
  worktree's copy of the file — including one that caught a real bug (the gate
  `[n/N]` label had silently become `[n/5]`, because CI's six gates run as five
  spawns). Fixing it in this tree turned it green, 16/16.
- **`check_readme_links.py --ci` reads this worktree.** A planted broken target in
  the paragraph this PR adds took it to **captured exit 1** naming
  `tools\mcp-conformance\README.md:128 -> ../../implementation/scripts/no-such-runner-planted.cjs`;
  the plant was reverted and the restore verified by git blob hash
  (`1f63264d…` before and after, identical), and the re-run returned **captured
  exit 0**.
- Both live runner invocations print their `cwd:` per step, and every line named
  this worktree.

**Ungated by construction:** the two copyable commands live inside fenced code
blocks in the README, and neither link gate reads inside a fence. They were checked
by hand, by running them: `-- --help` exits 0, `-- --liv` exits 64, and the default
profile run below used the fenced command verbatim.

Table column counts in the new README table were counted by hand (3 columns
throughout); no gate validates markdown tables.
