### PR TITLE
docs(method): there are six standing loops, not five

### DIFF
--- a/docs/the-mayor-method/README.md
+++ b/docs/the-mayor-method/README.md
@@ -268,7 +268,7 @@ Three siblings carry the operational detail:
 
 - [`bootstrap.md`](bootstrap.md) — the opening prompt, and the hard-won list of things that
   bite.
-- [`loops.md`](loops.md) — the 5 standing loops, and the merge criterion in full.
+- [`loops.md`](loops.md) — the 6 standing loops, and the merge criterion in full.
 - [`dispatch-prompt-template.md`](dispatch-prompt-template.md) — the worker-prompt shapes, the
   common preamble, the worktree-boundary block, and the gate-mechanics block. The last 3
   travel verbatim: the preamble into every dispatch, the other 2 into every editing one.

--- a/docs/the-mayor-method/bootstrap.md
+++ b/docs/the-mayor-method/bootstrap.md
@@ -75,11 +75,14 @@ and paste that block verbatim into every dispatch preamble. Skip the interview i
 the operator's opening message already names the stance; restate it as a one-line
 confirmation instead.
 
-SET UP THE LOOPS. The five loops are in `loops.md`. If you codify each as a command
-file so it is one invocation, keep that file a THIN pointer into `loops.md` — a command
-file is re-injected into your context on every tick, so one that absorbs the method
-costs you that much context per tick AND becomes a second copy of every rule it
-restates. Two copies disagree within days, and the loop follows the file that runs.
+SET UP THE LOOPS. They are in `loops.md`, and you take the list from that file's own
+section headings rather than from a count written in prose — this line said "five"
+while the file held six, and the loop a short count silently drops is the one that
+would have caught the miscount. If you codify each as a command file so it is one
+invocation, keep that file a THIN pointer into `loops.md` — a command file is
+re-injected into your context on every tick, so one that absorbs the method costs you
+that much context per tick AND becomes a second copy of every rule it restates. Two
+copies disagree within days, and the loop follows the file that runs.
 
 Acknowledge "I am the Mayor now".
 ```


### PR DESCRIPTION
Both front-door documents undercount `loops.md` by one.

- `README.md` — *"the 5 standing loops"*
- `bootstrap.md` — *"SET UP THE LOOPS. The five loops are in `loops.md`."*

`loops.md` has **six**: Merge, Dispatch, Backlog reread, Posture, Hygiene, Method reread.

**This is a long-standing stale constant, not recent drift.** The file already held six at the
commit where the README was last touched, so seventy-four commits and every Method reread since
have passed over it — because a count written in prose reads as authoritative and nothing checks
it against the headings.

**The consequence is self-concealing, which is why it is worth fixing rather than just correcting.**
A mayor following `bootstrap.md` literally codifies five command files and never creates the sixth
— and the sixth is **Method reread**, the loop whose whole job is catching stale measured
constants. The omission removes the thing that would have found the omission. Nothing errors; five
loops run perfectly well.

So the README takes the number, and bootstrap takes the durable fix instead: **enumerate the loops
from that file's own section headings rather than from a count**, so the seventh does not reopen
this. That is one sentence in the step that already exists, and it replaces a number that will go
stale again with an instruction that will not.

Checked for siblings before stopping: these are the only two numeric claims about loops in either
file, searched both as digits and as number-words. `bootstrap.md`'s *"five-clause criterion"* is a
different count and is **correct** — the merge criterion still has five clauses — which is why this
is two targeted edits rather than a replace.

## Quality gates

| Gate | Captured exit |
| --- | --- |
| `python scripts/check_doc_slugs.py` | **0** |
| `python -m mkdocs build --strict` | **0**, 0 WARNING lines |

**Coverage differs between the two files, and only one is gated.** The README line sits in ordinary
prose and carries a link, so both gates read it — proven by planting a broken target on that exact
line: `check_doc_slugs.py` **exit 1** naming `README.md:271`, and `mkdocs --strict` **exit 1**,
`Aborted with 1 warnings in strict mode!`. The edit was committed *before* the plant so the restore
target was the intended state, and the restore was verified by **blob** hash (`a70cc40d…` before and
after), not by reading a diff.

The `bootstrap.md` edit is **inside a fenced block** — it is a pasteable prompt — and both link gates
strip fences before reading, so neither gate sees it and their green says nothing about it. Verified
by hand: the paragraph carries no link or anchor, no heading was added, and the rewrap keeps every
line at or under 85 characters against a file maximum of 123.

Merge-base diff: two files, five insertions, two deletions.