### PR TITLE
ssr-node crossing (E/6): native-Hicasso product witness — hicasso.server body-only entry + login example server bundle (rf2-8arzr.5)

### DIFF
--- a/examples/scripts/examples-staging.cjs
+++ b/examples/scripts/examples-staging.cjs
@@ -243,10 +243,20 @@ function stripEdnComments(edn) {
     .join('\n');
 }
 
-// Parse every `:examples/<name>` build def into { build, outputDir, initFn }.
-// `build` is the colon-stripped coord shadow-cljs's CLI expects
-// (`examples/counter-uix`); `outputDir` is the build's `:output-dir`; `initFn`
-// is the `<ns>/run` symbol the build mounts.
+// Parse every `:examples/<name>` build def into { build, target, outputDir,
+// initFn }. `build` is the colon-stripped coord shadow-cljs's CLI expects
+// (`examples/counter-uix`); `target` is the build's `:target` keyword, COLON
+// INCLUDED (`:browser`); `outputDir` is the build's `:output-dir`; `initFn` is
+// the `<ns>/run` symbol the build mounts.
+//
+// `target` is what separates a PAGE build from a server-side one. Not every
+// `:examples/*` build is a page: a `:node-library` (the Hicasso login arm's
+// SSR bundle, rf2-8arzr.5) publishes an `:exports-var` for a Node sidecar to
+// `require` and correctly carries no `:init-fn` and no colocated index.html.
+// Such a build is still parsed — it IS an example build, and
+// check-examples-compile.cjs compiles it — but it is legitimately absent from
+// the runnable manifest listStandaloneExamples derives, and the out+init
+// invariant is asserted of `:browser` builds only.
 //
 // Line-based block scan: a build def opens with a two-space-indented
 // `  :examples/<name>` key (the opening `{` is on the SAME or the FOLLOWING
@@ -273,10 +283,12 @@ function parseExampleBuilds(edn) {
       bodyLines.push(lines[j]);
     }
     const body = bodyLines.join('\n');
+    const targetMatch = body.match(/:target\s+(:[\w.\-]+)/);
     const outMatch = body.match(/:output-dir\s+"([^"]+)"/);
     const initMatch = body.match(/:init-fn\s+([\w.\-]+\/[\w.\-]+)/);
     builds.push({
       build,
+      target: targetMatch ? targetMatch[1] : null,
       outputDir: outMatch ? outMatch[1] : null,
       initFn: initMatch ? initMatch[1] : null,
     });

--- a/examples/substrates/hicasso/login/README.md
+++ b/examples/substrates/hicasso/login/README.md
@@ -100,7 +100,9 @@ every node, subscription and scrap of component state.
 
 ```
 login/
-  core.cljs    — the Hicasso HALF: h/defview views + adapter init + frame + mount.
+  core.cljs    — the Hicasso HALF: h/defview views + adapter init + frame + boot.
+  server.cljs  — the SERVER bundle: the entry table the ssr-node sidecar loads.
+  host.clj     — the JVM half: one ssr-handler wired to the Node renderer.
   index.html   — minimal host page.
 ```
 
@@ -123,6 +125,92 @@ one-shot compile-and-serve.
 No backend ships. The login runs against the canned HTTP stub in
 [`login.model`](../../../core/login/model.cljs), so the password
 `correct-horse` succeeds and anything else fails the way the machine expects.
+
+## Rendering it on the server
+
+The same views render on a server, and the interesting part is *which* server.
+Hicasso interprets Hiccup at runtime through React, so there is no JVM string
+emitter to render it with — the page's body is rendered by **Node**, running
+this very application's compiled bundle, while a JVM Ring handler owns
+everything else. That split is the whole shape of it:
+
+| The JVM (`host.clj`) | Node (`server.cljs`) |
+|---|---|
+| the request frame, the boot-event drain, the settle | — |
+| the `<head>`, the shell, `__rf_payload`, status, headers, cookies, redirects | — |
+| error projection and frame teardown | — |
+| — | the body markup, and nothing else |
+
+Node is handed a **projection** of the settled frame — not the frame — under a
+policy the host declares, and it hands back a string. Nothing else crosses in
+either direction.
+
+### The two policies
+
+There are two allowlists, and reading them as one is the mistake worth
+avoiding. `:payload` answers *what may the browser see?*; `:render-state`
+answers *what does the render need?* They differ in both directions:
+
+```clojure
+:payload      [:auth]                                   ;; the browser's
+:render-state {:app-db     [:auth :auth.login/server-notice]
+               :runtime-db [:rf.runtime/machines]}      ;; the render's
+```
+
+`:rf.runtime/machines` is in the render's list and not the browser's *shape*
+because the two partitions are different places: the `:auth.login/flow`
+machine's snapshot lives in runtime-db, and it is what decides whether the page
+shows the form, the welcome or the locked panel. Leave it out and the server
+renders a signed-in visitor a login form.
+
+`:auth.login/server-notice` runs the other way: a deployment notice the host
+resolves per request, which the render may read and the browser never receives.
+**A key in that position must not change the markup.** The hydrating client
+renders from the payload, so a node the two halves disagree about is a node
+React recovers by re-rendering — one recoverable error, measured rather than
+asserted in `re-frame.hicasso.login-server-crossing-ssr-dom-cljs-test`. So
+`host.clj` ships with no notice in app-db, and the key is there to make the
+distinction between the two policies concrete rather than theoretical.
+
+The draft password shows the third case. It is classified `:sensitive` by the
+shared model, so BOTH projections redact it before either wire: the render
+cannot print a secret it was never handed, and the input comes back reading
+`redacted` on a server-rendered page.
+
+### Build it and run it
+
+```bash
+# From implementation/ — the server bundle and the client bundle.
+npx shadow-cljs compile :examples/login-hicasso-server
+npx shadow-cljs compile :examples/login-hicasso
+
+# The sidecar, pointed at the server bundle. It prints ONE JSON line on
+# stdout when it is listening; read the `url` out of that.
+node ssr-node/bin/serve.cjs --module out/examples/login-hicasso-server/server.js
+```
+
+For a deployment, stamp a real build identity into the bundle and give the JVM
+host the same string — the sidecar refuses a request that names a different
+one, and the adapter refuses an answer that comes back with one:
+
+```bash
+npx shadow-cljs release examples/login-hicasso-server   --config-merge '{:closure-defines {hicasso.login.server/build-id "2026-09-02-a1b2c3"}}'
+```
+
+Then serve `host.clj`'s `handler` from any Ring adapter, with
+`LOGIN_HICASSO_SSR_NODE` pointing at the sidecar's URL, and open the page. The
+client boots through the same `core.cljs` either way: it looks for
+`__rf_payload`, and hydrates when it finds one instead of mounting.
+
+**One thing is not done yet, and the JVM host cannot run without it.** A JVM
+host has to hold the application's state, so `login.model` — the owner of every
+`auth.login` schema, fx, machine, event and sub — has to be loadable from
+Clojure, and it is `model.cljs` today. The single line keeping it there is a
+`localStorage` write in the demo session effect. Making it `.cljc` is a change
+to a file all three login arms share and is not made here; until it is,
+`host.clj` is the wiring rather than a running server. The crossing itself is
+exercised end to end, against the real sidecar contract, by
+`implementation/hicasso/test/re_frame/hicasso/login_server_crossing_ssr_dom_cljs_test.cljs`.
 
 ## Copying this into your own app
 

--- a/examples/substrates/hicasso/login/core.cljs
+++ b/examples/substrates/hicasso/login/core.cljs
@@ -40,6 +40,11 @@
             ;; here.
             [login.model :as model]
             [re-frame.hicasso :as h]
+            ;; The client half of an SSR route: `ssr/hydrate!` installs the
+            ;; server's app-db from `__rf_payload` BEFORE the first client
+            ;; render. On a client-only load it finds no payload and is a
+            ;; no-op, which is what lets ONE `run` serve both pages.
+            [re-frame.ssr :as ssr]
             ;; Hicasso is a VIEW layer, not a substrate: it owns Hiccup
             ;; interpretation and the render boundary, while the reactive
             ;; container app-db lives in comes from an adapter. Hicasso ships
@@ -47,6 +52,31 @@
             ;; coordinate (docs/core/hicasso/00-installation.md §Hicasso needs a
             ;; substrate adapter).
             [re-frame.hicasso.substrate :as substrate]))
+
+;; ============================================================================
+;; THE SSR COORDINATES  (shared by the client boot and the server bundle)
+;; ============================================================================
+;;
+;; Three constants both halves of the crossing have to agree on, declared
+;; ONCE here because `server.cljs` requires this namespace and the client
+;; boot below is in it. A second copy is a second thing to keep in step.
+
+(def identifier-prefix
+  "React's `identifierPrefix`, handed unchanged to the server render and to
+  the hydrating client root. React numbers every `useId` per root from the
+  same start and prefixes it with this string, so a hydrating root given a
+  different one — or none, where the server had one — resolves every id in
+  the tree differently from the bytes it is adopting."
+  "rf-login-")
+
+(def app-element-id
+  "The element the JVM host's shell wraps Node's body markup in, and the one
+  the client adopts."
+  "app")
+
+(def frame-id
+  "The one frame this page owns, on both hosts."
+  :rf/default)
 
 ;; ============================================================================
 ;; VIEWS  (Hicasso — h/defview + h/sub + intents)
@@ -141,11 +171,47 @@
        locked? [locked-panel]
        :else   [login-form])]))
 
+;; The SERVER-ONLY read, and the one view in this file that only a server
+;; render can fill.
+;;
+;; `[:auth.login/server-notice]` is a TOP-LEVEL app-db key a JVM host puts a
+;; deployment notice in — a maintenance window, a region, whatever the
+;; operator resolves per request. It is declared HERE rather than in the
+;; shared `login.model` because only this arm has a server; the Reagent and
+;; UIx twins never see it, and the model stays substrate-free.
+;;
+;; It is the example's demonstration that the two SSR policies are DISTINCT:
+;; a host may name this key in `:render-state` (so the render can read it)
+;; while leaving it out of `:payload` (so the browser never receives it).
+;; **And that choice has a price, which is the rule to take away**: a
+;; render-state key the payload does not carry must not CHANGE THE MARKUP,
+;; because the hydrating client renders from the payload and React reports a
+;; recoverable error for every node the two disagree about. So the shipped
+;; host (`host.clj`) puts no notice in app-db and this banner renders
+;; nothing on both halves; the witness
+;; (`re-frame.hicasso.login-server-crossing-ssr-dom-cljs-test`) is where the
+;; key is filled, and it measures both the absence from `__rf_payload` and
+;; the hydration cost.
+(rf/reg-sub :auth.login/server-notice
+  {:doc "A deployment notice a JVM host may place at the top-level app-db
+         key of the same name. Absent on a client-only load, and absent
+         from the hydration payload whenever the host declares it
+         render-visible but not payload-visible."}
+  (fn sub-auth-login-server-notice [db _]
+    (:auth.login/server-notice db)))
+
+(h/defview server-notice
+  "The deployment notice, when there is one."
+  [_]
+  (when-some [notice (h/sub [:auth.login/server-notice])]
+    [:p.server-notice {:data-testid "login-server-notice"} notice]))
+
 (h/defview root-view
   "The example's root boundary."
   [_]
   [:div.app
    [:h1 "Sign in"]
+   [server-notice]
    [login-banner]])
 
 ;; ============================================================================
@@ -200,12 +266,34 @@
   (when-some [root @!root]
     (h/render! root [root-view])))
 
