### PR TITLE
fix(xray): represent an explicit nil egress frame without a registrable id (rf2-7htk7, third pass)

### DIFF
--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -724,11 +724,15 @@ The copy event therefore forwards `:frame` even when the picker has
 selected nothing: `elide-wire-value` validates the id against the live
 registry, so an unselected picker and a host frame destroyed between
 render and click both take the walker's frameless arm and egress the
-whole-value `:rf/redacted` sentinel. `egress-value` substitutes an
-unregisterable sentinel id for an explicitly-passed `nil` to make that
-so; a caller that omits `:frame` entirely keeps the ambient-resolution
-behaviour, which is what the palette's already-validated `with-frame`
-wrap wants.
+whole-value `:rf/redacted` sentinel. `egress-value` substitutes a
+private identity value for an explicitly-passed `nil` to make that so —
+an identity, not a keyword: the registry is keyed by whatever `:id`
+`make-frame` is handed, so any keyword, however it is namespaced, is a
+public frame id an app can register, and a live frame under the
+substitute's id would resolve and egress the value RAW under its empty
+registry (the third-pass collision regression pins this). A caller that
+omits `:frame` entirely keeps the ambient-resolution behaviour, which is
+what the palette's already-validated `with-frame` wrap wants.
 
 `egress-value` also takes an optional `:path` — the ABSOLUTE app-db path
 the value sits at. The framework's declarations (classified via the

--- a/tools/xray/src/day8/re_frame2_xray/egress.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/egress.cljs
@@ -25,6 +25,21 @@
   the defaults here makes the shortest call the safe one (rf2-rcogp)."
   (:require [re-frame.core :as rf]))
 
+(def ^:private no-frame
+  "Forwarded as `:frame` when a caller passes `:frame` EXPLICITLY as nil, so
+  `elide-wire-value` takes its unresolvable-frame arm instead of resolving
+  the ambient frame. It has to be a value no frame can be registered under,
+  and a keyword is not one: the registry is keyed by whatever `:id`
+  `make-frame` is handed, and every keyword — however it is namespaced — is
+  a public id an app can spell. The second pass used `::no-frame`, which is
+  `:day8.re-frame2-xray.egress/no-frame`; a live frame under that id made an
+  unselected copy resolve to it and egress RAW under its empty registry
+  (rf2-7htk7, third pass). A fresh host object is an IDENTITY rather than a
+  datum — nothing outside this var can produce an equal value — so no
+  registration can match it, and `frame/frame` misses on it exactly as on a
+  destroyed id."
+  (js/Object.))
+
 (defn egress-value
   "Project `value` for an off-box sink (console, clipboard) through the
   framework's wire-elision walker with the off-box defaults BAKED IN.
@@ -67,9 +82,9 @@
                                  :rf.size/include-large?     include-large?}
                           (seq path)              (assoc :path (vec path))
                           ;; An explicitly-passed `:frame` is forwarded even
-                          ;; when nil — substituting a sentinel that can never
-                          ;; be a registered frame id, so the walker takes its
-                          ;; unresolvable/fail-closed arm instead of falling
-                          ;; through to the ambient frame.
+                          ;; when nil — substituting `no-frame`, an identity
+                          ;; no registration can match, so the walker takes
+                          ;; its unresolvable/fail-closed arm instead of
+                          ;; falling through to the ambient frame.
                           (contains? opts :frame) (assoc :frame (or (:frame opts)
-                                                                    ::no-frame))))))
+                                                                    no-frame))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -556,6 +556,45 @@
             (str "the RAW value leaked to the clipboard under a destroyed "
                  "frame (rf2-7htk7). text: " (pr-str text)))))))
 
