### PR TITLE
ci(pair fixture): hash all five of the fixture's deps.edn files in the cache key (rf2-nsb3e)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5807,9 +5807,22 @@ jobs:
         with:
           node-version: '24'
 
-      # The fixture resolves core + reagent + epoch as `:local/root` entries, so
-      # a cold-cache run pulls every transitive dep (Reagent, Malli, …) before
-      # shadow-cljs can compile. Same cache shape as mcp-conformance-re-frame2-pair.
+      # The fixture resolves FIVE in-repo artefacts as `:local/root` entries —
+      # core, reagent, epoch, schemas and machines (the last two because the
+      # shipped preload `:require`s `re-frame.schemas` and `re-frame.machines`
+      # directly, per the fixture's own deps.edn) — so a cold-cache run pulls
+      # every transitive dep (Reagent, Malli, …) before shadow-cljs can compile.
+      #
+      # THE KEY MUST NAME ALL FIVE (rf2-nsb3e). It covered only core, reagent
+      # and epoch, so a schemas or machines dependency bump restored a classpath
+      # cache predating that bump and the job reported green against stale deps.
+      # The gap was unreachable while the job was skipped on those artefacts;
+      # rf2-f9f3p armed the reverse edges that now SCHEDULE it on a change under
+      # implementation/{epoch,schemas,machines}, which is what made it live.
+      #
+      # `mcp-conformance-re-frame2-pair` builds this same fixture and still
+      # carries the narrow three-artefact list — tracked as its own bead
+      # (rf2-cd0zz), not fixed here, since this file is one-toucher.
       - name: Cache Maven / gitlibs (fixture pure-test deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
@@ -5817,7 +5830,7 @@ jobs:
             ~/.m2/repository
             ~/.gitlibs
             ~/.deps.clj
-          key: ${{ runner.os }}-re-frame2-pair-fixture-${{ hashFiles('skills/re-frame2-pair/tests/fixture/deps.edn', 'skills/re-frame2-pair/tests/fixture/shadow-cljs.edn', 'implementation/core/deps.edn', 'implementation/adapters/reagent/deps.edn', 'implementation/epoch/deps.edn') }}
+          key: ${{ runner.os }}-re-frame2-pair-fixture-${{ hashFiles('skills/re-frame2-pair/tests/fixture/deps.edn', 'skills/re-frame2-pair/tests/fixture/shadow-cljs.edn', 'implementation/core/deps.edn', 'implementation/adapters/reagent/deps.edn', 'implementation/epoch/deps.edn', 'implementation/schemas/deps.edn', 'implementation/machines/deps.edn') }}
           restore-keys: |
             ${{ runner.os }}-re-frame2-pair-fixture-
             ${{ runner.os }}-cljs-


### PR DESCRIPTION
## The defect

`re-frame2-pair-fixture-pure` builds `skills/re-frame2-pair/tests/fixture`. That fixture's `deps.edn` resolves **five** in-repo artefacts as `:local/root` entries, but the job's Maven/gitlibs cache key hashed only **three** of them.

**The fixture's real roster** (`skills/re-frame2-pair/tests/fixture/deps.edn`, the five `:local/root` entries):

| artefact | `deps.edn` path | in the key before? |
| --- | --- | --- |
| `day8/re-frame2` | `implementation/core/deps.edn` | yes |
| `day8/re-frame2-reagent` | `implementation/adapters/reagent/deps.edn` | yes |
| `day8/re-frame2-epoch` | `implementation/epoch/deps.edn` | yes |
| `day8/re-frame2-schemas` | `implementation/schemas/deps.edn` | **no** |
| `day8/re-frame2-machines` | `implementation/machines/deps.edn` | **no** |

The last two are on the classpath because the shipped re-frame2-pair preload `:require`s `re-frame.schemas` and `re-frame.machines` directly — those vars were demoted off the `re-frame.core` facade by the `wad2fl` front-porch shrink, so the owned-namespace artefacts must be resolvable. The fixture's own header comment says so.

**Cache key `hashFiles` argument list — before:**

```
'skills/re-frame2-pair/tests/fixture/deps.edn',
'skills/re-frame2-pair/tests/fixture/shadow-cljs.edn',
'implementation/core/deps.edn',
'implementation/adapters/reagent/deps.edn',
'implementation/epoch/deps.edn'
```

**After** — the same list plus the two omitted artefacts:

```
'implementation/schemas/deps.edn',
'implementation/machines/deps.edn'
```

Set difference: `{schemas, machines}` — nothing removed, nothing reordered.

A dependency bump in schemas or machines therefore left the key unchanged, so the job restored a classpath cache predating the bump and compiled against stale dependencies **while reporting green**.

## Why it is live now

The gap was unreachable while the job was skipped on those artefacts. rf2-f9f3p (#8941) armed the reverse edges that now **schedule** this job on a change under `implementation/{epoch,schemas,machines}` — which is exactly what makes the incomplete key reachable: the job starts running on the very bumps its key cannot see. The two defects were harmless only in combination.

## Scope

The key alone. No new job, no change to the cache strategy, no shared key generator. The comment above the key named the same three artefacts and is corrected to the real roster.

**Sibling found, deliberately NOT fixed here:** `mcp-conformance-re-frame2-pair` builds this same fixture and still carries the narrow three-artefact list. Filed as **rf2-cd0zz** — `.github/workflows/**` is one-toucher. (A third site, `expensive-tests.yml`'s pair-MCP key, names no `implementation/*/deps.edn` at all; different shape, noted on that bead for separate judgement rather than assumed to be the same defect.)

## Verification

**A workflow edit cannot be gated locally, and no local gate covers this change.** That is measured, not assumed:

- `implementation/scripts/_changed-surfaces.test.cjs` — captured exit **0**, 335 assertions. It reads this job's block, but pins only `needs:` and `if:`; it contains no `hashFiles` or cache-key assertion (confirmed line-oriented *and* over whitespace-collapsed text, each control-run against a pattern it must find).
  - **Plant B (control that the gate is live):** broke the job's `if:` line → captured exit **1**, failing by name. So the suite is live on this block and reads this worktree.
  - **Plant A (coverage of the actual change):** narrowed the key back to three artefacts → captured exit **0**. The gate is blind to the key. Both plants restored and verified by git blob hash against the committed object.
- `scripts/check_gate_scheduling.py` — captured exit **0**, but it derives reachability from workflow `run:` values only and pins npm gate-command scheduling. This diff adds no npm script and touches no `run:` value, so **it inspected nothing changed here**; it is quoted as "not broken", not as coverage.
- `check_doc_slugs.py`, `check_readme_links.py --ci`, `mkdocs build --strict` are out of scope — `.github/**` is outside `docs_dir` and no markdown is edited.
- YAML re-parses; the resolved key renders as one expression naming all seven files (five artefacts + the fixture's own two).

**What this PR's green does and does not show.** CI green shows the job still schedules and still passes with the widened key. It does **not** demonstrate the benefit, because this PR bumps no dependency — with nothing changed under schemas or machines, the widened key and the narrow one select the same cache entry. What would actually demonstrate the fix is a commit that bumps a dependency in `implementation/schemas/deps.edn` or `implementation/machines/deps.edn` and observes a cache **miss** where the narrow key would have scored a hit on a pre-bump entry.

**Base:** rebased onto current `origin/main`; the merge-base diff (`origin/main...HEAD`) is one file, 17 insertions / 4 deletions, and the only deletions are the three stale comment lines and the old narrow key. #8943's `test.yml` additions (the `npm ci` step and `RF2_REQUIRE_NODE_PROBES`) survive verbatim — verified by reverse-applying that commit's diff, which checks clean.

Closes rf2-nsb3e.
