### PR TITLE
skill(xray): correct four claims against the shipped tool (rf2-fguoj, rf2-bbonr, rf2-itd1w, rf2-j0yk6)

### DIFF
--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -143,7 +143,7 @@ Four launch surfaces ship: one mount facade with three open verbs
 | Deep-link Xray to a tab / epoch / app-db path from code | **`focus!`** | `(xray/focus! {:panel :trace})`, or the fuller `{:frame :panel :epoch-id/:dispatch-id :path}` command. **Navigates an already-installed Xray — it does not install or mount** (preload / `init!` + a mount verb first). The only programmatic tab jump. |
 | Browse what's *registered* instead of one dispatch | **Static mode** | Flip the L1 mode pill or press `Cmd/Ctrl+Shift+M`. |
 | Have an AI agent inspect the runtime | **re-frame2-pair** | Out of scope here — see §First fork above. |
-| Debug a mobile browser | Not supported | Phones refuse to mount (`spec/011-Launch-Modes.md`). |
+| Debug a mobile browser | **Out of scope at v1.0** | There is no mobile launch mode (`spec/011-Launch-Modes.md` lock #5). Nothing *refuses* a phone — the mount path carries no user-agent check; the mode simply doesn't exist. |
 
 **Most common launch failure — "the panel never appeared."** Preload in,
 page loaded, no inline panel = a **missing layout host**: nothing matched

--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -131,6 +131,7 @@ Four launch surfaces ship: one mount facade with three open verbs
 | Mount where the host can't give Xray a layout column (full-screen canvas, no `[data-rf-xray-host]`) | **Overlay (fallback)** | `(xray/open-overlay!)` from CLJS, or `window.day8.re_frame2_xray.open_overlay_BANG_()` from devtools. Floats the shell above the host under `document.body`. The supported fallback — **not** the default path. |
 | Put Xray on a second monitor | **Pop-out window** | Click the visible **`⛶` pop-out button** in the panel top-bar's right-icons cluster (the canonical chrome path). Secondary programmatic path: `(xray/popout!)` from CLJS / `window.day8.re_frame2_xray.popout_BANG_()` (call it — note the parens) from a console. |
 | Install Xray from code (no preload) | **Programmatic `init!`** + a mount verb | Call `(xray/init! opts)` after `rf/init!` to install the foundation (it does **not** open a panel), then `(xray/open!)` / `(xray/open-overlay!)` / `(xray/popout!)` to make it visible. Idempotent. |
+| Deep-link Xray to a tab / epoch / app-db path from code | **`focus!`** | `(xray/focus! {:panel :trace})`, or the fuller `{:frame :panel :epoch-id/:dispatch-id :path}` command. **Navigates an already-installed Xray — it does not install or mount** (preload / `init!` + a mount verb first). The only programmatic tab jump. |
 | Browse what's *registered* instead of one dispatch | **Static mode** | Flip the L1 mode pill or press `Cmd/Ctrl+Shift+M`. |
 | Have an AI agent inspect the runtime | **re-frame2-pair** | Out of scope here — see §First fork above. |
 | Debug a mobile browser | Not supported | Phones refuse to mount (`spec/011-Launch-Modes.md`). |
@@ -207,7 +208,7 @@ deeper question loads at most **one** focused leaf:
 
 | Deep question about… | Load |
 |---|---|
-| Launch in depth — preload vs `init!`, the `[data-rf-xray-host]` contract, missing-host recovery, `open-overlay!`, pop-out lifecycle, the full hotkey contract | [`references/launch-modes.md`](references/launch-modes.md) |
+| Launch in depth — preload vs `init!`, the `[data-rf-xray-host]` contract, missing-host recovery, `open-overlay!`, pop-out lifecycle, the full hotkey contract, the `focus!` deep-link command | [`references/launch-modes.md`](references/launch-modes.md) |
 | The full tab inventory + scope matrix + the Static catalogues (explicit "list every tab") | [`references/panels.md`](references/panels.md) |
 | The Epoch cascade, Trace rows, or where issues surface | [`references/panels-epoch.md`](references/panels-epoch.md) |
 | app-db sections + diffs, or Views render causes | [`references/panels-state.md`](references/panels-state.md) |

--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -91,8 +91,17 @@ pretend to follow the event — route them by structure, not by dispatch.
 Dynamic mode's L3 tab bar holds **10 tabs**, left-to-right (mnemonics
 `e a v t m r s g u h`): **Epoch · app-db · Views · Trace · Machine ·
 Routes · Resources · Graph · Frames · Hicasso**. Static mode holds **5**:
