### PR TITLE
fix(ci): arm the Story browser gate on the macro producer (rf2-uqf5q)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -276,8 +276,37 @@ mark_all() {
 # HTML-only change used to classify as no-surface and skip the gate
 # entirely. It is a runtime path by the same test as the others: change
 # it and the browser sees something different.
+#
+# rf2-uqf5q — with the SAME ONE named exception both sibling predicates
+# below already carry: tools/story/src/re_frame/story/macros.clj. The
+# extension guard here excludes `.clj`, which is right for a JVM consumer
+# and wrong for the one CLJ namespace under either src tree that is a
+# compile-time PRODUCER. `re-frame.story` delegates every public
+# registration macro to it, so the CLJS a testbed's `(story/reg-story …)`
+# / `(story/reg-variant …)` call site compiles to — and therefore what the
+# Playwright deck actually renders — comes out of this file.
+#
+# MEASURED, NOT PREDICTED. story_xray_browser is this predicate's to arm,
+# and it read false for macros.clj — so the browser-gates job skipped
+# BOTH its tiers, the PR-smoke one and the full feature-load one, because
+# story_full_gate arms only on the gate's own spec modules and was false
+# too. Commit e1cbd089c4 (rf2-3xq1v) walked through exactly that hole: it
+# routed re-frame.story.macros/coords-form through
+# re-frame.source-coords/coords-form, which absolutises at
+# macro-expansion time, changing the source-coord rendered in the Story
+# pane. No browser gate ran, so nothing saw the pane it changed; it
+# surfaced ~1.5 hours later only because two unrelated PRs happened to
+# arm every surface, and it blocked both of them.
+#
+# Named rather than globbed, exactly as on the two predicates below: this
+# is the only CLJ macro namespace either tool ships, and a second one
+# should be a deliberate edit here rather than a silent widening of the
+# browser matrix. An ordinary JVM `.clj` beside it keeps the general
+# exclusion, and the testbed arms are untouched.
 is_story_xray_runtime_path() {
   case "$1" in
+    tools/story/src/re_frame/story/macros.clj)
+      return 0 ;;
     tools/story/src/*|tools/xray/src/*|tools/story/testbeds/*|tools/xray/testbeds/*)
       case "$1" in
         *.cljs|*.cljc|*.js|*.cjs|*.css|*.scss|*.html)
@@ -2085,11 +2114,14 @@ else
         esac
         # story_xray_browser is narrowed (rf2-k9ekz): it fires ONLY when
         # the changed path is under tools/{story,xray}/{src,testbeds}/**
-        # AND the file has a runtime extension
-        # (.cljs/.cljc/.js/.cjs/.css/.scss). Markdown specs, JVM unit
-        # tests under tools/{story,xray}/test/**, deps.edn, README.md,
-        # and *.txt do NOT fire it. The split-out framework-testbeds
-        # gate (formerly rf2-9grp6) was retired in rf2-t5slp.
+        # AND the file has a runtime extension — plus the one named
+        # macros.clj exception (rf2-uqf5q). Read the predicate for the
+        # authoritative extension list rather than a copy here; this
+        # summary has already drifted once (it predated `.html`,
+        # rf2-kttom). Markdown specs, JVM unit tests under
+        # tools/{story,xray}/test/**, deps.edn, README.md, and *.txt do
+        # NOT fire it. The split-out framework-testbeds gate (formerly
+        # rf2-9grp6) was retired in rf2-t5slp.
         if is_story_xray_runtime_path "$file"; then
           story_xray_browser=true
         fi

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -697,6 +697,59 @@ test('Story macros.clj keeps its existing non-CLJS fan-out (rf2-eyyd2)', () => {
   assert.equal(result.template_expensive, 'true');
 });
 
+// rf2-uqf5q — the THIRD predicate. rf2-eyyd2 armed macros.clj on the two CLJS
+// unit lanes above and left `is_story_xray_runtime_path` — the one that owns
+// story_xray_browser, i.e. the Playwright decks — still reading its `.clj`
+// extension guard. So a Story MACRO change fired NO browser gate at all:
+// story_xray_browser false skipped the PR-smoke tier, and story_full_gate arms
+// only on the feature-load gate's own spec modules, so the full tier skipped
+// with it. Commit e1cbd089c4 (rf2-3xq1v) went through that hole — it changed
+// the source-coord the Story pane renders, by way of this very macro
+// namespace, and no browser saw it until two unrelated PRs armed everything.
+
+test('Story macros.clj fires the Playwright browser gate (rf2-uqf5q)', () => {
+  // The macro namespace is the compile-time producer for every
+  // `(story/reg-story …)` / `(story/reg-variant …)` call site the testbed
+  // decks contain, so its emitted forms ARE what the deck renders.
+  const result = classify(STORY_MACROS);
+  assert.equal(
+    result.story_xray_browser,
+    'true',
+    'a Story macro change must schedule the Story/Xray browser gate: the decks ' +
+      'render what this namespace emits',
+  );
+});
+
+test('Story macros.clj now arms every lane its expansion reaches (rf2-uqf5q)', () => {
+  // The three predicates together, pinned in one place so a future narrowing
+  // of any one of them is visible as a narrowing rather than as a lane that
+  // quietly stopped running.
+  const result = classify(STORY_MACROS);
+  for (const lane of ['cljs_node_test', 'cljs_browser', 'story_xray_browser']) {
+    assert.equal(result[lane], 'true', `macros.clj must arm ${lane}`);
+  }
+});
+
+test('the browser-gate arm is macros.clj by NAME, not a `.clj` widening (rf2-uqf5q)', () => {
+  // The ruling was to complete an existing pattern on ONE predicate, not to
+  // widen the browser matrix. A hypothetical JVM consumer beside macros.clj,
+  // and an ordinary `.clj` under the Xray src tree, both keep the general
+  // exclusion — on the Playwright gate as on the two CLJS lanes.
+  for (const file of [
+    'tools/story/src/re_frame/story/jvm_only_helper.clj',
+    'tools/xray/src/day8/re_frame2_xray/jvm_only_helper.clj',
+  ]) {
+    assert.equal(classify(file).story_xray_browser, 'false', file);
+  }
+});
+
+test('macros.clj does not drag the FULL Story feature-load tier along (rf2-uqf5q)', () => {
+  // story_full_gate stays what rf2-65ajl made it: the feature-load runner's
+  // own spec modules and orchestration. A macro change belongs on the smoke
+  // tier, which is the tier that mounts the decks.
+  assert.equal(classify(STORY_MACROS).story_full_gate, 'false');
+});
+
 test('an ordinary JVM-only .clj under Story src stays off both CLJS lanes (rf2-eyyd2)', () => {
   // The named exception is macros.clj and nothing else: a hypothetical JVM
   // consumer beside it must keep the general `.clj` exclusion.
@@ -704,6 +757,33 @@ test('an ordinary JVM-only .clj under Story src stays off both CLJS lanes (rf2-e
   assert.equal(result.cljs_browser, 'false');
   assert.equal(result.cljs_node_test, 'false');
   assert.equal(result.tools_jvm, 'true');
+});
+
+test('macros.clj is still the ONLY .clj under either src tree (rf2-uqf5q)', () => {
+  // The teeth on the "named, not globbed" choice. Three predicates now name
+  // this one path; a SECOND macro namespace appearing beside it would be
+  // armed on none of them and would repeat rf2-3xq1v exactly. Read the tree
+  // rather than trusting the claim, and name what was found.
+  const found = [];
+  for (const tool of ['story', 'xray']) {
+    const root = path.join(REPO_ROOT, 'tools', tool, 'src');
+    const walk = (dir) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (entry.name.endsWith('.clj')) {
+          found.push(path.relative(REPO_ROOT, full).split(path.sep).join('/'));
+        }
+      }
+    };
+    if (fs.existsSync(root)) walk(root);
+  }
+  assert.deepEqual(
+    found.sort(),
+    [STORY_MACROS],
+    'a new .clj under tools/{story,xray}/src is armed by NO classifier arm; ' +
+      'name it in all three predicates or explain why it is a JVM consumer',
+  );
 });
 
 test('an ordinary JVM-only .clj test under Story/Xray stays off both CLJS lanes (rf2-eyyd2)', () => {


### PR DESCRIPTION
## What

`is_story_xray_runtime_path` in `.github/scripts/report-changed-surfaces.sh` extension-guards
`tools/{story,xray}/src/**` in a way that excludes `.clj`. Both sibling predicates —
`is_story_xray_node_test_path` and `is_story_xray_dom_test_path` — already carry a **named
exception** for `tools/story/src/re_frame/story/macros.clj` (rf2-eyyd2), because it is the one CLJ
namespace under either src tree that is a compile-time **producer** rather than a JVM consumer:
`re-frame.story` delegates every public registration macro to it, so the CLJS a testbed's
`(story/reg-story …)` / `(story/reg-variant …)` call site compiles to comes out of this file.

This adds that same named exception to the third predicate.

## Why — measured, not predicted

`story_xray_browser` is this predicate's to arm, and `story_full_gate` arms only on the feature-load
runner's own spec modules. Both were false for `macros.clj`, so the browser-gates job — whose `if:`
is `story_xray_browser == 'true' || story_full_gate == 'true'` — **skipped entirely**: a Story macro
change fired no browser gate at all, neither the PR-smoke tier nor the full one.

Commit `e1cbd089c4` (rf2-3xq1v) went through exactly that hole. It routed
`re-frame.story.macros/coords-form` through `re-frame.source-coords/coords-form`, which absolutises
at macro-expansion time and changed the source-coord the Story pane renders. Nothing saw the pane it
changed until two unrelated PRs happened to arm every surface ~1.5 hours later, and it blocked both.

## Scope

Completion of an existing pattern on **one** predicate, named rather than globbed exactly as on its
two siblings. The browser matrix is not otherwise widened, the testbed arms are untouched, and
`story_full_gate` is unchanged. No `.github/workflows/**` file is touched.

The call-site summary comment is also corrected: it enumerated a stale extension list that predated
`.html` (rf2-kttom), so it now points at the predicate instead of copying it.

## Probes — before and after, with controls in both directions

A surface classifier handed input it does not understand reports every surface unaffected, which is
indistinguishable from a genuinely unaffected change. So the defect probe is quoted beside a positive
control that proves the probe works, and a negative control that proves the arm did not widen.

| path | `story_xray_browser` before | after |
| --- | --- | --- |
| `tools/story/src/re_frame/story/macros.clj` (the defect) | `false` | **`true`** |
| `tools/story/src/re_frame/story.cljc` (positive control) | `true` | `true` |
| `tools/story/src/re_frame/story/jvm_only_helper.clj` (negative control) | `false` | `false` |

`macros.clj`'s existing fan-out is unchanged and re-checked: `cljs_node_test`, `cljs_browser`,
`examples_compile`, `tools_jvm`, `mcp_conformance`, `template_expensive` all stay `true`;
`story_full_gate` stays `false`.

## One-toucher pair

`.github/scripts/report-changed-surfaces.sh` and its mirror
`implementation/scripts/_changed-surfaces.test.cjs` are one-toucher by construction for any change
altering what the classifier outputs, and this alters it. **Both halves move in this single commit.**
PR #8941, which held the pair, is merged; its Pair-fixture roots and #8903's four MIG-23 cold-start
roots were checked by name and survive verbatim.

Five pins added to the mirror: the newly-armed lane; the three lanes together, so a future narrowing
of any one reads as a narrowing rather than as a lane that quietly stopped running; the
named-not-globbed narrowness, exercised on both src trees; `story_full_gate` staying `false`; and a
tree-read check that `macros.clj` is still the only `.clj` under either src tree — a second one would
be armed by no predicate at all and would repeat rf2-3xq1v.

## Gate

`implementation/scripts/_changed-surfaces.test.cjs`, run directly with node — the mirror that pins
the classifier's outputs. **Captured exit `0`, 335 passed.**

The three link/anchor gates and `mkdocs build --strict` are not nominated: this diff contains no
markdown, and `.github/**` is outside `docs_dir` entirely.

**This PR's own CI does not prove the edge.** Editing the classifier script hits its `mark_all` arm,
so everything arms here and the Story gate runs because *everything* runs. The real evidence is the
mirror plus a planted-fault red: removing the new arm from the predicate turned the suite red on
exactly the two new assertions (captured exit `1`, `2 failed`), and restoring it returned exit `0`
with the file's git blob hash matching the committed object. End-to-end confirmation is the next PR
touching only a Story `macros.clj`.

Closes rf2-uqf5q.
