### PR TITLE
docs(hicasso/pilots): app-owned behavioural baseline in each pilot workspace (rf2-xkhul)

### DIFF
--- a/docs/design/hicasso/product/pilots/README.md
+++ b/docs/design/hicasso/product/pilots/README.md
@@ -10,12 +10,14 @@ Filed under `rf2-v04s`, executing item 2 of [`rf2-hic-063`](#what-governs-this-d
 
 | Page | What it is | Read it when |
 | --- | --- | --- |
-| [`workspace.md`](workspace.md) | The per-pilot workspace: layout, the four project files copy-ready, the per-pilot source manifest, and the read fence | Setting a pilot up |
+| [`workspace.md`](workspace.md) | The per-pilot workspace: layout, the four project files copy-ready, the per-pilot source manifest with its behavioural baseline, and the read fence | Setting a pilot up |
 | [`brief-realworld.md`](brief-realworld.md) | Pilot 1's brief — RealWorld/Conduit, the feed and the article editor | Handing the brief to the agent |
 | [`brief-linearlite.md`](brief-linearlite.md) | Pilot 2's brief — LinearLite, the board and the grown card detail | Handing the brief to the agent |
 | [`friction-log.md`](friction-log.md) | The friction-log format, built around the seven outcomes | Before a pilot writes its first entry, and when dispositioning a finished log |
 
 The 2 briefs are the only pages a pilot agent ever sees. `workspace.md` is the operator's. `friction-log.md` is quoted into the brief by reference, and its blank template is copied into the workspace. But the pilot is never sent to this directory to read it, because this directory is inside the repository the pilot is blinded to.
+
+Beside the four pages, [`baseline/`](baseline/README.md) holds the two app-owned test files that `workspace.md`'s manifest copies into `app/test/` — the behavioural baseline outcome 1 is measured against. They are fixtures the workspace compiles, not a test lane of this repository, and nothing here runs them. Added under `rf2-xkhul`.
 
 ## The blinding is a read fence, not an absence
 

--- a/docs/design/hicasso/product/pilots/baseline/README.md
+++ b/docs/design/hicasso/product/pilots/baseline/README.md
@@ -1,0 +1,22 @@
+# The behavioural baselines
+
+Two test files, one per pilot, that [`workspace.md`](../workspace.md)'s source manifest copies into the workspace's `app/test/`. They are what outcome 1 of the [friction log](../friction-log.md) measures against: the operator runs them with the app still on Reagent and records the exit code, and the pilot runs them again after the migration.
+
+Added under `rf2-xkhul`, on `rf2-hic-063`'s 2026-09-02 ruling that a workspace with no runnable baseline leaves outcome 1 blocked at hour zero.
+
+| File | Lands at | Covers |
+| --- | --- | --- |
+| [`realworld_http/baseline_test.cljs`](realworld_http/baseline_test.cljs) | `app/test/realworld_http/` | The feed, the article editor, the routing both sit in, and boot |
+| [`linearlite/baseline_test.cljs`](linearlite/baseline_test.cljs) | `app/test/linearlite/` | The board: route-owned load, optimistic create / retitle / change-status, commit, rollback, and the demo backend's armed 503 |
+
+## Where they come from
+
+The examples tree is test-free by policy, so neither app carries tests of its own. Their behavioural suites live in the Reagent adapter's test tree — `implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs` and `linearlite_example_cljs_test.cljs` — and run on the in-repo harness, which co-loads every example into one bundle and carries hygiene for that (sequestering per-app registrations at load, isolating the trace bus, reinstating sibling namespaces). None of that applies to a workspace with one app in it, and none of it travels.
+
+What travels is the subset that exercises the nominated screens, rewritten as the app's own test namespace (`realworld-http.baseline-test`, `linearlite.baseline-test`). Each stands on `cljs.test`, on the canned-reply effects managed HTTP ships for exactly this, and on the runtime-reset fixture from core's test support — all of which the published `:local/root` route puts on the workspace classpath — and on nothing else. The whole RealWorld suite is deliberately not carried: the pilot migrates two screens, and the baseline is the behaviour of those two.
+
+## Two rules
+
+**No in-tree reference inside the files.** The pilot may read everything under `app/`, and these land there. A bead id, a spec section or a repository path in a test comment is a leak the pilot did not choose, so the files name none — the comments were rewritten in the app's voice, not merely trimmed. A change here that reintroduces one breaks the read fence.
+
+**These are fixtures, not a test lane.** Nothing in this repository compiles or runs them; the workspace does, through the `:test` build and `npm test` that `workspace.md` sets up. The proof they are green is the captured exit code from a workspace built by following that page alone, which is what step 5b records. When the adapter suites change in a way that touches the covered behaviour, refresh the corresponding file here by hand and re-run step 5b in a clean workspace before the next pilot is dispatched.

--- a/docs/design/hicasso/product/pilots/baseline/linearlite/baseline_test.cljs
+++ b/docs/design/hicasso/product/pilots/baseline/linearlite/baseline_test.cljs
@@ -64,25 +64,30 @@
 
 (defn- init!
   "Per-test setup, after the adapter is installed and the registry is live.
-   The app owns the URL through `:rf/default`, so re-register that frame the
-   same way; re-install the `:resource` / `:mutation` registrations the reset
-   wiped; reset routing's counters; re-publish the routing integration; and
-   stub managed HTTP and the URL push so route entry's ensure and navigation
-   are deterministic without a fetch or a browser."
+   Re-install the `:resource` / `:mutation` registrations the reset wiped;
+   reset routing's counters; re-publish the routing integration; stub managed
+   HTTP and the URL push so route entry's ensure and navigation are
+   deterministic without a fetch or a browser; and only THEN create the app's
+   frame. The app owns the URL through `:rf/default`, so it is re-registered
+   the same way.
+
+   The order matters. A frame resolves handlers through a generation sealed
+   when it is created, so everything a test needs the frame to see — the
+   re-installed registrations and the stubbed effects — is registered first,
+   and the frame is made last."
   []
   (reset! last-managed-args nil)
-  (rf/make-frame {:id :rf/default :url-bound? true
-                  :doc "linearlite default app frame."})
   ;; Re-install through `registrar/register!`, which writes the registry and
-  ;; the source store in lockstep and marks the live frame's projection dirty,
-  ;; so the frame's next resolution sees the reinstated registrations.
+  ;; the source store in lockstep.
   (doseq [[kind id->meta] resource-kind-snapshots
           [id meta] id->meta]
     (registrar/register! kind id meta))
   (routing/reset-counters!)
   (resources-route/install-routing-integration!)
   (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil)))
+  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
+  (rf/make-frame {:id :rf/default :url-bound? true
+                  :doc "linearlite default app frame."}))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture

--- a/docs/design/hicasso/product/pilots/baseline/linearlite/baseline_test.cljs
+++ b/docs/design/hicasso/product/pilots/baseline/linearlite/baseline_test.cljs
@@ -1,0 +1,413 @@
+(ns linearlite.baseline-test
+  "Behavioural baseline for the board — the screen under migration.
+
+   The board is a routed resource with optimistic writes: entering the route
+   ensures the `:linearlite/board` resource, the view reads it passively, and
+   every write (create, retitle, change status) applies an optimistic patch to
+   the board that COMMITS on `:ok` and ROLLS BACK on `:error`. These tests pin
+   that composition through the app's own events and subscriptions, without
+   rendering anything, so a view-layer migration that preserves behaviour
+   keeps them green untouched.
+
+   The demo backend defers each reply so the optimistic value is visible in
+   the browser. A unit test wants a synchronous settle, so each test installs
+   its own `:rf.http/managed` override: a capturing no-op whose reply the test
+   replays explicitly in the shape the live transport produces. The test
+   chooses success or failure by choosing which reply to replay. The URL push
+   is stubbed so navigation is deterministic without a browser.
+
+   Run with `npm test` from the app directory. The suite compiles to Node and
+   needs no browser."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
+            [re-frame.core :as rf]
+            [re-frame.fx :as fx]
+            [re-frame.registrar :as registrar]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            ;; Production HTTP + resources surfaces, so the resource runtime,
+            ;; the mutation runtime, managed-HTTP lowering and the routing
+            ;; integration resolve; the actual fetch is overridden per test.
+            [re-frame.http.managed]
+            [re-frame.http.test-support]
+            [re-frame.resources]
+            [re-frame.resources.route :as resources-route]
+            [re-frame.resources.state :as state]
+            [re-frame.resources.test-support]
+            [re-frame.routing :as routing]
+            ;; The app's production source — registers the :linearlite/board
+            ;; resource, the three optimistic mutations, routes, events, subs
+            ;; and views at load.
+            [linearlite.core]))
+
+;; ============================================================================
+;; Fixture
+;; ============================================================================
+
+(def ^:private last-managed-args (atom nil))
+
+;; The runtime-reset fixture clears the `:resource` and `:mutation` registry
+;; kinds between tests, and ClojureScript has no `(require … :reload)`. So
+;; snapshot the app's load-time registrations ONCE here — right after the
+;; `linearlite.core` require above ran them — and re-install them per test in
+;; `init!`. What gets re-installed is the app's own registrations, not copies.
+(def ^:private resource-kind-snapshots
+  (select-keys @registrar/kind->id->metadata [:resource :mutation]))
+
+;; Take those two kinds out of the live registry at load; `init!` puts them
+;; back before each test, so every test starts from the same registrations.
+(swap! registrar/kind->id->metadata
+       (fn [reg]
+         (reduce (fn [r [kind id->meta]]
+                   (update r kind (fn [m] (apply dissoc m (keys id->meta)))))
+                 reg
+                 resource-kind-snapshots)))
+
+(defn- init!
+  "Per-test setup, after the adapter is installed and the registry is live.
+   The app owns the URL through `:rf/default`, so re-register that frame the
+   same way; re-install the `:resource` / `:mutation` registrations the reset
+   wiped; reset routing's counters; re-publish the routing integration; and
+   stub managed HTTP and the URL push so route entry's ensure and navigation
+   are deterministic without a fetch or a browser."
+  []
+  (reset! last-managed-args nil)
+  (rf/make-frame {:id :rf/default :url-bound? true
+                  :doc "linearlite default app frame."})
+  ;; Re-install through `registrar/register!`, which writes the registry and
+  ;; the source store in lockstep and marks the live frame's projection dirty,
+  ;; so the frame's next resolution sees the reinstated registrations.
+  (doseq [[kind id->meta] resource-kind-snapshots
+          [id meta] id->meta]
+    (registrar/register! kind id meta))
+  (routing/reset-counters!)
+  (resources-route/install-routing-integration!)
+  (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil)))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn init!}))
+
+;; ============================================================================
+;; Helpers
+;; ============================================================================
+
+(defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
+
+(def ^:private board-query
+  {:resource :linearlite/board :scope :rf.scope/global :params {}})
+
+(defn- board-key []
+  (state/scoped-resource-key :rf.scope/global :linearlite/board {}))
+
+(defn- entry [] (get-in (runtime-db) (state/entry-path (board-key))))
+
+(defn- board-data
+  "The passive board `:data` the view reads (the `:rf.resource/data` sub),
+   computed against :rf/default's frame-state."
+  []
+  (rf/compute-sub [:rf.resource/data board-query]
+                  (rf/frame-state-value :rf/default)))
+
+(defn- issues [] (:issues (board-data)))
+
+(defn- issue-by-id [id] (some #(when (= id (:id %)) %) (issues)))
+
+(defn- mutation-state
+  "The passive `[:rf/mutation {:instance …}]` view-model the card view reads
+   (`{:pending? :success? :error? :settled? :optimistic? …}`)."
+  [instance]
+  (rf/compute-sub [:rf/mutation {:instance instance}]
+                  (rf/frame-state-value :rf/default)))
+
+(defn- reply-success!
+  "Replay the captured `:on-success` with the result appended as the LAST
+   argument — the shape the live managed-HTTP transport produces for an
+   accepted reply."
+  ([data] (reply-success! @last-managed-args data))
+  ([args data]
+   (rf/dispatch-sync (conj (:on-success args) {:status :ok :value data})
+                     {:frame :rf/default})))
+
+(defn- reply-failure!
+  "Replay the captured `:on-failure` with the failure appended — the shape a
+   503 produces, and what the app's fail-next-write toggle exhibits in the
+   browser."
+  ([failure] (reply-failure! @last-managed-args failure))
+  ([args failure]
+   (rf/dispatch-sync (conj (:on-failure args) {:status :error :error failure})
+                     {:frame :rf/default})))
+
+(def ^:private demo-board
+  "A canned board reply, the shape the backend returns for the read."
+  {:issues [{:id "srv-1" :title "Alpha" :status :backlog}
+            {:id "srv-2" :title "Beta"  :status :in-progress}]})
+
+(defn- load-board!
+  "Enter the board route and settle its first load with the canned board, so
+   the optimistic writes have a live board entry to patch."
+  []
+  (rf/dispatch-sync [:rf.route/navigate {:to :linearlite.app/board}])
+  (reply-success! demo-board)
+  (reset! last-managed-args nil))
+
+;; ============================================================================
+;; 1. Route entry ensures the board resource (the route owns the read)
+;; ============================================================================
+
+(deftest board-route-entry-ensures-the-board-under-the-route-owner
+  (testing "entering :linearlite.app/board ensures the :linearlite/board
+            resource under the route nav-token owner; the view reads the
+            passive board :data and settles to the issues on the reply (the
+            route CAUSES the load; the view never asks)"
+    (rf/dispatch-sync [:rf.route/navigate {:to :linearlite.app/board}])
+    (let [slice     (get-in (runtime-db) [:rf.runtime/routing :current])
+          nav-token (:nav-token slice)
+          e         (entry)]
+      (is (= :loading (:status e)) "first load → :loading")
+      (is (contains? (:active-owners e) [:route :linearlite.app/board nav-token])
+          "owned by the route nav-token owner [:route route-id nav-token]")
+      (reply-success! demo-board)
+      (is (= :loaded (:status (entry))) "settles :loaded on the reply")
+      (is (= demo-board (board-data)) "the view reads the merged board :data"))))
+
+;; ============================================================================
+;; 2. Optimistic apply — the write shows on the board BEFORE the reply
+;; ============================================================================
+
+(deftest create-issue-applies-optimistically-before-the-reply
+  (testing ":linearlite/create-issue applies its optimistic patch before the
+            request lowers: the new Backlog card appears immediately and the
+            watched mutation instance is :optimistic? while pending"
+    (load-board!)
+    (rf/dispatch-sync [:linearlite/create-issue "Gamma"])
+    ;; the optimistic apply ran before the request was sent.
+    (let [tmp (some #(when (= "Gamma" (:title %)) %) (issues))]
+      (is (some? tmp) "the new card appears in the board IMMEDIATELY (optimistic apply)")
+      (is (= :backlog (:status tmp)) "the optimistic card lands in Backlog")
+      (is (= 3 (count (issues))) "the board grew by one before any reply")
+      (let [ms (mutation-state [:create (:id tmp)])]
+        (is (true? (:pending? ms)) "the write is pending")
+        (is (true? (:optimistic? ms)) ":optimistic? true while the apply is showing"))
+      (is (some? @last-managed-args) "the write lowered a request to the transport"))))
+
+(deftest change-status-applies-optimistically-before-the-reply
+  (testing ":linearlite/change-status moves the card to the new column
+            IMMEDIATELY (optimistic apply), before the request settles"
+    (load-board!)
+    (rf/dispatch-sync [:linearlite/change-status "srv-1" :done])
+    (is (= :done (:status (issue-by-id "srv-1")))
+        "srv-1 jumped to :done the instant the move was dispatched (optimistic)")
+    (is (true? (:optimistic? (mutation-state [:status "srv-1"])))
+        "the change-status instance is :optimistic? while pending")))
+
+;; ============================================================================
+;; 3. Success commit — the :ok reply re-seeds the board with the server's value
+;; ============================================================================
+
+(deftest successful-write-commits-the-server-board-via-populates
+  (testing "an accepted :ok reply COMMITS: the mutation's `:populates`
+            overwrites the optimistic board with the server's authoritative
+            value (the temp id is replaced by the server id, the optimistic
+            marker clears), and the instance settles :success"
+    (load-board!)
+    (rf/dispatch-sync [:linearlite/create-issue "Gamma"])
+    (let [tmp-id   (:id (some #(when (= "Gamma" (:title %)) %) (issues)))
+          ;; the server's authoritative board: the new issue carries a SERVER id.
+          srv-board {:issues (conj (:issues demo-board)
+                                   {:id "srv-3" :title "Gamma" :status :backlog})}]
+      (is (string? tmp-id))
+      ;; settle the write with the server board (the :populates payload).
+      (reply-success! srv-board)
+      (is (= srv-board (board-data))
+          "the board is re-seeded with the server's authoritative value (commit)")
+      (is (nil? (issue-by-id tmp-id)) "the temporary optimistic id is gone after commit")
+      (is (some? (issue-by-id "srv-3")) "the committed issue carries the server id")
+      (is (not-any? :optimistic? (issues)) "no card carries the optimistic marker after commit")
+      (let [ms (mutation-state [:create tmp-id])]
+        (is (true? (:success? ms)) "the instance settled :success")
+        (is (false? (:optimistic? ms)) ":optimistic? false once settled (no longer pending)")))))
+
+(deftest successful-edit-title-commits-the-new-title
+  (testing "a successful :linearlite/edit-title commits the new title via
+            :populates (the optimistic title is confirmed by the server's
+            authoritative board)"
+    (load-board!)
+    (rf/dispatch-sync [:linearlite/commit-edit "srv-2" "Beta!"])
+    (is (= "Beta!" (:title (issue-by-id "srv-2"))) "optimistic title shows immediately")
+    (let [srv-board {:issues [{:id "srv-1" :title "Alpha" :status :backlog}
+                              {:id "srv-2" :title "Beta!" :status :in-progress}]}]
+      (reply-success! srv-board)
+      (is (= "Beta!" (:title (issue-by-id "srv-2"))) "the committed title persists")
+      (is (true? (:success? (mutation-state [:edit "srv-2"]))) "the edit instance settled :success"))))
+
+;; ============================================================================
+;; 4. Failure rollback — the :error reply reverts the optimistic change
+;; ============================================================================
+
+(deftest failed-create-rolls-the-optimistic-card-back-out
+  (testing "an accepted :error reply ROLLS BACK the optimistic apply: the
+            runtime restores the recorded snapshot inverse, so the
+            optimistically-added card VANISHES from the board and the
+            instance settles :error (no manual undo)"
+    (load-board!)
+    (rf/dispatch-sync [:linearlite/create-issue "Doomed"])
+    (let [tmp-id (:id (some #(when (= "Doomed" (:title %)) %) (issues)))]
+      (is (= 3 (count (issues))) "the optimistic card was added (board grew by one)")
+      ;; the request FAILS (a 503 — what the fail-next-write toggle produces).
+      (reply-failure! {:kind :rf.http/http-5xx :status 503})
+      (is (= 2 (count (issues))) "the optimistic card was rolled back OUT (board restored)")
+      (is (nil? (issue-by-id tmp-id)) "the never-committed card is gone")
+      (is (= demo-board (board-data)) "the board is restored to exactly its pre-write value")
+      (let [ms (mutation-state [:create tmp-id])]
+        (is (true? (:error? ms)) "the instance settled :error")
+        (is (false? (:optimistic? ms)) ":optimistic? false after rollback (no live apply)")))))
+
+(deftest failed-change-status-snaps-the-card-back-to-its-prior-column
+  (testing "a failed :linearlite/change-status rolls back: the card snaps
+            back to its prior column (the recorded `:before` is restored
+            verbatim)"
+    (load-board!)
+    (rf/dispatch-sync [:linearlite/change-status "srv-1" :done])
+    (is (= :done (:status (issue-by-id "srv-1"))) "optimistic move applied")
+    (reply-failure! {:kind :rf.http/http-5xx :status 503})
+    (is (= :backlog (:status (issue-by-id "srv-1")))
+        "the card snapped back to its prior :backlog column on failure (rollback)")
+    (is (= demo-board (board-data)) "the whole board is restored to its pre-move value")
+    (is (true? (:error? (mutation-state [:status "srv-1"]))) "the instance settled :error")))
+
+(deftest failed-edit-title-reverts-to-the-prior-title
+  (testing "a failed :linearlite/edit-title reverts the optimistic title to
+            the prior value on rollback"
+    (load-board!)
+    (rf/dispatch-sync [:linearlite/commit-edit "srv-2" "Wrong"])
+    (is (= "Wrong" (:title (issue-by-id "srv-2"))) "optimistic title applied")
+    (reply-failure! {:kind :rf.http/http-5xx :status 503})
+    (is (= "Beta" (:title (issue-by-id "srv-2"))) "the title reverted to its prior value (rollback)")
+    (is (= demo-board (board-data)) "the board is restored to its pre-edit value")))
+
+;; ============================================================================
+;; 5. The armed demo backend — "Fail the next write" answers a real 503
+;; ============================================================================
+;;
+;; Everything above BYPASSES the app's own demo backend: the capturing
+;; `:rf.http/managed` override replays hand-built replies, so those tests prove
+;; the mutation arcs but not that the backend the board actually runs against
+;; ever PRODUCES such a failure. These two tests drive the registered
+;; `:linearlite.demo/http-stub` directly and pin WHICH framework canned-reply
+;; effect it selects and WITH WHAT ARGUMENTS — the whole of the stub's
+;; observable act, since it resolves the canned effect from the registry at
+;; call time and hands off. The stub defers every reply, so the tests stop at
+;; its emitted arguments rather than carrying the reply on into the runtime:
+;; the runtime's handling of a classified 503 is pinned by section 4 above.
+
+(def ^:private parked-replies (atom []))
+
+(def ^:private canned-fx-ids
+  [:rf.http/managed-canned-success :rf.http/managed-canned-failure])
+
+(defn- install-canned-parkers!
+  "Re-register the two framework canned-reply effects with parkers that
+   RECORD the demo stub's answer — which effect it chose, the deferral it
+   asked for, and the arguments it built — and deliver nothing."
+  []
+  (doseq [fx-id canned-fx-ids]
+    (fx/reg-fx fx-id
+      {:doc "linearlite armed-demo-backend test parker (per-test; section 5)."}
+      (fn [_ctx args]
+        (swap! parked-replies conj {:fx-id    fx-id
+                                    :after-ms (:after-ms args)
+                                    :args     (dissoc args :after-ms)})
+        nil))))
+
+(defn- ask-the-demo-stub!
+  "Call the app's registered demo-backend effect exactly as the framework
+   would — `(handler frame-ctx args-map)` — and return what it parked.
+   `request` is the lowered request map the app's own mutation produces."
+  [request]
+  (reset! parked-replies [])
+  ((registrar/handler :fx :linearlite.demo/http-stub)
+   {:frame :rf/default}
+   {:request  request
+    :decode   :json
+    :on-success [:linearlite.test/reply]
+    :on-failure [:linearlite.test/reply]})
+  @parked-replies)
+
+(defn- change-status-request
+  "The request `:linearlite/change-status` lowers to — PUT /api/issues/:id
+   with a `{:status …}` body — read off the mutation's own request fn."
+  [id status]
+  {:method :put :url (str "/api/issues/" id) :body {:status status}})
+
+(defn- server-board
+  "The backend's canonical server board, read the only way a client can: ask
+   the demo backend for it."
+  []
+  (:value (:args (first (ask-the-demo-stub! {:method :get :url "/api/board"})))))
+
+(defn- server-issue [board id]
+  (some #(when (= id (:id %)) %) (:issues board)))
+
+(defn- fail-next-write? []
+  (rf/compute-sub [:linearlite/fail-next-write?]
+                  (rf/frame-state-value :rf/default)))
+
+(deftest armed-demo-backend-answers-a-classified-503
+  (testing "with 'Fail the next write' armed, the demo backend answers a
+            write through the framework's canned-FAILURE effect carrying a
+            503 in the shape that contract reads: top-level
+            :kind :rf.http/http-5xx plus :tags {:status 503 :message …}"
+    (install-canned-parkers!)
+    (rf/dispatch-sync [:linearlite/set-fail-next-write true])
+    (is (true? (fail-next-write?)) "armed")
+    (let [before (server-board)
+          parked (ask-the-demo-stub! (change-status-request "srv-1" :done))
+          {:keys [fx-id after-ms args]} (first parked)]
+      (is (= 1 (count parked)) "the stub answered exactly once")
+      (is (= :rf.http/managed-canned-failure fx-id)
+          "the ARMED branch was selected — the write met the canned-FAILURE effect")
+      (is (pos? after-ms)
+          "…deferred, as the demo does so the optimistic value paints first")
+      (is (= :rf.http/http-5xx (:kind args))
+          "the failure is classified :rf.http/http-5xx, not the default :rf.http/transport")
+      (is (= 503 (get-in args [:tags :status])) "…carrying the promised HTTP 503")
+      (is (= "Simulated server failure (the demo's rollback seam)."
+             (get-in args [:tags :message]))
+          "…and the demo's own message")
+      (is (nil? (:failure args))
+          "no vestigial `:failure` key")
+      ;; The armed branch answers BEFORE touching the canonical board, so the
+      ;; value the next read returns is untouched — the server-side half of
+      ;; the rollback the mutation runtime performs client-side.
+      (is (= before (server-board))
+          "the canonical server board is unchanged by the refused write"))))
+
+(deftest unarmed-demo-backend-answers-success-and-commits
+  (testing "positive control: an otherwise-identical UNARMED write through
+            the same demo backend selects the canned-SUCCESS effect and
+            returns the mutated authoritative board, proving the armed test
+            above selects the armed branch rather than passing because every
+            request fails"
+    (install-canned-parkers!)
+    (is (false? (fail-next-write?)) "unarmed (the fixture's fresh app-db)")
+    (let [original (:status (server-issue (server-board) "srv-1"))
+          target   (if (= :done original) :backlog :done)
+          parked   (ask-the-demo-stub! (change-status-request "srv-1" target))
+          {:keys [fx-id after-ms args]} (first parked)]
+      (is (= 1 (count parked)) "the stub answered exactly once")
+      (is (= :rf.http/managed-canned-success fx-id)
+          "the UNARMED branch was selected — the write met the canned-SUCCESS effect")
+      (is (pos? after-ms) "…deferred, like every reply this demo makes")
+      (is (nil? (:kind args))
+          "a success reply carries no failure classification")
+      (is (= target (:status (server-issue (:value args) "srv-1")))
+          "the authoritative board it returns carries the write applied — the
+           value that becomes the mutation's :populates payload")
+      ;; Compensating write: the demo stub *is* the server and its board is
+      ;; shared across the bundle, so put the issue back the way this test
+      ;; found it.
+      (ask-the-demo-stub! (change-status-request "srv-1" original))
+      (is (= original (:status (server-issue (server-board) "srv-1")))
+          "the compensating write restored the canonical board"))))

--- a/docs/design/hicasso/product/pilots/baseline/realworld_http/baseline_test.cljs
+++ b/docs/design/hicasso/product/pilots/baseline/realworld_http/baseline_test.cljs
@@ -1,0 +1,717 @@
+(ns realworld-http.baseline-test
+  "Behavioural baseline for the two screens under migration — the feed and
+   the article editor — plus the routing both depend on.
+
+   Every test spins its own frame, points the app's managed HTTP at a canned
+   reply, drives a feature through its events, and asserts on app-db and on
+   the subscriptions the views read. Nothing here renders: these tests pin
+   what the screens DO, so a view-layer migration that preserves behaviour
+   keeps them green untouched, and one that changes behaviour turns them red.
+
+   Run with `npm test` from the app directory. The suite compiles to Node and
+   needs no browser."
+  (:require [clojure.string :as str]
+            [cljs.test :refer-macros [deftest testing use-fixtures is]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.http.test-support]
+            ;; The app's production source. Requiring `realworld-http.core`
+            ;; chains in every feature namespace, so the handlers, subs, views,
+            ;; routes and machines register at load and the tests drive them.
+            [realworld-http.core]
+            [realworld-http.routing]
+            ;; Pure helpers the tests call directly.
+            [realworld-http.http :as rh]
+            [realworld-http.article-editor :as editor]
+            [realworld-http.tags :as tags])
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
+
+;; ============================================================================
+;; Canned replies
+;; ============================================================================
+;;
+;; The framework ships two canned-reply effects for managed HTTP,
+;; `:rf.http/managed-canned-success` and `:rf.http/managed-canned-failure`,
+;; which synthesise a reply in the transport's own shape. Each test registers
+;; a small effect that delegates to one of them with the payload the test
+;; wants, and points the app at it through the frame's `:fx-overrides`.
+
+(defn- reg-canned-success!
+  "Register `fx-id` to answer every managed request with `value`."
+  [fx-id value]
+  (rf/reg-fx fx-id
+    {:platforms #{:client :server}}
+    (fn [frame-ctx args]
+      (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+        (stub frame-ctx (assoc args :value value))))))
+
+(defn- reg-canned-success-by-url!
+  "Register `fx-id` to answer each managed request with `(f method url)`
+   (or `(f url)` when `f` takes one argument)."
+  [fx-id f]
+  (rf/reg-fx fx-id
+    {:platforms #{:client :server}}
+    (fn [frame-ctx args]
+      (let [stub   (registrar/handler :fx :rf.http/managed-canned-success)
+            req    (:request args)
+            method (or (:method req) :get)
+            url    (:url req)
+            arity  (try
+                     (.-length f)
+                     (catch :default _ 1))
+            value  (if (>= arity 2)
+                     (f method url)
+                     (f url))]
+        (stub frame-ctx (assoc args :value value))))))
+
+(defn- reg-canned-failure!
+  "Register `fx-id` to fail every managed request with `kind` and `tags`."
+  [fx-id kind tags]
+  (rf/reg-fx fx-id
+    {:platforms #{:client :server}}
+    (fn [frame-ctx args]
+      (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+        (stub frame-ctx (assoc args :kind kind :tags tags))))))
+
+;; A generic success: every managed request resolves with an empty map. Tests
+;; that only care about routing or client-side state use this one.
+(reg-canned-success! :realworld.test/canned-success-empty {})
+
+;; Each test creates its own top-level frame, so opt out of the ambient
+;; `:rf/default` scope: a frame's `:initial-events` then drain synchronously
+;; at boot, and every dispatch in a test body names its frame explicitly.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil}))
+
+(defn- sub
+  "Compute `query` against frame `f`'s current state."
+  [f query]
+  (rf/compute-sub query (rf/frame-state-value f)))
+
+;; ============================================================================
+;; The feed
+;; ============================================================================
+
+(defn- articles-load-test []
+  (reg-canned-success! :realworld.test/canned-articles
+                       {:articles [{:slug "hello-world"
+                                    :title "Hello, world"
+                                    :description "An intro"
+                                    :body "..."
+                                    :tagList ["intro"]
+                                    :createdAt "2026-05-01T00:00:00Z"
+                                    :updatedAt "2026-05-01T00:00:00Z"
+                                    :favorited false
+                                    :favoritesCount 0
+                                    :author {:username "alice" :bio nil :image nil
+                                             :following false}}]
+                        :articlesCount 1})
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/canned-articles}})]
+    (is (= :idle (:status (sub f [:articles/slice]))))
+    (rf/dispatch-sync [:articles/load] {:frame f})
+    (let [slice (sub f [:articles/slice])]
+      (is (= :loaded (:status slice)))
+      (is (= 1 (count (:data slice))))
+      (is (= "hello-world" (-> slice :data first :slug))))
+    (rf/dispatch-sync [:articles/load] {:frame f})
+    (let [slice (sub f [:articles/slice])]
+      (is (= :loaded (:status slice)))
+      (is (= 2 (:attempt slice))))))
+
+(defn- articles-load-failure-test []
+  (reg-canned-failure! :realworld.test/canned-articles-failure
+                       :rf.http/http-5xx
+                       {:status 500
+                        :body   "server error"})
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/canned-articles-failure}})]
+    (rf/dispatch-sync [:articles/load] {:frame f})
+    (is (= :error (:status (sub f [:articles/slice]))))
+    (is (some? (sub f [:articles/error])))))
+
+(defn- feed-load-test []
+  ;; :feed/load → :feed/loaded populates the user-feed slice and the grand count.
+  (reg-canned-success! :realworld.test/feed-ok
+    {:articles [{:slug "f1" :title "Feed one" :description "d" :body "b" :tagList []
+                 :createdAt "x" :updatedAt "x" :favorited false :favoritesCount 0
+                 :author {:username "bob" :bio nil :image nil :following true}}]
+     :articlesCount 7})
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/feed-ok}})]
+    (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+    (rf/dispatch-sync [:feed/load] {:frame f})
+    (is (= 1 (count (sub f [:feed/data])))
+        ":feed/loaded populates the user-feed slice")
+    (is (= 7 (sub f [:feed/count]))
+        "the grand articles-count is stored for pagination")
+    (is (not (sub f [:feed/loading?]))
+        "a settled feed load is no longer loading")))
+
+(defn- feed-load-failure-test []
+  (reg-canned-failure! :realworld.test/feed-fail :rf.http/http-5xx {:status 500 :body "boom"})
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/feed-fail}})]
+    (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+    (rf/dispatch-sync [:feed/load] {:frame f})
+    (is (some? (sub f [:feed/error]))
+        ":feed/load-failed surfaces a readable error on the feed slice")))
+
+(defn- tag-query-test []
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
+    ;; Applying a tag navigates to the `/tag/:tag` PATH route, so the active
+    ;; tag is a route param (read via `:home/selected-tag`), not a `?tag=` query.
+    (rf/dispatch-sync [:tags/apply-filter "clojure"] {:frame f})
+    (is (= :realworld/home-tag (sub f [:rf.route/id])))
+    (is (= "clojure" (sub f [:home/selected-tag])))
+    ;; The following feed uses the `?feed=following` token.
+    (rf/dispatch-sync [:home/show-your-feed] {:frame f})
+    (is (= "following" (:feed (sub f [:rf.route/query]))))))
+
+(defn- home-context-test []
+  ;; tags/home-context flattens the two home routes into one {:tag :feed :page}.
+  (let [rt {:rf.runtime/routing {:current {:params {:tag "clojure"}
+                                           :query  {:feed "following" :page 2}}}}]
+    (is (= {:tag "clojure" :feed "following" :page 2} (tags/home-context rt))
+        "the tag (path param) + feed/page (query) flatten into one context map"))
+  (let [rt {:rf.runtime/routing {:current {}}}]
+    (is (= {:tag nil :feed nil :page nil} (tags/home-context rt))
+        "an empty route yields an all-nil context (no NPE)")))
+
+(defn- paginate-path-integration-test []
+  ;; `paginate-path` prepends the path, encodes the filter, and appends the
+  ;; shared limit/offset window. Multi-key order isn't guaranteed, so assert
+  ;; on the (order-independent) parts.
+  (let [p (rh/paginate-path "/articles" nil 1)]
+    (is (str/starts-with? p "/articles?"))
+    (is (str/includes? p "limit=10"))
+    (is (str/includes? p "offset=0")))
+  (let [p (rh/paginate-path "/articles" {:tag "clojure"} 3)]
+    (is (str/includes? p "tag=clojure") "the filter rides the query")
+    (is (str/includes? p "limit=10"))
+    (is (str/includes? p "offset=20") "page 3 → offset 20")))
+
+(defn- pagination-nav-events-test []
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
+    ;; --- :home/show-page carries the active feed forward ---
+    ;; Global feed, then page 3: the home route, no ?feed=, ?page=3.
+    (rf/dispatch-sync [:home/show-global-feed] {:frame f})
+    (rf/dispatch-sync [:home/show-page 3] {:frame f})
+    (is (= :realworld/home (sub f [:rf.route/id])))
+    (is (= 3 (:page (sub f [:rf.route/query])))
+        "global feed page-nav sets ?page= on the home route")
+    (is (nil? (:feed (sub f [:rf.route/query])))
+        "no feed was active, so ?feed= stays absent")
+
+    ;; Following feed, then page 2: the following token is carried forward.
+    (rf/dispatch-sync [:home/show-your-feed] {:frame f})
+    (rf/dispatch-sync [:home/show-page 2] {:frame f})
+    (is (= :realworld/home (sub f [:rf.route/id])))
+    (is (= 2 (:page (sub f [:rf.route/query]))))
+    (is (= "following" (:feed (sub f [:rf.route/query])))
+        "paging the following feed carries ?feed=following forward")
+
+    ;; --- :home/show-page carries the active tag forward (re-aims at /tag/:tag) ---
+    (rf/dispatch-sync [:tags/apply-filter "clojure"] {:frame f})
+    (rf/dispatch-sync [:home/show-page 2] {:frame f})
+    (is (= :realworld/home-tag (sub f [:rf.route/id]))
+        "paging a tag-filtered list re-aims at the /tag/:tag PATH route")
+    (is (= "clojure" (:tag (sub f [:rf.route/params])))
+        "the tag param is preserved so paging stays inside the tag")
+    (is (= 2 (:page (sub f [:rf.route/query]))))
+
+    ;; --- :profile/show-page stays on the same tab + username, swaps only ?page= ---
+    (rf/dispatch-sync [:rf.route/navigate {:to :realworld.profile/show :params {:username "eve"}}] {:frame f})
+    (rf/dispatch-sync [:profile/show-page 2] {:frame f})
+    (is (= :realworld.profile/show (sub f [:rf.route/id]))
+        "profile page-nav stays on the same (authored) tab")
+    (is (= "eve" (:username (sub f [:rf.route/params])))
+        "the profile username is unchanged")
+    (is (= 2 (:page (sub f [:rf.route/query]))))
+
+    ;; The favorites tab pages independently, still on its own route.
+    (rf/dispatch-sync [:rf.route/navigate {:to :realworld.profile/favorites :params {:username "eve"}}] {:frame f})
+    (rf/dispatch-sync [:profile/show-page 3] {:frame f})
+    (is (= :realworld.profile/favorites (sub f [:rf.route/id]))
+        "the favorites tab stays on the favorites route when paging")
+    (is (= 3 (:page (sub f [:rf.route/query]))))))
+
+(deftest feed
+  (testing "global feed loads and re-loads bumping :attempt"
+    (articles-load-test))
+  (testing "global feed surfaces :error on http failure"
+    (articles-load-failure-test))
+  (testing "user feed :feed/load / :feed/loaded populate the slice"
+    (feed-load-test))
+  (testing "user feed :feed/load-failed surfaces an error"
+    (feed-load-failure-test))
+  (testing "tag filter and feed-kind round-trip via the route"
+    (tag-query-test))
+  (testing "home-context flattens the two home routes into {:tag :feed :page}"
+    (home-context-test))
+  (testing "paginate-path threads the page arithmetic + query encoding"
+    (paginate-path-integration-test))
+  (testing "page-nav events carry the active feed / tag / route forward"
+    (pagination-nav-events-test)))
+
+;; ============================================================================
+;; The article editor
+;; ============================================================================
+
+(defn- ed-has-tag? [f tag]
+  (sub f [:rf.machine/has-tag? :ui/article-editor tag]))
+
+(defn- editor-create-test []
+  (reg-canned-success! :realworld.test/canned-editor-save
+                       {:article {:slug "hello-world"
+                                  :title "Hello"
+                                  :description "Short"
+                                  :body "Body"
+                                  :tagList ["demo"]
+                                  :createdAt "2026-05-01"
+                                  :updatedAt "2026-05-01"
+                                  :favorited false
+                                  :favoritesCount 0
+                                  :author {:username "alice" :bio nil :image nil :following false}}})
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/canned-editor-save}})]
+    (rf/dispatch-sync [:editor/initialise] {:frame f})
+    ;; The :mode region starts at :create; the :lifecycle region starts at :idle.
+    (is (true? (ed-has-tag? f :mode/create)))
+    (is (true? (ed-has-tag? f :lifecycle/idle)))
+    ;; The :editor/can-submit? flow starts false — the draft is blank (invalid)
+    ;; and unchanged.
+    (is (false? (sub f [:editor/can-submit?])))
+    (rf/dispatch-sync [:editor/edit-field :title "Hello"] {:frame f})
+    (rf/dispatch-sync [:editor/edit-field :description "Short"] {:frame f})
+    (rf/dispatch-sync [:editor/edit-field :body "Body"] {:frame f})
+    ;; Now valid AND dirty → the flow materialised true at [:editor :can-submit?].
+    (is (true? (sub f [:editor/can-submit?])))
+    (rf/dispatch-sync [:editor/submit] {:frame f})
+    ;; A successful submit advances :mode → :edit and :lifecycle → :saved.
+    (is (true? (ed-has-tag? f :lifecycle/saved)))
+    (is (true? (ed-has-tag? f :mode/edit)))
+    (is (false? (sub f [:editor/dirty?])))))
+
+(defn- editor-can-leave-test []
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
+    (rf/dispatch-sync [:editor/initialise] {:frame f})
+    (is (true? (sub f [:editor/can-leave?])))
+    (rf/dispatch-sync [:editor/edit-field :title "Changed"] {:frame f})
+    (is (false? (sub f [:editor/can-leave?])))))
+
+(defn- editor-pure-helpers-test []
+  ;; validate-draft — one message per blank required field; empty map when valid.
+  (is (= {} (editor/validate-draft {:title "T" :description "D" :body "B"}))
+      "a fully-filled draft validates clean (no error map)")
+  (is (= #{:title :description :body}
+         (set (keys (editor/validate-draft {:title "" :description "" :body ""}))))
+      "every blank required field earns its own error")
+  (is (= #{:description}
+         (set (keys (editor/validate-draft {:title "T" :description "   " :body "B"}))))
+      "a whitespace-only field counts as blank (str/blank?)")
+  ;; parse-tag-list — split on comma, trim each, drop blanks, vector out.
+  (is (= ["a" "b" "c"] (editor/parse-tag-list "a, b ,c"))
+      "tags split on comma, each trimmed")
+  (is (= [] (editor/parse-tag-list "")) "empty string → no tags")
+  (is (= [] (editor/parse-tag-list nil)) "nil → no tags (no NPE on the split)")
+  (is (= ["x"] (editor/parse-tag-list " , x , ,")) "blank entries between commas are dropped")
+  ;; draft-from-article — joins the tagList vector back into the comma string
+  ;; the form edits.
+  (is (= {:title "T" :description "D" :body "B" :tagList "a, b"}
+         (editor/draft-from-article {:title "T" :description "D" :body "B" :tagList ["a" "b"]}))
+      "an article decodes into the editable draft shape (tagList joined)")
+  ;; article-body — wraps the draft into the {:article …} request body, parsing tags.
+  (is (= {:article {:title "T" :description "D" :body "B" :tagList ["a" "b"]}}
+         (editor/article-body {:title "T" :description "D" :body "B" :tagList "a, b"}))
+      "the request body parses the tag string back into a vector"))
+
+(defn- editor-edit-load-and-put-test []
+  (let [seen (atom [])]
+    (reg-canned-success-by-url! :realworld.test/editor-edit
+      (fn [method url]
+        (swap! seen conj [method url])
+        {:article {:slug "hello-world" :title "Hello, world" :description "Intro"
+                   :body "Body text" :tagList ["intro" "demo"]
+                   :createdAt "2026-05-01" :updatedAt "2026-05-01"
+                   :favorited false :favoritesCount 0
+                   :author {:username "alice" :bio nil :image nil :following false}}}))
+    (with-new-frame [f (frame/make-anon-frame-record!
+                         {:initial-events [[:app/initialise]]
+                          :fx-overrides {:rf.http/managed :realworld.test/editor-edit}})]
+      ;; /editor/:slug requires auth — sign in so the route's guard passes and
+      ;; its :on-match [:editor/load-article] fires (rather than a login redirect).
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      (rf/dispatch-sync [:rf.route/handle-url-change "/editor/hello-world"] {:frame f})
+      ;; :editor/load-article → :use-edit + :fetch-started + GET /articles/hello-world;
+      ;; the canned reply lands → :editor/loaded seeds the draft, :fetch-succeeded.
+      (is (true? (ed-has-tag? f :mode/edit)) "edit-mode entry flips the :mode region to :edit")
+      (is (true? (ed-has-tag? f :editor/can-delete)) ":mode/edit lights the :editor/can-delete tag")
+      (is (true? (ed-has-tag? f :lifecycle/idle)) "a settled load leaves the lifecycle region at :idle")
+      (let [slice (sub f [:editor/slice])
+            draft (sub f [:editor/draft])]
+        (is (= "hello-world" (:slug slice)) "the slug is captured for the PUT target")
+        (is (= "Hello, world" (:title draft)) "the draft is seeded from the loaded article")
+        (is (= "intro, demo" (:tagList draft)) "the tag list is joined into the comma-separated string"))
+      (is (false? (sub f [:editor/dirty?]))
+          "a freshly-seeded edit draft equals its baseline → not dirty")
+      (is (true? (sub f [:editor/can-leave?]))
+          "a clean edit draft may leave freely")
+      ;; Edit a field → dirty + valid → the flow enables submit → PUT (not POST).
+      (reset! seen [])
+      (rf/dispatch-sync [:editor/edit-field :title "Hello, edited"] {:frame f})
+      (is (true? (sub f [:editor/can-submit?]))
+          "an edited, valid draft can submit")
+      (rf/dispatch-sync [:editor/submit] {:frame f})
+      (is (some (fn [[m u]] (and (= :put m) (str/ends-with? u "/articles/hello-world"))) @seen)
+          "edit-mode submit issues a PUT to /articles/:slug (not a POST to /articles)")
+      ;; :editor/submit-success → :submit-succeeded (:saved) + :use-edit + navigate.
+      (is (true? (ed-has-tag? f :lifecycle/saved)) "a successful save advances the lifecycle → :saved")
+      (is (true? (ed-has-tag? f :mode/edit)) "the editor stays in :edit mode after saving"))))
+
+(defn- editor-load-failure-test []
+  (reg-canned-failure! :realworld.test/editor-load-fail
+                       :rf.http/http-5xx {:status 500 :body "server error"})
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/editor-load-fail}})]
+    (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+    (rf/dispatch-sync [:rf.route/handle-url-change "/editor/doomed"] {:frame f})
+    ;; :editor/load-article → GET fails → :editor/load-failed → :fetch-failed.
+    (is (true? (ed-has-tag? f :lifecycle/error))
+        "a load failure lands the lifecycle region in :error (the page-level error gate)")
+    (is (some? (sub f [:editor/submit-error]))
+        "the load-failure message is surfaced via :submit-error")))
+
+(defn- editor-delete-test []
+  (let [seen (atom [])]
+    (reg-canned-success-by-url! :realworld.test/editor-delete
+      (fn [method url]
+        (swap! seen conj [method url])
+        {:article {:slug "doomed" :title "Doomed" :description "d" :body "b" :tagList []
+                   :createdAt "x" :updatedAt "x" :favorited false :favoritesCount 0
+                   :author {:username "alice" :bio nil :image nil :following false}}}))
+    (with-new-frame [f (frame/make-anon-frame-record!
+                         {:initial-events [[:app/initialise]]
+                          :fx-overrides {:rf.http/managed :realworld.test/editor-delete}})]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      (rf/dispatch-sync [:rf.route/handle-url-change "/editor/doomed"] {:frame f})
+      (is (= "doomed" (:slug (sub f [:editor/slice])))
+          "the article is loaded into edit mode")
+      (reset! seen [])
+      (rf/dispatch-sync [:editor/delete] {:frame f})
+      ;; :editor/delete → DELETE /articles/doomed → :editor/delete-success → reset + home.
+      (is (some (fn [[m u]] (and (= :delete m) (str/ends-with? u "/articles/doomed"))) @seen)
+          ":editor/delete issues a DELETE to /articles/:slug")
+      (is (= :realworld/home (sub f [:rf.route/id]))
+          "a successful delete navigates home")
+      (is (nil? (:slug (sub f [:editor/slice])))
+          "the editor slice is reset to a blank create draft on delete")
+      (is (true? (ed-has-tag? f :mode/create))
+          "the :mode region resets to :create after a delete"))))
+
+(defn- editor-invalid-submit-test []
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
+    (rf/dispatch-sync [:editor/initialise] {:frame f})
+    ;; A create draft with only a title → description + body still blank → the
+    ;; client-invalid branch fires (per-field errors + :_form, no round trip).
+    (rf/dispatch-sync [:editor/edit-field :title "Only a title"] {:frame f})
+    (rf/dispatch-sync [:editor/submit] {:frame f})
+    (let [errors (sub f [:editor/errors])]
+      (is (contains? errors :description) "the blank description earns a per-field error")
+      (is (contains? errors :body) "the blank body earns a per-field error")
+      (is (not (contains? errors :title)) "the filled title has no error")
+      (is (= "Please fix the highlighted fields." (:_form errors))
+          "the whole-form prompt is set under :_form"))
+    (is (some? (sub f [:editor/field-error :description]))
+        "submit-attempted? makes a per-field error visible even on an untouched field")
+    (is (true? (ed-has-tag? f :lifecycle/idle))
+        "an invalid submit issues no request — lifecycle stays :idle (no :submit-started)")
+    (is (nil? (sub f [:editor/submit-error]))
+        "the client-validation branch clears :submit-error (that door is for transport failures)")))
+
+(defn- editor-same-slug-seed-preserves-typing-test []
+  ;; A stub that CAPTURES the request and never replies, so the GET stays in
+  ;; flight for as long as this test wants it to. Every other stub here settles
+  ;; on the spot, which is precisely the window this test needs to open.
+  (let [in-flight (atom nil)]
+    (rf/reg-fx :realworld.test/editor-in-flight
+      {:platforms #{:client :server}}
+      (fn [_frame-ctx args] (reset! in-flight args) nil))
+    (with-new-frame [f (frame/make-anon-frame-record!
+                         {:initial-events [[:app/initialise]]
+                          :fx-overrides {:rf.http/managed :realworld.test/editor-in-flight}})]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      (rf/dispatch-sync [:rf.route/handle-url-change "/editor/hello-world"] {:frame f})
+      (let [req (deref in-flight)]
+        (is (some? req) "entering the edit route lowered the article GET")
+        (is (true? (ed-has-tag? f :lifecycle/loading))
+            "the lifecycle region sits at :loading while the fetch is out")
+        ;; TYPE, while the fetch is still out — the ordinary case, not a race:
+        ;; the round trip is slower than the first keystroke.
+        (rf/dispatch-sync [:editor/edit-field :title "My unsaved heading"] {:frame f})
+        (is (= #{:title} (:touched (sub f [:editor/slice])))
+            "typing marked :title touched and nothing else")
+        ;; THE SETTLE. Replay the captured `:on-success` with the transport's
+        ;; success result appended, exactly as managed HTTP delivers it.
+        (rf/dispatch-sync (conj (:on-success req)
+                                {:status :ok
+                                 :value {:article {:slug "hello-world" :title "Hello, world"
+                                                   :description "Intro" :body "Body text"
+                                                   :tagList ["intro" "demo"]}}})
+                          {:frame f})
+        (let [slice (sub f [:editor/slice])
+              draft (sub f [:editor/draft])]
+          (is (= "My unsaved heading" (:title draft))
+              "the touched field keeps the user's text — the settle must not clobber typing")
+          (is (= "" (:title (:baseline slice)))
+              "the touched field keeps its own baseline too, so the typing reads as UNSAVED")
+          (is (= {:title "" :description "Intro" :body "Body text" :tagList "intro, demo"}
+                 (:baseline slice))
+              "the baseline is seeded leafwise in step with the draft")
+          (is (= "Intro" (:description draft)) "an untouched field IS seeded from the loaded article")
+          (is (= "intro, demo" (:tagList draft)) "…including the joined tag string")
+          (is (= "hello-world" (:slug slice)) "the slice still targets the loaded slug")
+          (is (true? (sub f [:editor/dirty?]))
+              "typing that survived a settle leaves the draft DIRTY — the save must send it")
+          (is (= #{:title} (:touched slice)) "the seed marks nothing touched of its own"))))))
+
+;; The cross-slug half of the same behaviour. The leafwise seed above protects a
+;; field the USER HAS TOUCHED — but a reply for article A landing on article B's
+;; slice finds every field untouched, so the merge would hand A's values over
+;; field by field. Two gates answer two questions: correlation decides WHETHER
+;; the reply belongs to this screen, the leafwise seed decides WHICH FIELDS it
+;; may write. These two tests drive the real sequence — A's GET out, navigate
+;; to B, A settles late — over both reply branches.
+
+(defn- editor-cross-slug-settle-is-refused-test []
+  ;; A stub that CAPTURES every lowered request and never replies, so BOTH the A
+  ;; and the B GET can be held open and settled by hand, in the order a slow
+  ;; network would pick.
+  (let [lowered (atom [])
+        article (fn [slug title]
+                  {:article {:slug slug :title title
+                             :description (str "About " slug)
+                             :body        (str "Body of " slug)
+                             :tagList     [slug]}})]
+    (rf/reg-fx :realworld.test/editor-cross-slug
+      {:platforms #{:client :server}}
+      (fn [_frame-ctx args] (swap! lowered conj args) nil))
+    (with-new-frame [f (frame/make-anon-frame-record!
+                         {:initial-events [[:app/initialise]]
+                          :fx-overrides {:rf.http/managed :realworld.test/editor-cross-slug}})]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      ;; Enter /editor/alpha — A's GET goes out and stays out.
+      (rf/dispatch-sync [:rf.route/handle-url-change "/editor/alpha"] {:frame f})
+      ;; …and move on to /editor/beta before A replies. A freshly-entered draft
+      ;; is clean, so `:can-leave` waves this through: an ordinary navigation.
+      (rf/dispatch-sync [:rf.route/handle-url-change "/editor/beta"] {:frame f})
+      (is (= 2 (count @lowered))
+          "each editor entry lowered its own article GET, and nothing else went out")
+      (let [[a-req b-req] @lowered]
+        (is (= [:editor/load-article "alpha"] (:request-id a-req))
+            "the two GETs carry DISTINCT per-slug request-ids, so A's reply is
+             delivered in full and correlating it is the app's job")
+        (is (= [:editor/load-article "beta"] (:request-id b-req)))
+        (is (= [:editor/loaded "alpha"] (:on-success a-req))
+            "so the reply target carries the slug it was requested for")
+        (is (= [:editor/load-failed "alpha"] (:on-failure a-req))
+            "…on the failure branch too")
+        ;; B settles normally first: the editor is fully seeded from beta.
+        (rf/dispatch-sync (conj (:on-success b-req)
+                                {:status :ok :value (article "beta" "Beta")})
+                          {:frame f})
+        (is (= "Beta" (:title (sub f [:editor/draft])))
+            "B's own reply seeds B's draft — the ordinary path is untouched")
+        ;; THE LATE ARRIVAL. Nothing has been typed, so every field of beta's
+        ;; slice is UNTOUCHED — which is precisely why the leafwise seed is no
+        ;; defence here.
+        (rf/dispatch-sync (conj (:on-success a-req)
+                                {:status :ok :value (article "alpha" "Alpha")})
+                          {:frame f})
+        (let [slice (sub f [:editor/slice])
+              draft (sub f [:editor/draft])]
+          (is (= "beta" (:slug slice))
+              "a late alpha reply must not re-slug the editor — the PUT target stays beta")
+          (is (= {:title "Beta" :description "About beta" :body "Body of beta" :tagList "beta"}
+                 draft)
+              "…nor rewrite beta's draft")
+          (is (= {:title "Beta" :description "About beta" :body "Body of beta" :tagList "beta"}
+                 (:baseline slice))
+              "…nor beta's baseline, which is what dirty-detection compares against")
+          (is (false? (sub f [:editor/dirty?]))
+              "so the form stays clean and `:can-leave` still lets the reader go")
+          (is (empty? (:touched slice))
+              "and the refusal marks nothing touched of its own"))))))
+
+(defn- editor-cross-slug-failure-is-refused-test []
+  ;; Same sequence, failure branch: beta's GET is still out when alpha's fails.
+  (let [lowered (atom [])]
+    (rf/reg-fx :realworld.test/editor-cross-slug-fail
+      {:platforms #{:client :server}}
+      (fn [_frame-ctx args] (swap! lowered conj args) nil))
+    (with-new-frame [f (frame/make-anon-frame-record!
+                         {:initial-events [[:app/initialise]]
+                          :fx-overrides {:rf.http/managed :realworld.test/editor-cross-slug-fail}})]
+      (rf/dispatch-sync [:auth/store-session {:username "alice" :token "jwt"}] {:frame f})
+      (rf/dispatch-sync [:rf.route/handle-url-change "/editor/alpha"] {:frame f})
+      (rf/dispatch-sync [:rf.route/handle-url-change "/editor/beta"] {:frame f})
+      (let [[a-req] @lowered]
+        (rf/dispatch-sync (conj (:on-failure a-req)
+                                {:status :error
+                                 :error  {:kind :rf.http/http-5xx :status 500}})
+                          {:frame f})
+        (is (nil? (sub f [:editor/submit-error]))
+            "alpha's late failure raises no error banner over beta's editor")
+        (is (true? (ed-has-tag? f :lifecycle/loading))
+            "…and leaves the lifecycle region at :loading, where beta's own fetch put it")
+        (is (false? (ed-has-tag? f :lifecycle/error))
+            "…so the page-level error gate stays shut for a reply that was never beta's")))))
+
+(deftest article-editor
+  (testing "editor create flow saves and clears :dirty?"
+    (editor-create-test))
+  (testing "editor :can-leave? blocks once the draft diverges"
+    (editor-can-leave-test))
+  (testing "pure helpers: validate-draft / parse-tag-list / draft-from-article / article-body"
+    (editor-pure-helpers-test))
+  (testing "edit-mode load seeds the draft, flips :mode/edit, and submit issues a PUT"
+    (editor-edit-load-and-put-test))
+  (testing "a load failure lands the lifecycle in :error and surfaces the message"
+    (editor-load-failure-test))
+  (testing ":editor/delete issues a DELETE, resets the slice, and navigates home"
+    (editor-delete-test))
+  (testing "a client-invalid submit fills per-field errors and fires no request"
+    (editor-invalid-submit-test))
+  (testing "a same-slug settle seeds LEAFWISE and does not clobber typing"
+    (editor-same-slug-seed-preserves-typing-test))
+  (testing "a CROSS-slug settle is refused outright — a late A cannot rewrite B's draft, baseline or slug"
+    (editor-cross-slug-settle-is-refused-test))
+  (testing "a CROSS-slug FAILURE is refused too — a late A error cannot banner B or trip B's lifecycle"
+    (editor-cross-slug-failure-is-refused-test)))
+
+;; ============================================================================
+;; Routing — the table both screens sit in, and the auth gate on the editor
+;; ============================================================================
+
+(defn- routing-tests []
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
+    (rf/dispatch-sync [:rf.route/navigate {:to :realworld.article/show :params {:slug "hello"}}] {:frame f})
+    (is (= :realworld.article/show (sub f [:rf.route/id])))
+    (is (= "hello" (:slug (sub f [:rf.route/params]))))
+
+    (rf/dispatch-sync [:rf.route/handle-url-change "/profile/eve"] {:frame f})
+    (is (= :realworld.profile/show (sub f [:rf.route/id])))
+
+    ;; `/settings` requires auth; this check is about the route TABLE, not the
+    ;; gate, so sign in first — otherwise the gate correctly refuses the
+    ;; logged-out entry and redirects to login (the gate is covered below).
+    (rf/dispatch-sync [:auth/store-session {:username "eve" :token "t"}] {:frame f})
+    (rf/dispatch-sync [:rf.route/handle-url-change "/settings"] {:frame f})
+    (is (= :realworld.user/settings (sub f [:rf.route/id])))
+
+    ;; The tag filter is the `/tag/:tag` PATH route — the tag is a route
+    ;; PARAM, not a `?tag=` query.
+    (rf/dispatch-sync [:rf.route/handle-url-change "/tag/clojure"] {:frame f})
+    (is (= :realworld/home-tag (sub f [:rf.route/id])))
+    (is (= "clojure" (:tag (sub f [:rf.route/params]))))
+
+    (rf/dispatch-sync [:rf.route/handle-url-change "/garbage/path"] {:frame f})
+    (is (= :rf.route/not-found (sub f [:rf.route/id])))))
+
+(defn- auth-guard-test []
+  ;; Each route that requires auth declares `:can-enter [:realworld.routing/authed?]`,
+  ;; and an `:rf.route/entry-denied` handler stashes the denied destination and
+  ;; replace-navigates to login. Entry denial is TERMINAL: it commits nothing
+  ;; and creates NO pending value, so the return after sign-in is a FRESH
+  ;; navigate, not a resume.
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
+    ;; Unauthenticated: navigating to a guarded route is denied and redirects
+    ;; to login.
+    (rf/dispatch-sync [:rf.route/navigate {:to :realworld.user/settings}] {:frame f})
+    (is (= :realworld.auth/login (sub f [:rf.route/id]))
+        "unauthenticated nav to a :requires-auth route redirects to login")
+
+    ;; A non-guarded route is unaffected.
+    (rf/dispatch-sync [:rf.route/navigate {:to :realworld/home}] {:frame f})
+    (is (= :realworld/home (sub f [:rf.route/id]))
+        "unguarded route navigates normally with the gate active")
+
+    ;; Fresh-return stash: the denial handler records the denied destination
+    ;; at [:auth :return-to]. No pending-navigation value is created.
+    (rf/dispatch-sync [:rf.route/navigate {:to :realworld.user/settings}] {:frame f})
+    (is (= {:to :realworld.user/settings}
+           (get-in (rf/frame-state-value f) [:rf.db/app :auth :return-to]))
+        "the denial stashes the canonical destination for the post-login return")
+    (is (nil? (get-in (rf/frame-state-value f) [:rf.db/runtime :rf.runtime/routing
+                                                :pending-navigation]))
+        "a terminal denial creates NO pending-navigation value")
+
+    ;; Authenticated: the same guarded nav now proceeds.
+    (rf/dispatch-sync [:auth/store-session {:username "eve" :token "t"}] {:frame f})
+    (rf/dispatch-sync [:rf.route/navigate {:to :realworld.user/settings}] {:frame f})
+    (is (= :realworld.user/settings (sub f [:rf.route/id]))
+        "authenticated nav to a :requires-auth route proceeds")
+
+    ;; The post-login return consumes the stashed destination and clears the
+    ;; slot — an ordinary FRESH navigate whose guard re-evaluates.
+    (rf/dispatch-sync [:auth/post-login-redirect] {:frame f})
+    (is (nil? (get-in (rf/frame-state-value f) [:rf.db/app :auth :return-to]))
+        ":auth/post-login-redirect clears the :return-to slot")))
+
+(deftest routing
+  (testing "navigate, handle-url-change, query, and not-found all resolve"
+    (routing-tests))
+  (testing "the auth gate redirects unauthenticated nav to guarded routes and returns after sign-in"
+    (auth-guard-test)))
+
+;; ============================================================================
+;; Boot
+;; ============================================================================
+
+(defn- app-boot-test []
+  (with-new-frame [f (frame/make-anon-frame-record!
+                       {:initial-events [[:app/initialise]]
+                        :fx-overrides {:rf.http/managed      :realworld.test/canned-success-empty
+                                       :auth.session/persist :rf/no-op}})]
+    ;; `:auth/initialise` consumes the `:auth.session/token` coeffect, so it is
+    ;; its own boot step in the real app. Dispatch it here with the token
+    ;; pinned through the dispatch-site coeffect stub (Node has no
+    ;; localStorage for the supplier to read, so the value would be nil anyway).
+    (rf/dispatch-sync [:auth/initialise]
+                      {:frame f :rf.cofx {:auth.session/token nil}})
+    ;; After init: the :auth + :articles slices and the :realworld/tags +
+    ;; :settings/form machine snapshots are present. App data is in app-db;
+    ;; machine snapshots in runtime-db.
+    (let [db (rf/app-db-value f)
+          rt (:rf.db/runtime (rf/frame-state-value f))]
+      (is (contains? db :auth))
+      (is (contains? db :articles))
+      (is (contains? (get-in rt [:rf.runtime/machines :snapshots]) :realworld/tags))
+      (is (contains? (get-in rt [:rf.runtime/machines :snapshots]) :settings/form)))))
+
+(deftest boot
+  (testing "app boot populates :auth, :articles, and the machine snapshots"
+    (app-boot-test)))

--- a/docs/design/hicasso/product/pilots/brief-linearlite.md
+++ b/docs/design/hicasso/product/pilots/brief-linearlite.md
@@ -4,7 +4,7 @@ Copy the block below into `<pilot-root>/BRIEF.md`. Everything inside it is writt
 
 The brief is deliberately free of in-tree references: no bead ids, no spec sections, no repository paths except the ones the published documentation itself tells a reader to use. That is not tidiness. A brief that leaks in-tree knowledge does not bend a rule, it invalidates the evidence the pilot exists to produce, and the leak is invisible in the output.
 
-Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification. Assemble the workspace first, per [`workspace.md`](workspace.md).
+Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the sentence naming the test command, under `rf2-xkhul`. Assemble the workspace first, per [`workspace.md`](workspace.md).
 
 **Why this pilot is shaped differently from [Pilot 1](brief-realworld.md), and it matters that it is.** Pilot 1 translates two screens that already exist, which measures whether the documentation supports *porting*. This one ports one screen and grows a second that does not exist yet, which measures whether the documentation supports *authoring* — reaching for a form you have never written, from the guide alone. Those are different failure modes and the two pilots are chosen to cover both, so the card detail is a shipped screen rather than a stretch goal and must not be softened into one when the brief is handed over.
 
@@ -21,7 +21,8 @@ between statuses. Its point is that every write shows on screen instantly and
 quietly reverts if the server rejects it. It runs offline against a fake
 backend in the page, so there is nothing to set up. It is in `app/`, it
 currently renders through Reagent, and it works today. Run it before you
-change anything.
+change anything. Its behavioural tests are in `app/test/`; `npm test` from
+`app/` runs them.
 
 You have two screens, and they are two different jobs.
 

--- a/docs/design/hicasso/product/pilots/brief-realworld.md
+++ b/docs/design/hicasso/product/pilots/brief-realworld.md
@@ -4,7 +4,7 @@ Copy the block below into `<pilot-root>/BRIEF.md`. Everything inside it is writt
 
 The brief is deliberately free of in-tree references: no bead ids, no spec sections, no repository paths except the ones the published documentation itself tells a reader to use. That is not tidiness. A brief that leaks in-tree knowledge does not bend a rule, it invalidates the evidence the pilot exists to produce, and the leak is invisible in the output.
 
-Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification. Assemble the workspace first, per [`workspace.md`](workspace.md).
+Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the sentence naming the test command, under `rf2-xkhul`. Assemble the workspace first, per [`workspace.md`](workspace.md).
 
 ---
 
@@ -18,7 +18,8 @@ The application is Conduit, a Medium-style blogging app: sign in, write
 articles, follow authors, favourite posts, comment, paginate. It runs offline
 against a fake backend that lives in the page, so there is nothing to set up
 and no network to depend on. It is in `app/`, it currently renders through
-Reagent, and it works today. Run it before you change anything.
+Reagent, and it works today. Run it before you change anything. Its
+behavioural tests are in `app/test/`; `npm test` from `app/` runs them.
 
 Your two screens are **the feed** and **the article editor**.
 

--- a/docs/design/hicasso/product/pilots/friction-log.md
+++ b/docs/design/hicasso/product/pilots/friction-log.md
@@ -4,7 +4,7 @@ The pilot's own record, kept as the work happens. It is the programme's delivera
 
 The format is built around [the seven outcomes](#part-1-the-seven-outcomes) rather than around a generic template, because those seven are what the ratification says the pilots prove. Two things follow: the log has a section per outcome and no free-floating "notes" bucket, and an outcome that was never attempted is a distinct verdict from one that failed.
 
-Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification. The blank template is [at the end](#the-blank-template); copy that into the workspace.
+Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the template's `Baseline:` header line, which the operator fills in at [workspace step 5b](workspace.md#assemble-a-workspace), under `rf2-xkhul`. The blank template is [at the end](#the-blank-template); copy that into the workspace.
 
 ## A short log is a bad sign, not a good one
 
@@ -111,6 +111,7 @@ Pilot:            <1 or 2>
 Agent:            <identifier>
 Workspace:        <pilot-root>
 Checkout pin:     <sha>
+Baseline:         npm test → exit <code>, with the app still on Reagent
 Docs read from:   <published site URL or local build>
 Started / ended:  <date> / <date>
 

--- a/docs/design/hicasso/product/pilots/workspace.md
+++ b/docs/design/hicasso/product/pilots/workspace.md
@@ -19,7 +19,7 @@ The published installation chapter tells a reader to clone the monorepo *beside*
     package.json
     public/index.html
     src/
-    test/
+    test/               the app's behavioural baseline, copied in with the source
   BRIEF.md              the pilot's brief, copied from this directory
   FRICTION-LOG.md       the blank log, copied from this directory
 ```
@@ -55,7 +55,7 @@ Its links into `spec/` and `docs/` are a different matter, and following one is 
 
 ## Assemble a workspace
 
-Six steps. Run them from anywhere; `<pilot-root>` and `<repo>` are yours to choose.
+Six steps, the fifth in two halves. Run them from anywhere; `<pilot-root>` and `<repo>` are yours to choose.
 
 **1. Clone and pin.**
 
@@ -70,23 +70,27 @@ git -C re-frame2 rev-parse HEAD    # record this in the log header
 Pilot 1 — RealWorld/Conduit:
 
 ```bash
-mkdir -p app/src/realworld_http app/src/realworld_shared app/public app/test
+mkdir -p app/src/realworld_http app/src/realworld_shared app/public app/test/realworld_http
 cp re-frame2/examples/real-apps/realworld_http/*.cljs   app/src/realworld_http/
 cp re-frame2/examples/real-apps/realworld_http/*.cljc   app/src/realworld_http/
 cp re-frame2/examples/real-apps/realworld_shared/*.cljs app/src/realworld_shared/
 cp re-frame2/examples/real-apps/realworld_http/default-avatar.svg app/public/
 cp re-frame2/examples/real-apps/realworld_http/index.html         app/public/
 cp re-frame2/examples/real-apps/realworld_http/README.md          app/
+cp re-frame2/docs/design/hicasso/product/pilots/baseline/realworld_http/baseline_test.cljs app/test/realworld_http/
 ```
 
 Pilot 2 — LinearLite:
 
 ```bash
-mkdir -p app/src/linearlite app/public app/test
+mkdir -p app/src/linearlite app/public app/test/linearlite
 cp re-frame2/examples/capabilities/resources/linearlite/core.cljs  app/src/linearlite/
 cp re-frame2/examples/capabilities/resources/linearlite/index.html app/public/
 cp re-frame2/examples/capabilities/resources/linearlite/README.md  app/
+cp re-frame2/docs/design/hicasso/product/pilots/baseline/linearlite/baseline_test.cljs app/test/linearlite/
 ```
+
+The last line of each manifest is the app's behavioural baseline, and it is the one file that does not come from the app's own directory. The examples tree is test-free by policy, so each app's behavioural suite lives in the Reagent adapter's test tree and runs on the in-repo harness; [`baseline/`](baseline/README.md) carries the subset that exercises the nominated screens, rewritten as the app's own test namespace so that it stands on `cljs.test`, the core test support and the canned HTTP replies — all of which the `:local/root` route resolves — and on nothing the workspace cannot see. The pilot may read it, since it is under `app/`, which is why it names no in-tree path, bead or spec: the fence holds inside the test file as it does inside the brief. Added under `rf2-xkhul`.
 
 **3. Write the four project files** from the templates below.
 
@@ -101,6 +105,14 @@ cd app && npm install
 ```bash
 npx shadow-cljs watch app     # then open http://localhost:8080
 ```
+
+**5b. Run the baseline, with the app still on Reagent**, and record its exit code in the log header beside the pin. This is outcome 1's "before" measurement, and it is the operator who takes it: a baseline that is not green before the pilot starts is a defect in the scaffolding, fixed here, never handed to the pilot as friction. The run also proves that the `:test` build resolves the test kit, the app and its test namespace from the clean workspace.
+
+```bash
+cd app && npm test > ../baseline-reagent.log 2>&1; echo "baseline exit $?"    # the number goes in the log header
+```
+
+The runner's closing line is the count to expect — as of `rf2-xkhul` the RealWorld baseline reports 4 tests and the LinearLite baseline 9, both with 0 failures and 0 errors — and it is the exit status that is recorded, not the count. Added under `rf2-xkhul`.
 
 **6. Copy the brief and the blank log** into `<pilot-root>/`, from [`brief-realworld.md`](brief-realworld.md) or [`brief-linearlite.md`](brief-linearlite.md), and from [`friction-log.md`](friction-log.md)'s template section.
 
@@ -131,31 +143,39 @@ Pilot 1 — RealWorld/Conduit:
 
 Pilot 2 — LinearLite: the same file with the `machines`, `flows`, `schemas` and `ssr` rows dropped and `day8/re-frame2-resources {:local/root "../re-frame2/implementation/resources"}` added.
 
-The `:test` alias follows the published testing chapter's `:local/root` route, where the Hicasso test kit lives on its own source root outside the artefact's `:paths` and has to be named explicitly. Both pilots need it from the first hour, because outcome 1 is to preserve the app's behavioural tests.
+The `:test` alias follows the published testing chapter's `:local/root` route, where the Hicasso test kit lives on its own source root outside the artefact's `:paths` and has to be named explicitly. Both pilots need it from the first hour, because outcome 1 is to preserve the app's behavioural tests. `"test"` on the same alias is the app's own test root: the baseline lands there in step 2, and the tests the pilot ports or adds go beside it.
 
 ### `app/shadow-cljs.edn`
 
 ```clojure
 {:deps     {:aliases [:shadow :test]}
  :dev-http {8080 "public"}
- :builds   {:app {:target     :browser
-                  :output-dir "public/js"
-                  :asset-path "/js"
-                  :modules    {:main {:init-fn realworld-http.core/run}}}}}
+ :builds   {:app  {:target     :browser
+                   :output-dir "public/js"
+                   :asset-path "/js"
+                   :modules    {:main {:init-fn realworld-http.core/run}}}
+            :test {:target    :node-test
+                   :output-to "out/test.js"
+                   :ns-regexp "-test$"}}}
 ```
 
 Pilot 2 uses `:init-fn linearlite.core/run`.
 
-Both aliases are named on purpose. `:shadow` puts the compiler on the classpath; without it the build dies at `Could not locate shadow/cljs/devtools/cli`. `:test` carries the test kit, and shadow reads its classpath from `deps.edn`, so an alias not named here is not on it.
+Both aliases are named on purpose. `:shadow` puts the compiler on the classpath; without it the build dies at `Could not locate shadow/cljs/devtools/cli`. `:test` carries the test kit and the app's test root, and shadow reads its classpath from `deps.edn`, so an alias not named here is not on it.
+
+The `:test` build compiles every namespace on the classpath whose name ends in `-test` — the baseline under `app/test/`, and whatever the pilot ports or adds beside it — into one Node script. Node is enough for the baseline, which drives events and reads subscriptions without rendering, and for the browser-free rungs of the published testing ladder. A test that mounts real React needs a DOM the Node target does not supply; what to do about that when a ported test reaches for it is the pilot's call, and a call worth logging.
 
 ### `app/package.json`
 
 ```json
 {
+  "scripts":         {"test": "shadow-cljs compile test && node out/test.js"},
   "dependencies":    {"react": "19.2.0", "react-dom": "19.2.0"},
   "devDependencies": {"shadow-cljs": "3.4.10", "@testing-library/dom": "^10"}
 }
 ```
+
+`npm test` is the one-line test command: the briefs name it, step 5b runs it, and outcome 1 quotes its exit code before and after. It compiles the `:test` build and then runs the script, chained with `&&` so a failed compile never runs a stale bundle, and the status it exits with is the test runner's own — one failing assertion is a non-zero exit, which is what makes the captured number evidence.
 
 The React pin is the published floor, not a preference: below 19.2 the lifecycle contract has nothing to run on, and 18 and earlier is not supported. `shadow-cljs` stays in `devDependencies` even though the JVM dependency compiles, because the npm package is where React's CommonJS `process` shim comes from. Testing Library is what the published testing ladder's L3 rung reaches for; add `@testing-library/user-event` if the pilot's ported tests drive real interactions.
 

--- a/docs/design/hicasso/product/pilots/workspace.md
+++ b/docs/design/hicasso/product/pilots/workspace.md
@@ -112,7 +112,7 @@ npx shadow-cljs watch app     # then open http://localhost:8080
 cd app && npm test > ../baseline-reagent.log 2>&1; echo "baseline exit $?"    # the number goes in the log header
 ```
 
-The runner's closing line is the count to expect — as of `rf2-xkhul` the RealWorld baseline reports 4 tests and the LinearLite baseline 9, both with 0 failures and 0 errors — and it is the exit status that is recorded, not the count. Added under `rf2-xkhul`.
+The runner's closing line is the count to expect — as of `rf2-xkhul` the RealWorld baseline reports `Ran 4 tests containing 123 assertions.` and the LinearLite baseline `Ran 10 tests containing 51 assertions.`, both with `0 failures, 0 errors.` — and it is the exit status that is recorded, not the count. The compile also prints a handful of `:infer-warning` lines from the framework's own source and a Clojure CLI deprecation notice about the test kit's external path; neither fails the run, and both are the framework's to log, not the operator's to hide. Added under `rf2-xkhul`.
 
 **6. Copy the brief and the blank log** into `<pilot-root>/`, from [`brief-realworld.md`](brief-realworld.md) or [`brief-linearlite.md`](brief-linearlite.md), and from [`friction-log.md`](friction-log.md)'s template section.
 
@@ -120,7 +120,7 @@ The runner's closing line is the count to expect — as of `rf2-xkhul` the RealW
 
 ### `app/deps.edn`
 
-Both pilots resolve every artefact from the one checkout. The rows differ only in which artefacts each application actually requires; a coordinate the app does not require may be dropped, and leaving it in costs nothing but classpath.
+Both pilots resolve every re-frame2 artefact from the one checkout. The rows differ only in which artefacts each application actually requires; a coordinate the app does not require may be dropped, and leaving it in costs nothing but classpath. RealWorld needs one library from Maven as well: its article body renders CommonMark through `io.github.nextjournal/markdown`, and without that row the build stops at `The required namespace "nextjournal.markdown" is not available` before a single test runs.
 
 Pilot 1 — RealWorld/Conduit:
 
@@ -134,14 +134,15 @@ Pilot 1 — RealWorld/Conduit:
          day8/re-frame2-flows    {:local/root "../re-frame2/implementation/flows"}
          day8/re-frame2-schemas  {:local/root "../re-frame2/implementation/schemas"}
          day8/re-frame2-ssr      {:local/root "../re-frame2/implementation/ssr"}
-         day8/re-frame2-hicasso  {:local/root "../re-frame2/implementation/hicasso"}}
+         day8/re-frame2-hicasso  {:local/root "../re-frame2/implementation/hicasso"}
+         io.github.nextjournal/markdown {:mvn/version "0.7.225"}}
 
  :aliases
  {:shadow {:extra-deps {thheller/shadow-cljs {:mvn/version "3.4.10"}}}
   :test   {:extra-paths ["test" "../re-frame2/implementation/hicasso/test_kit/src"]}}}
 ```
 
-Pilot 2 — LinearLite: the same file with the `machines`, `flows`, `schemas` and `ssr` rows dropped and `day8/re-frame2-resources {:local/root "../re-frame2/implementation/resources"}` added.
+Pilot 2 — LinearLite: the same file with the `machines`, `flows`, `schemas`, `ssr` and `markdown` rows dropped and `day8/re-frame2-resources {:local/root "../re-frame2/implementation/resources"}` added.
 
 The `:test` alias follows the published testing chapter's `:local/root` route, where the Hicasso test kit lives on its own source root outside the artefact's `:paths` and has to be named explicitly. Both pilots need it from the first hour, because outcome 1 is to preserve the app's behavioural tests. `"test"` on the same alias is the app's own test root: the baseline lands there in step 2, and the tests the pilot ports or adds go beside it.
 
@@ -167,13 +168,22 @@ The `:test` build compiles every namespace on the classpath whose name ends in `
 
 ### `app/package.json`
 
+Pilot 1 — RealWorld/Conduit:
+
 ```json
 {
   "scripts":         {"test": "shadow-cljs compile test && node out/test.js"},
-  "dependencies":    {"react": "19.2.0", "react-dom": "19.2.0"},
+  "dependencies":    {"react": "19.2.0", "react-dom": "19.2.0",
+                      "markdown-it": "^14.1.0", "markdown-it-block-image": "^0.0.3",
+                      "markdown-it-footnote": "^3.0.3", "markdown-it-texmath": "^1.0.0",
+                      "markdown-it-toc-done-right": "^4.2.0", "punycode": "2.1.1"},
   "devDependencies": {"shadow-cljs": "3.4.10", "@testing-library/dom": "^10"}
 }
 ```
+
+Pilot 2 — LinearLite: the same file with the six rows from `markdown-it` to `punycode` dropped; the board renders no Markdown.
+
+The six are what the Markdown library's ClojureScript side tokenizes with, and they are exactly the `:npm-deps` its jar declares. shadow-cljs would install them on its own the first time it compiled, but an installer that runs as a side effect of a compile is a surprise the pilot should not meet, so they are declared here and installed in step 4 with everything else.
 
 `npm test` is the one-line test command: the briefs name it, step 5b runs it, and outcome 1 quotes its exit code before and after. It compiles the `:test` build and then runs the script, chained with `&&` so a failed compile never runs a stale bundle, and the status it exits with is the test runner's own — one failing assertion is a non-zero exit, which is what makes the captured number evidence.
 


### PR DESCRIPTION
rf2-xkhul — put a runnable behavioural baseline in each pilot workspace (outcome 1 currently has none).

## What changed

Outcome 1 of the friction log measures the app's behavioural tests before and after the migration, but `workspace.md` copied nothing into `app/test/` and carried no test build: both pilots were blocked at hour zero, and the block would have been logged as the framework's friction. Everything here is under `docs/design/hicasso/product/pilots/`.

- **`baseline/`** — one app-voice test namespace per pilot, extracted from the two Reagent adapter suites and scoped to the nominated screens. RealWorld (`realworld-http.baseline-test`, 4 tests / 123 assertions): the feed, the article editor, the routing both sit in, and boot. LinearLite (`linearlite.baseline-test`, 10 tests / 51 assertions): the board's route-owned load, optimistic create / retitle / change-status, commit, rollback, and the demo backend's armed 503 plus its positive control. Both stand on `cljs.test`, core's `re-frame.test-support` fixture and the canned managed-HTTP replies — all on the published `:local/root` classpath — and on nothing the workspace cannot see. The pilot reads them (they land under `app/`), so they name no in-tree path, bead or spec; comments were rewritten in the app's voice. `baseline/README.md` records provenance and the two rules.
- **`workspace.md`** — the `:test` `:node-test` build in the copy-ready `shadow-cljs.edn`; `"scripts": {"test": …}` in `package.json` so `npm test` is the one-line command; **step 5b** (run the baseline with the app still on Reagent, record the exit code in the log header); the manifest line per pilot that copies the baseline into `app/test/`; the expected runner counts. Two further fixes that only running step 5b from a clean workspace revealed: Pilot 1's `deps.edn` needs `io.github.nextjournal/markdown` (the article body renders CommonMark — without it the build stops at `The required namespace "nextjournal.markdown" is not available`), and its `package.json` the six npm packages that jar's `deps.cljs` declares; Pilot 2 drops both.
- **`friction-log.md`** — a `Baseline:` line in the blank template's header, beside the pin.
- **`brief-realworld.md` / `brief-linearlite.md`** — one sentence each inside the pilot-facing block: "Its behavioural tests are in `app/test/`; `npm test` from `app/` runs them." No in-tree path, bead or spec enters either brief; the authorization is in each page's preamble, outside the block.
- **`README.md`** — the `workspace.md` row names the baseline; one paragraph points at `baseline/`.

Each amendment names `rf2-xkhul` at the site, per the directory's custody rule.

## Acceptance evidence — the clean workspaces

Both workspaces were built OUTSIDE the repository, by following `workspace.md` alone, on the documented `:local/root` route (Clojure CLI 1.12.4.1618, Node 24.13.0, shadow-cljs 3.4.10). One deviation from the page, necessarily: step 1's `git clone` was taken from this branch rather than from GitHub's `main`, which does not yet carry the baselines. The page's three fenced project files and both pilots' prose-derived variants were compared mechanically against the workspace files (all match), and all 11 manifest `cp` sources exist in the checkout.

Final runs, with both checkouts at this PR's rebased head, `npm test` redirected to a log and the runner's own status captured:

| Pilot | Command | Captured exit | Runner's closing lines |
| --- | --- | --- | --- |
| 1 RealWorld/Conduit | `npm test` in `app/` | **0** | `Testing realworld-http.baseline-test` / `Ran 4 tests containing 123 assertions.` / `0 failures, 0 errors.` |
| 2 LinearLite | `npm test` in `app/` | **0** | `Testing linearlite.baseline-test` / `Ran 10 tests containing 51 assertions.` / `0 failures, 0 errors.` |

Earlier attempts were the findings, in order: Pilot 1 attempt 1 exit **1** at compile (missing Markdown dependency — fixed on the page); Pilot 2 attempt 1 exit **1**, 16 failures / 51 assertions, reproduced identically with the adapter suite copied verbatim (so not the extraction), traced with load-time probes to registrations made after `make-frame` being invisible to the frame's sealed generation in the consumer bundle; the baseline's `init!` now registers everything first and makes the frame last, which is the correct order for an app fixture regardless. The framework-side question is filed as **rf2-ma8r** (P2) with the reproduction. Every compile also prints four `:infer-warning` lines from `re_frame/substrate/spine.cljs` and, on a cold classpath, the Clojure CLI's `Use of :paths external to the project has been deprecated` for the published test-kit route — neither fails the run; the second is filed as **rf2-luo6** against the published testing chapter.

## Quality gates

Every gate below was run from this worktree by absolute script path, redirected to a per-worktree, per-attempt log with the runner's own exit code echoed on the same command line; the numbers quoted are those captured, re-run on the final base after the rebase onto `origin/main`.

| Gate | Exit (final base) | Notes |
| --- | --- | --- |
| `python scripts/check_doc_slugs.py` | **0** | Planted-fault check: with the tree committed and clean, one anchor on an edited line of `friction-log.md` was changed to `#the-blank-templat` (match count 1 before the gate ran); the gate returned **exit 1** naming `friction-log.md:7 -> #the-blank-templat`; `git checkout HEAD --` restored it and the working file's blob hash `0faf1b13803adc575d8c7c2f6230853bd9b464e9` equals HEAD's blob for that path; re-run **0**. |
| `python scripts/check_provenance_pins.py --changed-since origin/main` | **0** | `6 pages inspected, 0 cited pins … 0 findings.` No commit hash is cited on any touched page. |
| `sh scripts/check-no-hardcoded-paths.sh` | **0** | Portability gate OK. |
| `mkdocs build --strict` | skipped | Not a gate for this tree: `mkdocs.yml` `exclude_docs` keeps `docs/design/**` out of the site. |
| `scripts/check_readme_links.py --ci` | skipped | Its roster is repo-root and beside-source markdown; every touched page is under `docs/`, which is `check_doc_slugs.py`'s surface. |

**Hand verification (no gate reads prose, tables or the copy-ready blocks).** Every link outside a fence on the six touched pages was resolved by script — 34 links, file and anchor, 0 bad — including the new `workspace.md#assemble-a-workspace`, `README.md#what-governs-this-directory`, and `baseline/README.md`'s links to `../workspace.md`, `../friction-log.md` and the two `.cljs` files. Table column counts: `README.md` "four pages" 3 columns × 6 rows and gaps 4 × 5; `workspace.md` read fence 2 × 6; `friction-log.md` resolutions 3 × 6 and outcomes 4 × 9; `baseline/README.md` 3 × 4; the blank template's fenced table 4 columns on all 9 rows — every row matches its header. The copy-ready `deps.edn`, `shadow-cljs.edn` and `package.json` blocks are byte-equal (modulo trailing whitespace) to the files the green workspaces ran on.

**Fixture leakage scan.** `grep` over both baseline files for bead ids, spec citations, EP ids, `implementation/`, `spec/`, `docs/`, `examples/` and home paths: 0 hits; the same pattern finds 11 hits in the source LinearLite suite (control).

**What this local run omits.** The required CI checks this run does not cover are derived, not listed — see `TESTING.md` § "Required checks the fast-PR spine does not run" (`python scripts/check_fast_pr_gap.py --list`). No hot-zone file, no `implementation/**` file and no `examples/**` file changes here; the two `.cljs` fixtures live under `docs/` and are on no shadow build's source path.
