### PR TITLE
test(ssr): guard the rebuilt frame's platform tag at the fourth call site (rf2-33lfn)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr/failed_root_isolation_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/failed_root_isolation_cljs_test.cljc
@@ -320,6 +320,13 @@
       ;; opts, exactly as `fresh-frame!` builds it: the rebuilt frame must
       ;; carry the same `:client` tag the original did.
       (rf/make-frame {:id fid :platform :client})
+      (is (= :client (:platform (rf/frame-meta fid)))
+          (str "the REBUILT frame carries the tag too. This is the only "
+               "`make-frame` in this file that does NOT go through "
+               "`fresh-frame!`, so `the-fixture-frames-are-actually-platform"
+               "-tagged` never reaches it: nesting THESE opts back to "
+               "`{:config {:platform :client}}` leaves that test green and "
+               "reds only this line."))
       (boot/hydrate! {:frame fid :payload (payload-for {:count 7})
                       :root-id :page/b})
       (is (hydrated? fid)


### PR DESCRIPTION
Second pass on rf2-33lfn, audit-reopened against its own merged PR #8945.

## What was already right

The merged code is correct: all four `make-frame` opts maps in the SSR fixtures
are flat. Verified at tip with two independent sweeps — line-oriented and
whitespace-collapsed — over `implementation/ssr/test/**`. No nested
`{:config {:platform …}}` survives anywhere in that tree.

## What fell short

The *proof* reached only three of the four corrected sites. Each
`the-fixture-frames-are-actually-platform-tagged` test calls its file's
`fresh-frame!` helper. The fourth corrected site is the direct teardown/rebuild
in `a-root-whose-seed-does-not-land-releases-its-claim`, which constructs its
frame inline and so is never covered by that test. The surrounding comment
already asserted in prose that the rebuilt frame "must carry the same `:client`
tag" — but nothing executable read it back.

## The change

One assertion, at that call site, reading the tag through `rf/frame-meta`.
That accessor is `(merge (:config f) (:lifecycle f) {:id (:id f)})` — it
flattens the frame's own config and does **not** fall back to the host-wide
platform marker, which is exactly what makes it discriminate a tagged frame
from an untagged one. No restructuring, no new fixture, no generalised helper.

## The discriminating control

A green run is not evidence here — that is the whole point of this bead. The
original fixtures passed green while completely untagged, and the previous
pass's tests pass green while missing this site. So the control was run
explicitly: revert **only** the fourth site to `{:config {:platform :client}}`,
recompile, and re-run.

Result — exactly one failure, the new assertion:

```
FAIL in (a-root-whose-seed-does-not-land-releases-its-claim) (…:323:11)
expected: (= :client (:platform (rf/frame-meta fid)))
  actual: (not (= :client nil))

Ran 15 tests containing 125 assertions.
1 failures, 0 errors.
```

`the-fixture-frames-are-actually-platform-tagged` stayed **green** throughout,
which is the half that matters: it confirms the existing proof genuinely does
not reach this site. Test and assertion counts were identical to the clean run
(15 / 125), so the plant was scoped and nothing dropped out of the build. The
plant was then reverted and the restore verified by git blob hash against the
committed object, not by reading a diff.

## Gates

Consolidated CLJS node-test suite (`test:cljs`), run split into its two phases:

| phase | captured exit |
| --- | --- |
| compile `node-test` | 0 — 1877 files, 0 warnings |
| run (clean, focused) | 0 — 15 tests, 125 assertions, 0 failures |
| run (planted control) | 1 — 1 failure, the new assertion only |
| run (full suite, restored) | 0 — 11196 tests, 55469 assertions, 0 failures |

shadow-cljs reported its config path as this branch's own worktree
`implementation/shadow-cljs.edn`, confirming the gate read the tree under test.

Diff is confined to `implementation/ssr/test/**` and is a pure addition — 7
insertions, 0 deletions against the merge base — so nothing from the previous
pass is reverted. Docs and link gates are out of scope for this surface and are
not nominated.
