### PR TITLE
fix(machines): hand a pre-announcement claim's /cancelled to the announcer (rf2-jqvgp, pass five)

### DIFF
--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -59,13 +59,17 @@
   ;;              The key is a map rather than a positional tuple — the map
   ;;              form lets readers ignore slot order.
   ;; Entry value:
-  ;;   {:handle <opaque host-clock handle>
+  ;;   {:handle <opaque host-clock handle; nil while arming>
   ;;    :reaction <subscription reaction or nil>
   ;;    :sub-watcher-key <key passed to add-watch>
   ;;    :resolved-ms <int>
   ;;    :epoch <int>
   ;;    :state <state-keyword>
-  ;;    :delay-source <:literal | :sub | :fn>}
+  ;;    :region <region name for a region :after, else nil>
+  ;;    :delay-source <:literal | :sub | :fn>
+  ;;    :token <this attempt's ownership token, `next-attempt-token`>
+  ;;    :announce <announcement cell, only on an arm that emits its own
+  ;;               /scheduled — see `defer-to-announcer?`>}
   ;;
   ;; Frame-scoping the outer key keeps the timer table out of process-global
   ;; state. Two consequences:
@@ -344,6 +348,47 @@
       (fn [] (not (frame/frame-incarnation-live? frame-id captured)))
       (constantly false))))
 
+(def ^:dynamic ^:private *announcing*
+  "The attempt tokens whose `:rf.machine.timer/scheduled` row is being
+  delivered on THIS thread. `schedule-after-timer!` binds it around its own
+  emit (a set, so a listener that arms a further timer nests cleanly) and
+  `defer-to-announcer?` reads it: a claim made on the announcing thread can
+  only come from a synchronous listener on the row itself, so the row is
+  already out and the claimant's `/cancelled` may follow it at once — before
+  anything the listener goes on to announce. A claim from any OTHER thread
+  cannot know whether the row is out yet, and hands its `/cancelled` to the
+  announcer instead (rf2-jqvgp)."
+  #{})
+
+(defn- defer-to-announcer?
+  "Decide, for an attempt this claimant has just won (`claim-entry!`), whether
+  its `:rf.machine.timer/cancelled` is owed by the ANNOUNCER rather than by
+  this claimant. True iff the attempt carries an announcement cell
+  (`:announce` — present only on an arm that emits its own `/scheduled`: the
+  hydration re-arm and the dynamic-delay reschedule), this is not the
+  announcing thread, and this claimant's CAS `nil -> reason` on the cell lands
+  first. That CAS both records the claim and carries `reason` to `announced!`,
+  which emits the `/cancelled` immediately AFTER its `/scheduled`. Losing the
+  CAS means the cell already reads `::announced`: the row is out, and the
+  claimant emits itself. An ordinary state-entry arm has no cell — the pure
+  side announced it before the fx ran — and always emits here (rf2-jqvgp)."
+  [claimed reason]
+  (when-let [cell (:announce claimed)]
+    (and (not (contains? *announcing* (:token claimed)))
+         (compare-and-set! cell nil reason))))
+
+(defn- announced!
+  "Consummate an attempt's announcement once its `/scheduled` row is out: CAS
+  the reservation's cell `nil -> ::announced`. Returns nil when no claimant
+  reached the sentinel first — every later claim emits its own `/cancelled` —
+  or the `reason` a claimant deposited while the row was still pending, which
+  the announcer now owes as the mirrored `/cancelled`. Nil-safe for an attempt
+  without a cell (rf2-jqvgp)."
+  [reservation]
+  (when-let [cell (:announce reservation)]
+    (when-not (compare-and-set! cell nil ::announced)
+      @cell)))
+
 (defn- claim-emit-release!
   "The ONE durable cancel step: claim the `[frame-id k]` slot by EXACTLY `token`,
   and only if that claim wins, emit the single owed `:rf.machine.timer/cancelled`
@@ -357,10 +402,19 @@
   entry + host handle survive byte-identical (rf2-ijlhj / rf2-j538f7.7).
   `owner-gone?` fences the shared `(frame,query-v)` subscription decrement inside
   `release-entry-resources!` (rf2-i4aj9c) so A's release cannot dispose a
-  reaction same-id B re-armed for the SAME query."
+  reaction same-id B re-armed for the SAME query.
+
+  rf2-jqvgp — the one owed trace is not always emitted HERE. When the claimed
+  attempt is a reservation whose own `/scheduled` row is not yet out — a claim
+  from another thread that landed between the reservation and the emit —
+  emitting now would put the closure BEFORE the row it closes.
+  `defer-to-announcer?` hands `reason` to the announcer in that case, and the
+  announcer emits the `/cancelled` immediately after its `/scheduled`. The
+  RELEASE is this claimant's either way: it won the sentinel."
   [frame-id k reason token owner-gone?]
   (when-let [claimed (claim-entry! frame-id k token)]
-    (emit-cancelled! frame-id k claimed reason)
+    (when-not (defer-to-announcer? claimed reason)
+      (emit-cancelled! frame-id k claimed reason))
     (release-entry-resources! frame-id claimed (:delay k) owner-gone?)))
 
 (defn- cancel-after-timer-entry!
@@ -378,7 +432,10 @@
   cancellation that claims an ARMING sentinel (`:handle nil`, host clock not yet
   armed) still emits the owed trace and releases the held subscription; the
   arming thread's publish phase then finds its token gone and cancels the
-  returned host handle.
+  returned host handle. When the sentinel's own `/scheduled` row is not yet out
+  (a claim from another thread inside the reserve-to-emit window), the trace is
+  handed to the announcer instead (`defer-to-announcer?`), which emits it right
+  after the row and arms nothing (rf2-jqvgp).
 
   Used by the reschedule single-cancels — `schedule-after-timer!`'s leading
   `:on-supersede` and `on-sub-changed!`'s `:on-resolution` — which DELIBERATELY
@@ -528,7 +585,27 @@
   `/scheduled` still precedes even a synchronously-firing host callback. The
   abort releases nothing further — see the comment at that recheck for why the
   one hold in flight is already gone with A, and why releasing it would land
-  on B."
+  on B.
+
+  rf2-jqvgp — reserving first opens the REVERSE window, and the cell on the
+  reservation closes it. Between the reservation and the emit the sentinel is
+  claimable but its row is not yet out, so a cleanup on another JVM thread
+  that claims it there must not emit `/cancelled` ahead of the `/scheduled` it
+  closes. A claimant therefore CASes its reason into the reservation's
+  `:announce` cell instead of emitting (`defer-to-announcer?`), and this fn,
+  once its emit has returned, CASes the same cell to consummate the
+  announcement (`announced!`); whichever CAS lands second reads the other's
+  verdict. A claimant that lost emits itself, because the row is out; an
+  announcer that lost emits the deferred `/cancelled` right after its
+  `/scheduled` and arms nothing. A claim made ON the announcing thread — a
+  synchronous listener on the row — bypasses the cell (`*announcing*`), since
+  for it the row is already out, so its closure lands before anything the
+  listener announces next (a same-id successor re-arming the same key would
+  otherwise announce between A's row and A's closure, and the two are
+  indistinguishable by `(actor-id, state, epoch)`). Every announced attempt
+  remains cancellable from the instant it is visible, the host clock is still
+  armed after the row, and no new trace vocabulary or `:reason` value is
+  involved: the deferred row carries the claimant's own reason."
   [frame-id parent-id invoke-id state delay-key epoch server? snapshot
    {:keys [emit-scheduled-trace? owner-gone?]}]
   (let [delay-source (transition/classify-delay-source delay-key)
@@ -619,7 +696,14 @@
                              :state           state
                              :region          region
                              :delay-source    delay-source
-                             :token           token}]
+                             :token           token
+                             ;; rf2-jqvgp — the announcement cell, present only
+                             ;; when THIS arm emits its own `/scheduled` below:
+                             ;; the hand-off between a claimant that reaches
+                             ;; the sentinel before that row is out and the
+                             ;; announcer that then owes its closure
+                             ;; (`defer-to-announcer?` / `announced!`).
+                             :announce        (when emit-scheduled-trace? (atom nil))}]
             ;; rf2-jqvgp — the reservation is taken BEFORE the `/scheduled`
             ;; fan-out below, not after it. The row's listener runs
             ;; synchronously, so an attempt that is only reserved afterwards is