-**Machines · Routes · Schemas · Flows · Interceptors** (mnemonics are
-mode-scoped — `m` opens the active mode's tab). The compact canonical
+**Machines · Routes · Schemas · Flows · Interceptors**, with its own
+letters — the same letter can label a tab in each mode, as `m` does for
+Dynamic's Machine and Static's Machines.
+
+**Those letters are tooltip hints, not keys.** Each is rendered into its
+tab button's `title` — `Trace (t)` — and is read by nothing else. **No
+bare letter selects a tab**; keyboard tab-jump is the command palette
+(`Cmd/Ctrl+K` → "Open Trace panel" / "Open Machines (Static)"), and from
+code it is `focus!`. Watch `s` in particular: it labels the Resources tab
+but *is* a live bare key — bound to the Settings popup (§Wired hotkeys),
+not to Resources. The compact canonical
 inventory — every tab's one-liner and the scope matrix in one place — is
 [`references/panels.md`](references/panels.md); load it for an explicit
 full-inventory request, not for routine routing.

--- a/skills/re-frame2-xray/references/chrome.md
+++ b/skills/re-frame2-xray/references/chrome.md
@@ -124,7 +124,10 @@ popup controls are:
 
 - **General** — panel position (right-rail inline / fullscreen overlay),
   auto-open-on-error, epoch-history depth (slider), the per-operator
-  editor-override picker, and the show-`:ungrouped` toggle.
+  editor-override picker, the show-`:ungrouped` toggle, and the
+  "Always show unchanged subs" pin (expands the Views panel's
+  `Show N unchanged subs` memo-hit disclosure for every event-bundle;
+  default OFF).
 - **Buffer** — events-retained (writes through to `(rf/configure!
   {:trace-buffer {:events-retained N}})`) + a destructive Clear-buffer
   button.

--- a/skills/re-frame2-xray/references/launch-modes.md
+++ b/skills/re-frame2-xray/references/launch-modes.md
@@ -219,12 +219,6 @@ Three recoveries, in order of preference:
 - **Fall back to the overlay** — `(xray/open-overlay!)` (§Overlay fallback
   below) when the host genuinely cannot give a column.
 
-Distinct from this is the **dev-build posture banner** — a dismissable
-yellow "Xray is enabled in this build" top banner shown when a non-elided
-dev build runs in production-like conditions (§Production posture below).
-That is a *warning to elide for production*, not the missing-host failure;
-don't conflate the two.
-
 ## Overlay fallback (open-overlay!)
 
 For hosts that **cannot accommodate a right column** — a full-screen
@@ -391,6 +385,14 @@ strip every side-effect — the trace collector registration, the
 epoch-cb registration, the keybinding listener, the mount call. CI
 verifies via `npm run test:elision`.
 
-A non-elided dev build running in production-like conditions shows a
-yellow top banner: "Xray is enabled in this build. Disable for
-production." Single-click dismiss, remembered for the session.
+**There is no in-build "Xray is enabled" warning banner.** A non-elided
+build gives no posture signal of its own — the tell that Xray shipped is
+simply that its surface is *there*: the panel mounts, the chrome renders,
+and `Ctrl+Shift+C` toggles it. So "would I notice Xray in production?"
+resolves to the elision gate above, not to a runtime warning: keep
+`npm run test:elision` in CI and the surface cannot reach a production
+build in the first place.
+(`spec/007-UX-IA.md` §Production posture does describe a dismissable
+yellow banner for this case. Nothing in `tools/xray/src` implements it —
+it is normative-future, in the same class as the unwired keymap under
+§Wired hotkeys. Don't teach it as a control the operator will see.)

--- a/skills/re-frame2-xray/references/launch-modes.md
+++ b/skills/re-frame2-xray/references/launch-modes.md
@@ -302,6 +302,79 @@ that worked against a newer Xray won't break an older one. (There is **no**
 server (Node/npm), not an `init!` knob.) See the `core.cljs` `init!` docstring for the
 authoritative per-opt contract.
 
+## Programmatic focus (focus!)
+
+`init!` and the mount verbs get Xray *visible*. `focus!` is the separate
+verb that says **where to look** — deep-link an already-mounted Xray to a
+tab, an epoch, an event bundle, or an app-db path from code (a Story
+narrative beat, a failed assertion, a docs link, your own REPL).
+
+**It navigates; it does not install or mount.** `focus!` assumes a host
+has already mounted Xray — it is not a launch verb, and it will not open a
+hidden shell. Reach it after the preload (or `init!`) plus a mount verb.
+
+```clojure
+(require '[day8.re-frame2-xray.core :as xray])
+
+(xray/focus! {:panel :trace})              ; just flip the tab
+(xray/focus! {:frame    :app/checkout      ; observe this host frame
+              :panel    :app-db            ; surface this L4 tab
+              :epoch-id 42                 ; pin the spine to this epoch
+              :path     [:checkout :state]}) ; highlight this app-db path
+```
+
+Every field is optional — an empty command `{}` is a well-formed no-op.
+The command keys, per
+[`focus.cljc`](../../../tools/xray/src/day8/re_frame2_xray/focus.cljc):
+
+| Key | Meaning |
+|---|---|
+| `:frame` | The **host** frame Xray should observe. Omit to keep the current scope. |
+| `:panel` | Which Dynamic L4 tab to surface (one of the ten ids below). |
+| `:epoch-id` | Settling epoch to pin the spine to. |
+| `:dispatch-id` | Event-bundle root to pin the spine to — an alternative to `:epoch-id`; passing both is fine. |
+| `:path` | app-db path to highlight in the app-db panel. |
+| `:source` | **Opaque** provenance echoed back in the result. Xray never reads into it — it is the host's own intent context. |
+| `:sync?` | Control key, never translated to a dispatch: fires `dispatch-sync` instead of `dispatch` (test rigs, same-tick host flows). |
+
+Valid `:panel` ids are the ten live Dynamic L4 tabs, re-exported as
+`xray/valid-focus-panels`: `:epoch` `:app-db` `:views` `:trace`
+`:machines` `:routing` `:resources` `:derivation-graph` `:module-view`
+`:hicasso`. These are internal **ids**, not the visible labels — the tab
+that renders as "Routes" is `:routing`, "Graph" is `:derivation-graph`,
+"Frames" is `:module-view`. Because a host naturally reaches for the
+visible noun, `:routes` is accepted as an alias and normalises to
+`:routing`.
+
+Two arities, per the `focus!` docstring:
+
+```clojure
+(xray/focus! command)             ; the command's own :frame scopes it
+(xray/focus! host-frame command)  ; positional frame, merged in as :frame
+                                  ;   (an explicit command :frame wins)
+```
+
+The translated events fire in a fixed order — `:frame` first (so the
+per-frame epoch ring is re-seeded before any epoch pin lands), then
+`:dispatch-id` / `:epoch-id`, then `:panel` and `:path`.
+
+`focus!` returns a data-shaped result rather than throwing:
+
+```clojure
+{:ok? true :applied [[:rf.xray/select-frame :app/checkout] ...] :source nil}
+```
+
+**An unknown `:panel` is the one rejected case** — it would otherwise
+silently land the L4 unknown-tab stub, so it comes back
+`{:ok? false :reason :unknown-panel :given <id> :valid #{...} :hint "..."}`.
+Every other field is permissive: a missing epoch or an evicted event
+bundle degrades through the spine's existing placeholder UX, not an error.
+
+**This is the only programmatic tab jump.** The tab mnemonics are tooltip
+letters, not keys (§Wired hotkeys) — a caller who wants a tab from code
+uses `focus!`, and a user who wants one from the keyboard uses the
+command palette.
+
 ## Pop-out to a second window
 
 Solves "I want Xray on a second monitor while the app runs

--- a/skills/re-frame2-xray/references/launch-modes.md
+++ b/skills/re-frame2-xray/references/launch-modes.md
@@ -409,9 +409,13 @@ Caveats inherited from the `window.opener` posture:
 - If the user closes the opener, the pop-out becomes orphaned. Pop-out
  detects this via `window.opener.closed` and shows a clean
  "opener gone — close this window" overlay.
-- The pop-out can't survive a hard reload of the opener — atoms get
- garbage-collected; the pop-out re-bootstraps via
- `window.opener.xrayRuntime` on opener reload.
+- The pop-out can't survive a hard reload of the opener — the opener's
+ atoms are garbage-collected and the pop-out is left reading a dead
+ runtime. **There is no re-bootstrap.** (`spec/011-Launch-Modes.md`
+ §Pop-out has the pop-out re-reading a `window.opener.xrayRuntime` handle
+ on opener reload; nothing in `tools/xray/src` ever sets that handle, so
+ it is normative-future.) Close the pop-out and open a fresh one from the
+ reloaded opener.
 - No keybinding is wired pre-alpha. The visible `⛶` top-bar button is the
  canonical chrome launch; the programmatic call is the secondary path.
 

--- a/skills/re-frame2-xray/references/panels.md
+++ b/skills/re-frame2-xray/references/panels.md
@@ -12,8 +12,10 @@ list is
 [`018-Event-Spine.md` §5](../../../tools/xray/spec/018-Event-Spine.md) +
 [`021-Dynamic-Panel-Designs.md` §9.1](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md)
 (Dynamic) + [`007-UX-IA.md` §Static mode](../../../tools/xray/spec/007-UX-IA.md)
-(Static). The executable drift gate + re-verification order live in
-[`../evals/README.md` §Keeping the tab inventory in sync](../evals/README.md).
+(Static). The executable drift gate is
+`scripts/check_skill_xray_tab_inventory_drift.py`, which fails CI if this
+inventory's ids, labels, tooltip letters or order diverge from the shipped
+registry.
 
 ## Dynamic mode — 10 tabs
 
@@ -76,7 +78,7 @@ letters, not keys: pressing one selects nothing, and the palette entry is
 |---|---|---|
 | **Machines** *(default)* | `m` | "What machines are registered, and what do they look like?" Registry browse + full topology (picker + zoom/pan/fit) + a 4-mode sub-strip incl. the Sim engine. |
 | **Routes** | `r` | "Which route would `/orders/42` match?" Every registered route + a Simulate-URL input. |
-| **Schemas** | `c` | "Show me the shape of `:order/schema`." Every registered schema + sample data + jump-to-source. |
+| **Schemas** | `c` | "Show me the shape of `:order/schema`." Every registered app-db / event / sub schema as its Malli EDN, with `:doc`, searchable, + jump-to-source. |
 | **Flows** | `f` | "What flows are registered?" The flows catalogue. |
 | **Interceptors** | `i` | "What runs, and in what order?" Pure-browse over the registered interceptor chains. |
 

--- a/skills/re-frame2-xray/references/panels.md
+++ b/skills/re-frame2-xray/references/panels.md
@@ -21,7 +21,14 @@ Left-to-right in tab order (mnemonics `e a v t m r s g u h`):
 **Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph ·
 Frames · Hicasso.**
 
-| Tab | Mnem | Scope | One-line purpose | Depth |
+The **Tooltip** column below is each tab's `:mnem` — the parenthesised
+letter in the tab button's `title` (`Trace (t)`), and nothing more. It is
+**not a key**: no bare letter selects a tab (`s` is a live bare key, but
+for the Settings popup, not for Resources). Jump by keyboard with the
+command palette, `Cmd/Ctrl+K` → "Open Trace panel"; from code, with
+[`focus!`](launch-modes.md#programmatic-focus-focus).
+
+| Tab | Tooltip | Scope | One-line purpose | Depth |
 |---|---|---|---|---|
 | **Epoch** *(default landing)* | `e` | focused epoch | The focused dispatch's full cascade as a numbered vertical timeline, per-step ✓/✗/⊘, exceptions inline under their step. | [panels-epoch.md](panels-epoch.md) |
 | **app-db** | `a` | focused epoch | State sectioned by reserved area, collapsible lazy-trees, inline `← was X` diffs, downstream-subs hover. | [panels-state.md](panels-state.md) |
@@ -57,12 +64,15 @@ the six focused-epoch lenses rebind.
 ## Static mode — 5 registry-browse tabs
 
 Event-INDEPENDENT browse of what's *registered* (3-layer chrome, no L2
-spine). Flip in with the L1 mode pill or `Cmd/Ctrl+Shift+M`. Mnemonics
-are mode-scoped (`m` here opens the Static Machines browse, not the
-Dynamic instance-inspector). Order per
+spine). Flip in with the L1 mode pill or `Cmd/Ctrl+Shift+M`. Static has
+its own tooltip letters, so a letter can appear in both modes' tab bars
+meaning that mode's tab — `m` labels the Static **Machines** browse here
+and the Dynamic instance-inspector there. As above, they are tooltip
+letters, not keys: pressing one selects nothing, and the palette entry is
+"Open Machines (Static)". Order per
 [`007-UX-IA.md` §Static mode](../../../tools/xray/spec/007-UX-IA.md):
 
