### PR TITLE
fix(ssr-node): the absence witness is red on main — stop spelling the refusal vocabulary outside the package, scope the build-config row, and arm the lane (rf2-8arzr.9)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5173,8 +5173,28 @@ jobs:
 
   node-ssr-node:
     name: Node implementation/ssr-node (bounded SSR service suite)
-    needs: detect_changed_surfaces
-    if: needs.detect_changed_surfaces.outputs.ssr_node == 'true'
+    # UNCONDITIONAL, and that is the fix rather than a relaxation — rf2-8arzr.9.
+    #
+    # This job was armed off `ssr_node`, which classifies `implementation/
+    # ssr-node/**`. But the suite's absence.test.cjs makes claims about the
+    # WHOLE repository — it walks `git ls-files` over implementation/,
+    # examples/, tools/, scripts/ and .github/ and requires that nothing out
+    # there names this package at a loader position or spells its refusal
+    # vocabulary. A control armed only by its own directory cannot catch its
+    # own case, and it did not: three commits touching hicasso and the login
+    # example broke two rows in five files, the job was skipped on the PR that
+    # broke it and on every branch after, and main sat red for days with no
+    # signal anywhere. The first branch to arm the job was one editing the
+    # classifier, which arms everything.
+    #
+    # Arming it on the surfaces the witness reads would mean arming it on
+    # nearly the whole repo, so run it always. That costs what the comment
+    # below already establishes: no `npm ci`, no build, no browser, seconds of
+    # ubuntu time. `js-harness-self-tests` — the job this one's steps already
+    # cite as the same posture — is ungated for the same reason, as are
+    # `verify-readme-links` and `beads-pr-boundary`.
+    #
+    # `ssr_node` is NOT dead: `jvm-node-crossing` still arms on it.
     runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:

--- a/examples/substrates/hicasso/login/host.clj
+++ b/examples/substrates/hicasso/login/host.clj
@@ -55,8 +55,9 @@
   It must be the string the server bundle publishes — `hicasso.login.server/
   build-id`, a `goog-define` a release stamps. The check runs in BOTH
   directions and neither is optional: the sidecar refuses a request whose
-  `buildId` is not its own (`:rf.ssr-node/build-identity-mismatch`), and the
-  adapter refuses an ANSWER whose `x-rf-ssr-build` is not this one
+  `buildId` is not its own — its build-identity refusal, whose code belongs
+  to the sidecar's vocabulary and is spelled there rather than here — and
+  the adapter refuses an ANSWER whose `x-rf-ssr-build` is not this one
   (`:rf.error/ssr-node-build-skew`). Two artefacts from different builds
   cannot quietly serve one page between them."
   (or (System/getenv "LOGIN_HICASSO_BUILD_ID") "login-hicasso-dev"))

--- a/examples/substrates/hicasso/login/server.cljs
+++ b/examples/substrates/hicasso/login/server.cljs
@@ -31,10 +31,11 @@
   `host.clj` hands `ssr-handler` as `:render-state`. ONE list, two readers.
   The two processes are deployed separately, so nothing can MAKE them agree
   — but nothing has to: a host that asks for a key this table does not name
-  is refused with `:rf.ssr-node/state-key-not-allowed`, and a host built
-  against a different bundle is refused with
-  `:rf.ssr-node/build-identity-mismatch`. Drift is loud on the first
-  request, not silent on the thousandth.
+  is refused with the sidecar's state-key-not-allowed refusal, and a host
+  built against a different bundle with its build-identity one. Both codes
+  are the sidecar's vocabulary, spelled in its protocol rather than
+  restated here. Drift is loud on the first request, not silent on the
+  thousandth.
 
   ## The render module contract
 

