### PR TITLE
skill(re-frame2-pair)+examples: state the raw-eval carve-out locally; name the has-tag? sub (rf2-wgvyx, rf2-1e8m)

### DIFF
--- a/examples/patterns/nine_states/README.md
+++ b/examples/patterns/nine_states/README.md
@@ -99,10 +99,10 @@ lifecycle that shares the machine's `:data` map with its siblings:
   homes.)
 - `:mode` region — the live/archived axis: `:active → :done`.
   `:done` is terminal and tagged `:mode/read-only`. The form and the
-  control buttons disable themselves by asking `machine-has-tag?` for
-  `:mode/read-only` — ask, don't tell. The view never needs to know
-  which state of which region carries the read-only intent; it asks a
-  question and gets a yes/no.
+  control buttons disable themselves by asking
+  `[:rf.machine/has-tag? :ui/nine-states :mode/read-only]` — ask, don't
+  tell. The view never needs to know which state of which region carries
+  the read-only intent; it asks a question and gets a yes/no.
 
 Every state declares `:tags` for its per-axis intent. The
 `render-priority` table over those tags is the one place the page's

--- a/examples/patterns/websocket/connection.cljs
+++ b/examples/patterns/websocket/connection.cljs
@@ -770,10 +770,10 @@
     (fn [snap _] (:state snap)))
 
   ;; One little yes/no sub per tag. Each chains off the FRAMEWORK sub
-  ;; `:rf.machine/has-tag?` (sugar: `(rf/machine-has-tag? :ws/connection
-  ;; tag)`), which returns the snapshot's tag-containment bit directly — so a
-  ;; view can ask "connected?" and get a boolean without unpacking the
-  ;; hierarchical `:state` vector or re-reading the snapshot itself.
+  ;; `:rf.machine/has-tag?`, which returns the snapshot's tag-containment bit
+  ;; directly — so a view can ask "connected?" and get a boolean without
+  ;; unpacking the hierarchical `:state` vector or re-reading the snapshot
+  ;; itself.
   ;; See docs/machines/glossary.md#state-tag.
   (rf/reg-sub :ws/connecting?
     :<- [:rf.machine/has-tag? :ws/connection :websocket/connecting]

--- a/skills/re-frame2-pair/references/screen-reads.md
+++ b/skills/re-frame2-pair/references/screen-reads.md
@@ -1,6 +1,8 @@
 # Reading what's on screen
 
-The **what is on screen, and why did it render** half of the op vocabulary, split out of [`ops.md`](ops.md) so a read/dispatch/trace/time-travel session does not load it and a screen-read session does not load the whole catalogue. Same transport, same conventions as `ops.md` — including its [privacy carve-out](ops.md#operations-catalogue) for raw `eval-cljs` forms.
+The **what is on screen, and why did it render** half of the op vocabulary, split out of [`ops.md`](ops.md) so a read/dispatch/trace/time-travel session does not load it and a screen-read session does not load the whole catalogue. Same transport, same conventions.
+
+> **Raw `eval-cljs` is un-elided — the carve-out, stated here so you need no second leaf.** The `dom/*` rows in §DOM source bridge below are raw `eval-cljs` forms. `eval-cljs` is default-ON (gated only by `--no-eval`) and is **not** governed by the `--allow-sensitive-reads` gate: it returns the form's value **without** running the wire-boundary elision walker, so whatever those forms read ships verbatim — rendered user text and attribute values included. The structured `read-dom` / `read-ui` tools do the opposite, capping and eliding per node at the source (`:rf.size/large-elided`), and `read-ui`'s `:text` additionally routes through `elide-wire-value`. So when the screen may carry privacy-sensitive content, prefer the structured tool; reach for a raw `dom/*` eval for that content only on explicit user/operator request. This is the same raw-eval carve-out as [SKILL.md §Style guidance](../SKILL.md), which is always loaded.
 
 Three doors, in the order you usually need them:
 

--- a/skills/re-frame2-pair/tests/prompts/prompt_regression_test.clj
+++ b/skills/re-frame2-pair/tests/prompts/prompt_regression_test.clj
@@ -304,14 +304,24 @@
         "ops.md must still name the raw trace-buffer / epoch-history surfaces the carve-out governs."))
   ;; screen-reads.md was split out of ops.md under rf2-wgvyx and took the raw
   ;; `eval-cljs` DOM rows with it, so the carve-out no longer sits "above" them