-| Tab | Mnem | Question it answers |
+| Tab | Tooltip | Question it answers |
 |---|---|---|
 | **Machines** *(default)* | `m` | "What machines are registered, and what do they look like?" Registry browse + full topology (picker + zoom/pan/fit) + a 4-mode sub-strip incl. the Sim engine. |
 | **Routes** | `r` | "Which route would `/orders/42` match?" Every registered route + a Simulate-URL input. |

--- a/skills/re-frame2-xray/references/shared-components.md
+++ b/skills/re-frame2-xray/references/shared-components.md
@@ -76,7 +76,7 @@ past an evicted row.
 Per §021 §17.1.5 (binding; HCM-safe because glyph alone carries
 signal, colour is never alone):
 
-| Tab (Dynamic) | Mnem | Icon | Stripe token |
+| Tab (Dynamic) | Tooltip | Icon | Stripe token |
 |---|---|---|---|
 | Epoch | `e` | `⚡` | `:accent-violet` |
 | app-db | `a` | `◐` | `:cyan` |


### PR DESCRIPTION
Four beads correcting the `re-frame2-xray` skill against the shipped tool. One commit per bead, smallest cleanup first.

`tools/xray` unchanged because this cluster corrects the SKILL against the shipped tool, not the tool. (The standing rule that a dispatch touching `tools/xray/` also updates `tools/xray/spec/*` is therefore not engaged — `git diff --name-only origin/main...HEAD -- tools/xray/` is empty.)

