### PR TITLE
fix(adapters/reagent): linearlite suite was green only because a sibling owned "/" (rf2-k4oe)

### DIFF
--- a/examples/capabilities/resources/resources/core.cljs
+++ b/examples/capabilities/resources/resources/core.cljs
@@ -65,6 +65,11 @@
             ;; route key, so it's loading *both* that makes a route allowed to
             ;; declare `:resources`.
             [re-frame.routing]
+            ;; State machines are an optional artefact too, and the reader
+            ;; machine below (`rf/reg-machine :resources.app/reader`) is the
+            ;; asking's other half — without this require that call throws
+            ;; `:rf.error/machines-artefact-missing` at ns load.
+            [re-frame.machines]
             [re-frame.adapter.reagent :as reagent-adapter]))
 
 ;; ============================================================================

--- a/implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs
@@ -115,12 +115,34 @@
    route entry's ensure + navigation are deterministic without a fetch / browser.
    The capturing managed-HTTP override replaces the example's own demo stub, so
    the test drives success-vs-failure by choosing which reply to replay (rather
-   than via the example's fail-next-write app-db seam)."
+   than via the example's fail-next-write app-db seam).
+
+   THE ORDER MATTERS, AND THE FRAME IS MADE LAST (rf2-k4oe). A `:url-bound?`
+   frame performs a synchronous initial URL sync AT CONSTRUCTION — `make-frame`
+   -> `frame/upsert-frame!`'s post-create hook -> routing's
+   `:routing/on-frame-registered!` -> `reconcile-url-listener!` — and under Node
+   that URL is `\"/\"`, which is where this example registers
+   `:linearlite.app/board` with a BLOCKING `:linearlite/board` route resource.
+   So the route-entry resource plan runs INSIDE `make-frame`. Construct the
+   frame before the `registrar/register!` loop below and that plan finds the
+   `:resource` kind still empty (the reset hook cleared it), records
+   `:transition :error` / `:rf.error/resource-route-plan` on the routing slice,
+   and — because the suite's own `navigate` never re-plans — the error is
+   STICKY: 16 of these 51 assertions read nil, across 7 of the 10 tests.
+
+   In the consolidated `:node-test` bundle that failure is INVISIBLE, which is
+   why it stood: seven in-tree example apps register a route at `\"/\"`, so `\"/\"`
+   resolves to a co-loaded SIBLING's route and this example's board resource is
+   never planned at construction. The suite was therefore green on account of
+   who it sat beside rather than on account of its own subject. Registering
+   everything first and making the frame last removes that dependence entirely,
+   and matches the committed pilot baseline
+   (`docs/design/hicasso/product/pilots/baseline/linearlite/baseline_test.cljs`).
+   Verified by building this suite in a single-app bundle: 16 failures before,
+   0 after."
   []
   (test-support/reinstate-app-registration! not-found-route-row)
   (reset! last-managed-args nil)
-  (rf/make-frame {:id :rf/default :url-bound? true
-                  :doc "linearlite-example default app frame."})
   ;; rf2-h1vqa4: reinstate through `registrar/register!` — NOT a raw
   ;; registrar-atom swap. Image-loaded frames resolve through the SOURCE
   ;; STORE (the default image is assembled from it), and the reset hook's
@@ -133,7 +155,12 @@
   (routing/reset-counters!)
   (resources-route/install-routing-integration!)
   (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil)))
