### PR TITLE
fix(machines): fence the hydration arm's own /scheduled fan-out (rf2-jqvgp)

### DIFF
--- a/implementation/machines/src/re_frame/machines/hydrate.cljc
+++ b/implementation/machines/src/re_frame/machines/hydrate.cljc
@@ -277,8 +277,12 @@
   ## One incarnation for the whole reconcile
 
   Both phases emit callback-bearing traces —
-  `:rf.machine.timer/cancelled` in phase 1 and again from each arm's
-  leading `:on-supersede` in phase 2 — and a listener on either can
+  `:rf.machine.timer/cancelled` in phase 1, and in phase 2 both each
+  arm's leading `:on-supersede` and the arm's own
+  `:rf.machine.timer/scheduled` (hydration arms with
+  `:emit-scheduled-trace?` true, so it is emitted here rather than by a
+  transition; on a frame that held no prior timer it is the FIRST
+  callback of the whole reconcile) — and a listener on any of them can
   `destroy-frame!` this frame and publish a same-id successor B. The
   declarations being reconciled are A's: they were enumerated from the
   runtime-db A held. Installing them into B would be host work derived
@@ -289,7 +293,10 @@
   phase, and every callback-bearing step is fenced by that ONE predicate
   (rf2-jqvgp): the cancel batch short-circuits on it, the arm loop
   rechecks it before each declaration, and each arm carries it down into
-  `schedule-after-timer!` in place of a fresh capture. Per-step capture
+  `schedule-after-timer!` in place of a fresh capture — where it fences
+  BOTH of that fn's callback boundaries, the leading `:on-supersede`
+  cancel and the `/scheduled` emit, each with its own recheck before any
+  durable step. Per-step capture
   is what fails here, and it fails silently: each step alone is correct
   about the owner it captured, and B — a live frame with the right id —
   accepts the work without complaint. The loop is explicit rather than a

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -505,7 +505,19 @@
   one. A fresh capture is right for a standalone arm, but wrong inside a batch:
   if an earlier step's cancellation already destroyed A and published same-id B,
   a re-capture names B as the owner and the A-derived arm proceeds into it. The
-  SSR hydration reconcile is the one such caller."
+  SSR hydration reconcile is the one such caller.
+
+  rf2-jqvgp — the supersede is not this fn's only callback boundary. With
+  `:emit-scheduled-trace?` true (the SSR hydration arm and the dynamic-delay
+  re-resolution) it emits `:rf.machine.timer/scheduled` ITSELF, synchronously,
+  AFTER the post-supersede recheck and BEFORE the slot is reserved — so a
+  listener on that row has the same reach as one on `/cancelled`, and on a frame
+  holding no prior timer it is the FIRST callback of the whole operation. The
+  same predicate is therefore rechecked once more, immediately after that emit:
+  every durable step (slot reservation, host arm, publish, watcher) sits behind
+  it. The abort deliberately releases nothing — see the comment at that recheck
+  for why the one hold in flight is already gone with A, and why releasing it
+  would land on B."
   [frame-id parent-id invoke-id state delay-key epoch server? snapshot
    {:keys [emit-scheduled-trace? owner-gone?]}]
   (let [delay-source (transition/classify-delay-source delay-key)
@@ -599,143 +611,167 @@
                              (= :sub delay-source)
                              (assoc :rf.sub/id      (first delay-key)
                                     :rf.sub/query-v (vec delay-key)))))
