### PR TITLE
test(websocket): drive the focused suite from the example's own registrations (rf2-idv1m)

### DIFF
--- a/examples/patterns/websocket/connection.cljs
+++ b/examples/patterns/websocket/connection.cljs
@@ -746,70 +746,78 @@
 ;; MACHINE HANDLER + SUBSCRIPTIONS + INIT EVENT
 ;; ============================================================================
 
-;; `reg-machine` marks this registration `:rf/machine? true` — the flag a
-;; declarative `:spawn` looks for when resolving its target. An unregistered
-;; target is rejected with `:rf.error/machine-spawn-unregistered-type`; no
-;; child snapshot is created.
-(rf/reg-machine :ws/connection connection-machine)
+(defn register!
+  "Install every `reg-*` this namespace owns, in one re-invocable place.
+   Called once at ns-load below — see `websocket.messages/register!` for
+   why the block is named rather than left as bare top-level forms."
+  []
+  ;; `reg-machine` marks this registration `:rf/machine? true` — the flag a
+  ;; declarative `:spawn` looks for when resolving its target. An unregistered
+  ;; target is rejected with `:rf.error/machine-spawn-unregistered-type`; no
+  ;; child snapshot is created.
+  (rf/reg-machine :ws/connection connection-machine)
 
-;; --- subs -------------------------------------------------------------
-;; The machine's snapshot lives in runtime-db, not app-db, so we read it
-;; through the framework `:rf/machine` sub rather than poking at app-db.
-;; See docs/machines/glossary.md#snapshot.
-(rf/reg-sub :ws/snapshot
-  :<- [:rf/machine :ws/connection]
-  (fn [snapshot _] snapshot))
+  ;; --- subs -------------------------------------------------------------
+  ;; The machine's snapshot lives in runtime-db, not app-db, so we read it
+  ;; through the framework `:rf/machine` sub rather than poking at app-db.
+  ;; See docs/machines/glossary.md#snapshot.
+  (rf/reg-sub :ws/snapshot
+    :<- [:rf/machine :ws/connection]
+    (fn [snapshot _] snapshot))
 
-(rf/reg-sub :ws/state
-  :<- [:ws/snapshot]
-  (fn [snap _] (:state snap)))
+  (rf/reg-sub :ws/state
+    :<- [:ws/snapshot]
+    (fn [snap _] (:state snap)))
 
-;; One little yes/no sub per tag. Each chains off the FRAMEWORK sub
-;; `:rf.machine/has-tag?` (sugar: `(rf/machine-has-tag? :ws/connection
-;; tag)`), which returns the snapshot's tag-containment bit directly — so a
-;; view can ask "connected?" and get a boolean without unpacking the
-;; hierarchical `:state` vector or re-reading the snapshot itself.
-;; See docs/machines/glossary.md#state-tag.
-(rf/reg-sub :ws/connecting?
-  :<- [:rf.machine/has-tag? :ws/connection :websocket/connecting]
-  (fn [has-tag? _] has-tag?))
+  ;; One little yes/no sub per tag. Each chains off the FRAMEWORK sub
+  ;; `:rf.machine/has-tag?` (sugar: `(rf/machine-has-tag? :ws/connection
+  ;; tag)`), which returns the snapshot's tag-containment bit directly — so a
+  ;; view can ask "connected?" and get a boolean without unpacking the
+  ;; hierarchical `:state` vector or re-reading the snapshot itself.
+  ;; See docs/machines/glossary.md#state-tag.
+  (rf/reg-sub :ws/connecting?
+    :<- [:rf.machine/has-tag? :ws/connection :websocket/connecting]
+    (fn [has-tag? _] has-tag?))
 
-(rf/reg-sub :ws/authenticating?
-  :<- [:rf.machine/has-tag? :ws/connection :websocket/authenticating]
-  (fn [has-tag? _] has-tag?))
+  (rf/reg-sub :ws/authenticating?
+    :<- [:rf.machine/has-tag? :ws/connection :websocket/authenticating]
+    (fn [has-tag? _] has-tag?))
 
-(rf/reg-sub :ws/connected?
-  :<- [:rf.machine/has-tag? :ws/connection :websocket/connected]
-  (fn [has-tag? _] has-tag?))
+  (rf/reg-sub :ws/connected?
+    :<- [:rf.machine/has-tag? :ws/connection :websocket/connected]
+    (fn [has-tag? _] has-tag?))
 
-(rf/reg-sub :ws/reconnecting?
-  :<- [:rf.machine/has-tag? :ws/connection :websocket/reconnecting]
-  (fn [has-tag? _] has-tag?))
+  (rf/reg-sub :ws/reconnecting?
+    :<- [:rf.machine/has-tag? :ws/connection :websocket/reconnecting]
+    (fn [has-tag? _] has-tag?))
 
-(rf/reg-sub :ws/failed?
-  :<- [:rf.machine/has-tag? :ws/connection :websocket/failed]
-  (fn [has-tag? _] has-tag?))
+  (rf/reg-sub :ws/failed?
+    :<- [:rf.machine/has-tag? :ws/connection :websocket/failed]
+    (fn [has-tag? _] has-tag?))
 
-(rf/reg-sub :ws/queue-depth
-  :<- [:ws/snapshot]
-  (fn [snap _] (count (get-in snap [:data :queue]))))
+  (rf/reg-sub :ws/queue-depth
+    :<- [:ws/snapshot]
+    (fn [snap _] (count (get-in snap [:data :queue]))))
 
-(rf/reg-sub :ws/retries
-  :<- [:ws/snapshot]
-  (fn [snap _] (get-in snap [:data :retries])))
+  (rf/reg-sub :ws/retries
+    :<- [:ws/snapshot]
+    (fn [snap _] (get-in snap [:data :retries])))
 
-(rf/reg-sub :ws/error
-  :<- [:ws/snapshot]
-  (fn [snap _] (get-in snap [:data :error])))
+  (rf/reg-sub :ws/error
+    :<- [:ws/snapshot]
+    (fn [snap _] (get-in snap [:data :error])))
 
-;; --- init event -------------------------------------------------------
-(rf/reg-event :ws.connection/initialise
-  {:doc "Wake the connection machine up in its `:disconnected` start
-         state. A machine's first snapshot only materialises when it first
-         receives an event, so this gives it the canonical eager kick."}
-  (fn handler-ws-connection-initialise [_ _]
-    ;; `[:rf.machine/start]` is re-frame2's spelling of XState v5's
-    ;; `createActor(machine).start()`: it runs the initial-entry cascade
-    ;; and then stops, materialising the `:disconnected` snapshot so tests
-    ;; (and the UI) can read the state before anyone clicks Connect.
-    {:fx [[:dispatch [:ws/connection [:rf.machine/start]]]]}))
+  ;; --- init event -------------------------------------------------------
+  (rf/reg-event :ws.connection/initialise
+    {:doc "Wake the connection machine up in its `:disconnected` start
+           state. A machine's first snapshot only materialises when it first
+           receives an event, so this gives it the canonical eager kick."}
+    (fn handler-ws-connection-initialise [_ _]
+      ;; `[:rf.machine/start]` is re-frame2's spelling of XState v5's
+      ;; `createActor(machine).start()`: it runs the initial-entry cascade
+      ;; and then stops, materialising the `:disconnected` snapshot so tests
+      ;; (and the UI) can read the state before anyone clicks Connect.
+      {:fx [[:dispatch [:ws/connection [:rf.machine/start]]]]})))
+
+;; Loading this namespace registers it — the production-app idiom.
+(register!)

--- a/examples/patterns/websocket/core.cljs
+++ b/examples/patterns/websocket/core.cljs
@@ -70,18 +70,26 @@
 ;; APP-BOOT EVENT
 ;; ============================================================================
 
-(rf/reg-event :ws.app/initialise
-  {:doc "Boot the app: seed the messages slice and bring the connection
-         machine to life in its `:disconnected` start state.
+(defn register!
+  "Install the boot event this namespace owns, in one re-invocable place.
+   Called once at ns-load below — see `websocket.messages/register!` for
+   why the block is named rather than left as a bare top-level form."
+  []
+  (rf/reg-event :ws.app/initialise
+    {:doc "Boot the app: seed the messages slice and bring the connection
+           machine to life in its `:disconnected` start state.
 
-         The `:ws.app/*` prefix (rather than a plain `:app/initialise`)
-         is deliberate. Several examples (the realworld + counter
-         examples among them) share one test bundle, and a common event
-         key would have them stepping on each other's registrations.
-         Namespacing keeps each example to itself."}
-  (fn handler-app-initialise [_ _]
-    {:fx [[:dispatch [:ws.messages/initialise]]
-          [:dispatch [:ws.connection/initialise]]]}))
+           The `:ws.app/*` prefix (rather than a plain `:app/initialise`)
+           is deliberate. Several examples (the realworld + counter
+           examples among them) share one test bundle, and a common event
+           key would have them stepping on each other's registrations.
+           Namespacing keeps each example to itself."}
+    (fn handler-app-initialise [_ _]
+      {:fx [[:dispatch [:ws.messages/initialise]]
+            [:dispatch [:ws.connection/initialise]]]})))
+
+;; Loading this namespace registers it — the production-app idiom.
+(register!)
 
 ;; ============================================================================
 ;; MOUNT

--- a/examples/patterns/websocket/messages.cljs
+++ b/examples/patterns/websocket/messages.cljs
@@ -455,153 +455,168 @@
 ;; REGISTRATIONS
 ;; ============================================================================
 
-;; Register the actor the connection machine spawns. As before,
-;; `reg-machine` is what flips on `:rf/machine? true` — the flag the spawn
-;; needs to find its target.
-(rf/reg-machine :websocket/socket socket-actor-machine)
+(defn register!
+  "Install every `reg-*` this namespace owns, in one re-invocable place.
 
-;; For every message that comes in — a correlated reply or a server push —
-;; the connection machine dispatches `[:ws/handle-message body]`, and this
-;; handler is where it lands in app-db for the views to read.
-;;
-;; This is a SYSTEM BOUNDARY: the body is the server's bytes, and on a
-;; compromised or hostile server it is whatever the sender chose.
-;; `:rf.schema/at-boundary` is what keeps the check in the RELEASE build
-;; (a bare `:schema` is a dev diagnostic and elides under :advanced). A
-;; frame that fails the closed `InboundMessage` union is dropped whole:
-;; the handler never runs, nothing reaches app-db, and the always-on
-;; `:rf.error/schema-validation-failure` record is the counter to alert
-;; on. See spec/Pattern-WebSocket.md §Inbound frames are untrusted.
-;;
-;; The connection machine holds the frame to this SAME contract one step
-;; earlier, in its `:trusted-frame?` guard — it has to, because it clears
-;; correlation slots the frame names. That is not a reason to relax the
-;; check here: this is the ingress app-db is behind, and every refused
-;; frame the machine forwards arrives here precisely so this handler
-;; produces the one canonical rejection record.
-(rf/reg-event :ws/handle-message
-  {:doc "Fold one inbound frame into app-db. UNTRUSTED INGRESS — the body
-         is validated against the closed `InboundMessage` wire union, in
-         every build, before this handler runs. It joins the
-         [:messages :received] log, and if it's a correlated reply it also
-         lands at [:messages :last-reply]. Each one gets a monotonic
-         `:rx-seq` stamp on the way in — that's the inbox's stable React
-         `:key`. (Server pushes carry no `:request-id`, so we can't lean
-         on identity from the wire, and list position shifts as new
-         messages arrive at the top.)"
-   :schema       [:cat [:= :ws/handle-message] schema/InboundMessage]
-   :interceptors [:rf.schema/at-boundary]}
-  (fn handler-ws-handle-message [{:keys [db]} [_ body]]
-    {:db (let [rx-seq (get-in db [:messages :rx-count] 0)]
-      (-> db
-          (update-in [:messages :received]
-                     (fn [received]
-                       (vec (cons (assoc body :rx-seq rx-seq) (or received [])))))
-          (assoc-in [:messages :rx-count] (inc rx-seq))
-          (cond-> (:request-id body)
-            (assoc-in [:messages :last-reply] body))))}))
+   It is called once at ns-load below, so loading the namespace still IS
+   the registration — the production-app idiom the rest of this example
+   assumes, and `core/run` does nothing extra. Naming the block buys one
+   thing: a test fixture that has to recover from an upstream
+   `registrar/clear-all!` re-fires THESE definitions rather than keeping a
+   hand-mirrored copy, so the handler bodies and the boundary metadata
+   below are the only ones that exist anywhere and cannot drift out from
+   under the tests that certify them."
+  []
+  ;; Register the actor the connection machine spawns. As before,
+  ;; `reg-machine` is what flips on `:rf/machine? true` — the flag the spawn
+  ;; needs to find its target.
+  (rf/reg-machine :websocket/socket socket-actor-machine)
 
-;; --- app-level events -------------------------------------------------
-(rf/reg-event :ws.app/send
-  {:doc "Send the form's current draft, and clear the input."}
-  (fn handler-app-send [{:keys [db]} [_ body]]
-    {:db (assoc-in db [:messages :draft] "")
-     :fx [[:dispatch [:ws/connection [:ws/send {:type :note :body body}]]]]}))
+  ;; For every message that comes in — a correlated reply or a server push —
+  ;; the connection machine dispatches `[:ws/handle-message body]`, and this
+  ;; handler is where it lands in app-db for the views to read.
+  ;;
+  ;; This is a SYSTEM BOUNDARY: the body is the server's bytes, and on a
+  ;; compromised or hostile server it is whatever the sender chose.
+  ;; `:rf.schema/at-boundary` is what keeps the check in the RELEASE build
+  ;; (a bare `:schema` is a dev diagnostic and elides under :advanced). A
+  ;; frame that fails the closed `InboundMessage` union is dropped whole:
+  ;; the handler never runs, nothing reaches app-db, and the always-on
+  ;; `:rf.error/schema-validation-failure` record is the counter to alert
+  ;; on. See spec/Pattern-WebSocket.md §Inbound frames are untrusted.
+  ;;
+  ;; The connection machine holds the frame to this SAME contract one step
+  ;; earlier, in its `:trusted-frame?` guard — it has to, because it clears
+  ;; correlation slots the frame names. That is not a reason to relax the
+  ;; check here: this is the ingress app-db is behind, and every refused
+  ;; frame the machine forwards arrives here precisely so this handler
+  ;; produces the one canonical rejection record.
+  (rf/reg-event :ws/handle-message
+    {:doc "Fold one inbound frame into app-db. UNTRUSTED INGRESS — the body
+           is validated against the closed `InboundMessage` wire union, in
+           every build, before this handler runs. It joins the
+           [:messages :received] log, and if it's a correlated reply it also
+           lands at [:messages :last-reply]. Each one gets a monotonic
+           `:rx-seq` stamp on the way in — that's the inbox's stable React
+           `:key`. (Server pushes carry no `:request-id`, so we can't lean
+           on identity from the wire, and list position shifts as new
+           messages arrive at the top.)"
+     :schema       [:cat [:= :ws/handle-message] schema/InboundMessage]
+     :interceptors [:rf.schema/at-boundary]}
+    (fn handler-ws-handle-message [{:keys [db]} [_ body]]
+      {:db (let [rx-seq (get-in db [:messages :rx-count] 0)]
+        (-> db
+            (update-in [:messages :received]
+                       (fn [received]
+                         (vec (cons (assoc body :rx-seq rx-seq) (or received [])))))
+            (assoc-in [:messages :rx-count] (inc rx-seq))
+            (cond-> (:request-id body)
+              (assoc-in [:messages :last-reply] body))))}))
 
-;; The request-id is a fact the system has to *remember*: it's written into
-;; the machine's :in-flight slot, and the reply that eventually comes back
-;; is matched against it. So it can't be conjured with a bare
-;; `(random-uuid)` at the handler — replay would mint a fresh one, it
-;; wouldn't match the recorded request, and the correlation would silently
-;; fall apart. The fix is to make the id a *recordable* coeffect: a
-;; `reg-cofx` that runs at context-assembly, gets written onto the event's
-;; causal token, and is replayed back verbatim. `:ws.app/request` asks for
-;; it via `:rf.cofx/requires` and reads it from the coeffects map.
-;; See docs/core/glossary.md#recordable-vs-ambient-coeffects.
-(rf/reg-cofx :ws.app/request-id
-  {:recordable? true
-   :doc "A replayable correlation id for one request-reply round-trip."}
-  (fn [] (random-uuid)))
+  ;; --- app-level events -------------------------------------------------
+  (rf/reg-event :ws.app/send
+    {:doc "Send the form's current draft, and clear the input."}
+    (fn handler-app-send [{:keys [db]} [_ body]]
+      {:db (assoc-in db [:messages :draft] "")
+       :fx [[:dispatch [:ws/connection [:ws/send {:type :note :body body}]]]]}))
 
-(rf/reg-event :ws.app/request
-  {:doc "Fire off a request and expect a reply back. It goes through the
-         connection machine's correlation slot; when the mock server
-         echoes, the reply turns up at [:messages :last-reply]. The
-         correlation id comes from the `:ws.app/request-id` recordable
-         coeffect (never minted on the spot), so a replay reuses the same
-         id and the reply still finds its request.
+  ;; The request-id is a fact the system has to *remember*: it's written into
+  ;; the machine's :in-flight slot, and the reply that eventually comes back
+  ;; is matched against it. So it can't be conjured with a bare
+  ;; `(random-uuid)` at the handler — replay would mint a fresh one, it
+  ;; wouldn't match the recorded request, and the correlation would silently
+  ;; fall apart. The fix is to make the id a *recordable* coeffect: a
+  ;; `reg-cofx` that runs at context-assembly, gets written onto the event's
+  ;; causal token, and is replayed back verbatim. `:ws.app/request` asks for
+  ;; it via `:rf.cofx/requires` and reads it from the coeffects map.
+  ;; See docs/core/glossary.md#recordable-vs-ambient-coeffects.
+  (rf/reg-cofx :ws.app/request-id
+    {:recordable? true
+     :doc "A replayable correlation id for one request-reply round-trip."}
+    (fn [] (random-uuid)))
 
-         Worth being clear: this is *the app's* request/reply, not a
-         framework feature. re-frame2 ships no managed WebSocket, so
-         per-message correlation over an open socket is yours to build —
-         here, from a `:request-id`, a registered `:reply` target, and the
-         machine's `:in-flight` map. The wire `:request-id` is your own
-         protocol detail, kept deliberately separate from anything the
-         framework does."
-   :rf.cofx/requires [:ws.app/request-id]}
-  (fn handler-app-request [{rid :ws.app/request-id} [_ body]]
-    {:fx [[:dispatch [:ws/connection
-                      [:ws/request {:request-id rid
-                                    :body       {:type :request
-                                                 :body body}
-                                    :reply      [:ws.app/request-reply]
-                                    :timeout-ms 5000}]]]]}))
+  (rf/reg-event :ws.app/request
+    {:doc "Fire off a request and expect a reply back. It goes through the
+           connection machine's correlation slot; when the mock server
+           echoes, the reply turns up at [:messages :last-reply]. The
+           correlation id comes from the `:ws.app/request-id` recordable
+           coeffect (never minted on the spot), so a replay reuses the same
+           id and the reply still finds its request.
 
-(rf/reg-event :ws.app/request-reply
-  {:doc "The request's outcome arrived. Two producers reach this event,
-         and the closed `RequestOutcome` union admits exactly those two —
-         discriminating on `:origin`, which the connection machine stamps
-         after receipt and no sender can forge. (1) `:ws/server` — the
-         correlated WIRE reply, and it reached this event only because the
-         `:request-token` it echoed still identified the registration in
-         the slot: a reply under a REUSED id that answers a registration
-         since displaced never gets here. This is the SECOND untrusted
-         ingress: a reply arriving under a known :request-id is still the
-         server's bytes, held to the closed `ReplyMessage` fields in every
-         build.
-         (2) `:ws/local` — a failure the machine minted itself when the
-         socket dropped or the deadline elapsed. Local truth about the
-         connection, and unreachable from the wire.
+           Worth being clear: this is *the app's* request/reply, not a
+           framework feature. re-frame2 ships no managed WebSocket, so
+           per-message correlation over an open socket is yours to build —
+           here, from a `:request-id`, a registered `:reply` target, and the
+           machine's `:in-flight` map. The wire `:request-id` is your own
+           protocol detail, kept deliberately separate from anything the
+           framework does."
+     :rf.cofx/requires [:ws.app/request-id]}
+    (fn handler-app-request [{rid :ws.app/request-id} [_ body]]
+      {:fx [[:dispatch [:ws/connection
+                        [:ws/request {:request-id rid
+                                      :body       {:type :request
+                                                   :body body}
+                                      :reply      [:ws.app/request-reply]
+                                      :timeout-ms 5000}]]]]}))
 
-         Both are checked here even though the machine already held the
-         frame to the same wire contract upstream. The two checks answer
-         different questions: the machine's guards protect its own
-         correlation state, this one protects app-db, and a boundary that
-         only holds because something upstream is careful is not a
-         boundary. Either way the outcome files at [:messages :last-reply].
-         See :ws.app/request for the correlation it completes."
-   :schema       [:cat [:= :ws.app/request-reply] schema/RequestOutcome]
-   :interceptors [:rf.schema/at-boundary]}
-  (fn handler-app-request-reply [{:keys [db]} [_ body]]
-    {:db (assoc-in db [:messages :last-reply] body)}))
+  (rf/reg-event :ws.app/request-reply
+    {:doc "The request's outcome arrived. Two producers reach this event,
+           and the closed `RequestOutcome` union admits exactly those two —
+           discriminating on `:origin`, which the connection machine stamps
+           after receipt and no sender can forge. (1) `:ws/server` — the
+           correlated WIRE reply, and it reached this event only because the
+           `:request-token` it echoed still identified the registration in
+           the slot: a reply under a REUSED id that answers a registration
+           since displaced never gets here. This is the SECOND untrusted
+           ingress: a reply arriving under a known :request-id is still the
+           server's bytes, held to the closed `ReplyMessage` fields in every
+           build.
+           (2) `:ws/local` — a failure the machine minted itself when the
+           socket dropped or the deadline elapsed. Local truth about the
+           connection, and unreachable from the wire.
 
-(rf/reg-event :ws.app/subscribe-demo
-  {:doc "Subscribe to a demo topic. The mock server acks with a synthetic
-         push, so you get to watch the subscribe-then-push shape play out
-         end to end."}
-  (fn handler-app-subscribe-demo [_ _]
-    {:fx [[:dispatch [:ws/connection [:ws/subscribe :demo-topic]]]]}))
+           Both are checked here even though the machine already held the
+           frame to the same wire contract upstream. The two checks answer
+           different questions: the machine's guards protect its own
+           correlation state, this one protects app-db, and a boundary that
+           only holds because something upstream is careful is not a
+           boundary. Either way the outcome files at [:messages :last-reply].
+           See :ws.app/request for the correlation it completes."
+     :schema       [:cat [:= :ws.app/request-reply] schema/RequestOutcome]
+     :interceptors [:rf.schema/at-boundary]}
+    (fn handler-app-request-reply [{:keys [db]} [_ body]]
+      {:db (assoc-in db [:messages :last-reply] body)}))
 
-(rf/reg-event :ws.app/edit-draft
-  (fn handler-app-edit-draft [{:keys [db]} [_ text]]
-    {:db (assoc-in db [:messages :draft] text)}))
+  (rf/reg-event :ws.app/subscribe-demo
+    {:doc "Subscribe to a demo topic. The mock server acks with a synthetic
+           push, so you get to watch the subscribe-then-push shape play out
+           end to end."}
+    (fn handler-app-subscribe-demo [_ _]
+      {:fx [[:dispatch [:ws/connection [:ws/subscribe :demo-topic]]]]}))
 
-(rf/reg-event :ws.messages/initialise
-  (fn handler-messages-initialise [{:keys [db]} _]
-    {:db (assoc db :messages {:draft "" :received [] :last-reply nil :rx-count 0})}))
+  (rf/reg-event :ws.app/edit-draft
+    (fn handler-app-edit-draft [{:keys [db]} [_ text]]
+      {:db (assoc-in db [:messages :draft] text)}))
 
-;; --- subs -------------------------------------------------------------
-(rf/reg-sub :messages/slice
-  (fn [db _] (:messages db)))
+  (rf/reg-event :ws.messages/initialise
+    (fn handler-messages-initialise [{:keys [db]} _]
+      {:db (assoc db :messages {:draft "" :received [] :last-reply nil :rx-count 0})}))
 
-(rf/reg-sub :messages/draft
-  :<- [:messages/slice]
-  (fn [m _] (:draft m)))
+  ;; --- subs -------------------------------------------------------------
+  (rf/reg-sub :messages/slice
+    (fn [db _] (:messages db)))
 
-(rf/reg-sub :messages/received
-  :<- [:messages/slice]
-  (fn [m _] (:received m)))
+  (rf/reg-sub :messages/draft
+    :<- [:messages/slice]
+    (fn [m _] (:draft m)))
 
-(rf/reg-sub :messages/last-reply
-  :<- [:messages/slice]
-  (fn [m _] (:last-reply m)))
+  (rf/reg-sub :messages/received
+    :<- [:messages/slice]
+    (fn [m _] (:received m)))
+
+  (rf/reg-sub :messages/last-reply
+    :<- [:messages/slice]
+    (fn [m _] (:last-reply m))))
+
+;; Loading this namespace registers it — the production-app idiom.
+(register!)

--- a/examples/patterns/websocket/schema.cljs
+++ b/examples/patterns/websocket/schema.cljs
@@ -297,14 +297,22 @@
 ;; SCHEMA REGISTRATIONS
 ;; ============================================================================
 
-;; Only `:messages` gets an app-schema here, and that's on purpose. A
-;; machine's snapshot lives in runtime-db, not app-db, so pointing
-;; `reg-app-schema` at a snapshot path would validate precisely nothing —
-;; the machine's own `[:schemas :data]` is what guards that.
-;;
-;; One wrinkle: `reg-app-schema` is frame-local, so it needs a frame in
-;; scope. Call it bare at ns-load and you get :rf.error/no-frame-context.
-;; This example lives in the :rf/default frame, so we name that frame
-;; explicitly. See docs/core/glossary.md#capture-frame.
-(rf/with-frame :rf/default
-  (rf/reg-app-schema [:messages]                   MessagesSlice))
+(defn register!
+  "Install the app-schema this namespace owns, in one re-invocable place.
+   Called once at ns-load below — see `websocket.messages/register!` for
+   why the block is named rather than left as a bare top-level form."
+  []
+  ;; Only `:messages` gets an app-schema here, and that's on purpose. A
+  ;; machine's snapshot lives in runtime-db, not app-db, so pointing
+  ;; `reg-app-schema` at a snapshot path would validate precisely nothing —
+  ;; the machine's own `[:schemas :data]` is what guards that.
+  ;;
+  ;; One wrinkle: `reg-app-schema` is frame-local, so it needs a frame in
+  ;; scope. Call it bare at ns-load and you get :rf.error/no-frame-context.
+  ;; This example lives in the :rf/default frame, so we name that frame
+  ;; explicitly. See docs/core/glossary.md#capture-frame.
+  (rf/with-frame :rf/default
+    (rf/reg-app-schema [:messages]                   MessagesSlice)))
+
+;; Loading this namespace registers it — the production-app idiom.
+(register!)

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -34,19 +34,20 @@
             [websocket.schema :as ws.schema]
             [websocket.connection :as ws.connection]
             [websocket.messages :as messages]
-            [websocket.core])
-  (:require-macros [re-frame.core :refer [with-frame with-new-frame]]))
+            [websocket.core :as ws.core])
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 ;; ============================================================================
 ;; TEST-ONLY RE-REGISTRATION SCAFFOLDING
 ;; ============================================================================
 ;;
-;; The websocket example's sub-namespaces — `websocket.schema`,
-;; `websocket.connection`, `websocket.messages` — each install their
-;; reg-machine / reg-event / reg-sub / reg-app-schema entries at
-;; ns-load time (the production-app idiom; loading the ns IS the
-;; registration). The example's `core.cljs` then registers the top-level
-;; `:ws.app/initialise` event in the same idiomatic ns-load shape.
+;; The websocket example's namespaces — `websocket.schema`,
+;; `websocket.connection`, `websocket.messages`, `websocket.core` — each
+;; install their reg-machine / reg-event / reg-cofx / reg-sub /
+;; reg-app-schema entries at ns-load time (the production-app idiom;
+;; loading the ns IS the registration). Each does it by calling its own
+;; `register!`, and that named entry point is the whole reason this file
+;; can recover the registrations without owning a copy of them.
 ;;
 ;; Some test fixtures upstream of this example (alphabetically before
 ;; `re-frame.websocket-cljs-test` in the node-test run order) call
@@ -56,8 +57,8 @@
 ;; this test ns gets a chance to run. `register-all!` recovers from that
 ;; — the `:each` fixture's `:init-fn` calls it. Idempotent
 ;; (last-write-wins). Production `(websocket.core/run)` does NOT call it;
-;; the example's sub-namespaces install their registrations at ns-load,
-;; so the recovery dance lives here (the example source stays test-free).
+;; the example's namespaces install their registrations at ns-load, so the
+;; recovery dance lives here (the example source stays test-free).
 ;;
 ;; The narrow `(rf/reg-sub :rf/... ...)` calls below are recovery only —
 ;; the user-code 'must not register under :rf/*' rule (Spec Conventions
@@ -97,148 +98,45 @@
       (contains? (get-in rt [:rf.runtime/machines :snapshots machine-id :tags]) tag))))
 
 (defn- register-all!
-  "Re-fire every `reg-*` the websocket example depends on. Safe to call
-   at any point — every `reg-*` is last-write-wins. Each block below
-   mirrors the ns-load registrations in the named sub-namespace; if a
-   `reg-*` is added there, mirror it here so the recovery is complete.
+  "Recover every `reg-*` the websocket example owns, by calling the
+   example's OWN registration entry points. Safe to call at any point —
+   every `reg-*` is last-write-wins.
 
-   KNOW WHICH HALF OF THE EXAMPLE THESE TESTS ACTUALLY DRIVE, because
-   last-write-wins cuts both ways: this fixture runs on every test, so
-   where a block below re-declares a handler BODY inline, that body — not
-   the example's — is what the suite exercises, and an edit to the
-   example's copy alone changes nothing here (measured rf2-tb442: a fault
-   planted in `websocket.messages`' `:ws.app/request-reply` body left the
-   suite fully green). Where a block instead points at an example VAR —
-   `ws.connection/connection-machine`, `messages/socket-actor-machine`,
-   `ws.schema/InboundMessage` / `RequestOutcome`, and the mock server the
-   actor reaches through — the example's own code IS under test, and a
-   fault planted there reds immediately. The machine, the schemas and the
-   mock transport are therefore genuinely covered; the two ingress
-   handler bodies are covered only as far as their twins here agree with
-   them. Mirror a body change into both, or the drift is invisible."
+   THERE IS DELIBERATELY NO TEST-LOCAL COPY OF ANY EXAMPLE REGISTRATION
+   HERE, and re-introducing one silently guts this suite. This fn used to
+   re-declare the two ingress handlers, their bodies and their boundary
+   metadata inline; because it runs on EVERY test and `reg-*` is
+   last-write-wins, those copies replaced the example's own handlers
+   before a single assertion ran. The suite then certified the copy: a
+   fault planted in `websocket.messages`' `:ws.app/request-reply` body
+   left it fully green, and `inbound-boundary-structural-test` read back
+   the metadata this file had just installed rather than the example's
+   (measured, rf2-idv1m). Calling `register!` is what puts the shipped
+   definitions under test; `example-registrations-are-live-test` is the
+   tripwire that fails first if a twin ever comes back.
+
+   The only thing this file still installs itself is the FRAMEWORK's
+   `:rf.machine/*` fx and subs, which no example namespace owns."
   []
   (re-register-machines-fx-and-subs!)
-
-  ;; --- websocket.schema --------------------------------------------------
-  ;; EP-0001 (rf2-vzld77): machine snapshots are runtime-db, not app-db — an
-  ;; `reg-app-schema` on a machine-snapshot path no longer validates anything
-  ;; (app schemas validate the app-db partition only, Mike ruling #11). The
-  ;; machine's own `:data-schema` is the snapshot-validation surface; the
-  ;; vestigial app-schema reg is dropped. Only the genuine app-db slice
-  ;; (`[:messages]`) keeps its app-schema.
-  ;;
   ;; rf2-ofzxh9 — `reg-app-schema` is EP-0002 context-required frame-local
   ;; (rf2-5q7um6): it resolves `*current-frame*` and raises
   ;; `:rf.error/no-frame-context` under no scope. `register-all!` runs from
   ;; the fixture's `:init-fn`, which fires OUTSIDE the fixture's ambient
   ;; `*current-frame*` binding (`make-reset-runtime-fixture` invokes `:init-fn`
   ;; before it `binding`s the ambient frame around the test body). Bare, this
-  ;; threw `:rf.error/no-frame-context` — and because the node-test build runs
-  ;; every `*_cljs_test` ns in ONE shared JS runtime, that throw, fired during
-  ;; a concurrently-pending async test's `done` window, surfaced as the
+  ;; threw `:rf.error/no-frame-context` — and because the node-test build
+  ;; runs every `*_cljs_test` ns in ONE shared JS runtime, that throw, fired
+  ;; during a concurrently-pending async test's `done` window, surfaced as the
   ;; intermittent `FAIL in () (:) unexpected reject: :rf.error/no-frame-context`
-  ;; + `Async test called done more than one time` flake. Name `:rf/default`
-  ;; explicitly here, mirroring the example's own `(with-frame :rf/default …)`
-  ;; ns-load idiom (examples/patterns/websocket/schema.cljs) — the fixture has
-  ;; already `ensure-default-frame!`'d it.
-  (with-frame :rf/default
-    (rf/reg-app-schema [:messages]                 ws.schema/MessagesSlice))
-
-  ;; --- websocket.connection ----------------------------------------------
-  (rf/reg-machine :ws/connection ws.connection/connection-machine)
-  (subs/reg-runtime-sub :ws/snapshot (fn [rt _] (get-in rt [:rf.runtime/machines :snapshots :ws/connection])))
-  (rf/reg-sub :ws/state          :<- [:ws/snapshot] (fn [snap _] (:state snap)))
-  ;; The per-tag subs mirror the example: each chains off the framework
-  ;; `:rf.machine/has-tag?` sub rather than re-reading the snapshot's :tags.
-  (rf/reg-sub :ws/connecting?     :<- [:rf.machine/has-tag? :ws/connection :websocket/connecting]     (fn [has-tag? _] has-tag?))
-  (rf/reg-sub :ws/authenticating? :<- [:rf.machine/has-tag? :ws/connection :websocket/authenticating] (fn [has-tag? _] has-tag?))
-  (rf/reg-sub :ws/connected?      :<- [:rf.machine/has-tag? :ws/connection :websocket/connected]      (fn [has-tag? _] has-tag?))
-  (rf/reg-sub :ws/reconnecting?   :<- [:rf.machine/has-tag? :ws/connection :websocket/reconnecting]   (fn [has-tag? _] has-tag?))
-  (rf/reg-sub :ws/failed?         :<- [:rf.machine/has-tag? :ws/connection :websocket/failed]         (fn [has-tag? _] has-tag?))
-  (rf/reg-sub :ws/queue-depth    :<- [:ws/snapshot] (fn [snap _] (count (get-in snap [:data :queue]))))
-  (rf/reg-sub :ws/retries        :<- [:ws/snapshot] (fn [snap _] (get-in snap [:data :retries])))
-  (rf/reg-sub :ws/error          :<- [:ws/snapshot] (fn [snap _] (get-in snap [:data :error])))
-  (rf/reg-event :ws.connection/initialise
-    (fn handler-ws-connection-initialise [_ _]
-      {:fx [[:dispatch [:ws/connection [:rf.machine/start]]]]}))
-
-  ;; --- websocket.messages -------------------------------------------------
-  (rf/reg-machine :websocket/socket messages/socket-actor-machine)
-  ;; UNTRUSTED INGRESS — mirrors the example's registration exactly: the
-  ;; closed InboundMessage wire union as :schema plus the
-  ;; :rf.schema/at-boundary interceptor, so the check is release-resident
-  ;; (rf2-iyjae). The boundary-rejection tests below exercise THIS
-  ;; registration (register-all! is last-write-wins over the ns-load one).
-  (rf/reg-event :ws/handle-message
-    {:schema       [:cat [:= :ws/handle-message] ws.schema/InboundMessage]
-     :interceptors [:rf.schema/at-boundary]}
-    (fn handler-ws-handle-message [{:keys [db]} [_ body]]
-      {:db (let [rx-seq (get-in db [:messages :rx-count] 0)]
-        (-> db
-            (update-in [:messages :received]
-                       (fn [received]
-                         (vec (cons (assoc body :rx-seq rx-seq) (or received [])))))
-            (assoc-in [:messages :rx-count] (inc rx-seq))
-            (cond-> (:request-id body)
-              (assoc-in [:messages :last-reply] body))))}))
-  (rf/reg-event :ws.app/send
-    (fn handler-app-send [{:keys [db]} [_ body]]
-      {:db (assoc-in db [:messages :draft] "")
-       :fx [[:dispatch [:ws/connection [:ws/send {:type :note :body body}]]]]}))
-  ;; EP-0017 (rf2-1g0ba6): the request-id is a DURABLE correlation fact (it
-  ;; is folded into the connection machine's :in-flight slot and the reply is
-  ;; matched against it), so it must be a FOLDED FACT from a recordable cofx,
-  ;; NOT an ambient `(random-uuid)` read inside the handler — replay would
-  ;; otherwise mint a fresh id and break the correlation. Mirrors the
-  ;; production `:ws.app/request-id` reg-cofx in
-  ;; examples/patterns/websocket/messages.cljs.
-  (rf/reg-cofx :ws.app/request-id
-    {:recordable? true
-     :doc "Replayable correlation id for an outbound request-reply (EP-0017)."}
-    (fn [] (random-uuid)))
-  (rf/reg-event :ws.app/request
-    {:rf.cofx/requires [:ws.app/request-id]}
-    (fn handler-app-request [{rid :ws.app/request-id} [_ body]]
-      {:fx [[:dispatch [:ws/connection
-                        [:ws/request {:request-id rid
-                                      :body       {:type :request
-                                                   :body body}
-                                      :reply      [:ws.app/request-reply]
-                                      :timeout-ms 5000}]]]]}))
-  ;; The SECOND untrusted ingress — a correlated reply is still the
-  ;; server's bytes. RequestOutcome admits exactly the closed wire :reply
-  ;; arm OR the machine's locally synthesised loss/timeout failure shape
-  ;; (rf2-iyjae). Mirrors the example's registration.
-  (rf/reg-event :ws.app/request-reply
-    {:schema       [:cat [:= :ws.app/request-reply] ws.schema/RequestOutcome]
-     :interceptors [:rf.schema/at-boundary]}
-    (fn handler-app-request-reply [{:keys [db]} [_ body]]
-      {:db (assoc-in db [:messages :last-reply] body)}))
-  (rf/reg-event :ws.app/subscribe-demo
-    (fn handler-app-subscribe-demo [_ _]
-      {:fx [[:dispatch [:ws/connection [:ws/subscribe :demo-topic]]]]}))
-  (rf/reg-event :ws.app/edit-draft
-    (fn handler-app-edit-draft [{:keys [db]} [_ text]]
-      {:db (assoc-in db [:messages :draft] text)}))
-  (rf/reg-event :ws.messages/initialise
-    (fn handler-messages-initialise [{:keys [db]} _]
-      {:db (assoc db :messages {:draft "" :received [] :last-reply nil :rx-count 0})}))
-  (rf/reg-sub :messages            (fn [db _] (:messages db)))
-  (rf/reg-sub :messages/draft      :<- [:messages] (fn [m _] (:draft m)))
-  (rf/reg-sub :messages/received   :<- [:messages] (fn [m _] (:received m)))
-  (rf/reg-sub :messages/last-reply :<- [:messages] (fn [m _] (:last-reply m)))
-
-  ;; --- websocket.core ----------------------------------------------------
-  (rf/reg-event :ws.app/initialise
-    {:doc "App boot. Seeds the messages slice + materialises the
-           connection machine's initial `:disconnected` snapshot.
-
-           Namespaced under `:ws.app/*` (not `:app/initialise`) so the
-           example can coexist with the realworld + counter examples
-           without re-registering a common event key."}
-    (fn handler-app-initialise [_ _]
-      {:fx [[:dispatch [:ws.messages/initialise]]
-            [:dispatch [:ws.connection/initialise]]]})))
+  ;; + `Async test called done more than one time` flake. The example's own
+  ;; `websocket.schema/register!` names `:rf/default` explicitly in its
+  ;; `(rf/with-frame :rf/default …)` — exactly what this call site needs,
+  ;; and one more thing that stays correct here only because it is not copied.
+  (ws.schema/register!)
+  (ws.connection/register!)
+  (messages/register!)
+  (ws.core/register!))
 
 ;; `:init-fn` re-fires every `rf/reg-*` this example owns so the ns-load
 ;; registrations the tests depend on are present even when an
@@ -1586,6 +1484,52 @@
       (is (some #{:rf.schema/at-boundary} (:interceptors m))
           (str ingress " attaches :rf.schema/at-boundary — the release-resident half")))))
 