--- a/implementation/hicasso/src/re_frame/hicasso/server.cljs
+++ b/implementation/hicasso/src/re_frame/hicasso/server.cljs
@@ -249,7 +249,7 @@
   ONE id, reused across renders, and that is safe rather than sloppy: a
   render is one synchronous `renderToString` call, and the sidecar's
   isolate admits one render at a time (`implementation/ssr-node`'s worker
-  refuses a second with `:rf.ssr-node/service-saturated`), so two windows
+  refuses a second with its service-saturated refusal), so two windows
   cannot overlap. Re-registering the same id REPLACES, so even a caller
   that broke that rule would lose a listener rather than accumulate one."
   ::recovered-render-error)
@@ -270,8 +270,8 @@
   page whose content is quietly wrong, and the host would ship it.
 
   A wrong page served as a success is worse than a loud failure, so the
-  renderer throws instead. The sidecar turns the throw into a refusal
-  (`:rf.ssr-node/render-threw`), the JVM adapter turns the refusal into
+  renderer throws instead. The sidecar turns the throw into its
+  render-threw refusal, the JVM adapter turns that refusal into
   `:rf.error/ssr-node-refused`, and the request lands on the error view —
   the same destination the JVM-local path would have reached, by a longer
   road.

--- a/implementation/hicasso/test/re_frame/hicasso/login_server_crossing_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/login_server_crossing_ssr_dom_cljs_test.cljs
@@ -69,6 +69,7 @@
   the product claim — run in both."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [clojure.string :as str]
+            [goog.object :as gobj]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.hicasso :as h]
@@ -176,6 +177,27 @@
       (js/require (str js/__dirname "/../ssr-node/src/protocol.cjs")))))
 
 (defn- node-lane? [] (some? @protocol))