-            ;; PHASE 1 — RESERVE the slot with an arming sentinel (`:handle
-            ;; nil`) carrying this attempt's `:token`, BEFORE arming any host
-            ;; clock. The reaction + watch-key ride the sentinel so a claiming
-            ;; cleanup releases the held subscription ref-count even though the
-            ;; physical add-watch is deferred to publication.
-            (swap! after-timers assoc-in [frame-id k]
-                   {:handle          nil
-                    :reaction        reaction
-                    :sub-watcher-key watch-key
-                    :resolved-ms     resolved-ms
-                    :epoch           epoch
-                    :state           state
-                    :region          region
-                    :delay-source    delay-source
-                    :token           token})
-            (let [handle
-                  ;; Shared positive-delay-guarded arm — the host-clock arm
-                  ;; step both timer artefacts share. `resolved-ms` is already
-                  ;; known-positive here (the non-positive case was handled by
-                  ;; the prior `cond` branch), so the guard is a no-op
-                  ;; pass-through.
-                  (managed-timer/arm!
-                    (fn []
-                      ;; ATOMICALLY claim THIS fire's slot — dispatch AUTHORITY
-                      ;; + reap in a single swap (mirrors core `:dispatch-later`,
-                      ;; rf2-j538f7.2). If a cleanup / supersede claimed the slot
-                      ;; first — even a synchronous host callback firing before
-                      ;; `arm!` returns, or a JVM cleanup racing the arm — this
-                      ;; fire has LOST authority: suppress the dead-on-arrival
-                      ;; dispatch and touch nothing (the claimer already released
-                      ;; our resources). On the live path the claim wins:
-                      (when-let [claimed (claim-entry! frame-id k token)]
-                        (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-                          ;; Stamp `:source :after-timer` so the Epoch panel's
-                          ;; DISPATCH step labels it "from :after timer" and
-                          ;; Xray's L2 timeline can prefix the row + per-source
-                          ;; filter pills can discriminate timer-fired cascades
-                          ;; (closed-enum per Spec-Schemas
-                          ;; §`:rf/dispatch-envelope`). Per Spec 005 §Hierarchy
-                          ;; interaction: carry the scheduling node's decl-path
-                          ;; (`invoke-id`) so the pure side routes the firing to
-                          ;; the correct per-path epoch — colliding delay-keys
-                          ;; across hierarchy levels resolve unambiguously.
-                          (dispatch! [parent-id [:rf.machine.timer/after-elapsed
-                                                 delay-key epoch (vec invoke-id)]]
-                                     {:frame  frame-id
-                                      :source :after-timer}))
-                        ;; A one-shot `:after` timer fires exactly once per
-                        ;; arming (XState §delayed transitions). Release THIS
-                        ;; fire's sub-reaction watcher + held subscription
-                        ;; ref-count (the host handle just fired, so its cancel
-                        ;; is a harmless no-op). This is what keeps a
-                        ;; GUARD-SUPPRESSED fire (no state exit → no `:on-exit`
-                        ;; cancel) from stranding the entry, and stops a spent
-                        ;; one-shot from re-arming on a later sub-vec change. The
-                        ;; release is silent — a fired timer was not cancelled,
-                        ;; so no `:cancelled` trace is emitted.
-                        (release-entry-resources! frame-id claimed (:delay k))))
-                    resolved-ms)
-                  ;; PHASE 2 — PUBLISH the host handle IFF this attempt still
-                  ;; owns the slot. `swap-vals!` is a pure replace-if-token-
-                  ;; present; the cancel/add-watch side effects below ride the
-                  ;; CAS-derived old snapshot, never inside the swap.
-                  [old _new]
-                  (swap-vals! after-timers
-                              (fn [m]
-                                (if (= token (:token (get-in m [frame-id k])))
-                                  (assoc-in m [frame-id k :handle] handle)
-                                  m)))
-                  owned? (= token (:token (get-in old [frame-id k])))]
-              (if owned?
-                (do
-                  ;; We own the now-armed slot — attach the dynamic-delay
-                  ;; change-watcher (a sub-value change cancels + reschedules).
-                  ;; Attached ONLY here so a publication that LOST to cleanup
-                  ;; never strands an orphan watcher on a released reaction.
-                  (when (and reaction watch-key)
-                    ;; Surface `add-watch` exceptions rather than silently
-                    ;; dropping them; the re-resolution watcher won't fire if
-                    ;; `add-watch` failed, so the author needs a signal the
-                    ;; dynamic-delay subscription is not actually wired up.
-                    (try
-                      ;; ACTIVATE, then watch — the order is the whole fix for
-                      ;; rf2-wmpte. It first landed in the internal observation
-                      ;; port's `build-node-handle!` (rf2-8cnxg / rf2-jt8vz);
-                      ;; that port was retired on 2026-08-21 (rf2-63t1i), so
-                      ;; the rule now lives at each of its call sites rather
-                      ;; than in one canonical statement.
-                      ;;
-                      ;; `resolve-delay-ms`'s "subscribe to keep the reaction
-                      ;; live" is FALSE on the ratom family, and silently so. A
-                      ;; `reagent.ratom/Reaction` learns its sources ONLY through
-                      ;; `deref-capture`; the plain `deref` `resolve-delay-ms`
-                      ;; takes runs outside `*ratom-context*` with no `auto-run`,
-                      ;; so it runs the body raw and leaves `watching` nil. The
-                      ;; node is then in no source's watcher set: `_handle-change`
-                      ;; is never called, `_queued-run` short-circuits on
-                      ;; `(some? watching)`, and the `add-watch` below RECORDS a
-                      ;; callback that can never fire. The first arming resolved
-                      ;; correctly and the dynamic delay then never re-resolved
-                      ;; for the rest of the arming's life — no trace, no error.
-                      ;;
-                      ;; A Reagent COMPONENT never hits this because its render
-                      ;; IS the capture context; a timer is not a component, so
-                      ;; nothing but this call supplies one. It runs BEFORE
-                      ;; `add-watch` so activation's own first recompute cannot
-                      ;; fan a priming change at this watcher. Total and
-                      ;; idempotent: the React-hook spine (UIx) is
-                      ;; push-based from birth and
-                      ;; publishes no hook, so the routed chain-bottom returns
-                      ;; nil; plain-atom / JVM derived values have no capture
-                      ;; step. A throw here lands on the same
-                      ;; `:recovery :static-delay` signal as a failed
-                      ;; `add-watch` — both mean the dynamic delay is not wired.
-                      (interop/activate-derived-value! reaction)
-                      (add-watch reaction watch-key
-                                 (fn [_ _ old-v new-v]
-                                   (on-sub-changed! frame-id parent-id invoke-id
-                                                    delay-key state old-v new-v)))
-                      (catch #?(:clj Throwable :cljs :default) e
-                        ;; Owning actor INSTANCE under `:actor-id`; canonical
-                        ;; subscription identity (`:rf.sub/id` + `:rf.sub/query-v`).
-                        (trace/emit-error! :rf.error/machine-after-watch-failed
-                                           {:exception      e
-                                            :actor-id       parent-id
-                                            :rf.sub/id      (first delay-key)
-                                            :rf.sub/query-v (vec delay-key)
-                                            :frame          frame-id
-                                            :recovery       :static-delay}))))
-                  handle)
-                ;; A cleanup / supersede / synchronous fire claimed the sentinel
-                ;; while we armed — do NOT republish; cancel the orphan handle
-                ;; (idempotent even if it already fired). The claimer already
-                ;; released the reaction and emitted the single owed `:cancelled`
-                ;; trace (or, for a self-fire, dispatched + released silently).
-                (do (managed-timer/cancel! handle)
-                    nil))))))))))
+            ;; rf2-jqvgp — that `/scheduled` emit is the LAST callback-bearing
+            ;; step before the durable arm, and until now the only one this fn
+            ;; did not fence. `trace/emit!` invokes listeners SYNCHRONOUSLY, so
+            ;; a `:rf.machine.timer/scheduled` listener can `destroy-frame!` the
+            ;; owning incarnation A and publish a same-id successor B right
+            ;; here — after the post-supersede recheck above and before the slot
+            ;; is reserved. The reservation is keyed by the BARE frame id, which
+            ;; then denotes B, so the arm would install an A-derived entry, host
+            ;; handle and change-watcher into a frame that enumerated none of
+            ;; them. Recheck the SAME predicate — the batch caller's when it
+            ;; supplied one — rather than capturing a fresh owner, which would
+            ;; name B and pass.
+            ;;
+            ;; The abort releases NOTHING, and that is the rf2-i4aj9c rule
+            ;; rather than an omission. The one hold this step can have taken is
+            ;; a sub-vec delay's `(frame, query-v)` ref-count, bumped by
+            ;; `resolve-delay-ms` against A's OWN sub-cache — which
+            ;; `destroy-frame!` disposed wholesale
+            ;; (`:subs.cache/dispose-all-for-frame-destroy!`) on this very
+            ;; stack. `subs/unsubscribe` addresses the frame by bare id, so a
+            ;; decrement here would land on B and could dispose a reaction B
+            ;; holds for the same query. Nothing of A's survives to release, and
+            ;; the release that would reach it is the one that must not run.
+            (when-not (owner-gone?)
+             ;; PHASE 1 — RESERVE the slot with an arming sentinel (`:handle
+             ;; nil`) carrying this attempt's `:token`, BEFORE arming any host
+             ;; clock. The reaction + watch-key ride the sentinel so a claiming
+             ;; cleanup releases the held subscription ref-count even though the
+             ;; physical add-watch is deferred to publication.
+             (swap! after-timers assoc-in [frame-id k]
+                    {:handle          nil
+                     :reaction        reaction
+                     :sub-watcher-key watch-key
+                     :resolved-ms     resolved-ms
+                     :epoch           epoch
+                     :state           state
+                     :region          region
+                     :delay-source    delay-source
+                     :token           token})
+             (let [handle
+                   ;; Shared positive-delay-guarded arm — the host-clock arm
+                   ;; step both timer artefacts share. `resolved-ms` is already
+                   ;; known-positive here (the non-positive case was handled by
+                   ;; the prior `cond` branch), so the guard is a no-op
+                   ;; pass-through.
+                   (managed-timer/arm!
+                     (fn []
+                       ;; ATOMICALLY claim THIS fire's slot — dispatch AUTHORITY
+                       ;; + reap in a single swap (mirrors core `:dispatch-later`,
+                       ;; rf2-j538f7.2). If a cleanup / supersede claimed the slot
+                       ;; first — even a synchronous host callback firing before
+                       ;; `arm!` returns, or a JVM cleanup racing the arm — this
+                       ;; fire has LOST authority: suppress the dead-on-arrival
+                       ;; dispatch and touch nothing (the claimer already released
+                       ;; our resources). On the live path the claim wins:
+                       (when-let [claimed (claim-entry! frame-id k token)]
+                         (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+                           ;; Stamp `:source :after-timer` so the Epoch panel's
+                           ;; DISPATCH step labels it "from :after timer" and
+                           ;; Xray's L2 timeline can prefix the row + per-source
+                           ;; filter pills can discriminate timer-fired cascades
+                           ;; (closed-enum per Spec-Schemas
+                           ;; §`:rf/dispatch-envelope`). Per Spec 005 §Hierarchy
+                           ;; interaction: carry the scheduling node's decl-path
+                           ;; (`invoke-id`) so the pure side routes the firing to
+                           ;; the correct per-path epoch — colliding delay-keys
+                           ;; across hierarchy levels resolve unambiguously.
+                           (dispatch! [parent-id [:rf.machine.timer/after-elapsed
+                                                  delay-key epoch (vec invoke-id)]]
+                                      {:frame  frame-id
+                                       :source :after-timer}))
+                         ;; A one-shot `:after` timer fires exactly once per
+                         ;; arming (XState §delayed transitions). Release THIS
+                         ;; fire's sub-reaction watcher + held subscription
+                         ;; ref-count (the host handle just fired, so its cancel
+                         ;; is a harmless no-op). This is what keeps a
+                         ;; GUARD-SUPPRESSED fire (no state exit → no `:on-exit`
+                         ;; cancel) from stranding the entry, and stops a spent
+                         ;; one-shot from re-arming on a later sub-vec change. The
+                         ;; release is silent — a fired timer was not cancelled,
+                         ;; so no `:cancelled` trace is emitted.
+                         (release-entry-resources! frame-id claimed (:delay k))))
+                     resolved-ms)
+                   ;; PHASE 2 — PUBLISH the host handle IFF this attempt still
+                   ;; owns the slot. `swap-vals!` is a pure replace-if-token-
+                   ;; present; the cancel/add-watch side effects below ride the
+                   ;; CAS-derived old snapshot, never inside the swap.
+                   [old _new]
+                   (swap-vals! after-timers
+                               (fn [m]
+                                 (if (= token (:token (get-in m [frame-id k])))
+                                   (assoc-in m [frame-id k :handle] handle)
+                                   m)))
+                   owned? (= token (:token (get-in old [frame-id k])))]
+               (if owned?
+                 (do
+                   ;; We own the now-armed slot — attach the dynamic-delay
+                   ;; change-watcher (a sub-value change cancels + reschedules).
+                   ;; Attached ONLY here so a publication that LOST to cleanup
+                   ;; never strands an orphan watcher on a released reaction.
+                   (when (and reaction watch-key)
+                     ;; Surface `add-watch` exceptions rather than silently
+                     ;; dropping them; the re-resolution watcher won't fire if
+                     ;; `add-watch` failed, so the author needs a signal the
+                     ;; dynamic-delay subscription is not actually wired up.
+                     (try
+                       ;; ACTIVATE, then watch — the order is the whole fix for
+                       ;; rf2-wmpte. It first landed in the internal observation
+                       ;; port's `build-node-handle!` (rf2-8cnxg / rf2-jt8vz);
+                       ;; that port was retired on 2026-08-21 (rf2-63t1i), so
+                       ;; the rule now lives at each of its call sites rather
+                       ;; than in one canonical statement.
+                       ;;
+                       ;; `resolve-delay-ms`'s "subscribe to keep the reaction
+                       ;; live" is FALSE on the ratom family, and silently so. A
+                       ;; `reagent.ratom/Reaction` learns its sources ONLY through
+                       ;; `deref-capture`; the plain `deref` `resolve-delay-ms`
+                       ;; takes runs outside `*ratom-context*` with no `auto-run`,
+                       ;; so it runs the body raw and leaves `watching` nil. The
+                       ;; node is then in no source's watcher set: `_handle-change`
+                       ;; is never called, `_queued-run` short-circuits on
+                       ;; `(some? watching)`, and the `add-watch` below RECORDS a
+                       ;; callback that can never fire. The first arming resolved
+                       ;; correctly and the dynamic delay then never re-resolved
+                       ;; for the rest of the arming's life — no trace, no error.
+                       ;;
+                       ;; A Reagent COMPONENT never hits this because its render
+                       ;; IS the capture context; a timer is not a component, so
+                       ;; nothing but this call supplies one. It runs BEFORE
+                       ;; `add-watch` so activation's own first recompute cannot
+                       ;; fan a priming change at this watcher. Total and
+                       ;; idempotent: the React-hook spine (UIx) is
+                       ;; push-based from birth and
+                       ;; publishes no hook, so the routed chain-bottom returns
+                       ;; nil; plain-atom / JVM derived values have no capture
+                       ;; step. A throw here lands on the same
+                       ;; `:recovery :static-delay` signal as a failed
+                       ;; `add-watch` — both mean the dynamic delay is not wired.
+                       (interop/activate-derived-value! reaction)
+                       (add-watch reaction watch-key
+                                  (fn [_ _ old-v new-v]
+                                    (on-sub-changed! frame-id parent-id invoke-id
+                                                     delay-key state old-v new-v)))
+                       (catch #?(:clj Throwable :cljs :default) e
+                         ;; Owning actor INSTANCE under `:actor-id`; canonical
+                         ;; subscription identity (`:rf.sub/id` + `:rf.sub/query-v`).
+                         (trace/emit-error! :rf.error/machine-after-watch-failed
+                                            {:exception      e
+                                             :actor-id       parent-id
+                                             :rf.sub/id      (first delay-key)
+                                             :rf.sub/query-v (vec delay-key)
+                                             :frame          frame-id
+                                             :recovery       :static-delay}))))
+                   handle)
+                 ;; A cleanup / supersede / synchronous fire claimed the sentinel
+                 ;; while we armed — do NOT republish; cancel the orphan handle
+                 ;; (idempotent even if it already fired). The claimer already
+                 ;; released the reaction and emitted the single owed `:cancelled`
+                 ;; trace (or, for a self-fire, dispatched + released silently).
+                 (do (managed-timer/cancel! handle)
+                     nil)))))))))))
 
 (defn after-schedule-fx
   "fx handler for `:rf.machine/after-schedule`. Per Spec 005 §Delayed

--- a/implementation/machines/test/re_frame/machine_hydration_reconcile_incarnation_fence_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_hydration_reconcile_incarnation_fence_cljs_test.cljc
@@ -32,6 +32,19 @@
       That arm aborts correctly on its own captured owner — and the NEXT
       iteration captures B and arms another A-derived declaration into it.
 
+    - INSIDE ONE ARM (audit of PR #8942). `/cancelled` is not the only
+      callback-bearing trace the reconcile emits. A hydration arm passes
+      `:emit-scheduled-trace? true`, so `schedule-after-timer!` emits
+      `:rf.machine.timer/scheduled` ITSELF — synchronously, after its
+      post-supersede recheck and BEFORE it reserves the timer-table slot. A
+      listener on THAT row could destroy A and publish B, and the arm went on
+      to reserve the A-derived slot under the bare frame id (which now denotes
+      B), arm the host clock and attach the change-watcher. This is the one
+      boundary a `/cancelled` tooth cannot reach: on a frame holding no prior
+      timer there is no cancellation anywhere in the reconcile, and the
+      `/scheduled` row is the FIRST callback-bearing trace of the whole
+      operation.
+
   The failure is silent by construction: every step is right about the owner it
   captured, and B is a live frame under the right id, so it accepts the timer,
   the watcher, the subscription ref-count and the `/scheduled` trace without
@@ -39,13 +52,18 @@
 
   ## Shape of the controls
 
-  Two mutation teeth, one per direction, each publishing same-id B from the
-  FIRST callback-bearing trace of its phase — then four readings of B: its
-  timer table, the `/scheduled` trace stream, the subscription ref-count, and
+  Three mutation teeth — cancel→arm, arm→arm, and within one arm — each
+  publishing same-id B from the FIRST callback-bearing trace of its phase, then
+  reading B's timer table, the host-clock arm, the subscription calls, and
   whether a change in the delay's value reaches a surviving watcher. A table
   check alone would miss the last two.
 
-  The third test is the control the fence must not break: with no successor
+  The `/scheduled` tooth runs twice, once per delay source, because the abort it
+  pins releases nothing for a LITERAL delay and must still fire: a fence written
+  around the sub-vec resources alone would leave the literal arm installing a
+  host handle into B.
+
+  The last test is the control the fence must not break: with no successor
   published, a multi-live reconcile arms every declaration, so the loop that
   replaced the `doseq` still runs to completion.
 
@@ -282,6 +300,130 @@
             (is (not (identical? token-a @token-b))
                 "and B is a DISTINCT incarnation from A")
             (assert-successor-took-no-a-work! cfid reaction subscribes)))))))