+(defn- example-registrations-are-live-test []
+  ;; rf2-idv1m — THE ANTI-SHADOWING CONTROL, and the reason the fixture
+  ;; above calls the example's `register!` fns instead of re-declaring what
+  ;; they install.
+  ;;
+  ;; `register-all!` used to mirror the two ingress registrations inline.
+  ;; It runs on every test and `reg-*` is last-write-wins, so those copies
+  ;; replaced the example's own handlers before a single assertion ran, and
+  ;; the suite became a certificate for the copy: a fault planted in
+  ;; `websocket.messages`' `:ws.app/request-reply` body left all 29 tests
+  ;; green, and `inbound-boundary-structural-test` read back the `:schema`
+  ;; and `:rf.schema/at-boundary` this very file had just installed rather
+  ;; than the example's. Three assertions, one per way the coupling can be
+  ;; lost.
+  (with-new-frame [f (new-frame)]
+    (let [m (rf/handler-meta :event :ws.app/request-reply)]
+      ;; (1) IDENTITY. The live registration is the EXAMPLE's, not a
+      ;; look-alike. The example documents this ingress at length and the
+      ;; hand-mirrored twin never carried the prose, so the registered
+      ;; `:doc` is a direct, cheap witness to WHICH definition won the
+      ;; last write — and it is what reds first if a twin comes back.
+      (is (some? (:doc m))
+          ":ws.app/request-reply is registered with the example's own :doc")
+      (is (str/includes? (str (:doc m)) "RequestOutcome")
+          "the live :ws.app/request-reply IS websocket.messages' registration")
+      ;; (2) BOUNDARY METADATA, read off the live registry. Reds if the
+      ;; example drops `:rf.schema/at-boundary` (the release-resident half)
+      ;; or its closed `:schema`. This is the same pair
+      ;; `inbound-boundary-structural-test` pins — asserted here too,
+      ;; because until this fn existed that test was reading the fixture's
+      ;; own metadata back to itself.
+      (is (some? (:schema m))
+          "the example declares the closed RequestOutcome wire contract")
+      (is (some #{:rf.schema/at-boundary} (:interceptors m))
+          "the example attaches :rf.schema/at-boundary"))
+    ;; (3) BODY. Driven through a real dispatch, so it is the REGISTERED
+    ;; handler that runs. Reds if the example's handler body stops
+    ;; recording the outcome — the exact fault that used to pass.
+    (let [outcome {:origin     :ws/local
+                   :request-id (random-uuid)
+                   :ok         false
+                   :error      :ws/timeout}]
+      (rf/dispatch-sync [:ws.app/request-reply outcome] {:frame f})
+      (is (= outcome (get-in (rf/app-db-value f) [:messages :last-reply]))
+          "the example's own :ws.app/request-reply body recorded the outcome"))))
+
 (defn- inbound-boundary-rejection-test []
   ;; Malformed and unknown frames from the LIVE socket are refused, and
   ;; refused EARLY: the audit of the first rf2-iyjae pass found the
@@ -2011,3 +1955,10 @@
             raw bearer sentinel is absent from the exercised snapshot,
             app-db, event and trace surface"
     (credential-discipline-test)))