-  ;; in the same file. The new leaf must keep a pointer back to it.
-  (testing "screen-reads.md points back at ops.md's raw-eval privacy carve-out"
-    (is (and (includes-ci? @screen-reads-md "privacy carve-out")
-             (str/includes? @screen-reads-md "ops.md"))
+  ;; in the same file. The leaf must therefore state the CONSEQUENCE itself.
+  ;; Pinning a pointer back to ops.md instead would lock in a
+  ;; SKILL -> screen-reads -> ops load chain, which skills/README.md and
+  ;; spec/authoring-prompt.md ("no SKILL -> A -> B chains") both forbid — and a
+  ;; mere substring test for "ops.md" is satisfied by the provenance sentence
+  ;; ("split out of ops.md") while the safety rule itself is absent.
+  (testing "screen-reads.md states the raw-eval un-elided rule locally"
+    (is (and (includes-ci? @screen-reads-md "un-elided")
+             (includes-ci? @screen-reads-md "eval-cljs"))
         (str "references/screen-reads.md carries raw `eval-cljs` DOM rows but no "
-             "longer points at ops.md's privacy carve-out — a reader who loads only "
-             "this leaf would not learn that those forms return un-elided values "
-             "(rf2-wgvyx)."))))
+             "longer states locally that those forms return un-elided values — a "
+             "reader who loads only this leaf must learn the carve-out HERE, not by "
+             "opening a second leaf (rf2-wgvyx)."))
+    (is (not (str/includes? @screen-reads-md "(ops.md#operations-catalogue)"))
+        (str "references/screen-reads.md routes its raw-eval safety rule into "
+             "ops.md, so a screen-read task loads SKILL.md -> screen-reads.md -> "
+             "ops.md — the leaf-to-leaf chain skills/README.md and "
+             "spec/authoring-prompt.md forbid (rf2-wgvyx)."))))
 
 ;; ---------------------------------------------------------------------------
 ;; MCP-surface conformance drift


### PR DESCRIPTION
Two beads, one PR. **Item 1's ruled action turned out to be already done at tip** — reported below with the evidence — so what landed for it is the bead's other live acceptance criterion. Item 2 is fixed in full.

## Item 1 — rf2-wgvyx: the Hicasso split was ALREADY DONE; the leaf-to-leaf chain was not

**The premise does not hold.** The ruling asked me to split the Hicasso-evidence block out of `ops.md` "the same way the screen-read block came out". It came out *with* the screen-read block, in the same commit.

`eaf6591310` ("split the screen-read block out of ops.md (rf2-wgvyx)", merged 2026-09-02) removed 105 lines from `ops.md` and created `screen-reads.md` with 106 — carrying all three sections the bead's own RECOMMENDATION nominated: DOM source bridge, `read-dom` vs `read-ui`, **and** Hicasso evidence. At tip:

- `ops.md` contains no Hicasso content. Its only match for `hicasso` (case-insensitive) is line 19, a §Contents row pointing at `screen-reads.md#hicasso-evidence-…` — exactly the "one-line row per moved section" the recommendation prescribed.
- `screen-reads.md` carries the full `## Hicasso evidence — mounted boundaries, read attribution, render cause` section (7 `hicasso` matches).

`ops.md`'s remaining headings are Read / Frames / Write / Trace / Live watch / Signal recording / Hot-reload coordination / Time-travel / Dropped from v1 — precisely the "**Catalogue (keep together, locked)**" list the bead itself locked, and which the bead's RECOMMENDATION addresses explicitly: "Do NOT split hot-reload or the v1 map (locked + tested), and do not split the op tables". So there is no second block to lift, and I did not invent one.

Per the ruling's own STOP clause I measured and stopped rather than trimming teaching to reach a number.

### Figures (LF-normalised bytes), against the bead's stale ones

| File | Bead DESCRIPTION says | Before (my base `7da2a538e6`) | After |
|---|---|---|---|
| `references/ops.md` | 318 lines / 63,758 B | 220 lines / 46,461 B | **220 lines / 46,461 B** (untouched) |
| `references/screen-reads.md` | (did not exist) | 106 lines / 18,832 B | **108 lines / 19,670 B** |

The description's figures are stale by 98 lines / 17,297 bytes, as the bead's own re-measurement note already recorded. `ops.md` is unchanged by this PR.

### What DID land for this bead

The bead's ACCEPTANCE CRITERIA carry a second obligation, from the PR #9013 audit note, which was still unmet at tip:

> screen-reads.md locally states that raw eval-cljs returns un-elided values and does not require loading ops.md to learn that safety rule; the prompt regression pins the local rule without enforcing a leaf-to-leaf chain