+(deftest copy-value-with-no-observed-frame-fails-closed-under-id-collision
+  (testing "rf2-7htk7 (third pass) — an app registers a LIVE frame under the
+            public keyword the earlier explicit-nil substitute expanded to,
+            :day8.re-frame2-xray.egress/no-frame. With the picker unselected
+            the copy must still redact whole: a substitute that is itself a
+            registrable frame id resolved to that live frame, took the
+            walker's live-frame branch, and its empty declaration registry
+            shipped the value RAW"
+    (registry/register-xray-handlers!)
+    ;; The app's own frame holds the secret and declares it sensitive — but
+    ;; the picker never selects it, so its policy is not what governs here.
+    (rf/make-frame {:id :rf/default})
+    (rf/with-frame :rf/default (seed-sensitive-schema!))
+    ;; The colliding frame: an ordinary public keyword any app can spell.
+    (rf/make-frame {:id :day8.re-frame2-xray.egress/no-frame})
+    (try
+      (let [captured (atom [])]
+        (rf/make-frame {:id :rf/xray
+                        :fx-overrides {:rf.xray.fx/copy-to-clipboard
+                                       (fn [_ctx args] (swap! captured conj args))}})
+        ;; No :rf.xray/set-target-frame — the unselected picker.
+        (rf/with-frame :rf/xray
+          (rf/dispatch-sync
+            [:rf.xray/copy-value-to-clipboard
+             {:auth {:username "ada" :password "shh"}}]))
+        (is (= 1 (count @captured)))
+        (let [text (:text (first @captured))]
+          (is (= ":rf/redacted" text)
+              (str "no observed frame must egress the whole-value redaction "
+                   "sentinel even with a live frame registered under the "
+                   "explicit-nil substitute's id. text: " (pr-str text)))
+          (is (not (re-find #"shh" text))
+              (str "the RAW secret leaked to the clipboard through a live "
+                   "frame colliding with the explicit-nil substitute "
+                   "(rf2-7htk7). text: " (pr-str text)))))
+      (finally
+        ;; Never leave the colliding id live for a sibling test.
+        (rf/destroy-frame! :day8.re-frame2-xray.egress/no-frame)))))
+
 (deftest copy-path-is-not-a-value-egress
   (testing "rf2-uo0rc.2 — the path-copy variant copies only the path
             vector (key names, no values); it is not a value-egress site


### PR DESCRIPTION
## Summary

Third pass on rf2-7htk7. The audit of PR #8972 found one residual: `egress-value` substituted `::no-frame` for an explicitly-passed nil `:frame`, but that expands to the ordinary public frame id `:day8.re-frame2-xray.egress/no-frame`, which `make-frame` accepts like any other keyword. With such a frame live, an unselected clipboard copy resolved to it, took the walker's live-frame branch, and its empty declaration registry shipped the value raw. Reproduced on the merged code before anything was changed (see the control below).

## Change

- `tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs` — the collision regression, written first on the merged code: register a live frame under the literal id, leave the picker unselected, copy a value whose `[:auth :password]` is declared sensitive on the (unselected) app frame, assert the clipboard text is `:rf/redacted` and not the secret. The two existing regressions (absent target, destroyed target) stay green.
- `tools/xray/src/day8/re_frame2_xray/egress.cljs` — the substitute is now a private identity value (a fresh host object held in a private var) rather than a keyword. Nothing outside the var can produce an equal value, so no registration can match it and `frame/frame` misses on it exactly as on a destroyed id; the walker keeps owning the liveness decision. Omitted-key ambient resolution is untouched.
- `tools/xray/spec/API.md` §Off-box egress — the sentence describing the substitute now says what it is and why a keyword was not it.

No Pair change, no compatibility layer, no new public surface. `elision.cljc` is untouched.

### Remedy chosen, and the measurement that decided it

The audit offered two completions: (a) have `elide-wire-value` distinguish a present `:frame` key from an absent one (core), or (b) a private identity value outside the frame-id grammar (Xray). Measured at tip: (a) changes the semantics of an explicit `{:frame nil}` for the 22 non-test `elide-wire-value` call sites outside `elision.cljc`, and at least one of them — `project-egress` seeding `:frame` from a record's own top-level slot — carries spec prose (`spec/API.md` `project-egress` row; `spec/015` §Projection) promising fallback to the carried scope when neither the opt nor the record names a frame, so (a) is a core change plus a hot-zone spec change. (b) is one expression in one Xray file whose only callers are Xray's two off-box sinks. The stance prefers the smaller honest change, so (b). One nuance: `make-frame` validates no `:id` type at all, so "outside the grammar" has to mean a value an app cannot spell, not merely a non-keyword — hence an identity object rather than any datum.

Core carries the same design in `implementation/core/src/re_frame/derivation/egress.cljc` (`dead-frame-sentinel` is the keyword `::no-egress-frame`). That is outside this audit note's scope and is filed as rf2-g1vu rather than widened into here.

## Quality gates

All from this worker's worktree; every exit code below was captured by the same shell that ran the gate (redirect to a log, `echo $?` to an exit file, one command line), never piped.

CLJS lane (`npm run test:cljs`'s two phases, run split as the brief allows — `node scripts/compile-node-test.cjs node-test out/node-test.js`, then `node out/node-test.js`, from `implementation/`):

- Compile 1, merged code plus the new test only: exit 0 — `1881 files, 1880 compiled, 0 warnings`.
- BEFORE, focused `--test=day8.re-frame2-xray.panels.app-db-diff-cljs-test`: exit 1 — `Ran 27 tests containing 86 assertions. 2 failures, 0 errors.` Failing assertion actual: `(not (= ":rf/redacted" "{:auth {:username \"ada\", :password \"shh\"}}"))` — the secret on the clipboard, through a live frame `make-frame` accepted under the sentinel's keyword.
- BEFORE, full lane: exit 1 — `Ran 11148 tests containing 55578 assertions. 2 failures, 0 errors.` (both the new test's).
- Compile 2, with the fix: exit 0 — `1881 files, 233 compiled, 0 warnings`.
- AFTER, focused: exit 0 — `Ran 27 tests containing 86 assertions. 0 failures, 0 errors.`
- AFTER, full lane: exit 0 — `Ran 11148 tests containing 55578 assertions. 0 failures, 0 errors.`
- Revert-in-place control: the pre-fix `egress.cljs` checked out from the test-only commit (working blob hash `7f99d814ea60d69300f60d3eeb1a567ab0dea25a`, so the plant applied), compile 3 exit 0 (`233 compiled`, so the runtime saw it), focused run exit 1 with the same two failures and the same secret. Restored with `git checkout HEAD --`; the working file's blob hash `714d332211b842dab75c368f54ea9e01d02def67` equals HEAD's blob for that path; status clean.

Other gates:

- `python scripts/check_doc_slugs.py` (this PR touches `tools/xray/spec/API.md`, inside its roots): exit 0.
- `sh scripts/test-fast-pr.sh` on the rebased base (`origin/main` = `09f94abe35`): exit 0, `PASS fast PR spine`. The spine printed a gate root naming this worker's worktree. The classifier armed the documentation tier (doc gates plus `mkdocs --strict`), the node/CLJS tier (node-test compile `1881 files, 233 compiled, 0 warnings`; `Ran 11148 tests containing 55578 assertions. 0 failures, 0 errors.`; the JS harness self-tests; the hicasso modules compile) and the pinned clj-kondo 2026.04.15; the JVM tier was skipped because no JVM artefact changed.
- Focused Xray namespace on the spine-built final-base bundle: exit 0 — `Ran 27 tests containing 86 assertions. 0 failures, 0 errors.`

Skipped, with reason:

- `clojure -M:test` in `implementation/core` — not run: `elision.cljc` (and every other core file) is untouched.
- Pair conformance suite — not run: no Pair change.
- Required CI checks the spine does not run: see `TESTING.md` §Required checks the fast-PR spine does not run (the spine's own digest reports 96 for this diff; CI owns them).

`tools/xray/spec/*`: updated in this PR — `API.md` §Off-box egress. `014-Registry-Catalogue.md`'s `:rf.xray/copy-value-to-clipboard` row is unchanged because it describes the forwarded `:frame` opt, not the substitute.

Verified by hand (no gate covers it): the `API.md` edit sits in prose (not inside a fenced block), touches no table, and adds or changes no heading anchor.

### Audit finding discharged (verbatim, from the bead's newest note)

> AUDIT PR #8972: REOPENED exact owner; no duplicate.
>
> Completeness: the new regressions cover an absent target and an ordinary destroyed target, but not a live frame colliding with the substitute used for explicit nil.
>
> Correctness: egress-value calls the supposedly unregisterable sentinel ::no-frame, but that expands to the ordinary frame-id keyword :day8.re-frame2-xray.egress/no-frame. The frame registry is keyed by public keyword ids, so an app can legitimately register that exact id. With such a frame live, an unselected copy rewrites explicit nil to that id; elide-wire-value resolves it, takes the live-frame branch, and an empty declaration registry passes the clipboard value through raw. The new fail-closed path can therefore still fail open. A focused control can register that literal id, leave Xray unselected, and observe the secret instead of :rf/redacted on the merged code.
>
> Implementation quality: forwarding the observed frame and centralising liveness in the walker are the right simplifications, but a forgeable keyword is not a safe representation of no frame. Minimal completion: preserve omitted-frame ambient resolution while representing explicit nil without a registrable id, preferably by having elide-wire-value distinguish a present :frame key from an absent one; alternatively use a genuinely private identity value outside the public frame-id grammar. Add the collision regression. No Pair change, compatibility layer, or new public surface.
