### PR TITLE
fix(bundle-isolation): give the login gate an adapter-owned Hicasso sentinel (rf2-fmns2)

### DIFF
--- a/implementation/scripts/check-login-bundle-isolation.cjs
+++ b/implementation/scripts/check-login-bundle-isolation.cjs
@@ -22,8 +22,8 @@
  *     fingerprints and NO UIx spine or Hicasso strings;
  *   - the UIx login bundle contains the UIx spine's gensym-prefix strings and
  *     NO Reagent or Hicasso fingerprints;
- *   - the Hicasso login bundle contains the Hicasso codec's own markers and
- *     NO Reagent or UIx fingerprints.
+ *   - the Hicasso login bundle contains the Hicasso codec's AND adapter's own
+ *     markers and NO Reagent or UIx fingerprints.
  *
  * A regression — e.g. a stray `[re-frame.adapter.reagent]` slipping into
  * `login.model` — drags Reagent into all three bundles, so the UIx and
@@ -42,8 +42,10 @@
  *     parameterised on (re-frame.adapter.uix). They reach the bundle as
  *     string literals (the spine derives a watch-key keyword namespace from
  *     them), unique to the substrate's adapter, and reachable on every mount.
- *   Hicasso — `hicassoBoundary` / `rf.error/hicasso-empty-vector`: the SAME
- *     two literals scripts/check-bundle-isolation.cjs already carries for the
+ *   Hicasso — TWO TIERS, because the artefact ships a view runtime and an
+ *     adapter and a bundle can carry either without the other.
+ *     `hicassoBoundary` / `rf.error/hicasso-empty-vector` are the SAME two
+ *     literals scripts/check-bundle-isolation.cjs already carries for the
  *     `hicasso` artefact, and the choice matters more here than the others'.
  *     Most Hicasso strings would make a FALSE-GREEN sentinel: the package's
  *     complaint machinery folds away under `:advanced` with `goog.DEBUG`
@@ -56,6 +58,13 @@
  *     `mark-boundary!` stamps via `unchecked-set` with a literal string key,
  *     ungated; `rf.error/hicasso-empty-vector` is a refusal id minted by
  *     `fail!` on the path every build keeps.
+ *     But BOTH live in `re-frame.hicasso.impl.codec` alone, and the codec is
+ *     not what a Hicasso application installs as its SUBSTRATE. So the set
+ *     also carries `rf-hic-sub-` / `rf-hic-use-sub-`, the gensym prefixes
+ *     `re-frame.hicasso.substrate` parameterises the shared spine on —
+ *     the exact analogue of the UIx pair. Without them a leak of the
+ *     adapter ALONE into the Reagent / UIx login bundles answered ABSENT on
+ *     every Hicasso sentinel and the gate passed (rf2-fmns2 audit of #8954).
  *
  * Each view layer's set is checked PRESENT in its own bundle (methodology
  * sanity — proves the grep has signal + the model and views actually compiled
@@ -64,8 +73,10 @@
  * letting the cross-bundle ABSENT greps go silently vacuous — re-derive from a
  * sibling literal (Reagent: `Compiler.parse-tag` / `ReagentInput`; UIx: the
  * `-use-sub-` / `-derived-` prefixes, or the substrate-name warning text;
- * Hicasso: re-read check_production_erasure.cjs's own positive controls, which
- * is where these two came from).
+ * Hicasso: for the codec tier, re-read check_production_erasure.cjs's own
+ * positive controls, which is where those two came from; for the adapter tier,
+ * re-read `re-frame.hicasso.substrate`'s `make-react-spine` call — and keep
+ * ONE marker from EACH tier, or the gap this set closed reopens).
  *
  * Exit 0 on PASS, 1 on FAIL.
  */
