### PR TITLE
test(realworld): two production-seam receipts against the demo backend (rf2-k5lbd)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -2,7 +2,9 @@
   "Integration test: drives the realworld (Conduit) example (rf2-4v73)
    feature by feature. Each helper spins a fresh frame via `make-frame`,
    drives a feature flow with a canned :rf.http/managed stub, and asserts
-   the resulting app-db / sub state.
+   the resulting app-db / sub state. The one row that uses NO canned stub is
+   the production-seam receipt at the bottom (rf2-k5lbd): managed HTTP wired
+   to the app's own demo backend, replies awaited rather than injected.
 
    The fixture fns + the canned-stub helpers live HERE (the adapter test
    tree), not under examples/real-apps/realworld_http/ — the example source stays
@@ -22,7 +24,7 @@
    load), and the restore on the way out leaves them intact for any
    subsequent test ns."
   (:require [clojure.string :as str]
-            [cljs.test :refer-macros [deftest testing use-fixtures is]]
+            [cljs.test :refer-macros [deftest testing use-fixtures is async]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
@@ -61,7 +63,12 @@
             ;; The `home-context` pure flattener (tags.cljs) exercised directly by
             ;; home-context-test (rf2-rq65wv).
             [realworld-http.tags :as tags]
-            [realworld-http.ssr :as ssr])
+            [realworld-http.ssr :as ssr]
+            ;; The shared demo backend the app's production `:rf.http/managed`
+            ;; override (`:realworld.demo/http-stub`, realworld-http.http) steps —
+            ;; for the pure "server truth" read the production-seam receipt at
+            ;; the bottom compares the settled slice against.
+            [realworld-shared.demo-backend :as demo])
   (:require-macros [re-frame.core :refer [with-new-frame]]
                    [re-frame.test-support :refer [with-trace-recorder!]]))
 