Diff is five files, all under `skills/re-frame2-xray/`. No sibling landed anything under that path between this branch's base and `origin/main`, so nothing here reverts a peer's work.

---

## The four beads

### rf2-fguoj — the dev-build posture banner does not ship

`launch-modes.md` taught a dismissable yellow **"Xray is enabled in this build"** banner twice: as a distinct posture signal under §Missing host, and as a single-click-dismiss control under §Production posture.

**Verified:** a fixed-string census over the 147 tracked files under `tools/xray/src`, run **both** line-oriented and over the whole text with whitespace deleted, returns **0** for `enabled in this build`, `Disable for production` and `production-like`. Control needle `dismiss` returns **43** hits over the same corpus, so the zero is a real absence rather than a dead pattern. `mount.cljs` and `preload.cljs` carry no production-like-conditions detector.

**One correction to the bead's own premise.** The bead reported 0 hits across `tools/xray/spec` as well. That is not the case: `tools/xray/spec/007-UX-IA.md` §Production posture specifies the banner nearly verbatim (a yellow top banner, that exact string, single-click dismiss, remembered for the session). So the claim was *reproduced from the spec*, not invented — which is why a bare deletion would not have held: the next reviewer would have re-added it from 007. §Production posture now marks it normative-future explicitly and answers the question the banner stood in for — *how would I know Xray leaked into a production build?* — with the mechanism that does ship (the surface is simply present; `npm run test:elision` is what keeps it out).