+;; ONE boot, two pages. A client-only load has no `__rf_payload` in the
+;; document, so `ssr/hydrate!` is a no-op and the root MOUNTS — exactly the
+;; three lines above. A server-rendered load has one, so the payload is
+;; installed first and the root ADOPTS the markup already on the page
+;; instead of throwing it away.
+;;
+;; The branch is on the payload rather than on a build flag deliberately:
+;; one bundle serves both, so `npm run dev:example -- examples/login-hicasso`
+;; keeps working unchanged and the SSR route needs no second build.
+;;
+;; No `:render-tree-fn` is passed to `ssr/hydrate!`. The render-tree hash is
+;; hiccup-tier-only, and this is an adoption-tier root: Hicasso's server
+;; render ships no `:rf/render-hash` and there is nothing to compare
+;; against. Adoption is verified by React itself — a divergence surfaces as
+;; a recoverable error on this root's own stream.
+
 (defn run []
   (rf/init! substrate/adapter)
-  (rf/make-frame (merge {:id  :rf/default
+  (rf/make-frame (merge {:id  frame-id
                          :doc "Login (Hicasso) demo frame."}
                         model/frame-config))
   (when-let [el (and (exists? js/document)
-                     (js/document.getElementById "app"))]
-    (reset! !root (h/mount! el {:frame :rf/default} [root-view])))
+                     (js/document.getElementById app-element-id))]
+    (let [payload (ssr/read-server-payload)
+          config  {:frame             frame-id
+                   :identifier-prefix identifier-prefix}]
+      (if (some? payload)
+        (do (ssr/hydrate! {:frame frame-id :payload payload})
+            (reset! !root (h/hydrate! el config [root-view])))
+        (reset! !root (h/mount! el config [root-view])))))
   nil)

