### PR TITLE
docs(method): name WHEN to re-check a close — across the publish sequence, on both sides

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1564,6 +1564,22 @@ rollback to an earlier snapshot, a re-import over the top — and nothing in the
 session's "closed" count quietly overstates. Verifying at the moment you close is not enough. Each cycle,
 re-check everything closed this session and re-close what genuinely reverted, with evidence.
 
+**That rule records the hazard but leaves its discriminating test open — WHEN in the cycle — and the
+answer is: across the sequence that exports the tracker, restores it from version control and publishes
+it.** *Each cycle* puts the re-read at the next loop, so a revert stays live for as long as a loop is
+long; one caught that way had been standing over an hour and surfaced by accident during an unrelated
+read rather than by the rule. That publish sequence is the one disturbance every cycle reliably
+contains, and it sits between the close and the next re-read, so it is where to look rather than
+somewhere to look eventually.
+
+**Read BOTH sides of it, not just after.** Measured in one session: two closes verified only at close
+time were both gone by the next read, while a third — re-read immediately before *and* after that
+sequence, then confirmed by parsing the published export for that item's own status field — held. A
+single check afterwards tells you a close is missing but not which side of the sequence lost it, and
+the two have different remedies. **Do not infer the mechanism from the coincidence**: a sequence
+containing several steps is not evidence about which step moved the state, and naming a culprit you
+have not isolated converts a reliable check into a wrong explanation that will be repeated.
+
 **But a status change made by a LIVE worker is that worker speaking, not corruption.** The rule
 above trains you to read an unexpected status as a bad write, and it supplies no competing
 reading, so the wrong one arrives with nothing to check it. A worker that un-claims an item is


### PR DESCRIPTION
## The drift

Tracker mechanics already records the hazard — *"A tracker write can silently revert"* — and prescribes *"Each cycle, re-check everything closed this session."* That is **a hazard recorded without its discriminating test**, which is one of the four things §6 sends this loop looking for.

`Each cycle` puts the re-read at the *next* loop, so a revert stays live for as long as a loop is long. The missing half is **when within the cycle**, and this session measured the answer.

## What was measured

Two closes verified only at close time were both gone by the next read. One of them had been standing **over an hour** and surfaced by accident during an unrelated read rather than by the rule that exists to catch it.

A third close — re-read immediately **before and after** the sequence that exports the tracker, restores it from version control and publishes it, then confirmed by parsing the published export for that item's own `status` field — **held**.

That sequence is the one disturbance every cycle reliably contains, and it sits between the close and the next re-read. So it is *where to look*, not *somewhere to look eventually*.

## Why both sides, not just after

A single check afterwards tells you a close is missing but not **which side of the sequence lost it**, and the two have different remedies.

## What this deliberately does NOT say

It does not name a culprit step. The sequence has several and this session isolated none of them — the incidents are consistent with more than one, and one of the two even had an unrelated `index.lock` abort in the middle. Asserting a mechanism I have not isolated would convert a reliable check into a wrong explanation that then gets repeated, which is the failure mode this document has recorded against itself twice already.

## Bounded in change, not in search

Searched for siblings first: the closure-verification rule exists in exactly **one** place across both method pages (`loops.md` Tracker mechanics). `dispatch-prompt-template.md`'s only `silently revert` hit is about surface merge-conflicts, not closures. Nothing else to fix, so the change is one paragraph pair at the point of the existing rule.

## Gates

| gate | captured exit | tree-read proof |
|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | planted → **exit 1**, `BROKEN TARGET: docs\the-mayor-method\loops.md:1575` |
| `python -m mkdocs build --strict` | **0** | planted → **exit 1**, `WARNING - Doc file 'the-mayor-method/loops.md' contains a link 'rf2-planted-closewhen-file.md'` |

Both plants restored in one act; restore verified by git **blob** hash against the committed object (`b2c77a4299…`, identical before and after), never by reading a diff. Anchor match count read as 1 before planting.

**Incidental confirmation of two recorded constants**: the same plant carried a broken *anchor* alongside the broken *file link*, and mkdocs graded the anchor at **INFO** while grading the link at **WARNING** — so `--strict` failed on the link and would have shipped the anchor silently. That is exactly what `mkdocs.yml`'s own commentary says, and it is why `check_doc_slugs.py` stays the anchor gate.

No fenced blocks added. Merge-base diff (`origin/main...HEAD`) is one file, 16 insertions, 0 deletions — nothing reverted.