+
+;; ---------------------------------------------------------------------------
+;; Tooth 3 — WITHIN ONE ARM: the arm's own `/scheduled` republishes the frame
+;; ---------------------------------------------------------------------------
+
+(defn- republish-on-scheduled-once!
+  "As `republish-frame-once!`, but triggered by the arm's OWN
+  `:rf.machine.timer/scheduled` row rather than by a cancellation — the boundary
+  a `/cancelled` tooth cannot reach.
+
+  `zero!` runs immediately after B is published, so every host-work counter the
+  caller passes it records only what happened AFTER the swap. The subscription
+  hold and the delay resolution both precede the trace and belong to A; what is
+  under test is what the arm does with them once A is gone."
+  [listener-id frame-id fired? token-b zero!]
+  (trace-tooling/register-listener!
+    listener-id
+    (fn [ev]
+      (when (and (= :rf.machine.timer/scheduled (:operation ev))
+                 (compare-and-set! fired? false true))
+        (frame/destroy-frame! frame-id)
+        (rf/make-frame {:id frame-id :platform :client})
+        (reset! token-b (frame/frame-incarnation-token frame-id))
+        (zero!)))))
+
+(deftest a-scheduled-trace-callback-that-republishes-the-frame-arms-nothing-into-b
+  (testing "SUB-VEC delay: the arm's own `/scheduled` destroys frame A and
+            publishes same-id B before the timer-table slot is reserved. The
+            A-derived slot, its host handle and its change-watcher must not
+            land in B"
+    (rf/reg-machine :hydfence/sched dyn-machine)
+    (let [reaction     (atom 2500)
+          subscribes   (atom 0)
+          unsubscribes (atom 0)
+          arms         (atom 0)
+          fired?       (atom false)
+          token-b      (atom nil)]
+      (with-redefs [subs/subscribe            (fn ([_q] (swap! subscribes inc) reaction)
+                                                ([_q _o] (swap! subscribes inc) reaction))
+                    subs/unsubscribe          (fn ([_q] (swap! unsubscribes inc) nil)
+                                                ([_f _q] (swap! unsubscribes inc) nil))
+                    interop/schedule-after!   (fn [_thunk _ms] (swap! arms inc) ::handle)
+                    interop/cancel-scheduled! (fn [_h] nil)]
+        (let [rt      (server-runtime-db [[:hydfence/sched [[:go]]]])
+              cfid    (fresh-frame! :client)
+              token-a (frame/frame-incarnation-token cfid)]
+          (is (empty? (inner cfid))
+              (str "precondition: a FRESH client frame holds no `:after` timer, "
+                   "so phase 1 cancels nothing and the single arm supersedes an "
+                   "empty slot — the `/scheduled` row is therefore the FIRST "
+                   "callback-bearing trace of the whole reconcile"))
+          (mtest/reset-captured!)
+          (republish-on-scheduled-once!
+            ::sched-phase cfid fired? token-b
+            #(do (reset! subscribes 0) (reset! unsubscribes 0) (reset! arms 0)))
+          (try
+            (install! cfid rt)
+            (finally (trace-tooling/unregister-listener! ::sched-phase)))
+
+          (is (true? @fired?)
+              "the `/scheduled` listener ran (the seam is exercised)")
+          (is (some? @token-b) "same-id successor B is live after the swap")
+          (is (not (identical? token-a @token-b))
+              "and B is a DISTINCT incarnation from A")
+
+          (is (empty? (inner cfid))
+              (str "successor B holds NO timer-table entry. The slot is keyed by "
+                   "the BARE frame id, so a reservation taken after the swap "
+                   "lands in B — a timer B never enumerated, whose eventual fire "
+                   "dispatches an A-derived `:rf.machine.timer/after-elapsed` "
+                   "into it"))
+          (is (zero? @arms)
+              (str "and no host clock was armed in B's name — the arm sits "
+                   "between the reserve and the publish, so a table check alone "
+                   "would not see it"))
+          (is (zero? @unsubscribes)
+              (str "and the abort issued NO `(frame, query-v)` decrement: A's "
+                   "hold was taken against A's own sub-cache, which "
+                   "`destroy-frame!` disposed wholesale on this very stack, "
+                   "while `subs/unsubscribe` addresses the frame by bare id — "
+                   "which now denotes B. There is nothing of A's left to "
+                   "release, and releasing would drop a count B holds "
+                   "(rf2-i4aj9c)"))
+
+          (mtest/reset-captured!)
+          (reset! reaction 9000)
+          (is (empty? (mtest/events-of :rf.machine.timer/scheduled))
+              "a change in the delay's value re-resolves nothing in B")
+          (is (empty? (mtest/events-of :rf.machine.timer/cancelled))
+              (str "and reaches NOTHING at all — an arm that ran past the "
+                   "`/scheduled` callback attaches its re-resolution watcher to "
+                   "the reaction here, and the watcher re-enters the timer "
+                   "machinery under B")))))))
+
+(deftest a-scheduled-trace-callback-aborts-a-literal-delays-arm-too
+  (testing "LITERAL delay: the same boundary, with no subscription, reaction or
+            watcher in play. The abort must be driven by the owner check alone —
+            a fence built around the dynamic-delay resources would let this one
+            through"
+    (rf/reg-machine :hydfence/sched-lit literal-machine)
+    (let [arms    (atom 0)
+          fired?  (atom false)
+          token-b (atom nil)]
+      (with-redefs [interop/schedule-after!   (fn [_thunk _ms] (swap! arms inc) ::handle)
+                    interop/cancel-scheduled! (fn [_h] nil)]
+        (let [rt      (server-runtime-db [[:hydfence/sched-lit [[:go]]]])
+              cfid    (fresh-frame! :client)
+              token-a (frame/frame-incarnation-token cfid)]
+          (is (empty? (inner cfid))
+              "precondition: the client frame holds no prior timer")
+          (mtest/reset-captured!)
+          (republish-on-scheduled-once!
+            ::sched-phase-lit cfid fired? token-b #(reset! arms 0))
+          (try
+            (install! cfid rt)
+            (finally (trace-tooling/unregister-listener! ::sched-phase-lit)))
+
+          (is (true? @fired?) "the `/scheduled` listener ran")
+          (is (not (identical? token-a @token-b))
+              "B is a distinct incarnation from A")
+          (is (empty? (inner cfid))
+              "successor B holds no timer-table entry")
+          (is (zero? @arms)
+              "and no host clock was armed in B's name"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Control — the fence is scoped strictly to owner LOSS


### PR DESCRIPTION
Third audit pass on rf2-jqvgp (audit of PR #8942). The finding holds at tip and is fixed here.

## The gap

Pass two threaded one incarnation predicate through the SSR hydration reconcile and, in `schedule-after-timer!`, rechecked it after the leading `:on-supersede` cancel. That fn has a **second** callback boundary it did not fence.

With `:emit-scheduled-trace? true` — which the hydration arm (`rearm-hydrated-after-timer!`) and the dynamic-delay re-resolution (`on-sub-changed!`) both pass, the only two such call sites — `schedule-after-timer!` emits `:rf.machine.timer/scheduled` itself. `trace/emit!` delivers to listeners **synchronously**, and that emit sits *after* the post-supersede recheck and *before* the timer-table slot is reserved. A listener on that row can `destroy-frame!` incarnation A and publish a same-id successor B; execution then reserved the A-derived slot under the **bare frame id** — which now denotes B — armed the host clock and attached the change-watcher.

On a frame holding no prior timer the reconcile cancels nothing, so `/scheduled` is the **first** callback-bearing trace of the whole operation. That is the boundary the pass-two `/cancelled` teeth cannot reach, and it is why the contract added in pass two ("every callback-bearing step is fenced by that ONE predicate") was false as written.

## The repair

One `(when-not (owner-gone?) …)` immediately after the `/scheduled` emit, rechecking the **same** predicate (the batch caller's, when one was supplied — a fresh capture would name B and pass). Every durable step — slot reservation, host arm, publish, watcher — now sits behind it. No new mechanism, no new trace vocabulary, no epoch system.

**The abort deliberately releases nothing, and that narrows the audit's third clause.** The one hold in flight is a sub-vec delay's `(frame, query-v)` ref-count, bumped by `resolve-delay-ms` against **A's own** sub-cache. `destroy-frame!` disposes that cache wholesale (`:subs.cache/dispose-all-for-frame-destroy!`) on the same stack, so nothing of A's survives; and `subs/unsubscribe` addresses the frame by bare id, so a decrement here would land on **B** and could dispose a reaction B holds for the same query. That is exactly the rf2-i4aj9c hazard, and the established rule is to skip the shared decrement once the owner is lost. The reasoning is recorded in the comment at the recheck so a later reader does not "complete" the fix by adding the unsubscribe.

`spec/005-StateMachines.md` is untouched: no new trace vocabulary and no observable change on the ordinary live-owner path.

## Regressions

Two deftests added to the pass-two fence namespace (`machine_hydration_reconcile_incarnation_fence_cljs_test.cljc`), one per delay source, each publishing same-id B from the arm's own `/scheduled` row:

- **sub-vec delay** — reads B's timer table, the host-clock arm, the subscription calls, and whether a value change reaches a surviving watcher.
- **literal delay** — the same boundary with no reaction in play, so a fence written around the dynamic-delay resources alone would not pass it.

The existing `a-live-owner-reconcile-arms-every-live-declaration` control stays green, proving the recheck does not truncate an ordinary hydration.

## Sabotage witness

The recheck reverted at a single-line anchor (`(when-not (owner-gone?)` → `(when-not false`, 1 replacement, count read before the run):

- machines lane **exit 1**, **1239 tests / 4435 assertions** — the **same totals** as the clean run, so nothing was skipped or crashed — with **5 failures, all confined to the two new deftests**.
- Green under the same plant: every pre-existing machines test, including all three pass-two teeth in the same file.
- The watcher failure printed the audit's mechanism verbatim: a `:rf.machine.timer/cancelled :reason :on-resolution` fired from a **surviving watcher** stamped with the successor frame, one value change after the arm should have aborted.
- Restored by `git checkout` and verified by git **blob** hash against the committed object (identical before and after), not by reading a diff.

## Gates

All re-run on the final rebased base, each exit code captured on the same command line as the redirect:

| gate | result | exit |
| --- | --- | --- |
| `clojure -M:test` from `implementation/machines` | 1239 tests / 4435 assertions, 0 failures | 0 |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` | 1877 files, 0 warnings | 0 |
| `node out/node-test.js` | 11198 tests / 55484 assertions, 0 failures | 0 |

The consolidated CLJS lane was **split** into its two phases rather than detached, so both verdicts stayed in the foreground. Its shadow-cljs config line named this branch's own checkout.

Diff is `implementation/machines/**` only — no markdown, no `spec/`, no workflows — so `check_doc_slugs.py`, `check_readme_links.py --ci` and `mkdocs build --strict` are out of scope.

`timer.cljc` shows a wide line count because the guarded block is shifted one column; `git diff -w` isolates the change to 40 lines (docstring, comment, the `when-not` and one closing paren).