This leaves a genuine **spec ↔ implementation gap** in `tools/xray` for the mayor to file: 007 §Production posture specifies a control nothing implements. Out of this cluster's surface, so not touched here.

### rf2-bbonr — route the shipped `focus!` deep-link command

**Verified:** `focus!` is re-exported at `core.cljs` as a `def` alias (alongside `valid-focus-panels`), contracted in `008-Embedding-Contract.md` §Host-facing focus API and listed in `spec/API.md`. A census over the 16 tracked files under `skills/re-frame2-xray/` returned **0** for `focus!` line-oriented and whitespace-deleted; control needle `focus` returned **72** hits across 13 of those files.

Read from source rather than from the bead, which differed in three places:

- the command carries **six** fields — `:frame` `:panel` `:epoch-id` `:dispatch-id` `:path` `:source` — plus the `:sync?` control key; the bead named four.
- `:source` is **opaque** provenance Xray echoes but never reads into.
- the ten `:panel` values are internal **ids**, not visible labels (`:routing` renders "Routes", `:derivation-graph` "Graph", `:module-view` "Frames"); `:routes` normalises to `:routing`.

Also read `apply-focus!` to settle the bead's open question: **it does not open a hidden shell.** The namespace requires only `re-frame.core`, `defaults` and `panel-registry` — no `mount` — and dispatches into the `:rf/xray` frame regardless of visibility. Both new passages lead with that, since it is what strands people.