Both halves were live defects. `screen-reads.md:3` read "Same transport, same conventions as `ops.md` — including its [privacy carve-out](ops.md#operations-catalogue) for raw `eval-cljs` forms", and the assertion required `screen-reads.md` to contain both `"privacy carve-out"` and `"ops.md"` — locking in the `SKILL.md -> screen-reads.md -> ops.md` chain that `skills/README.md` and `spec/authoring-prompt.md:49` ("no SKILL -> A -> B chains") forbid, and which this bead's own close claim contradicted.

- `screen-reads.md` now states the consequence **locally**: raw `eval-cljs` is default-ON, is not governed by `--allow-sensitive-reads`, and returns values without the wire-boundary elision walker — with the contrast against `read-dom`/`read-ui`, which cap and elide at the source. It points at `SKILL.md §Style guidance`, which is *always loaded*, so no second leaf is required.
- The assertion now pins that local rule and **forbids** the chain link. Worth noting why the old form was weak independently of the chain: a bare substring test for `"ops.md"` is satisfied by the provenance sentence ("split out of `ops.md`") even when the safety rule is entirely absent.

The other acceptance criteria were already met at tip and I verified rather than assumed: `spec/design.md:120,137` and `spec/authoring-prompt.md:34` both list the leaf.

### Routing — no `SKILL.md -> A -> B` chain

`SKILL.md` routes to `screen-reads.md` as a **sibling**, four times, all one level deep:

- `181` — prose: screen reads "are their own leaf (`screen-reads.md`)"
- `186` — `| Pick a screen-read op … | references/screen-reads.md |`
- `189` — `read-ui` / `read-dom` -> `screen-reads.md#view--rendered-content--producing-entity-uiread`
- `190`, `191` — the Hicasso doors -> `screen-reads.md#hicasso-evidence--mounted-boundaries-read-attribution-render-cause`

`ops.md` links to `screen-reads.md` only from its §Contents (lines 17-19) as post-split signposts, never as the routing path. `grep -c -F '(ops.md#operations-catalogue)' references/screen-reads.md` is now **0**.

### Still open, and NOT re-argued here

The ruling refused the catalogue exemption for this leaf, but `ops.md` is still 46,461 B — 2.8x the 16 KB ceiling — and every remaining section is one the bead forbids splitting. Meanwhile `skills/re-frame2-pair/spec/design.md:135` and `spec/authoring-prompt.md:49` both still grant `ops.md` the exemption in writing. That is a real contradiction between the ruling and the package's own spec, and resolving it needs a maintainer decision about which locked section moves — not a worker's reflex. Filed as a follow-up rather than actioned.

## Item 2 — rf2-1e8m: `machine-has-tag?` in two examples

Both fixed, matching the wording already in the tree rather than inventing phrasing — `spec/005-StateMachines.md:530` (`[:rf.machine/has-tag? <machine-id> <tag>]` subscription) and `docs/machines/tags.md:101` ("The membership question is `[:rf.machine/has-tag? machine-id tag]`").

- `examples/patterns/nine_states/README.md` — "asking `machine-has-tag?` for `:mode/read-only`" becomes "asking `[:rf.machine/has-tag? :ui/nine-states :mode/read-only]`". The machine id is the real one: `core.cljs:438` registers `:ui/nine-states`, and `core.cljs:742,759` already use exactly this subscription vector, so the README now matches the code beside it.
- `examples/patterns/websocket/connection.cljs` — the `sugar: (rf/machine-has-tag? :ws/connection tag)` parenthetical is **dropped outright** rather than reworded, per the bead's explicit fix shape.

### `connection.cljs:773` is a COMMENT, not live code

Verified by reading the site: it is a `;;` line inside the subs section. The live code directly beneath it (lines 778+) already chains off the correct framework sub — `:<- [:rf.machine/has-tag? :ws/connection :websocket/connecting]` and siblings. So there is **no larger finding**: the example was never calling a function that does not exist, and no compile gate was ever red. The comment simply advertised retired sugar over the correct sub it named in the same breath. The file still parses: 9 top-level forms read clean with `:read-cond :allow`.

### Census — all three forms, over `git ls-files examples/` (167 files)

| Pass | Before | After | Control `has-tag?` |
|---|---|---|---|
| Line-oriented (`git grep -F`) | 2 hits / 2 files | **0** | 73 -> 72 hits, 22 files |
| Whitespace-collapsed | 2 hits / 2 files | **0** | 73 -> 72 hits, 22 files |
| Whitespace-stripped | 2 hits / 2 files | **0** | 73 -> 72 hits, 22 files |
| Hyphen-break variant `machine-has- tag?` | 0 | 0 | — |

