### PR TITLE
docs: three drift fixes - machine-has-tag? is a sub, and the test-kit route deprecation warning (rf2-whsi, rf2-wr0w0, rf2-luo6)

### DIFF
--- a/docs/api/re-frame.machines.md
+++ b/docs/api/re-frame.machines.md
@@ -571,7 +571,7 @@ The registration-time and `:data`-schema-boundary validators. The three `:data` 
 
 ## See also
 
-- [re-frame.core.md](re-frame.core.md) — `reg-machine` / `defmachine` / `machine-has-tag?` are reached on the `re-frame.core` facade; `dispatch` / `subscribe` / `reg-event` drive and read a machine.
+- [re-frame.core.md](re-frame.core.md) — `reg-machine` / `defmachine` are reached on the `re-frame.core` facade; `dispatch` / `subscribe` / `reg-event` drive and read a machine. A tag read is the `[:rf.machine/has-tag? <machine-id> <tag>]` subscription — a subscription vector, not a fn.
 - [re-frame.schemas.md](re-frame.schemas.md) — machines declare schemas for their `:data` slot the same way ordinary handlers do; the `validate-*-data!` validators gate them.
 - [The table](../machines/concepts.md) — the flat-table contract: guards, actions, encapsulation, finals, schemas. The numbered Machines pages grow one login machine through tags, automatic transitions, hierarchy, parallel regions, history, and actors.
 - [Glossary](../machines/glossary.md) — the surface vocabulary in one place.