+  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
+  ;; LAST — see the ordering note in the docstring. Everything the frame's
+  ;; construction-time URL sync needs (the reinstated `:resource` / `:mutation`
+  ;; rows, the routing integration, the stubbed fx) is registered above.
+  (rf/make-frame {:id :rf/default :url-bound? true
+                  :doc "linearlite-example default app frame."}))
 
 (defn- isolate-trace-bus-fixture
   "OUTER fixture: keep this resource/mutation-registering suite from leaking


### PR DESCRIPTION
Fixes rf2-k4oe.

`re-frame.linearlite-example-cljs-test` passed in the consolidated `:node-test`
bundle for a reason unrelated to its own subject.

## The mechanism

`init!` created `(rf/make-frame {:id :rf/default :url-bound? true})` **before**
the `registrar/register!` loop that reinstates the `:resource` / `:mutation`
rows the shared fixture's reset hook clears. A `:url-bound?` frame performs a
synchronous initial URL sync at construction (`make-frame` →
`frame/upsert-frame!`'s post-create hook → routing's
`:routing/on-frame-registered!` → `reconcile-url-listener!`), and under Node
that URL is `"/"` — exactly where the example registers
`:linearlite.app/board` with a **blocking** `:linearlite/board` route resource.
So the route-entry resource plan ran *inside* `make-frame`, found the
`:resource` kind still empty, and recorded `:transition :error` /
`:rf.error/resource-route-plan` on the routing slice. The suite's own `navigate`
never re-plans, so the error was sticky and 16 assertions read nil.

**Why it was invisible in-repo.** Seven in-tree example apps register a route at
`"/"`, so in the consolidated bundle `"/"` resolved to a co-loaded *sibling's*
route and this example's board resource was never planned at construction. The
suite's colour depended on which siblings happened to be co-loaded — it was not
evidence about its own subject, and it would have flipped red on an unrelated
co-load change.

## The fix

Register everything first and make the frame last, matching the committed pilot
baseline (`docs/design/hicasso/product/pilots/baseline/linearlite/baseline_test.cljs`,
which already documents *"the frame is made last"*). This removes the masking
dependence rather than hiding it: the diagnostic probe in the bead — moving the
example's route off `"/"` — would also have gone green while leaving the
ordering bug in place, so it is deliberately **not** what landed here.

The ordering constraint and its cause are now written into the `init!`
docstring, so a future edit cannot silently reorder it back.

## Second defect, found by the sweep

`re-frame.resources-example-cljs-test` was green by the same *disease* through a
different organ. `examples/capabilities/resources/resources/core.cljs` calls
`rf/reg-machine :resources.app/reader` but required neither `re-frame.machines`
nor anything pulling it in. State machines are an optional artefact, so that
call resolves only when something else has already loaded it — which, in the
consolidated bundle, something always has. Built alone, the example's own
ns-load throws
`rf/reg-machine requires day8/re-frame2-machines on the classpath`
(`:rf.error/machines-artefact-missing`) before a single test runs.

Every other example that calls `reg-machine` already requires `re-frame.machines`
in the same file; this was the sole omission.

## Co-load masking sweep

The bead's residual question was whether any *other* example suite is green only
by co-load masking. The cheap test is one single-app `:node-test` bundle per app,
so I ran fifteen — each an anchored `^re-frame.<ns>$` `:ns-regexp`, so exactly
one suite and its app are in the bundle.

| suite | tests / assertions | exit | note |
| --- | --- | --- | --- |
| `linearlite-example` | 10 / 51 | 0 | **was 16 failures / 7 of 10 tests** |
| `resources-example` | 9 / 39 | 0 | **was an ns-load throw, 0 tests run** |
| `infinite-feed-example` | 5 / 38 | 0 | same `init!` ordering, but its `"/"` route declares no resources |
| `realworld-resources` | 33 / 286 | 0 | same ordering; `"/"` resources are non-blocking |
| `realworld` (http) | 20 / 389 | 0 | |
| `routing` | 2 / 11 | 0 | |
| `todomvc` | 9 / 30 | 0 | |
| `nine-states` | 6 / 55 | 0 | |
| `flows-example` | 2 / 14 | 0 | |
| `boot` | 5 / 9 | 0 | |
| `login` | 4 / 17 | 0 | |
| `websocket` | 30 / 245 | 0 | |
| `long-running-work` | 5 / 32 | 0 | |
| `crud` | 9 / 33 | 0 | |
| `circle-drawer-undo` | 6 / 31 | 0 | |

155 tests / 1180 assertions across fifteen isolated bundles, all green on the
final rebased base.

**All seven apps that register a route at `"/"` are covered** — `infinite_feed`,
`linearlite`, `realworld_http`, `realworld_resources`, `resources`, `routing`,
`todomvc`. A census of every `reg-route` form under `examples/` (paren-balanced
over flattened text, run against a known-present control first) shows LinearLite
is the **only** app with a *blocking* route resource at `"/"`, which is why it
was the only hard failure of that mechanism. Three other suites share the
`make-frame`-before-`register!` ordering — `infinite-feed-example`,
`realworld-resources`, `resources-example` — and are green in isolation today
only because their `"/"` routes declare no blocking resource. That is latent
rather than broken: adding a blocking resource to any of their root routes would
reproduce this bug exactly. I have left them alone rather than churn three
working suites, and filed the observation as a follow-up.

## Quality gates

Every number below is the exit code captured by the runner itself (`echo $?` to a
file on the same command line), not one reported about the run.

Main moved 56 commits mid-flight. The branch was rebased onto `c06b76dc36` and
the load-bearing gates **re-run on that final base** — both single-app bundles
and `test:cljs`, all captured exit 0 (`10/51`, `9/39` and `11183/55720`, 0
failures each). Those 56 commits touch `implementation/hicasso/**`,
`implementation/scripts/**`, `implementation/ssr-node/**` and
`examples/substrates/hicasso/**` — no overlap with either file this PR changes —
so the remaining rows (`test:browser`, `test:examples-compile`,
`test:adapter-smokes`, `test:bundle-isolation`, `test:cljs-isolation`, the sweep)
were captured on the immediately prior base `690b99309f` and are not re-asserted
for `c06b76dc36`; CI settles those on the merged result.

| gate | captured exit | result |
| --- | --- | --- |
| single-app bundle, `linearlite` — **before fix** | **1** | `Ran 10 tests containing 51 assertions. 16 failures, 0 errors.` |
| single-app bundle, `linearlite` — **after fix** | **0** | `Ran 10 tests containing 51 assertions. 0 failures, 0 errors.` |
| single-app bundle, `resources-example` — **before fix** | **1** | ns-load throw, 0 tests run |
| single-app bundle, `resources-example` — **after fix** | **0** | `Ran 9 tests containing 39 assertions. 0 failures, 0 errors.` |
| co-load sweep, 15 suites | **0** | 155 tests / 1180 assertions, 0 failures |
| `npm run test:cljs` | **0** | `Ran 11183 tests containing 55720 assertions. 0 failures, 0 errors.` |
| `npm run test:browser` | **0** | `Ran 774 tests containing 4203 assertions. 0 failures, 0 errors.` |
| `npm run test:examples-compile` | **0** | |
| `npm run test:adapter-smokes` | **0** | |
| `npm run test:bundle-isolation` | **0** | |
| `npm run test:cljs-isolation` (per-ns) | **0** | all 16 namespaces pass standalone, 190 tests / 700 assertions |
| `scripts/test-fast-pr.sh` | **no captured exit** — see below | every tier green except one environmental step, re-run separately to exit 0 |

**On the spine, stated rather than papered over.** The spine ran for ~61 minutes
under three-way JVM contention on this box and was then killed by the harness
before it could write an exit code, so **it has no captured verdict and I am not
claiming one**. What its log does show, up to the kill: the whole static/drift
tier PASS; `clj-kondo` `errors: 0`; JVM `implementation/core`
`Ran 2175 tests containing 11144 assertions. 0 failures, 0 errors.`; the CLJS
node tier `Ran 11183 tests containing 55720 assertions. 0 failures, 0 errors.`
(identical to the standalone `test:cljs` above); and exactly one `FAIL` line in
359 KB of log — `FAIL per-ns test isolation`.

That one failure was **environmental, and the gate says so itself**: it reported
`INDETERMINATE — 4 of 16 run(s) never became a verdict about their namespace`,
all four exiting `3221225794` (`0xC0000142`, the Windows process-startup
failure), arriving as the contiguous tail its own diagnostics tell you to expect
when something rebuilds `out/node-test.js` underneath the sweep. Its message is
explicit: *"This is NOT a finding about these namespaces."* Re-run on a quiet
box it is green — all 16 standalone, captured exit 0, the row above. The spine
as a whole is therefore left to CI rather than asserted here.

`test:cljs` at 11183/55720 and `test:browser` at 774/4203 are both slightly above
the last recorded figures (11166/55643 and 765/4187); the deltas are trunk
landings and PR #8992's adapter tests, not this change, which adds no tests.

### How the single-app bundle was built

`:ns-regexp` narrowing against the shared `:node-test` build id is what rf2-6t03c
forbids doing directly, so the compile goes through
`scripts/compile-node-test.cjs`'s cache-isolation helper
(`core/test/re_frame/bench/lane_cache.cjs`) rather than invoking shadow-cljs by
hand: cache cleared before **and** after, `:output-to` deleted before compiling,
compile exit status checked, and the `Build completed.` warning tally read and
required to be zero (rf2-4a6ei). One wrinkle worth recording for whoever does
this next: `compile-node-test.cjs` clears the cache *after* compiling, and a
dev-target `:node-test` bundle `SHADOW_IMPORT`s its modules from that same
directory at **run** time — so running the bundle after that script exits dies
with `ENOENT` on `goog.debug.error.js` before a single test executes. The run has
to happen inside the isolated window: clear → compile → **run** → clear.

### Coverage limits

1. **The consolidated bundle is exactly the instrument that hid this defect, so
   the green `test:cljs` above does not establish that either suite is now
   sound.** It establishes only that the fixes broke nothing else. What
   establishes soundness is the single-app bundle, and only for the fifteen
   suites listed — each proves its suite passes on its own subject, with no
   sibling app co-loaded to satisfy a route or an optional artefact on its
   behalf. The two rows that moved from red to green are the controls: they were
   red on this tree before the fix and green after, which is also what proves the
   instrument was reading this worktree.

2. **What the sweep did not cover.** Only suites that load an example app were
   swept; the rest of the `:node-test` lane (~11,000 tests) was not run in
   isolation, and this sweep says nothing about co-load masking among framework
   suites. `re-frame.example-frame-scoping-cljs-test` is excluded by
   construction — it loads seven apps deliberately and cross-app scoping *is* its
   subject, so a single-app bundle of it would be meaningless.
   `ssr-streaming-example`, `realworld-markdown` and the `realworld-shared-*`
   suites load no example app namespace and are outside the mechanism. The three
   latent same-ordering suites named above are green today and were left
   unchanged. A follow-up bead carries the remainder.

3. `scripts/test-fast-pr.sh` is a spine, not a mirror — the required checks it
   does not run are enumerated in `TESTING.md` §"Required checks the fast-PR
   spine does not run" and derived mechanically by
   `scripts/check_fast_pr_gap.py`. CI is the authority for those.
