### PR TITLE
ci(pair fixture): name all five artefacts in the two remaining fixture cache keys (rf2-cd0zz)

### DIFF
--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -368,6 +368,23 @@ jobs:
         with:
           node-version: '24'
 
+      # This job's hermetic step (`test:re-frame2-pair-live-hermetic-suite`,
+      # below) boots shadow-cljs against `skills/re-frame2-pair/tests/fixture/`,
+      # so this cache covers the fixture's classpath as well as the two MCP
+      # servers'. That fixture resolves FIVE in-repo artefacts as `:local/root`
+      # entries — core, reagent, epoch, schemas and machines (the last two
+      # because the shipped preload `:require`s `re-frame.schemas` and
+      # `re-frame.machines` directly, per the fixture's own deps.edn).
+      #
+      # THE KEY MUST NAME ALL FIVE (rf2-cd0zz). It named NONE of them, so any
+      # artefact dependency bump left the key unchanged: the pre-bump entry
+      # kept being restored and — because an exact key hit suppresses the
+      # save — never refreshed, returning the cold-resolve cost this key
+      # exists to amortise, against an orchestrator that fails the job when
+      # its `SHADOW_BOOT_TIMEOUT_MS` watchdog beats the nREPL port file.
+      # Same roster as `mcp-conformance-re-frame2-pair` and
+      # `re-frame2-pair-fixture-pure` in test.yml (rf2-nsb3e widened the
+      # latter). The tools/* entries stay — they key the server bundles.
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
@@ -375,7 +392,7 @@ jobs:
             ~/.m2/repository
             ~/.gitlibs
             ~/.deps.clj
-          key: ${{ runner.os }}-expensive-mcp-live-${{ hashFiles('tools/re-frame2-pair-mcp/shadow-cljs.edn', 'tools/re-frame2-pair-mcp/package.json', 'tools/mcp-conformance/package.json', 'tools/story-mcp/deps.edn', 'skills/re-frame2-pair/tests/fixture/deps.edn', 'skills/re-frame2-pair/tests/fixture/shadow-cljs.edn') }}
+          key: ${{ runner.os }}-expensive-mcp-live-${{ hashFiles('tools/re-frame2-pair-mcp/shadow-cljs.edn', 'tools/re-frame2-pair-mcp/package.json', 'tools/mcp-conformance/package.json', 'tools/story-mcp/deps.edn', 'skills/re-frame2-pair/tests/fixture/deps.edn', 'skills/re-frame2-pair/tests/fixture/shadow-cljs.edn', 'implementation/core/deps.edn', 'implementation/adapters/reagent/deps.edn', 'implementation/epoch/deps.edn', 'implementation/schemas/deps.edn', 'implementation/machines/deps.edn') }}
           restore-keys: |
             ${{ runner.os }}-expensive-mcp-live-
             ${{ runner.os }}-cljs-tools-re-frame2-pair-mcp-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5348,26 +5348,39 @@ jobs:
       # Single Maven/gitlibs cache that covers BOTH shadow-cljs boots in
       # this job — the re-frame2-pair-mcp server bundle compile AND the hermetic
       # fixture watch (rf2-c565x). The fixture at
-      # `skills/re-frame2-pair/tests/fixture/` resolves core + reagent +
-      # epoch as `:local/root` entries, so a cold-cache run pulls every
-      # transitive dep of those three artefacts (Reagent, Malli, …)
+      # `skills/re-frame2-pair/tests/fixture/` resolves FIVE in-repo
+      # artefacts as `:local/root` entries — core, reagent, epoch, schemas
+      # and machines (the last two because the shipped preload `:require`s
+      # `re-frame.schemas` and `re-frame.machines` directly, per the
+      # fixture's own deps.edn) — so a cold-cache run pulls every
+      # transitive dep of those five artefacts (Reagent, Malli, …)
       # before shadow-cljs can even write the nREPL port file.
       #
       # On a cold-cache GHA runner that resolve takes >240s and the
       # hermetic orchestrator's `SHADOW_BOOT_TIMEOUT_MS` watchdog fires
       # before the port file lands — "boot failed: nREPL port not
       # found". Hashing the fixture's deps.edn / shadow-cljs.edn and the
-      # three local-root deps.edn files into the cache key keeps the
+      # five local-root deps.edn files into the cache key keeps the
       # cache warm across runs that don't touch those files; the wider
       # `restore-keys` ladder still lets a partial hit land when only
       # one file changes.
+      #
+      # THE KEY MUST NAME ALL FIVE (rf2-cd0zz). It named only core, reagent
+      # and epoch, so a schemas or machines dependency bump left the key
+      # unchanged: the pre-bump entry kept being restored and — because an
+      # exact key hit suppresses the save — never refreshed, returning the
+      # very cold-resolve cost this key exists to amortise. Same omission
+      # rf2-nsb3e fixed on `re-frame2-pair-fixture-pure` below; it was
+      # unreachable while the job was skipped on those artefacts, and
+      # rf2-f9f3p armed the reverse edges that now SCHEDULE this job on a
+      # change under implementation/{epoch,schemas,machines}.
       - name: Cache Maven / gitlibs (shadow-cljs deps for re-frame2-pair-mcp build + hermetic fixture)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             ~/.m2/repository
             ~/.gitlibs