The control bites hard in every pass, so the post-fix zeros are checks that passed rather than patterns that missed. The control drops by exactly 1 because the dropped `connection.cljs` parenthetical contained one `has-tag?`, while the README's replacement retains one — arithmetic that confirms both edits landed. The collapsed pass's known blind spot (a hyphen-broken token becoming `machine-has- tag?`) was probed explicitly and is 0 in this tree.

Nothing was widened beyond `examples/`. The two `skills/` carriers the parent bead rf2-17wco named were cleared by `4554fdd3d3`, which landed on main during this work and is in this branch's base — verified: a repo-wide grep now returns no `skills/` hits.

Remaining repo-wide carriers are all out of scope and all deliberate or unclassified per the bead: the private `defn-` test helpers in three adapter test namespaces, `docs/machines/tags.md:101` (which names it only to deny it), and `docs/EP/EP-0002` plus `docs/tools/playground/**` (bead: "were not classified — check before editing").

## Gates

Every gate foreground, unfiltered, exit code captured on the same command line and quoted from my own capture — not from any harness report. All re-run on the **final rebased base** (`origin/main` moved from `7da2a538e6` to `02deabf227` mid-work; the rebase was clean and main touched none of my four files, so nothing here reverts a sibling's landing).

| Gate | Exit | Applies? |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | yes — `skills/` is in its roots |
| `python scripts/check_readme_links.py --ci` | **0** | yes — this, not `check_doc_slugs.py`, is the gate for `examples/**/README.md` |
| `python scripts/check_skill_package_refs.py --ci` | **0** | yes — `re-frame2-pair` has a `package.json`; it rglobs `references/*.md` |
| `python scripts/check_skill_mcp_drift.py --verbose` | **0** | yes — 30=30 tools, 30 doc rows, single-host OK |
| `python scripts/check_skill_pair_authoring_drift.py` | **0** | yes — pins `re-frame2-pair/spec/*` |
| `bb tests/prompts/prompt_regression_test.clj` | **0** | yes — 28 tests, 211 assertions, 0 failures |
| `python scripts/check_retired_spellings.py` | **0** | runs over `examples/`, but see the gap below |

**Gates I checked and found do NOT apply**, rather than assuming: `check_skill_re_frame2_drift.py` (names `re-frame2-pair` only inside a prose string; it gates the `re-frame2` skill), `check_skill_eval_packaging.py` (targets `re-frame2-pair-**retro**`, a different package), `check_readme_inventories.py` (targets `tools/re-frame2-pair-mcp/README.md`, not the skill).

### Gate discrimination — proved by planted fault, not assumed

Neither link gate prints a root, so per the brief I proved coverage with faults planted at lines I was already editing. The working tree was committed first, and each restore was verified by git **blob** hash, not by reading a diff.

1. **`check_doc_slugs.py`** — planted `#dom-source-bridge` -> `#dom-source-bridge-planted-fault-pairskill-e` in `screen-reads.md` (match count read as 1 *before* running, so the plant could not silently no-op). Gate went **exit 1**: `BROKEN ANCHOR: skills\re-frame2-pair\references\screen-reads.md:9 -> #dom-source-bridge-planted-fault-pairskill-e`. The fault existed only in my worktree, so a run that had wandered into a sibling checkout would have come back green.
2. **`prompt_regression_test.clj`** — planted the *old chain wording* back (restored the `ops.md#operations-catalogue` link, removed the local paragraph). Both **new** assertions fired, **exit 1**, and the failure named my worktree's own path. This is the meaningful sabotage: it proves the new assertion pins the local rule rather than merely passing on whatever text happens to be there.

Blob hash `7534a1a5b24ea35c43b933412536d57809d19a5f` before both plants and again after both restores; `git status` clean; both gates re-run green afterwards.

## Finding for triage: the retired-spelling gate does not know this name

`scripts/check_retired_spellings.py` is EP-0007's ("One Name Per Fact") enforcement gate and its roots already include `examples`, `skills`, `implementation`, `tools`, `testbeds`, `migration` — but `machine-has-tag?` is not in its roster (0 matches for `has-tag` in the script; control: 83 matches for `retired`, so the search instrument bit). Had it been listed, it would have caught this whole family automatically instead of via three hand-run censuses across two beads.

I did not add it: `scripts/` is outside this PR's fence, and adding the spelling today would red the tree, because the legitimate private `defn-` test helpers in the adapter tests would all match and need an allow-list entry first. Filed as a follow-up.
