### PR TITLE
fix(skill-pair): the Story recorder recipe publishes a runnable arity (rf2-p1keh)

### DIFF
--- a/skills/re-frame2-pair/references/stories.md
+++ b/skills/re-frame2-pair/references/stories.md
@@ -103,7 +103,25 @@ Every Story read worth having in a live session is a public `re-frame.story/*` f
 | The variant the user is looking at right now | `(:selected-variant (re-frame.story.ui.state/get-state))` — the shell tracks the active variant there; there is no `:story/active?` frame-metadata flag. Pair has no DOM bridge that locates the canvas iframe specifically; use `dom/source-at` on something inside it. |
 | Tear down or re-run one variant | `(re-frame.story/destroy-variant! id)` / `(re-frame.story/reset-variant id)`. |
 
-**Capture a live interaction back into a `:script`.** The recorder is browser-side too: `(re-frame.story/start-recording!)` → let the user interact → `(re-frame.story/stop-recording!)` → `(re-frame.story/gen-play-snippet)`, all through `eval-cljs`. The user lands the snippet back in source. Filtering is fixed by `re-frame.story.recorder/recordable-event?` — operation `:rf.event/dispatched`, frame-scope match against the target, internal-namespace skip (`:rf.assert/*`, `:rf.story/*`, `:re-frame.story.*`) — it is not free-form.
+**Capture a live interaction back into a `:script`.** The recorder is browser-side too, so it drives from `eval-cljs` like everything else — but it is not a zero-arity trio. `start-recording!` takes the variant it records against, and `gen-play-snippet` takes the captured events plus an opts map whose `:variant-id` is required. Only `stop-recording!` is zero-arity, so bind what it returns and feed that in:
+
+```
+mcp__re-frame2-pair__eval-cljs {form: "(:recording? (re-frame.story/start-recording! :story.counter/loaded))"}
+;; => true          … now let the user interact with the canvas …
+
+mcp__re-frame2-pair__eval-cljs {
+  form: "(let [{:keys [events cofx]} (re-frame.story/stop-recording!)]
+           (re-frame.story/gen-play-snippet
+             events
+             {:variant-id :story.counter/recorded-flow, :cofx cofx}))"
+}
+;; => "(story/reg-variant :story.counter/recorded-flow
+;;        {:script {:auto-run? true :script [[:dispatch-sync [:counter/inc]] …]}})"
+```
+
+`stop-recording!` returns the recorder state — `:recording?` false, `:events` the captured event vectors in declared order, `:cofx` index-aligned with them, `:variant-id` naming the source. Stopping preserves that capture, so `(re-frame.story/recorder-state)` re-reads the same `:events` if you split the two round-trips. Passing `:cofx` is optional; without it the pasted snippet restamps coeffects on replay instead of re-presenting the recorded ones. The user lands the returned string back in source.
+
+`gen-play-snippet` renders the bare `:events` stream — **dispatched events only**. Canvas clicks, typed input and form submits are captured too, but into `:entries`, and this snippet is blind to them: for those, `(re-frame.story/recording->script-body entries opts)` returns the live `{:script [...] :auto-run? …}` body, and the shell's own REC save dialog renders the rich pasteable form. What is captured at all is not free-form either: the trace-bus listener only offers `:rf.event/dispatched` events whose `:frame` matches the recording target, and `re-frame.story.recorder/recordable-event?` then drops Story's internal namespaces (`:rf.assert/*`, `:rf.story/*`, `re-frame.story.*`).
 
 ## What is per-variant, and what is not
 

--- a/skills/re-frame2-pair/tests/prompts/prompt_regression_test.clj
+++ b/skills/re-frame2-pair/tests/prompts/prompt_regression_test.clj
@@ -699,6 +699,88 @@
         "SKILL.md still routes to the deleted references/variant-as-frame.md.")))
 
 ;; ---------------------------------------------------------------------------
