### PR TITLE
docs(method): a fence-lift names the fence, not the item

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -85,6 +85,17 @@ The order is what makes it accurate. Each step is a check the next depends on.
    the work or, as measured here, costs the worker a justification round it should not have had to
    write. Both shapes went out in real briefs, and the worker caught both.
 
+   **Read the INVERSE with more care than either, because it is the one that fails open.** A note
+   lifting a fence names *the fence it lifts*, not the item — so an item can carry a second sequencing
+   the lift says nothing about, and its newest layer then reads *released* while a live precondition
+   sits underneath. The two above merely re-block work that was already clear; this one dispatches into
+   a surface somebody else holds, or into one gated by a decision nobody has made. Measured: an item
+   whose fence had been lifted on the holder's own explicit words still sat behind an older note
+   sequencing it behind an unruled operator call — and the *other* half of that same older note had
+   genuinely cleared, which is exactly what made the whole of it look discharged. **Where the tracker
+   can express a precondition, encode it there rather than leaving it in prose**: a fence that exists
+   only in a note is re-derived every pass, and a fence re-derived every pass is eventually missed.
+
    **And where you sweep a whole board for hold markers, that sweep is a candidate filter and never a
    verdict.** It narrows the open items to a handful; the hold is then established by READING each
    candidate, which is affordable at that size and is the only thing that separates a live banner from


### PR DESCRIPTION
Step 1 of *Write the brief in this order* already names two sequencing shapes, and **both fail
closed**: they re-block work the item had already released, costing a worker a justification
round. The inverse is unnamed and **fails open**.

A note lifting a fence names *the fence it lifts*, not the item — so an item can carry a second
sequencing the lift says nothing about, and its newest layer then reads *released* while a live
precondition sits underneath. That does not merely re-block clear work; it dispatches into a
surface somebody else holds, or into one gated by a decision nobody has made.

**Measured live, in the loop that found it.** An item whose fence had been lifted an hour earlier
on the holding worker's own explicit words still sat behind an older note sequencing it behind an
unruled operator call — and the *other* half of that same older note had genuinely cleared, which
is exactly what made the whole of it look discharged. It was one command from being dispatched.

The durable remedy is named alongside the hazard rather than left as another thing to remember:
**where the tracker can express a precondition, encode it there** — a fence that exists only in a
note is re-derived every pass, and a fence re-derived every pass is eventually missed.

One paragraph, inside the existing step, no new section and no mechanism. The two shapes already
there are untouched.

## Quality gates

| Gate | Captured exit |
| --- | --- |
| `python scripts/check_doc_slugs.py` | **0** |
| `python -m mkdocs build --strict` | **0**, 0 WARNING lines |

**Both greens are about the rest of the file, not about this change** — the added paragraph
carries no link and no anchor, and link targets plus heading anchors are the whole of what these
two gates check, so no automated gate covers this prose. Verified by hand instead: no heading
added, so the anchor set is unchanged; no table touched; and the block's three-space indentation
confirmed byte-wise against its neighbours so it stays inside numbered item 1.

Discrimination proved, so the greens are known to be about *this* worktree: an anchor planted at a
line being edited turned `check_doc_slugs.py` **red, exit 1**, naming
`dispatch-prompt-template.md:97` and the planted target. The edit was committed *before* the plant
so the restore target was the intended state, and the restore was verified by **blob** hash against
the committed object (`c5c4c156…` before and after), not by reading a diff. `mkdocs --strict` grades
a broken anchor at INFO and would not have caught it.

Merge-base diff is one file, eleven insertions, no deletions.