### PR TITLE
fix(machines): reserve the timer attempt before the /scheduled fan-out so an aborted arm closes its pair (rf2-jqvgp)

### DIFF
--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -519,9 +519,11 @@
   rf2-jqvgp — the ORDER of the reservation against that emit is itself the
   contract. The attempt's timer-table slot is reserved BEFORE the fan-out, so
   the announced attempt is a CANCELLABLE one from the instant it becomes
-  visible: the recheck's abort reclaims it by its own token and emits the
-  mirrored `/cancelled`, leaving no `/scheduled` row that can never be followed
-  by `/fired` or `/cancelled` (Spec 005 §Trace event catalogue pairs the two by
+  visible, and the mirrored `/cancelled` closes it — emitted by the destroying
+  frame's own `cancel-all-timers!` sweep where that reached the sentinel first,
+  and by the recheck's own token-exact abort otherwise. Either way no
+  `/scheduled` row is left that can never be followed by `/fired` or
+  `/cancelled` (Spec 005 §Trace event catalogue pairs the two by
   `(actor-id, state, epoch)`). The host clock is still armed AFTER the emit, so
   `/scheduled` still precedes even a synchronously-firing host callback. The
   abort releases nothing further — see the comment at that recheck for why the
@@ -627,10 +629,12 @@
             ;; 005 §Trace event catalogue has the two events mirror each other
             ;; precisely so consumers can pair them by `(actor-id, state,
             ;; epoch)`. Reserving first makes the attempt a claimable one from
-            ;; the instant it is announced, so every abort below closes the pair
-            ;; with the entry's OWN `/cancelled`. The host clock is still armed
-            ;; after the emit, so a host that fires synchronously cannot beat
-            ;; `/scheduled` to the stream.
+            ;; the instant it is announced, so the pair below is closed by the
+            ;; entry's OWN `/cancelled` — whether the claim comes from the
+            ;; destroying frame's `cancel-all-timers!` sweep (which can now see
+            ;; the sentinel) or from the abort's token-exact reclaim. The host
+            ;; clock is still armed after the emit, so a host that fires
+            ;; synchronously cannot beat `/scheduled` to the stream.
             (swap! after-timers assoc-in [frame-id k] reservation)
             (when emit-scheduled-trace?
               (trace/emit! :rf.machine :rf.machine.timer/scheduled

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -510,14 +510,23 @@
   rf2-jqvgp — the supersede is not this fn's only callback boundary. With
   `:emit-scheduled-trace?` true (the SSR hydration arm and the dynamic-delay
   re-resolution) it emits `:rf.machine.timer/scheduled` ITSELF, synchronously,
-  AFTER the post-supersede recheck and BEFORE the slot is reserved — so a
-  listener on that row has the same reach as one on `/cancelled`, and on a frame
-  holding no prior timer it is the FIRST callback of the whole operation. The
-  same predicate is therefore rechecked once more, immediately after that emit:
-  every durable step (slot reservation, host arm, publish, watcher) sits behind
-  it. The abort deliberately releases nothing — see the comment at that recheck
-  for why the one hold in flight is already gone with A, and why releasing it
-  would land on B."
+  AFTER the post-supersede recheck — so a listener on that row has the same
+  reach as one on `/cancelled`, and on a frame holding no prior timer it is the
+  FIRST callback of the whole operation. The same predicate is therefore
+  rechecked once more, immediately after that emit, and the host arm, publish
+  and watcher sit behind it.
+
+  rf2-jqvgp — the ORDER of the reservation against that emit is itself the
+  contract. The attempt's timer-table slot is reserved BEFORE the fan-out, so
+  the announced attempt is a CANCELLABLE one from the instant it becomes
+  visible: the recheck's abort reclaims it by its own token and emits the
+  mirrored `/cancelled`, leaving no `/scheduled` row that can never be followed
+  by `/fired` or `/cancelled` (Spec 005 §Trace event catalogue pairs the two by
+  `(actor-id, state, epoch)`). The host clock is still armed AFTER the emit, so
+  `/scheduled` still precedes even a synchronously-firing host callback. The
+  abort releases nothing further — see the comment at that recheck for why the
+  one hold in flight is already gone with A, and why releasing it would land
+  on B."
   [frame-id parent-id invoke-id state delay-key epoch server? snapshot
    {:keys [emit-scheduled-trace? owner-gone?]}]
   (let [delay-source (transition/classify-delay-source delay-key)
@@ -592,9 +601,37 @@
           ;; host scheduler that fires the callback synchronously before
           ;; `arm!` returns — can atomically CLAIM this attempt and leave the
           ;; publish phase to find its token gone and cancel the orphan handle.
-          (let [token     (next-attempt-token)
-                watch-key (when (= :sub delay-source)
-                            [::after-watch frame-id parent-id invoke-id delay-key])]
+          (let [token       (next-attempt-token)
+                watch-key   (when (= :sub delay-source)
+                              [::after-watch frame-id parent-id invoke-id delay-key])
+                ;; PHASE 1 — RESERVE the slot with an arming sentinel (`:handle
+                ;; nil`) carrying this attempt's `:token`, BEFORE arming any host
+                ;; clock. The reaction + watch-key ride the sentinel so a claiming
+                ;; cleanup releases the held subscription ref-count even though the
+                ;; physical add-watch is deferred to publication.
+                reservation {:handle          nil
+                             :reaction        reaction
+                             :sub-watcher-key watch-key
+                             :resolved-ms     resolved-ms
+                             :epoch           epoch
+                             :state           state
+                             :region          region
+                             :delay-source    delay-source
+                             :token           token}]
+            ;; rf2-jqvgp — the reservation is taken BEFORE the `/scheduled`
+            ;; fan-out below, not after it. The row's listener runs
+            ;; synchronously, so an attempt that is only reserved afterwards is
+            ;; not yet cancellable at the moment it becomes VISIBLE: a listener
+            ;; that destroys the owning incarnation leaves a `/scheduled` row
+            ;; that can never be followed by `/fired` or `/cancelled`, and Spec
+            ;; 005 §Trace event catalogue has the two events mirror each other
+            ;; precisely so consumers can pair them by `(actor-id, state,
+            ;; epoch)`. Reserving first makes the attempt a claimable one from
+            ;; the instant it is announced, so every abort below closes the pair
+            ;; with the entry's OWN `/cancelled`. The host clock is still armed
+            ;; after the emit, so a host that fires synchronously cannot beat
+            ;; `/scheduled` to the stream.
+            (swap! after-timers assoc-in [frame-id k] reservation)
             (when emit-scheduled-trace?
               (trace/emit! :rf.machine :rf.machine.timer/scheduled
                            (cond-> {;; the timer's owning actor INSTANCE;
@@ -612,44 +649,44 @@
                              (assoc :rf.sub/id      (first delay-key)
                                     :rf.sub/query-v (vec delay-key)))))
             ;; rf2-jqvgp — that `/scheduled` emit is the LAST callback-bearing
-            ;; step before the durable arm, and until now the only one this fn
-            ;; did not fence. `trace/emit!` invokes listeners SYNCHRONOUSLY, so
-            ;; a `:rf.machine.timer/scheduled` listener can `destroy-frame!` the
-            ;; owning incarnation A and publish a same-id successor B right
-            ;; here — after the post-supersede recheck above and before the slot
-            ;; is reserved. The reservation is keyed by the BARE frame id, which
-            ;; then denotes B, so the arm would install an A-derived entry, host
-            ;; handle and change-watcher into a frame that enumerated none of
-            ;; them. Recheck the SAME predicate — the batch caller's when it
-            ;; supplied one — rather than capturing a fresh owner, which would
-            ;; name B and pass.
+            ;; step before the durable arm. `trace/emit!` invokes listeners
+            ;; SYNCHRONOUSLY, so a `:rf.machine.timer/scheduled` listener can
+            ;; `destroy-frame!` the owning incarnation A and publish a same-id
+            ;; successor B right here — after the post-supersede recheck above.
+            ;; The slot is keyed by the BARE frame id, which then denotes B, so
+            ;; an unfenced arm would leave an A-derived entry, host handle and
+            ;; change-watcher in a frame that enumerated none of them. Recheck
+            ;; the SAME predicate — the batch caller's when it supplied one —
+            ;; rather than capturing a fresh owner, which would name B and pass.
             ;;
-            ;; The abort releases NOTHING, and that is the rf2-i4aj9c rule
-            ;; rather than an omission. The one hold this step can have taken is
-            ;; a sub-vec delay's `(frame, query-v)` ref-count, bumped by
-            ;; `resolve-delay-ms` against A's OWN sub-cache — which
-            ;; `destroy-frame!` disposed wholesale
+            ;; The abort releases NOTHING BEYOND THE RESERVATION ITSELF, and
+            ;; that is the rf2-i4aj9c rule rather than an omission. The one hold
+            ;; this step can have taken is a sub-vec delay's `(frame, query-v)`
+            ;; ref-count, bumped by `resolve-delay-ms` against A's OWN sub-cache
+            ;; — which `destroy-frame!` disposed wholesale
             ;; (`:subs.cache/dispose-all-for-frame-destroy!`) on this very
             ;; stack. `subs/unsubscribe` addresses the frame by bare id, so a
             ;; decrement here would land on B and could dispose a reaction B
             ;; holds for the same query. Nothing of A's survives to release, and
-            ;; the release that would reach it is the one that must not run.
-            (when-not (owner-gone?)
-             ;; PHASE 1 — RESERVE the slot with an arming sentinel (`:handle
-             ;; nil`) carrying this attempt's `:token`, BEFORE arming any host
-             ;; clock. The reaction + watch-key ride the sentinel so a claiming
-             ;; cleanup releases the held subscription ref-count even though the
-             ;; physical add-watch is deferred to publication.
-             (swap! after-timers assoc-in [frame-id k]
-                    {:handle          nil
-                     :reaction        reaction
-                     :sub-watcher-key watch-key
-                     :resolved-ms     resolved-ms
-                     :epoch           epoch
-                     :state           state
-                     :region          region
-                     :delay-source    delay-source
-                     :token           token})
+            ;; the release that would reach it is the one that must not run —
+            ;; which is exactly why the abort routes through
+            ;; `cancel-snapshotted-entry!` with this same `owner-gone?`: the
+            ;; shared decrement is skipped, while the sentinel's own `:handle`
+            ;; (nil) and never-attached watcher are released harmlessly.
+            (if (owner-gone?)
+             ;; ABORT — reclaim the reservation by its OWN attempt token, which
+             ;; both keeps the A-derived sentinel out of B's table and closes the
+             ;; `/scheduled` row just emitted with the mirrored `/cancelled`.
+             ;; `:on-frame-destroy` is the accurate member of the closed
+             ;; `:reason` set: `owner-gone?` can flip only through
+             ;; `destroy-frame!` + same-id reconstruction, so the bearing frame
+             ;; incarnation WAS destroyed (Spec 005 §Trace event catalogue). No
+             ;; new vocabulary, and idempotent — the destroy's own
+             ;; `cancel-all-timers!` sweep may already have claimed this sentinel
+             ;; on the listener's own stack, in which case this CAS fails,
+             ;; nothing is emitted twice, and the pair is already closed.
+             (cancel-snapshotted-entry! frame-id k reservation
+                                        :on-frame-destroy owner-gone?)
              (let [handle
                    ;; Shared positive-delay-guarded arm — the host-clock arm
                    ;; step both timer artefacts share. `resolved-ms` is already

--- a/implementation/machines/test/re_frame/machine_hydration_reconcile_incarnation_fence_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_hydration_reconcile_incarnation_fence_cljs_test.cljc
@@ -63,6 +63,14 @@
   around the sub-vec resources alone would leave the literal arm installing a
   host handle into B.
 
+  Each `/scheduled` tooth also reads the TRACE stream (audit of PR #8955). The
+  four host-work readings say nothing about what the abort left behind for
+  tooling, and an abort placed after an observable success-shaped row leaves a
+  `/scheduled` that can never be followed by `/fired` or `/cancelled` —
+  a wall-clock window that never opened, and one no epoch or active-path gate
+  can retract, because those gates suppress a stale FIRE and there is no fire.
+  `assert-no-orphan-scheduled-row!` pins the closed pair.
+
   The last test is the control the fence must not break: with no successor
   published, a multi-live reconcile arms every declaration, so the loop that
   replaced the `doseq` still runs to completion.
@@ -325,6 +333,53 @@
         (reset! token-b (frame/frame-incarnation-token frame-id))
         (zero!)))))
 
+(defn- assert-no-orphan-scheduled-row!
+  "The abort's TRACE obligation (audit of PR #8955). The four readings above are
+  about HOST work; this one is about what tooling is left holding.
+
+  Spec 005 §Trace event catalogue mirrors `:rf.machine.timer/cancelled` on
+  `:rf.machine.timer/scheduled` — same `:actor-id` / `:state` / `:delay` /
+  `:epoch` / `:frame` slots — expressly so a consumer can pair scheduled →
+  fired / cancelled by `(actor-id, state, epoch)`, and §Dynamic delay
+  re-resolution has every `/scheduled` row mark a FRESH wall-clock window. An
+  arm that announces itself and then aborts emits neither `/fired` nor
+  `/cancelled` unless the abort closes the pair, so the row stands for a window
+  that never opened. Nothing downstream can retract it: the epoch and
+  active-path gates suppress a stale FIRE, and there is no fire."
+  []
+  (let [scheduled (mtest/events-of :rf.machine.timer/scheduled)
+        cancelled (mtest/events-of :rf.machine.timer/cancelled)
+        pair-keys [:actor-id :state :delay :epoch :frame]
+        timer-ops (filterv (comp #{:rf.machine.timer/scheduled
+                                   :rf.machine.timer/cancelled}
+                                 :operation)
+                           (mtest/captured-events))]
+    (is (= 1 (count scheduled))
+        (str "precondition: the aborted arm DID announce itself — exactly one "
+             "`:rf.machine.timer/scheduled` row reached the stream before the "
+             "listener destroyed the owning incarnation"))
+    (is (= 1 (count cancelled))
+        (str "and that row is CLOSED by exactly one `:rf.machine.timer/"
+             "cancelled`. Reserving the attempt only AFTER the fan-out leaves "
+             "nothing to cancel, so the abort is silent and the `/scheduled` "
+             "row can never be followed by `/fired` or `/cancelled` — tooling "
+             "is left rendering a timer that never existed"))
+    (is (= (mapv :operation timer-ops)
+           [:rf.machine.timer/scheduled :rf.machine.timer/cancelled])
+        "and in that order — the announcement first, its closure second")
+    (is (= (select-keys (:tags (first scheduled)) pair-keys)
+           (select-keys (:tags (first cancelled)) pair-keys))
+        (str "and the two rows pair: same `(actor-id, state, epoch)` — plus "
+             "the same `:delay` window and `:frame` — so a consumer joining "
+             "the mirrored payloads sees one closed attempt, not an open one "
+             "beside an unrelated cancellation"))
+    (is (= :on-frame-destroy (:reason (:tags (first cancelled))))
+        (str "stamped with an EXISTING member of the closed `:reason` set. "
+             "`owner-gone?` flips only through `destroy-frame!` + same-id "
+             "reconstruction, so the bearing frame incarnation really was "
+             "destroyed; the repair owes no new trace vocabulary and no spec "
+             "change"))))
+
 (deftest a-scheduled-trace-callback-that-republishes-the-frame-arms-nothing-into-b
   (testing "SUB-VEC delay: the arm's own `/scheduled` destroys frame A and
             publishes same-id B before the timer-table slot is reserved. The
@@ -383,6 +438,7 @@
                    "which now denotes B. There is nothing of A's left to "
                    "release, and releasing would drop a count B holds "
                    "(rf2-i4aj9c)"))
+          (assert-no-orphan-scheduled-row!)
 
           (mtest/reset-captured!)
           (reset! reaction 9000)
@@ -423,7 +479,12 @@
           (is (empty? (inner cfid))
               "successor B holds no timer-table entry")
           (is (zero? @arms)
-              "and no host clock was armed in B's name"))))))
+              "and no host clock was armed in B's name")
+          ;; The same trace obligation with no subscription in play. The pair is
+          ;; owed by the ANNOUNCEMENT, not by the resources the arm happened to
+          ;; hold, so a repair that only closed the sub-vec case would leave the
+          ;; literal arm's `/scheduled` row hanging.
+          (assert-no-orphan-scheduled-row!))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Control — the fence is scoped strictly to owner LOSS