+;; Published call ARITY, read against the defining facade
+;; ---------------------------------------------------------------------------
+;;
+;; Every guard above proves a recipe still NAMES an op. None of them says
+;; whether the published call would RUN. references/stories.md shipped
+;; `(re-frame.story/start-recording!)` and `(re-frame.story/gen-play-snippet)`
+;; with zero args against a facade requiring `[variant-id]` and
+;; `[events opts]` — an arity error before capture or codegen happens at all —
+;; and every structural check stayed green through the merge (rf2-p1keh,
+;; audit of PR #8951). These guards read the defining `defn` and the
+;; published call, and relate the two.
+
+(def ^:private story-facade
+  ;; The public Story facade, two levels up from skill-root (repo `tools/story/`).
+  ;; Newlines are normalised: the repo stores LF but a Windows checkout under
+  ;; `core.autocrlf=true` hands back CRLF, and an anchor ending in "\n" then
+  ;; matches nothing — silently, with the guards below reading as vacuous.
+  (delay (-> (io/file skill-root ".." ".." "tools" "story" "src"
+                      "re_frame" "story.cljc")
+             slurp
+             (str/replace "\r\n" "\n"))))
+
+(defn- defn-form
+  "Source text of the top-level `(defn <sym> …)` form, from its opening
+  paren to the blank line before the next top-level form. nil when the
+  facade does not declare `sym` on its own line."
+  [src sym]
+  (when-let [start (str/index-of src (str "(defn " sym "\n"))]
+    (let [tail (subs src start)
+          end  (str/index-of tail "\n\n(")]
+      (if end (subs tail 0 end) tail))))
+
+(defn- zero-arity?
+  "True iff `defn-src` declares a zero-arity — a bare `[]` arg vector alone
+  on its line, or an `([] …)` multi-arity clause."
+  [defn-src]
+  (boolean (re-find #"(?m)^\s*\[\]\s*$|^\s*\(\[\]" defn-src)))
+
+(deftest recorder-recipe-calls-match-the-facade-arity
+  (testing "the facade declares the arities the leaf must satisfy (rf2-p1keh)"
+    (let [src @story-facade]
+      ;; Control. `zero-arity?` answering "false" for every input would clear
+      ;; the two assertions below in the same voice as a correct facade, so
+      ;; exercise it against the one recorder entry point that IS zero-arity.
+      (is (some? (defn-form src "stop-recording!"))
+          (str "could not locate `(defn stop-recording!` in the Story facade "
+               "— the arity guards below are vacuous, not satisfied "
+               "(rf2-p1keh)."))
+      (is (zero-arity? (defn-form src "stop-recording!"))
+          (str "`re-frame.story/stop-recording!` no longer reads as zero-arity, "
+               "so `zero-arity?` is not measuring what it claims and the "
+               "guards below prove nothing (rf2-p1keh)."))
+      (doseq [sym ["start-recording!" "gen-play-snippet"]]
+        (let [form (defn-form src sym)]
+          (is (some? form)
+              (str "could not locate `(defn " sym "` in the Story facade — "
+                   "references/stories.md publishes a call to it, so either "
+                   "the fn moved or this guard is reading the wrong file "
+                   "(rf2-p1keh)."))
+          (is (not (zero-arity? form))
+              (str "`re-frame.story/" sym "` now declares a zero-arity. If that "
+                   "is deliberate, references/stories.md may simplify its "
+                   "recorder sequence; until then the leaf must keep passing "
+                   "arguments (rf2-p1keh)."))))))
+
+  (testing "references/stories.md publishes no zero-arg recorder call (rf2-p1keh)"
+    (let [md @stories-md]
+      (doseq [sym ["start-recording!" "gen-play-snippet"]]
+        (is (not (str/includes? md (str "(re-frame.story/" sym ")")))
+            (str "references/stories.md publishes `(re-frame.story/" sym ")` "
+                 "with zero args. The facade requires arguments, so following "
+                 "the recipe throws before it captures anything (rf2-p1keh).")))
+      (is (str/includes? md "(re-frame.story/start-recording! :story.")
+          (str "references/stories.md no longer passes a variant id to "
+               "`start-recording!` — the recording's address IS the variant "
+               "frame (rf2-p1keh)."))
+      (is (str/includes? md ":variant-id :story.")
+          (str "references/stories.md no longer supplies `gen-play-snippet`'s "
+               "required `:variant-id` opt — the snippet has no id to render "
+               "the `reg-variant` form against (rf2-p1keh).")))))
+
+;; ---------------------------------------------------------------------------
 ;; Catalogue-cardinality drift
 ;; ---------------------------------------------------------------------------
 ;;


### PR DESCRIPTION
Second pass on rf2-p1keh, opened against the audit of its own merged PR #8951.

## The defect

`skills/re-frame2-pair/references/stories.md` taught the Story recorder as a zero-arity trio:

```
(re-frame.story/start-recording!) → let the user interact → (re-frame.story/stop-recording!) → (re-frame.story/gen-play-snippet)
```

Two of those three calls do not exist at that arity. The defining public facade in `tools/story/src/re_frame/story.cljc` declares `start-recording!` as `[variant-id]` and `gen-play-snippet` as `[events opts]`, whose `opts` map must carry `:variant-id`. Only `stop-recording!` is `[]`. Following the published recipe threw before it captured a single event.

This is not inferred from reading. Executed on the JVM against the real facade (the three entry points are plain `defn` in `.cljc`, and Story's own comment says they are exposed so headless integrations can drive recording without the toolbar):

```
--- (re-frame.story/start-recording!) ---
THREW: ArityException - Wrong number of args (0) passed to: re-frame.story/start-recording!

--- (re-frame.story/stop-recording!) ---
RESULT: {:recording? false, :variant-id nil, :events [], :cofx [], :entries [], :started-ms nil}

--- (re-frame.story/gen-play-snippet) ---
THREW: ArityException - Wrong number of args (0) passed to: re-frame.story/gen-play-snippet
```

## The corrected sequence

The same probe, running the sequence exactly as the leaf now publishes it, renders a valid snippet:

```
step 1: (:recording? (re-frame.story/start-recording! :story.counter/loaded))  => true
step 2: (let [{:keys [events cofx]} (re-frame.story/stop-recording!)]
          (re-frame.story/gen-play-snippet events {:variant-id :story.counter/recorded-flow, :cofx cofx}))
     => (story/reg-variant :story.counter/recorded-flow
          {:script {:auto-run? true :script [[:dispatch-sync [:counter/inc]]
                                             [:dispatch-sync [:counter/set 7]]]}})
```

A `:rf.assert/*` event fed through the same capture is absent from the output, so the leaf's claim about the internal-namespace filter is confirmed too.

Two further limits the old text did not carry are now stated, because both make the recipe silently lossy rather than loud:

- `gen-play-snippet` renders the bare `:events` stream. Canvas clicks, typed input and form submits are captured into `:entries`, and the snippet is blind to them — the shell installs DOM capture at mount, so in the leaf's own "let the user interact" scenario those interactions are dropped. `recording->script-body` and the shell's REC save dialog are the `:entries`-aware routes.
- The capture filter is split: the trace-bus listener gates on operation (`:rf.event/dispatched`) and frame scope; `recordable-event?` drops Story's internal namespaces. The old text attributed all three to the predicate.

## Full arity census of the leaf

The audit named three functions; it did not claim they were the only ones. Every `re-frame.story/*` call the leaf publishes was read against its defining `defn`. Twenty-five invocation forms across nineteen distinct functions; the two above were the only mismatches. `references/recipes.md` publishes eleven more and all eleven agree.

The census was run twice — once line-oriented, once over whitespace-collapsed text, because a call wrapped across two lines is invisible to a line-oriented search and so is a control sharing that shape. Both passes returned the same thirty symbol occurrences. A control fixture carrying the same dotted/hyphenated/slashed shape, once inline and once wrapped, confirmed the line-oriented pass sees the symbol but not the wrapped arguments, and the collapsed pass sees both.

## Why the previous pass shipped this

PR #8951's structural checks proved names and prefixes, never call arities, and its handoff records that no live Pair session exercised a recipe. Every gate was green and every gate was blind. So the prompt regression grows a guard for that class: it reads the defining `defn` out of the Story facade and relates it to the call the leaf publishes, rather than pinning another token. The guard carries a control that exercises its zero-arity predicate against `stop-recording!`, where the answer is known, so a predicate that answered "false" everywhere could not clear it vacuously.

Verified by planting the original defect back: the guard goes red naming the offending call, and green once restored (restore confirmed by blob hash, not by reading a diff).

## Gates

All exit codes captured from the runner, not reported by the harness.

| Gate | Exit |
|---|---|
| `bb tests/prompts/prompt_regression_test.clj` (28 tests, 189 assertions) | 0 |
| `bb tests/runtime/*_test.clj` (12 files, each run separately) | 0 each |
| `scripts/check_skill_mcp_drift.py --self-test --ci` | 0 |
| `scripts/check_skill_mcp_drift.py --verbose --ci` | 0 |
| `scripts/check_skill_pair_authoring_drift.py` | 0 |
| `scripts/check_skill_package_refs.py` | 0 |
| `scripts/check_doc_slugs.py` | 0 |
| JVM arity probe (old sequence throws, corrected sequence renders) | 0 |

**`check_doc_slugs.py`'s green does not cover this change.** It covers `skills/`, but it strips fenced code blocks before it reads a single link, and the corrected recipe lives inside a fence. Measured in both directions on this very file: an identical broken link returns exit 1 in prose and exit 0 inside the fence my change occupies. The prose paragraphs I added carry no links, so there is nothing there for it to check either. The gate is quoted as green because it must be green, not as evidence about the fix.

**No live Pair session exercised this.** That needs an attached browser with a Story-enabled shadow-cljs build, which this worktree does not have. The JVM probe is the strongest available substitute: it runs the identical facade calls at the identical arities, and it is what turns "read the signature" into "reproduced the throw". What it cannot cover is the `eval-cljs` transport and the browser heap.

`mkdocs build --strict` is not a candidate: `docs_dir` is `docs`, so `skills/` is outside the site build.

Closes rf2-p1keh.