@@ -147,6 +154,11 @@
     ;; carry explicit `{:frame f}` or run inside the `with-new-frame` scope.
     {:adapter       reagent-adapter/adapter
      :ambient-frame nil
+     ;; Map-form (rf2-k5lbd): the production-seam receipt at the bottom is an
+     ;; `(async done …)` row — it awaits the demo backend's deferred replies —
+     ;; and cljs.test runs one only under a map fixture. Sync rows are served
+     ;; identically (re-frame.async-reset-fixture-cljs-test pins that).
+     :async?        true
      ;; rf2-h1vqa4: reinstate the sequestered per-app not-found route for
      ;; this suite's own tests (see the sequester def above).
      :init-fn       (fn []
@@ -2923,3 +2935,117 @@
 ;; duplicated per app. This app retains only the integration assertion above
 ;; (`paginate-path-integration-test`) proving its request builder threads that
 ;; shared contract through.
+
+;; ============================================================================
+;; THE PRODUCTION-SEAM RECEIPT — write, then load, against the demo backend the
+;; served app runs on (rf2-9n43e part B, rf2-k5lbd)
+;; ============================================================================
+;;
+;; Every stub above is a canned reply the test chose, which is the right tool
+;; for pinning what a handler does with a given reply and the wrong one for the
+;; claim the README makes: that a comment you post is still there when the page
+;; re-reads. rf2-9n43e found the shipped backend answering every later GET out
+;; of a frozen seed, and no test here could see it, because no test here let
+;; the backend answer.
+;;
+;; This receipt chooses nothing. The frame is wired the way `realworld.core/
+;; mount!` wires the served app (`:fx-overrides {:rf.http/managed
+;; :realworld.demo/http-stub}`), so the article page's own public events — the
+;; route's `:comments/load`, `:comment-form/submit`, and a later `:comments/load`
+;; — all go to the app's own `demo-state` world through the shared demo backend,
+;; and each reply comes back through the backend's own deferred path
+;; (`:after-ms` → `:dispatch-later`, a real 20 ms later). The test WAITS for the
+;; slice to settle rather than settling it.
+;;
+;; Async, and the fixture above is `:async? true` for this row: `cljs.test` runs
+;; an `(async done …)` body only under a map fixture, and the deferred reply is
+;; unreachable from a synchronous body (its first hop is an async router
+;; dispatch). `with-new-frame` is deliberately NOT used — it destroys the frame
+;; when the body RETURNS, before anything has settled — so the frame is a plain
+;; anon record and every dispatch names it.
+
+(def ^:private demo-user
+  "The demo world's one user, as `POST /users/login` issues them — the identity
+   the backend stamps on every write."
+  {:email "demo@conduit.dev" :token "stub.demo.jwt" :username "demo"
+   :bio "Canned demo user." :image ""})
+
+(defn- backend-comments
+  "What the demo backend would answer `GET /articles/<slug>/comments` with RIGHT
+   NOW — a pure read of the app's own world, no frame involved. This is the
+   server truth the receipt compares the settled slice against."
+  [slug]
+  (:comments
+    (:ok (second (demo/transition @rh/demo-state
+                                  {:request {:method :get
+                                             :url    (rh/full-url
+                                                       (str "/articles/" slug "/comments"))}})))))
+
+(deftest realworld-production-seam-receipt-a-comment-survives-a-later-load
+  (testing "examples/real-apps/realworld_http — against the app's PRODUCTION demo
+            backend, with no canned reply anywhere: the article route's own
+            :comments/load settles from the backend; :comment-form/submit POSTs
+            through the same seam and the saved comment replaces the optimistic
+            card; a LATER :comments/load through the normal public event still
+            has it — the write survived a later normal read"
+    (async done
+      ;; The documented reset boundary: this receipt's world, and nobody else's.
+      (reset! rh/demo-state (demo/fresh-state))
+      (let [f        (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides   {:rf.http/managed :realworld.demo/http-stub}})
+            slug     "hello-conduit"
+            comments #(rf/compute-sub [:comments/data] (rf/frame-state-value f))
+            status   #(rf/compute-sub [:comments/status] (rf/frame-state-value f))]
+        (rf/dispatch-sync [:article/initialise] {:frame f})
+        (rf/dispatch-sync [:comments/initialise] {:frame f})
+        (rf/dispatch-sync [:comment-form/initialise] {:frame f})
+        (rf/dispatch-sync [:auth/store-session demo-user] {:frame f})
+        ;; The article route's `:on-match` fires `:article/load` + `:comments/load`.
+        (rf/dispatch-sync [:rf.route/handle-url-change (str "/article/" slug)] {:frame f})
+        (is (= :loading (status))
+            "the route's own :comments/load is in flight against the demo backend")
+        (-> (test-support/poll-until
+              #(= :loaded (status))
+              {:label "the route's comments load settles from the demo backend"})
+            (.then (fn [_]
+                     (is (= [1] (mapv :id (comments)))
+                         "the first load is the backend's one seeded comment — nothing canned")
+                     (is (= (backend-comments slug) (comments))
+                         "…and equal to what the backend answers that GET with right now")
+                     ;; The page's own form: optimistic card now, POST through the seam.
+                     (rf/dispatch-sync [:comment-form/edit-field :body "great read"] {:frame f})
+                     (rf/dispatch-sync [:comment-form/submit] {:frame f})
+                     (is (= 2 (count (comments)))
+                         "the optimistic temp card is on screen before the backend answers")
+                     (is (str/starts-with? (str (:id (second (comments)))) "temp-")
+                         "…under its recordable temp-id")
+                     (test-support/poll-until
+                       #(= 1000 (:id (second (comments))))
+                       {:label "the POST settles from the demo backend and the saved comment replaces the temp card"})))
+            (.then (fn [_]
+                     (is (= "" (:body (rf/compute-sub [:comment-form/draft] (rf/frame-state-value f))))
+                         "the form reset on save")
+                     ;; A LATER LOAD through the normal public event — the page re-reading.
+                     (rf/dispatch-sync [:comments/load] {:frame f})
+                     (is (= :fetching (status))
+                         "a same-slug re-load keeps the list up while it refreshes")
+                     (test-support/poll-until
+                       #(= :loaded (status))
+                       {:label "the later load settles from the demo backend"})))
+            (.then (fn [_]
+                     (is (= [1 1000] (mapv :id (comments)))
+                         "the later load still has the comment just written — the write survived a later normal read, and the id is the backend's deterministic one")
+                     (is (= "great read" (:body (second (comments))))
+                         "the body is the one the form submitted")
+                     (is (= "demo" (-> (comments) second :author :username))
+                         "the backend stamped the world's one user as the author")
+                     (is (= (backend-comments slug) (comments))
+                         "the slice is at the backend's CURRENT truth — the later read consulted the state the write landed in, not a seed")
+                     (is (= 2 (count (get-in @rh/demo-state [:comments slug])))
+                         "the write landed in this app's own world")))
+            ;; Report and release; `done` runs once, in the one trailing step.
+            (.catch (fn [e]
+                      (is false (str "production-seam receipt did not settle: " (.-message e)))
+                      nil))
+            (.then (fn [_] (done))))))))

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -23,7 +23,12 @@
         departing principal's scoped caches via `:rf.resource/clear-scope`
         (the mandatory teardown path);
      6. THE AUTH MACHINE — login drives :idle → :submitting → :authed via managed
-        HTTP and stores the session.
+        HTTP and stores the session;
+     7. THE PRODUCTION-SEAM RECEIPT (§11, rf2-k5lbd) — with managed HTTP wired to
+        the app's OWN demo backend, a comment posted through the comment form
+        survives the refetch its invalidation causes: the runtime refetches the
+        route-owned comments read on its own, and the refetch settles on the
+        backend's current state.
 
    The fixture fns + the deterministic transport stub live HERE (the adapter test
    tree), not under examples/real-apps/realworld_resources/ — the example source
@@ -37,12 +42,16 @@
    DETERMINISM. Each test installs its own capturing `:rf.http/managed` override
    and replays the reply explicitly via the transport's real 3-element reply-
    event-append shape (`(conj on-success {:status :ok :value …})`). Routing's
-   url-push is stubbed so navigation is deterministic without a browser.
+   url-push is stubbed so navigation is deterministic without a browser. The one
+   exception is §11, which answers nothing by hand: it drives the production demo
+   backend and awaits its deferred replies (`:after-ms` → `:dispatch-later`) with
+   `test-support/poll-until`, which is why the suite runs under the MAP-FORM
+   (`:async? true`) reset fixture.
 
    Per rf2-am9d this ns uses snapshot/restore via re-frame.test-support so the
    contract is uniform across CLJS fixtures."
   (:require [clojure.string :as str]
-            [cljs.test :refer-macros [deftest testing use-fixtures is]]
+            [cljs.test :refer-macros [deftest testing use-fixtures is async]]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
             [re-frame.frame :as frame]
@@ -75,6 +84,12 @@
             ;; strategies (already loaded via core; aliased for the ui-arm
             ;; url-strategy pins — rf2-nn5s8 audit rider).
             [realworld-resources.routing :as app-routing]
+            ;; The app's HTTP surface — its `defonce`d demo-backend world
+            ;; (`demo-state`, the documented reset boundary) and `full-url` — plus
+            ;; the shared demo backend itself, for the pure "server truth" read the
+            ;; §11 receipt compares the settled entry against.
+            [realworld-resources.http :as app-http]
+            [realworld-shared.demo-backend :as demo]
             ;; The shared WIRE contract (User / UserResponse) + this app's durable
             ;; app-db schemas (AuthSlice), for the default-frame validator
             ;; regression (rf2-3fc89f.32).
@@ -186,7 +201,7 @@
                                 nil))
   (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil)))
 