### PR DESCRIPTION
Fourth pass on rf2-jqvgp, against the `AUDIT PR #8955` note (the newest text-bearing change on the bead, confirmed by walking `bd history --json` adjacent pairs newest-first).

## The finding, verified at source before building

Both halves of the audit note held exactly as written at tip.

`schedule-after-timer!` emitted `:rf.machine.timer/scheduled` and only *then* reserved the attempt's timer-table slot. `trace/emit!` delivers to listeners **synchronously**, so a listener on that row can `destroy-frame!` the owning incarnation A and publish a same-id successor B on that very stack. Pass three's post-fan-out recheck then correctly aborted every durable step — slot reservation, host arm, publish, change-watcher — but the `/scheduled` row was already visible with nothing left to cancel.

That row could never be followed by `/fired` or `/cancelled`. Spec 005 §Dynamic delay re-resolution has every `/scheduled` mark a *fresh wall-clock window*, and §Trace event catalogue mirrors the `/cancelled` payload on `/scheduled` — same `:actor-id` / `:state` / `:delay` / `:epoch` / `:frame` — expressly so consumers can pair scheduled → fired/cancelled by `(actor-id, state, epoch)`. So the runtime leak was fixed while tooling was left holding a timer that never existed, and nothing downstream could retract it: the epoch and active-path gates suppress a stale **fire**, and there is no fire.

