### PR TITLE
feat(ssr-node): package.json exports + serve launcher, absence witness rewritten (rf2-8arzr.2)

### DIFF
--- a/implementation/ssr-node/README.md
+++ b/implementation/ssr-node/README.md
@@ -10,8 +10,9 @@ never reachable from another's.
 It is a plain Node package. No ClojureScript, no npm dependencies, no
 build step, and no entry in any shadow-cljs build or in the top-level
 `deps.edn` — `node:worker_threads`, `node:http` and `node:crypto` are the
-whole dependency list. That is a deliberate property and it is checked
-rather than asserted; see
+whole dependency list, and its `package.json` declares none and links
+nowhere outside its own tree. That is a deliberate property and it is
+checked rather than asserted; see
 [Client v0 is unaffected](#client-v0-is-unaffected-when-the-service-is-absent).
 
 Status: v0. Built to the specification on `rf2-hic-056` under the
@@ -433,8 +434,84 @@ it and does not depend on it.
 
 ## Using it
 
+The package is `@day8/re-frame2-ssr-node`: private, and installed from
+its directory rather than a registry — `npm install <checkout>/implementation/ssr-node`,
+or a `file:` entry in the host's `package.json`. The install is a link
+and not a download, because the manifest declares no dependency. Its
+public surface is the serve command and the two entry points in its
+`exports` map; a path into `src/` is not part of it.
+
+### The serve command
+
+What a JVM host talks to. The manifest's `bin` is `re-frame2-ssr-node`,
+and `node bin/serve.cjs` from the package directory is the same program:
+
+```
+re-frame2-ssr-node --module /srv/my-app/out/server-bundle.cjs
+
+  --module <path>            the application server bundle (required; resolved
+                             against the working directory)
+  --port <n>                 TCP port to listen on; 0 picks a free one             [8148]
+  --host <name>              interface to bind                                      [127.0.0.1]
+  --isolates <n>             worker threads; each renders one request at a time     [2]
+  --timeout-ms <n>           render deadline when the request names none            [1000]
+  --max-timeout-ms <n>       ceiling on the deadline a request may ask for          [5000]
+  --admission-ms <n>         how long a request waits for a free isolate before 503 [250]
+  --max-request-bytes <n>    ceiling on the request body, and on its state          [1048576]
+```
+
+`http://127.0.0.1:8148` is the default endpoint, and the one a JVM host
+assumes when told nothing else. The tests bind an ephemeral port (`0`)
+rather than a fixed one, so a run never collides with a developer's
+server or with a concurrent worker's.
+
+```
+POST /render          Content-Type: application/json   -> 200 text/html
+POST /render?stream=1                                  -> 200, chunked
+GET  /health                                           -> 200 application/json
+```
+
+Response headers: `x-rf-ssr-build` (the build identity), `x-rf-ssr-chunks`,
+`x-rf-ssr-render-ms`, and `x-rf-ssr-request` when the caller sent a
+`requestId`. A refusal answers with `application/json`, the refusal frame
+as its body, and `x-rf-ssr-refusal` carrying the code — 4xx for a caller
+fault, 503 for saturation or shutdown, 504 for a deadline, 500 for ours.
+
+### The ready line
+
+Once the socket is listening the launcher writes one line to stdout, and
+nothing else, ever:
+
+```json
+{"rf.ssr-node":"ready","url":"http://127.0.0.1:8148","host":"127.0.0.1","port":8148,"buildId":"reference-build-1","protocol":1}
+```
+
+One JSON object, these six keys in this order, newline-terminated. `host`
+and `port` are the address the socket is bound to as the OS reports it —
+so a supervisor that passed `--port 0` reads the real port here — and
+`url` is that address spelled for a dialler (an IPv6 host gets its
+brackets). `buildId` is the loaded bundle's identity, the same value
+`/health` and every render response carry; `protocol` is the version the
+service speaks. A reader should scan stdout for the line whose
+`"rf.ssr-node"` key is `"ready"` rather than assume it is the first one:
+the launcher itself never writes anything else there, but an application
+bundle that logs at boot does so through the same descriptor.
+
+Everything diagnostic goes to stderr. The exit code is `0` after SIGTERM
+or SIGINT and a graceful close, `1` when the service could not start (the
+module refused, the port is taken), and `2` for a wrong command line,
+which also prints the usage. `test/serve.test.cjs` pins the line field by
+field.
+
+### In process
+
+A Node host that would rather not cross a socket imports through the
+exports map — `./service` for the service, `./http` for the transport the
+launcher runs:
+
 ```js
-const { createService } = require('.../implementation/ssr-node/src/service.cjs');
+const { createService } = require('@day8/re-frame2-ssr-node/service');
+const { serve } = require('@day8/re-frame2-ssr-node/http');
 
 const service = await createService({
   modulePath: '/srv/my-app/out/server-bundle.cjs',   // absolute
@@ -454,31 +531,11 @@ const { html } = await service.renderToString({
 // …or, for a streaming caller, the primitive the wrapper above is built on:
 for await (const frame of service.renderFrames(request)) { /* … */ }
 
+// …or the transport, on a port of your choosing; 0 picks a free one:
+const http = await serve({ service, port: 8148 });
+
 await service.close();
 ```
-
-Or over HTTP, which is what a JVM caller uses:
-
-```js
-const { serve } = require('.../implementation/ssr-node/src/http.cjs');
-const http = await serve({ service, port: 8148 });
-```
-
-```
-POST /render          Content-Type: application/json   -> 200 text/html
-POST /render?stream=1                                  -> 200, chunked
-GET  /health                                           -> 200 application/json
-```
-
-Port 8148 is this package's default. The tests bind an ephemeral port
-(`0`) rather than a fixed one, so a run never collides with a developer's
-server or with a concurrent worker's.
-
-Response headers: `x-rf-ssr-build` (the build identity), `x-rf-ssr-chunks`,
-`x-rf-ssr-render-ms`, and `x-rf-ssr-request` when the caller sent a
-`requestId`. A refusal answers with `application/json`, the refusal frame
-as its body, and `x-rf-ssr-refusal` carrying the code — 4xx for a caller
-fault, 503 for saturation or shutdown, 504 for a deadline, 500 for ours.
 
 ### Deployment
 
@@ -492,9 +549,13 @@ practice:
    release as the JVM host — the bundle contains the application's own
    compiled views, and a skew between the two is two different
    applications answering one request.
-2. Run it as `node serve.cjs` behind a supervisor that restarts on
-   exit. The service is stateless between requests; a restart loses
-   nothing but warm isolates.
+2. Run `re-frame2-ssr-node --module <bundle>` — or `node bin/serve.cjs`
+   with the same flags — behind a supervisor that restarts on exit and
+   stops it with SIGTERM, which closes the socket and the isolates and
+   exits 0. Every knob is a flag of [the serve command](#the-serve-command),
+   and the supervisor learns the port from [the ready line](#the-ready-line).
+   The service is stateless between requests; a restart loses nothing but
+   warm isolates.
 3. Size the pool. One isolate renders one request at a time, so the
    pool size is the concurrency. Each isolate is a worker thread with its
    own V8 heap and its own copy of the bundle, so memory scales with it.
@@ -502,14 +563,14 @@ practice:
    service refuses before the caller gives up. A
    `:rf.ssr-node/render-timeout` is a diagnosable event; a socket the
    caller abandoned is not.
-5. Pin the runtime. The workflows pin Node 24 for CI only, and the
-   server-arm pricing lists that as an open row for a production sidecar.
-   This package uses `node:worker_threads`, `node:http` and `node:crypto`
-   only, and nothing newer than Node 18 semantics.
-6. Wire the JVM side. `ssr-ring`'s render call is a single hard-wired
-   line to the hiccup emitter, and a new render seam at that call site is
-   work both server arms need and neither has. It is not this package's;
-   see below.
+5. Pin the runtime. The manifest's `engines` says `node >=24`, which is
+   the version CI runs this suite on. The package uses
+   `node:worker_threads`, `node:http` and `node:crypto` only, so the pin
+   records what has been witnessed rather than a feature it needs.
+6. Wire the JVM side. `ssr-ring`'s `:renderer` seam and the
+   `re-frame.ssr.ring.node` adapter that dials this service are the
+   ssr-node crossing programme's work (`rf2-8arzr`, slices A and D), not
+   this package's; see below.
 
 ### Health
 
@@ -556,25 +617,18 @@ that is out of scope here.
 node implementation/ssr-node/test/run.cjs
 ```
 
-No build, no npm install, no browser, roughly 7 seconds — 8
-suites, 83 rows. Each suite runs in its own process, because several of
+No build, no npm install, no browser, roughly 8 seconds — 9
+suites, 96 rows. Each suite runs in its own process, because several of
 them deliberately kill worker threads and a shared process would let one
 file's leaked isolate turn the next file's clean failure into a hang.
 
-There is deliberately no npm script and no CI job yet, and the reason is
-measurable rather than aesthetic. Adding one line to
-`implementation/package.json` moves that file into the diff, and the
-changed-surface classifier CI shares with the local spine reads a
-`package.json` edit as reaching 11 expensive lanes — the browser
-suites, bundle isolation, the production-elision probes, the Hicasso HMR
-testbed. Every file in this package arms none of them. Paying 11
-CI lanes for the convenience of `npm run` over `node` is the wrong trade
-in a PR whose entire point is that it touches nothing, so the wiring is
-left as a follow-up to be sequenced against that file's other traffic.
-
-That classification is also the empirical half of the absence claim below:
-the classifier, which is the repo's own answer to "what can this diff
-affect", answers nothing for this package's files.
+`npm run test:ssr-node` from `implementation/` runs the same file, and
+CI's `node-ssr-node` job runs it on every change under this directory
+(rf2-n8vp) — with no `npm ci` before it, because the package needs
+nothing installed. That lane is the empirical half of the absence claim
+below: the changed-surface classifier, which is the repo's own answer to
+"what can this diff affect", arms this one lane for this package's files
+and nothing else.
 
 The suite drives the service against reference render modules under
 `test/fixtures/` — well-behaved, mutating, sloppy-mode, hanging, throwing,
@@ -627,9 +681,10 @@ strength:
   for a build to pick up if one ever did. This is the strong reading:
   absence from the graph is not a property anyone has to maintain by care
 - it adds no dependency. Every `require` in `src/` is a `node:` builtin
-  or a sibling file here, and the package carries no `package.json` of its
-  own, so it contributes nothing to `implementation/package.json` and
-  nothing to any consumer's closure
+  or a sibling file here, and the package's own `package.json` declares no
+  dependency of any kind and links — `exports`, `bin` — only to files
+  inside this tree, so it contributes nothing to `implementation/package.json`
+  and nothing to any consumer's closure
 
 Each of the 3 is paired with a row that plants exactly that fault in a
 scratch directory and requires the scan to find it. The first of those

--- a/implementation/ssr-node/bin/serve.cjs
+++ b/implementation/ssr-node/bin/serve.cjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+'use strict';
+// THE LAUNCHER — the process an operator runs, and the one a JVM host spawns.
+//
+//     re-frame2-ssr-node --module /srv/my-app/out/server-bundle.cjs
+//     node bin/serve.cjs --module ./out/server-bundle.cjs --port 0
+//
+// Everything that decides an outcome lives in `src/`. This file turns flags
+// into `createService` and `serve` arguments, says where it is listening,
+// and stops cleanly when asked. It is deliberately the least interesting
+// file in the package.
+//
+// ## THE READY LINE
+//
+// Once the socket is listening it writes ONE line to stdout, and nothing
+// else, ever:
+//
+//     {"rf.ssr-node":"ready","url":"http://127.0.0.1:8148","host":"127.0.0.1","port":8148,"buildId":"…","protocol":1}
+//
+// A supervisor that asked for `--port 0` reads the port it actually got
+// from there. It is JSON on one line so a host in any language — the JVM
+// witness in `re-frame.ssr.ring.node` is one — parses it without a
+// grammar, and it carries the discriminator key so a reader that scans
+// stdout line by line can pick it out even if the application bundle
+// logged something at boot. `host` and `port` are the address the socket
+// is BOUND to, as the OS reports it; `url` is that address spelled for a
+// dialler. Diagnostics go to stderr.
+//
+// ## EXIT CODES
+//
+//     0  stopped by SIGTERM or SIGINT after a graceful close
+//     1  the service could not start: the module refused, or the port is taken
+//     2  the command line was wrong
+//
+// Node on Windows has no graceful signal — a `kill` there terminates the
+// process outright, which loses nothing but in-flight renders, and a
+// second signal on any platform does the same.
+
+const path = require('node:path');
+const { parseArgs } = require('node:util');
+const { createService } = require('../src/service.cjs');
+const { serve } = require('../src/http.cjs');
+
+/** Every flag, its default, and the one line of help that describes it. */
+const FLAGS = [
+  ['module', undefined, '<path>  the application server bundle (required; resolved against the working directory)'],
+  ['port', '8148', '<n>     TCP port to listen on; 0 picks a free one'],
+  ['host', '127.0.0.1', '<name>  interface to bind'],
+  ['isolates', '2', '<n>     worker threads; each renders one request at a time'],
+  ['timeout-ms', '1000', '<n>     render deadline when the request names none'],
+  ['max-timeout-ms', '5000', '<n>     ceiling on the deadline a request may ask for'],
+  ['admission-ms', '250', '<n>     how long a request waits for a free isolate before 503'],
+  ['max-request-bytes', String(1 << 20), '<n>     ceiling on the request body, and on its state'],
+];
+
+const OPTIONS = Object.fromEntries(
+  FLAGS.map(([name, def]) => [name, { type: 'string', ...(def === undefined ? {} : { default: def }) }]),
+);
+OPTIONS.help = { type: 'boolean', short: 'h', default: false };
+
+const USAGE = [
+  'usage: re-frame2-ssr-node --module <path> [flags]',
+  '',
+  ...FLAGS.map(([name, def, help]) => {
+    const flag = `  --${name} ${help}`;
+    return def === undefined ? flag : `${flag}  [${def}]`;
+  }),
+  '  -h, --help',
+  '',
+].join('\n');
+
+const log = (line) => process.stderr.write(`[rf.ssr-node] ${line}\n`);
+
+/** A non-negative integer flag, or a usage error naming the flag. */
+function integer(flags, name, min) {
+  const text = flags[name];
+  const n = Number(text);
+  if (!/^\d+$/.test(text) || !Number.isSafeInteger(n) || n < min) {
+    throw new UsageError(`--${name} must be an integer of at least ${min}; got ${JSON.stringify(text)}`);
+  }
+  return n;
+}
+
+class UsageError extends Error {}
+
+const describe = (err) => (err && err.code ? `${err.code} — ${err.message}` : String(err && err.message ? err.message : err));
+
+/** The bound address, spelled for a dialler: IPv6 gets its brackets. */
+const urlOf = (host, port) => `http://${host.includes(':') ? `[${host}]` : host}:${port}`;
+
+async function main(argv) {
+  let flags;
+  try {
+    ({ values: flags } = parseArgs({ args: argv, options: OPTIONS, strict: true, allowPositionals: false }));
+    if (flags.help) {
+      process.stdout.write(USAGE);
+      return 0;
+    }
+    if (!flags.module) throw new UsageError('--module is required');
+  } catch (err) {
+    process.stderr.write(`${USAGE}\n[rf.ssr-node] ${err.message}\n`);
+    return 2;
+  }
+
+  let limits;
+  try {
+    limits = {
+      port: integer(flags, 'port', 0),
+      isolates: integer(flags, 'isolates', 1),
+      defaultTimeoutMs: integer(flags, 'timeout-ms', 1),
+      maxTimeoutMs: integer(flags, 'max-timeout-ms', 1),
+      admissionTimeoutMs: integer(flags, 'admission-ms', 0),
+      maxRequestBytes: integer(flags, 'max-request-bytes', 1),
+    };
+  } catch (err) {
+    process.stderr.write(`${USAGE}\n[rf.ssr-node] ${err.message}\n`);
+    return 2;
+  }
+
+  const modulePath = path.resolve(flags.module);
+  let service;
+  try {
+    service = await createService({ modulePath, ...limits });
+  } catch (err) {
+    log(`could not start: ${describe(err)}`);
+    return 1;
+  }
+
+  let http;
+  try {
+    http = await serve({ service, port: limits.port, host: flags.host, maxRequestBytes: limits.maxRequestBytes });
+  } catch (err) {
+    log(`could not listen on ${flags.host}:${limits.port}: ${describe(err)}`);
+    await service.close();
+    return 1;
+  }
+
+  const bound = http.server.address();
+  process.stdout.write(
+    `${JSON.stringify({
+      'rf.ssr-node': 'ready',
+      url: urlOf(bound.address, bound.port),
+      host: bound.address,
+      port: bound.port,
+      buildId: service.buildId,
+      protocol: service.protocol,
+    })}\n`,
+  );
+
+  const signal = await new Promise((resolve) => {
+    for (const sig of ['SIGTERM', 'SIGINT']) process.once(sig, () => resolve(sig));
+  });
+  log(`${signal}: closing`);
+  await http.close();
+  await service.close();
+  return 0;
+}
+
+main(process.argv.slice(2)).then(
+  (code) => process.exit(code),
+  (err) => {
+    log(describe(err));
+    process.exit(1);
+  },
+);

--- a/implementation/ssr-node/package.json
+++ b/implementation/ssr-node/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@day8/re-frame2-ssr-node",
+  "version": "0.1.0",
+  "private": true,
+  "description": "The bounded Node/React SSR service — a sidecar the JVM ssr-ring host calls for body markup, and nothing else.",
+  "license": "MIT",
+  "type": "commonjs",
+  "engines": {
+    "node": ">=24"
+  },
+  "exports": {
+    "./service": "./src/service.cjs",
+    "./http": "./src/http.cjs"
+  },
+  "bin": {
+    "re-frame2-ssr-node": "./bin/serve.cjs"
+  },
+  "scripts": {
+    "test": "node test/run.cjs"
+  }
+}

--- a/implementation/ssr-node/test/absence.test.cjs
+++ b/implementation/ssr-node/test/absence.test.cjs
@@ -19,9 +19,10 @@
 //      from the graph is not a property anyone has to maintain by care.
 //   3. IT ADDS NO DEPENDENCY. Every `require` in `src/` names a `node:`
 //      builtin or a sibling file here, and the one whose specifier is
-//      COMPUTED takes it from the caller, so the package contributes
-//      nothing to `implementation/package.json` and nothing to any
-//      consumer's dependency closure.
+//      COMPUTED takes it from the caller; its own manifest declares no
+//      dependency of any kind and links only to files inside this tree.
+//      So the package contributes nothing to `implementation/package.json`
+//      and nothing to any consumer's dependency closure.
 //
 // ## EVERY CHECK PLANTS ITS OWN FAULT, EVERY RUN
 //
@@ -924,20 +925,118 @@ test('CONTROL — a third-party require is caught, spelled out or computed', () 
   }
 });
 
