### PR TITLE
docs(method): the id's other locations before the path search; the open change as routing's precondition (rf2-e9z2e, rf2-abl0i)

### DIFF
--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -671,7 +671,11 @@ workers on one file.
 **Then route it**, rather than waiting for the holder to finish and losing the context it
 was found in: message the worker that holds the file, and the fix lands inside the change
 that is already open. Six routed findings landed that way in one evening, none
-conflicting, several fixed minutes after they were found.
+conflicting, several fixed minutes after they were found. **That the change is still open is
+a precondition rather than scene-setting**: routing works because there is an open change for
+the fix to land in, so test that before testing whether the agent is reachable. Where the
+holder's change has already merged there is nothing for the fix to land in, and a reachable
+agent is not a route — take queue-and-note below, even though no fence is being widened.
 
 **But routing does not create an owner, and that is the half people drop.** The message
 lives in one agent's transcript, so if that agent dies, times out, or reasonably declines the

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -1199,14 +1199,24 @@ that finished normally, and for the eighth held a hardlink to the real transcrip
 file returned one plausible non-empty result and made the wrong conclusion self-consistent.
 
 **An empty file keyed by the id says nothing whatever about whether a report exists** — it is a
-fact about that file. Measured again later, at larger scale: the sink read empty for fifteen of
-seventeen worktrees, every one of those fifteen transcripts sat complete elsewhere, and fourteen of
-them opened with the completion sentence the test demands. The two non-empty ones are what made it
-read as a survey rather than an artefact — a wholly empty result would have looked broken and sent
-the reader looking. So the id names a FILE only once you know which file is the agent's OWN; until
-then it names a directory to search. Read emptiness as *not found here*, never as *not written* —
-the cost of the wrong reading is the whole point of this section, since it converts "no report
-exists" into a standing residue that nothing will ever clear.
+fact about that one location, never about the id. Measured again later, at larger scale: the sink
+read empty for fifteen of seventeen worktrees, every one of those fifteen transcripts sat complete
+elsewhere, and fourteen of them opened with the completion sentence the test demands. The two
+non-empty ones are what made it read as a survey rather than an artefact — a wholly empty result
+would have looked broken and sent the reader looking. So the id names a FILE only once you know
+which file is the agent's OWN; until then it names a directory to search. **And an id may key
+several locations rather than one** — the scratch sink is one of them and the store holding the
+session's own transcript is another, under a different root and a different naming convention — so
+the step between an empty sink and the path search below is to enumerate the id's remaining
+locations and read those, which is cheap and exact where the search is neither. Measured later
+still, across forty candidate worktrees in a single pass: the sink was empty for thirty-one of
+them, and a second id-keyed location held a complete transcript for all thirty-one, no misses.
+Twenty-nine of those opened with the completion sentence; the other two ended on interim status and
+were correctly refused the reap, so enumerating the locations discriminates in both directions
+rather than merely finding reports. The search below was needed for exactly two of the forty, and
+both were trees with no recorded id at all — which is what that search is for. Read emptiness as
+*not found here*, never as *not written* — the cost of the wrong reading is the whole point of this
+section, since it converts "no report exists" into a standing residue that nothing will ever clear.
 
 **When no id was recorded at all, the report is not missing — only unindexed.** Search the
 transcripts for the worktree's own path, which a dispatch names and so does the report that ends


### PR DESCRIPTION
Two prose repairs to `docs/the-mayor-method/loops.md`, in different sections that do not touch the
same paragraphs. The second was routed onto this change mid-flight because this worker holds the
file under the sole-toucher rule — **please read the note on rf2-abl0i's disposition at the bottom
before merging**, because that item's newest note says the routing did *not* land.

## 1. §5 Hygiene, *Reaping* — rf2-e9z2e