## The repair

Move the reservation to **before** the fan-out. The attempt's token-owned arming sentinel (`:handle nil`) is installed first, so the announced attempt is a **cancellable** one from the instant it becomes visible; the recheck's abort then reclaims it through `cancel-snapshotted-entry!` with the same threaded `owner-gone?`.

- **Ordering is preserved.** The host clock is still armed *after* the emit, so `/scheduled` continues to precede even a synchronously-firing host callback.
- **The closure is incarnation-exact.** The CAS is bound to this attempt's own token, so a successor's re-arm under the same reused key survives byte-identical (rf2-j538f7.7 / rf2-ijlhj).
- **It is idempotent, and in practice the sweep usually gets there first.** `destroy-frame!` runs `cancel-all-timers!` via the `:machines/on-frame-destroyed!` hook, which can *now* see the sentinel and claims it on the listener's own stack; the abort's own reclaim then finds its token gone and emits nothing twice. It remains the token-exact backstop for any path the sweep does not reach. The docstring and the comment at the recheck name both claimants rather than crediting one.
- **The abort still releases nothing further.** The shared `(frame, query-v)` decrement stays skipped per rf2-i4aj9c — `release-entry-resources!` receives the same `owner-gone?` — while the sentinel's nil handle and never-attached watcher release harmlessly.

