### PR TITLE
skill(re-frame2): has-tag? sub, CLJS poll-until, the 401 worked-example home, and re-measured spec meta-docs (rf2-17wco, rf2-519x5, rf2-03oes, rf2-7wv5n)

### DIFF
--- a/skills/re-frame2/decision-trees/slice-or-machine.md
+++ b/skills/re-frame2/decision-trees/slice-or-machine.md
@@ -118,7 +118,7 @@ If a reference contradicts the leaf, **the reference wins** — and if it's the 
 - [`pick-a-pattern.md`](pick-a-pattern.md) — pattern choice (orthogonal to state-shape choice).
 - [`../references/state-machines/reg-machine.md`](../references/state-machines/reg-machine.md) — how to author `reg-machine` (states / initial / guards / actions).
 - [`../references/state-machines/regions.md`](../references/state-machines/regions.md) — single-region and `:type :parallel` regions.
-- [`../references/state-machines/tags.md`](../references/state-machines/tags.md) — `:tags` on states + `machine-has-tag?` query.
+- [`../references/state-machines/tags.md`](../references/state-machines/tags.md) — `:tags` on states + the `[:rf.machine/has-tag? <machine-id> <tag>]` subscription.
 - [`../references/state-machines/spawn.md`](../references/state-machines/spawn.md) — `:spawn` and `:spawn-all` for child machines.
 - [`../references/state-machines/history.md`](../references/state-machines/history.md) — `:type :history` re-entry (shallow / deep / default).
 - [`../references/state-machines/cancellation.md`](../references/state-machines/cancellation.md) — the actor-destroy cascade.

--- a/skills/re-frame2/evals/evals.json
+++ b/skills/re-frame2/evals/evals.json
@@ -72,7 +72,7 @@
         "The output calls (rf/reg-machine ...) with a machine-id keyword and a machine-map.",
         "The machine declares :initial, :data, and :states (or :type :parallel + :regions — but for this prompt :initial + :states is the canonical shape).",
         "The machine has at least the five canonical states: :idle, :loading, :fetching, :loaded, :error.",
-        "Each in-flight state carries a :tags set that includes a shared 'in-flight'-style tag (e.g. :tags/in-flight) so a single machine-has-tag? query answers 'anything in flight?'.",
+        "Each in-flight state carries a :tags set that includes a shared 'in-flight'-style tag (e.g. :tags/in-flight) so a single [:rf.machine/has-tag? machine-id tag] subscription answers 'anything in flight?'.",
         "Actions are registered as keyword entries in the top-level :actions map and referenced by keyword from transitions (not exclusively inlined as anonymous fns) — the inspectability bias.",
         "Action functions return an effect-shaped map {:data ...} (and/or {:fx ...}) — not a bare data map.",
         "The output requires re-frame.machines at the namespace top (the artefact load-hook) OR notes that requirement.",

--- a/skills/re-frame2/patterns/boot.md
+++ b/skills/re-frame2/patterns/boot.md
@@ -127,7 +127,7 @@ Each link is a Pattern-AsyncEffect interaction. Past three links, scatter wins; 
 
 ## Variations
 