-          key: ${{ runner.os }}-mcp-conformance-re-frame2-pair-${{ hashFiles('tools/re-frame2-pair-mcp/shadow-cljs.edn', 'tools/re-frame2-pair-mcp/package.json', 'skills/re-frame2-pair/tests/fixture/deps.edn', 'skills/re-frame2-pair/tests/fixture/shadow-cljs.edn', 'implementation/core/deps.edn', 'implementation/adapters/reagent/deps.edn', 'implementation/epoch/deps.edn') }}
+          key: ${{ runner.os }}-mcp-conformance-re-frame2-pair-${{ hashFiles('tools/re-frame2-pair-mcp/shadow-cljs.edn', 'tools/re-frame2-pair-mcp/package.json', 'skills/re-frame2-pair/tests/fixture/deps.edn', 'skills/re-frame2-pair/tests/fixture/shadow-cljs.edn', 'implementation/core/deps.edn', 'implementation/adapters/reagent/deps.edn', 'implementation/epoch/deps.edn', 'implementation/schemas/deps.edn', 'implementation/machines/deps.edn') }}
           restore-keys: |
             ${{ runner.os }}-mcp-conformance-re-frame2-pair-
             ${{ runner.os }}-cljs-tools-re-frame2-pair-mcp-
@@ -5820,9 +5833,10 @@ jobs:
       # rf2-f9f3p armed the reverse edges that now SCHEDULE it on a change under
       # implementation/{epoch,schemas,machines}, which is what made it live.
       #
