### PR TITLE
docs(method): literal-path artefact cleanup; say what the ambiguity window is for

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -1058,6 +1058,15 @@ this route more often than the peer collision, since detaching is the sanctioned
 kill-and-restart is routine. **And clean the artefacts up: one leftover is enough to make a
 worktree unreapable.**
 
+**Delete them by their LITERAL path, never through a variable.** A deletion whose target a static
+permission check cannot evaluate is one that check has to stop and ask about, and the ask lands on
+an operator who may not be watching — so the cleanup stalls mid-turn, and the work queued behind it
+stalls with it. What is being guarded is real rather than theoretical: an unset or empty variable
+turns `"$DIR"/*name*` into a glob rooted at the top of the filesystem. Write the directory out in
+full. Where a variable is genuinely unavoidable, make the shell itself refuse an empty one — POSIX
+shells spell that `"${DIR:?}"` — but that removes the hazard and not the prompt, so it is the
+fallback rather than the rule.
+
 **Verify a restore by hashing the bytes, never by reading a diff.** A rewrite that flips line
 endings reads clean having changed every line — and **a patch that never applied reads clean too**,
 because "unchanged" and "not attempted" are the same diff. That second one is the dangerous half:

--- a/docs/the-mayor-method/loops.md
+++ b/docs/the-mayor-method/loops.md
@@ -943,6 +943,17 @@ and both readings went wrong in a single day here, in opposite directions.
    ambiguity, but because the two errors are priced differently — waiting costs a tick, and acting
    costs a duplicate worker in a live worktree.
 
+   **Say what the window is FOR, though, because a rule that only forbids leaves the interval empty
+   and a coordinator fills an empty interval with more measurement.** The re-read catches exactly one
+   thing — movement, which is proof of life and needs no corroboration — so read it twice, record the
+   freeze, and go do something else; the tenth reading answers what the second did. And carry a sense
+   of the scale, because that is what makes the non-signal bearable rather than ominous: **a freeze
+   measured in hours is unremarkable on a heavyweight gate.** Measured across one session — six
+   readings over ninety minutes, every one identical, while five workers whose transcripts had not
+   gained a byte were all alive and all completed normally, at durations from an hour and forty
+   minutes to nearly three hours. The coordinator who knows that stops after the second reading; the
+   one who does not keeps going, because silence that long feels like it has to mean something.
+
    **That clock says "no activity" in four voices and you can only tell them apart with a control.**
    Besides the reading worker and the poller treated just below, a path that resolves to nothing
    answers identically — and so does a span shorter than the worktree's own age, where every file is
@@ -1085,6 +1096,15 @@ Stop it, then merge. That is an act with a definite outcome where every clock ab
 with none, and it needs no new discriminator — a stopped agent cannot be working, so the question the
 four clocks could not answer stops being asked. Verify the change against §1 in full, exactly as for
 any other change, and do not reopen the stopped worker's items or redispatch them.
+
+**But it is not an escape hatch from the ambiguity above, and reading it as one is the natural
+mistake, because it is the only ACT on offer in a section that otherwise says wait.** It authorises
+publishing a change whose author you have positive reason to think is finished; it is not a way to
+resolve a freeze the clocks cannot read. Putting that freeze to the operator as a decision spends
+their attention on a question time usually answers by itself, and it arrives dressed as diligence,
+which is why it is worth naming: measured once, five agents were escalated as possibly stopped, all
+five were alive, and every one reported normally within the hour — the operator's answer, had it
+come, would have been to destroy four live runs.
 
 **The ORDER is the whole rule, and reversing it looks identical afterwards.** Merging first and
 stopping second reaches the same end state by the forbidden route: the merge rests on an inference and


### PR DESCRIPTION
Two method repairs, both from live friction this session. One file each, no overlap.

---

## 1 — Delete gate artefacts by literal path, never through a variable

Operator-reported: worker cleanup is written as `rm -f "$SP"/*<worktree>*`, and a static
permission check cannot evaluate `$SP`, so it stops and asks. The ask lands on an operator
who may not be watching, and the worker stalls mid-turn with the work behind it.

The hazard being guarded is real rather than theoretical — an unset or empty variable turns
the glob into one rooted at the top of the filesystem — so the repair removes the ambiguity
rather than the check. One paragraph in the gate-mechanics block, beside the artefact-naming
rule that generates this cleanup in the first place: delete by the **literal** path; and where
a variable is genuinely unavoidable, make the shell itself refuse an empty one (`"${DIR:?}"`),
named as the **fallback**, because it removes the hazard without removing the prompt.

## 2 — Say what the ambiguity window is for, and that stopping is not an escape hatch from it

The frozen-clock passage in §4 says the reading is ambiguous, that no amount of re-reading
converts it into evidence, and that you should declare a window and wait. It never says what
to do with the interval — and **a rule that only forbids leaves the interval empty, which a
coordinator fills with more measurement**: six readings over ninety minutes in one session,
every one identical. It also carries no sense of scale, which is what makes a multi-hour
freeze read as ominous rather than ordinary. Both are now stated, with this session's
numbers: five workers frozen on every clock, **five alive**, completing normally at durations
from an hour and forty minutes to nearly three hours.

The stop-then-merge rule then reads as the way out, because it is the only *act* on offer in
a section that otherwise says wait. It is not, and a clause now says so: it authorises
publishing a change whose author you have positive reason to think is finished, not resolving
a freeze the clocks cannot read. Putting that freeze to the operator arrives dressed as
diligence — and in the measured case the operator's answer, had it come, would have destroyed
four live runs.

Both branches of the existing rule are untouched, no mechanism is added, and the §4 addition
sits at the same three-space indentation as its neighbours, inside numbered item 1.

---

## Quality gates

| Gate | Captured exit |
| --- | --- |
| `python scripts/check_doc_slugs.py` | **0** |
| `python -m mkdocs build --strict` | **0**, 0 WARNING lines |

**Both greens are about the rest of these files, not about these changes.** Neither addition
carries a link or an anchor, and link targets plus heading anchors are the whole of what these
two gates check — so no automated gate covers this prose. Verified by hand instead: no heading
added, so the anchor set is unchanged; no table touched, so no column counts to check; and the
§4 block's indentation confirmed byte-wise to match its neighbours so it stays inside its list
item.

Discrimination was proved so the greens are known to be about *this* worktree and not a
sibling's: a broken anchor planted at a line being edited turned `check_doc_slugs.py` **red,
exit 1**, naming `dispatch-prompt-template.md:1066` and the planted target. The edit was
committed *before* the plant so the restore target was the intended state, and the restore was
verified by **blob** hash against the committed object (`eb917ee7…` before and after), not by
reading a diff. `mkdocs --strict` grades a broken anchor at INFO and would not have caught it,
which is why the slug checker carries this proof.

Merge-base diff (`origin/main...HEAD`) is two files, 29 insertions, no deletions — nothing to
revert.