The reaping route records the empty-sink hazard correctly and at length — *"beware a per-agent
scratch sink that merely shares the id"*, *"an empty file keyed by the id says nothing whatever
about whether a report exists"*, the fifteen-of-seventeen measurement. It then says the id *"names
a directory to search"*, and the very next paragraph — headed *When no id was recorded at all* —
gives the expensive fallback: search every transcript for the worktree's own path, rank by hit
count, confirm by the report's claimed root.

Between those sits a step the page never named: **try the id at its other location.** An agent id
is not one path, and the section's own evidence already implies a second one — *"their real
transcripts sat complete elsewhere"* — but *elsewhere* was never turned into a step. So a reader
who has just been told the sink lies goes straight to the search, which is far more expensive and,
by this page's own warning, many-to-one and misrankable.

Three things are added inside the paragraph that already carries the hazard — not a new block, and
not a restatement of the hazard, which was already there and correct:

* that an id may key **several locations rather than one**;
* that an empty one is a fact about **that location**, not about the id (`it is a fact about that
  file` becomes `it is a fact about that one location, never about the id`);
* that the step between them is to **enumerate the id's remaining locations** before falling back
  to the path search.

The path search is left exactly where it is and reads exactly as it did. It is the route for an id
that was never recorded, which is what it is actually for — and the new measurement is what shows
that.

**Measured**, one hygiene pass, forty candidate worktrees. The sink was empty for thirty-one of
them, and a second id-keyed location held a complete transcript for **all thirty-one**, no misses.
Twenty-nine of those opened with the completion sentence the reap test demands; the other two ended
on interim status and were correctly **refused** the reap — so enumerating the locations
discriminates in both directions rather than merely finding reports, which is what makes it a test
rather than a shortcut. The path search was needed for exactly two of the forty, and both were
trees with no recorded id at all.

**Genericity.** Stated as *"an id may key several locations rather than one"*, naming kinds of
store rather than any directory layout. Two paragraphs further down this same page says a
transcript path the platform documents as an implementation detail is not a contract, so a concrete
path would contradict the page it sits on within a screen. The durable instruction is *enumerate
the id's locations*, not *look in some named place*.

## 2. §2 Dispatch, *Routing a finding onto a live worker's file* — rf2-abl0i

That section offers two moves. Route-and-note: the fix *"lands inside the change that is already
open"*. Queue-and-note, introduced by *"Sometimes routing is the wrong move altogether. It widens a
deliberately bounded fence mid-flight."*

The route branch's *"already open"* reads as a description of the happy path rather than as a
precondition to test, and the queue branch names exactly one trigger. So a mayor holding a finding
whose surface is held by a live agent **whose change has already merged** finds neither branch
obviously applicable, and the pull is to route anyway — routing is the headline move and the agent
is right there and messageable. That hands fresh work to a transient owner with no open change to
carry it, which is the precise shape the section's own next paragraph says evaporates. The section
records that hazard against the **agent** (it may die or decline) and not against the **change**, so
a reader who has confirmed the agent is alive reads the warning as discharged.

One clause is added inside the existing route paragraph, not as a third branch: that the change
being open is the precondition routing turns on, to be tested before reachability; and that where
the holder's change has already merged there is nothing to land the fix in, so queue-and-note is
the move even though no fence is being widened. Both branches and both existing reasons stand
exactly as they were — this adds a second trigger to the queue branch rather than replacing the
first. **No mechanism added**: the section says an owner plus one note wants no routing registry,
no tracking field and no script, and that binds this repair.

**Verified at source before writing**, since the item's claim was that the discriminator is
nowhere stated: across that section `merged`, `no open change`, `has closed`, `finished` and `not
open` are all absent, while `already open` and `landed` are present. The same instrument over the
same text finds `route-and-note`, `queue-and-note` and `widens a deliberately bounded fence`, so
the absences are real rather than the probe being wrong.

## Quality gates