-test('the package declares no npm dependency of its own', () => {
-  // No package.json here at all: the service is meant to be droppable into
-  // a deployment without an install step, and a manifest would be the
-  // first place a dependency would appear.
-  assert.strictEqual(
-    fs.existsSync(path.join(PACKAGE_DIR, 'package.json')),
-    false,
-    'this package deliberately carries no manifest — see the README',
+// ---------------------------------------------------------------------------
+// 3b. The manifest — what it makes checkable, now that there is one
+// ---------------------------------------------------------------------------
+
+/**
+ * The manifest fields that DECLARE a dependency: the subset of
+ * `MANIFEST_LINK_FIELDS` whose presence, with anything in it, puts a second
+ * package into this one's closure. `workspaces` is here because it links
+ * sibling packages, which is a dependency spelled as a directory.
+ */
+const DEPENDENCY_FIELDS = [
+  'dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies',
+  'bundleDependencies', 'bundledDependencies', 'workspaces',
+];
+
+/** The manifest fields whose leaves are PATHS a resolver follows. */
+const PATH_LINK_FIELDS = ['exports', 'imports', 'main', 'module', 'browser', 'bin', 'types', 'typings'];
+
+/** Every string leaf under a field value — `exports` nests, and `bin` may. */
+const leaves = (v) =>
+  typeof v === 'string' ? [v] : v && typeof v === 'object' ? Object.values(v).flatMap(leaves) : [];
+
+/**
+ * What is wrong with a manifest, as sentences — empty when the package's
+ * closure is the package. Two invariants, and they are the SAME claim
+ * Reading 3 makes of `src/`, read off the file a resolver consults first:
+ * (a) it declares no dependency of any kind, and (b) every path it links a
+ * resolver to lies inside the package and exists. (b) is the manifest's
+ * spelling of "a builtin, a sibling, or the caller's own path" — a `main`
+ * at `../core/…`, or an `exports` leaf naming a bare package, is an edge
+ * out of this tree that no scan of `src/`'s requires can see.
+ */
+function manifestFaults(manifest, packageDir) {
+  const faults = [];
+  for (const field of DEPENDENCY_FIELDS) {
+    if (manifest[field] !== undefined) {
+      faults.push(`${field} is declared: ${JSON.stringify(manifest[field])}`);
+    }
+  }
+  for (const field of PATH_LINK_FIELDS) {
+    for (const leaf of leaves(manifest[field])) {
+      const rel = path.relative(packageDir, path.resolve(packageDir, leaf));
+      if (!leaf.startsWith('./') || rel.startsWith('..') || path.isAbsolute(rel)) {
+        faults.push(`${field} links outside the package: ${leaf}`);
+      } else if (!fs.existsSync(path.join(packageDir, rel))) {
+        faults.push(`${field} links to a file the package does not ship: ${leaf}`);
+      }
+    }
+  }
+  return faults;
+}
+
+test('the manifest declares no dependency of any kind, and links only to files it ships', () => {
+  // THE MANIFEST IS WHERE A DEPENDENCY WOULD APPEAR FIRST, which is why
+  // this package carried none at all until it grew an exports map, a serve
+  // bin and an engines pin (rf2-8arzr.2). This row used to assert the file
+  // did not exist. That was the weaker reading dressed as the stronger one:
+  // nothing can be declared in a file that is not there, but nothing can be
+  // SHOWN about one either, and the property the README states — no
+  // dependency, nothing reachable outside the tree — is only checkable now
+  // that there is a manifest to check it against.
+  const manifest = JSON.parse(fs.readFileSync(path.join(PACKAGE_DIR, 'package.json'), 'utf8'));
+  assert.deepStrictEqual(
+    manifestFaults(manifest, PACKAGE_DIR),
+    [],
+    'the manifest reaches outside the package, or declares a dependency',
   );
+});
+
+test('nothing in implementation/package.json reaches this package', () => {
+  // The rows from before this package had a manifest, kept as they were:
+  // the top-level manifest is the one a client install reads. Reading 1
+  // already scans its link fields for the path; this pins the two
+  // spellings a dependency on this package would actually take there.
   const pkg = JSON.parse(
     fs.readFileSync(path.join(REPO_ROOT, 'implementation', 'package.json'), 'utf8'),
   );
   for (const dep of Object.keys(pkg.devDependencies ?? {})) {
     assert.ok(!dep.includes('ssr-node'), `${dep} should not exist`);
   }
-  assert.strictEqual(pkg.dependencies, undefined, 'this package must add no runtime dependency');
+  assert.strictEqual(pkg.dependencies, undefined, 'the top-level manifest must add no runtime dependency');
+});
+
+test('CONTROL — a manifest that grows a dependency, or links past its own tree, is caught', () => {
+  const dir = scratch({ 'src/service.cjs': 'module.exports = {};\n' });
+  try {
+    const clean = { name: 'x', exports: { './service': './src/service.cjs' }, bin: { x: './src/service.cjs' } };
+    assert.deepStrictEqual(manifestFaults(clean, dir), [], 'the control must be clean, or the zero above proves nothing');
+
+    // Each fault alone, so the sentence names the field and not a neighbour.
+    assert.deepStrictEqual(
+      manifestFaults({ ...clean, dependencies: { react: '^19' } }, dir),
+      ['dependencies is declared: {"react":"^19"}'],
+    );
+    assert.deepStrictEqual(manifestFaults({ ...clean, devDependencies: {} }, dir), ['devDependencies is declared: {}']);
+    assert.deepStrictEqual(
+      manifestFaults({ ...clean, main: '../core/src/index.cjs' }, dir),
+      ['main links outside the package: ../core/src/index.cjs'],
+    );
+    assert.deepStrictEqual(
+      manifestFaults({ ...clean, exports: { './service': 'react' } }, dir),
+      ['exports links outside the package: react'],
+    );
+    assert.deepStrictEqual(
+      manifestFaults({ ...clean, exports: { './service': { require: './src/../../escape.cjs' } } }, dir),
+      ['exports links outside the package: ./src/../../escape.cjs'],
+    );
+    assert.deepStrictEqual(
+      manifestFaults({ ...clean, bin: { x: './bin/absent.cjs' } }, dir),
+      ['bin links to a file the package does not ship: ./bin/absent.cjs'],
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/implementation/ssr-node/test/run.cjs
+++ b/implementation/ssr-node/test/run.cjs
@@ -37,6 +37,7 @@ const FILES = [
   'timeout.test.cjs',
   'bytes.test.cjs',
   'envelope.test.cjs',
+  'serve.test.cjs',
   'absence.test.cjs',
 ];
 

--- a/implementation/ssr-node/test/serve.test.cjs
+++ b/implementation/ssr-node/test/serve.test.cjs
@@ -65,7 +65,12 @@ function launch(args) {
   const ready = new Promise((resolve, reject) => {
     child.stdout.on('data', () => {
       const line = out.stdout.split('\n').find((l) => l.includes('"rf.ssr-node"'));
-      if (line !== undefined) resolve(JSON.parse(line));
+      if (line === undefined) return;
+      try {
+        resolve(JSON.parse(line));
+      } catch (err) {
+        reject(new Error(`the ready line is not one JSON object: ${JSON.stringify(line)} (${err.message})`));
+      }
     });
     exited.then(() => reject(new Error(`exited before a ready line\nstdout: ${out.stdout}\nstderr: ${out.stderr}`)));
   });

--- a/implementation/ssr-node/test/serve.test.cjs
+++ b/implementation/ssr-node/test/serve.test.cjs
@@ -1,0 +1,157 @@
+'use strict';
+// THE LAUNCHER, END TO END — a process, not a function.
+//
+//     node implementation/ssr-node/test/serve.test.cjs
+//
+// Every other suite here drives the service in-process. This one spawns
+// `bin/serve.cjs` the way a supervisor or a JVM host would, and reads the
+// same three things they read: the ready line on stdout, `/health`, and a
+// render. It is a SMOKE test by design — one request, no `state`, the
+// well-behaved fixture — because the five guarantees are witnessed
+// elsewhere and this file's only claim is that the launcher wires them to
+// a socket and gets out of the way. Sending no `state` at all is
+// deliberate as well: it keeps the row independent of the request's
+// partition vocabulary, which `protocol.test.cjs` owns.
+//
+// ## THE READY LINE IS THE CONTRACT UNDER TEST
+//
+// A JVM witness spawns this launcher on port 0 and parses the ready line to
+// learn where to dial, so its shape is pinned here field by field rather
+// than merely parsed: a launcher that printed a perfectly good JSON object
+// under a different key would strand every reader written against the
+// README.
+//
+// ## PORT 0, ALWAYS
+//
+// Same reason as the HTTP rows elsewhere: a fixed port is a fixed
+// collision with a developer's server or a concurrent worker's.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { spawn, spawnSync } = require('node:child_process');
+const { fixture, post } = require('./_support.cjs');
+const manifest = require('../package.json');
+
+const PACKAGE_DIR = path.resolve(__dirname, '..');
+const LAUNCHER = path.join(PACKAGE_DIR, 'bin', 'serve.cjs');
+
+/** Worker boot is the slow part, and a cold box is slower than this one. */
+const BOOT_MS = 20000;
+/** A graceful close is milliseconds; this is the bound the acceptance names. */
+const STOP_MS = 5000;
+
+const withTimeout = (p, ms, what) =>
+  Promise.race([
+    p,
+    new Promise((_, reject) => setTimeout(() => reject(new Error(`${what} within ${ms} ms`)), ms).unref()),
+  ]);
+
+/**
+ * Spawn the launcher. `ready` resolves with the parsed ready line — found
+ * by scanning stdout for the discriminator key, which is how the README
+ * tells a reader to find it — or rejects if the process exits first.
+ */
+function launch(args) {
+  const child = spawn(process.execPath, [LAUNCHER, ...args], { stdio: ['ignore', 'pipe', 'pipe'] });
+  const out = { stdout: '', stderr: '' };
+  child.stdout.on('data', (d) => {
+    out.stdout += d;
+  });
+  child.stderr.on('data', (d) => {
+    out.stderr += d;
+  });
+  const exited = new Promise((resolve) => child.once('exit', (code, signal) => resolve({ code, signal })));
+  const ready = new Promise((resolve, reject) => {
+    child.stdout.on('data', () => {
+      const line = out.stdout.split('\n').find((l) => l.includes('"rf.ssr-node"'));
+      if (line !== undefined) resolve(JSON.parse(line));
+    });
+    exited.then(() => reject(new Error(`exited before a ready line\nstdout: ${out.stdout}\nstderr: ${out.stderr}`)));
+  });
+  return { child, out, ready: withTimeout(ready, BOOT_MS, 'no ready line'), exited };
+}
+
+test('the launcher boots on port 0, announces itself, answers /health and a render, and stops on SIGTERM', async () => {
+  const run = launch(['--module', fixture('reference'), '--port', '0', '--isolates', '1']);
+  try {
+    const ready = await run.ready;
+
+    // The shape, field by field — see the header.
+    assert.deepStrictEqual(
+      Object.keys(ready),
+      ['rf.ssr-node', 'url', 'host', 'port', 'buildId', 'protocol'],
+      'the ready line carries these keys, in this order, and no others',
+    );
+    assert.strictEqual(ready['rf.ssr-node'], 'ready');
+    assert.strictEqual(ready.host, '127.0.0.1', 'the default host, as the OS reports the bound address');
+    assert.ok(Number.isInteger(ready.port) && ready.port > 0, `port 0 must become a real port; got ${ready.port}`);
+    assert.strictEqual(ready.url, `http://127.0.0.1:${ready.port}`);
+    assert.strictEqual(ready.buildId, 'reference-build-1');
+    assert.strictEqual(ready.protocol, 1);
+
+    const health = await fetch(`${ready.url}/health`);
+    assert.strictEqual(health.status, 200);
+    const body = await health.json();
+    assert.strictEqual(body.status, 'ok');
+    assert.strictEqual(body.buildId, ready.buildId, '/health and the ready line name the same bundle');
+    assert.strictEqual(body.isolates.total, 1, '--isolates reached the pool');
+
+    // One render and no `state`: the fixture renders its entry id, which
+    // is all this row needs to see to know a request crossed the socket.
+    const r = await post(`${ready.url}/render`, { protocol: 1, entry: 'app/root' });
+    assert.strictEqual(r.status, 200, r.text);
+    assert.strictEqual(r.headers.get('x-rf-ssr-build'), 'reference-build-1');
+    assert.match(r.text, /^<div data-entry="app\/root"/);
+
+    const asked = Date.now();
+    run.child.kill('SIGTERM');
+    const { code, signal } = await withTimeout(run.exited, STOP_MS, 'the launcher did not exit');
+    assert.ok(Date.now() - asked <= STOP_MS, 'and it went within the bound');
+    if (process.platform === 'win32') {
+      // Node on Windows has no graceful signal: `kill` terminates the
+      // process outright, so the graceful arm below is witnessed on the
+      // POSIX runners and only the bound is witnessed here.
+      assert.strictEqual(signal, 'SIGTERM');
+    } else {
+      assert.strictEqual(code, 0, `exit ${code} (${signal})\nstderr: ${run.out.stderr}`);
+      assert.match(run.out.stderr, /SIGTERM: closing/, 'the close was the graceful one, not a crash');
+    }
+    assert.strictEqual(run.out.stdout.trim().split('\n').length, 1, 'stdout is the ready line and nothing else');
+  } finally {
+    if (run.child.exitCode === null && run.child.signalCode === null) run.child.kill('SIGKILL');
+  }
+});
+
+test('a wrong command line is exit 2 with the usage on stderr, and nothing on stdout', () => {
+  for (const [why, args] of [
+    ['no --module', []],
+    ['an unknown flag', ['--module', fixture('reference'), '--bogus', '1']],
+    ['a non-integer port', ['--module', fixture('reference'), '--port', 'abc']],
+    ['zero isolates', ['--module', fixture('reference'), '--isolates', '0']],
+  ]) {
+    const r = spawnSync(process.execPath, [LAUNCHER, ...args], { encoding: 'utf8', timeout: BOOT_MS });
+    assert.strictEqual(r.status, 2, `${why}: exit ${r.status}\n${r.stderr}`);
+    assert.match(r.stderr, /^usage: re-frame2-ssr-node --module <path>/, why);
+    assert.strictEqual(r.stdout, '', `${why}: stdout is reserved for the ready line`);
+  }
+  const help = spawnSync(process.execPath, [LAUNCHER, '--help'], { encoding: 'utf8', timeout: BOOT_MS });
+  assert.strictEqual(help.status, 0);
+  assert.match(help.stdout, /^usage: re-frame2-ssr-node/, '--help is the one thing besides the ready line stdout carries');
+});
+
+test('a module the service refuses at boot is exit 1, the refusal code on stderr, and no ready line', () => {
+  const r = spawnSync(process.execPath, [LAUNCHER, '--module', fixture('bad-protocol'), '--port', '0'], {
+    encoding: 'utf8',
+    timeout: BOOT_MS,
+  });
+  assert.strictEqual(r.status, 1, r.stderr);
+  assert.match(r.stderr, /:rf\.ssr-node\/malformed-render-module/);
+  assert.strictEqual(r.stdout, '');
+});
+
+test('the manifest points its bin at this launcher, exports the two entry points, and pins the Node CI runs', () => {
+  assert.deepStrictEqual(Object.values(manifest.bin), ['./bin/serve.cjs']);
+  assert.deepStrictEqual(manifest.exports, { './service': './src/service.cjs', './http': './src/http.cjs' });
+  assert.strictEqual(manifest.engines.node, '>=24');
+});


### PR DESCRIPTION
Slice B of the ssr-node crossing programme (rf2-8arzr, RULING 2026-09-02). Bead: rf2-8arzr.2.

`implementation/ssr-node/` gains a manifest and a launcher, and the absence witness that used to assert "no manifest exists" now asserts what the manifest makes checkable. Six files, all under `implementation/ssr-node/`; nothing in `implementation/package.json`, `shadow-cljs.edn`, `deps.edn` or `.github/`.

## What landed

- **`package.json`** — `@day8/re-frame2-ssr-node`, private, `type: commonjs`, `engines: {node: ">=24"}` (S7; matches the `node-ssr-node` job's `node-version: '24'`), an `exports` map (`./service` → `src/service.cjs`, `./http` → `src/http.cjs`), a `bin` (`re-frame2-ssr-node` → `bin/serve.cjs`), `scripts.test`, and **no** `dependencies` / `devDependencies` of any kind.
- **`bin/serve.cjs`** — the launcher. Flags: `--module <path>` (required; resolved against the working directory), `--port` (default 8148; 0 = ephemeral), `--host` (default 127.0.0.1), `--isolates`, `--timeout-ms`, `--max-timeout-ms`, `--admission-ms`, `--max-request-bytes`. `node:util` `parseArgs`, strict: an unknown flag or a non-integer value is exit 2 with the usage on stderr. A module the service refuses at boot, or a port it cannot bind, is exit 1 with the refusal code on stderr. SIGTERM / SIGINT → `http.close()` → `service.close()` → exit 0. Nothing goes to stdout except the ready line (and `--help`).
- **`test/absence.test.cjs`** — the final row rewritten (see below); the header's Reading 3 widened by one sentence. Readings 1 and 2 and every existing reachability row are untouched.
- **`test/serve.test.cjs`** (new) + **`test/run.cjs`** roster: 8 → 9 suites.
- **`README.md`** — the absence sentence at the top; `## Using it` restructured into `### The serve command`, `### The ready line`, `### In process` (imports through the exports map — the `require('.../src/service.cjs')` era ends); `### Deployment` steps 2, 5, 6; `## Running the tests` count (9 suites, 96 rows) and its two paragraphs that said there was no npm script and no CI job (there have been both since rf2-n8vp); the third reading under `## Client v0 is unaffected`. The `### A gap this protocol does not paper over` section is slice C's and is untouched.

## The ready line (what slice D parses)

Once the socket is listening the launcher writes exactly one line to stdout:

```json
{"rf.ssr-node":"ready","url":"http://127.0.0.1:8148","host":"127.0.0.1","port":8148,"buildId":"reference-build-1","protocol":1}
```

One JSON object, these six keys in this order, `\n`-terminated. `host`/`port` are the bound address as the OS reports it (so `--port 0` yields the real port); `url` is that address for a dialler (IPv6 hosts bracketed); `buildId` and `protocol` are the loaded bundle's. Readers should scan stdout for the line whose `"rf.ssr-node"` key is `"ready"` rather than assume it is line 1 — the launcher never writes anything else to stdout, but an application bundle that logs at boot shares the descriptor. Diagnostics go to stderr. Exit codes: 0 graceful stop, 1 could not start, 2 wrong command line. `test/serve.test.cjs` pins the key set and order.

## S2 / S7 / Acceptance → where each landed

| Clause | Where |
|---|---|
| S2 ownership line (Node returns body markup and nothing else) | Unchanged by this slice; the launcher adds no surface — `bin/serve.cjs` header says so, README `## What this is not` still holds |
| S7 default endpoint `http://127.0.0.1:8148` | `bin/serve.cjs` defaults (`--port 8148`, `--host 127.0.0.1`); README `### The serve command` |
| S7 `engines: {node: ">=24"}` matching CI | `package.json`; pinned by `serve.test.cjs`'s manifest row; README `### Deployment` step 5 |
| Acceptance 1 — suite count +1, smoke: port 0 → ready line parsed → `GET /health` 200 → one render via an existing fixture entry with NO `state` → SIGTERM exits 0 within a bound | `test/serve.test.cjs` row 1 (`reference.cjs` `app/root`, request `{protocol: 1, entry: 'app/root'}`); `run.cjs` roster 8 → 9 |
| Acceptance 2 — absence witness rewritten and green; no shadow build / no deps.edn entry / no browser reachability still witnessed | `absence.test.cjs` §3b: `manifestFaults` — (a) none of `dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`, `bundleDependencies`, `bundledDependencies`, `workspaces` declared; (b) every leaf of `exports`/`imports`/`main`/`module`/`browser`/`bin`/`types`/`typings` starts with `./`, resolves inside the package and exists. Plus the kept `implementation/package.json` rows and a CONTROL planting each fault alone. Readings 1 and 2 unchanged |
| Acceptance 3 — README consumer API updated; no `src/` path in a consumer-facing snippet | `### In process` uses `require('@day8/re-frame2-ssr-node/service')` / `/http`; verified by hand: zero fenced blocks in the README mention `src/` (the remaining `src/` mentions are the five-guarantees "where it lives" table and prose about the package's own layout) |

One platform note, stated in the suite: Node on Windows has no graceful signal — `child.kill('SIGTERM')` terminates the process outright — so on `win32` the row asserts the bound and `signalCode === 'SIGTERM'`; on the POSIX runners (CI) it asserts exit 0 and the `SIGTERM: closing` stderr line. Measured locally on Windows: exit within 7 ms.

## Quality gates

All foreground, to completion, exit codes captured on the same command line as the redirect, never piped. Gate root printed by `run.cjs` matched this worker's worktree on every run.

| Gate | Command (from `implementation/`) | Exit | Result |
|---|---|---|---|
| ssr-node, baseline before edits | `npm run test:ssr-node` | 0 | 8 suites, all green |
| ssr-node, after edits | `npm run test:ssr-node` | 0 | 9 suites, 96 rows, 96 pass, 0 fail |
| ssr-node, on the final base after rebase onto `4d54ba5200` | `npm run test:ssr-node` | 0 | 9 suites, 96 rows, 96 pass, 0 fail (per suite: protocol 22, egress 12, isolation 7, concurrency 5, timeout 9, bytes 15, envelope 4, serve 4, absence 18) |
| README links (from repo root) | `python scripts/check_readme_links.py --ci` | 0 | clean |

### Controls (the plants, each restored and blob-hashed)

| Control | Plant | Exit | Red named | Restore |
|---|---|---|---|---|
| Absence witness bites | `"dependencies": {"react": "^19"}` added to `package.json` — blob hash `7d23f38005509d1b429d29e612ea3921edf3ff82` → planted blob hash `cb35334e1745017afcdf35aabfcaf4b5d87d0ac7` | `node ssr-node/test/absence.test.cjs` → 1 | 17/18 pass; `the manifest declares no dependency of any kind…` failed with `'dependencies is declared: {"react":"^19"}'` | `git checkout HEAD --`; blob hash back to `7d23f38005509d1b429d29e612ea3921edf3ff82` = HEAD's |
| Smoke suite bites | ready line prefixed with a bare word in `bin/serve.cjs` (anchor matched exactly once) — blob hash `5964c743d8167ce4f163aedbdf4b88ee059a3af0` → planted blob hash `2e2edd7ed0e28da52864fdf02d94f7ed62ebcb46` | `node ssr-node/test/serve.test.cjs` → 1 | 3/4 pass; row 1 failed with `the ready line is not one JSON object: "ready {\"rf.ssr-node\":…"` | `git checkout HEAD --`; blob hash back to `5964c743d8167ce4f163aedbdf4b88ee059a3af0` = HEAD's |
| README-links gate reads this README | `(#the-ready-line)` → `(#the-ready-lime)` in Deployment step 2 (1 match before, 1 after) — blob hash `62a464b24079db55f578da8bebe56ea956629b06` | `python scripts/check_readme_links.py --ci` → 1 | `BROKEN ANCHOR: implementation/ssr-node/README.md:556 -> #the-ready-lime` | `git checkout HEAD --`; blob hash back to `62a464b24079db55f578da8bebe56ea956629b06` = HEAD's |

### Not run, and why

- `mkdocs build --strict` — `docs_dir` is `docs/`; this README is outside it. `check_readme_links.py --ci` is the gate for READMEs beside source, and it ran (above). Its CI counterpart is `test.yml`'s `verify-readme-links` job.
- The changed-surface classifier maps `implementation/ssr-node/*` to `ssr_node=true` and nothing else, so no browser / JVM / CLJS lane is armed by this diff; none was run locally.
- No `npm ci` and no `node_modules` link: the package is dependency-free and the gate needs nothing installed.

### Verified by hand

- No consumer-facing snippet requires a `src/` path (flattened scan of every fenced block in the README: 0 mention `src/`).
- Anchors `#the-serve-command` and `#the-ready-line` resolve (the gate checked; the plant shows it looking).
- No table column counts changed: the only table edited is none — the five-guarantees table is untouched.
- No new `:rf.error/*` id: the launcher's refusals are the sidecar's existing JS-string codes and process exit codes.

## Fence and collisions

- Slice A (#8981) merged under this branch; rebased cleanly — A touched `ssr-ring/**` and `spec/**` only.
- Slice C (#8982, `worker/renderstate-8arzr3`) is open and edits `src/protocol.cjs`, `src/worker.cjs`, `test/protocol.test.cjs`, `test/fixtures/**` and the README's `### A gap…` region (its hunks end at old line 433; `## Using it` begins at 434). This branch touches none of C's files except the README, in different sections. The smoke render carries no `state` field, so C's protocol revision (which treats an absent partition as `{}`) does not move it. Whoever lands second rebases keeping both intents.
- Left alone on purpose: `test.yml:5123`'s stale "73 rows across 7 suites" comment (hot-zone; slice D's), and `.github/scripts/report-changed-surfaces.sh`'s "seven suites and their nine fixtures" comment (same file class).