-(defn- isolate-trace-bus-fixture
+(def ^:private isolate-trace-bus-fixture
   "OUTER fixture: keep this resource/mutation-registering suite from leaking
    trace residue into later cross-cutting tooling tests (the Xray/Story panel e2e
    seeds read the process-global trace bus). The leak this closes:
@@ -207,6 +222,12 @@
    the framework trace rings so no collector is active to capture any burst, and
    its teardown clears them again so this suite leaves a clean trace bus.
 
+   MAP-FORM (`{:before :after}`), like the reset fixture beside it (`:async?
+   true`): `cljs.test` runs an `(async done …)` row — §11's production-seam
+   receipt — only when EVERY `:each` fixture is a map, and it runs map
+   `:before`s in listing order and `:after`s in reverse, so listing this one
+   first still makes it the outermost wrapper.
+
    (The registrar side is handled separately: this suite's resources / mutations /
    scopes are removed from the SHARED registrar at NS LOAD — see the top-level
    `swap!` above — and captured in the per-test snapshot baseline as ABSENT, so
@@ -214,18 +235,23 @@
    persisting for another suite's reset to clear.) A later e2e test re-registers
    its own collector (its helper calls `reset-sentinels!` +
    `register-trace-collector!`), so clearing here is safe."
-  [f]
-  (trace-tooling/clear-listeners!)
-  (trace-tooling/clear-trace-rings!)
-  (f)
-  (trace-tooling/clear-listeners!)
-  (trace-tooling/clear-trace-rings!))
+  {:before (fn []
+             (trace-tooling/clear-listeners!)
+             (trace-tooling/clear-trace-rings!))
+   :after  (fn []
+             (trace-tooling/clear-listeners!)
+             (trace-tooling/clear-trace-rings!))})
 
 (use-fixtures :each
   isolate-trace-bus-fixture
   (test-support/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter
-     :init-fn init!}))
+     :init-fn init!
+     ;; Map-form (rf2-k5lbd): §11's production-seam receipt is an
+     ;; `(async done …)` row, and cljs.test runs one only under map fixtures.
+     ;; Sync rows are served identically (re-frame.async-reset-fixture-cljs-test
+     ;; pins that).
+     :async?  true}))
 
 ;; ============================================================================
 ;; HELPERS