**No new trace vocabulary and no spec change owed.** `:on-frame-destroy` is the accurate existing member of the closed six-value `:reason` set (`reply/timer-cancel-reasons`; Spec 005 §Trace event catalogue, "the bearing frame was destroyed"), because `owner-gone?` can flip *only* through `destroy-frame!` plus same-id reconstruction. `spec/005-StateMachines.md` is untouched. No new public API, no trace transaction framework.

The whole change is one `swap!` moved above the emit, a `when-not` turned into an `if` with the abort as its first branch, and the docstring/comment paragraphs whose ordering claims were now false. `git diff -w` on `timer.cljc` is small; nothing from the three sibling passes is reverted, checked by reading the deletions of `git diff origin/main...HEAD` directly.

## Controls

Both `/scheduled` teeth in pass three's regression namespace now also read the trace stream, through one shared `assert-no-orphan-scheduled-row!`: exactly one `/scheduled`, closed by exactly one `/cancelled`, **in that order**, with the mirrored payload slots equal and a `:reason` from the closed set. It runs in the literal-delay tooth too, because the pair is owed by the **announcement**, not by the resources the arm happened to hold — a repair scoped to the dynamic-delay case alone would leave the literal arm's row hanging. No new file; the assertions land in the namespace the earlier passes wrote.

