### PR TITLE
fix(realworld-http): gate the article delete SUCCESS on the ACTIVE ROUTE (rf2-amhpk)

### DIFF
--- a/examples/real-apps/realworld_http/comments.cljs
+++ b/examples/real-apps/realworld_http/comments.cljs
@@ -14,8 +14,9 @@
      identity — the reads, the comment mutations, and the article's own
      social buttons alike: each slice records the slug it is loading, every
      settle carries the slug it was requested for, and one that no longer
-     belongs to the screen is refused (see `reply-for-current-slug?` below —
-     the same correlation law article_editor.cljs spells for the editor).
+     belongs to the screen is refused (see `reply-for-current-slug?` and its
+     route-level sibling `article-route-for-slug?` below — the same
+     correlation law article_editor.cljs spells for the editor).
    - Optimistic post / delete flows that roll back through nothing fancier
      than ordinary events."
   (:require [clojure.string :as str]
@@ -66,8 +67,10 @@
 ;; slice, so alpha's article is never renderable under `/article/beta`.
 ;;
 ;; The rule is now universal in this file: EVERY settle that touches
-;; route-owned state carries the slug it was requested for and asks this
-;; question before acting. Ten do —
+;; route-owned state carries the slug it was requested for and asks, before
+;; acting, whether that slug still owns the thing it is about to change. Ten
+;; do — nine of them asking about the slice, one asking about the route (TWO
+;; QUESTIONS, below, is why) —
 ;;
 ;;   - the three route-driven READS: `:article/load`'s reply hat,
 ;;     `:comments/loaded`, `:comments/load-failed` (rf2-iy3d6);
@@ -98,6 +101,26 @@
 ;; server deletion succeeded regardless, beta is a fine place to be, and
 ;; returning to alpha later fails and reloads like any other missing article.
 ;;
+;; TWO QUESTIONS, because there are two owners. Ask the one that matches the
+;; OUTCOME, not the one nearest to hand:
+;;
+;;   - a WRITE into `[:article …]` / `[:comments …]` is the SLICE's, so
+;;     `reply-for-current-slug?` asks which slug the slice is loading. That is
+;;     the right owner for the nine db writes: a settle for the slug the slice
+;;     still targets is that slice's own business wherever the reader has
+;;     wandered off to meanwhile, and coming back to it is a same-slug refresh
+;;     that clears the error and re-reads the truth anyway.
+;;
+;;   - a NAVIGATION is the ROUTE's, so `article-route-for-slug?` asks whether
+;;     the committed route is still `/article/<that slug>`. Nothing weaker
+;;     will do, because leaving an article for a NON-ARTICLE page — home, a
+;;     profile, login, the editor — runs that route's own `:on-match` and
+;;     never touches `[:article]`, so the slice goes on naming alpha long
+;;     after alpha left the screen. Alpha → beta HIDES that (beta's
+;;     `:article/load` happens to overwrite the cached slug on the way in);
+;;     alpha → `/profile/eve` exposes it, and a slug-only gate took that
+;;     reader home just as an ungated one did.
+;;
 ;; Why a gate ALONE is enough for all ten, where the comment form also needed
 ;; a reset: everything gated here lives in a slice that `:article/load` or
 ;; `:comments/load` REBUILDS on a slug change, so the navigation has already
@@ -116,8 +139,8 @@
 ;; `:article/delete-success` also satisfies while very much needing the gate,
 ;; but "produces no outcome the route owns".
 ;;
-;; The gate correlates ROUTE IDENTITY, not request identity: it asks which
-;; slug the screen is on, so alpha → beta → alpha readmits an alpha reply
+;; Both gates correlate ROUTE IDENTITY, not request identity: they ask which
+;; article the screen is on, so alpha → beta → alpha readmits an alpha reply
 ;; issued before the round trip. That is the same strength the reads have
 ;; had since rf2-iy3d6, and it is deliberate — a per-request epoch or a
 ;; cancellation scheme would buy a much narrower race at the cost of the
@@ -132,6 +155,21 @@
    reply carries equals the slug the slice currently targets."
   [db slice-key slug]
   (= slug (get-in db [slice-key :slug])))
