### PR TITLE
docs(method): a worker's contradiction is evidence about the brief; a marker scan is a filter, not a verdict

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -1100,6 +1100,15 @@ moved most. In the dominant toolchain that is the three-dot form, `<TRUNK>...HEA
 * Which numbers are captured, and which are reported by the harness?
 * What did it decline to do, and why? A report with no refusals, on a task that had a plausible one, is worth a second
   look.
+* **Where it CONTRADICTS the brief, that is evidence about the brief.** Read it as such before defending or
+  re-explaining: verify the worker's claim at source, and if it holds, the brief was wrong. This is not a courtesy.
+  Measured across one session: seven briefs carried a defect — a hold the item recorded and the brief did not, work the
+  item had already split, a sequencing precondition the item had discharged and the brief re-fenced, and a ruling made
+  from a page's confident prose without checking the spec that owned it. **A worker surfaced every one. The coordinator
+  caught none.** The clause that makes this work is the preamble's *these premises are claims, not findings*, which
+  reads like a guard for the WORKER and functions as error-correction for the COORDINATOR — so never trim it to save
+  room, and never treat the pushback it produces as friction. A dispatch that comes back saying *the premise does not
+  hold* has done its job.
 * Are you about to quote a figure or a phrase OUT of this report and into the next brief? Then it is a claim like
   any other and the question is what produced it. A sequence of measurements and a correction to one measurement
   read identically once compressed to a line: one mayor turned four per-window figures into “the number moved”

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1528,6 +1528,23 @@ terms, beside the question you are asking.** The gap is invisible in the answer 
 moment both sentences are on the page. This is the harder half to catch, because a wrong answer
 gives you something to be suspicious of and a right one does not.
 
+**Take the marker scan in that list further, because it fails in BOTH directions and the remedy follows
+from that rather than from either half.** It over-reports: an item that QUOTES a marker — recounting
+another item's hold, or listing the very strings the scan searches for — matches, and so does one whose
+marker has been struck and whose text says so. It also under-reports: a hold written in ordinary prose
+carries no marker at all, and one item reached the ready list reading free on a probe of **six** distinct
+marker phrases while its own text said *"what remains is one decision"*. **And a second scan built to
+discriminate the two fails the same way**, because the standing marker text itself instructs whoever
+rules to strike it, so the word *struck* appears inside every live marker.
+
+**So a marker scan is a CANDIDATE FILTER and never a verdict.** It narrows a board to a handful; the
+hold is then established by READING each candidate, which is affordable at that size and is the only
+thing that separates a live marker from one quoted, discussed, or already struck. Report the number you
+read, never the number you scanned. **Where a project wants this machine-checkable, the durable answer
+is a structured field on the item rather than a marker in prose** — that is a tracker change and an
+operator's decision, but every failure above is a consequence of encoding state in text that also
+discusses state.
+
 **A dependency can outlive what it was enforcing.** An item blocked "until X lands" stays blocked if X
 is later reopened by an audit for an unrelated residual — even though the thing it was waiting for
 shipped. Force the close and **write the reasoning on the item**: what the dependency was enforcing,


### PR DESCRIPTION
Retrospective on `/docs/the-mayor-method` after one long coordinating session. **Two additions, both measured, both placed at existing rules rather than as new sections.** The README is deliberately untouched — neither finding belongs there.

## 1. A worker's contradiction is evidence about the brief

`Reviewing what comes back` already asks *"What did it decline to do, and why?"* and treats a refusal as a **report-quality** signal. What this session measured is stronger and different.

**Seven briefs carried a defect. A worker surfaced every one. The coordinator caught none.**

- a hold the item recorded and the brief did not;
- work the item had already split into a dispatchable half and a sequenced half;
- a sequencing precondition the item had already discharged, which the brief re-fenced with a blanket "do not touch, STOP and report";
- a ruling made from one page's confident prose without checking the spec that owned it — which a worker refused, filing the evidence chain instead of complying.

The clause that produces this is the preamble's *these premises are claims, not findings*. It **reads** like a guard for the worker; it **functions** as error-correction for the coordinator. That reframing has two operational consequences worth writing down: never trim the clause to save room in a long brief, and never read the pushback it produces as friction. A dispatch that comes back saying *the premise does not hold* has done its job.

**Placement**: one bullet appended to the existing refusals bullet, not a new section — it sharpens a question the section already asks.

## 2. The marker-scan hazard, completed

Tracker mechanics lists "a marker scan finding a banner read as *this item is held*" among four instruments that are right and answer a different question. That names the **over-reporting** half only. Both halves were measured this session:

**Over-reports** — an item that *quotes* a marker matches (recounting another item's hold, or listing the very strings the scan searches for), and so does one whose marker was struck and whose text says so. I hit this on a bead I wrote myself, which is how it was caught.

**Under-reports** — a hold written in ordinary prose carries no marker at all. One item reached the ready list reading free on a probe of **six** distinct marker phrases while its own text said *"what remains is one decision"*.

**And the obvious fix fails identically**: a second scan built to discriminate live markers from struck ones does not work, because the standing marker text instructs whoever rules to strike it — so the word *struck* appears inside every **live** marker. An item known to be held scored equally on both signals.

The remedy follows from both halves rather than from either: **a scan is a candidate filter, a read is the verdict.** It narrows a board to a handful; reading each candidate is affordable at that size and is the only thing separating a live marker from one quoted, discussed or already struck. Report the number you read, never the number you scanned. Where a project wants this machine-checkable, the durable answer is a **structured field** rather than a marker in prose — noted as an operator's decision, not prescribed, since every failure above is a consequence of encoding state in text that also discusses state.

## Deliberately not included

Two other frictions from this session are already filed as items with proposed fixes and are not duplicated here: the coordinator briefing from an item's oldest layer (with the newest-mutation read proposed as a step), and CLAUDE.md-level guidance about a rebase remedy measured insufficient. Neither is a method-document gap.

## Gates

| gate | captured exit | tree-read proof |
|---|---|---|
| `scripts/check_doc_slugs.py` | **0** | planted broken targets in **both** changed files → **exit 1**, 4 references naming them |
| `python -m mkdocs build --strict` | **0** | same plants → **exit 1**, 2 references naming them |

Both plants restored in one act; each file's restore verified by git **blob** hash against its committed object (`283c2e343e…`, `65ea9ac973…`, identical before and after), never by reading a diff. Run as `python -m mkdocs` — bare `mkdocs` returns 127 here, which is no verdict. No fenced blocks added. Merge-base diff is 26 insertions, 0 deletions — nothing reverted.