### PR TITLE
docs(method): revert the loop-count change — five loops, six bodies

### DIFF
--- a/docs/the-mayor-method/README.md
+++ b/docs/the-mayor-method/README.md
@@ -268,7 +268,7 @@ Three siblings carry the operational detail:
 
 - [`bootstrap.md`](bootstrap.md) — the opening prompt, and the hard-won list of things that
   bite.
-- [`loops.md`](loops.md) — the 6 standing loops, and the merge criterion in full.
+- [`loops.md`](loops.md) — the 5 standing loops, and the merge criterion in full.
 - [`dispatch-prompt-template.md`](dispatch-prompt-template.md) — the worker-prompt shapes, the
   common preamble, the worktree-boundary block, and the gate-mechanics block. The last 3
   travel verbatim: the preamble into every dispatch, the other 2 into every editing one.

--- a/docs/the-mayor-method/bootstrap.md
+++ b/docs/the-mayor-method/bootstrap.md
@@ -75,14 +75,11 @@ and paste that block verbatim into every dispatch preamble. Skip the interview i
 the operator's opening message already names the stance; restate it as a one-line
 confirmation instead.
 
-SET UP THE LOOPS. They are in `loops.md`, and you take the list from that file's own
-section headings rather than from a count written in prose — this line said "five"
-while the file held six, and the loop a short count silently drops is the one that
-would have caught the miscount. If you codify each as a command file so it is one
-invocation, keep that file a THIN pointer into `loops.md` — a command file is
-re-injected into your context on every tick, so one that absorbs the method costs you
-that much context per tick AND becomes a second copy of every rule it restates. Two
-copies disagree within days, and the loop follows the file that runs.
+SET UP THE LOOPS. The five loops are in `loops.md`. If you codify each as a command
+file so it is one invocation, keep that file a THIN pointer into `loops.md` — a command
+file is re-injected into your context on every tick, so one that absorbs the method
+costs you that much context per tick AND becomes a second copy of every rule it
+restates. Two copies disagree within days, and the loop follows the file that runs.
 
 Acknowledge "I am the Mayor now".
 ```


### PR DESCRIPTION
**Reverts PR #8974, which I raised an hour ago and got wrong.** Byte-identical to the
pre-#8974 blobs for both files.

## What #8974 claimed, and why it was false

It said the README's *"the 5 standing loops"* and bootstrap's *"The five loops are in
`loops.md`"* were stale, because `loops.md` has six `## N` sections.

`loops.md` declares **five** loops in its cadence table — Merge + dispatch, Backlog reread,
Posture + stranded sweep, Hygiene, Method reread — and then states the distinction outright,
twenty lines above where I was looking:

> **Five loops, six bodies.** Merge and dispatch share one tick, but each is long enough to
> want a heading of its own, so they are written separately below. The numbering follows the
> bodies; the cadence follows the table.

I counted headings, got six, and called the front-door count stale without reading the
paragraph that exists to pre-empt exactly that confusion. The sentence immediately before it —
*"Some people prefer merge and dispatch as separate loops"* — is the same warning again.

**The strongest counter-evidence was inside my own working.** I established that the count was
already "wrong" at the commit where the README was last touched, and read that as a
long-standing stale constant. The correct reading is that it was right then and is right now.
A number that has never changed across seventy-four commits is more likely correct than
uniquely overlooked, and I argued the opposite.

## The bootstrap half had to go regardless of the number

That rewrite told a mayor to *"take the list from that file's own section headings rather than
from a count written in prose."* Followed literally it produces **six** loops and six command
files — contradicting the cadence table and splitting the one tick that exists precisely so a
merge can refill the slot it frees. That is worse than a wrong number: it is an instruction
that manufactures a structural error every time it is obeyed.

## Nothing is added

No new caution, no clarifying sentence. The document's own *"Five loops, six bodies"* is
complete and discriminating, and it did not fail — I failed to read it. Adding a warning about
a trap the page already names would repeat the mistake in the other direction.

## Quality gates

| Gate | Captured exit |
| --- | --- |
| `python scripts/check_doc_slugs.py` | **0** |
| `python -m mkdocs build --strict` | **0**, 0 WARNING lines |

Discrimination is not re-proved here and does not need to be: both gates were exercised against
a planted fault on the very line this reverts (`README.md:271`) two hours ago, returning exit 1
each. The change is a restore verified the way restores are verified — by **blob** hash against
the pre-#8974 objects, `b5279169…` and `1429042e…`, both MATCH — rather than by reading a diff.