+
+(defn article-route-for-slug?
+  "Is the ACTIVE ROUTE still the detail page for `slug`? True exactly when the
+   committed route is `:realworld.article/show` and its `:slug` param is this
+   one. Reads RUNTIME-db, where the route slice lives — handlers get it as the
+   `:rf.db/runtime` coeffect.
+
+   The stronger sibling of `reply-for-current-slug?`, and the question a
+   settle whose outcome is a NAVIGATION has to ask: the slice's slug survives
+   a walk to any non-article page, the route's does not. See TWO QUESTIONS
+   above."
+  [rt slug]
+  (let [{:keys [route-id params]} (get-in rt [:rf.runtime/routing :current])]
+    (and (= :realworld.article/show route-id)
+         (= slug (:slug params)))))
 
 ;; ============================================================================
 ;; RECORDABLE COEFFECTS
@@ -590,16 +628,21 @@
 
 (rf/reg-event :article/delete-success
   {:doc "The DELETE's `:on-success`, carrying the slug it was issued for.
-         Correlation-gated like the rest — this one writes no db, but it
-         NAVIGATES, and the route is the most visible state the active article
-         owns. Delete alpha, walk to beta while the server thinks about it, and
-         an ungated success takes the reader away from the article they chose.
+         Correlation-gated like the rest — but against the ROUTE rather than
+         the slice, because what it produces is a navigation and the route is
+         what owns that. Delete alpha, walk away while the server thinks about
+         it, and an ungated success takes the reader off whatever they chose
+         instead. Asking the slice alone would catch only the walk to another
+         ARTICLE — every non-article page leaves `[:article :slug]` saying
+         alpha, so the slice would answer yes and the reader would be sent
+         home anyway. See TWO QUESTIONS above.
 
          Refusing strands nothing: the server deletion succeeded either way,
-         beta is a perfectly good place to be, and coming back to alpha later
-         just fails and reloads like any other missing article."}
-  (fn [{:keys [db]} [_ slug _reply]]
-    (when (reply-for-current-slug? db :article slug)
+         wherever the reader has got to is a perfectly good place to be, and
+         coming back to alpha later just fails and reloads like any other
+         missing article."}
+  (fn [{rt :rf.db/runtime} [_ slug _reply]]
+    (when (article-route-for-slug? rt slug)
       {:fx [[:dispatch [:rf.route/navigate {:to :realworld/home}]]]})))
 
 (rf/reg-event :article/delete-failed

--- a/examples/real-apps/realworld_http/schema.cljs
+++ b/examples/real-apps/realworld_http/schema.cljs
@@ -41,9 +41,12 @@
 
    `:slug` is the ACTIVE ROUTE IDENTITY a route-keyed slice is loading — the
    correlation fact `reply-for-current-slug?` (comments.cljs) gates every
-   article/comments settle against, so a late reply for a slug the reader has
-   left can't overwrite the current page. Optional because only the
-   `/article/:slug`-driven slices (`:article`, `:comments`) carry it."
+   article/comments settle that WRITES a slice against, so a late reply for a
+   slug the reader has left can't overwrite the current page. (A settle whose
+   outcome is a NAVIGATION asks the route instead — `article-route-for-slug?`,
+   same file: THIS slug outlives a walk to a non-article page, the route's
+   does not.) Optional because only the `/article/:slug`-driven slices
+   (`:article`, `:comments`) carry it."
   [:map
    [:status         [:enum :idle :loading :fetching :loaded :error]]
    [:data           {:default nil} :any]

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -2436,6 +2436,16 @@
 ;; deletion succeeded on the server either way, so there is no retry to lose
 ;; and nothing left half-done.
 ;;
+;; And it needs a DIFFERENT gate from the other three, which is what the
+;; second pass on this bead found. The three writes land in `[:article …]`, so
+;; the slice's own slug is the right owner to ask about. The navigation does
+;; not — it is the ROUTE's — and the slice's slug outlives a walk to any
+;; NON-ARTICLE page, because home, a profile, login and the editor all run
+;; their own `:on-match` without touching `[:article]`. Alpha → beta cannot
+;; show that (beta's `:article/load` overwrites the cached slug on the way in),
+;; which is precisely why the first pass's refusal test passed over the gap;
+;; alpha → `/profile/eve` shows it, and that is the test below.
+;;
 ;; The fix is the gate alone, with NO reset half — the difference from
 ;; rf2-84iek that matters. `[:comment-form]` was a boot-time singleton that
 ;; rode across the navigation still `:submitting`, so gating it without a
@@ -2569,6 +2579,50 @@
         (is (= "beta" (:slug (article-slice* f)))
             "…and beta's article is still the one on screen")))))
 
+(defn- article-delete-non-article-route-late-success-is-refused-test []
+  ;; The same late success, except the reader walks somewhere that is not an
+  ;; article at all. This is the case a slug-only gate cannot see, and the
+  ;; reason `:article/delete-success` asks the ROUTE rather than the slice:
+  ;; `/profile/eve` runs its OWN `:on-match` and never touches `[:article]`,
+  ;; so the slice still targets alpha long after alpha has left the screen.
+  ;; Ask "is alpha the slug the slice is on?" and the answer is yes; ask "is
+  ;; the reader still on alpha's page?" and it is no. Navigation is the
+  ;; route's own outcome, so the route is the question that has to be asked.
+  ;;
+  ;; `/article/beta` cannot expose this, because `:article/load` happens to
+  ;; overwrite the cached slug on the way in — which is exactly why the first
+  ;; pass's refusal test passed while this gap stayed open.
+  (with-held-comment-fx :realworld.test/article-delete-off-article
+    (fn [f lowered]
+      (rf/dispatch-sync [:rf.route/handle-url-change "/article/alpha"] {:frame f})
+      (settle-article-with-author! f lowered "alpha" "eve" false)
+      (rf/dispatch-sync [:article/delete] {:frame f})
+      (let [delete-req (req-by-method+url @lowered :delete "/articles/alpha")]
+        (is (some? delete-req) "the article DELETE went out and is held open")
+        ;; The reader gives up waiting and opens the author's profile.
+        (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})
+        (is (= :realworld.profile/show
+               (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+            "the reader is on a NON-ARTICLE route")
+        ;; The witness the whole test turns on: a non-article route releases
+        ;; nothing, so the slice's own slug is still alpha's.
+        (is (= "alpha" (:slug (article-slice* f)))
+            "the article slice still carries alpha — the profile route's
+             :on-match leaves [:article] alone, so a slug-only gate admits
+             what follows")
+        ;; And nothing is stranded by refusing it, for the same reason as the
+        ;; four settles above: the server deletion stands, the Delete button
+        ;; carries no pending state, and returning to alpha later just fails
+        ;; and reloads like any other missing article.
+        (rf/dispatch-sync (conj (:on-success delete-req) {:status :ok :value nil})
+                          {:frame f})
+        (is (= :realworld.profile/show
+               (rf/compute-sub [:rf.route/id] (rf/frame-state-value f)))
+            "a LATE alpha DELETE SUCCESS does not yank a reader off a
+             NON-ARTICLE route (rf2-amhpk)")
+        (is (= {:username "eve"} (route-params* f))
+            "…the reader's own newer route choice is the one that stands")))))
+
 (defn- article-delete-current-slug-still-navigates-home-test []
   ;; The navigation control for the gate above: refusing a STALE success must
   ;; not cost the ordinary one. Delete the article you are reading, settle it
@@ -2636,6 +2690,9 @@
   (testing "a LATE alpha DELETE success cannot navigate beta's reader home
             (rf2-amhpk)"
     (article-delete-cross-slug-late-success-is-refused-test))
+  (testing "…nor a reader who walked to a NON-ARTICLE route, which no
+            slug-only gate can see (rf2-amhpk)"
+    (article-delete-non-article-route-late-success-is-refused-test))
   (testing "…while a delete settled on its own slug still goes home — the
             navigation control (rf2-amhpk)"
     (article-delete-current-slug-still-navigates-home-test))


### PR DESCRIPTION
Second pass on rf2-amhpk, audit-reopened against its own merged PR #8938.

## The finding, verified at source

The first pass gated `:article/delete-success` on `reply-for-current-slug?`, which asks only whether the reply's slug equals the one `[:article :slug]` names. **That slug outlives the article page.** Walking from `/article/alpha` to any NON-article route — `:realworld/home`, `:realworld.profile/show`, `:realworld.auth/login`, either editor route — runs that route's own `:on-match`, and not one of them touches `[:article]` (checked in `routing.cljs`: home and home-tag run `[:home/load]`, the profile routes run `[:profile/load]` + a list load, login and register run nothing). So the slice goes on saying `alpha`, the gate answers yes, and a late alpha DELETE success navigates the reader home over the newer route they chose.

`/article/beta` hides it, because `:article/load`'s request hat overwrites the cached slug on the way in — which is exactly why the first pass's own refusal test passed straight over the gap.

## The repair

Navigation is owned by the **route**, so the route is the question to ask. `article-route-for-slug?` reads the route slice off the `:rf.db/runtime` coeffect and admits the settle only while the committed route is `:realworld.article/show` for that same slug. It is the shape the resources twin already uses for its editor (`still-editing?` in `realworld_resources/article_editor.cljs` compares `(:route-id current)` and `(:params :slug)` the same way) — no request epoch, no cancellation machinery, no new abstraction.

The nine db-writing settles keep `reply-for-current-slug?` unchanged: what they change belongs to the **slice**, so the slice's own slug is the right owner to ask about, and a same-slug return is a refresh that clears the error and re-reads the truth anyway. The correlation-gate note now spells that split out under **TWO QUESTIONS**, and `schema.cljs` no longer claims the slice gate covers every settle.

Refusing still strands nothing, for the same reasons the first pass established: the server deletion succeeded either way, the Delete button carries no pending or disabled state, and returning to alpha later fails and reloads like any other missing article.

## The regression is the evidence

`article-delete-non-article-route-late-success-is-refused-test` reads alpha, holds its DELETE open, walks to `/profile/eve`, and pins that the reader stays there. It carries its own witness assertion — the article slice still reads `alpha` at that moment — which is precisely why a slug-only gate admits the settle.

**Red before the fix** (unmodified source, the strongest control there is), exactly two assertions:

- `a LATE alpha DELETE SUCCESS does not yank a reader off a NON-ARTICLE route` — actual `:realworld/home`
- `…the reader's own newer route choice is the one that stands` — actual `{}`

**Green after**, with the existing `/article/beta` refusal, the current-slug navigation control, the three sibling db-write refusals and their non-vacuity control all still passing.

## Gates

Exit codes captured with `echo $?` on the redirect's own command line and quoted from the file. Both lanes print their shadow-cljs config path, and both named this worktree's `implementation/shadow-cljs.edn`.

| Gate | Pre-fix control | Final base |
| --- | --- | --- |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` | exit 0 | exit 0 |
| `node out/node-test.js` | **exit 1** — 11196 tests / 55473 assertions, 2 failures, 0 errors | **exit 0** — 11198 tests / 55490 assertions, 0 failures, 0 errors |
| `implementation/scripts/check-examples-compile.cjs` | — | exit 0, all **57** swept builds compiled with zero warnings |

A peer measured this gate at 56/56 clean earlier today; the sweep is 57 on the final base because `origin/main` added the `examples/login-hicasso` build (PR for rf2-fmns2) between that measurement and this rebase. Both readings are all-green, zero-warning.

The `test:cljs` script was split into its two phases rather than detached, so each verdict stayed in the foreground. The post-fix compile recompiled the edited namespaces (11 files on the first post-fix pass), which is the positive evidence that the runtime observed the edit rather than replaying a cached build; `examples/realworld` is in the swept build set and compiled with zero warnings.

## Scope

`examples/real-apps/realworld_http/` plus the production-source adapter regression, per the bead. No framework, routing or resources code touched. Examples stay test-free — the regression lives in `implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs`, where the first pass put its coverage.

`:editor/delete-success` in `article_editor.cljs` is a different slice with its own `still-editing?` law and is out of scope, as the first pass recorded.

## Interaction with #8948

PR #8948 (rf2-9n43e) landed on `examples/real-apps/` shortly before this work and was re-derived at tip rather than assumed. **It did not move the seam this gate sits in.** It rewrote `realworld_shared/demo_backend.cljs` and the two apps' app-local `:rf.http/managed` override wiring in each `http.cljs`; the gate lives one layer up, in the `comments.cljs` handler, and `rh/request`'s reply-target shape is unchanged. The merge-base diff and #8948's file list have zero overlap, and the regression harness supplies its own capturing `:rf.http/managed` stub, so the demo backend is not in its path either.