-      # `mcp-conformance-re-frame2-pair` builds this same fixture and still
-      # carries the narrow three-artefact list — tracked as its own bead
-      # (rf2-cd0zz), not fixed here, since this file is one-toucher.
+      # `mcp-conformance-re-frame2-pair` above and `mcp-live` in
+      # expensive-tests.yml build this same fixture; both carried a key that
+      # named fewer than five, and both were widened to this roster under
+      # rf2-cd0zz. All three sites keyed on this fixture now name it in full.
       - name: Cache Maven / gitlibs (fixture pure-test deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:


### PR DESCRIPTION
## The defect

`skills/re-frame2-pair/tests/fixture/deps.edn` resolves **five** in-repo artefacts as `:local/root` entries. Three CI cache keys are keyed on that fixture. rf2-nsb3e (#8957) widened one of them to the full roster; the other two were left, and this PR closes both.

**The roster, re-derived from the fixture's own `deps.edn` at this tip** (not from #8957's note) — the five `:local/root` entries in `:deps`:

| artefact | `deps.edn` path |
| --- | --- |
| `day8/re-frame2` | `implementation/core/deps.edn` |
| `day8/re-frame2-reagent` | `implementation/adapters/reagent/deps.edn` |
| `day8/re-frame2-epoch` | `implementation/epoch/deps.edn` |
| `day8/re-frame2-schemas` | `implementation/schemas/deps.edn` |
| `day8/re-frame2-machines` | `implementation/machines/deps.edn` |

The last two are on the classpath because the shipped re-frame2-pair preload `:require`s `re-frame.schemas` and `re-frame.machines` directly — those vars were demoted off the `re-frame.core` facade by the `wad2fl` front-porch shrink. The fixture's own header comment says so.

The roster stops at five: `:deps` in those five artefacts reaches only `../core`, already on the list. The wider `:local/root` sets in each artefact live under `:aliases → :test → :extra-deps`, and the fixture's `shadow-cljs.edn` runs `:deps true` with no alias, so they are not on this classpath.

**All three sites keyed on this fixture, enumerated line-oriented *and* over the whitespace-collapsed text** (a wrapped `hashFiles(...)` list is invisible to a line-oriented search; the collapsed pass was exercised against a string it had to find, and against one it must not):

| site | artefacts named before | after |
| --- | --- | --- |
| `re-frame2-pair-fixture-pure` (test.yml) | all five — fixed by #8957 | unchanged |
| `mcp-conformance-re-frame2-pair` (test.yml) | core, reagent, epoch | **all five** |
| `mcp-live` (expensive-tests.yml) | **none of the five** | **all five** |

Nothing is removed or reordered from either key. The `tools/*` entries in the expensive-tests key stay — they key the two MCP server bundles that job also compiles.

## What the omission costs

The key exists to invalidate when the fixture's resolved classpath changes. With an artefact's `deps.edn` missing from the `hashFiles` list, a bump to it leaves the key unchanged, so the entry saved *before* the bump keeps being restored — and because `actions/cache` skips the save on an exact key hit, it is never refreshed. Every run after such a bump pays the resolve the key exists to amortise, against an orchestrator whose `SHADOW_BOOT_TIMEOUT_MS` watchdog fails the job when a cold resolve beats the nREPL port file (the failure mode the comment above the `mcp-conformance-re-frame2-pair` key already documents at >240s).

## The third site: judged, not assumed

rf2-cd0zz flagged `expensive-tests.yml`'s `mcp-live` key as a *separate judgement* — its `hashFiles` list names no `implementation/*/deps.edn` at all, and whether it wants the artefact roster depends on what that job actually compiles.

Read at source, it compiles the fixture. `mcp-live`'s last conformance step runs `npm run test:re-frame2-pair-live-hermetic-suite` → `tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs`, whose `FIXTURE_DIR` is `skills/re-frame2-pair/tests/fixture` and which boots shadow-cljs there (`fixture missing:` is its own hard error if `shadow-cljs.edn` is absent). That is the same boot `mcp-conformance-re-frame2-pair` performs, sharing one `~/.m2` + `~/.gitlibs` cache with the two server-bundle compiles. So it is the same defect on the same fixture, one degree worse — none of the five named rather than three of five — and it is fixed here.

The `tools/story-mcp/deps.edn` and `tools/*/package.json` entries already in that key are correct for the other things the job builds and are untouched.

## The stale comments

Both keys carried a comment repeating the wrong roster, which is what regenerates the defect: `mcp-conformance-re-frame2-pair`'s named "core + reagent + epoch" and "the three local-root deps.edn files"; `mcp-live`'s cache step carried no roster note at all. Both now name the five and say why. #8957's own pointer on `re-frame2-pair-fixture-pure` — "`mcp-conformance-re-frame2-pair` … still carries the narrow three-artefact list … not fixed here" — is updated, since it is no longer true.

## Quality gates

**Local coverage of a workflow-cache-key edit is partial, and that is measured with plants rather than assumed.** Every number below is the runner's own exit code, captured to a file on the same command line as the redirect.

| gate | exit | result |
| --- | --- | --- |
| `node implementation/scripts/_changed-surfaces.test.cjs` | **0** | 335 passed |
| `python scripts/check_workflow_yaml.py` | **0** | PASS, 11 files under `.github/workflows` |
| `python scripts/check_workflow_job_timeouts.py` | **0** | PASS, 114 jobs across 11 files |
| `python scripts/check_gate_scheduling.py --verbose` | **0** | 33 gate commands, 29 scheduled, 4 declared |

Re-run on the final content after every plant was restored (surfaces **0**, workflow-YAML **0**); each restore verified by comparing the file's blob hash to the committed object, not by reading a diff.

**Plants, both directions:**

- **Breaking a job's `if:`** — `mcp_live` → `mcp_liveX` on `mcp-conformance-re-frame2-pair` — takes `_changed-surfaces.test.cjs` to exit **1**, failing *by name* on that job (and on the epoch live-redaction assertion over the same line). It also proves the gate read this checkout, since the failure text quotes the planted token.
- **Narrowing the cache key back** to three artefacts leaves `_changed-surfaces.test.cjs` at exit **0**, 335 passed. **The surfaces test is blind to the cache key itself** — it pins job `if:` wiring, not `hashFiles` contents. Confirms the same measurement #8957 reported.
- **Breaking YAML on the edited key line** in `expensive-tests.yml` takes `check_workflow_yaml.py` to exit **1**, naming the file, line and column — so that gate does cover the second file, for well-formedness.

`check_gate_scheduling.py` derives reachability from `run:` values and pins npm gate scheduling. **This diff adds no npm script and changes no `run:` value, so its green covers nothing changed here** — it is reported for completeness, not as evidence.

**What a green CI run will and will not show.** It will show the workflows still parse, schedule and pass. It will **not** demonstrate the benefit: this PR bumps no dependency, so the widened key and the narrow one hash to the same value and select the same cache entry. What would demonstrate it is a later commit bumping `implementation/schemas/deps.edn` or `implementation/machines/deps.edn` and observing a cache *miss* on these jobs where the narrow key would have hit a pre-bump entry.

**Rebase safety.** Diffed against the merge base (`origin/main...HEAD`): four hunks, two per file, all of them this change. #8957's widened `re-frame2-pair-fixture-pure` key line is byte-identical to its landed form on this tip; #8943's `test.yml` diff reverse-applies clean against this tip, so nothing of either is reverted. (#8957's *comment* hunk does not reverse-apply, because this PR deliberately rewrites the three lines of it that named this job as unfixed.)

Both files are wholly CRLF and both parse as YAML (`yaml.safe_load`: 70 jobs in `test.yml`, 5 in `expensive-tests.yml`).

Closes rf2-cd0zz.