### rf2-itd1w — mnemonics are tooltip letters, not keys

**This is the bead whose premise needed narrowing, and the answer the dispatch asked for.**

A window-level **capture-phase** keydown listener demonstrably exists — `keybinding.cljs` `attach!` calls `document.addEventListener("keydown", f, true)`, gated on `:rf.xray/keybinding-enabled?`. So a blanket "no bare-letter handler exists" is too strong.

**What the keybinding table actually binds.** `spine-key-id` maps **seven** unmodified keys, and `handle-keydown` adds the chords:

| Binding | Dispatches | Tab? |
|---|---|---|
| `Space` | `:rf.xray/toggle-live-pause` | no |
| `l` | `:rf.xray/follow-head` | no |
| `Shift+G` | `:rf.xray/follow-head` | no |
| `j` | `:rf.xray/focus-event-prev` | no |
| `k` | `:rf.xray/focus-event-next` | no |
| `,` | `:rf.xray/settings-toggle` | no |
| `s` | `:rf.xray/settings-toggle` | no |
| `Ctrl+Shift+C` | `mount/toggle!` | no |
| `Cmd/Ctrl+Shift+M` | `:rf.xray/toggle-mode` | no |
| `Cmd/Ctrl+K` | `:rf.xray/palette-toggle` | no |
| `Esc` (when the editor-hint toast is open) | `:rf.xray/editor-hint-dismiss` | no |

**So: no bare letter opens a tab.** No arm dispatches `:rf.xray/select-tab`, and `handle-keydown` has no tab branch. The narrow claim holds; the blanket one does not. Bare letters *are* handled — seven of them — but none selects an L4 tab.

**Two findings the bead did not have.**

1. **`s` is a live collision the old wording hid.** `s` is the Dynamic **Resources** tab's `:mnem` *and* a real bare key — bound to `:rf.xray/settings-toggle`. A reader who believed the letters were keys and pressed `s` for Resources got the **Settings popup**. That is now the worked example in `SKILL.md`.
2. **Bare letters *do* switch tabs in exactly one place** — the Settings modal's own four inner tabs (`g`/`k`/`b`/`d`), via the dialog's own keydown, and deliberately kept off the global listener by `target-inside-modal?`. Those are not L4 panel tabs.

Keyboard tab-jump is the palette: `palette/sources.cljc` emits `"Open <label> panel"` and `"Open <label> (Static)"`. From code it is `focus!`. Both are now named where the wrong keystroke used to be. The per-tab letters are unchanged (the drift gate pins the `:mnem` values) — only the verb was wrong. Columns relabelled **Mnem → Tooltip** in `panels.md` and `shared-components.md` so the letters read as labels structurally, not just in corrected prose.

### rf2-j0yk6 — five prose-accuracy items, each with its own control

- **(a) "Phones refuse to mount"** — overstated. `mount.cljs` has no userAgent / navigator / mobile check at all (control: the file parses, 39 `defn`s). `spec/011` says "No mobile launch mode (lock #5)" and the summary row reads "Out of scope at v1.0". Reworded to match: no mobile mode, not a refusal.
- **(b) `window.opener.xrayRuntime` re-bootstrap** — never shipped. **0** line-oriented hits over `tools/xray/src`; the single whitespace-deleted hit is a false positive — the phrase *"No second Xray **runtime** model"* in `focus.cljc` folding together, not the identifier. Control needle `opener`: **81** hits. `spec/011` §Pop-out does describe the handle, so it is marked normative-future rather than dropped silently, and the shipped behaviour is stated instead.
- **(c) Settings → General list** — incomplete. `settings/view.cljs` `general-section` reads **six** slots; the leaf named five. Added the **"Always show unchanged subs"** pin (restored under rf2-16y3x).
- **(d) `../evals/README.md` link from a shipped leaf** — `package.json` `files[]` is SKILL.md / README.md / LICENSE / references/ / .claude-plugin/, so `evals/` is absent from the npm artefact and the link dangles there. Gate script named inline instead.
- **(e) Static Schemas "sample data"** — renders none. **0** hits for `sample` in `static/schemas/panel.cljs` against a control of **121** `schema` hits in that same file; its §Data sources lists the Malli EDN, `:doc`, and the `:file`/`:line`/`:ns` coord. Replaced with what the panel shows.