@@ -637,21 +721,26 @@
             ;; synchronously cannot beat `/scheduled` to the stream.
             (swap! after-timers assoc-in [frame-id k] reservation)
             (when emit-scheduled-trace?
-              (trace/emit! :rf.machine :rf.machine.timer/scheduled
-                           (cond-> {;; the timer's owning actor INSTANCE;
-                                    ;; `:machine-id` is reserved for the
-                                    ;; registered TYPE.
-                                    :actor-id     parent-id
-                                    :state        state
-                                    :delay        resolved-ms
-                                    :delay-source delay-source
-                                    :epoch        epoch
-                                    :frame        frame-id}
-                             ;; canonical subscription identity:
-                             ;; `:rf.sub/id` + `:rf.sub/query-v`.
-                             (= :sub delay-source)
-                             (assoc :rf.sub/id      (first delay-key)
-                                    :rf.sub/query-v (vec delay-key)))))
+              ;; rf2-jqvgp — mark THIS thread as the row's announcer for the
+              ;; duration of the fan-out, so a listener on the row that claims
+              ;; this attempt (the destroy sweep, typically) knows the row is
+              ;; already out and emits its `/cancelled` at once, in place.
+              (binding [*announcing* (conj *announcing* token)]
+                (trace/emit! :rf.machine :rf.machine.timer/scheduled
+                             (cond-> {;; the timer's owning actor INSTANCE;
+                                      ;; `:machine-id` is reserved for the
+                                      ;; registered TYPE.
+                                      :actor-id     parent-id
+                                      :state        state
+                                      :delay        resolved-ms
+                                      :delay-source delay-source
+                                      :epoch        epoch
+                                      :frame        frame-id}
+                               ;; canonical subscription identity:
+                               ;; `:rf.sub/id` + `:rf.sub/query-v`.
+                               (= :sub delay-source)
+                               (assoc :rf.sub/id      (first delay-key)
+                                      :rf.sub/query-v (vec delay-key))))))
             ;; rf2-jqvgp — that `/scheduled` emit is the LAST callback-bearing
             ;; step before the durable arm. `trace/emit!` invokes listeners
             ;; SYNCHRONOUSLY, so a `:rf.machine.timer/scheduled` listener can
@@ -677,142 +766,159 @@
             ;; `cancel-snapshotted-entry!` with this same `owner-gone?`: the
             ;; shared decrement is skipped, while the sentinel's own `:handle`
             ;; (nil) and never-attached watcher are released harmlessly.