@@ -1885,3 +1911,128 @@
                         (routing/route-link-render {:to :realworld.auth/login}))]
         (is (= "/realworld-resources/login" (:href attrs))
             "the Reagent arm's generated link carries its own mount base")))))
+
+;; ============================================================================
+;; 11. THE PRODUCTION-SEAM RECEIPT — read → write → invalidate → refetch against
+;;     the demo backend the served app runs on (rf2-9n43e part B, rf2-k5lbd)
+;; ============================================================================
+;;
+;; Every other test in this file answers managed HTTP by hand: `init!` swaps
+;; `:rf.http/managed` for a capture, and each test replays the reply it wants.
+;; That pins the app's wiring, but it cannot pin the one claim the example's
+;; README makes — that a write is still there after the refetch it causes —
+;; because the reply is whatever the test says it is. rf2-9n43e found exactly
+;; that gap: the old comment test hand-injected the write reply and asserted
+;; only that a refetch BEGAN, while the shipped backend answered the refetch
+;; out of a frozen seed and every comment vanished on success.
+;;
+;; This receipt answers nothing by hand. The frame is wired the way `core.cljs`
+;; wires the served app (`:fx-overrides {:rf.http/managed
+;; :realworld-resources.demo/http-stub}`), so every read and write goes to the
+;; app's own `demo-state` world through the shared demo backend; each reply
+;; comes back through the backend's own deferred path (`:after-ms` →
+;; `:dispatch-later`, a real 20 ms later); and the test WAITS for the runtime to
+;; settle rather than settling it. `:realworld/post-comment` declares
+;; `:invalidates` and no `:populates`, so the only way the new comment can
+;; reach the entry is the refetch the invalidation causes — which is the
+;; example's headline, and the sequence this row proves.
+;;
+;; Async, and the suite's fixtures are map-form for exactly this row: the
+;; deliverer's first hop is an async router dispatch that a `dispatch-sync`
+;; body never drains (linearlite_example_cljs_test.cljs §5 records the same
+;; boundary), and `cljs.test` runs an `(async done …)` body only under map
+;; fixtures. `with-new-frame` is deliberately NOT used — it destroys the frame
+;; when the body RETURNS, which for an async body is before anything settles —
+;; so the frame is a plain anon record and every dispatch names it.
+
+(def ^:private demo-user
+  "The demo world's one user, as `POST /users/login` issues them — the identity
+   the backend stamps on every write, and the viewer the reads land under."
+  {:email "demo@conduit.dev" :token "stub.demo.jwt" :username "demo"
+   :bio "Canned demo user." :image ""})
+
+(defn- production-seam-frame!
+  "A frame wired the way `realworld-resources.core/mount!` wires the served app:
+   URL-owning, with managed HTTP redirected to this app's PRODUCTION demo-backend
+   seam. url-push and the session-persist fx are no-op'd, as in `restore-frame!`."
+  []
+  (frame/make-anon-frame-record!
+    {:url-bound?   true
+     :fx-overrides {:rf.http/managed                     :realworld-resources.demo/http-stub
+                    :rf.nav/push-url                     :rf/no-op
+                    :realworld-resources.session/persist :rf/no-op}}))
+
+(defn- comment-ids [e] (mapv :id (get-in e [:data :comments])))
+
+(defn- backend-comments
+  "What the demo backend would answer `GET /articles/<slug>/comments` with RIGHT
+   NOW — a pure read of the app's own world, no frame involved. This is the
+   server truth the receipt compares the settled entry against."
+  [slug]
+  (:ok (second (demo/transition @app-http/demo-state
+                                {:request {:method :get
+                                           :url    (app-http/full-url
+                                                     (str "/articles/" slug "/comments"))}}))))
+
+(deftest production-seam-receipt-a-comment-survives-the-refetch-it-causes
+  (testing "examples/real-apps/realworld_resources — against the app's PRODUCTION
+            demo backend, with no hand-injected reply anywhere: the article route
+            plans the comments read; it settles from the backend; the comment
+            form's own submit runs :realworld/post-comment through the same seam;
+            the write settles, invalidates the route-owned read, the runtime
+            refetches it on its own, and the refetch settles on the backend's
+            CURRENT state — the comment just written is in it"
+    (async done
+      ;; The documented reset boundary: this receipt's world, and nobody else's.
+      (reset! app-http/demo-state (demo/fresh-state))
+      (let [f          (production-seam-frame!)
+            slug       "hello-conduit"
+            k          (comments-key "demo" slug)
+            first-load (atom nil)]
+        (rf/dispatch-sync [:auth/store-session demo-user] {:frame f})
+        (rf/dispatch-sync [:rf.route/navigate {:to :realworld.article/show :params {:slug slug}}]
+                          {:frame f})
+        (is (= :loading (:status (entry f k)))
+            "route entry planned the comments read under the demo viewer, in flight")
+        (-> (test-support/poll-until
+              #(= :loaded (:status (entry f k)))
+              {:label "the route-owned comments read settles from the demo backend"})
+            (.then (fn [_]
+                     (let [e (entry f k)]
+                       (reset! first-load (select-keys e [:generation :loaded-at]))
+                       (is (= [1] (comment-ids e))
+                           "the first load is the backend's one seeded comment — nothing hand-injected")
+                       (is (= (backend-comments slug) (:data e))
+                           "…and equal to what the backend answers that GET with right now"))
+                     ;; The app's own comment form. `:comment-form/submit` executes
+                     ;; `:realworld/post-comment`, whose reply goes to the mutation
+                     ;; runtime, never to the entry: `:invalidates`, no `:populates`.
+                     (rf/dispatch-sync [:comment-form/edit "great read"] {:frame f})
+                     (rf/dispatch-sync [:comment-form/submit slug] {:frame f})
+                     (test-support/poll-until
+                       #(let [e (entry f k)
+                              m (rf/compute-sub [:rf/mutation {:instance [:post-comment slug]}]
+                                                (state-value f))]
+                          (and (true? (:success? m))
+                               (> (:generation e) (:generation @first-load))
+                               (= :loaded (:status e))))
+                       {:label "the write settles, the invalidated read refetches, and the refetch settles"})))
+            (.then (fn [_]
+                     (let [e (entry f k)]
+                       (is (= [1 1000] (comment-ids e))
+                           "the refetched read carries the seeded comment AND the one just written — the write survived the refetch it caused, and the id is the backend's deterministic one")
+                       (is (= "great read" (-> e :data :comments second :body))
+                           "the body is the one the form submitted")
+                       (is (= "demo" (-> e :data :comments second :author :username))
+                           "the backend stamped the world's one user as the author")
+                       (is (= (backend-comments slug) (:data e))
+                           "the entry is at the backend's CURRENT truth — the refetch consulted the state the write landed in, not a seed")
+                       (is (nil? (:invalidated-at e))
+                           "the refetch cleared the invalidation it answered")
+                       (is (= 2 (count (get-in @app-http/demo-state [:comments slug])))
+                           "the write landed in this app's own world"))))
+            ;; Report and release; `done` runs once, in the one trailing step.
+            (.catch (fn [e]
+                      (is false (str "production-seam receipt did not settle: " (.-message e)))
+                      nil))
+            (.then (fn [_] (done))))))))