---

## Quality gates

Every gate run in the foreground, exit code captured from the runner itself (never piped through a filter), and **re-run on the final rebased base** — the numbers below are from that last run, not a pre-rebase one.

| Gate | Invocation | Exit |
|---|---|---|
| Xray tab-inventory drift | `--self-test` | **0** |
| Xray tab-inventory drift | `--verbose --ci` | **0** |
| skill package refs | `--self-test` | **0** |
| skill package refs | `--verbose --ci` | **0** |
| skill eval docs | `--verbose --ci` | **0** |
| skill eval packaging | `--verbose --ci` | **0** |
| doc slugs | (default) | **0** |
| readme links | `--ci` | **0** |
| implementor partition drift | `--ci` | **0** |
| mcp drift | `--ci` | **0** |
| migration contract drift | `--ci` | **0** |
| migration o1617 router drift | `--ci` | **0** |
| pair authoring drift | `--ci` | **0** |
| re-frame2 drift | `--ci` | **0** |
| setup counter drift | `--ci` | **0** |
| skill redirect anchors | `--ci` | **0** |
| implementor order | `--ci` | **0** |
| migration cites | `--ci` | **0** |

The whole `check_skill_*_drift.py` set was run because CI's `repo-invariants` job runs every one of them, not only this skill's.

**The tab-inventory gate was run immediately after the rf2-itd1w commit, before anything else** — that commit edits exactly what the gate watches (`:mnem` values, the ordered label sentence, the mnemonic sequence). Green both times.

**Planted-fault verification of `check_doc_slugs.py`.** That gate prints no root, so a planted fault is the only proof it read this worktree rather than a sibling's.

1. Pre-plant blob hash of `references/panels.md`: `87159d1bef27eb59f98199a8db8f19306319c5f6`, equal to the committed object.
2. Match count for the anchor target read **first**: `1` — so the plant could not silently no-op.
3. Planted a single-line broken anchor at line 29, a line already being edited by this PR.
4. Gate returned **exit 1**, naming the file, the line, and the planted target: `BROKEN ANCHOR: skills\re-frame2-xray\references\panels.md:29 -> launch-modes.md#programmatic-focus-DELIBERATELY-BROKEN`. The fault existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green.
5. Restored; blob hash back to `87159d1bef27eb59f98199a8db8f19306319c5f6` (verified against the committed object, not by reading a diff).
6. Gate re-run: **exit 0**.

**Skips.** No CLJS / JVM / browser suite was run: the diff is five markdown files under `skills/re-frame2-xray/` and touches no source, build config or workflow. Required checks this local run does not cover are the CI matrix in [`TESTING.md`](TESTING.md) — see §Required checks the fast-PR spine does not run.

**No gate reads this skill's prose or checks a claim against the shipped tool**, so every claim above was verified by hand against `tools/xray` source or spec, per bead, as set out in each section. Where a verification rests on a search returning zero, a control needle sharing the target's shape was run first and bit; the `xrayRuntime` case additionally required both a line-oriented and a whitespace-deleted pass, and the flattened hit turned out to be a false positive that the line-oriented pass alone would have reported correctly and the flattened pass alone would have got wrong.

**Hand verification the gates do not perform.** Nothing validates markdown prose, tables, rendering or nav. Checked by hand: all **10** tables across the five changed files have header, separator and every row at equal cell counts (0 mismatches) — including the two relabelled headers, the new 7-row `focus!` command table, and the `§Launching` table that gained a row. The one new anchor link (`launch-modes.md#programmatic-focus-focus`) resolves — confirmed by `check_doc_slugs.py` green, and that gate is proven to bite on this exact anchor by the sabotage run above.