+
+(deftest websocket-example-registrations-are-live
+  (testing "rf2-idv1m — the suite exercises the EXAMPLE's ingress
+            registration, not a fixture-local twin: its :doc, its closed
+            :schema, its :rf.schema/at-boundary and its handler body are all
+            read back off the live registry / a real dispatch"
+    (example-registrations-are-live-test)))


### PR DESCRIPTION
Closes rf2-idv1m (audit finding from PR #8959).

## The finding, reproduced before it was fixed

`register-all!` in the focused WebSocket fixture re-declared the example's
ingress registrations inline. `reg-*` is last-write-wins and the fixture runs
on every test, so those copies replaced `websocket.messages`' own handlers
before a single assertion ran. The suite was a certificate for the copy while
the runnable example was free to drift.

Measured on this branch, both directions, before any change:

| plant, on the pre-fix tree | focused suite |
| --- | --- |
| gut the example's `:ws.app/request-reply` body (`{:db db}`) | **exit 0** — 29 tests, 240 assertions, 0 failures |
| delete the example's `:rf.schema/at-boundary` from `:ws.app/request-reply` | **exit 0** — 29 tests, 240 assertions, 0 failures |

The second is the one the finding called weakened "by construction":
`inbound-boundary-structural-test` read `handler-meta` back for metadata the
fixture itself had installed moments earlier, so removing the example's
release-resident interceptor was invisible to it. The finding measured only
the first direction; the second is measured here.

## The repair

Each example namespace — `websocket.schema`, `websocket.connection`,
`websocket.messages`, `websocket.core` — now installs its registrations
through a named, re-invocable `register!`, still called once at ns-load, so
the production-app idiom is unchanged and `core/run` does nothing extra.
Ignoring whitespace, the diff to the four example files is exactly the
wrapper: a `defn register!`, one extra closing paren, and the `(register!)`
call. No registration's content changed.

The fixture calls those four entry points and keeps no copy. The only things
it still registers are its own `:ws.test/*` reply-log targets and the two
framework `:rf.machine/*` runtime subs that no example namespace owns — down
from 30 registered ids to 5.

The `register-all!` docstring that told maintainers to mirror body changes
into both copies is gone with the mechanism it described.

## The control

`websocket-example-registrations-are-live` is the new tripwire, three
assertions for the three ways the coupling can be lost: the registered `:doc`
(identity — which definition won the last write), the registered `:schema` and
`:rf.schema/at-boundary` read off the live registry, and the handler body
exercised through a real dispatch.

Both plants replayed against the repaired tree:

| plant, on the repaired tree | focused suite |
| --- | --- |
| gut the example's `:ws.app/request-reply` body | **exit 1** — 18 failures across 8 tests, the new control among them |
| delete the example's `:rf.schema/at-boundary` | **exit 1** — 2 failures: `websocket-inbound-boundary-structural` and the new control |

Every plant was applied to a single anchored line with the match count read
first, and every restore was verified by comparing the file's blob hash
against the committed object rather than by reading a diff.

## Quality gates

Run from `implementation/`, `test:cljs` split into its two phases so each
verdict stayed in the foreground. Exit codes below are the runner's own,
captured to a file on the same command line as the redirect. All re-run after
the rebase onto the current base.

| gate | captured exit | result |
| --- | --- | --- |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` | **0** | 1876 files, 0 warnings |
| `node out/node-test.js` (full CLJS contract suite) | **0** | 11121 tests, 55163 assertions, 0 failures, 0 errors |
| `node out/node-test.js --test=re-frame.websocket-cljs-test` (focused) | **0** | 30 tests, 245 assertions, 0 failures, 0 errors |

The focused suite goes 29 tests / 240 assertions → 30 / 245: the added control.
Each compile's `config:` line named this worktree's `shadow-cljs.edn`, and the
sabotage reds confirm the runs read this tree.

Prose, tables and anchors in the changed files were checked by hand; the two
link gates do not reach `.cljs` sources, and this PR touches no markdown.