--- a/examples/substrates/hicasso/login/host.clj
+++ b/examples/substrates/hicasso/login/host.clj
@@ -1,0 +1,98 @@
+(ns hicasso.login.host
+  "The JVM half of the login example's SSR route — a Ring handler that
+  renders this page's BODY on Node and everything else itself.
+
+  Ten lines of wiring and a page of why. The wiring is the whole point:
+  swapping a JVM-local render for a Node one is ONE construction opt, and
+  nothing else about the handler moves.
+
+  ## The file name
+
+  `host.clj`, not `server.clj`, and that is a compiler constraint rather
+  than a preference. ClojureScript implicitly requires `foo/bar.clj` as the
+  MACRO namespace of `foo.bar` whenever a `foo/bar.cljs` exists, so a
+  `server.clj` beside `server.cljs` would be loaded into every compile of
+  the server bundle — as macros, on a classpath that has no Ring on it.
+
+  ## What this owns, and what Node owns (rf2-8arzr shared contract S2)
+
+  The JVM keeps the request frame, the boot-event drain, the blocking-
+  resource settle, the `<head>`, `__rf_payload`, the shell, the status,
+  headers, cookies, redirects, error projection and frame teardown. Node
+  returns body markup and nothing else. `:root-view` is absent because it
+  is read only by the default JVM-local renderer.
+
+  ## The two policies, and why there are two
+
+  `:payload` answers *what may the BROWSER see?*; `:render-state` answers
+  *what does the RENDER need?* They differ in both directions, and this
+  handler is where that is declared. The render-state policy is
+  `hicasso.login.server/render-state-policy` — the SAME map the bundle
+  derives its entry allowlists from, so one list is read by both halves and
+  a host that reaches past it is refused by the sidecar rather than served.
+
+  ## Running it
+
+  See the example README. There is one thing this file cannot do on its
+  own, and it is worth knowing before you try: a JVM host has to hold the
+  application's state, so the shared `login.model` — the owner of every
+  `auth.login` schema, fx, machine, event and sub — has to be loadable from
+  Clojure. It is `examples/core/login/model.cljs` today, ClojureScript
+  only, and the single line that keeps it there is a `localStorage` write
+  in the demo session fx. Making it `.cljc` is a separate change to a file
+  three example arms share, so it is not made here; until it is, this
+  namespace is the WIRING rather than a running server, and the crossing it
+  describes is exercised end to end by
+  `re-frame.hicasso.login-server-crossing-ssr-dom-cljs-test`."
+  (:require [re-frame.ssr.ring :as ssr-ring]
+            [re-frame.ssr.ring.node :as node]
+            ;; The application, on the JVM. See §Running it above.
+            #_[login.model]))
+
+(def build-id
+  "The bundle this host was deployed against.
+
+  It must be the string the server bundle publishes — `hicasso.login.server/
+  build-id`, a `goog-define` a release stamps. The check runs in BOTH
+  directions and neither is optional: the sidecar refuses a request whose
+  `buildId` is not its own (`:rf.ssr-node/build-identity-mismatch`), and the
+  adapter refuses an ANSWER whose `x-rf-ssr-build` is not this one
+  (`:rf.error/ssr-node-build-skew`). Two artefacts from different builds
+  cannot quietly serve one page between them."
+  (or (System/getenv "LOGIN_HICASSO_BUILD_ID") "login-hicasso-dev"))
+
+(def endpoint
+  "Where the sidecar is listening. The adapter's default is the launcher's
+  default bind, and it accepts any absolute http(s) URL — a non-loopback
+  sidecar is not refused. Render state can carry server-only values, so a
+  remote one is the operator's network and transport to secure."
+  (or (System/getenv "LOGIN_HICASSO_SSR_NODE") node/default-endpoint))
+
+(def handler
+  "The Ring handler. One `ssr-handler`, one `:renderer`.
+
+  `:render-state` and `:payload` are the two policies; `:initial-events`
+  seeds the form slice before the first render exactly as the browser boot
+  does, so the two halves render the same page from the same events."
+  (ssr-ring/ssr-handler
+    {:initial-events [[:auth.login/initialise-form]]
+     ;; What the BROWSER may see: the form slice, and nothing else.
+     :payload        [:auth]
+     ;; What the RENDER may see. Read from the bundle's own map when it is
+     ;; on this classpath; spelled here otherwise, and the sidecar refuses
+     ;; the difference rather than serving it.
+     :render-state   {:app-db     [:auth :auth.login/server-notice]
+                      :runtime-db [:rf.runtime/machines]}
+     ;; No `:root-view` — only the default JVM-local renderer reads one.
+     :renderer       (node/renderer
+                       {:endpoint     endpoint
+                        :entry        "hicasso.login/root"
+                        :build-id     build-id
+                        ;; The same two policies the seam projects under.
+                        :render-state {:app-db     [:auth :auth.login/server-notice]
+                                       :runtime-db [:rf.runtime/machines]}
+                        :timeout-ms   1000})
+     ;; The client bundle, and the element it adopts. `hicasso.login.core/run`
+     ;; reads `__rf_payload`, finds one, and HYDRATES rather than mounting.
+     :app-element-id "app"
+     :script-src     "/js/main.js"}))

--- a/examples/substrates/hicasso/login/server.cljs
+++ b/examples/substrates/hicasso/login/server.cljs
@@ -1,0 +1,171 @@
+(ns hicasso.login.server
+  "The login example's SERVER BUNDLE — the module `implementation/ssr-node`'s
+  sidecar loads, and the Node half of the ssr-node crossing.
+
+  This is the whole of what an application writes to render on Node. It is
+  short on purpose: the framework owns the render (`re-frame.hicasso.server/
+  render-body`), the state install (`re-frame.ssr.render-state/restore!`) and
+  the wire domain, so what is left here is an ENTRY TABLE and a boot.
+
+      npx shadow-cljs compile :examples/login-hicasso-server
+      node implementation/ssr-node/bin/serve.cjs \\
+        --module implementation/out/examples/login-hicasso-server/server.js
+
+  ## What crosses, and what does not
+
+  The JVM host (`host.clj`) owns the request frame, the boot-event drain,
+  the `<head>`, `__rf_payload`, the shell, the status and the response.
+  **Node returns body markup and nothing else** — so there is no payload
+  policy here, no head model, no cookies and no status. The service refuses
+  a request carrying any of them, by name, with the reason attached.
+
+  ## The two allowlists, and who owns them
+
+  `entries` publishes, per entry, the top-level keys of EACH partition that
+  entry may be handed. The lists belong to the ENTRY rather than to the
+  caller, so a JVM host cannot widen its own allowance, and an entry that
+  declares no list for a partition cannot be rendered at all — absence is a
+  refusal, never a licence to read everything.
+
+  They are derived from `render-state-policy` below, which is also the map
+  `host.clj` hands `ssr-handler` as `:render-state`. ONE list, two readers.
+  The two processes are deployed separately, so nothing can MAKE them agree
+  — but nothing has to: a host that asks for a key this table does not name
+  is refused with `:rf.ssr-node/state-key-not-allowed`, and a host built
+  against a different bundle is refused with
+  `:rf.ssr-node/build-identity-mismatch`. Drift is loud on the first
+  request, not silent on the thousandth.
+
+  ## The render module contract
+
+  `{:protocol 1 :buildId <string> :entries {…} :boot fn :render fn}`, and
+  `render` has ONE output channel — `emit`. It returns `js/undefined`
+  rather than `nil`, and the difference is not pedantry: the service
+  refuses a module that returns a VALUE, and CLJS `nil` compiles to `null`,
+  which the contract calls \"a sentence someone wrote\" and refuses along
+  with every other value."
+  (:require [re-frame.core :as rf]
+            [re-frame.hicasso.server :as server]
+            [re-frame.hicasso.substrate :as substrate]
+            [re-frame.ssr.render-state :as render-state]
+            ;; The views, the SSR coordinates and every `auth.login`
+            ;; registration (the model rides in through this one require).
+            [hicasso.login.core :as views]
+            [login.model :as model]))
+
+;; ---------------------------------------------------------------------------
+;; Build identity
+;; ---------------------------------------------------------------------------
+
+;; The identity of THIS bundle, published to the sidecar and checked against
+;; the `:build-id` the JVM host was deployed with — in both directions (the
+;; sidecar refuses a mismatched request, the adapter refuses a mismatched
+;; answer). A `goog-define` so a release stamps the real thing:
+;;
+;;     shadow-cljs release examples/login-hicasso-server \
+;;       --config-merge '{:closure-defines {hicasso.login.server/build-id "2026-09-02-a1b2c3"}}'
+;;
+;; The default is deliberately a DEV marker rather than a plausible version:
+;; a host that never stamped one and a bundle that never stamped one agree by
+;; accident, and a value that says so is the honest way to make that visible.
+;; (`goog-define` takes a name and a default and no docstring, which is why
+;; this one is written as a comment.)
+(goog-define build-id "login-hicasso-dev")
+
+;; ---------------------------------------------------------------------------
+;; The render-state policy — the one list both halves read
+;; ---------------------------------------------------------------------------
+
+(def render-state-policy
+  "What the render is allowed to see. `host.clj` passes this map to
+  `ssr-handler` as `:render-state`; `entries` below publishes the same keys
+  as the sidecar's per-partition allowlists.
+
+  It is DISTINCT from the host's `:payload` policy, and deliberately so:
+
+    `:auth`                   the form slice at `[:auth :login-form]` — the
+                              draft the inputs are bound to. Also in the
+                              payload, because the client needs it to
+                              re-render the same controlled inputs. The
+                              draft PASSWORD is classified `:sensitive` by
+                              the shared model, so the projection redacts it
+                              on both wires: the render cannot print a
+                              secret it was never handed.
+    `:auth.login/server-notice`  a deployment notice the host resolves per
+                              request. NOT in the payload — the browser
+                              never receives it. See the note beside the
+                              sub in `core.cljs` for the rule that comes
+                              with that choice.
+    `:rf.runtime/machines`    the machine snapshots. `:auth.login/flow` is
+                              what decides which of the page's three faces
+                              renders, so without this partition the server
+                              would render the form for an authenticated
+                              visitor. It lives in runtime-db, which is
+                              exactly why the render state is TWO
+                              partitions and not one."
+  {:app-db     [:auth :auth.login/server-notice]
+   :runtime-db [:rf.runtime/machines]})
+
+(def root-entry
+  "The entry identifier a JVM host names in its renderer opts. One root, one
+  entry; a bigger application publishes one per server-rendered route."
+  "hicasso.login/root")
+
+(defn- allowlist
+  "The EDN text of each key in one slot of `render-state-policy` — the
+  spelling the protocol's key grammar admits (`:foo`, `:foo/bar`), and the
+  same spelling `render-state/serialize` puts on the wire."
+  [slot]
+  (into-array (map pr-str (get render-state-policy slot))))
+
+;; ---------------------------------------------------------------------------
+;; The module
+;; ---------------------------------------------------------------------------
+
+(defn- boot!
+  "Once per isolate, before the first render: seat the substrate. Hicasso
+  ships its own, so this is the same one line the browser boot runs.
+
+  Nothing else. No frame is made here — a frame made at boot would be
+  shared by every request in this isolate, which is the one thing a
+  per-request renderer must not do."
+  []
+  (rf/init! substrate/adapter)
+  js/undefined)
+
+(defn- render!
+  "Render one request's body. `call` is the frozen `{entry, state, runtime,
+  args}` the service hands a module; `emit` is its only output channel.
+
+  `state` and `runtime` arrive as key-text -> EDN-text, per partition,
+  because the service does not decode application data. `deserialize`
+  reads them back under the bundled SAFE EDN reader, and `render-body`
+  installs both partitions into a fresh per-request frame in one write."
+  [^js call emit]
+  (let [partitions (render-state/deserialize
+                     {:rf/app-db     (js->clj (.-state call))
+                      :rf/runtime-db (js->clj (.-runtime call))})]
+    (emit (server/render-body
+            {:hiccup            [views/root-view]
+             :render-state      partitions
+             :identifier-prefix views/identifier-prefix
+             ;; The app's own frame config — `:fx-overrides` points
+             ;; `:rf.http/managed` at the demo stub, exactly as it does in
+             ;; the browser. Its `:initial-events` are NOT run:
+             ;; `render-body` forces the setup vector empty, because the
+             ;; JVM already drained them and the projection is the settled
+             ;; result.
+             :frame-opts        model/frame-config})))
+  ;; `undefined`, not `nil` — see the namespace docstring.
+  js/undefined)
+
+(def module
+  "`module.exports` for the sidecar. Named in `shadow-cljs.edn` as the
+  `:examples/login-hicasso-server` build's `:exports-var`."
+  #js {:protocol 1
+       :buildId  build-id
+       :entries  (js-obj root-entry
+                         #js {:stateAllowlist   (allowlist :app-db)
+                              :runtimeAllowlist (allowlist :runtime-db)})
+       :boot     boot!
+       :render   render!})

--- a/implementation/hicasso/src/re_frame/hicasso/server.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/server.cljs
@@ -11,8 +11,14 @@
 
       (:document (server/render {:hiccup [views/page {}] …}))
 
-  `render` is the door. `payload-script` and `document` are the
-  composition helpers a host needs to rebuild the envelope without
+  `render` is the door for a host that owns the whole page.
+  `render-body` is the door for one that owns everything EXCEPT the
+  body: it takes a render-state projection the JVM already made, seeds
+  a fresh frame from it, and answers the inner markup alone — the
+  bounded Node sidecar's half of the ssr-node crossing (rf2-8arzr,
+  shared contract S2). Neither is built on the other, and neither
+  changes the other's spellings. `payload-script` and `document` are
+  the composition helpers a host needs to rebuild the envelope without
   writing a second renderer; the roster and the argument for it are
   naming-ledger rows 22 and 50
   (`docs/design/hicasso/product/naming-ledger.md`). The determinism
@@ -40,11 +46,13 @@
   (`docs/design/hicasso/studio/ssr-spike-witness.md`). It is not a
   production HTTP host: the response contract is `re-frame.ssr.ring`'s."
   (:require [re-frame.core :as rf]
+            [re-frame.error :as error]
             [re-frame.hicasso.impl.mount :as mount]
             [re-frame.hicasso.impl.roots :as roots]
             [re-frame.ssr.constants :as ssr-constants]
             [re-frame.ssr.html-helpers :as ssr-html]
             [re-frame.ssr.payload-policy :as payload-policy]
+            [re-frame.ssr.render-state :as render-state]
             ["react-dom/server" :as rdom-server]))
 
 ;; ---------------------------------------------------------------------------
@@ -228,5 +236,182 @@
       (finally
         ;; The window first — `destroy-frame!` may itself throw, and the
         ;; window must already be shut when it runs.
+        (roots/close-adoption-window! window)
+        (rf/destroy-frame! frame-id)))))
+
+;; ---------------------------------------------------------------------------
+;; The body-only entry
+;; ---------------------------------------------------------------------------
+
+(def ^:private recovered-error-listener-id
+  "The id `render-body` registers its error-stream listener under.
+
+  ONE id, reused across renders, and that is safe rather than sloppy: a
+  render is one synchronous `renderToString` call, and the sidecar's
+  isolate admits one render at a time (`implementation/ssr-node`'s worker
+  refuses a second with `:rf.ssr-node/service-saturated`), so two windows
+  cannot overlap. Re-registering the same id REPLACES, so even a caller
+  that broke that rule would lose a listener rather than accumulate one."
+  ::recovered-render-error)
+
+(defn- refuse-recovered-render-error!
+  "Fail the render because the runtime recorded an error it RECOVERED from
+  during the pass.
+
+  This is the one place `render-body` is stricter than `render`, and the
+  asymmetry is the whole reason the entry exists as its own function. A
+  sub that throws mid-render does not take the render down: the
+  framework's built-in recovery yields `nil`, the view renders a hole, and
+  the pass returns a string. On a JVM host that is survivable because the
+  SAME process holds the record, so `re-frame.ssr`'s projection turns it
+  into a 5xx before any bytes reach a client. Across the ssr-node crossing
+  the record is made in the NODE process and the projector is on the JVM,
+  so nothing on the JVM can see it: the sidecar would answer 200 with a
+  page whose content is quietly wrong, and the host would ship it.
+
+  A wrong page served as a success is worse than a loud failure, so the
+  renderer throws instead. The sidecar turns the throw into a refusal
+  (`:rf.ssr-node/render-threw`), the JVM adapter turns the refusal into
+  `:rf.error/ssr-node-refused`, and the request lands on the error view —
+  the same destination the JVM-local path would have reached, by a longer
+  road.
+
+  The id is `:rf.error/ssr-render-failed` — the SSR family's render-time
+  failure, reused rather than multiplied. Nothing about this failure is
+  Hicasso's: it is the framework's render-failure category, raised from
+  the one host that has to raise it by hand."
+  [frame-id {:keys [error] :as record} recorded]
+  (error/throw-error!
+    :rf.error/ssr-render-failed
+    're-frame.hicasso.server/render-body
+    (str "the render completed but the runtime recorded " recorded
+         " error" (when (not= 1 recorded) "s") " it recovered from during the "
+         "pass — the first was " (pr-str error) " — so the markup is not what "
+         "the application meant to render. This renderer does not share a "
+         "process with the error projector, so a 200 here would ship a wrong "
+         "page as a success; the render is failed instead. Fix the surface the "
+         "record names, not the renderer.")
+    {:recovery :fail-the-render
+     :extra    {:frame    frame-id
+                :recorded recorded
+                :record   record}}))
+
+(defn- watch-recovered-errors!
+  "Register a listener on the always-on ERROR-EMIT stream for the extent of
+  one render, and return the atom it fills.
+
+  The always-on stream, not `re-frame.ssr`'s per-frame buffer, and the
+  choice is measured rather than stylistic. That buffer is keyed by frame,
+  and it is filled only for records that CARRY a frame — while Hicasso's
+  render reads its subscriptions through the pure `compute-sub` path
+  (`impl.collector`'s cold read), whose `:rf.error/sub-exception` record is
+  stamped `:frame nil` by construction and documented as such in
+  `re-frame.subs` (\"a `compute-sub`-driven SSR harness that wants the
+  per-frame projection must use the reactive `subscribe` path\"). A
+  per-frame check therefore reads CLEAN on exactly the failure this entry
+  exists to catch — measured, not reasoned: the first cut of this function
+  used the per-frame buffer and its refusal row rendered markup.
+
+  The stream is what survives production hardening (`goog.DEBUG=false`),
+  which is the posture Spec 011 mandates SSR run in, so this reads the same
+  in a release bundle as it does under test. Scoping it to the render
+  window is what makes an unattributed record safe to act on: a render is
+  one synchronous call in an isolate that admits one at a time, so anything
+  arriving inside the window came from the render."
+  []
+  (let [!recorded (atom {:n 0 :first-record nil})]
+    (rf/register-listener! :errors recovered-error-listener-id
+                           (fn [record]
+                             (swap! !recorded
+                                    (fn [seen]
+                                      {:n            (inc (:n seen))
+                                       :first-record (or (:first-record seen) record)}))))
+    !recorded))
+
+(defn render-body
+  "Render one request to the app root's INNER MARKUP and nothing else —
+  no payload, no document, no head, no status. The body-only half of the
+  ssr-node crossing (rf2-8arzr shared contract S2): the JVM owns the
+  request frame, the boot-event drain, `__rf_payload`, the shell and the
+  response; this renders the body from a projection of what the JVM had
+  settled, and returns a string.
+
+  `opts`:
+
+      :hiccup            REQUIRED. The root hiccup form.
+      :render-state      REQUIRED. The two-partition envelope
+                         `{:rf/app-db {…} :rf/runtime-db {…}}` that
+                         `re-frame.ssr.render-state/project` produced on the
+                         JVM and `deserialize` read back here. Installed in
+                         ONE atomic frame-state write by
+                         `render-state/restore!`.
+      :identifier-prefix React's `identifierPrefix`. The hydrating root must
+                         be handed the same string, or every `useId` in the
+                         tree diverges.
+      :frame-opts        merged UNDER the id, the platform and the empty
+                         setup vector, so a request needing `:images`,
+                         `:url-strategy` or `:fx-overrides` declares them the
+                         way any other frame does.
+
+  Three things this deliberately does NOT do, each because the JVM already
+  did it:
+
+    - **no boot-event replay.** `:initial-events` is forced empty even when
+      `frame-opts` carries one, exactly as `render` forces its own. The JVM
+      drained the boot events and the projection IS the settled result;
+      running them again here would be a second drain against a state that
+      has already moved past them.
+    - **no `:snapshot` re-seeding.** `render`'s `:rf/set-db` door seeds the
+      app-db partition alone. The render state is BOTH partitions — the
+      route slice and the machine snapshots live in runtime-db — so it
+      installs through `restore!`, which is the surface that can write
+      both at once.
+    - **no payload.** `__rf_payload` is built on the JVM from the JVM's own
+      app-db under the SEPARATE `:payload` policy. A renderer that built one
+      would be a renderer deciding what the browser may see.
+
+  The frame is `:platform :server`. That is not decoration: it is what
+  gates client-only fx out of a render that has no client.
+
+  **A render that recorded a recovered error is FAILED, not returned** —
+  see `watch-recovered-errors!` for what is watched and
+  `refuse-recovered-render-error!` for why a hole in the page is worse
+  than a refusal.
+
+  One fresh frame per request, and the adoption window open around the
+  render; the window is closed and the frame destroyed in a `finally`, in
+  that order, so a render that threw leaks no more than one that returned."
+  [{:keys [hiccup render-state identifier-prefix frame-opts]}]
+  (let [frame-id  (fresh-frame-id)
+        window    (roots/open-adoption-window!)
+        ;; Armed BEFORE the frame is made, so a fault in construction or in
+        ;; the restore is inside the window too — those are part of the
+        ;; pass, and a page rendered over a half-installed state is the same
+        ;; silent wrong page a recovered sub gives.
+        !recorded (watch-recovered-errors!)]
+    (try
+      (rf/make-frame (assoc frame-opts
+                            :id             frame-id
+                            :platform       :server
+                            ;; This module's, and not overridable — see the
+                            ;; docstring's first bullet.
+                            :initial-events []))
+      (render-state/restore! frame-id render-state)
+      (let [element (mount/tree {:frame frame-id :adoption window} hiccup)
+            ropts   (render-options identifier-prefix)
+            html    (if ropts
+                      (rdom-server/renderToString element ropts)
+                      (rdom-server/renderToString element))
+            {:keys [n first-record]} @!recorded]
+        (when (pos? n)
+          (refuse-recovered-render-error! frame-id first-record n))
+        html)
+      (finally
+        ;; Unregistered FIRST, so the teardown below is outside the window:
+        ;; a destroy-time fault belongs to the process's logs, not to the
+        ;; verdict on markup that has already been decided.
+        (rf/unregister-listener! :errors recovered-error-listener-id)
+        ;; The window before the frame — `destroy-frame!` may itself throw,
+        ;; and the window must already be shut when it runs.
         (roots/close-adoption-window! window)
         (rf/destroy-frame! frame-id)))))

--- a/implementation/hicasso/test/re_frame/hicasso/login_server_crossing_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/login_server_crossing_ssr_dom_cljs_test.cljs
@@ -1,0 +1,485 @@
+(ns re-frame.hicasso.login-server-crossing-ssr-dom-cljs-test
+  "THE PRODUCT WITNESS for the ssr-node crossing (rf2-8arzr.5, slice E) — the
+  real Hicasso login example, rendered on Node from a projection of a real
+  settled JVM-shaped frame, through the real sidecar module contract.
+
+  Nothing here is a fixture standing in for the product. The views are
+  `examples/substrates/hicasso/login/core.cljs`'s, the registrations are the
+  substrate-free `login.model`'s, the entry table and allowlists are
+  `hicasso.login.server`'s (the module `shadow-cljs compile
+  :examples/login-hicasso-server` emits), and the request validator is
+  `implementation/ssr-node/src/protocol.cjs` itself, required as JavaScript
+  rather than restated — a copy of those rules would be a second authority
+  with nothing holding it in step with the first.
+
+  ## What stands in for what
+
+  ONE thing is simulated: the transport. The JVM half runs here in CLJS
+  because `re-frame.ssr.render-state` is `.cljc` and `project` / `serialize`
+  are the same code on both hosts, and the sidecar's HTTP/worker layer is
+  already witnessed by `implementation/ssr-node`'s own suites and by
+  `re-frame.ssr.ring.node-crossing-test` (slice D). What this file adds is
+  the half neither of those can reach: an APPLICATION on the other side of
+  the wire.
+
+  So `crossing!` performs, in order, exactly what a request performs:
+  project the settled frame under the host's `:render-state` policy,
+  serialize both partitions to per-key EDN text, validate the request
+  against the module's published tables, and hand the module the frozen
+  call shape `worker.cjs` builds. Only the socket is missing.
+
+  ## The rows, and the pair each of them is half of
+
+  §1  the module satisfies `protocol/validateModule` — the sidecar's own
+      door, so a malformed entry table fails here rather than at deploy.
+  §2  the happy path, and the RUNTIME partition doing work: the page's face
+      is chosen by the `:auth.login/flow` machine, whose snapshot lives in
+      runtime-db. The pair is `:idle` (the form) against `:authed`
+      (\"Welcome!\") — one render-state, one wire, two pages.
+  §3  render state is NOT the payload. A server-only key renders, and is
+      absent from the `__rf_payload` the JVM builds from the same frame
+      under the SEPARATE `:payload` policy. Its control is the classified
+      draft password, which is absent from BOTH — the render cannot print a
+      secret it was never handed.
+  §4  build-id skew is refused, with the distinct code. Control: the same
+      request with the module's own build id renders.
+  §5  the entry's allowlist is the entry's. A host asking for a key the
+      table does not name is refused; control, the keys it does name pass.
+  §6  (DOM) hydration. The client boots the way `core.cljs` boots — the
+      payload through `ssr/hydrate!`, the DOM through `h/hydrate!` with the
+      example's own `identifier-prefix` — and adopts the server's bytes
+      with NO `:rf.ssr/hydration-mismatch`. Its control is §7.
+  §7  (DOM) **the price of a server-only value**, measured rather than
+      asserted. A render-state key the payload does not carry CHANGES THE
+      MARKUP, and the hydrating client renders from the payload, so React
+      recovers and the framework emits the mismatch §6 proves absent. This
+      row is why the shipped `host.clj` puts no notice in app-db, and why
+      the rule is written beside the sub in `core.cljs`.
+
+  ## Two lanes, and a stated skip in each
+
+  §1, §4 and §5 go through `implementation/ssr-node/src/protocol.cjs` — the
+  service's OWN module and request validator, so the refusal codes are read
+  off the source of truth rather than restated. It is loaded with `require`
+  at RUN time rather than compiled in, because `implementation/ssr-node` is
+  not on the CLJS classpath and shadow refuses a relative require that
+  leaves it. So those rows run in the NODE lane and state their skip in the
+  browser one; §6 and §7 need a real React DOM and state theirs in Node.
+  Neither degrades to a false green, and §2 and §3 — the two rows that carry
+  the product claim — run in both."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.impl.mount :as mount]
+            [re-frame.hicasso.roots-frames-support :as sup]
+            [re-frame.hicasso.substrate :as substrate]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.payload-policy :as payload-policy]
+            [re-frame.ssr.render-state :as render-state]
+            [re-frame.test-support :as test-support]
+            ;; The example, whole: views + SSR coordinates, the server module's
+            ;; entry table, and the substrate-free model every `auth.login`
+            ;; registration lives in.
+            [hicasso.login.core :as views]
+            [hicasso.login.server :as app-server]
+            [login.model :as model]))
+
+;; Registered ABOVE `use-fixtures`, and that is load-bearing rather than
+;; stylistic: the reset fixture captures its registrar baseline when the
+;; `use-fixtures` form is EVALUATED and restores to it before every row, so a
+;; registration written below it is erased before the first one runs. Measured
+;; here rather than taken on trust — with this `reg-event` below the fixture
+;; the seeding dispatch hit no handler, recovered silently, and §3 reported a
+;; page with no notice in it.
+(rf/reg-event ::seed-server-only
+  {:doc "Stand in for whatever a host does to resolve a per-request
+         server-side value — a session lookup, a feature-flag read — and put
+         it at a top-level app-db key."}
+  (fn [{:keys [db]} [_ k v]] {:db (assoc db k v)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    ;; The example's OWN adapter — `hicasso.login.core/run` installs this one.
+    {:adapter       substrate/adapter
+     ;; The witness makes its own top-level frames, so the fixture's carried
+     ;; `:rf/default` stamp would be a scope no request is rendering; and
+     ;; `:initial-events` must drain synchronously rather than be treated as
+     ;; a mid-cascade child-frame creation.
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The JVM half
+;; ---------------------------------------------------------------------------
+
+(def ^:private payload-policy-opts
+  "What the HOST lets the browser see — `[:auth]`, the form slice, and
+  nothing else. Narrower than `app-server/render-state-policy` on purpose:
+  that is the whole claim of §3."
+  {:payload [:auth]})
+
+(defn- server-frame!
+  "A settled JVM request frame: `:platform :server`, the app's own
+  `frame-config` (so `:auth.login/initialise-form` drains and installs the
+  draft-password `:sensitive` classification), then `events` in order, then
+  whatever `extra-db` the host resolved for this request.
+
+  Returns the frame id. The caller destroys it."
+  ([events] (server-frame! events nil))
+  ([events extra-db]
+   (let [fid (keyword "rf.login-crossing" (str (gensym "request-")))]
+     (rf/make-frame (merge {:id fid :platform :server} model/frame-config))
+     (rf/with-frame fid
+       (doseq [e events] (rf/dispatch-sync e))
+       (when (seq extra-db)
+         (doseq [[k v] extra-db]
+           (rf/dispatch-sync [::seed-server-only k v]))))
+     fid)))
+
+(defn- payload-of
+  "The `__rf_payload` map the JVM builds from `frame-id` — its own app-db
+  under `payload-policy-opts`, plus the durable runtime-db slice, exactly as
+  `ssr-ring` assembles one. Anonymous server frame, so no `:rf/frame-id`."
+  [frame-id]
+  (let [runtime (payload-policy/project-runtime-db
+                  (frame/frame-runtime-db-value frame-id) frame-id)
+        opts    (cond-> payload-policy-opts
+                  (some? runtime) (assoc :runtime-db runtime))]
+    (payload-policy/build-payload
+      nil
+      (payload-policy/project-app-db-egress
+        (payload-policy/apply-policy (rf/app-db-value frame-id) opts) frame-id)
+      nil
+      opts)))
+
+;; ---------------------------------------------------------------------------
+;; The crossing
+;; ---------------------------------------------------------------------------
+
+(def ^:private protocol
+  "`implementation/ssr-node/src/protocol.cjs`, or nil where there is no
+  `require` (the browser lane). Resolved from the test bundle's own
+  directory — `implementation/out` for every `:node-test` build here — so it
+  does not depend on the working directory. A moved package throws from
+  `require` rather than reading as an absent one: the `delay` is forced by
+  the rows that need it, and only the ABSENCE of `require` is tolerated."
+  (delay
+    ;; BOTH, and `__dirname` is the one that matters: shadow's browser
+    ;; output carries a `require` shim, so a `require`-only guard reads TRUE
+    ;; in a lane with no CommonJS behind it and the row then dereferences
+    ;; null. Measured — that is exactly how the browser lane first went red.
+    (when (and (exists? js/require) (exists? js/__dirname))
+      (js/require (str js/__dirname "/../ssr-node/src/protocol.cjs")))))
+
+(defn- node-lane? [] (some? @protocol))
+
+(def ^:private module
+  "`module.exports` as the sidecar receives it."
+  app-server/module)
+
+(def ^:private tables
+  #js {:buildId (.-buildId module)
+       :entries (.-entries module)})
+
+(defn- request-js
+  "The JSON request body the JVM adapter POSTs, as the object the service
+  parses it into."
+  [wire {:keys [build-id entry state]}]
+  #js {:protocol 1
+       :entry    (or entry app-server/root-entry)
+       :state    (clj->js (or state (:rf/app-db wire)))
+       :runtime  (clj->js (:rf/runtime-db wire))
+       :buildId  (or build-id (.-buildId module))})
+
+(defn- wire-of
+  "The JVM half: project the settled frame under the host's `:render-state`
+  policy and serialize both partitions to per-key EDN text."
+  [frame-id]
+  (render-state/serialize
+    (render-state/project frame-id {:render-state app-server/render-state-policy})))
+
+(defn- hand-to-module!
+  "Hand the module the frozen call shape `worker.cjs` builds, and answer
+  `{:html … :returned …}`. `:returned` is what `render` gave back, which the
+  contract requires to be `undefined`."
+  [^js request]
+  (let [call     (js/Object.freeze
+                   #js {:entry   (.-entry request)
+                        :state   (js/Object.freeze (.-state request))
+                        :runtime (js/Object.freeze (.-runtime request))
+                        :args    (.-args request)})
+        !html    (atom nil)
+        returned ((.-render module) call (fn [html] (reset! !html html)))]
+    {:html @!html :returned returned}))
+
+(defn- crossing!
+  "One request, end to end: project -> serialize -> VALIDATE -> render.
+  Throws the sidecar's own `Refusal` when the request is refused — the rows
+  that are about a refusal catch it and read `.code`. Needs the validator,
+  so it is a node-lane row."
+  ([frame-id] (crossing! frame-id nil))
+  ([frame-id opts]
+   (hand-to-module!
+     (.validateRequest @protocol (request-js (wire-of frame-id) opts) tables #js {}))))
+
+(defn- rendered!
+  "The same crossing WITHOUT the request validator, for the DOM rows.
+
+  §6 and §7 are about ADOPTION rather than about the request door, and the
+  browser lane cannot load a CommonJS module — so they skip the one step
+  §1-§5 exist to hold, and take the module's own answer to a request that
+  has already been proved valid there. The `state` / `runtime` objects are
+  the wire's, unchanged; only the door is missing."
+  [frame-id]
+  (:html (hand-to-module! (request-js (wire-of frame-id) nil))))
+
+(defn- refusal-code
+  "The `code` of the sidecar refusal `f` raises, or `::no-refusal` with what
+  it answered instead. Written so a row that expects a refusal can never
+  pass because something else went wrong."
+  [f]
+  (try [::no-refusal (f)]
+       (catch :default e (.-code e))))
+
+(defn- with-frame! [events extra-db f]
+  (let [fid (server-frame! events extra-db)]
+    (try (f fid) (finally (rf/destroy-frame! fid)))))
+
+(def ^:private idle-events
+  "A visitor who has typed an email and a password and submitted nothing."
+  [[:auth.login/edit-field :email "ada@example.com"]
+   [:auth.login/edit-password {:value "correct-horse"}]])
+
+(def ^:private authed-events
+  "The same visitor, signed in. Both machine events are credential-free —
+  `submit-form` owns the credential and the machine never sees one."
+  (into idle-events [[:auth.login/flow [:auth.login/submit]]
+                     [:auth.login/flow [:auth.login/success]]]))
+
+(def ^:private notice "Scheduled maintenance 02:00-03:00 UTC")
+
+(def ^:private server-only-db {:auth.login/server-notice notice})
+
+
+;; ---------------------------------------------------------------------------
+;; The lane guard
+;; ---------------------------------------------------------------------------
+
+(defn- crossing-row!
+  "Run a crossing row, or state the skip in the lane that cannot load the
+  service's validator. Every §1-§5 row is written through this, so a lane
+  that cannot perform the crossing says so once, in one voice, and never
+  reports a green about a request it never validated."
+  [f]
+  (if (node-lane?)
+    (f)
+    (sup/skip! "a crossing goes through the service's own validator, a CommonJS module off the CLJS classpath")))
+
+;; ---------------------------------------------------------------------------
+;; §1 - the module is one the sidecar will load
+;; ---------------------------------------------------------------------------
+
+(deftest the-server-bundle-satisfies-the-render-module-contract
+  (testing "the entry table, which every lane can read"
+    (let [entry (aget (.-entries module) app-server/root-entry)]
+      (is (some? entry) "the module publishes the entry a host names")
+      (is (= [":auth" ":auth.login/server-notice"] (vec (.-stateAllowlist entry)))
+          "both allowlists, in the EDN spelling the protocol's key grammar admits")
+      (is (= [":rf.runtime/machines"] (vec (.-runtimeAllowlist entry))))))
+  (crossing-row!
+    (fn []
+      (is (some? (.validateModule @protocol module "hicasso.login.server"))
+          "the sidecar's own door - a malformed entry table fails here, not at deploy"))))
+
+;; ---------------------------------------------------------------------------
+;; §2 - the happy path, and the runtime partition doing the work
+;; ---------------------------------------------------------------------------
+
+(deftest the-login-page-renders-from-the-projection
+  (crossing-row!
+    (fn []
+      (with-frame! idle-events nil
+        (fn [fid]
+          (let [{:keys [html returned]} (crossing! fid)]
+            (is (str/includes? html "Sign in") "the page rendered")
+            (is (str/includes? html "ada@example.com")
+                "the app-db partition reached the controlled input's :value")
+            (is (undefined? returned)
+                "`emit` is the module's only output channel - a returned VALUE is refused")))))))
+
+(deftest the-machine-snapshot-decides-which-face-renders
+  (crossing-row!
+    (fn []
+      (testing "the two faces come from ONE render-state policy and TWO runtime-db values"
+        (let [idle   (with-frame! idle-events   nil #(:html (crossing! %)))
+              authed (with-frame! authed-events nil #(:html (crossing! %)))]
+          (is (str/includes? idle "login-form")
+              ":idle - the machine carries no tag, so the form renders")
+          (is (not (str/includes? idle "Welcome!")))
+          (is (str/includes? authed "Welcome!")
+              ":authed - the `:auth/authenticated` tag flips the banner")
+          (is (not (str/includes? authed "login-form"))
+              "and the form is gone, which is the runtime partition doing real work")
+          (is (not= idle authed)))))))
+
+;; ---------------------------------------------------------------------------
+;; §3 - render state is NOT the payload
+;; ---------------------------------------------------------------------------
+
+(deftest a-server-only-value-renders-and-is-absent-from-the-payload
+  (crossing-row!
+    (fn []
+      (with-frame! idle-events server-only-db
+        (fn [fid]
+          (let [html    (:html (crossing! fid))
+                payload (payload-of fid)
+                edn     (pr-str payload)]
+            (is (str/includes? html notice)
+                "the render read a key the host declared render-visible")
+            (is (not (str/includes? edn notice))
+                "and the browser is never handed it - the two policies are distinct")
+            (is (not (contains? (:rf/app-db payload) :auth.login/server-notice))
+                "not by redaction either: the key is absent from the payload entirely")
+            (testing "the control - a key the payload DOES carry is in both"
+              (is (str/includes? edn "ada@example.com"))
+              (is (str/includes? html "ada@example.com")))))))))
+
+(deftest a-classified-secret-reaches-neither-wire
+  (crossing-row!
+    (fn []
+      (with-frame! idle-events nil
+        (fn [fid]
+          (let [html (:html (crossing! fid))
+                edn  (pr-str (payload-of fid))]
+            (is (not (str/includes? html "correct-horse"))
+                "the draft password is classified :sensitive, so the projection redacts it BEFORE the wire - the render cannot print what it was never handed")
+            (is (not (str/includes? edn "correct-horse")))
+            (testing "the control - the value really was in the frame's app-db"
+              (is (= "correct-horse"
+                     (get-in (rf/app-db-value fid)
+                             [:auth :login-form :draft :password]))))))))))
+
+;; ---------------------------------------------------------------------------
+;; §4 - build-id skew
+;; ---------------------------------------------------------------------------
+
+(deftest a-build-id-skew-is-refused-with-its-own-code
+  (crossing-row!
+    (fn []
+      (with-frame! idle-events nil
+        (fn [fid]
+          (is (= ":rf.ssr-node/build-identity-mismatch"
+                 (refusal-code #(crossing! fid {:build-id "some-other-build"})))
+              "a host deployed against a different bundle is refused, not served")
+          (testing "the control - this bundle's own id renders"
+            (is (str/includes? (:html (crossing! fid {:build-id app-server/build-id}))
+                               "Sign in"))))))))
+
+;; ---------------------------------------------------------------------------
+;; §5 - the allowlist is the entry's
+;; ---------------------------------------------------------------------------
+
+(deftest a-key-the-entry-does-not-name-is-refused
+  (crossing-row!
+    (fn []
+      (with-frame! idle-events nil
+        (fn [fid]
+          (is (= ":rf.ssr-node/state-key-not-allowed"
+                 (refusal-code #(crossing! fid {:state {":secrets" "{:token \"t\"}"}})))
+              "the allowlist belongs to the entry, so a caller cannot widen its own allowance")
+          (is (= ":rf.ssr-node/unknown-entry"
+                 (refusal-code #(crossing! fid {:entry "hicasso.login/nope"}))))
+          (testing "the control - the keys the table names pass"
+            (is (str/includes? (:html (crossing! fid)) "Sign in"))))))))
+
+;; ---------------------------------------------------------------------------
+;; §6 / §7 — hydration, and what a server-only value costs it
+;; ---------------------------------------------------------------------------
+
+(defn- hydrate-row!
+  "Boot the client the way `hicasso.login.core/run` boots it on a
+  server-rendered page — the payload through `ssr/hydrate!`, then the DOM
+  through `h/hydrate!` with the example's own `identifier-prefix` — over
+  `html`, and answer a promise of `{:seen :adopted-html}`.
+
+  The client frame is a FRESH one seeded exactly as the browser seeds it:
+  `frame-config`, so the classification effects re-run, and then the payload
+  replaces its state.
+
+  `:adopted-html` is read BEFORE `unmount!`, which is not tidiness: React
+  empties the container on unmount, so a row reading it afterwards asserts
+  against an empty container and fails whatever the adoption did. Measured — that is how
+  §6 first went red on a run whose adoption was clean.
+
+  `swallow-uncaught?` is the caller's, because it is a real decision. React
+  routes a recovered hydration failure to `reportError`, and the browser
+  runner fails a run on ANY uncaught `pageerror`; a row that MANUFACTURES
+  the divergence and asserts on it is the one call site where swallowing is
+  not the fail-open that rule exists to prevent. §6 must not pass it — a
+  clean adoption raises nothing to swallow, and arming the swallow there
+  would hide a real regression."
+  [html payload {:keys [swallow-uncaught?]}]
+  (let [container (sup/server-dom! html)
+        cfid      (keyword "rf.login-crossing" (str (gensym "client-")))
+        watch     (sup/watch-mismatches!)
+        console   (sup/open-console-capture! {:swallow-uncaught? swallow-uncaught?})]
+    (rf/make-frame (merge {:id cfid} model/frame-config))
+    (ssr/hydrate! {:frame cfid :payload payload})
+    (let [handle (h/hydrate! container
+                             {:frame             cfid
+                              :identifier-prefix views/identifier-prefix}
+                             [views/root-view])]
+      (.then (sup/adopted! handle)
+             (fn [_]
+               (let [seen  ((:stop! watch))
+                     shown (.-innerHTML container)]
+                 ((:close! console))
+                 (h/unmount! handle)
+                 (rf/destroy-frame! cfid)
+                 {:seen seen :adopted-html shown}))))))
+
+(deftest the-client-adopts-the-server-bytes-with-no-recoverable-error
+  (if-not (mount/browser?)
+    (sup/skip! "adoption is React's own DOM business")
+    (async done
+      (sup/leave-act-environment!)
+      (let [fid     (server-frame! authed-events)
+            html    (rendered! fid)
+            payload (payload-of fid)]
+        (rf/destroy-frame! fid)
+        (sup/settle-row!
+          (.then (hydrate-row! html payload {:swallow-uncaught? false})
+                 (fn [{:keys [seen adopted-html]}]
+                   (is (= [] seen)
+                       "the payload the JVM wrote is enough for the client to render the same page")
+                   (is (str/includes? adopted-html "Welcome!")
+                       "and the page it adopted is still the authed one")))
+          {:row  :adopts-cleanly
+           :done done})))))
+
+(deftest a-render-state-key-the-payload-omits-costs-one-recovered-adoption
+  ;; §6's control, and the measurement the example's README turns into a rule.
+  (if-not (mount/browser?)
+    (sup/skip! "a recoverable error is React's own DOM business")
+    (async done
+      (sup/leave-act-environment!)
+      (let [fid     (server-frame! authed-events server-only-db)
+            html    (rendered! fid)
+            payload (payload-of fid)]
+        (rf/destroy-frame! fid)
+        (is (str/includes? html notice) "the server rendered the notice")
+        (is (not (str/includes? (pr-str payload) notice))
+            "and the client will not be handed it")
+        (sup/settle-row!
+          (.then (hydrate-row! html payload {:swallow-uncaught? true})
+                 (fn [{:keys [seen]}]
+                   (is (seq seen)
+                       "so the two halves disagree about one node and React recovers — which is WHY a render-state key the payload omits must not change the markup")
+                   (is (every? #(= :rf.ssr/hydration-mismatch (:operation %)) seen)
+                       "and the framework says so on its own channel, not only React's")))
+          {:row  :server-only-value-costs-a-recovery
+           :done done})))))

--- a/implementation/hicasso/test/re_frame/hicasso/server_render_body_ssr_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/server_render_body_ssr_cljs_test.cljs
@@ -1,0 +1,226 @@
+(ns re-frame.hicasso.server-render-body-ssr-cljs-test
+  "`re-frame.hicasso.server/render-body` — the body-only entry, measured on
+  its own (rf2-8arzr.5, slice E of the ssr-node crossing programme; the
+  parent's shared contract S2/S3).
+
+  The product witness for the whole crossing is
+  `re-frame.hicasso.login-server-crossing-ssr-cljs-test`, which drives the
+  real login example through the real sidecar module contract. This file is
+  the narrow one: every row here is a claim about the ENTRY, written so a
+  failure names the entry rather than the example.
+
+  ## The four claims, and why the fourth is the one that matters
+
+  1. It answers INNER MARKUP. No document, no payload, no `<script>` — the
+     JVM owns those, and a renderer that emitted one would be a renderer
+     deciding what the browser may see.
+  2. It restores BOTH partitions in one write, with no boot-event replay.
+     `render`'s `:snapshot` door seeds app-db alone; the render state is
+     app-db AND runtime-db, because the route slice and the machine
+     snapshots live in the second one.
+  3. It hands React the caller's `identifierPrefix`, so a `useId` agrees
+     with the hydrating client root that was handed the same string.
+  4. **It FAILS the render when the runtime recorded an error it recovered
+     from.** A reactive sub that throws mid-render does not take the render
+     down — the framework's built-in recovery yields `nil` and the pass
+     returns a string with a hole in it. On a JVM host that is survivable
+     because the same process holds the buffered trace and projects it into
+     a 5xx before any bytes ship. Across this crossing the buffer is in the
+     NODE process and the projector is on the JVM, so the JVM cannot see
+     it: a 200 would ship a wrong page as a success. §4 is therefore
+     written as a PAIR — the refusal, and the control that renders the same
+     tree with a sub that does not throw and gets its markup — because a
+     refusal row on its own cannot tell 'the check fired' from 'the render
+     was broken all along'.
+
+  Runtime: `-cljs-test`, so the focused `:node-test-hicasso` build and the
+  always-on `:node-test`. Every row renders to a string; none needs a DOM."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.hicasso :as h]
+            [re-frame.hicasso.impl.collector :as collector]
+            [re-frame.hicasso.server :as server]
+            [re-frame.subs :as subs]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]))
+
+;; Registered ABOVE `use-fixtures`, for the sibling suites' reason: the reset
+;; fixture captures its source-store baseline when the `use-fixtures` form is
+;; EVALUATED, so a registration written below it is erased before the first
+;; row runs.
+
+(rf/reg-sub ::greeting (fn [db _] (:greeting db)))
+
+(subs/reg-runtime-sub ::flavour
+  (fn [runtime-db _] (get-in runtime-db [::kitchen :flavour])))
+
+(def ^:private !boot-events-run
+  "Every event id the frame's setup vector managed to run. MUST stay empty:
+  the JVM drained the boot events and the projection is the settled result."
+  (atom []))
+
+(rf/reg-event ::boot-event
+  (fn [{:keys [db]} _]
+    (swap! !boot-events-run conj ::boot-event)
+    {:db (assoc db :greeting "FROM A REPLAYED BOOT EVENT")}))
+
+;; The throwing sub of §4. An ORDINARY registered sub whose body throws —
+;; not a hand-planted trace event — so the row measures the path a real
+;; application takes rather than the shape of a fixture.
+(rf/reg-sub ::detonates
+  (fn [_ _] (throw (js/Error. "the sub that recovers to nil"))))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     ;; `:ambient-frame nil` — `render-body` makes its own top-level frame,
+     ;; and the fixture's carried `:rf/default` stamp would be a scope the
+     ;; request is not rendering. The sibling `frame_doors_ssr` suite opts
+     ;; out for the same reason.
+     :ambient-frame nil
+     :init-fn       (fn []
+                      (reset! !boot-events-run [])
+                      (collector/reset-runtime!))}))
+
+;; ---------------------------------------------------------------------------
+;; The probes
+;; ---------------------------------------------------------------------------
+
+(h/defview both-partitions
+  "Reads one app-db sub and one runtime-db sub, so a row can tell WHICH
+  partition failed to restore rather than only that something did."
+  [_]
+  [:div.page
+   [:p.greeting (str (h/sub [::greeting]))]
+   [:p.flavour (str (h/sub [::flavour]))]])
+
+(h/defview detonating
+  "Reads the sub that throws. The framework recovers it to `nil`, so this
+  body returns normally and the render produces markup — which is exactly
+  the hazard §4 is about."
+  [_]
+  [:div.page [:p.greeting (str (h/sub [::detonates]))]])
+
+(defn- id-probe
+  "One `useId`, rendered as text. A React hook, so it is written where React
+  hooks are written — a raw React component behind a `{:server :render}`
+  host, the only policy that puts a foreign body into a server response."
+  [^js _props]
+  (react/createElement "b" #js {:className "probe"} (react/useId)))
+
+(h/defhost id-host id-probe {:server :render})
+
+(h/defview id-page
+  [_]
+  [:div.page [id-host {}]])
+
+;; ---------------------------------------------------------------------------
+;; The request
+;; ---------------------------------------------------------------------------
+
+(defn- state
+  "A render-state envelope in the shape `render-state/deserialize` produces:
+  both partitions, both maps."
+  ([] (state "hello"))
+  ([greeting]
+   {:rf/app-db     {:greeting greeting}
+    :rf/runtime-db {::kitchen {:flavour "vanilla"}}}))
+
+(defn- render-body! [hiccup opts]
+  (server/render-body (merge {:hiccup hiccup :render-state (state)} opts)))
+
+(defn- live-frame-ids []
+  (set (keys @frame/frames)))
+
+;; ---------------------------------------------------------------------------
+;; §1 — inner markup, and nothing else
+;; ---------------------------------------------------------------------------
+
+(deftest answers-the-inner-markup-alone
+  (let [html (render-body! [both-partitions {}] {})]
+    (is (string? html) "the entry answers a string, not a map")
+    (is (str/includes? html "hello")
+        "the app-db partition reached the view")
+    (testing "no envelope of any kind"
+      (is (not (str/includes? html "<!DOCTYPE")) "no document")
+      (is (not (str/includes? html "<script")) "no payload script")
+      (is (not (str/includes? html "__rf_payload")) "no payload at all")
+      (is (not (str/includes? html "<body")) "no shell"))))
+
+;; ---------------------------------------------------------------------------
+;; §2 — both partitions, restored, with nothing replayed
+;; ---------------------------------------------------------------------------
+
+(deftest restores-both-partitions
+  (let [html (render-body! [both-partitions {}] {})]
+    (is (str/includes? html "hello")   "the app-db partition")
+    (is (str/includes? html "vanilla") "the runtime-db partition")))
+
+(deftest replays-no-boot-events-even-when-frame-opts-declares-them
+  (let [html (render-body! [both-partitions {}]
+                           {:frame-opts {:initial-events [[::boot-event]]}})]
+    (is (= [] @!boot-events-run)
+        "the JVM drained the boot events; a second drain here would run them against a state that has already moved past them")
+    (is (str/includes? html "hello")
+        "and the projection — not the replay — is what the view read")
+    (is (not (str/includes? html "FROM A REPLAYED BOOT EVENT")))))
+
+(deftest a-non-envelope-render-state-is-refused-before-anything-renders
+  (let [thrown (try (render-body! [both-partitions {}] {:render-state {:nope 1}})
+                    (catch :default e (ex-data e)))]
+    (is (= :rf.error/ssr-render-state-invalid (:rf.error/id thrown))
+        "restore!'s own fail-closed envelope guard, reached through this entry")
+    (is (= :envelope (:invalid thrown)))))
+
+;; ---------------------------------------------------------------------------
+;; §3 — the identifier prefix
+;; ---------------------------------------------------------------------------
+
+(deftest the-identifier-prefix-reaches-react
+  (let [a (render-body! [id-page {}] {:identifier-prefix "pfx-a-"})
+        b (render-body! [id-page {}] {:identifier-prefix "pfx-b-"})]
+    (is (str/includes? a "pfx-a-") "React derived the id under the caller's prefix")
+    (is (str/includes? b "pfx-b-"))
+    (is (not= a b)
+        "two prefixes, two documents — the premise the equality above rests on")))
+
+;; ---------------------------------------------------------------------------
+;; §4 — the recovered render error, and its control
+;; ---------------------------------------------------------------------------
+;;
+;; Read the pair together. The control proves the tree renders and the
+;; refusal proves the check bites; either alone is a green that means
+;; nothing.
+
+(deftest a-recovered-render-error-fails-the-render
+  (let [thrown (try (render-body! [detonating {}] {})
+                    (catch :default e e))]
+    (is (instance? ExceptionInfo thrown)
+        "a sub that throws mid-render must not answer 200 with a hole in the page")
+    (let [data (ex-data thrown)]
+      (is (= :rf.error/ssr-render-failed (:rf.error/id data)))
+      (is (= 're-frame.hicasso.server/render-body (:where data)))
+      (is (= :fail-the-render (:recovery data)))
+      (is (pos? (:recorded data)) "the refusal counts what it saw")
+      (is (= :rf.error/sub-exception (:error (:record data)))
+          "and names the category, so the sidecar log points at the real surface"))))
+
+(deftest the-control-a-tree-with-no-recovered-error-renders
+  (let [html (render-body! [both-partitions {}] {})]
+    (is (string? html))
+    (is (str/includes? html "hello")
+        "the same entry, the same shape of tree, no refusal — so the row above measures the recovered error and not the entry")))
+
+;; ---------------------------------------------------------------------------
+;; §5 — teardown, on both exits
+;; ---------------------------------------------------------------------------
+
+(deftest the-request-frame-is-destroyed-on-success-and-on-failure
+  (let [before (live-frame-ids)]
+    (render-body! [both-partitions {}] {})
+    (is (= before (live-frame-ids)) "success leaves no frame behind")
+    (try (render-body! [detonating {}] {}) (catch :default _ nil))
+    (is (= before (live-frame-ids)) "and neither does a refusal")))

--- a/implementation/scripts/_examples-staging.test.cjs
+++ b/implementation/scripts/_examples-staging.test.cjs
@@ -109,6 +109,11 @@ const FIXTURE = `{:builds
                    :output-dir "out/examples/gamma"
                    :modules {:main {:init-fn seven-guis.gamma.core/run}}}
 
+  :examples/delta-server
+  {:target      :node-library
+   :output-dir  "out/examples/delta-server"
+   :exports-var delta.server/module}
+
   :some-other-build
   {:target :browser}}}`;
 
@@ -116,7 +121,7 @@ it('parseExampleBuilds recovers every adjacent example build (no skip-every-othe
   const builds = parseExampleBuilds(FIXTURE);
   assert.deepStrictEqual(
     builds.map((b) => b.build).sort(),
-    ['examples/alpha', 'examples/beta', 'examples/gamma'],
+    ['examples/alpha', 'examples/beta', 'examples/delta-server', 'examples/gamma'],
   );
 });
 
@@ -134,15 +139,39 @@ it('parseExampleBuilds ignores commented-out build keys', () => {
   assert.ok(!ids.includes('examples/should-be-ignored'));
 });
 
+// `target` is what separates a PAGE build from a server-side one, and a
+// non-`:browser` example build must still be RECOVERED (it is an example
+// build; check-examples-compile.cjs compiles it) while carrying no :init-fn.
+// Dropping it from the parse would hide it from every reader at once.
+it('parseExampleBuilds recovers :target, and a :node-library build keeps no :init-fn', () => {
+  const byId = Object.fromEntries(parseExampleBuilds(FIXTURE).map((b) => [b.build, b]));
+  assert.strictEqual(byId['examples/alpha'].target, ':browser');
+  assert.strictEqual(byId['examples/gamma'].target, ':browser');
+  assert.strictEqual(byId['examples/delta-server'].target, ':node-library');
+  assert.strictEqual(byId['examples/delta-server'].outputDir, 'out/examples/delta-server');
+  assert.strictEqual(byId['examples/delta-server'].initFn, null);
+});
+
 // ---- real-repo derivation: non-vacuous + the three UIx examples ----------
 
-it('parseExampleBuilds(shadow-cljs.edn) is non-vacuous and every build has out+init', () => {
+// The out+init invariant is asserted of the PAGE builds — the `:browser` ones
+// listStandaloneExamples turns into runnable entries. A server-side example
+// build (`:node-library`, publishing an `:exports-var` for a Node sidecar to
+// require — rf2-8arzr.5) is not a page and correctly declares neither, so
+// holding it to the page invariant asserts something false of the domain.
+// Every build must still declare a `:target`: a null one would silently drop a
+// real page build out of the loop below, which is the vacuity this pins shut.
+it('parseExampleBuilds(shadow-cljs.edn) is non-vacuous and every :browser build has out+init', () => {
   const builds = parseExampleBuilds(readShadowEdn());
-  assert.ok(
-    builds.length >= 30,
-    `expected the full example set (>=30), got ${builds.length} — parser/edn drift`,
-  );
   for (const b of builds) {
+    assert.ok(b.target, `build ${b.build} declares no :target — parser/edn drift`);
+  }
+  const pages = builds.filter((b) => b.target === ':browser');
+  assert.ok(
+    pages.length >= 30,
+    `expected the full example page set (>=30), got ${pages.length} of ${builds.length} — parser/edn drift`,
+  );
+  for (const b of pages) {
     assert.ok(b.outputDir, `build ${b.build} missing :output-dir`);
     assert.ok(b.initFn, `build ${b.build} missing :init-fn`);
   }

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -1625,6 +1625,44 @@
    :asset-path "."
    :modules    {:main {:init-fn hicasso.login.core/run}}}
 
+  ;; rf2-8arzr.5 — the SERVER half of the Hicasso login arm: the module
+  ;; `implementation/ssr-node`'s sidecar loads, so a JVM `ssr-handler`
+  ;; running `re-frame.ssr.ring.node/renderer` can render this page's body
+  ;; on Node. A `:node-library` rather than a `:node-script`: the sidecar
+  ;; `require`s the artefact and reads the entry table it exports, and
+  ;; `:exports-var` is what publishes one whole object as `module.exports`.
+  ;;
+  ;; NO `:init-fn`, and no `index.html` beside it — this build is not a
+  ;; page. `examples/scripts/examples-staging.cjs` skips a build with
+  ;; neither, so it stays out of the runnable manifest `npm run dev:example`
+  ;; reads, while `scripts/check-examples-compile.cjs` (which derives its
+  ;; roster from every `:examples/*` key here) compiles it warnings-fatal
+  ;; like the rest.
+  ;;
+  ;; The build id it publishes is a `goog-define`
+  ;; (`hicasso.login.server/build-id`); a release stamps the real one
+  ;; through `--config-merge :closure-defines`. See the example README.
+  ;; `:optimizations :simple` and `:infer-externs false` go TOGETHER and are
+  ;; one decision rather than two. A server bundle is not shipped over a
+  ;; wire, so `:advanced`'s only products here would be unreadable stack
+  ;; traces and a property-renaming hazard; under `:simple` nothing is
+  ;; renamed, which is what makes turning externs inference off free rather
+  ;; than a suppression. It has to be off because a NODE target carries no
+  ;; browser externs, so core's `substrate/spine.cljs` — DOM-reading code
+  ;; this bundle never runs — raises eight `:infer-warning`s that
+  ;; `check-examples-compile.cjs` treats as failures. That is the same
+  ;; measurement rf2-bl0j recorded when it put `:hicasso-modules-compile` on
+  ;; a `:browser` target, and the same reason `:node-test-hicasso` above
+  ;; sets the flag. Externs inference is JUDGED on the browser builds, which
+  ;; is where a renamed property could actually bite.
+  :examples/login-hicasso-server
+  {:target      :node-library
+   :output-dir  "out/examples/login-hicasso-server"
+   :output-to   "out/examples/login-hicasso-server/server.js"
+   :exports-var hicasso.login.server/module
+   :compiler-options {:optimizations  :simple
+                      :infer-externs  false}}
+
   :examples/realworld
   {:target     :browser
    :output-dir "out/examples/realworld"


### PR DESCRIPTION
Slice E of the ssr-node crossing programme (rf2-8arzr.5) — the **product witness**. The whole chain below it (A #8981, B #8985, C #8982, D #8991) is merged, so this builds against the real seams.

## What lands

**`re-frame.hicasso.server/render-body`** — a fourth name beside `render`, `payload-script` and `document`; none of their settled spellings move. It restores a two-partition render-state projection into a fresh `:platform :server` frame through `render-state/restore!`, replays no boot events, re-seeds no snapshot, builds no payload, and returns the app root's inner markup.

**The refusal is the load-bearing half.** A sub that throws mid-render does not take the render down: the framework recovers it to `nil` and the pass returns a string with a hole in it. On a JVM host that is survivable because the same process holds the record and projects it into a 5xx; across this crossing the record is made in Node and the projector is on the JVM, so a 200 would ship a wrong page as a success. `render-body` watches the always-on error-emit stream for the extent of the render and throws `:rf.error/ssr-render-failed` if anything was recorded.

**That instrument was chosen by measurement, not by reasoning.** The first cut used `re-frame.ssr`'s per-frame `pending-error-trace?` buffer — and its refusal row rendered markup. Hicasso reads its subscriptions through the pure `compute-sub` path (`impl.collector`'s cold read), whose `:rf.error/sub-exception` record is stamped `:frame nil` **by construction** and documented as such in `re-frame.subs` ("a `compute-sub`-driven SSR harness that wants the per-frame projection must use the reactive `subscribe` path"). A per-frame check reads CLEAN on exactly the failure this entry exists to catch.

**`examples/substrates/hicasso/login/`** gains `server.cljs` (the sidecar module: entry table, two allowlists derived from one `render-state-policy`, a `goog-define` build identity), `host.clj` (the JVM `ssr-handler` + `node/renderer` wiring), an isomorphic `run` in `core.cljs`, and a README section. **`implementation/shadow-cljs.edn`** gains one `:node-library` build, as its own commit.

## Ruling clauses this implements (verbatim)

> S2 OWNERSHIP LINE (the bead's, restated because every slice cites it). Node returns body markup and nothing else. The JVM owns the request frame, boot-event drain, blocking-resource settle, head, hydration payload (`__rf_payload`), shell, status/headers/cookies/redirects, error projection and frame teardown. The sidecar's HTTP status is never copied to the browser response.
>
> S3 RENDER STATE. The render-visible projection is DISTINCT IN POLICY from the hydration payload's but SHARES ITS ENVELOPE: the partition shape `{:rf/app-db {...} :rf/runtime-db {...}}` the payload already uses (payload.clj:5-13) and the client's `:rf/hydrate` already installs (hydrate.cljc). It is declared like `:payload` — a fail-closed allowlist per partition (top-level app-db keys; top-level runtime-db keys such as the route slice and machine snapshots) — as a new handler opt `:render-state`, with a `(fn [frame-id] -> partition-map)` escape hatch for a projector the allowlist vocabulary cannot express. The FRAMEWORK does the projecting, in a new `re-frame.ssr.render-state` cljc namespace reusing payload_policy.cljc's apply/project machinery. The serialization domain is the payload's existing EDN domain — reuse it, never invent a second one; slice C supplies the round-trip corpus and the negative fixture. The Node-side restore seeds a FRESH per-request frame with both partitions WITHOUT replaying boot events (the JVM drained them), reusing hydrate.cljc's partition-install path minus verification and DOM. This is the "second install door" the ssr-node README (:355-365) declined to invent in a sidecar; the framework decides it here, by ruling.

And from the same ruling's REJECTED OPTIONS:

> - REAGENT SSR example as the witness: proves plumbing for a path nobody would ship; weakens criterion five. BOTH witnesses: the Reagent module is throwaway.

The bead's own stop condition, reproduced because it was **not** reached:

> ## Stop and report to Mike
>
> If the login root turns out to need the whole unprojected frame rather than an explicit render snapshot, or cannot hydrate cleanly from the JVM-owned payload. Leave the PR open with what works and say so on this bead.

Neither holds. The explicit render snapshot is sufficient — the login root renders every one of its faces from it — and the client hydrates the JVM-owned payload with **zero** `:rf.ssr/hydration-mismatch`, measured in a real browser.

## The one finding worth Mike's eye

Acceptance 2 asks for a server-only value that renders and is absent from `__rf_payload`, **and** for clean hydration. Those are properties of two different render-state/payload configurations of the page, and cannot both hold of one render: the hydrating client renders from the payload, so a node the two halves disagree about is a node React recovers. That is a fact about React, not about re-frame2.

The witness proves both and **measures the tension** rather than papering over it (its §6 is clean, its §7 costs exactly one recovered adoption). The shipped example ships the configuration that hydrates clean; the rule — *a render-state key the payload does not carry must not change the markup* — is stated in the README and beside the sub in `core.cljs`.

## Quality gates

Rebased onto `origin/main` at `3cfa6220e4` and re-run there. Every number below is a captured exit code (`echo $? > <file>.exit`, one shell, never piped).

### The red check, and what fixed it

`tests :: JS harness self-tests (quiet reporters + path policy)` was red on one assertion in `implementation/scripts/_examples-staging.test.cjs`:

```
FAIL  parseExampleBuilds(shadow-cljs.edn) is non-vacuous and every build has out+init
      build examples/login-hicasso-server missing :init-fn
```

The assertion was true of the roster as it stood — all 43 `:examples/*` builds were `:browser` pages — and this branch adds the first that is not one. A `:node-library` publishes an `:exports-var` for the Node sidecar to `require`; it has no `:init-fn` and no colocated `index.html` because it is not a page, so holding it to the page invariant asserts something false of the domain. Giving the build an `:init-fn` to quiet the assertion would have been the lie; the assertion is what was overstated.

So `parseExampleBuilds` now recovers `:target` alongside `:output-dir` and `:init-fn`, and the real-repo assertion holds out+init of the `:browser` builds only. The non-page build is still **parsed** — it is an example build, and `check-examples-compile.cjs` compiles it warnings-fatal — merely absent from the runnable manifest, which is what `listStandaloneExamples`' existing null-filter already did without saying so. Two guards keep the exemption from going vacuous: every build must declare a `:target` (a null one would silently drop a real page out of the loop), and the page count keeps its own `>=30` floor rather than inheriting the total. The synthetic fixture gains a `:node-library` entry, so the parse-it-do-not-drop-it half has teeth off the live EDN too.

Script and test moved in one commit; they are two halves of one contract.

### Re-run on the final base (`3cfa6220e4`)

| Gate | Exit | Result |
|---|---|---|
| `npm run test:scripts` — the failing job's own command | **0** | tests 122 / pass 122 / fail 0 (CI was 122 / 121 / 1) |
| `node examples/scripts/check-examples-assets.cjs` — a direct consumer of the edited helper | **0** | 33 host pages resolve their assets; `_shared` tree intact |
| `python implementation/hicasso/scripts/check_optional_module_reachability.py` (+ `--self-test`) | **0** | `server` still unreachable from the public door |
| `python scripts/check_readme_links.py --ci` | **0** | the edited example README |

### Cited rather than re-run — and why the citation holds

`npm run test:cljs` (11167 tests / 55676 assertions), `npm run test:browser` (771 / 4186), `npm run test:examples-compile` (58 builds), `npm run test:bundle-isolation` (4 checkers), `npx shadow-cljs compile :examples/login-hicasso-server :examples/login-hicasso`, `npm run test:hicasso-compile` (11 namespaces) and `python scripts/check_keyword_catalogue_drift.py` were each exit 0 on the pre-rebase head, and are cited here rather than re-run.

That citation is not "it passed before". `git diff --stat <pre-rebase head> HEAD` enumerates the **complete** difference between the tree those gates were measured on and this one: `skills/**` markdown plus one evals JSON, `.beads/issues.jsonl`, and the two Node-side files this fix touches. No CLJS source, no `shadow-cljs.edn`, no `examples/**` source, no workflow. And neither compile gate reads the edited helper: `check-examples-compile.cjs` requires only `child_process`, `fs`, `path` and `_path-policy.cjs`, and none of the four bundle-isolation checkers requires it either. Those gates' inputs are byte-identical across the rebase.

The focused `:node-test-hicasso` build was used for iteration (exit 0, 1170 tests / 4344 assertions) but is **not** cited as a gate: it is not a CI job, and it was RED on the merge base before this branch — `re-frame.hicasso.substrate-react-shared-cljs-test` errors with `:rf.error/schemas-artefact-missing` because that focused classpath carries no loader for `re-frame.schemas`. This branch incidentally clears it, because the witness requires `login.model`.

### Coverage limits, stated rather than papered over

- **`host.clj` is loaded by no gate.** It sits on the JVM test classpath (`implementation/deps.edn`'s test alias adds `../examples/substrates`), but no namespace requires `hicasso.login.host` and its name does not match the runner's `-test` selector, so nothing ever compiles it. A compile error in that file would pass every gate silently.
- **The witness's `protocol.cjs` require resolves at run time**, from `js/__dirname` (`login_server_crossing_ssr_dom_cljs_test.cljs:176`). A package move therefore fails in the node lane rather than at compile.

**Not run locally, cited per `TESTING.md`:** the JVM lanes (`test-jvm-implementation.sh`, `test-jvm-tools.sh`), `jvm-node-crossing` (slice D's, untouched here), the Xray feature gate, mcp-conformance, the perf-bundle gate, the docs and portability workflows, and the release-sized sweep. Nothing here touches a JVM artefact, a workflow or a spec file.

**Anchors and table column counts in the README were checked by hand** — neither doc gate reads a fenced block, and the new section is mostly fences and one two-column table.

### Controls on the gates this fix re-ran

Each plant was applied alone, its match count read before the run (1 in each case), then restored and verified by `git hash-object` against the committed blob.

| Plant | Gate result | Restored blob hash |
|---|---|---|
| the `:target` capture regex broken in the edited helper | exit **1** — both new guards fired, naming `build examples/counter declares no :target` | `da9ff646efaec2b9d55e94f734ab694ef5430b28` |
| a broken relative link appended to the example README | exit **1**, naming the planted target at `README.md:233` | `f0830c4da24b9351aebacb924c0801124aacb5e6` |

The first also shows the suite read **this** tree rather than a sibling checkout: the original red named `examples/login-hicasso-server`, a build that exists on no other tree, and the plant's red named a fault present in no other tree either.

## Sabotage controls (on the change itself)

Each plant was applied alone, exercised, then restored and verified by `git hash-object` against the committed blob.

| Plant | Gate result | Rows red | Restored blob hash |
|---|---|---|---|
| `render-body`'s accumulator check disabled (`(pos? n)` becomes `(pos? -1)`) | exit **1**, 6 failures | `a-recovered-render-error-fails-the-render`, and nothing else | `ffdbda11ef43d7731139b2315ad5fdbc692e6a90` |
| `render-body` drops `:identifier-prefix` (`(render-options nil)`) | exit **1**, 3 failures | `the-identifier-prefix-reaches-react` | `ffdbda11ef43d7731139b2315ad5fdbc692e6a90` |
| `render-state-policy` drops `:runtime-db` | exit **1** | the entry-table row plus every crossing row — the sidecar refuses the partition fail-closed rather than rendering the wrong face | `948c80307955331218d76fe2a4806a8124ab10a4` |
| the host's `:payload` policy widened to carry the server-only key | exit **1**, 2 failures | exactly the two absence assertions in `a-server-only-value-renders-and-is-absent-from-the-payload` | `a380edb22354e092a1f5b694aaf976abeaae41c7` |

Each plant's match count was read before the run (1 in every case), so none was a silent no-op.

**The server module does not leak into the browser build**, checked with a control that bites: the `hicasso.ssr` keyword-namespace sentinel (a string literal `:advanced` cannot rename — `check_bundle_isolation.cjs`'s own) appears in 2 files of the server output tree and **0** times in the released `out/examples/login-hicasso/main.js`, which also carries no `renderToString`.

**And the crossing was driven end to end against the real sidecar**, outside any test harness: `node ssr-node/bin/serve.cjs --module out/examples/login-hicasso-server/server.js` on the compiled bundle, four POSTs — a locked-out machine snapshot rendering the locked panel (200), an idle one rendering the form with the draft email and a `redacted` password box (200), a build-id skew refused 409 `:rf.ssr-node/build-identity-mismatch`, and an unallowed state key refused 400 `:rf.ssr-node/state-key-not-allowed` naming the entry's allowlist.

## Follow-ups (not done here, deliberately)

1. **`host.clj` is the wiring, not a running server.** A JVM host must hold the application's state, so `login.model` has to be loadable from Clojure; it is `examples/core/login/model.cljs` today and the single line keeping it there is a `localStorage` write in the demo session fx. Making it `.cljc` is a change to a file all three login arms share — outside this slice's fence. Said plainly in `host.clj` and in the README.
2. **Spec 009's `:rf.error/ssr-render-failed` row now has a second emitter.** The id was reused rather than a new one minted, because a new `:rf.error/*` id needs a Spec 009 catalogue row and `spec/*.md` is fenced out of this dispatch. The row's prose names only `ssr-ring/pipeline` as its emitter. Slice F (rf2-8arzr.6) owns spec reconciliation.
3. **`examples/substrates/README.md` and `examples/README.md`** describe the three login arms and do not mention the server build. Outside the fence; a line each for slice F.