Run from the worker worktree; each number is the runner's own captured exit code, redirected and
echoed on one command line, never a harness-reported figure. Re-run in full on the **final base**
after the last rebase onto `origin/main` (`f79e7a106b`); the numbers below are those post-rebase
runs, with both repairs in the tree.

| Gate | Captured exit |
|---|---|
| `python scripts/check_doc_slugs.py` | `0` |
| `python -m mkdocs build --strict` | `0` |
| `scripts/test-fast-pr.sh` | `0` — `PASS fast PR spine` |

The spine classified the diff as documentation-only (`docs=true jvm=false node=false`) and printed
its gate root as this worker's worktree. The mkdocs build log lists `the-mayor-method/loops.md`
among the files it built.

**Both doc gates were proved to read this worktree by a planted fault**, each planted on a single
uniquely-matched line (match count read as `1` before each run) and restored afterwards:

* a broken anchor took `check_doc_slugs.py` to exit `1`, naming
  `docs/the-mayor-method/loops.md:1211` against `#planted-anchor-e9z2e-nonexistent`;
* a broken link target took `mkdocs build --strict` to exit `1`, naming
  `the-mayor-method/loops.md` — which also confirms `exclude_docs` does not hide this directory.

Each restore was verified by hashing the bytes against the committed blob object
(`git hash-object` against `git rev-parse HEAD:<path>`), not by reading a diff.

`mkdocs --strict` grades a broken *anchor* at INFO and still exits 0, so it gates links and not
anchors; `check_doc_slugs.py` is the only anchor gate for these pages.

One intermediate run is worth recording because it produced a plausible wrong number: a gate
chained behind a fetch with `&&` never ran when that fetch lost a race, and the captured `1` was
the fetch's status rather than a verdict. The absent log file was the tell; the gate was re-run
standalone.

## Verified by hand

No automated gate reads this file's prose, tables, rendering or nav, so:

* **Anchors** — the heading set is byte-identical to the base (a diff over all heading lines is
  empty). No heading text changed, so every anchor into this page is stable; only line numbers
  below each hunk shifted. Neither addition introduces a link or an anchor (link-pattern scan over
  the added lines returns zero, controlled against known link lines elsewhere in the file, which it
  finds).
* **Table column counts** — the file's single table (the loop-cadence table near the top) is
  byte-identical to the base and is untouched by both hunks. Checked anyway: header, separator and
  all five rows carry 4 pipes each, i.e. 3 balanced columns.
* **No prose lost in either rewrap.** The diff shows 23 insertions against 9 deletions because both
  paragraphs were re-wrapped; every deleted line belongs to one of the two edited paragraphs. Each
  distinctive phrase from the deleted lines was confirmed present in the new file — run twice, once
  line-oriented and once over the text with whitespace collapsed, because this file is hard-wrapped
  and **7 of the 11 phrases in the §5 paragraph, and 6 of the 7 in the §2 paragraph, are invisible
  to a line-oriented search**. Controls both ways: a same-shape phrase that should not exist is not
  found, and the one phrase intentionally changed is confirmed gone with its replacement present.
* **Register** — full sentences throughout, no headings, lists or scaffolding the surrounding text
  does not already use. Longest added line is 101 characters, against 168 already in the file.

## Note on rf2-abl0i's disposition — needs the mayor's decision

rf2-abl0i's **newest** note (written 02:48, verified 02:52) records that the routing *did not*
land: it read this PR's added lines at the time, found no §2 content, and concluded *"It is NOT
carried by #8966 and must not be closed against it"*, with the item to dispatch on its own once the
method surface frees.

That observation was correct when written — the routed message reached this worker only later, and
the §2 repair is in this PR as the second commit. So the note is overtaken by events rather than
wrong. Since the item explicitly says it must not be closed against this PR, **this body does not
claim to close rf2-abl0i**; it needs the mayor either to update that note or to close the item
deliberately against this change. rf2-e9z2e is unaffected and is carried here as intended.

Closes rf2-e9z2e.
