### PR TITLE
docs(method): make the newest-mutation read a dispatch step; test that a correction is established, not merely re-pointed

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -72,6 +72,31 @@ The order is what makes it accurate. Each step is a check the next depends on.
    costs a dispatch rather than a defect. **Do not let that safety net become the plan**: it
    spends a worker's context re-deriving what one query answers, and the mayor learns nothing,
    because a brief refuted politely reads much like a brief fulfilled.
+
+   **Do that read before the brief exists, and read it for two things: a HOLD, and SEQUENCING.** It is
+   a step rather than another note because the knowledge is already written down and already travelling —
+   the common preamble below orders the worker to read by tracker timestamps, at length and with the
+   reasoning, and the mayor pastes that into every dispatch and then does not do it. A hold is the newest
+   field often enough that the description cannot be trusted to mention it, so an item reads as an
+   ordinary defect report while the live instruction is *wait*. Sequencing is the mirror case and the
+   easier one to miss, because the brief's instinct is right by default: a triage note naming the
+   predecessors that had to land first is an **authorisation with a precondition**, so restating a
+   generic fence over it converts a satisfied precondition back into a blocker — which either strands
+   the work or, as measured here, costs the worker a justification round it should not have had to
+   write. Both shapes went out in real briefs, and the worker caught both.
+
+   **And where you sweep a whole board for hold markers, that sweep is a candidate filter and never a
+   verdict.** It narrows the open items to a handful; the hold is then established by READING each
+   candidate, which is affordable at that size and is the only thing that separates a live banner from
+   one quoted, discussed, or already struck. Write the question the sweep answers beside the question you
+   are asking — *does this text contain these characters* against *is this item currently held* — because
+   the gap is invisible in the answer. Measured: a sweep reported eleven of twenty-seven open items held
+   and the number reached the operator before anyone read a candidate; the first two falsified were an
+   item quoting another item's banner and an item whose own text said its banner was struck. Why the
+   sweep fails in both directions, why a second sweep built to tell live from struck fails the same way,
+   and the structured field that is the durable answer where a project wants this machine-checkable, are
+   under *Tracker mechanics* in [`loops.md`](loops.md#tracker-mechanics) — this step is the concrete
+   instance and does not restate them.
 2. **Check every factual claim you are about to write.** Does the symbol resolve?
    Does the file say what you think? Is the count still true? Is the ruling you cite
    *ruled*, or only recommended? A recommendation and a decision read identically in

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1477,12 +1477,16 @@ and a containment scan demoted from a verdict to triage kept a clause saying it 
 case"*, two sentences from the words *"triage, not a verdict"*. Both were caught by an outside
 reader, not by the loop that wrote them.
 
-**The discharging test is one question, and it costs nothing: would the evidence that falsified the
-old claim also falsify the new one?** If it would, the new claim is not established — it is the old
-error re-pointed. Workers completing alive falsifies *dormant*; it does not establish *about to
-report*, because a stopped worker produces the same reading. Where the honest answer is that the
-observation supports neither side, **say so plainly and let the guidance rest on the asymmetric cost
-of the two errors instead** — that is a real reason to wait, and it survives the next counterexample,
+**The discharging test is one question, and it costs nothing: what would you expect to SEE that is
+different if the new claim were false?** If the only answer is *the evidence that refuted the old
+one*, nothing has been established — that evidence rules the old claim out and leaves the replacement
+standing among several survivors, which is the old error re-pointed. Workers completing alive refutes
+*dormant*, and a stopped run shows the same frozen clock as one about to report, so nothing observed
+tells those two apart. The containment scan's misses refute *this settles it*, and a scan that is
+right usually and one that is right rarely produce identical output, so *settles the common case*
+rests on a frequency nobody measured. Where the honest answer is that the observation supports
+neither side, **say so plainly and let the guidance rest on the asymmetric cost of the two errors
+instead** — that is a real reason to wait, and it survives the next counterexample,
 which a re-pointed claim does not. Being wrong twice about the same sentence is the ordinary case
 here, and this loop is where the second round is supposed to be caught.
 


### PR DESCRIPTION
Two prose repairs in `docs/the-mayor-method/`, one branch — the tree is sole-toucher hot-zone, so they are clustered rather than sequenced. No code changes.

## rf2-ute0q — `dispatch-prompt-template.md`, step 1 of *Write the brief in this order*

The mayor writes a preamble that orders the worker to read the item by tracker timestamps, at length and with the reasoning, and then does not do it. Five briefs in one day carried a defect the item already recorded, and the worker caught all five. The remedy is a step where it cannot be forgotten rather than a sixth note.

Step 1 gains two paragraphs (no new top-level section):

- **Read the newest text-bearing mutation before the brief exists, for a HOLD and for SEQUENCING.** A hold is the newest field often enough that the description cannot be trusted to mention it. Sequencing is the mirror case: a triage note naming the predecessors that had to land first is an authorisation with a precondition, so restating a generic fence over it converts a satisfied precondition back into a blocker — which strands the work or costs the worker a justification round.
- **A hold-marker sweep is a candidate filter and never a verdict.** It narrows the board; the hold is then established by reading each candidate, which is affordable at that size and is the only thing separating a live banner from one quoted, discussed or struck. The question the sweep answers (*does this text contain these characters*) is written beside the question being asked (*is this item currently held*).

The mechanics stay in **one** place. Why the sweep fails in both directions, why a second sweep built to tell live from struck fails the same way, and the structured field that is the durable answer where a project wants this machine-checkable are all already under *Tracker mechanics* in `loops.md`; this step points there rather than restating them, and does not design the structured field.

## rf2-f7fby — `loops.md` §6, the discharging test

The advertised question was *would the evidence that falsified the old claim also falsify the new one?* Applied to its own frozen-clock example it fails to bite: workers completing alive falsifies *dormant* but does not falsify *about to report*, so the unsupported inverse passes the written test. The paragraph then reached the right conclusion only by silently switching to a different discriminator — *a stopped worker produces the same reading* — leaving the bold test and the sentence explaining it on different criteria.

The question is now *what would you expect to SEE that is different if the new claim were false?*, and if the only answer is the evidence that refuted the old one, nothing has been established. **Both** named examples now fail it, each for its stated reason: a stopped run and one about to report show the same frozen clock; and a scan right usually and one right rarely produce identical output, so *settles the common case* rests on a frequency nobody measured.

Preserved unchanged in force: the corrected worker outcomes, the ambiguity guidance, and the asymmetric-cost wait rule. No new mechanism; one paragraph, rewrapped.

## Quality gates

All exit codes below are the runner's own status, captured by redirecting to a log and writing `$?` to a file on the same command line, then read back from that file. Both doc gates were exercised with a planted fault to prove they read this worktree, and each restore was verified by content hash against the committed object rather than by reading a diff.

| Gate | Captured exit | Result |
| --- | --- | --- |
| `python scripts/check_doc_slugs.py` | 0 | pass, no broken link targets or anchors |
| `python -m mkdocs build --strict` | 0 | pass, 0 WARNING lines |
| `sh scripts/test-fast-pr.sh` | 0 | `PASS fast PR spine` — 411 PASS lines, 0 FAIL; tiers `docs=true jvm=false node=false` |

Controls, both planted at the one link this change adds and both restored to a matching hash:

- broken **anchor** (`loops.md#tracker-mechanics-planted-fault-methodstep`) → `check_doc_slugs.py` exit **1**, naming `docs/the-mayor-method/dispatch-prompt-template.md:98` and the anchor. This is the only anchor gate for these pages; `--strict` grades a broken anchor at INFO and stays green.
- broken **link target** (`loops-planted-fault-methodstep.md`) → `python -m mkdocs build --strict` exit **1**, `Aborted with 1 warnings in strict mode!`, naming the file and the missing target. `exclude_docs` does not hide `the-mayor-method/`.

The spine printed its own `gate root` as this worktree, so its green is about this tree.

Ran as `python -m mkdocs`, never bare `mkdocs` — the bare form returns 127 in Git Bash here, which is no verdict rather than a pass.

**Verified by hand, because no gate covers it:** the prose, register and paragraph flow of both edited passages; the one added link resolves to the live `## Tracker mechanics` heading in `loops.md` (confirmed present, and confirmed by the planted-anchor red and its green restore); the numbered-list continuation indent on the two added paragraphs matches the three-space indent the surrounding step-1 paragraphs already use, so both render inside item 1 rather than closing the list. **No tables were added or touched** — the diff contains zero lines carrying a table delimiter, so there are no column counts to check. The diff against the merge base (`origin/main...HEAD`) was read for reverts: 34 insertions, 5 deletions, the five deletions being exactly the replaced sentences of the one repaired paragraph, with the ambiguity and asymmetric-cost sentences carried through intact.