-**The retry-ownership boundary.** Mixed transport-vs-semantic retry — e.g. auth machine handling 401-then-refresh-then-retry — sits at the boundary between `:rf.http/managed :retry` (transport: backoff + attempt count) and machine transitions (semantic: refresh-then-loop-back-to `:loading-me`). Both compose. See `patterns/managed-http.md`.
+**The retry-ownership boundary.** Mixed transport-vs-semantic retry — e.g. auth machine handling 401-then-refresh-then-retry — sits at the boundary between `:rf.http/managed :retry` (transport: backoff + attempt count) and machine transitions (semantic: refresh-then-loop-back-to `:loading-me`). Both compose. Boundary table → `patterns/managed-http.md`; the worked 401-then-refresh shape (the `:got-401?` guard, the `:refreshing` state, and the loop-back to the *original* request's state) → SKILL-REDIRECT.md → *Pattern — Boot* §Worked example — auth-machine and the retry-ownership boundary.
 
 **Boot UI — single signal.** The snapshot lives in the **runtime-db** partition, so derive from the framework `:rf/machine` sub (which reads runtime-db) rather than reaching into a partition layer-1 subs don't see:
 

--- a/skills/re-frame2/patterns/managed-http.md
+++ b/skills/re-frame2/patterns/managed-http.md
@@ -124,7 +124,7 @@ A single test: **does the retry decision depend on anything other than failure c
 | "Body says `:rate-limited`, wait the hinted delay." | State machine — semantic. |
 | "Retry only if user is still on the page." | State machine — semantic. |
 
-Both layers compose. A machine's `:spawn` spawns a managed request that itself retries 5xx; once that loop terminates the machine sees one `:succeeded` / `:failed` and transitions. The full auth-machine worked example combining 5xx-retry-at-transport AND 401-refresh-at-semantic lives in `patterns/boot.md`.
+Both layers compose. A machine's `:spawn` spawns a managed request that itself retries 5xx; once that loop terminates the machine sees one `:succeeded` / `:failed` and transitions. The full auth-machine worked example combining 5xx-retry-at-transport AND 401-refresh-at-semantic lives in SKILL-REDIRECT.md → *Pattern — Boot* §Worked example — auth-machine and the retry-ownership boundary.
 
 ## Variations
 
@@ -151,13 +151,13 @@ Both layers compose. A machine's `:spawn` spawns a managed request that itself r
 
 `examples/core/managed_http_counter/` — each button issues a managed HTTP request. Covers success (`GET /api/inc.json`), 404 (`:rf.http/http-4xx` with HTML body — NOT `:rf.http/decode-failure` despite `:decode :json`), canned-success stub for retry-recover, and `:request-id` cancellation via `:rf.http/managed-abort`.
 
-For the machine-form wrapper in production, see the auth-flow in `patterns/boot.md`.
+For the machine-form wrapper in production, see the auth-flow worked example — SKILL-REDIRECT.md → *Pattern — Boot* §Worked example — auth-machine and the retry-ownership boundary.
 
 ## Pointers
 
 - Full spec — args map, request envelope, failure categories, reply payload, test stubs (`with-managed-request-stubs`, ships in `re-frame.http.test-support`) → SKILL-REDIRECT.md → *EP — HTTP requests (014)*.
 - Schema-driven decode → SKILL-REDIRECT.md → *EP — Schemas (010)*.
-- Retry-ownership worked example → `patterns/boot.md`.
+- Retry-ownership worked example (401-then-refresh) → SKILL-REDIRECT.md → *Pattern — Boot* §Worked example — auth-machine and the retry-ownership boundary.
 - `:spawn` substrate → SKILL-REDIRECT.md → *EP — State machines (005)*.
 
 ---

--- a/skills/re-frame2/references/cross-cutting/testing-views.md
+++ b/skills/re-frame2/references/cross-cutting/testing-views.md
@@ -40,12 +40,33 @@ For an async settle, poll the re-rendered view with `ts/poll-until` until it mat
 
 ```clojure
 ;; Async — a queued dispatch (HTTP reply, scheduled event, machine :after)
-;; settles past dispatch-sync; poll the re-rendered view.
+;; settles past dispatch-sync; poll the re-rendered view. (JVM shown; on CLJS
+;; poll-until returns a Promise — use the cljs.test/async form below.)
 (deftest status-eventually-ready
   (rf/dispatch [:cart/fetch])                              ;; plain dispatch — queues
   (is (ts/poll-until
         #(= "ready" (h/text-content (h/find-by-testid (cart-view) "status")))
         {:timeout-ms 5000 :label "status ready"})))
+```
+
+On CLJS that `is` would assert the **Promise object**, which is truthy the moment it
+is created — green before the predicate settles, and green again when it later
+rejects. Await it instead:
+
+```clojure
+;; CLJS — compose the Promise under cljs.test/async; assert inside .then.
+(deftest status-eventually-ready-cljs
+  (async done
+    (-> (ts/poll-until
+          #(= "ready" (h/text-content (h/find-by-testid (cart-view) "status")))
+          {:timeout-ms 5000 :label "status ready"})
+        (.then (fn [_]
+                 (is (= "ready" (h/text-content
+                                  (h/find-by-testid (cart-view) "status"))))
+                 (done)))
+        (.catch (fn [e]
+                  (is false (str "poll-until timed out: " (.-message e)))
+                  (done))))))
 ```
 
 `ts/poll-until` opts: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label` (timeout-message tag). **Per-platform shape**: **JVM** synchronous — returns the truthy value, throws `ex-info` (`:rf.error/id :rf.error/poll-until-timeout`) on timeout; **CLJS** returns a `js/Promise` — resolves with the truthy value, rejects on timeout, compose with `cljs.test/async`. For sync runs, a `find-by-testid` / `text-content` walk after `dispatch-sync` suffices — reach for `poll-until` only when the run is genuinely async. Not a substitute for timer-semantics sleeps (grace-period elapse, throttle/debounce window).

--- a/skills/re-frame2/spec/design.md
+++ b/skills/re-frame2/spec/design.md
@@ -12,7 +12,7 @@ Help an AI write working re-frame2 ClojureScript application code while spending
 
 1. **Correctness — recipes over explanations.** Operationalised guidance ("use a machine when X") over abstract principles. The AI reaches for a canonical shape, doesn't derive one. **No verification module** — no `references/verify.md`, no essay on why tests matter (Pillar 4: the AI already knows). What the skill does carry is one line of workflow: on an existing project the agent runs the project's own declared gate after it edits, and reports the result (L3).
 2. **Idiomaticness — verified against `implementation/**` + `examples/**`.** The CLJS reference is the source of truth for *what the API is*. The spec corpus is *why*; it's never quoted for surface claims.
-3. **Context economy — distillation discipline.** `SKILL.md` is a router; one-level-deep leaves carry the depth. Every line costs context every time it loads. SKILL.md targets ~180 lines (well under Anthropic's 500-line ceiling); reference / pattern leaves target ~150, ceiling 250.
+3. **Context economy — distillation discipline.** `SKILL.md` is a router; one-level-deep leaves carry the depth. Every line costs context every time it loads. SKILL.md targets ~180 lines (well under Anthropic's 500-line ceiling); reference / pattern leaves target ~150 lines. Both leaf ceilings — lines *and* bytes — are set once in [`skills/README.md` §Leaf size discipline](../../README.md#leaf-size-discipline); this file defers there rather than restating a partial figure.
 4. **Assume training knowledge — teach only the re-frame2 binding.** The AI already knows what WebSockets, FSMs, optimistic updates, and HTTP retry are. The skill's job is to bridge that to the specific re-frame2 features (`reg-machine`, `:rf.http/managed`, `:fsm/parallel-regions`, etc.). The **cut-test**: if a sentence could be written about React, Vue, or Elm unchanged, it belongs in training data, not this skill.
 
 ## 3. Locked decisions
@@ -72,8 +72,8 @@ Per Mike's standing memory rule "Findings is local-only" — design exploration 
 ### In scope
 
 - ClojureScript application authors writing re-frame2 code.
-- The `reg-*` family — `reg-event` (the one public event registrar), `reg-sub`, `reg-fx`, `reg-cofx`, `reg-flow`, `reg-interceptor`, `reg-view`, `reg-machine`, `reg-route`, `reg-story`, `reg-app-schema`, `reg-resource`, `reg-mutation`.
-- The canonical patterns — RemoteData, Forms, Boot, WebSocket, NineStates, ManagedHTTP, AsyncEffect, LongRunningWork, StaleDetection.
+- The `reg-*` family — `reg-event` (the one public event registrar), `reg-sub`, `reg-fx`, `reg-cofx`, `reg-flow`, `reg-interceptor`, `reg-view`, `reg-machine`, `reg-route`, `reg-story`, `reg-app-schema`, `reg-resource`, `reg-resource-scope`, `reg-mutation`.
+- The canonical patterns — RemoteData, Resources, ResourcesMutations, Forms, Boot, WebSocket, NineStates, ManagedHTTP, AsyncEffect, LongRunningWork, StaleDetection, ReusableComponents, StatefulComponents, FormAction — fourteen, one leaf each under `patterns/`, and the same roster `SKILL.md`'s frontmatter `description` advertises.
 - Frames, regions, tags, machine snapshots, the event-state cycle.
 - Test-authoring (`make-reset-runtime-fixture`, `dispatch-sync`, `compute-sub`, `with-frame`).
 
@@ -94,6 +94,7 @@ skills/re-frame2/
 ├── README.md                    (human-facing intro)
 ├── LICENSE                      (MIT)
 ├── package.json                 (npm metadata)
+├── .claude-plugin/              (plugin manifest — shipped, per package.json files[])
 ├── examples-map.md              (pattern → worked-example cross-ref)
 ├── references/
 │   ├── fundamentals/            (events, fx, cofx, subs, views, flows, schemas, frames, images, event-state-cycle, project-structure)
@@ -109,11 +110,11 @@ skills/re-frame2/
     └── authoring-prompt.md      (one-shot reauthor prompt)
 ```
 
-Each reference / pattern / decision-tree leaf targets ~150 lines; in practice they range ~80–320. The view-test recipe SKILL.md routes to is its own leaf (`cross-cutting/testing-views.md`), so a state-only test session no longer loads it. A typical authoring session reads SKILL.md (~170) + one reference leaf + one pattern leaf ≈ ~480 LoC — well under any reasonable context budget.
+Per-leaf size discipline — the line ceiling *and* the byte ceiling — is set once in [`skills/README.md` §Leaf size discipline](../../README.md#leaf-size-discipline) and is not restated here. In practice the 47 reference / pattern / decision-tree leaves range ~50–320 lines, and a handful currently sit over one or both ceilings. The view-test recipe SKILL.md routes to is its own leaf (`cross-cutting/testing-views.md`), so a state-only test session no longer loads it. A typical authoring session reads SKILL.md (~170) + one reference leaf + one pattern leaf ≈ ~480 LoC — well under any reasonable context budget.
 
 ## 6. Discovery surface (frontmatter `description`)
 
-The `description` is "pushy" per Anthropic best practice — it lists every re-frame2 surface that should trigger discovery: `reg-event` (the one event form — EP-0018), `reg-sub`, `reg-fx`, `reg-cofx`, `reg-flow`, `reg-view`, `reg-machine`, `reg-route`, `reg-story`, `reg-app-schema`, `dispatch`, `subscribe`, `app-db`, `flows`, `frames`, `regions`, `tags`, `managed HTTP`, `RemoteData lifecycles`, plus the natural-language framing "writing tests for a re-frame2 app". The description also explicitly carves out the adjacent skills (`re-frame2-pair`, `re-frame2-setup`) so the AI routes correctly.
+The `description` is "pushy" per Anthropic best practice — it lists every re-frame2 surface that should trigger discovery: `reg-event` (the one event form — EP-0018), `reg-sub`, `reg-fx`, `reg-cofx`, `reg-flow`, `reg-view`, `reg-machine`, `reg-route`, `reg-story`, `reg-app-schema`, `dispatch`, `subscribe`, `app-db`, `flows`, `frames`, `regions`, `tags`, `managed HTTP`, `RemoteData lifecycles`, `reg-resource`, `reg-mutation`, `the nine UI states`, cached server-state / query-cache / TanStack-Query shapes, state-machine-for-HTTP shapes, plus the natural-language framing "writing tests for a re-frame2 app". The list itself is maintained in `SKILL.md`'s frontmatter; this section describes its shape rather than holding a second copy that can drift. The description also explicitly carves out the **five** adjacent skills — `re-frame2-pair` (live-app inspection), `re-frame2-setup` (greenfield bootstrap), `re-frame-migration` (v1→v2), `reagent-migration` (porting Reagent views onto Hicasso), and `re-frame2-implementor` (porting re-frame2 itself) — so the AI routes correctly.
 
 ## 7. Anti-patterns the skill explicitly resists
 

--- a/skills/re-frame2/spec/inputs.md
+++ b/skills/re-frame2/spec/inputs.md
@@ -20,7 +20,7 @@ Specific files the leaves lean on:
 - `implementation/core/src/re_frame/test_support.cljc` — `make-reset-runtime-fixture`, `snapshot-registrar` / `restore-registrar!`, `assert-path-equals`, `poll-until`.
 - `implementation/core/src/re_frame/substrate/plain_atom.cljc` — JVM-side adapter.
 - `implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs` — `frame-provider`, plain-Reagent-fn warning.
-- `implementation/machines/src/re_frame/machines.cljc` — `reg-machine`, `:spawn`, parallel regions, tags.
+- `implementation/machines/src/re_frame/machines/**` — the 33-file machine artefact (`transition`, `parallel`, `spawn_order`, `timer`, `tooling`, `lifecycle_fx/`, …): `:spawn`, parallel regions, tags. `machines.cljc` beside it is the façade that re-exports that tree — read it for the public surface, the sub-namespaces for behaviour. The `reg-machine` / `defmachine` **macros** live in `implementation/core/src/re_frame/core.cljc`, not here.
 - `implementation/http/src/re_frame/http.cljc` — `:rf.http/managed`, failure categories, request stubs.
 
 ## 2. Secondary input — `examples/**`
@@ -58,7 +58,7 @@ Used for *why*, not *what*. The leaves cite EPs by name for design rationale (fr
 
 These shape the skill's voice and structure but aren't quoted directly.
 
-- **`ai/findings/re-frame2-skill-design-v2.md`** — the design rationale captured during the v2 redesign. Sources Q14 (no verification module), the four pillars, the cut-test, the routing model.
+- **`ai/findings/re-frame2-skill-design-v2.md`** — the v2 redesign rationale: the four pillars, the cut-test, the routing model. **Historical, and not available in a clone** — the `ai/` tree is local-only and untracked (per L11), so a fresh reauthoring session cannot read it; design.md §2–§3 carry everything it fed. It also sourced the original **Q14 — no verification module** posture, which was **unlocked on 2026-08-31**: see design.md L3 *History*. Do not reproduce Q14 as a live constraint.
 - **`skills/re-frame-migration/spec/**`** + **`skills/re-frame2-implementor/spec/**`** — the existing `spec/` triad pattern (design / inputs / authoring-prompt). This skill's spec/ mirrors that shape.
 - **`SKILL-REDIRECT.md`** (repo root) — the canonical pointer table the leaves redirect to for deep-dive content.
 - Anthropic skills guidance — `name` ≤ 64 chars, lowercase + hyphens; `description` "pushy"; SKILL.md under ~500 lines; leaves one level deep; avoid time-sensitive content (deferred to lookup leaves like `references/deps-versions.md` in the sibling setup skill).


### PR DESCRIPTION
Four beads in the `skills/re-frame2` lane, one PR. Every premise was checked at source before editing; three of the beads' own figures had moved and are corrected here rather than copied. Write scope was `skills/re-frame2/**` only — no `spec/**`, `implementation/**` or `.beads/**` change. The worker-worktree guard ran and exited 0.

`rf2-ytkt` was fenced off and is untouched: `references/state-machines/reg-machine.md` and `spawn.md` are not in this diff.

## 1. `machine-has-tag?` — the census (rf2-17wco, skills half)

**Ground truth, verified independently of the bead.** `git grep -F machine-has-tag -- 'implementation/*/src'` returns **no hits at all** — no source namespace defines such a function. The shipped surface is the runtime sub registered at `implementation/machines/src/re_frame/machines.cljc:407`. The skill's own `references/state-machines/tags.md:47` already said "there is no named-read-sugar fn layered over it", so both carriers contradicted the leaf they pointed at.

**Instruments — three, because none is a superset of the others.**

| pass | instrument | carriers in `skills/` | control |
|---|---|---|---|
| line-oriented | `git grep -n -F 'machine-has-tag' -- skills/` | 2 | `-F 'has-tag?'` → **30 lines / 17 files**, so it bites |
| whitespace-collapsed | per-file `re.sub(r"\s+"," ")` over `git ls-files` | 2 | `has-tag?` → **41 occurrences / 17 files** |
| whitespace-stripped | per-file `re.sub(r"\s+","")` | 2 | asserted self-test on a hyphen-broken probe before running |

The third pass exists because the self-test **found a real blind spot in the second**: collapsing whitespace to a *space* turns a token broken at its hyphen into `machine-has- tag?`, which the needle no longer matches. The stripped pass asserts, before it scans, that it finds `machine-has-tag` in the probe `"a single machine-has-\ntag? query"`; the run aborts if that assertion fails. All three passes agree, and after the edit all three read **zero** in `skills/`.

**Carriers found and fixed (both in scope):**

- `decision-trees/slice-or-machine.md:121` — the bead's named site.
- `evals/evals.json:75` — the third carrier, named only in a bead note, not in the description.

Both now name the `[:rf.machine/has-tag? <machine-id> <tag>]` subscription, matching the wording already landed at `spec/005-StateMachines.md:530`.

**Carriers outside this PR's write scope, reported not fixed.** The repo-wide stripped pass returns 121 occurrences across 16 files. Classified:

- **Real residuals, out of scope:** `examples/patterns/nine_states/README.md:102` ("control buttons disable themselves by asking `machine-has-tag?`") and `examples/patterns/websocket/connection.cljs:773` (presents `rf/machine-has-tag?` as live "sugar"). Both assert the retired fn as real. Worth a follow-up bead against `examples/`.
- **Correct, leave alone:** `docs/machines/tags.md` names the fn only to *deny* it ("There is no `machine-has-tag?` function") and keeps a back-compat `<a id="querying-with-machine-has-tag">` anchor that `scripts/check_doc_slugs.py:575` allowlists.
- **Deliberate records, must not be "cleaned up":** `spec/api-manifest-metadata.edn:816` (the retirement record for the removed facade sugar) and the private `defn-` test helpers in three adapter test namespaces plus `derivation_graph_test.clj` / `tags_test.clj`.
- `docs/EP/EP-0002` and `docs/tools/playground/**` also carry the name; both are outside this lane.

A note on method: an early repo-wide listing was piped through `tail -12`, which silently hid the `docs/` rows. The table above is from the untruncated run.

## 2. Testing-leaf audit residual (rf2-519x5)

The description's six items shipped in #9004 and the shared-import fix in #9022; the live instruction was the `MERGED-PR AUDIT #9022` note, which is what this addresses.

**Premise verified at source.** `implementation/core/src/re_frame/test_support.cljc` carries two reader-conditional arms: `:1019` (JVM — returns the truthy value, throws on timeout) and `:1055` (CLJS — *"Returns a `js/Promise` that resolves … or rejects"*). `references/cross-cutting/testing-views.md` asserted `(is (ts/poll-until …))` with no platform label, so on CLJS `is` saw a truthy Promise the instant it was created: green before the predicate settled, and green again when it later rejected.

The JVM fence is now labelled *JVM shown* and an awaited `cljs.test/async` `.then`/`.catch` form sits beside it, mirroring `spec/008-Testing.md` §Pattern 5 (which carries the identical in-fence label) and its `#### poll-until example`. No CLJS sample asserts a Promise directly.

**Fences are invisible to the link gates, so this deliverable was verified by running a real reader.** All 6 `clojure` fences in the leaf (8 forms) parse under `clojure.core/read` with `:read-cond :allow`, exit 0; a deliberately unbalanced control returned exit 1 ("EOF while reading"), so that zero is earned.

## 3. The 401-refresh worked example (rf2-03oes)

**All three claims verified, with line numbers re-derived** — the bead's `boot.md:264,298` predate PRs #8989/#8995/#8999 and are now `:130,:164`.

- `managed-http.md:127,154,160` promised the worked example to `patterns/boot.md`. ✔
- `boot.md:130,164` pointed back at `patterns/managed-http.md`. ✔
- Neither leaf contained the example; `spec/Pattern-Boot.md:272` §*Worked example — auth-machine and the retry-ownership boundary* does — the `:got-401?` guard (`:326`), `:failed → :refreshing` (`:342`), and the `:refreshing → :loading-me` loop-back (`:350`) that is precisely the trap the leaves could not convey. ✔

**Shape chosen: (b) — one home, pointers to it.** `managed-http.md` was already **14956 bytes, 91% of the 16 KB per-leaf ceiling**; lifting a ~35-line worked example in would have breached it, and a duplicated worked example is exactly the content a later split has to pull back out. `boot.md` already routed `SKILL-REDIRECT.md → *Pattern — Boot*` for auth-machine retry-ownership, so the home was half-declared already.

**The example is not duplicated — it stays only in the spec.** `managed-http.md` now contains **no reference to `boot.md` at all**. `boot.md`'s three remaining references to `managed-http.md` are the umbrella link (`:5`), the boundary *table* (`:130`) and the boundary pointer (`:164`); none promises a worked example. A census for `retry-ownership|auth-machine|401` across the rest of the skill found no other carrier of the promise.

## 4. `spec/design.md` + `inputs.md` — all five drifts re-measured (rf2-7wv5n)

| # | bead's figure | re-measured at this base | action |
|---|---|---|---|
| 1 | 9 of 14 patterns | `patterns/` ships **14**; §4 listed **9** | listed all fourteen |
| 1b | roster lacks `reg-resource-scope` | confirmed — it is a real registrar (`patterns/resources.md` §Named scope resolvers) | added |
| 2 | "`testing.md` the one over-ceiling leaf"; `privacy-and-elision.md` 258; 22 of 50 leaves over 16 KB | wording **already gone**; **three** leaves now exceed 250 lines (`testing.md` 320, `websocket.md` 275, `privacy-and-elision.md` **268**); **14 of 47** exceed 16 KB; range is **~50–320**, not ~80–320 | deferred to `skills/README.md` §Leaf size discipline instead of restating any number |
| 2b | §5 tree omits `.claude-plugin/` | confirmed — `package.json` `files[]` ships it | added to the tree |
| 3 | §6 omits several triggers; carve-outs 2 vs 5 | carve-outs confirmed **2 → 5**; missing triggers confirmed | fixed; §6 now points at the frontmatter rather than holding a second copy |
| 3b | description carries `reg-interceptor` | **premise does not hold** — the shipped description does not list it (it appears in §4's `reg-*` roster, a different section) | not added |
| 4 | `machines.cljc` is a façade over a 33-file tree; macros at `core.cljc:644-731` | façade confirmed by its own docstring ("Public surface re-exported from the sub-namespaces"); tree is **exactly 33 `.cljc` files**; macros at `core.cljc:647` / `:695` | rewritten |
| 5 | `ai/` untracked; Q14 unlocked | `git ls-files ai/` returns nothing; `design.md:36` records Q14 unlocked 2026-08-31 | marked historical; Q14 no longer cited as live |

Two traps avoided, both flagged by the dispatch:

- **`SKILL.md`'s "500-line ceiling" is left untouched.** That is the *orchestrator* ceiling (`skills/README.md`: "`SKILL.md` orchestrators SHOULD be ≤500 lines"), a different number from the ≤250-line leaf ceiling, and it is stated correctly.
- **Following the bead's own list would have regressed the skill.** Its enumeration of the five missing patterns names `SSR-Loaders`, but `patterns/ssr-loaders.md` was deleted by #8989 — adding it back would have re-introduced a dead pattern.

The eleven `L1`–`L11` lock statements in §3 are untouched. One deliberate edit sits outside the bead's `§4/§5/§6` summary: §2 Pillar 3 was the *primary* site restating a line-only ceiling (the bead names it explicitly as "more importantly"), so it now defers as well. The pillar's substance is unchanged.

**Size note, stated rather than hidden:** `spec/design.md` grew 15665 → 16911 bytes, over the 16 KB figure. It is a `spec/` meta-doc carrying the "not loaded during normal skill operation" banner, not a leaf — the ceiling in `skills/README.md` governs `references/` / `patterns/` / `decision-trees/` leaves, all of which stay within it here. Flagging it in case the maintainers want the meta-docs held to the same bar.

## Gates

Every gate run in the foreground, unfiltered, exit code captured on the runner's own command line and **re-run on the final rebased base** (`8b617dd529`):

| gate | exit |
|---|---|
| `check_skill_re_frame2_drift.py --verbose --ci` | 0 |
| `check_skill_re_frame2_drift.py --self-test` | 0 (all cases passed) |
| `check_doc_slugs.py` | 0 |
| `check_skill_eval_docs.py --ci` | 0 |
| `check_skill_eval_packaging.py` | 0 |
| `check_skill_package_refs.py --ci` | 0 |
| `check_skill_redirect_anchors.py` | 0 |
| `test-fast-pr.sh` | 0 |

**`--plan` on this diff:** `documentation gates: run`, `reason: classified`, JVM / node / clj-kondo tiers skipped. The documentation tier therefore did run — the log carries `--- documentation surface changed → running link/anchor/status gates ---` — so the two link validators are genuinely exercised here rather than skipped past.

**Both silent gates were shown to read this worktree, by planted fault rather than by assumption** (the spine and `--plan` print their gate root, which named this worktree; the two Python gates print none):

- A bead id planted at the line already being edited in `slice-or-machine.md` turned `check_skill_re_frame2_drift.py` **red, exit 1**, naming `slice-or-machine.md:121: BEAD-ID-LEAK: rf2-17wco`.
- A broken anchor planted on the two `skills/README.md` deferral links turned `check_doc_slugs.py` **red, exit 1**, naming `design.md:15` and `design.md:113`.

Both faults existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green. Both restores were verified by **git blob hash** against the committed object, not by reading a diff: `slice-or-machine.md` back to `494da5572258af090e5cce55205e6215e11f2536` and `design.md` back to `f1d7e912c6922cf91bdd397ba48f795b0a99ab38`, with the gates green again afterwards.

### Gates that do NOT cover this skill

Named because their names invite the assumption that they do:

- `check_skill_implementor_order.py` and `check_skill_implementor_partition_drift.py` — `SKILL_DIR = skills/re-frame2-implementor`.
- `check_skill_xray_tab_inventory_drift.py` — `SKILL_DIR = skills/re-frame2-xray`.
- `check_skill_pair_authoring_drift.py` — guards `skills/re-frame2-pair/spec/{design,inputs,authoring-prompt}.md`. This is the direct analogue of item 4's subject, but for the *pair* skill: **`skills/re-frame2/spec/design.md` and `inputs.md` have no equivalent content gate**, which is why item 4's drift accumulated unnoticed.
- `check_skill_setup_counter_drift.py` (`re-frame2-setup`), `check_skill_mcp_drift.py` (`re-frame2-pair-mcp`), and the three `check_skill_migration_*` gates (`re-frame-migration`).

### Hand verification, because nothing validates prose

`check_doc_slugs.py` strips fenced code blocks before it reads a link, so it says nothing about the fenced Clojure that is the substance of item 2 — hence the real-reader parse above. Nothing validates prose, tables or rendering at all. Verified by hand: the `spec/Pattern-Boot.md` §*Worked example — auth-machine and the retry-ownership boundary* heading text is quoted exactly as it appears at `:272`; the `SKILL-REDIRECT.md` *Pattern — Boot* entry exists at `:96`; the new §4 table in this description and the `.claude-plugin/` tree row keep their column and box-drawing alignment; and `evals/evals.json` still parses as JSON after the edit.

All seven touched files keep CRLF line endings unchanged (verified by counting CRLF vs bare LF before and after each edit), and the diff is 36 insertions / 14 deletions across those seven files with no incidental reflow.

Closes rf2-17wco, rf2-519x5, rf2-03oes, rf2-7wv5n.