@@ -103,6 +114,7 @@ const UIX_SENTINELS = [
 ];
 
 const HICASSO_SENTINELS = [
+  // --- VIEW tier: re-frame.hicasso.impl.codec (the interpreted Hiccup runtime)
   // re-frame.hicasso.impl.codec — mark-boundary!'s own-property marker, set
   // with a literal string key via `unchecked-set` and never goog.DEBUG-gated.
   { source: 're-frame.hicasso.impl.codec mark-boundary! (hicassoBoundary)',
@@ -111,6 +123,36 @@ const HICASSO_SENTINELS = [
   // minted by `fail!` on the path every build keeps.
   { source: 're-frame.hicasso.impl.codec vector-kind (hicasso-empty-vector)',
     sentinel: 'rf.error/hicasso-empty-vector' },
+
+  // --- ADAPTER tier: re-frame.hicasso.substrate (the standalone adapter)
+  // The two above are BOTH codec-only, and the codec is NOT what the login arm
+  // installs. `re-frame.hicasso.substrate` — the adapter `hicasso.login.core`
+  // passes to `rf/init!` — `:require`s only `react` plus core's
+  // `adapter.context` / `frame` / `substrate.spine` / `views.frame-boundary`;
+  // it never names the codec or the public `re-frame.hicasso` door. So a
+  // codec-only sentinel set answers ABSENT for a bundle carrying the whole
+  // Hicasso ADAPTER, and the two ABSENT arms below would have passed while a
+  // foreign adapter sat in the Reagent and UIx login bundles. The own-bundle
+  // PRESENT arm could not reveal it either: `hicasso.login.core` requires the
+  // public door as well, so its bundle carries both tiers regardless.
+  //
+  // These two close that half, and they are the DIRECT ANALOGUE of the UIx
+  // pair above — the same spine, the same key, one substrate over. Same
+  // production-stability argument, too: `re-frame.substrate.spine` calls
+  // `(gensym gensym-prefix-sub)` per subscription and derives the
+  // `use-subscribe` watch-key keyword namespace from `gensym-prefix-use-sub`
+  // by `subs` at adapter-construction time, so both reach the `:advanced`
+  // bundle as string literals on paths no `goog.DEBUG` guards. The sibling
+  // gate hicasso/scripts/check_bundle_isolation.cjs already leans on exactly
+  // this for the UIx twin: `rf-uix-sub-` is one of its POSITIVE CONTROLS,
+  // proved PRESENT in an `:advanced` release bundle.
+  //
+  // `rf-hic-` is unique to that one namespace repo-wide, so an occurrence in a
+  // Reagent or UIx login bundle can only have come from the Hicasso adapter.
+  { source: 're-frame.hicasso.substrate spine subscribe gensym prefix',
+    sentinel: 'rf-hic-sub-' },
+  { source: 're-frame.hicasso.substrate spine use-subscribe gensym prefix',
+    sentinel: 'rf-hic-use-sub-' },
 ];
 
 // Each login bundle: the view runtime it MUST contain (own) + the two it must NOT.
@@ -259,7 +301,10 @@ function main() {
       console.error('  / codec refactor) or the build stopped depending on its view layer.');
       console.error('  Re-derive the sentinel set in this script (Reagent: Compiler.parse-tag /');
       console.error('  ReagentInput; UIx: the -use-sub- / -derived- gensym prefixes; Hicasso:');
-      console.error('  hicasso/scripts/check_production_erasure.cjs\'s own positive controls).');
+      console.error('  codec tier — hicasso/scripts/check_production_erasure.cjs\'s own positive');
+      console.error('  controls; adapter tier — re-frame.hicasso.substrate\'s make-react-spine');
+      console.error('  gensym prefixes. Keep one marker from EACH Hicasso tier: a codec-only');
+      console.error('  set answers ABSENT for a bundle carrying the adapter alone.');
     }
   }
   console.error('');


### PR DESCRIPTION
Closes the false-green an audit of #8954 found in the login cross-view-layer bundle-isolation gate (rf2-fmns2).

## The gap, verified at source

`implementation/scripts/check-login-bundle-isolation.cjs` claims the shared `login.model` is free of every foreign view library **or adapter**, and exports `COVERS_RUNTIMES` including `hicasso`. Both of its Hicasso sentinels are defined in exactly one namespace:

- `hicassoBoundary` — `implementation/hicasso/src/re_frame/hicasso/impl/codec.cljs:459,465`
- `:rf.error/hicasso-empty-vector` — same file, `:1605,1617`

`git grep` finds no other definition of either anywhere in the source trees.

But the codec is not what a Hicasso application installs as its **substrate**. `re-frame.hicasso.substrate` — the adapter `hicasso.login.core` hands to `rf/init!` — `:require`s only `react` plus core's `adapter.context` / `frame` / `substrate.spine` / `views.frame-boundary`. It never names the codec or the public `re-frame.hicasso` door.

So an adapter-only leak from `login.model` put the whole foreign Hicasso adapter into the Reagent and UIx login bundles while both chosen sentinels stayed absent, and the gate passed. The own-Hicasso PRESENT arm could not reveal it: `hicasso.login.core` requires the public door separately, so its bundle carries both tiers regardless — which is exactly why the positive control looked healthy.

## The change

Sentinel set only, one file. `HICASSO_SENTINELS` gains an **adapter tier** beside its existing codec tier:

| sentinel | owner |
|---|---|
| `hicassoBoundary` | `re-frame.hicasso.impl.codec` (view tier, unchanged) |
| `rf.error/hicasso-empty-vector` | `re-frame.hicasso.impl.codec` (view tier, unchanged) |
| `rf-hic-sub-` | `re-frame.hicasso.substrate` (adapter tier, **new**) |
| `rf-hic-use-sub-` | `re-frame.hicasso.substrate` (adapter tier, **new**) |

These are the gensym prefixes `re-frame.hicasso.substrate` parameterises `re-frame.substrate.spine` on — the direct analogue of the `rf-uix-sub-` / `rf-uix-use-sub-` pair the gate already carries, on the same spine keys, one substrate over.

**Why they are production-stable.** The spine calls `(gensym gensym-prefix-sub)` per subscription (`spine.cljs:510-518`) and derives the `use-subscribe` watch-key keyword namespace from `gensym-prefix-use-sub` by `subs` at adapter-construction time (`spine.cljs:2663-2670`). Both are ordinary runtime calls on the literal, on paths no `goog.DEBUG` guards, reachable on every mount. The sibling gate `implementation/hicasso/scripts/check_bundle_isolation.cjs` already leans on exactly this for the UIx twin: `rf-uix-sub-` is one of its POSITIVE CONTROLS, proved PRESENT in an `:advanced` release bundle.

Measured rather than argued — hit counts in the three `:advanced` release bundles:

```
                                  login   login-uix   login-hicasso
rf-hic-sub-                           0           0               1
rf-hic-use-sub-                       0           0               1
hicassoBoundary                       0           0               2
rf.error/hicasso-empty-vector         0           0               1
rf-uix-sub-           (control)       0           1               0
cljsRatom             (control)       4           0               0
```

The two controls confirm the instrument has signal. Each count was taken three ways — whole-blob substring (what the gate does), line-oriented, and over the text with whitespace collapsed — and all three agree; the release bundles are ~2400 lines with a 2286-char longest line, so the line-spanning hazard does not arise here, but it was checked in both directions rather than assumed.

`rf-hic-` occurs in exactly one file repo-wide (`substrate.cljs`), so an occurrence in a Reagent or UIx login bundle can only have come from the Hicasso adapter.

## Red-then-green demonstration

Run on this PR's final base. A reachable adapter-only leak was planted in `examples/core/login/model.cljs` — `[re-frame.hicasso.substrate :as PLANTED-leak]` plus a top-level def referencing `PLANTED-leak/adapter` — and all three login bundles were released from it. The Reagent bundle grew 1091795 → 1107729 chars; file counts went 229 → 230 and 230 → 231, so the adapter really entered the module graph.

| checker | captured exit | result |
|---|---|---|
| **pre-change** (this PR's parent commit) on the planted bundles | `0` | **PASS** — 18 sentinel checks, the false-green reproduced |
| **post-change** on the same planted bundles | `1` | **FAIL** — names `rf-hic-sub-` and `rf-hic-use-sub-` PRESENT (1) in *both* the Reagent and the UIx login bundle |

And the FAIL detail is the audit's finding, byte for byte — on a bundle carrying the whole Hicasso adapter, the two codec sentinels still read ABSENT:

```
    foreign substrate Hicasso (must be ABSENT):
      [OK] ...impl.codec mark-boundary! (hicassoBoundary): "hicassoBoundary" expected ABSENT (0), was ABSENT (0)
      [OK] ...impl.codec vector-kind (hicasso-empty-vector): "rf.error/hicasso-empty-vector" expected ABSENT (0), was ABSENT (0)
      [FAIL] ...substrate spine subscribe gensym prefix: "rf-hic-sub-" expected ABSENT (0), was PRESENT (1)
      [FAIL] ...substrate spine use-subscribe gensym prefix: "rf-hic-use-sub-" expected ABSENT (0), was PRESENT (1)
```

The plant was then reverted and verified by content hash against the committed blob (not by reading a diff), and the bundles rebuilt: all three returned to their exact pre-plant sizes (1091795 / 1079484 / 1111281) and the gate went green again.

## Scope

Sentinel set and its rationale comments only. No generalized source scanner, no new matrix, no new build id, no example change, no `shadow-cljs.edn` or `deps.edn` touch. `examples/TESTING.md` and `examples/substrates/README.md` describe this gate without naming its sentinel strings, so both stay accurate unchanged.

## Quality gates

All exit codes below are captured from the runner itself (`echo $? > file` on the same command line), not read from a harness report.

| gate | captured exit | result |
|---|---|---|
| `shadow-cljs release examples/login examples/login-uix examples/login-hicasso` | `0` | 3 builds, 0 warnings |
| `node implementation/scripts/check-login-bundle-isolation.cjs` | `0` | PASS — 3 login bundles, **24** sentinel checks (was 18) |
| `scripts/test-fast-pr.sh` | `0` | `PASS fast PR spine` |

Both gates were re-run from scratch on the final base after the rebase. Each was confirmed to have read this branch's checkout rather than a sibling: the release build prints its `shadow-cljs.edn` path, the spine prints its `gate root:`, and the isolation gate prints the three bundle directories it inspected — and, as the planted-fault route, was made to go red at the lines this PR edits.

The bundle-isolation gate is not in the fast-PR spine's tiers (it is a CI-only lane, and the spine's own PASS line says so), which is why it is run and quoted separately above.
