### PR TITLE
fix(pair-mcp): recorder witness asserts the post-dispatch value, not the baseline; retire stale stream carriers (rf2-ahjbc)

### DIFF
--- a/skills/re-frame2-pair/docs/TESTING.md
+++ b/skills/re-frame2-pair/docs/TESTING.md
@@ -28,8 +28,8 @@ against the **exact shipped code** rather than a copied mirror (rf2-etsj8p):
 fixture compiles `re-frame2-pair.pure` (on the `../../preload` source path) and
 the tests at `tests/fixture/test/re_frame2_pair/pure_test.cljs`, running them
 under Node. These exercise the EXACT pure fns the runtime delegates to — no
-mirror — so the covered matrices (multi-frame ambiguity, redaction, streaming
-eviction/timing, read-sub validation, snapshot/orient, cascade outcome, and the
+mirror — so the covered matrices (multi-frame ambiguity, redaction, epoch
+timing/matching, read-sub validation, snapshot/orient, cascade outcome, and the
 hash-cache bedrock invariant) test the shipped preload directly.
 
 **To run:**

--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -54,9 +54,10 @@ absent.
 ### Live pair conformance
 
 The live tests exercise behaviour that requires a connected browser
-runtime: overflow, progress notifications, sensitive-value projection,
-the universal `isError`/`:ok?` relationship, recordable coeffects, and
-event metadata.
+runtime: overflow, turn-shaped observation (dispatch consequence,
+`watch-epochs`, `watch-until`, the recorder read-back), sensitive-value
+projection, the universal `isError`/`:ok?` relationship, recordable
+coeffects, and event metadata.
 
 [`scripts/live-test-inventory.cjs`](scripts/live-test-inventory.cjs) is
 the single owner of the live-test roster. Both `npm test` and the

--- a/tools/mcp-conformance/TOKEN-BUDGETS.md
+++ b/tools/mcp-conformance/TOKEN-BUDGETS.md
@@ -71,9 +71,9 @@ structural dedup must be reflected in the payload that `apply-cap`
 measures. The cap then either returns the result unchanged or replaces
 the payload with the fixed-shape overflow marker.
 
-The pair server additionally bounds streaming queues by event count and
-bytes. That upstream resource control is distinct from the per-response
-wire cap. Story-mcp has no streaming surface.
+Neither server has a streaming surface: the pair server's push-streaming
+queues and their event-count / byte bounds — an upstream resource control
+distinct from the per-response wire cap — were retired under rf2-ahjbc.
 
 The detailed mechanism order belongs to the server specs:
 

--- a/tools/mcp-conformance/test/_runner.cjs
+++ b/tools/mcp-conformance/test/_runner.cjs
@@ -357,7 +357,7 @@ function assertClassificationRatchet(tools, expected) {
       if (ro || de) {
         throw new Error(
           'tool ' + t.name + ' classification regressed: fixture pins ' +
-            '`neither` (a session-pin / streaming tool — NEITHER readOnlyHint ' +
+            '`neither` (a session-pin tool — NEITHER readOnlyHint ' +
             'NOR destructiveHint true) but the live descriptor has ' +
             'readOnlyHint=' + JSON.stringify(a.readOnlyHint) +
             ', destructiveHint=' + JSON.stringify(a.destructiveHint) +

--- a/tools/mcp-conformance/test/live-re-frame2-pair-cofx.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-cofx.cjs
@@ -128,9 +128,10 @@ async function readStampedAt(client) {
 
 // Dispatch `[:counter/stamp]` with a scripted `cofx`, queued so the
 // fixture's depth-0 epoch-recording posture does not surface a
-// `:no-epoch-recorded` isError (same rationale as the subscribe gate's
-// `:queued`). The db commit is synchronous regardless of epoch recording,
-// so the subsequent `:stamped-at` read sees the folded value.
+// `:no-epoch-recorded` isError (the turn-observation harness meets the
+// same posture and enables recording instead — see its header). The db
+// commit is synchronous regardless of epoch recording, so the subsequent
+// `:stamped-at` read sees the folded value.
 async function dispatchStamp(client, timeMs) {
   const resp = await client.callTool({
     name: 'dispatch',

--- a/tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs
@@ -73,23 +73,23 @@
 
 // ## DRY-on-3 resolution
 //
-// This file and its `live-re-frame2-pair-*.cjs` siblings (subscribe,
-// redaction) share the nREPL SKIP-gate (via $SHADOW_CLJS_NREPL_PORT) and
-// the SDK-spawn ceremony. Both are now factored: the SKIP gate routes
-// through `runWithWatchdog.skip`, and the spawn+connect+teardown ceremony
-// is `_runner.cjs`'s `connectServer` / `closeQuietly` (the redaction arm's
-// second-server boot uses it directly). What is NOT shared — by design —
-// is each variant's data-driven field validator: this variant's overflow
-// parsing/validation lives in the overflow-SPECIFIC `lib/overflow-marker.cjs`
-// (`REQUIRED_FIELDS` + `assertOverflowBody` + the closed-wrapper guard),
-// while subscribe keeps `REQUIRED_PARAMS` + `assertProgressParams` inline.
-// Each pins a DISTINCT Malli schema (`ReFrame2PairOverflowBody` vs
-// `ReFrame2PairProgressNotificationParams`) and the JVM cross-encoding gate
-// in `wire_vocab_test.clj` greps each validator's literal source rows by
-// name — collapsing them into one GENERIC helper would dissolve that
-// per-schema attribution and weaken the conformance contract. (The overflow
-// helper was extracted so its pure logic is unit-testable off the live
-// path; it is not shared with subscribe.)
+// This file and its `live-re-frame2-pair-*.cjs` siblings (turn-observation,
+// redaction, isError, cofx, event-meta) share the nREPL SKIP-gate (via
+// $SHADOW_CLJS_NREPL_PORT) and the SDK-spawn ceremony. Both are factored:
+// the SKIP gate routes through `runWithWatchdog.skip`, and the
+// spawn+connect+teardown ceremony is `_runner.cjs`'s `connectServer` /
+// `closeQuietly` (the redaction and turn-observation arms' second-server
+// boots use it directly). What is NOT shared — by design — is this
+// variant's data-driven field validator: overflow parsing/validation lives
+// in the overflow-SPECIFIC `lib/overflow-marker.cjs` (`REQUIRED_FIELDS` +
+// `assertOverflowBody` + the closed-wrapper guard). It pins ONE Malli
+// schema (`ReFrame2PairOverflowBody`), and the JVM cross-encoding gate in
+// `wire_vocab_test.clj` greps the validator's literal source rows by name —
+// folding it into a GENERIC helper would dissolve that per-schema
+// attribution and weaken the conformance contract. (The helper was
+// extracted so its pure logic is unit-testable off the live path. The
+// retired streaming harness kept its own progress-params validator inline
+// for the same per-schema reason; rf2-ahjbc removed it with the subsystem.)
 
 const path = require('node:path');
 const os = require('node:os');

--- a/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
@@ -96,7 +96,7 @@
 // ## Gating
 //
 // **Skipped unless `$SHADOW_CLJS_NREPL_PORT` is set.** Same posture as
-// the sibling `live-re-frame2-pair-overflow.cjs` / `-subscribe.cjs`:
+// the sibling `live-re-frame2-pair-overflow.cjs` / `-turn-observation.cjs`:
 // without a live nREPL the server runs degraded and every tool returns
 // the same `:nrepl-port-not-found` envelope — no `:db-*` ever crosses, so
 // the redaction surface is unreachable. The hermetic orchestrator

--- a/tools/mcp-conformance/test/live-re-frame2-pair-turn-observation.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-turn-observation.cjs
@@ -26,7 +26,10 @@
 //   4. `record` + `read-recording` capture a change driven while the
 //      recorder observes (the human/browser-driven capture path — here
 //      the change is driven by a dispatch between the two calls) and
-//      return the change-log as a completed read.
+//      return the change-log as a completed read. The recorder's own
+//      pre-dispatch baseline entry is drained first, so the proof is an
+//      entry carrying the exact post-dispatch value — never "at least
+//      one entry", which the baseline alone satisfies.
 //
 // Every call above is awaited to completion before the next fires —
 // the sequential shape an ordinary coding agent drives. A regression
@@ -110,6 +113,34 @@ function fatalIfError(label, resp) {
         'this completed result. Got: ' +
         (responseText(resp) || JSON.stringify(resp)).slice(0, 400),
     );
+  }
+}
+
+// Every `:value <int>` slot in a read-recording result, in change-log
+// order. With ONE recorded signal these are exactly the entries' values —
+// the envelope's other integer slots ride `:count` / `:frames-sampled` /
+// `:t` / `:frame`, none of which is spelled `:value`.
+function entryValues(text) {
+  return Array.from(text.matchAll(/:value (\d+)/g), (m) => parseInt(m[1], 10));
+}
+
+// Poll `read-recording` on a short cadence until `done(values)` holds or
+// the deadline passes (bounded — the outer watchdog caps the whole
+// harness). The recorder samples per animation frame, so an entry lands a
+// frame or two after its change. Each poll is itself a completed tool
+// call. Returns the LAST read's values + text; the caller judges them.
+async function pollReadRecording(client, recordingId, extraArgs, label, done) {
+  const deadline = Date.now() + 8000;
+  for (;;) {
+    const resp = await client.callTool({
+      name: 'read-recording',
+      arguments: { 'recording-id': recordingId, ...extraArgs },
+    });
+    fatalIfError('read-recording ' + recordingId + ' (' + label + ')', resp);
+    const text = responseText(resp) || '';
+    const values = entryValues(text);
+    if (done(values) || Date.now() >= deadline) return { values, text };
+    await new Promise((r) => setTimeout(r, 250));
   }
 }
 
@@ -293,11 +324,32 @@ runWithWatchdog(
         target + '}',
     );
 
-    // ---- 4. record -> drive a change -> read-recording ----
+    // ---- 4. record -> drain the baseline -> drive a change -> read-recording ----
     //
     // The recorder observes while the app is driven (in production use a
     // human/browser drives it; here a dispatch between the two calls
     // stands in). The change-log comes back as a completed read.
+    //
+    // The recorder's FIRST tick records every signal's first sample as a
+    // baseline entry (`recording-sampler-tick!`'s last-values starts
+    // empty), so "at least one entry" holds before anything is driven and
+    // would stay green if the recorder missed the dispatch entirely (the
+    // rf2-ahjbc audit's false-green finding). The proof of a
+    // DISPATCH-DRIVEN capture is therefore three steps: await and DRAIN
+    // the pre-dispatch baseline, pinned to the value read before `record`;
+    // dispatch; then require an entry carrying the exact post-dispatch
+    // value, which existed nowhere in app-db before the dispatch.
+    const recBeforeResp = await client.callTool({
+      name: 'get-path',
+      arguments: { path: '[:count]' },
+    });
+    fatalIfError('get-path [:count] (recorder arm)', recBeforeResp);
+    const recBefore = parseCountValue(
+      responseText(recBeforeResp) || '',
+      'get-path [:count] (recorder arm)',
+    );
+    const recTarget = recBefore + 1;
+
     const recResp = await client.callTool({
       name: 'record',
       arguments: { signals: '[{:app-db [:count]}]' },
@@ -313,35 +365,59 @@ runWithWatchdog(
     const recordingId = idMatch[1];
     console.log('OK   record -> recording installed (' + recordingId + ')');
 
+    // Await the baseline and drain it (`drain: true` consumes the buffered
+    // entries; the recording keeps running). It must be exactly one entry
+    // carrying the pre-dispatch value — anything else means the recorder
+    // is not observing the signal we think it is.
+    const baseline = await pollReadRecording(
+      client,
+      recordingId,
+      { drain: true },
+      'baseline',
+      (values) => values.length > 0,
+    );
+    if (baseline.values.length !== 1 || baseline.values[0] !== recBefore) {
+      throw new Error(
+        'read-recording (drain) MUST return exactly the pre-dispatch ' +
+          'baseline entry (:value ' + recBefore + ') before anything is ' +
+          'driven; got values ' + JSON.stringify(baseline.values) + ': ' +
+          baseline.text.slice(0, 400),
+      );
+    }
+    console.log(
+      'OK   read-recording (drain) -> pre-dispatch baseline entry :value ' +
+        recBefore + ' drained',
+    );
+
     const recIncResp = await client.callTool({
       name: 'dispatch',
       arguments: { event: '[:counter/inc]', sync: true },
     });
     fatalIfError('dispatch [:counter/inc] (recorder arm)', recIncResp);
 
-    // The recorder samples per animation frame; poll the read-back on a
-    // short cadence until the change lands (bounded — the outer watchdog
-    // caps the whole harness). Each poll is itself a completed tool call.
-    const READ_DEADLINE = Date.now() + 8000;
-    let sawChange = false;
-    let lastReadText = '';
-    while (Date.now() < READ_DEADLINE && !sawChange) {
-      const readResp = await client.callTool({
-        name: 'read-recording',
-        arguments: { 'recording-id': recordingId },
-      });
-      fatalIfError('read-recording ' + recordingId, readResp);
-      lastReadText = responseText(readResp) || '';
-      // At least one change entry sampled — `:count <n>` with n >= 1.
-      const cm = /:count (\d+)/.exec(lastReadText);
-      if (cm && parseInt(cm[1], 10) >= 1) sawChange = true;
-      if (!sawChange) await new Promise((r) => setTimeout(r, 250));
-    }
-    if (!sawChange) {
+    // The dispatch-driven entry: the exact post-dispatch value, and only
+    // that — the drained baseline must not come back.
+    const driven = await pollReadRecording(
+      client,
+      recordingId,
+      {},
+      'post-dispatch',
+      (values) => values.includes(recTarget),
+    );
+    if (!driven.values.includes(recTarget)) {
       throw new Error(
-        'read-recording never returned a captured change for the ' +
-          'dispatch driven while recording (waited 8s): ' +
-          lastReadText.slice(0, 400),
+        'read-recording never returned an entry carrying the post-dispatch ' +
+          'value :value ' + recTarget + ' for the dispatch driven while ' +
+          'recording (waited 8s; values seen ' +
+          JSON.stringify(driven.values) + '): ' + driven.text.slice(0, 400),
+      );
+    }
+    if (driven.values.includes(recBefore)) {
+      throw new Error(
+        'read-recording MUST NOT return the drained baseline (:value ' +
+          recBefore + ') again — the post-drain log should carry only ' +
+          'dispatch-driven entries; got values ' +
+          JSON.stringify(driven.values) + ': ' + driven.text.slice(0, 400),
       );
     }
     // Stop + tear down the recorder.
@@ -351,7 +427,8 @@ runWithWatchdog(
     });
     fatalIfError('read-recording (stop)', stopResp);
     console.log(
-      'OK   record + read-recording -> driven change captured and returned as a completed read',
+      'OK   record + read-recording -> dispatch-driven change captured (:value ' +
+        recTarget + ') and returned as a completed read',
     );
 
     // ---- Restore the fixture's boot posture (shared-runtime hygiene) ----

--- a/tools/mcp-conformance/wire-vocab/README.md
+++ b/tools/mcp-conformance/wire-vocab/README.md
@@ -36,7 +36,7 @@ including:
   `canonical-markers` schema/fixture), asserted as the legitimate
   additive slot the operating-frame open-map schema must accept
 - `:rf/redacted`
-- progress notifications and event bundles
+- event bundles
 - reply-envelope trace rows
 - suppression indicator fields and shared input slots
 - operating-frame addresses and egress profiles

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/event_bundle_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/event_bundle_test.clj
@@ -2,20 +2,22 @@
   "Event-bundle wire-shape gate (rf2-mscih). Split out of
   `wire_vocab_test.clj` by rf2-7ckmwx.
 
-  re-frame2-pair-mcp's streaming `subscribe` tool ships matched events
-  under one of two payload-slots per the sub's topic:
+  An event bundle is the framework's per-run trace projection — one
+  record per `:rf.trace/dispatch-id`, the shape `(rf/trace-buffer
+  frame-id)` returns per spec/009 §Event-bundle projection + Tool-Pair
+  §Reading the per-frame trace ring. It reaches an MCP consumer as a
+  completed tool result: read directly through `eval-cljs`, while the
+  turn-shaped epoch reads (`trace-window` / `watch-epochs`) return
+  `:rf/epoch-record`s whose `:trace-events` are the same rows this
+  projection groups. The bundle is the load-bearing shape that lets AI
+  consumers reason about cause→effect at `:dispatch-id` granularity
+  without re-folding raw trace streams.
 
-    - `:event-bundles` — vector of event bundles on `:trace`/`:fx`/`:error`
-                    (event-bundle delivery, rf2-mscih). Each bundle
-                    matches `(rf/trace-buffer frame-id)` shape per
-                    spec/009 §Event-bundle projection + Tool-Pair §Reading
-                    the per-frame trace ring.
-    - `:events`   — flat vector on `:epoch` and `:frameless` (no
-                    event-bundle structure to bundle).
-
-  Pre-rf2-mscih every topic shipped under `:events`. The reshape is the
-  load-bearing change that lets AI consumers reason about cause→effect
-  at `:dispatch-id` granularity without re-folding raw streams.
+  History: the shape first crossed the MCP wire as the `:event-bundles`
+  slot of the streaming `subscribe` tool's per-tick payload (rf2-mscih —
+  `:trace`/`:fx`/`:error` topics shipped bundles, `:epoch`/`:frameless`
+  a flat `:events` vector). rf2-ahjbc retired that subsystem; this gate
+  pins the SHAPE, which outlived its first carrier.
 
   The gate shape mirrors the per-marker pattern:
     1. A canonical Malli schema for one event-bundle.
@@ -23,18 +25,18 @@
        event-bundle slots.
     3. (No source-text pin — the event-bundle SHAPE is the framework's
        `(rf/trace-buffer frame-id)` projection, not a re-frame2-pair-mcp
-       literal. The MCP server walks the drain envelope's `:event-bundles`
-       slot transparently.)"
+       literal.)"
   (:require [clojure.test :refer [deftest is testing]]
             [malli.core   :as m]
             [malli.error  :as me]))
 
 (defn- not-ungrouped?
   "True for any `:dispatch-id` value EXCEPT the `:ungrouped` sentinel.
-  `:ungrouped` is `group-by-event`'s marker for frameless events; the
-  runtime filters those out of event-bundle topics before bundling, so
-  an event-bundle on the wire MUST NOT carry it. Any other value (a
-  typed/numeric dispatch id) is application-shaped and accepted."
+  `:ungrouped` is `group-by-event`'s marker for frameless events
+  (registry-time emits, frame lifecycle outside a drain, REPL evals) —
+  the frameless bucket, not a run — so an event-bundle on the wire MUST
+  NOT carry it. Any other value (a typed/numeric dispatch id) is
+  application-shaped and accepted."
   [v]
   (not= :ungrouped v))
 
@@ -46,14 +48,14 @@
 
   Required slots:
     :dispatch-id        — the dispatch id. Any value EXCEPT the
-                          `:ungrouped` sentinel (rf2-mscih filters
-                          frameless events before bundling); the
-                          event-bundle topics never ship `:ungrouped`.
+                          `:ungrouped` sentinel (rf2-mscih filtered
+                          frameless events out before bundling); the
+                          bundled wire never ships `:ungrouped`.
                           Enforced at the schema level by the
                           `not-ungrouped?` predicate (rf2-voux7 finding 3):
                           the pre-fix `[:dispatch-id :any]` let a regression
                           that routed frameless / `:ungrouped` shapes onto
-                          an event-bundle topic validate, breaking the
+                          the bundled wire validate, breaking the
                           event-vs-frameless wire distinction this gate
                           claims to pin.
     :trace-events       — raw events for the run (vector). May
@@ -84,13 +86,12 @@
    [:parent-dispatch-id {:optional true} :any]])
 
 (def EventBundleVector
-  "A drain tick's `:event-bundles` slot — a vector of event bundles."
+  "A vector of event bundles — the per-frame ring projection's shape."
   [:sequential EventBundle])
 
 (def ^:private re-frame2-pair-event-bundle-fixture
-  "Canonical event-bundle shape for a single run — what
-  `subscribe`'s `:trace`/`:fx`/`:error` topics ship inside the
-  `:event-bundles` slot per tick (rf2-mscih)."
+  "Canonical event-bundle shape for a single run — one `group-by-event`
+  record (rf2-mscih)."
   {:dispatch-id        17
    :frame              :rf/default
    :event              [:cart/add-item {:sku "abc"}]
@@ -167,20 +168,19 @@
 (deftest event-bundle-rejects-frameless-shape
   ;; An `:ungrouped` `:dispatch-id` (`:ungrouped` is the
   ;; `group-by-event` sentinel for frameless events) MUST NOT ship on
-  ;; the event-bundle wire — the runtime filters frameless events
-  ;; out of event-bundle topics. Per rf2-voux7 finding 3 the schema
-  ;; now ENFORCES this directly via the `not-ungrouped?` predicate, in
-  ;; addition to the positive topic-routing pin below: the pre-fix
+  ;; the event-bundle wire — rf2-mscih filtered frameless events out
+  ;; before bundling. Per rf2-voux7 finding 3 the schema ENFORCES this
+  ;; directly via the `not-ungrouped?` predicate: the pre-fix
   ;; `[:dispatch-id :any]` let a regression that routed frameless /
-  ;; `:ungrouped` shapes onto an event-bundle topic validate, masking
+  ;; `:ungrouped` shapes onto the bundled wire validate, masking
   ;; the event-vs-frameless distinction this gate claims to pin.
   (testing "schema REJECTS an :ungrouped dispatch-id on an event-bundle"
     (let [frameless-bundle (assoc re-frame2-pair-event-bundle-fixture
                                   :dispatch-id :ungrouped)]
       (is (not (m/validate EventBundle frameless-bundle))
           (str "EventBundle MUST reject :dispatch-id :ungrouped — the "
-               ":ungrouped sentinel marks frameless events the runtime "
-               "filters OUT of event-bundle topics (rf2-mscih / "
+               ":ungrouped sentinel marks the frameless bucket, which "
+               "never ships as a bundle (rf2-mscih / "
                "rf2-voux7 finding 3). A bundle carrying it is a "
                "frameless-shape leak onto the event wire."))))
   (testing "schema REJECTS an :ungrouped bundle inside an EventBundleVector"

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
@@ -94,8 +94,9 @@
       ;; Match against `fx/strip-comments-and-strings`-neutered source so a
       ;; docstring / comment MENTION of `wire/with-indicators` can't satisfy
       ;; the routing pin — only a real CODE reference counts (rf2-qyfy1m).
-      ;; subscribe.cljs names the helper in two docstrings; without the
-      ;; strip, deleting its real splices would leave the pin green.
+      ;; (The motivating case was the since-retired subscribe.cljs, which
+      ;; named the helper in two docstrings — rf2-ahjbc; the hazard is
+      ;; generic to any tool source and the strip stays.)
       (let [src      (fx/read-source rel)
             stripped (fx/strip-comments-and-strings src)]
         (is (str/includes? stripped "wire/with-indicators")

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/reply_envelope_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/reply_envelope_test.clj
@@ -9,15 +9,15 @@
   reply envelope among the record-shaped tool egress
   (spec/Tool-Pair.md §`project-egress` record-shaped egress).
   `tools/mcp-conformance` is the client-side MCP gate for re-frame2-pair-mcp's
-  `trace-window` / `subscribe` surfaces — the off-box delivery path over the
+  `trace-window` / `watch-epochs` surfaces — the off-box delivery path over the
   authoritative per-frame trace rings (Tool-Pair §Reading the per-frame
   trace ring). But the surface validated only the MCP wrapper / event-bundle
   envelope and a simple counter dispatch — it pinned NO managed-async
   reply-envelope trace content. `rg \"EP-0011|reply-envelope|rf\\.reply\"
   tools/mcp-conformance` returned no matches before this gate.
 
-  This is the wire-vocab counterpart to the live-`subscribe` end-to-end
-  path: a pure-JVM schema + fixture + source-pin gate (the same shape as
+  This is the wire-vocab counterpart to the live turn-shaped end-to-end
+  path (`live-re-frame2-pair-turn-observation.cjs`): a pure-JVM schema + fixture + source-pin gate (the same shape as
   `event_bundle_test` / the `canonical-markers` table) that pins the
   ADDITIVE `:rf.reply/*` trace vocabulary an MCP consumer reads off a
   `trace-window` / event-bundle `:trace-events` row, so a rename / drop /
@@ -67,7 +67,7 @@
   re-validate the whole managed-effect suite (the runtime / resources /
   Xray tests own family-internal correctness + the live emission); it is
   the MCP-egress-visible contract that those keys reach a `trace-window` /
-  `subscribe` consumer un-renamed. See README §EP-0011 coverage boundary."
+  `watch-epochs` consumer un-renamed. See README §EP-0011 coverage boundary."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [malli.core :as m]

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -122,7 +122,8 @@
 ;; `re-frame.mcp-conformance.wire-vocab.source-pins`; and five
 ;; independent marker families moved to their own `*_test.clj`
 ;; namespaces (cursor-stale, result-envelope, redacted-sentinel,
-;; progress-notification, event-bundle). This ns keeps the CORE
+;; progress-notification, event-bundle; progress-notification has since
+;; gone with the streaming retirement, rf2-ahjbc). This ns keeps the CORE
 ;; wrapper-marker contract: fixture-conformance over `canonical-markers`,
 ;; the per-marker negative/live-emission gates, the marker-literal source
 ;; pins, the JS cross-encoding pin, server-coverage, the story-mcp
@@ -136,15 +137,15 @@
 ;;     home / doc-source moved — extend `source_pins.clj`. The generic
 ;;     fixture-conformance + source-pin sweeps in THIS file then cover it.
 ;;   - Non-wrapper marker (a `:reason` value, a bare scalar, a
-;;     tagged-union, a streaming-notification shape): give it its own
+;;     tagged-union): give it its own
 ;;     `*_test.clj` namespace (the cursor-stale / result-envelope /
-;;     redacted-sentinel / progress-notification / event-bundle files
+;;     redacted-sentinel / event-bundle files
 ;;     are the templates) requiring the shared `schemas` + `source-pins`
 ;;     support nses. Keep the schema co-located with its tests when it is
 ;;     referenced only by that family.
 ;;   - Cross-encoding (JS) pin: if a live `.cjs` harness re-encodes the
 ;;     shape, add the per-field grep-marker table next to the family's
-;;     fixture (see the overflow / progress JS pins).
+;;     fixture (see the overflow JS pin).
 ;;   - Near-miss anti-pin: every new marker should be swept by
 ;;     `near-miss-variants` (wrapper markers) or a bespoke variant set
 ;;     (scalars — see redacted-sentinel).

--- a/tools/re-frame2-pair-mcp/test/README.md
+++ b/tools/re-frame2-pair-mcp/test/README.md
@@ -52,8 +52,8 @@ What this layer covers:
   / `re-frame.schemas-conformance-test` / `re-frame.flows-conformance-test`
   on the framework side.
 - Snapshot pipeline / wire shape — `snapshot_test.cljs`,
-  `subscribe_test.cljs`, `list_subscriptions_test.cljs`,
-  `wire_cap_test.cljs`, `typical_tokens_test.cljs`. These exercise
+  `list_subscriptions_test.cljs`, `wire_cap_test.cljs`,
+  `typical_tokens_test.cljs`. These exercise
   the SHAPE the server emits without ever opening a socket; nREPL is
   stubbed at `nrepl/cljs-eval-value`.
 
@@ -89,9 +89,8 @@ runs deterministically. Exercises:
   `inputSchema.properties` keys. A renamed property fails this test
   (the rename is part of the wire contract; users' MCP-host configs
   depend on it).
-- Selected app-facing calls (`eval-cljs`, `snapshot`, `get-path`,
-  `subscribe`, and `unsubscribe`) return
-  `:reason :nrepl-port-not-found` with no app endpoint.
+- Selected app-facing calls (`eval-cljs`, `snapshot`, and `get-path`)
+  return `:reason :nrepl-port-not-found` with no app endpoint.
 - An unknown tool returns an `isError` envelope with
   `:reason :unknown-tool` before endpoint discovery.
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/probe_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/probe_test.cljs
@@ -1,7 +1,7 @@
 (ns re-frame2-pair-mcp.probe-test
   "Unit tests for the runtime preload probe + per-socket probe cache.
 
-  The probe runs one bencode round-trip per non-streaming tool entry
+  The probe runs one bencode round-trip per tool entry
   to confirm the re-frame2-pair runtime is loaded into the consumer build
   before any tool form is sent. That fixed cost would double cheap-read
   latency on every call, so it is cached: once the preload is confirmed
@@ -205,7 +205,7 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest ensure-runtime-shares-the-cache
-  ;; The five non-streaming tools call `ensure-runtime!`, which
+  ;; Every runtime-touching tool calls `ensure-runtime!`, which
   ;; delegates to `runtime-preloaded?`. The cache benefit MUST flow
   ;; through — one round-trip across many `ensure-runtime!` calls
   ;; for the same conn+build.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/sensitive_filter_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/sensitive_filter_test.cljs
@@ -281,7 +281,7 @@
          :trace-events [{:operation :rf.event/run-end :tags {:rf.trace/phase :run-end} :sensitive? true}]})))
 
 ;; ---------------------------------------------------------------------------
-;; strip-sensitive on epoch records — the streaming-surface defense-in-depth
+;; strip-sensitive on epoch records — the epoch-read defense-in-depth
 ;; scenarios. These match how trace-window-tool / watch-epochs-tool feed
 ;; epoch vectors through the same helper.
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes rf2-ahjbc (the PR #8815 audit reopen). Two residuals; no runtime, tool, schema or spec change.

## Residual 1 — the criterion-4 recorder witness was false-green

`tools/mcp-conformance/test/live-re-frame2-pair-turn-observation.cjs` accepted the first `:count n` with `n >= 1` anywhere in the read-recording text. `recording-sampler-tick!` (`runtime.cljs` ~3173) keys change detection on `(get last-values i ::unset)`, so the first tick records every signal's first sample as a baseline entry — the check held before anything was driven, and would have stayed green had the recorder missed the dispatch entirely.

The arm now: reads `[:count]` before `record`; polls `read-recording {drain true}` until the baseline lands and asserts it is exactly one entry carrying that pre-dispatch value; dispatches `[:counter/inc]`; then polls until an entry carries the exact post-dispatch value and asserts the drained baseline did not come back. Two small helpers (`entryValues`, `pollReadRecording`) replace the inline loop.

**Witness-side only (option a), with the count that decides it.** Readers whose meaning changes if the runtime stopped emitting baselines as entries: `runtime.cljs` header (2972) and tick comment (3174), `references/ops.md:243`, `references/recipes.md:299`, `tests/runtime/recorder_test.clj:21` (a structural test pinning "a steady signal yields one baseline entry"), `spec/003-Tool-Catalogue.md:2788`, `descriptors_data.cljs:1370` and the generated `tool-descriptors.edn` — eight, three of them in rf2-ov144's fence — plus the `{:changes N}` stop condition, which counts baselines. Not zero, and (b) would not have simplified the witness, which must assert the post-dispatch value either way.

## Residual 2 — current-tense carriers of the retired tools / files / fixture

Census over `tools/re-frame2-pair-mcp/`, `tools/mcp-conformance/`, `skills/re-frame2-pair/` for subscribe / unsubscribe / list-streams / get-stream-controls / subscribe_test / resource_controls / "progress stream" / notifications/progress / streaming / push-mode, run line-oriented and again with whitespace collapsed (control: both instruments found the two known README hits), excluding `.beads/` and `ai/`. `list-subscriptions` (retained, reactive sub cache) untouched.

Rewritten here (current-tense → retained routes, or dated history):
- `tools/re-frame2-pair-mcp/test/README.md` — `subscribe_test.cljs` dropped from the suite roster; the stdio-roundtrip degraded-call list now names what the script calls (`eval-cljs`, `snapshot`, `get-path`).
- `tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs` — the DRY-on-3 paragraph named the deleted subscribe harness and its progress-params validator as live siblings; rewritten around the six current siblings, with the retired validator as dated history.
- `tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs` — sibling pointer `-subscribe.cjs` → `-turn-observation.cjs`.
- `tools/mcp-conformance/test/live-re-frame2-pair-cofx.cjs` — "same rationale as the subscribe gate's `:queued`" → points at the turn-observation header.
- `tools/mcp-conformance/wire-vocab/test/.../event_bundle_test.clj` — the ns docstring described the streaming `subscribe` tool's per-tick `:event-bundles`/`:events` slots as live; now describes the bundle as the framework's `(rf/trace-buffer frame-id)` projection reached through `eval-cljs` / the epoch reads, with the subscribe carrier as dated history. Schema and assertions unchanged; "topic" wording in the `:ungrouped` pin reworded.
- `.../reply_envelope_test.clj` — `trace-window` / `subscribe` → `trace-window` / `watch-epochs`; "live-`subscribe` end-to-end path" → the turn-observation harness.
- `.../indicator_field_test.clj` — the `subscribe.cljs` rationale for stripping comments is now dated history.
- `.../wire_vocab_test.clj` — the split notes named a deleted `progress-notification` family as a template and "the overflow / progress JS pins".
- `tools/mcp-conformance/README.md` (live roster: "progress notifications" → turn-shaped observation), `TOKEN-BUDGETS.md` (the pair server "bounds streaming queues" → dated), `wire-vocab/README.md` ("progress notifications and event bundles"), `test/_runner.cjs` (`neither` posture described as "session-pin / streaming"; the fixture's `neither` tools are the two operating-frame session pins).
- `skills/re-frame2-pair/docs/TESTING.md` — the pure-test matrix listed "streaming eviction/timing"; `pure_test.cljs` has no such tests (epoch timing/matching is what it covers).
- `tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/probe_test.cljs`, `sensitive_filter_test.cljs` — "non-streaming tool" / "streaming-surface" qualifiers with nothing left to contrast against.

Delta against the audit's list: the audit's `event_bundle_test`, `reply_envelope_test`, `indicator_field_test` DO exist at tip — as `.clj` under `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/` — and are fixed here; `wire.cljs` exists too but is in the rf2-ov144 fence (below). New beyond the audit: overflow/redaction/cofx harness headers, `wire_vocab_test.clj`, the two mcp-conformance READMEs and TOKEN-BUDGETS, `_runner.cjs`, `TESTING.md`, `probe_test.cljs`, `sensitive_filter_test.cljs`.

**Routed to rf2-ov144 (its fence, not edited):** `tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs:237` (lists `subscribe` among tools routing through `with-indicators`), `.../tools/raw_state.cljs:153` (lists `subscribe` among state-emitting tools), `tools/re-frame2-pair-mcp/README.md:641` ("existing pull-mode / push-mode surfaces cover…").

**Hot zone, filed instead:** `spec/Security.md:266` still cites the deleted `live-re-frame2-pair-subscribe.cjs` as the live `--no-eval` wire gate → rf2-7c0mu (the carrier is now this harness's flag-gate riders).

Correct dated history, left alone: `skills/re-frame2-pair/STATUS.md:17,33`, `docs/initial-spec.md:151`, `spec/API.md:433`, `spec/DESIGN-RATIONALE.md:281–313`, `spec/003:2972–2979`, this harness's own header.

## Quality gates

All from the worker worktree by absolute path, each redirected to a per-attempt log with the runner's exit code captured in the same shell; numbers below are the captured ones. Every gate was re-run on the final base after the rebase onto `origin/main` (only `.beads/issues.jsonl` had moved).

| Gate | Command | Result |
|---|---|---|
| Pair package CLJS suite | `tools/re-frame2-pair-mcp`: `npm test` | exit 0 — 1108 tests, 4011 assertions, 0 failures |
| **The failing gate** — hermetic live suite | `tools/mcp-conformance`: `npm run test:re-frame2-pair-live-hermetic-suite` | exit 0 — 6 inner tests green; verbose transcript: `read-recording (drain) -> pre-dispatch baseline entry :value 7 drained`, then `dispatch-driven change captured (:value 8)` |
| mcp-conformance package suite | `tools/mcp-conformance`: `npm test` | exit 0 — all conformance green (the 6 live gates SKIP without a port, as designed; exercised by the hermetic run) |
| wire-vocab JVM gates (edited `.clj` docstrings) | `tools/mcp-conformance/wire-vocab`: `clojure -M:test` | exit 0 — 94 tests, 1026 assertions, 0 failures |
| skills-structural (`test.yml` job steps) | `skills/re-frame2-pair`: `bb tests/prompts/prompt_regression_test.clj` + every `tests/runtime/*_test.clj` | exit 0 — 13 files, 94 tests, 397 assertions, 0 failures |
| README-beside-source links | `python scripts/check_readme_links.py --ci` | exit 0; control: a planted broken link in the pair-mcp test README returned exit 1 naming it, restore verified by blob hash |
| docs-tree links/anchors (`skills/` is in its roots) | `python scripts/check_doc_slugs.py` | exit 0 |

**Sabotage control (the deliverable).** With the recorder-arm dispatch changed to `[:counter/stamp]` — an event that never touches `[:count]` (`:rf/time-ms` is a provided cofx, so the dispatch itself succeeds) — the hermetic suite returned **captured exit 1**, failing at the turn-observation harness with `read-recording never returned an entry carrying the post-dispatch value :value 8 … (values seen []) … :frames-sampled 489, :count 0, :entries []`. The pre-plant blob was `d3afd94d…`, the planted file `f21125c3…`, and the restore hashed back to `d3afd94d…` (`git hash-object` vs `HEAD:` blob). The old check would have read that same run green off the baseline entry. Then the real dispatch: **captured exit 0** (runs 2–4).

**Surfaces / CI.** `report-changed-surfaces.sh` over this diff arms `tools_jvm`, `mcp_conformance`, `mcp_live`, `skills_structural`. Omitted locally: the other `tools_jvm` lanes (story/xray JVM suites), the re-frame2-setup structural tests and `re-frame2-pair-fixture-pure` job the `skills_structural` output also schedules, story-mcp conformance, and `lint` / `docs`. `check_skill_mcp_drift.py --self-test` was not run: SKILL.md and `spec/**` are untouched.

**Environment notes.** `tools/re-frame2-pair-mcp` ignores `package-lock.json` (its `.gitignore`), so it was installed with `npm install`, not `npm ci`; `tools/mcp-conformance` has no playwright dependency, so playwright 1.59.1 was installed there with `--no-save` into the worktree's own tree — no junction to the mayor checkout was created. On Windows the orchestrator's SIGTERM reaches the `npx` shim and leaves the fixture's shadow JVM listening on 8030 with `.shadow-cljs/server.pid` intact after "cleanup complete (clean)"; each run's orphan was identified by `server.pid` + command line and killed before the next.