## Sabotage result

Reverting **only the source half** to `origin/main` (pass three's code) beside the new tests — a whole-file `git checkout`, so the fault is exact and precisely restorable:

- machines JVM lane **exit 1**, **1239 tests / 4445 assertions** — the *same* totals as the clean run, so no namespace was skipped or crashed — with **8 failures**, all of them the four new pairing assertions in each of the two `/scheduled` teeth (`…:361`, `:367`, `:370`, `:376`).
- **Green under the same revert:** the `(= 1 (count scheduled))` precondition in both, every pre-existing host-work assertion in both, all three earlier teeth, and every other machines test.
- The readings printed the mechanism verbatim: `actual: (not (= :on-frame-destroy nil))` — under the pre-repair ordering the abort emitted no `/cancelled` at all, so the `/scheduled` row stood alone. That also settles which claimant matters: pre-repair, the frame-destroy sweep found an empty table and emitted nothing.
- Restored by `git checkout HEAD --` and verified by **git blob hash** against the committed object (identical before and after), not by reading a diff.

## Quality gates

All re-run on the final rebased base, each exit code captured on the same command line as the redirect (never piped through a filter, never taken from a harness report):

| gate | result | exit |
| --- | --- | --- |
| CLJS compile — `node scripts/compile-node-test.cjs node-test out/node-test.js` | 1877 files, 0 warnings | **0** |
| CLJS run — `node out/node-test.js` | 11199 tests / 55515 assertions, 0 failures, 0 errors | **0** |
| machines JVM — `clojure -M:test` | 1239 tests / 4445 assertions, 0 failures, 0 errors | **0** |

The consolidated `npm run test:cljs` lane was **split into its two phases** rather than detached, so both verdicts stayed in the foreground. Its `config:` line named this branch's own checkout, confirming the gate read this worktree.

Diff is `implementation/machines/**` only — no markdown, no `spec/`, no workflows — so `check_doc_slugs.py` and `check_readme_links.py --ci` are out of scope, and `mkdocs build --strict` is not a candidate (`docs_dir` is `docs`).