### PR DESCRIPTION
Part B of rf2-9n43e (rf2-k5lbd). Every RealWorld test answered managed HTTP by hand, so none could see the defect part A (#8948) fixed: the shipped demo backend answering the refetch a write caused out of a frozen seed, erasing every comment on success. Each app now has one receipt that drives its PRODUCTION `:rf.http/managed` override — the app's own `demo-state` world through the shared demo backend — and awaits the backend's deferred replies (`:after-ms` → `:dispatch-later`, a real 20 ms) with `test-support/poll-until` instead of injecting them.

## What landed

**`implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs` — §11, the Resources receipt.** Frame wired as `core.cljs` wires the served app (`:fx-overrides {:rf.http/managed :realworld-resources.demo/http-stub}`). The article route plans the comments read; it settles from the backend (the one seeded comment, equal to a pure read of the backend's world); the comment form's own `:comment-form/submit` runs `:realworld/post-comment` through the same seam; the write settles `:success`, invalidates the route-owned read, the runtime refetches it on its own, and the refetch settles on the backend's CURRENT state with the new comment (id `1000`, the backend's deterministic counter) in it. Also pinned: the entry's `:generation` advanced (a NEW load, not a patch), `:invalidated-at` cleared, and the write is in the app's own world.

**`implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs` — the Managed-HTTP receipt.** Frame wired as `realworld.core/mount!` wires the served app (`:fx-overrides {:rf.http/managed :realworld.demo/http-stub}`). The route's own `:comments/load` settles from the backend; `:comment-form/submit` POSTs through the seam (optimistic temp card first, then the saved comment replaces it); a LATER `:comments/load` through the normal public event still has it, equal to the backend's current truth.

**Fixture shape.** Both rows are `(async done …)`, and `cljs.test` runs one only when every `:each` fixture is a map, so both suites move to the map-form reset fixture (`:async? true`); the resources suite's outer trace-bus fixture becomes `{:before :after}` (cljs.test runs map `:before`s in listing order and `:after`s in reverse, so it stays outermost). Sync rows are served identically — `re-frame.async-reset-fixture-cljs-test` pins that, and the two suites' existing rows all ran green under the new shape (counts below). `with-new-frame` is deliberately not used in the receipts: it destroys the frame when the body RETURNS, which for an async body is before anything settles.

`examples/` untouched (rf2-8cevm). No hot-zone file touched.

## Quality gates

All from `implementation/`, the always-on `:node-test` lane in two foreground phases (compile via `node scripts/compile-node-test.cjs node-test out/node-test.js`, then `node out/node-test.js`), each phase's exit code captured on the same command line as its redirect; the harness's own "exit 0" for the shell was ignored throughout (it disagreed with the captured file on both sabotage runs — the rf2-9n43e trap, measured twice more). The compile prints its config path, which named this worktree on every attempt; the node run prints no root, so the planted reds below are the proof it read this tree.

| # | Gate | Tree | Captured exit | Result |
|---|------|------|---------------|--------|
| 1 | compile (cold) | this PR | 0 | 1881 files, 1880 compiled, **0 warnings** |
| 1 | run, two suites | this PR | 0 | **Ran 53 tests containing 675 assertions. 0 failures** |
| 1 | run, each receipt alone (`--test=<ns>/<var>`) | this PR | 0, 0 | resources receipt **9 assertions**; HTTP receipt **12 assertions** |
| 1 | run, full lane | this PR | 0 | **Ran 11149 tests containing 55596 assertions. 0 failures, 0 errors** |
| 2 | compile + run, two suites | BEFORE (both files at base `dd26ca5af2`, blob-verified `8f60c7c5…` / `129d4fd1…`) | 0, 0 | **Ran 51 tests containing 654 assertions. 0 failures** — restored to HEAD, blobs `e4e2a74f…` / `6bce57f2…` verified |
| 3 | compile + run, two suites | Resources SABOTAGE | 0, **1** | **4 failures**, all in `production-seam-receipt-a-comment-survives-the-refetch-it-causes`, nothing else red — restored, blob `e4e2a74f…` verified |
| 4 | compile + run, two suites | HTTP SABOTAGE | 0, **1** | **4 failures**, all in `realworld-production-seam-receipt-a-comment-survives-a-later-load`, nothing else red — restored, blob `6bce57f2…` verified |
| 5 | compile + run, full lane | FINAL BASE (rebased onto `origin/main` `09f94abe35`) | 0, 0 | compile `1881 files, 2 compiled, 0 warnings`; **Ran 11149 tests containing 55596 assertions. 0 failures, 0 errors** |

**Deltas.** Two suites: 51 → 53 tests, 654 → 675 assertions (+9 resources, +12 HTTP), measured on both trees rather than derived — and the equality of the two BEFORE readings (measured 654 vs 675 − 21) is the check that the fixture-shape change moved no existing row's count.

**The controls.** Each plant re-registers the app's production demo-backend fx so it RESETS the world before every request — the exact rf2-9n43e defect (a backend that forgets every write), reached through the production `respond`. Under it the initial load and the write both still succeed, so only the temporal claim can fail, and it does, naming the seam:

- Resources: `the refetched read carries the seeded comment AND the one just written — the write survived the refetch it caused …` expected `[1 1000]`, actual `[1]`; plus body/author `nil` and `the write landed in this app's own world` (2 vs 1).
- HTTP: `the later load still has the comment just written — the write survived a later normal read …` expected `[1 1000]`, actual `[1]`; plus body/author `nil` and the world count (2 vs 1).

**What this local run omits.** Everything `TESTING.md` §"Required checks the fast-PR spine does not run" enumerates (derive it with `python scripts/check_fast_pr_gap.py --list`): the browser lanes, the JVM tiers, lint/docs/portability and the rest of the required set run only in CI. Cite CI for those. No link validator was nominated: the diff adds no markdown and no doc links (one `.cljs` comment names a sibling test file by path, in prose).

**Anchors and tables** in this body were checked by hand; no fenced blocks were added to any tracked markdown.