--- a/docs/core/hicasso/15-testing.md
+++ b/docs/core/hicasso/15-testing.md
@@ -56,7 +56,15 @@ not named here is not on it:
 ```
 
 The path is relative to *your* `deps.edn`, exactly as the artifact coordinates
-above are. Which build target the tests then run under is a choice per level, and
+above are. It also reaches outside your project root, and the Clojure CLI names
+that on every invocation: `WARNING: Use of :paths external to the project has
+been deprecated`. Nothing fails — the root goes on the classpath and `ht` and
+`hm` resolve — and the warning belongs to this route rather than to your project.
+It is the cost of a checkout that is not yet a published coordinate, and it goes
+away with the checkout: resolve Hicasso from a coordinate and the kit arrives in
+the jar with nothing to add and no path to escape.
+
+Which build target the tests then run under is a choice per level, and
 the ladder below is the guide to it: L0–L2 are browser-free and need no DOM, while
 L3 mounts real React and L4 wants real engines.
 


### PR DESCRIPTION
Three P3 docs-drift beads of one class: published documentation naming something the shipped code does not have, or teaching a route that misbehaves. **Two changed files, both prose. One bead fixed, one refuted, one partially fixed and deliberately left open.**

## rf2-whsi — fixed

`docs/api/re-frame.machines.md:574` named `machine-has-tag?` alongside `reg-machine` / `defmachine` as "reached on the `re-frame.core` facade". It is not a facade export and does not exist: `spec/api-manifest-metadata.edn` records the `machine-has-tag?` / `sub-machine` subscription-sugar fns as REMOVED (rf2-il99l3, reversing rf2-2cmcas) — a machine read is the `[:rf.machine/has-tag? id tag]` / `[:rf/machine id]` subscription vector, one read grammar.

The line now names the subscription. Wording follows the two siblings rather than inventing a third phrasing — the same `[:rf.machine/has-tag? <machine-id> <tag>]` subscription form rf2-17wco landed at `spec/005-StateMachines.md:530` and rf2-lzsrd landed at `skills/re-frame2-improver/spec/inputs.md:27`.

`reg-machine` and `defmachine` were checked and **kept**: both carry `["re-frame.core" ...]` rows in the manifest and both are macros defined in `implementation/core/src/re_frame/core.cljc`. Only the third name was struck. The correction also resolves an internal contradiction — the same page's L10 already said "There is no named-read-sugar fn: every runtime-db framework read is a subscription vector, one grammar", and L14 already listed only the two macros as facade exports.

## rf2-wr0w0 — refuted, no edit

The claim was that `docs/core/hicasso/troubleshooting.md:531` documents `:rf.error/hicasso-contenteditable-not-controllable` "as a complaint the runtime raises". **It does not.** The id sits in a table headed **Reserved**, whose prose immediately above says the opposite: *"none of them can appear in an error you caught"*, *"a refusal this guide already teaches by mechanism, on a surface that is not built yet"*, and *"a reservation is promoted, never drifted into"*.

So "no emitter, no Spec 009 row" is that table's **definition**, not drift in it. The census bears that out — all 5 reserved ids and the 1 tombstoned id are 0 rows / 0 emitters, while all 8 live `hicasso-*` controls carry both. The subject id is not singled out; if it were drift, the other four would be too.

The reservation is also still **accurate**, so it has not silently missed its promotion: the only `contenteditable` under `implementation/hicasso/src` is a focus-trap CSS selector (`impl/overlay.cljs:180`), the controlled converge recognises exactly `input` and `textarea` (`impl/controlled.cljs:158`), and the testbed asserts `contenteditable-is-not-a-controlled-field` in terms. Neither fix shape offered applies.

**One real defect did come out of that census, one page over and outside this PR's scope**: `docs/core/hicasso/04-controlled-inputs.md:95` states the same refusal in the present tense — "Binding `:value` to it throws at the source" — and nothing throws. Filed as **rf2-ws00**.

## rf2-luo6 — partially fixed, bead stays OPEN

The published `:local/root` test-kit route prints a Clojure CLI deprecation warning on every build. Measured against the CLI the bead names (1.12.4.1618), three variants on a minimal project:

| Variant | Result |
| --- | --- |
| `:extra-paths ["../kit/src"]` (published shape) | warning reproduced **verbatim**; root on classpath — the control, and it bites |
| `:local/root "../kit"`, no `deps.edn` in `kit/` | **hard failure**: `Error building classpath. Manifest file not found` |
| `:local/root "../kit"` + `kit/deps.edn {:paths ["src"]}` | **no warning**, `kit/src` on the classpath — the answer |

**The durable fix is two files, and variant 2 is why**: `implementation/hicasso/test_kit/` has no `deps.edn` today, so writing the coordinate into the chapter alone would not merely keep warning — it would **break** the published route with a hard classpath error. Step 1 is a new file under `implementation/`, outside this worker's fence and inside a live peer's. Option (2) stays rejected on the artefact `deps.edn`'s own extensively-documented grounds for keeping `test_kit/src` off `:paths`.

So this PR lands option (3) only: one paragraph naming the warning, saying nothing fails, and pointing at the published-coordinate route as the shape that does not warn. It removes the surprise for a pilot reader without pretending the route is clean, and it is strictly compatible with the coordinate route landing later. **The bead stays open, because the warning still prints**; the measured spelling and the two remaining steps are recorded on it.

## Quality gates

All captured exit codes are from the runner's own `$?` redirected to a file on one command line, re-run on the **final post-rebase base**.

| Gate | Exit | Sees which of my files |
| --- | --- | --- |
| `python -m mkdocs build --strict` | **0** (0 WARNINGs) | both — neither is under `exclude_docs` |
| `python scripts/check_doc_slugs.py` | **0** | both |
| `python scripts/check_doc_slugs.py --self-test` | **0** | n/a |
| `python implementation/hicasso/scripts/check_guide_samples.py` | **0** | `15-testing.md` (74 verbs, 378 sites, 29 pages) |
| `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine` | both |

`mkdocs.yml`'s `exclude_docs` holds `tools/playground/`, the two codemod trees, `design/freehand/`, `design/hicasso/` and `design/retirement/`. **Neither of my files is in it**, so the strict build genuinely publishes and validates both. (`design/hicasso/` being excluded is why the pilot workspace page named in rf2-luo6 would need `check_provenance_pins.py` and a hand read, not the strict build.)

**The classifier called this diff documentation**: `--plan` reports `documentation gates: run`, `PLAN docs=true jvm=false node=false`, reason `classified`. It was exercised against a control first — handed `origin/main...HEAD` (a revision, the documented trap) it returns output **byte-identical** to the real-path invocation, both all-false; here that coincides with the truth, since the diff touches none of the 28 gated code surfaces, which makes the trap especially deceptive. A path known to flag (`implementation/core/src/re_frame/core.cljc` gives `implementation_jvm=true`) confirmed the instrument bites. Note the classifier emits no `documentation` key at all; the docs tier keys on documentation content, separately.

`check_readme_links.py --ci` is **not** credited: `docs/` is a docs-gate root, and I touched nothing outside it.

**Both gates were shown to read this worktree by planted faults, not by a reported path**: a broken anchor planted in `docs/api/re-frame.machines.md` took `check_doc_slugs.py` to **exit 1** naming `:574`; a broken link planted in `docs/core/hicasso/15-testing.md` took the strict build to **exit 1** naming `core/hicasso/15-testing.md`. Both faults were reverted and each restore verified by **git blob hash** against the committed object, not by reading a diff.

### Coverage limits

1. **Neither doc gate looks inside fenced code blocks** — both share one extractor that strips fences before reading a link. This matters for rf2-luo6, whose *durable* deliverable is a fenced `deps.edn` snippet that no gate would bear on. The edit that landed is deliberately **prose**, so it sits inside what the gates see; the fenced `deps.edn` block was left untouched and was checked by hand. Separately verified that `docs/core/hicasso/` is **not** digest-pinned the way `docs/core/freehand/` is — `check_guide_samples.py`'s own docstring says "It pins nothing: a prose edit ... is a one-file change with no roster to regenerate."
2. **No gate resolves a symbol or an error id.** All three absence claims were verified by hand against `implementation/` and `spec/009-Instrumentation.md`, each with a control that bites:
   - `machine-has-tag` under any `*/src/` = **0** line-oriented and **0** whitespace-collapsed. Controls: same needle unscoped across `implementation/` = **79**; `:rf.machine/has-tag?` scoped identically = **11**, including the live registration `implementation/machines/src/re_frame/machines.cljc:407`. Repo-wide the two counting modes disagree (**97** vs **117**), so neither is a superset of the other.
   - Reserved/live error-id split as tabulated above. Control: `:rf.error/` in `spec/009-Instrumentation.md` = **617** line-oriented / **958** collapsed.
   - The 27 distinct `:rf.error/hicasso-*` ids emitted under `implementation/hicasso/src` carry no contenteditable refusal and no generic unsupported-controlled-shape refusal.
3. **Nothing validates prose, tables, rendering or nav.** Verified by hand: this diff introduces **0** anchors, **0** table rows, and exactly **1** link (`[re-frame.core.md](re-frame.core.md)`, carried across unchanged from the line it replaced; target resolves, and the strict build confirms it). The testing-ladder table on the page I edited is untouched and consistent at **3 columns** across header, separator and all 5 rows.

Nothing under `.beads/`, `implementation/`, `spec/` or `skills/` is touched, and none of PR #9015's fenced files is edited.