-            (if (owner-gone?)
-             ;; ABORT — reclaim the reservation by its OWN attempt token, which
-             ;; both keeps the A-derived sentinel out of B's table and closes the
-             ;; `/scheduled` row just emitted with the mirrored `/cancelled`.
-             ;; `:on-frame-destroy` is the accurate member of the closed
-             ;; `:reason` set: `owner-gone?` can flip only through
-             ;; `destroy-frame!` + same-id reconstruction, so the bearing frame
-             ;; incarnation WAS destroyed (Spec 005 §Trace event catalogue). No
-             ;; new vocabulary, and idempotent — the destroy's own
-             ;; `cancel-all-timers!` sweep may already have claimed this sentinel
-             ;; on the listener's own stack, in which case this CAS fails,
-             ;; nothing is emitted twice, and the pair is already closed.
-             (cancel-snapshotted-entry! frame-id k reservation
-                                        :on-frame-destroy owner-gone?)
-             (let [handle
-                   ;; Shared positive-delay-guarded arm — the host-clock arm
-                   ;; step both timer artefacts share. `resolved-ms` is already
-                   ;; known-positive here (the non-positive case was handled by
-                   ;; the prior `cond` branch), so the guard is a no-op
-                   ;; pass-through.
-                   (managed-timer/arm!
-                     (fn []
-                       ;; ATOMICALLY claim THIS fire's slot — dispatch AUTHORITY
-                       ;; + reap in a single swap (mirrors core `:dispatch-later`,
-                       ;; rf2-j538f7.2). If a cleanup / supersede claimed the slot
-                       ;; first — even a synchronous host callback firing before
-                       ;; `arm!` returns, or a JVM cleanup racing the arm — this
-                       ;; fire has LOST authority: suppress the dead-on-arrival
-                       ;; dispatch and touch nothing (the claimer already released
-                       ;; our resources). On the live path the claim wins:
-                       (when-let [claimed (claim-entry! frame-id k token)]
-                         (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-                           ;; Stamp `:source :after-timer` so the Epoch panel's
-                           ;; DISPATCH step labels it "from :after timer" and
-                           ;; Xray's L2 timeline can prefix the row + per-source
-                           ;; filter pills can discriminate timer-fired cascades
-                           ;; (closed-enum per Spec-Schemas
-                           ;; §`:rf/dispatch-envelope`). Per Spec 005 §Hierarchy
-                           ;; interaction: carry the scheduling node's decl-path
-                           ;; (`invoke-id`) so the pure side routes the firing to
-                           ;; the correct per-path epoch — colliding delay-keys
-                           ;; across hierarchy levels resolve unambiguously.
-                           (dispatch! [parent-id [:rf.machine.timer/after-elapsed
-                                                  delay-key epoch (vec invoke-id)]]
-                                      {:frame  frame-id
-                                       :source :after-timer}))
-                         ;; A one-shot `:after` timer fires exactly once per
-                         ;; arming (XState §delayed transitions). Release THIS
-                         ;; fire's sub-reaction watcher + held subscription
-                         ;; ref-count (the host handle just fired, so its cancel
-                         ;; is a harmless no-op). This is what keeps a
-                         ;; GUARD-SUPPRESSED fire (no state exit → no `:on-exit`
-                         ;; cancel) from stranding the entry, and stops a spent
-                         ;; one-shot from re-arming on a later sub-vec change. The
-                         ;; release is silent — a fired timer was not cancelled,
-                         ;; so no `:cancelled` trace is emitted.
-                         (release-entry-resources! frame-id claimed (:delay k))))
-                     resolved-ms)
-                   ;; PHASE 2 — PUBLISH the host handle IFF this attempt still
-                   ;; owns the slot. `swap-vals!` is a pure replace-if-token-
-                   ;; present; the cancel/add-watch side effects below ride the
-                   ;; CAS-derived old snapshot, never inside the swap.
-                   [old _new]
-                   (swap-vals! after-timers
-                               (fn [m]
-                                 (if (= token (:token (get-in m [frame-id k])))
-                                   (assoc-in m [frame-id k :handle] handle)
-                                   m)))
-                   owned? (= token (:token (get-in old [frame-id k])))]
-               (if owned?
-                 (do
-                   ;; We own the now-armed slot — attach the dynamic-delay
-                   ;; change-watcher (a sub-value change cancels + reschedules).
-                   ;; Attached ONLY here so a publication that LOST to cleanup
-                   ;; never strands an orphan watcher on a released reaction.
-                   (when (and reaction watch-key)
-                     ;; Surface `add-watch` exceptions rather than silently
-                     ;; dropping them; the re-resolution watcher won't fire if
-                     ;; `add-watch` failed, so the author needs a signal the
-                     ;; dynamic-delay subscription is not actually wired up.
-                     (try
-                       ;; ACTIVATE, then watch — the order is the whole fix for
-                       ;; rf2-wmpte. It first landed in the internal observation
-                       ;; port's `build-node-handle!` (rf2-8cnxg / rf2-jt8vz);
-                       ;; that port was retired on 2026-08-21 (rf2-63t1i), so
-                       ;; the rule now lives at each of its call sites rather
-                       ;; than in one canonical statement.
-                       ;;
-                       ;; `resolve-delay-ms`'s "subscribe to keep the reaction
-                       ;; live" is FALSE on the ratom family, and silently so. A
-                       ;; `reagent.ratom/Reaction` learns its sources ONLY through
-                       ;; `deref-capture`; the plain `deref` `resolve-delay-ms`
-                       ;; takes runs outside `*ratom-context*` with no `auto-run`,
-                       ;; so it runs the body raw and leaves `watching` nil. The
-                       ;; node is then in no source's watcher set: `_handle-change`
-                       ;; is never called, `_queued-run` short-circuits on
-                       ;; `(some? watching)`, and the `add-watch` below RECORDS a
-                       ;; callback that can never fire. The first arming resolved
-                       ;; correctly and the dynamic delay then never re-resolved
-                       ;; for the rest of the arming's life — no trace, no error.
-                       ;;
-                       ;; A Reagent COMPONENT never hits this because its render
-                       ;; IS the capture context; a timer is not a component, so
-                       ;; nothing but this call supplies one. It runs BEFORE
-                       ;; `add-watch` so activation's own first recompute cannot
-                       ;; fan a priming change at this watcher. Total and
-                       ;; idempotent: the React-hook spine (UIx) is
-                       ;; push-based from birth and
-                       ;; publishes no hook, so the routed chain-bottom returns
-                       ;; nil; plain-atom / JVM derived values have no capture
-                       ;; step. A throw here lands on the same
-                       ;; `:recovery :static-delay` signal as a failed
-                       ;; `add-watch` — both mean the dynamic delay is not wired.
-                       (interop/activate-derived-value! reaction)
-                       (add-watch reaction watch-key
-                                  (fn [_ _ old-v new-v]
-                                    (on-sub-changed! frame-id parent-id invoke-id
-                                                     delay-key state old-v new-v)))
-                       (catch #?(:clj Throwable :cljs :default) e
-                         ;; Owning actor INSTANCE under `:actor-id`; canonical
-                         ;; subscription identity (`:rf.sub/id` + `:rf.sub/query-v`).
-                         (trace/emit-error! :rf.error/machine-after-watch-failed
-                                            {:exception      e
-                                             :actor-id       parent-id
-                                             :rf.sub/id      (first delay-key)
-                                             :rf.sub/query-v (vec delay-key)
-                                             :frame          frame-id
-                                             :recovery       :static-delay}))))
-                   handle)
-                 ;; A cleanup / supersede / synchronous fire claimed the sentinel
-                 ;; while we armed — do NOT republish; cancel the orphan handle
-                 ;; (idempotent even if it already fired). The claimer already
-                 ;; released the reaction and emitted the single owed `:cancelled`
-                 ;; trace (or, for a self-fire, dispatched + released silently).
-                 (do (managed-timer/cancel! handle)
-                     nil)))))))))))
+            (let [deferred (announced! reservation)]
+             (cond
+              deferred
+              ;; A cleanup on ANOTHER thread claimed the sentinel between the
+              ;; reservation and the row — the window the reserve-first
+              ;; ordering opened. It released the entry's resources and,
+              ;; because the row was not yet out, handed its reason here
+              ;; instead of emitting. The announcer now owes the mirrored
+              ;; `/cancelled`, immediately after its `/scheduled`, and arms
+              ;; NOTHING: the attempt is already closed, so a host arm could
+              ;; only be cancelled again by the publish CAS's failure.
+              ;; `owner-gone?` is not consulted — the claimant already
+              ;; decided the shared release under its own predicate.
+              (emit-cancelled! frame-id k reservation deferred)
+
+              (owner-gone?)
+              ;; ABORT — reclaim the reservation by its OWN attempt token, which
+              ;; both keeps the A-derived sentinel out of B's table and closes the
+              ;; `/scheduled` row just emitted with the mirrored `/cancelled`.
+              ;; `:on-frame-destroy` is the accurate member of the closed
+              ;; `:reason` set: `owner-gone?` can flip only through
+              ;; `destroy-frame!` + same-id reconstruction, so the bearing frame
+              ;; incarnation WAS destroyed (Spec 005 §Trace event catalogue). No
+              ;; new vocabulary, and idempotent — the destroy's own
+              ;; `cancel-all-timers!` sweep may already have claimed this sentinel
+              ;; on the listener's own stack, in which case this CAS fails,
+              ;; nothing is emitted twice, and the pair is already closed.
+              (cancel-snapshotted-entry! frame-id k reservation
+                                         :on-frame-destroy owner-gone?)
+
+              :else
+              (let [handle
+                    ;; Shared positive-delay-guarded arm — the host-clock arm
+                    ;; step both timer artefacts share. `resolved-ms` is already
+                    ;; known-positive here (the non-positive case was handled by
+                    ;; the prior `cond` branch), so the guard is a no-op
+                    ;; pass-through.
+                    (managed-timer/arm!
+                      (fn []
+                        ;; ATOMICALLY claim THIS fire's slot — dispatch AUTHORITY
+                        ;; + reap in a single swap (mirrors core `:dispatch-later`,
+                        ;; rf2-j538f7.2). If a cleanup / supersede claimed the slot
+                        ;; first — even a synchronous host callback firing before
+                        ;; `arm!` returns, or a JVM cleanup racing the arm — this
+                        ;; fire has LOST authority: suppress the dead-on-arrival
+                        ;; dispatch and touch nothing (the claimer already released
+                        ;; our resources). On the live path the claim wins:
+                        (when-let [claimed (claim-entry! frame-id k token)]
+                          (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+                            ;; Stamp `:source :after-timer` so the Epoch panel's
+                            ;; DISPATCH step labels it "from :after timer" and
+                            ;; Xray's L2 timeline can prefix the row + per-source
+                            ;; filter pills can discriminate timer-fired cascades
+                            ;; (closed-enum per Spec-Schemas
+                            ;; §`:rf/dispatch-envelope`). Per Spec 005 §Hierarchy
+                            ;; interaction: carry the scheduling node's decl-path
+                            ;; (`invoke-id`) so the pure side routes the firing to
+                            ;; the correct per-path epoch — colliding delay-keys
+                            ;; across hierarchy levels resolve unambiguously.
+                            (dispatch! [parent-id [:rf.machine.timer/after-elapsed
+                                                   delay-key epoch (vec invoke-id)]]
+                                       {:frame  frame-id
+                                        :source :after-timer}))
+                          ;; A one-shot `:after` timer fires exactly once per
+                          ;; arming (XState §delayed transitions). Release THIS
+                          ;; fire's sub-reaction watcher + held subscription
+                          ;; ref-count (the host handle just fired, so its cancel
+                          ;; is a harmless no-op). This is what keeps a
+                          ;; GUARD-SUPPRESSED fire (no state exit → no `:on-exit`
+                          ;; cancel) from stranding the entry, and stops a spent
+                          ;; one-shot from re-arming on a later sub-vec change. The
+                          ;; release is silent — a fired timer was not cancelled,
+                          ;; so no `:cancelled` trace is emitted.
+                          (release-entry-resources! frame-id claimed (:delay k))))
+                      resolved-ms)
+                    ;; PHASE 2 — PUBLISH the host handle IFF this attempt still
+                    ;; owns the slot. `swap-vals!` is a pure replace-if-token-
+                    ;; present; the cancel/add-watch side effects below ride the
+                    ;; CAS-derived old snapshot, never inside the swap.
+                    [old _new]
+                    (swap-vals! after-timers
+                                (fn [m]
+                                  (if (= token (:token (get-in m [frame-id k])))
+                                    (assoc-in m [frame-id k :handle] handle)
+                                    m)))
+                    owned? (= token (:token (get-in old [frame-id k])))]
+                (if owned?
+                  (do
+                    ;; We own the now-armed slot — attach the dynamic-delay
+                    ;; change-watcher (a sub-value change cancels + reschedules).
+                    ;; Attached ONLY here so a publication that LOST to cleanup
+                    ;; never strands an orphan watcher on a released reaction.
+                    (when (and reaction watch-key)
+                      ;; Surface `add-watch` exceptions rather than silently
+                      ;; dropping them; the re-resolution watcher won't fire if
+                      ;; `add-watch` failed, so the author needs a signal the
+                      ;; dynamic-delay subscription is not actually wired up.
+                      (try
+                        ;; ACTIVATE, then watch — the order is the whole fix for
+                        ;; rf2-wmpte. It first landed in the internal observation
+                        ;; port's `build-node-handle!` (rf2-8cnxg / rf2-jt8vz);
+                        ;; that port was retired on 2026-08-21 (rf2-63t1i), so
+                        ;; the rule now lives at each of its call sites rather
+                        ;; than in one canonical statement.
+                        ;;
+                        ;; `resolve-delay-ms`'s "subscribe to keep the reaction
+                        ;; live" is FALSE on the ratom family, and silently so. A
+                        ;; `reagent.ratom/Reaction` learns its sources ONLY through
+                        ;; `deref-capture`; the plain `deref` `resolve-delay-ms`
+                        ;; takes runs outside `*ratom-context*` with no `auto-run`,
+                        ;; so it runs the body raw and leaves `watching` nil. The
+                        ;; node is then in no source's watcher set: `_handle-change`
+                        ;; is never called, `_queued-run` short-circuits on
+                        ;; `(some? watching)`, and the `add-watch` below RECORDS a
+                        ;; callback that can never fire. The first arming resolved
+                        ;; correctly and the dynamic delay then never re-resolved
+                        ;; for the rest of the arming's life — no trace, no error.
+                        ;;
+                        ;; A Reagent COMPONENT never hits this because its render
+                        ;; IS the capture context; a timer is not a component, so
+                        ;; nothing but this call supplies one. It runs BEFORE
+                        ;; `add-watch` so activation's own first recompute cannot
+                        ;; fan a priming change at this watcher. Total and
+                        ;; idempotent: the React-hook spine (UIx) is
+                        ;; push-based from birth and
+                        ;; publishes no hook, so the routed chain-bottom returns
+                        ;; nil; plain-atom / JVM derived values have no capture
+                        ;; step. A throw here lands on the same
+                        ;; `:recovery :static-delay` signal as a failed
+                        ;; `add-watch` — both mean the dynamic delay is not wired.
+                        (interop/activate-derived-value! reaction)
+                        (add-watch reaction watch-key
+                                   (fn [_ _ old-v new-v]
+                                     (on-sub-changed! frame-id parent-id invoke-id
+                                                      delay-key state old-v new-v)))
+                        (catch #?(:clj Throwable :cljs :default) e
+                          ;; Owning actor INSTANCE under `:actor-id`; canonical
+                          ;; subscription identity (`:rf.sub/id` + `:rf.sub/query-v`).
+                          (trace/emit-error! :rf.error/machine-after-watch-failed
+                                             {:exception      e
+                                              :actor-id       parent-id
+                                              :rf.sub/id      (first delay-key)
+                                              :rf.sub/query-v (vec delay-key)
+                                              :frame          frame-id
+                                              :recovery       :static-delay}))))
+                    handle)
+                  ;; A cleanup / supersede / synchronous fire claimed the sentinel
+                  ;; while we armed — do NOT republish; cancel the orphan handle
+                  ;; (idempotent even if it already fired). The claimer already
+                  ;; released the reaction and emitted the single owed `:cancelled`
+                  ;; trace (or, for a self-fire, dispatched + released silently).
+                  (do (managed-timer/cancel! handle)
+                      nil))))))))))))
 
 (defn after-schedule-fx
   "fx handler for `:rf.machine/after-schedule`. Per Spec 005 §Delayed

--- a/implementation/machines/test/re_frame/after_timer_announce_claim_race_test.clj
+++ b/implementation/machines/test/re_frame/after_timer_announce_claim_race_test.clj
@@ -1,0 +1,268 @@
+(ns re-frame.after-timer-announce-claim-race-test
+  "rf2-jqvgp (audit of PR #8965) — a cleanup that claims an `:after` attempt's
+  timer-table sentinel BEFORE the attempt's `:rf.machine.timer/scheduled` row
+  is out must not put its `:rf.machine.timer/cancelled` in front of that row.
+
+  ## The gap
+
+  PR #8965 moved the timer-table reservation ABOVE the `/scheduled` emit in
+  `schedule-after-timer!`, so an announced attempt is cancellable from the
+  instant it is visible. That opened the reverse window: between the
+  reservation and the emit the sentinel is claimable but the row is not yet
+  out. On the JVM a concurrent cleanup — state exit, actor destroy, epoch
+  restore, frame destroy — can claim it there, and `claim-emit-release!`
+  emitted `/cancelled` on the claimant's own stack, immediately. The arming
+  thread then emitted `/scheduled`; its owner check still passed (none of
+  those cleanups changes the frame incarnation), the host arm was attempted,
+  publication lost to the earlier claim, and no later row closed the now-last
+  `/scheduled`. The stream read `/cancelled` then an orphan `/scheduled` — the
+  pairing contract Spec 005 §Trace event catalogue states on `(actor-id,
+  state, epoch)`, inverted.
+
+  ## The interleaving is driven, not raced
+
+  `trace/emit!` is wrapped for the duration of one hydration. On the attempt's
+  own `/scheduled` row — the point at which the sentinel is reserved and the
+  row is not yet delivered — the cleanup runs to completion on a second
+  thread and is joined before the real emit proceeds. That reaches the exact
+  reserve-to-emit boundary on every run; nothing here depends on scheduling
+  luck, and there is no sleep. A raw `Thread` rather than a `future`, on
+  purpose: `future` conveys the caller's dynamic bindings, and the repair
+  marks the announcing THREAD through one, so a conveyed cleanup would read as
+  a synchronous listener on the row and defeat the control.
+
+  The second test is the control on the other side of that thread mark: a
+  claim made ON the announcing thread comes from a listener on the row itself,
+  so the row is already out and the `/cancelled` must follow it immediately —
+  before anything the listener goes on to announce. A repair that handed
+  every pre-consummation claim to the announcer would put a same-id
+  successor's `/scheduled` between A's row and A's closure, and a consumer
+  pairing on `(actor-id, state, epoch)` — identical for A and B here — would
+  read B's fresh timer as the cancelled one.
+
+  JVM only (`.clj`): the window exists only where a second thread can run
+  between two instructions of the arm; CLJS has no such interleaving, and the
+  same-thread case is already pinned on both hosts by
+  `machine_hydration_reconcile_incarnation_fence_cljs_test`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            ;; Loading `re-frame.machines` installs the artefact's late-bind
+            ;; hooks + reserved fxs; under a single-ns run nothing else does.
+            [re-frame.machines]
+            [re-frame.machines.hydrate :as m-hydrate]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines.timer :as timer]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  mtest/trace-capture-fixture)
+
+;; ---------------------------------------------------------------------------
+;; Fixtures
+;; ---------------------------------------------------------------------------
+
+(def ^:private frame-counter (atom 0))
+
+(defn- fresh-frame!
+  "A frame of the given platform under an id no other test in this shared
+  process has used. `make-frame` opts are FLAT."
+  [platform]
+  (let [fid (keyword "rf.announce" (str (name platform) (swap! frame-counter inc)))]
+    (rf/make-frame {:id fid :platform platform})
+    fid))
+
+(defn- inner
+  "`frame-id`'s inner `:after` timer table, or `{}` when it holds none."
+  [frame-id]
+  (get @timer/after-timers frame-id {}))
+
+(defn- server-runtime-db
+  "Run `machine-id` into its `:after`-bearing state on a real SERVER frame,
+  assert it armed no host timer, and return the resulting runtime-db value —
+  a genuine server-produced hydration slice rather than a literal."
+  [machine-id]
+  (let [sfid (fresh-frame! :server)]
+    (rf/dispatch-sync [machine-id [:go]] {:frame sfid})
+    (is (empty? (inner sfid))
+        "precondition: the SERVER armed no `:after` host timer")
+    (frame/frame-runtime-db-value sfid)))
+
+(defn- install!
+  "Replace `frame-id`'s runtime-db with `runtime-db` and run the machines
+  hydration seam — what `:rf/hydrate` does once its runtime-db effect has
+  committed."
+  [frame-id runtime-db]
+  (frame/replace-runtime-db! frame-id runtime-db)
+  (m-hydrate/rearm-after-timers! frame-id))
+
+(def ^:private literal-machine
+  "One literal-delay `:after`, so the hydration arm is exactly one attempt and
+  the only resources in play are the sentinel and the host handle."
+  {:initial :idle
+   :data    {}
+   :states  {:idle    {:on {:go :waiting}}
+             :waiting {:after {5000 {:target :timeout}}}
+             :timeout {}}})
+
+(def ^:private pair-keys
+  "The slots `:rf.machine.timer/cancelled` mirrors from `/scheduled` so a
+  consumer can pair the two rows."
+  [:actor-id :state :delay :epoch :frame])
+
+(defn- timer-ops
+  "The captured `/scheduled` and `/cancelled` rows, oldest first."
+  []
+  (filterv (comp #{:rf.machine.timer/scheduled :rf.machine.timer/cancelled}
+                 :operation)
+           (mtest/captured-events)))
+
+(defn- on-another-thread!
+  "Run `f` to completion on a fresh raw `Thread` and join it, rethrowing
+  anything it threw. NOT a `future` — see the ns docstring."
+  [f]
+  (let [failure (atom nil)
+        t       (Thread. ^Runnable (fn [] (try (f)
+                                               (catch Throwable e
+                                                 (reset! failure e)))))]
+    (.start t)
+    (.join t)
+    (when-let [e @failure] (throw e))))
+
+(defn- hydrate-with-cleanup-in-the-window!
+  "Hydrate `frame-id` with `runtime-db`, and at the reserve-to-emit boundary
+  of its one arm run `(cleanup! frame-id k)` to completion on a second
+  thread. Returns `{:bit? :reserved? :arms}`: whether the boundary was
+  reached, whether the sentinel was already in the table there, and how many
+  host clocks were armed."
+  [frame-id runtime-db cleanup!]
+  (let [orig-emit! trace/emit!
+        bit?       (atom false)
+        reserved?  (atom nil)
+        arms       (atom 0)]
+    (with-redefs [interop/schedule-after!   (fn [_thunk _ms] (swap! arms inc) ::handle)
+                  interop/cancel-scheduled! (fn [_h] nil)
+                  trace/emit!
+                  (fn [op operation tags]
+                    (when (and (= :rf.machine.timer/scheduled operation)
+                               (compare-and-set! bit? false true))
+                      ;; The attempt's sentinel is reserved; its row is not
+                      ;; yet delivered. The cleanup claims it HERE.
+                      (let [[k _entry] (first (inner frame-id))]
+                        (reset! reserved? (some? k))
+                        (when k (on-another-thread! #(cleanup! frame-id k)))))
+                    (orig-emit! op operation tags))]
+      (install! frame-id runtime-db))
+    {:bit? @bit? :reserved? @reserved? :arms @arms}))
+
+;; ---------------------------------------------------------------------------
+;; The audit's interleaving — a concurrent claim inside the window
+;; ---------------------------------------------------------------------------
+
+(deftest a-claim-before-the-row-is-out-closes-the-row-rather-than-preceding-it
+  (doseq [[label reason cleanup!]
+          [["frame destroy" :on-frame-destroy
+            (fn [frame _k] (timer/cancel-all-timers! frame))]
+           ["epoch restore" :on-restore
+            (fn [frame _k] (timer/cancel-frame-timers-on-restore! frame))]
+           ["actor destroy" :on-destroy
+            (fn [frame k] (timer/cancel-actor-timers! frame (:parent k)))]
+           ["state exit" :on-exit
+            (fn [frame k] (timer/after-cancel-fx {:frame frame}
+                                                 {:rf/parent-id (:parent k)
+                                                  :rf/invoke-id (:spawn k)}))]]]
+    (testing (str "cleanup owner: " label)
+      (let [mid  (keyword "announce" (name reason))
+            _    (rf/reg-machine mid literal-machine)
+            rt   (server-runtime-db mid)
+            cfid (fresh-frame! :client)]
+        (is (empty? (inner cfid))
+            "precondition: the client frame holds no prior timer, so the
+             hydration is exactly one arm")
+        (mtest/reset-captured!)
+        (let [{:keys [bit? reserved? arms]}
+              (hydrate-with-cleanup-in-the-window! cfid rt cleanup!)
+              scheduled (mtest/events-of :rf.machine.timer/scheduled)
+              cancelled (mtest/events-of :rf.machine.timer/cancelled)]
+          (is (true? bit?)
+              "the arm's own `/scheduled` row was intercepted (seam exercised)")
+          (is (true? reserved?)
+              (str "precondition: at that boundary the attempt was already "
+                   "RESERVED — cancellable before its row was out, which is "
+                   "PR #8965's ordering and the window under test"))
+          (is (= [:rf.machine.timer/scheduled :rf.machine.timer/cancelled]
+                 (mapv :operation (timer-ops)))
+              (str "the announcement first, its closure second. A claimant "
+                   "that emits on its own stack inside this window puts "
+                   "`/cancelled` BEFORE the row it closes, and the "
+                   "`/scheduled` that follows is then the last row for this "
+                   "`(actor-id, state, epoch)` — an orphan nothing downstream "
+                   "retracts"))
+          (is (= 1 (count scheduled))
+              "exactly one `/scheduled` — the attempt announced itself once")
+          (is (= 1 (count cancelled))
+              "and exactly one `/cancelled` closes it — never two, never none")
+          (is (= reason (:reason (:tags (first cancelled))))
+              (str "stamped with the CLAIMANT's own reason from the closed "
+                   "set — whoever emits the row, the cause is the cleanup's"))
+          (is (= (select-keys (:tags (first scheduled)) pair-keys)
+                 (select-keys (:tags (first cancelled)) pair-keys))
+              "and the two rows pair on the mirrored payload slots")
+          (is (empty? (inner cfid))
+              "the claimed attempt was never published")
+          (is (zero? arms)
+              (str "and no host clock was armed for an attempt already "
+                   "claimed — the arm sits behind the consummated "
+                   "announcement, so a claim that reached the sentinel first "
+                   "spends nothing on the host")))))))
+
+;; ---------------------------------------------------------------------------
+;; Control — a claim ON the announcing thread is a claim on a delivered row
+;; ---------------------------------------------------------------------------
+
+(deftest a-same-thread-claim-from-the-rows-own-listener-closes-it-before-a-successor-announces
+  (testing "a `/scheduled` listener destroys A, publishes same-id B and
+            hydrates the SAME snapshot into B — re-arming the same key. A's
+            closure must land before B's announcement, or a consumer pairing
+            on `(actor-id, state, epoch)` reads B's live timer as cancelled"
+    (rf/reg-machine :announce/succ literal-machine)
+    (let [rt      (server-runtime-db :announce/succ)
+          cfid    (fresh-frame! :client)
+          token-a (frame/frame-incarnation-token cfid)
+          fired?  (atom false)
+          token-b (atom nil)]
+      (with-redefs [interop/schedule-after!   (fn [_thunk _ms] ::handle)
+                    interop/cancel-scheduled! (fn [_h] nil)]
+        (mtest/reset-captured!)
+        (trace-tooling/register-listener!
+          ::succ
+          (fn [ev]
+            (when (and (= :rf.machine.timer/scheduled (:operation ev))
+                       (compare-and-set! fired? false true))
+              (frame/destroy-frame! cfid)
+              (rf/make-frame {:id cfid :platform :client})
+              (reset! token-b (frame/frame-incarnation-token cfid))
+              (install! cfid rt))))
+        (try
+          (install! cfid rt)
+          (finally (trace-tooling/unregister-listener! ::succ))))
+      (is (true? @fired?) "the `/scheduled` listener ran (seam exercised)")
+      (is (not (identical? token-a @token-b))
+          "and B is a DISTINCT incarnation from A")
+      (is (= [:rf.machine.timer/scheduled
+              :rf.machine.timer/cancelled
+              :rf.machine.timer/scheduled]
+             (mapv :operation (timer-ops)))
+          (str "A's row, A's closure, THEN B's row. The destroy sweep claimed "
+               "A's sentinel on the row's own stack, where the row is already "
+               "out, so its `/cancelled` follows immediately rather than "
+               "waiting for the announcer to return"))
+      (is (= :on-frame-destroy
+             (:reason (:tags (first (mtest/events-of :rf.machine.timer/cancelled)))))
+          "A's closure carries the sweep's reason")
+      (is (= 1 (count (inner cfid)))
+          "B's own timer is armed and survives A's token-exact abort"))))


### PR DESCRIPTION
Pass five on rf2-jqvgp (audit of PR #8965). Diff is `implementation/machines/**` only: one source file and one new JVM test namespace.

## What the audit asked / what shipped / what was narrowed

**Premise, verified at source before building.** At the branch's base, `schedule-after-timer!` took `(swap! after-timers assoc-in [frame-id k] reservation)` and only then emitted `:rf.machine.timer/scheduled`; `claim-emit-release!` emitted `/cancelled` on the claimant's own stack the instant its token-exact claim won. So on the JVM any cleanup path — state exit, actor destroy, epoch restore, frame destroy — could claim the sentinel in the reserve-to-emit window and publish `/cancelled` ahead of the `/scheduled` it closes; the arming thread's owner check still passed (none of those change the frame incarnation), the host arm was attempted, publication lost, and the now-last `/scheduled` had nothing to close it. Nothing on `implementation/machines` had landed since #8965 (`git log 2b4350910589..origin/main -- implementation/machines` is empty), and no smaller mechanism was already present: the token-owned sentinel is kept, and the coordination rides on it.

**What shipped.** The reservation carries an announcement cell (`:announce`, an atom, present only when the arm emits its own `/scheduled` — the hydration re-arm and the dynamic-delay reschedule; an ordinary state-entry arm has no cell because the pure side announced it before the fx ran).

- A claimant that wins the sentinel CASes its `reason` into the cell (`defer-to-announcer?`). Winning that CAS means the row is not yet out: the claimant releases the entry's resources as before and emits nothing. Losing it means the cell already reads `::announced`, so the claimant emits its own `/cancelled` exactly as before.
- The announcer, once `trace/emit!` has returned, CASes the same cell `nil -> ::announced` (`announced!`). Winning means no claim reached the sentinel first, and the existing recheck/arm path runs unchanged. Losing means a claim did, so it emits the deferred `/cancelled` immediately after its `/scheduled` — with the claimant's own reason — and arms nothing.
- A claim made ON the announcing thread — a synchronous listener on the row — bypasses the cell via `*announcing*` (a dynamic set of tokens bound around the emit), since for it the row is already out. That keeps A's closure ahead of anything the listener announces next: a same-id successor re-hydrating the same snapshot re-arms the same key, and its `/scheduled` is indistinguishable from A's by `(actor-id, state, epoch)`, so a deferred A `/cancelled` landing after it would read as B's closure.

Every announced attempt remains cancellable from the instant it is visible (the sentinel is in the table before the row, ungated), the host clock is still armed after the row, the closed six-value `:reason` set and the trace vocabulary are untouched (the deferred row carries the claimant's reason), `owner-gone?` is still captured once per reconcile and threaded (the deferred clause does not consult it — the claimant already decided the shared release under its own predicate, and the announcer releases nothing), the abort still releases nothing beyond the sentinel (rf2-i4aj9c), no entry/cascade replay, epoch-restore semantics untouched, `spec/**` untouched. Docstrings on `schedule-after-timer!`, `claim-emit-release!` and `cancel-after-timer-entry!` now say what is true, including who emits in each case.

**Narrowed / declined.** Nothing the audit asked for was declined. One thing it did not ask for was added and is pinned: an attempt whose sentinel was claimed before its announcement now arms no host clock at all (previously it armed, lost the publish CAS, and cancelled the handle). The CLJS mirror of the regression was not written: the interleaving needs a second thread, and the same-thread case is already pinned on both hosts by `machine_hydration_reconcile_incarnation_fence_cljs_test`.

## A vs B — the cost that decided it

| | (A) hand-off on the reservation — **shipped** | (B) announced?-gated claimability |
|---|---|---|
| Lines in `timer.cljc` (`git diff -w`) | 116 insertions / 10 deletions; ~17 of them code (dynamic var, two 4-line helpers, one `when-not`, one map slot, one `binding`, `let`+`cond` around the existing abort/arm), the rest docstrings and comments | Gate in `claim-entry!` (+2) and a post-emit swap (+3) are cheap, but a refused cleanup has no "after" to re-check from — state exit runs once. Either (B-i) it spins until announced (JVM loop, +6; deadlocks for a same-thread claim inside the emit, so it needs the same thread mark anyway, +8), or (B-ii) it leaves a cancel request on the table entry for the announcer to honour (+6) — which is (A) with the reason travelling through the table slot, and that slot is overwritten by a same-key successor's `assoc-in` reservation on the listener's stack, so the deferred `/cancelled` is lost unless the reservation, publish and claim swaps all carry the mark (+4 each). ~25–30 lines, more states, more places to get wrong |
| Every announced attempt cancellable | Yes — the sentinel is claimable from the instant it is in the table; only the emission of the claim's row is coordinated | (B-i) yes, but a claim that arrives before the row blocks for the whole listener fan-out; (B-ii) yes |
| Host arm after the announcement | Yes, unchanged | Yes |
| New trace event / `:reason` value | None; the deferred row carries the claimant's reason | None |
| Deterministic regression | Yes: wrap `trace/emit!`, run the cleanup to completion on a raw `Thread` at the row, join, then emit — no latch, no timeout | (B-i) no: the second thread blocks on the announcer, so the join deadlocks unless bounded by a timeout; (B-ii) yes |

The choice of a dynamic var over a thread marker in the cell (a fourth cell state) is a readability call at equal line count.

## Tests

- New `after_timer_announce_claim_race_test.clj` (JVM only): `a-claim-before-the-row-is-out-closes-the-row-rather-than-preceding-it` drives the interleaving once per cleanup owner (frame destroy, epoch restore, actor destroy, state exit) and asserts the row order, exactly one of each row, the claimant's reason, the mirrored payload, an empty table and zero host arms. `a-same-thread-claim-from-the-rows-own-listener-closes-it-before-a-successor-announces` is the control for the thread mark: a `/scheduled` listener destroys A, publishes same-id B and hydrates the same snapshot into B; the stream must read A `/scheduled`, A `/cancelled`, B `/scheduled`. (That control passes on the base too — it fails only under a cell-only design that defers every pre-consummation claim.)
- Every existing tooth stays green: `machine_hydration_reconcile_incarnation_fence_cljs_test`, `machine_after_hydration_reconcile_cljs_test`, `machine_after_hydration_rearm_cljs_test`, `after_timer_arm_publish_race_cljs_test`, `machine_timer_incarnation_fence_cljs_test`.

## Quality gates

All run in the foreground, exit codes captured on the same command line as the redirect, all re-run on the final rebased base (c474d0dfd8). Round-four figures in brackets.

| Gate | Command | Result |
|---|---|---|
| machines JVM | `clojure -M:test` in `implementation/machines` | exit 0 — 1241 tests / 4495 assertions, 0 failures [1239 / 4445; +2 tests / +50 assertions are the new namespace] |
| epoch JVM | `clojure -M:test` in `implementation/epoch` (every `:on-restore` cancellation now passes through the changed `claim-emit-release!`) | exit 0 — 543 tests / 7176 assertions, 0 failures [round two: 543 / 7176] |
| CLJS compile | `node scripts/compile-node-test.cjs node-test out/node-test.js` in `implementation` | exit 0 — 1876 files, 0 warnings; the shadow-cljs config line named this branch's own checkout [1877 files — see below] |
| CLJS run | `node out/node-test.js` | exit 0 — 11123 tests / 55179 assertions, 0 failures [11199 / 55515 — see below] |

**On the CLJS totals.** They are below round four's, and that is not a crashed namespace: CI's `:node-test` job on main after round four (run 33541807014, job 99970612843, head 9bf9ab654b) reads `1876 files` and `Ran 11123 tests containing 55179 assertions` — identical to this run — and on PR #8965's own head it read 1876 files / 11120 / 55168. Round four's local figures carried one namespace the tracked tree does not; the +3 tests since #8965 are the three deftests added on main (xray `app_db_diff_cljs_test`, reagent `websocket_cljs_test`). Every `*cljs_test` file the build's source paths offer is in this compile (869 of 872 in the tree; the three outside are `tools/mcp-base/test` and `tools/re-frame2-pair-mcp/test`, which the `:node-test` build does not list and which run in their own lanes).

**Sabotage (the control).** With both commits in place, only the source half was reverted — `git checkout origin/main -- implementation/machines/src/re_frame/machines/timer.cljc` — leaving the new regression in place: machines JVM lane exit 1, **1241 tests / 4495 assertions — the same totals as the clean run**, 8 failures, all of them in `a-claim-before-the-row-is-out-closes-the-row-rather-than-preceding-it` (two assertions × four cleanup owners): the row-order assertion, printing `actual: [:rf.machine.timer/cancelled :rf.machine.timer/scheduled]` — the audit's `/cancelled` then orphan `/scheduled` verbatim — and the zero-host-arms assertion (`actual: (not (zero? 1))`). Green under the same revert: the same-thread control, every precondition, and every other machines test. Restored by `git checkout HEAD -- <file>` and verified by git **blob** hash against the committed object: working file `55da753f2eb300afd882654934d3379d8772ad40` before the plant, `eb5b11fcf93e13b72759a6f89fea0cbd9d27b750` planted (equal to origin/main's blob, and `defer-to-announcer?` absent from the file), `55da753f2eb300afd882654934d3379d8772ad40` after the restore — identical to `HEAD:` for that path.

**Out of scope, stated rather than cited.** The diff carries no markdown, no `spec/`, no workflows, so `check_doc_slugs.py`, `check_readme_links.py --ci` and `mkdocs build --strict` inspect nothing here.

**Reading trap in the diff.** `timer.cljc` reports 264/158 raw because the abort and arm block shifted one column under the new `cond`; `git diff -w` reduces it to 116/10, and its non-whitespace deletions are the ten lines this change replaces (two comment lines, four docstring line-ends, one `emit-cancelled!` call, the `:token` map line, the emit's closing line, the `(if (owner-gone?)` and the closing parens). Nothing of passes two, three or four is reverted.