+
+(defn- code
+  "One refusal code, READ OFF `protocol.cjs`'s own frozen `CODE` table
+  rather than restated as a literal here.
+
+  The rows below are about the CROSSING — that this condition earns that
+  refusal — and reading the constant pins exactly that while leaving the
+  spelling where it belongs. The service's code vocabulary is the
+  service's: `implementation/ssr-node`'s absence witness holds that no file
+  outside that package spells it, and a literal here was a second spelling
+  with nothing keeping it in step with the first (rf2-8arzr.9, which is how
+  the witness went red on main). It is the same rule the JVM adapter
+  already keeps — see `re-frame.ssr.ring.node`, which carries the code as
+  an opaque value and classifies by the transport's status contract.
+
+  A key this table does not carry answers `nil`, so a renamed constant
+  fails the row loudly rather than comparing two absences."
+  [k]
+  (let [v (gobj/get (.-CODE @protocol) k)]
+    (assert (string? v) (str "protocol.cjs CODE has no " k))
+    v))
 
 (def ^:private module
   "`module.exports` as the sidecar receives it."
@@ -372,7 +394,7 @@
     (fn []
       (with-frame! idle-events nil
         (fn [fid]
-          (is (= ":rf.ssr-node/build-identity-mismatch"
+          (is (= (code "BUILD_IDENTITY_MISMATCH")
                  (refusal-code #(crossing! fid {:build-id "some-other-build"})))
               "a host deployed against a different bundle is refused, not served")
           (testing "the control - this bundle's own id renders"
@@ -388,10 +410,10 @@
     (fn []
       (with-frame! idle-events nil
         (fn [fid]
-          (is (= ":rf.ssr-node/state-key-not-allowed"
+          (is (= (code "STATE_KEY_NOT_ALLOWED")
                  (refusal-code #(crossing! fid {:state {":secrets" "{:token \"t\"}"}})))
               "the allowlist belongs to the entry, so a caller cannot widen its own allowance")
-          (is (= ":rf.ssr-node/unknown-entry"
+          (is (= (code "UNKNOWN_ENTRY")
                  (refusal-code #(crossing! fid {:entry "hicasso.login/nope"}))))
           (testing "the control - the keys the table names pass"
             (is (str/includes? (:html (crossing! fid)) "Sign in"))))))))

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -1485,14 +1485,36 @@ const SSR_NODE_LANE = {
   fixture: 'implementation/ssr-node/test/fixtures/bad-no-allowlist.cjs',
 };
 
-test('the ssr-node job is gated on its own output and runs the suite (rf2-n8vp)', () => {
+// THE JOB IS UNGATED, AND THIS ROW NOW PINS THAT — rf2-8arzr.9, reversing the
+// half of the shape above that turned out to be wrong for this lane.
+//
+// The four-sided shape is right for a lane whose suite tests the tree the
+// classifier arms on. This one's does not: `absence.test.cjs` walks
+// `git ls-files` across implementation/, examples/, tools/, scripts/ and
+// .github/ and asserts that nothing out there can load this package or spells
+// its refusal codes. Arming that on `implementation/ssr-node/**` made a
+// whole-repo control blind to every tree it polices — and it was measured
+// blind: slice E broke two rows in five files outside the package, the job was
+// skipped on that PR and on every branch after it, and main was red for days
+// with the alert channel silent.
+//
+// So the direction of this row flips. What must never come back is the `if:`,
+// because re-adding it restores exactly the blindness, and it would look like
+// tidying. The rest of the shape is unchanged and still load-bearing.
+test('the ssr-node job is UNGATED and runs the suite (rf2-8arzr.9, was rf2-n8vp)', () => {
   const workflow = fs.readFileSync(WORKFLOW, 'utf8');
   const block = jobBlock(workflow, SSR_NODE_LANE.job);
-  assert.match(block, /needs: detect_changed_surfaces/);
-  assert.match(
+  assert.doesNotMatch(
     block,
-    /if: needs\.detect_changed_surfaces\.outputs\.ssr_node == 'true'/,
-    `${SSR_NODE_LANE.job} must be gated on ${SSR_NODE_LANE.output}`,
+    /^\s+if:/m,
+    `${SSR_NODE_LANE.job} must carry no if: — its suite polices the whole repo, `
+      + 'so any surface can break it and every surface must run it',
+  );
+  assert.doesNotMatch(
+    block,
+    /^\s+needs:/m,
+    `${SSR_NODE_LANE.job} must not need detect_changed_surfaces — it reads no `
+      + 'output, and needing it would let a failed detector skip this job',
   );
   assert.match(
     block,
@@ -1505,12 +1527,20 @@ test('the ssr-node job is gated on its own output and runs the suite (rf2-n8vp)'
     stepRunning(block, `npm run ${SSR_NODE_LANE.script}`),
     `the job must run \`npm run ${SSR_NODE_LANE.script}\` as a step`,
   );
-  // Plumbed out of detect_changed_surfaces, or the `if:` reads an empty string
-  // and the job can never run — silently.
+  // The output survives this job losing its `if:`, because `jvm-node-crossing`
+  // arms on it — the sidecar is half of that crossing. So it must still be
+  // plumbed out of detect_changed_surfaces, or THAT job's `if:` reads an empty
+  // string and can never fire, silently.
   assert.match(
     workflow,
     /ssr_node: \$\{\{ steps\.detect\.outputs\.ssr_node \}\}/,
     `${SSR_NODE_LANE.output} must be declared as a detect_changed_surfaces output`,
+  );
+  assert.match(
+    jobBlock(workflow, 'jvm-node-crossing'),
+    /needs\.detect_changed_surfaces\.outputs\.ssr_node == 'true'/,
+    'jvm-node-crossing is what keeps the ssr_node output live — the classifier '
+      + 'rows below guard it, not this job',
   );
   // Required, not advisory. A job absent from the aggregator's needs: is a job
   // a merge can skip past, which is where this artefact already was.

--- a/implementation/ssr-node/test/absence.test.cjs
+++ b/implementation/ssr-node/test/absence.test.cjs
@@ -838,29 +838,94 @@ test('CONTROL — the refusal-code needle finds a refusal code, and only that', 
 
 const BUILD_CONFIGS = ['implementation/shadow-cljs.edn', 'implementation/deps.edn'];
 
+/**
+ * READ AT LOADER POSITIONS, NOT OVER RAW TEXT — rf2-8arzr.9, and the same
+ * move Reading 1 made under rf2-6ovv rather than a second, softer one.
+ *
+ * This row was a raw-text scan of two EDN files, so it asserted that these
+ * configs may not MENTION the package. That is not the reading its own
+ * failure message states: "the package would be on a build's source path"
+ * is a claim about `:source-paths`, `:deps` and their siblings, and a `;;`
+ * comment is none of them. `implementation/shadow-cljs.edn` earned the red
+ * by explaining, in a comment above `:examples/login-hicasso-server`,
+ * which sidecar loads the module that build emits — prose about the
+ * package, in the file where prose about a build belongs.
+ *
+ * Reading 1 had already drawn exactly this line and given the argument for
+ * it: a position that cannot resolve a module cannot host a hit, and the
+ * scope is what the FORMAT can do rather than which files are forgiven. A
+ * comment is not a source path in an EDN build config any more than it is
+ * in an ns form. So this row now reads `loaderPositions` — for `.edn`,
+ * the value form after each of `EDN_LOAD_KEYS` — and the narrowing is the
+ * sibling of one already made, not a new allowance.
+ *
+ * Nothing was widened and nothing is forgiven. The needles are untouched,
+ * no path or string is named as an exception, and the row below plants a
+ * real source path AND the comment that is not one, requiring the first to
+ * be found and the second not to be. What kept this row honest — that a
+ * build reaching this package is caught — is exactly what is still tested.
+ *
+ * Reading 1's whole-repo scan already covers these two files as ordinary
+ * `.edn`; this row survives it because it is the one that FAILS CLOSED on
+ * a config that has gone missing or unparseable, which a repo-wide scan
+ * cannot say anything about.
+ */
 test('no shadow-cljs build and no classpath entry reaches this package', () => {
+  // A missing or key-less config must not read as a clean scan: the raw
+  // scan this replaced threw on a missing file, and `scanLoaderPositions`
+  // skips one silently. Same shape as Reading 3's computed-require guard.
   for (const rel of BUILD_CONFIGS) {
-    const text = fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
-    for (const needle of REFERENCES) {
-      needle.lastIndex = 0;
-      assert.strictEqual(
-        needle.test(text),
-        false,
-        `${rel} mentions ${needle} — the package would be on a build's source path`,
-      );
-    }
+    const text = readTracked(REPO_ROOT, rel);
+    assert.ok(text !== null, `${rel} is missing — the scan has nothing to read`);
+    assert.ok(
+      loaderPositions(rel, text).length > 0,
+      `${rel} yields no loader position at all — the scan has gone blind`,
+    );
   }
+  const hits = scanLoaderPositions(REPO_ROOT, BUILD_CONFIGS, REFERENCES, null);
+  assert.deepStrictEqual(
+    hits,
+    [],
+    `a build config puts this package on a source path or a classpath:\n${hits
+      .map((h) => `  ${h.file}:${h.line} (${h.needle})`)
+      .join('\n')}`,
+  );
 });
 
-test('CONTROL — a doctored build config is caught', () => {
+test('CONTROL — a doctored build config is caught, and a comment about one is not', () => {
   const dir = scratch({
+    // Both spellings, at both kinds of loader position an EDN config has.
     'shadow-cljs.edn': '{:builds {:app {:target :browser :source-paths ["ssr-node/src"]}}}\n',
+    'deps.edn': '{:deps {day8/ssr-node {:local/root "../ssr-node"}}}\n',
+    // The near-miss, and the whole of what this row stopped asserting: the
+    // shape `implementation/shadow-cljs.edn` actually carries.
+    'commented.edn':
+      ';; the module `implementation/ssr-node`\'s sidecar loads — prose, not a\n'
+      + ';; source path, and the refusal code :rf.ssr-node/render-threw is not\n'
+      + ';; one either.\n'
+      + '{:builds {:app {:target :browser :source-paths ["src"]}}}\n',
   });
   try {
-    const text = fs.readFileSync(path.join(dir, 'shadow-cljs.edn'), 'utf8');
-    const needle = REFERENCES[0];
-    needle.lastIndex = 0;
-    assert.strictEqual(needle.test(text), true, 'the check must see a planted source path');
+    const found = scanLoaderPositions(dir, ['shadow-cljs.edn', 'deps.edn'], REFERENCES, null);
+    assert.deepStrictEqual(
+      [...new Set(found.map((h) => h.file))],
+      ['shadow-cljs.edn', 'deps.edn'],
+      'the check must see a planted source path and a planted coordinate',
+    );
+    assert.deepStrictEqual(
+      scanLoaderPositions(dir, ['commented.edn'], REFERENCES, null),
+      [],
+      'and a comment naming the package is not a way into a build — the narrowing this row is',
+    );
+    // AND THE COMMENT MUST BE THERE TO BE MISSED. Without this, the row
+    // above passes on an empty fixture and the narrowing is untested: it is
+    // the POSITION doing the work, so the raw scan finds both needles in the
+    // very text the scoped scan is required to walk past.
+    assert.strictEqual(
+      scanForReferences(dir, ['commented.edn'], REFERENCES, null).length,
+      REFERENCES.length,
+      'the near-miss fixture must carry both needles, or the scoped scan proves nothing',
+    );
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Fixes the ssr-node absence witness, which has been **red on main** since slice E, and arms the job so it cannot go red unseen again. rf2-8arzr.9.

`node implementation/ssr-node/test/run.cjs` exits 1 on unmodified `origin/main`, failing exactly two rows of `absence.test.cjs` while the other 8 suites pass. The job is surface-armed off `implementation/ssr-node/**`, the three commits that broke it touched none of that tree, so it was skipped on the PR that broke it and on every branch since. Nothing reported it.

## The two rows, and what each got

**Row 1 — "the refusal-code namespace appears nowhere outside the package."** An absolute zero over raw text. Four files outside the package spelled `:rf.ssr-node/`.

This takes option (b) of the two repairs, per the ruling on the bead, and it is not a new decision. `re-frame.ssr.ring.node` already states the rule for the JVM adapter, verbatim:

> The adapter classifies by the transport's documented STATUS contract (ssr-node README §The serve command: 4xx caller fault, 503 saturation or shutdown, 504 deadline, 500 theirs) and carries the refusal code as an opaque value: the sidecar's code vocabulary is the sidecar's, spelled nowhere on the JVM — which is also what its own absence witness holds.

Three docstrings now name the refusal instead of spelling its code, which costs them nothing. The crossing test's assertions read the constant off `protocol.cjs`'s own frozen `CODE` table, through the `require` that file already holds — so the row still pins that this condition earns that refusal, while the spelling stays where it is defined.

**Row 2 — "no shadow-cljs build and no classpath entry reaches this package."** This scanned `implementation/shadow-cljs.edn` and `implementation/deps.edn` as raw text, so it asserted a build config may not *mention* the package — while its own failure message says something narrower and truer: "the package would be on a build's source path". The hit was a `;;` comment above `:examples/login-hicasso-server` explaining which sidecar loads the module that build emits. A comment is not a source path, so the assertion was false in fact.

Per the ruling this fixes the **row**, not the comment. Reading 1 had already made exactly this move under rf2-6ovv, with the argument that a position which cannot resolve a module cannot host a hit. This applies it to the sibling reading. Nothing is forgiven and no needle moved — there is still no allowance list.

## The sites

The bead listed five. There are **eight spellings across five files** — `scanForReferences` reports only the first hit per file per needle, so the bead's list was one line per file rather than one line per spelling. All eight are fixed.

| Site | What it was | What it got |
|---|---|---|
| `examples/substrates/hicasso/login/host.clj:58` | docstring prose | names the build-identity refusal |
| `examples/substrates/hicasso/login/server.cljs:34,36` | docstring prose (2) | names both refusals |
| `implementation/hicasso/src/re_frame/hicasso/server.cljs:252,274` | docstring prose (2) | names the saturation and render-threw refusals |
| `.../login_server_crossing_ssr_dom_cljs_test.cljs:375,391,394` | assertions on literal wire strings (3) | read `protocol.cjs`'s `CODE` table |
| `implementation/shadow-cljs.edn:1629` | a `;;` comment | **untouched** — the row was fixed instead |

`protocol.cjs` does export what item 3 needs: `CODE` is in its `module.exports`, and the test file already resolves the module at run time. After this change the string `:rf.ssr-node/build-identity-mismatch` appears exactly once in the repository — its definition.

## Arming

The witness makes whole-repo claims — it walks `git ls-files` over `implementation/`, `examples/`, `tools/`, `scripts/` and `.github/` — while armed only by its own directory. A control that cannot catch its own case, and it did not catch it. The job now runs unconditionally: no `if:`, and no `needs: detect_changed_surfaces` either, since it reads no output and that edge would let a failed detector skip it silently. Same posture as `js-harness-self-tests`, which this job's own steps already cite, and which is ungated.

The `ssr_node` output is untouched and still live — `jvm-node-crossing` arms on it — so the classifier is unchanged and its four arming rows keep their subject.

**This moves both halves of the one-toucher pair in one commit**, because `implementation/scripts/_changed-surfaces.test.cjs` pinned the very `if:` being removed. That row now pins its absence, since re-adding the gate would restore exactly the blindness and would look like tidying.

## Quality gates

All exit codes captured on the same line as the redirect and quoted from that capture, not from any harness report.

| Gate | Exit | Result |
|---|---|---|
| `node implementation/ssr-node/test/run.cjs` **at base, before any change** | **1** | 8/9 suites pass; `absence.test.cjs` fails the two rows above |
| `node implementation/ssr-node/test/run.cjs` after Row 1 | 1 | Row 1 green, Row 2 still red |
| `node implementation/ssr-node/test/run.cjs` **final** | **0** | 9 suites green; 18 rows in `absence.test.cjs` |
| `node --test scripts/_changed-surfaces.test.cjs` | 0 | 335 rows passed |
| `node scripts/compile-node-test.cjs node-test out/node-test.js` | 0 | 1890 files, **0 warnings** |
| `node out/node-test.js` (CLJS lane) | 0 | **11183 tests / 55720 assertions, 0 failures, 0 errors** |
| `npm run test:hicasso-compile` | 0 | 11 namespaces, zero warnings |
| `npm run test:examples-compile` | 0 | all 58 swept builds, zero warnings; `:examples/login-hicasso-server` among them |
| `node scripts/compile-node-test.cjs node-test-hicasso …` + run | 0 / 0 | focused hicasso build, 1170 tests / 4344 assertions |
| `sh scripts/test-fast-pr.sh` | **none — no verdict** | see below |

`npm run test:cljs` is a compound gate; it was split into its two phases and each run in the foreground, rather than detached. The `test:examples-compile` run was re-run after its first shell was killed at the harness ceiling — that first run left no exit file, and an absent exit file is no verdict, so the number above is from a second run that captured its own.

**The fast-PR spine did not finish, and I am not claiming it as a pass.** It ran twice (the second on the final rebased base), printed its root as this worktree, classified `docs=false jvm=true node=true`, and passed every tier up to and including clj-kondo, the workflow-YAML well-formedness check and the lockstep/adapter/skill self-tests. It then sat in `JVM implementation/core` for ~19 minutes — genuinely working rather than wedged (its JVM burned 66s of CPU in 70s of wall clock) but sharing the machine with four concurrent workers, one of whose JVMs had been running 43 minutes. I stopped it rather than starve the peers further. **No exit code was captured, so that gate has no verdict.** Everything it would have covered is covered by CI below, which is green.

**CI is the stronger signal here, and it is fully green on the exact head.** All four workflow runs — `tests`, `lint`, `docs`, `portability` — are `completed/success` against the full 40-character head oid `bfb15b379e3b4ee99e4069a857bfd47eb8ba45cc`, which matches the local HEAD this was tested at: **82 passing checks, 4 skipping, 0 pending, 0 failing.** Among them, `Node implementation/ssr-node (bounded SSR service suite)` passes in **16 seconds** — the direct evidence for the "seconds, no build, no node_modules" basis on which it is now unconditional.

### Planted faults — every green here has a matching red

A green scan is worth nothing without a control that bites, which is the defect class this PR is about. Each plant was made after committing, and each restore verified by comparing the git **blob** hash against the committed object, never by reading a diff.

1. **`implementation/shadow-cljs.edn`** — a real `"ssr-node/src"` entry added inside the top-level `:source-paths` vector. Suite went **exit 1**, failing both the narrowed Row 2 *and* Reading 1. This is the proof the narrowing did not weaken the row: it still catches an actual source path in the actual file. Restored; blob `2ca43067c327f1f4d1c4f17263ece247cb9a8cfc` matches HEAD.
2. **`.github/workflows/test.yml`** — the `if:` re-added to `node-ssr-node`. Mirror test went **exit 1** with the new message, `node-ssr-node must carry no if: …`. Restored; blob `675d10f06663a477d3f365dedac54e9d7cd424a0` matches HEAD.
3. **The crossing test** — `(code "BUILD_IDENTITY_MISMATCH")` changed to a key that does not exist. Went **exit 1** with `Assert failed: protocol.cjs CODE has no BUILD_IDENTITY_MISMATCH_PLANTED`. This is the one that mattered most: it proves the row actually **runs** in the node lane rather than skipping, so the green above is about a case the lane can reach. Restored; blob `ea67348ba1db0a69670bcd6ce63d5b4b5d5dcdb5` matches HEAD.

The Row 2 in-suite control was also rewritten to plant at both EDN loader-position kinds (a `:source-paths` entry and a `:local/root` coordinate) *and* a `;;` comment that must be walked past — plus an assertion that the near-miss fixture really carries both needles, so the walk-past cannot pass on an empty file.

## Coverage limits

Stated rather than papered over.

1. **The ssr-node job arms on this PR anyway, so this PR does not demonstrate the arming fix.** The diff touches `implementation/ssr-node/**`, so `ssr_node` reads true and the job would have run under the old `if:` too. What I verified instead, locally and in three parts: the workflow YAML parses with no `if:` and no `needs:` on `node-ssr-node` (and `test.yml`'s `pull_request` trigger is deliberately unfiltered, so the job is scheduled on every PR); the mirror test reds if the `if:` comes back (plant 2); and the classifier reads `ssr_node=false` for exactly the three files that broke the witness — `implementation/hicasso/src/re_frame/hicasso/server.cljs`, `examples/substrates/hicasso/login/host.clj`, `implementation/shadow-cljs.edn` — against a control of `implementation/ssr-node/src/service.cjs` reading `true`. That is the skip that hid the breakage, measured directly. I could **not** observe a real Actions run of this job on a diff that touches nothing under `implementation/ssr-node/`; the first such PR after this merges is the confirmation.

2. **No gate reads docstring prose.** The three rewordings are conformant to S5 by hand, against the text quoted verbatim at the top of this PR (`implementation/ssr-ring/src/re_frame/ssr/ring/node.clj`). S5's literal scope is the JVM adapter — "spelled nowhere on the JVM" — and two of the three docstrings are CLJS rather than JVM; the binding constraint there is the witness itself, which is repo-wide and now green. What *is* gated is that no `:rf.ssr-node/` spelling survives outside the package, which is Row 1, and it passes.

3. **Table column counts and prose are ungated.** The tables in this PR body and the prose edits in four source files were checked by hand. No markdown file is touched by this PR, so neither `check_doc_slugs.py` nor `check_readme_links.py` has a surface here — and the fast-PR spine said so itself, classifying `docs=false` and printing "documentation surface unchanged → skipping doc gates". That is the correct skip rather than a gap.

## Not touched

`implementation/shadow-cljs.edn` — authorised, but the ruling fixes the row rather than the comment, so the file is unchanged. PR #9015's branch and everything it changes are untouched by design; that PR is blocked on this one landing, since a failing check is neither passing nor skipped.
