### PR TITLE
gates: the conformance corpus gets an EDN well-formedness check, and package-ref links get scoped by resolution (rf2-x91a, rf2-kgw8z)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -736,6 +736,32 @@ jobs:
         continue-on-error: true
         run: python scripts/check_inject_cofx_residue.py --verbose
 
+      # EDN well-formedness for the conformance corpus (rf2-x91a). Both fixture
+      # loaders read a fixture with `clojure.edn/read-string`, which returns the
+      # FIRST form and ignores the rest — so a fixture whose expectation block
+      # closes one brace early still loads, still runs and still reports as
+      # PASSING while every assertion outside that block is discarded. That is
+      # rf2-5mr6: `routing-not-found.edn`, one extra `}`, two `:trace-emissions`
+      # assertions never executed, green for however long it sat there.
+      #
+      # A STEP HERE RATHER THAN A JOB, and unconditional rather than gated. The
+      # classifier's `spec/conformance/fixtures/*` arm sets only
+      # implementation_jvm / cljs_node_test / cljs_browser / cljs_prod — four
+      # heavy JVM/Node/Chromium lanes, and no cheap flag exists to ride. Buying
+      # a whole job (or a wider surface) for a stdlib bracket scan over 247
+      # small files, which costs milliseconds, is the same trade the inject-cofx
+      # gate above declined for the same reason. Stdlib-only, so it keeps this
+      # job's defining dependency-free property intact.
+      - name: Self-test the conformance fixture EDN gate
+        id: check_conformance_fixture_edn_selftest
+        continue-on-error: true
+        run: python scripts/check_conformance_fixture_edn.py --self-test --verbose
+
+      - name: Validate every conformance fixture is one well-formed EDN form
+        id: check_conformance_fixture_edn
+        continue-on-error: true
+        run: python scripts/check_conformance_fixture_edn.py --verbose
+
       # THE WORKFLOW JOB-CAP RATCHET (rf2-rsn1e) DOES NOT LIVE HERE, AND THE
       # REASON IS THIS JOB'S DEFINING PROPERTY. It landed beside these checkers
       # and redded every PR: it parses the workflow documents with PyYAML —

--- a/scripts/check_conformance_fixture_edn.py
+++ b/scripts/check_conformance_fixture_edn.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""EDN well-formedness gate for the conformance corpus (rf2-x91a).
+
+The invariant this gate enforces:
+
+    Every file under `spec/conformance/fixtures/` is a well-formed EDN file
+    holding EXACTLY ONE top-level form, with nothing after it.
+
+The defect this prevents (rf2-5mr6): both fixture loaders read a fixture with
+`clojure.edn/read-string` over the whole file. `read-string` returns the FIRST
+form and IGNORES everything after it, silently. So a fixture whose expectation
+block is closed one brace early still loads, still runs, and still reports as
+PASSING — while every assertion that fell outside the block is discarded. That
+is what `routing-not-found.edn` did: one extra `}` at line 46, two
+`:trace-emissions` assertions never executed, green for however long it sat
+there.
+
+BOTH HALVES OF THE CHECK ARE LOad-BEARING, and neither alone is enough:
+
+  * A "does it read without error" check catches NOTHING here — reading
+    without error on a malformed file is precisely what `read-string` does.
+  * A bracket-balance check alone misses trailing text that happens to
+    balance: `{:a 1} {:b 2}` is perfectly balanced and still hides the
+    second form from every loader.
+
+So this scans for three things: bracket depth that never goes negative, a
+final depth of zero, and exactly one top-level form.
+
+WHY A SCANNER AND NOT A PARSER. Python has no EDN reader in the stdlib, and
+this gate must run in the fast-PR spine with no dependency to install. The
+scan is deliberately lexical: it blanks `;` comments to end of line, treats a
+double-quoted string as opaque (honouring backslash escapes), and treats a
+backslash outside a string as introducing a one-character char literal (so
+`\\(` and `\\"` are consumed, not counted). That is enough to count brackets
+correctly, which is the whole job.
+
+This is a corpus scanner, not a loader change, and it catches one thing a
+loader change could not: a fixture whose capabilities are out of claim is
+SKIPPED by the runner, so a defect inside it is invisible to any check that
+runs at load time. Making the loaders themselves refuse trailing text remains
+worthwhile and is tracked separately.
+
+Exit code:
+    0  no defects
+    1  at least one defect
+    2  invocation / setup error
+
+Usage:
+    python scripts/check_conformance_fixture_edn.py
+    python scripts/check_conformance_fixture_edn.py --verbose
+    python scripts/check_conformance_fixture_edn.py --ci          # terse; CI-shaped
+    python scripts/check_conformance_fixture_edn.py --self-test   # built-in fixtures
+
+rf2-x91a.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURES_ROOT = REPO_ROOT / "spec" / "conformance" / "fixtures"
+
+# Force UTF-8 on output streams — the corpus carries → / em-dash etc. and the
+# default Windows console codec (cp1252) would crash on them.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
+    except (AttributeError, ValueError):  # pragma: no cover - non-reconfigurable stream
+        pass
+
+_OPEN = "([{"
+_CLOSE = ")]}"
+# EDN treats a comma as whitespace.
+_WS = " \t\r\f\v,"
+
+
+class Scan:
+    """The lexical facts about one fixture's text."""
+
+    __slots__ = (
+        "final_depth",
+        "min_depth",
+        "first_negative_line",
+        "top_level_forms",
+        "second_form_line",
+        "unterminated_string_line",
+    )
+
+    def __init__(self) -> None:
+        self.final_depth = 0
+        self.min_depth = 0
+        self.first_negative_line: int | None = None
+        self.top_level_forms = 0
+        self.second_form_line: int | None = None
+        self.unterminated_string_line: int | None = None
+
+    @property
+    def ok(self) -> bool:
+        return (
+            self.final_depth == 0
+            and self.first_negative_line is None
+            and self.top_level_forms == 1
+            and self.unterminated_string_line is None
+        )
+
+    def summary(self) -> str:
+        return (
+            f"final-depth={self.final_depth} "
+            f"min-depth={self.min_depth} "
+            f"top-level-forms={self.top_level_forms}"
+        )
+
+
+def scan_edn(text: str) -> Scan:
+    """Lexically scan EDN text for bracket balance and top-level form count.
+
+    Not a reader: it never builds a value, and it does not care whether the
+    forms are semantically valid EDN. It answers exactly the two questions
+    `clojure.edn/read-string` will not — is it balanced, and is there anything
+    after the first form.
+    """
+    s = Scan()
+    depth = 0
+    line = 1
+    in_string = False
+    string_start_line = 1
+    # True while we are part-way through a run of non-whitespace at depth 0,
+    # i.e. inside a top-level form we have already counted.
+    in_run = False
+    i = 0
+    n = len(text)
+
+    while i < n:
+        ch = text[i]
+
+        if ch == "\n":
+            line += 1
+            i += 1
+            if not in_string:
+                in_run = False
+            continue
+
+        if in_string:
+            if ch == "\\":
+                i += 2  # escaped char inside a string — consume both
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+
+        if ch in _WS:
+            in_run = False
+            i += 1
+            continue
+
+        if ch == ";":
+            # Comment to end of line. Deliberately BEFORE the form-start
+            # check: a header comment is not a top-level form.
+            nl = text.find("\n", i)
+            if nl == -1:
+                break
+            i = nl  # the newline branch bumps the line and clears the run
+            continue
+
+        # Any other non-whitespace character at depth 0 that is not already
+        # part of a counted run begins a new top-level form.
+        if depth == 0 and not in_run:
+            s.top_level_forms += 1
+            if s.top_level_forms == 2 and s.second_form_line is None:
+                s.second_form_line = line
+            in_run = True
+
+        if ch == "\\":
+            i += 2  # char literal: `\(`, `\"`, `\space` ... consume the pair
+            continue
+
+        if ch == '"':
+            in_string = True
+            string_start_line = line
+            i += 1
+            continue
+
+        if ch in _OPEN:
+            depth += 1
+            i += 1
+            continue
+
+        if ch in _CLOSE:
+            depth -= 1
+            if depth < s.min_depth:
+                s.min_depth = depth
+            if depth < 0 and s.first_negative_line is None:
+                s.first_negative_line = line
+            if depth <= 0:
+                # The form closed: anything after this, even with no
+                # whitespace between, is a NEW top-level form.
+                in_run = False
+            i += 1
+            continue
+
+        i += 1
+
+    if in_string:
+        s.unterminated_string_line = string_start_line
+    s.final_depth = depth
+    return s
+
+
+def _defect_reason(s: Scan) -> str | None:
+    """The single most informative reason this scan is a defect, or None."""
+    if s.unterminated_string_line is not None:
+        return (
+            f"unterminated string opened at line {s.unterminated_string_line} "
+            f"({s.summary()})"
+        )
+    if s.first_negative_line is not None:
+        return (
+            f"unbalanced brackets — a closing bracket at line "
+            f"{s.first_negative_line} closes more than is open, so the form "
+            f"ends early and every assertion after it is discarded by "
+            f"read-string ({s.summary()})"
+        )
+    if s.final_depth != 0:
+        return (
+            f"unbalanced brackets — {s.final_depth} unclosed at end of file "
+            f"({s.summary()})"
+        )
+    if s.top_level_forms == 0:
+        return f"no top-level EDN form ({s.summary()})"
+    if s.top_level_forms > 1:
+        return (
+            f"trailing text after the first form — a second top-level form "
+            f"begins at line {s.second_form_line}, and read-string returns "
+            f"only the FIRST, so everything after it is silently discarded "
+            f"({s.summary()})"
+        )
+    return None
+
+
+def _iter_fixtures(fixtures_root: Path) -> Iterable[Path]:
+    if not fixtures_root.is_dir():
+        return
+    yield from sorted(fixtures_root.rglob("*.edn"))
+
+
+def check(fixtures_root: Path, verbose: bool = False, ci: bool = False) -> tuple[int, int]:
+    """Scan every fixture.  Return (n_scanned, n_defects)."""
+    findings: list[tuple[Path, str]] = []
+    n_scanned = 0
+
+    for fixture in _iter_fixtures(fixtures_root):
+        n_scanned += 1
+        try:
+            text = fixture.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            findings.append((fixture, f"unreadable: {exc}"))
+            continue
+        reason = _defect_reason(scan_edn(text))
+        if reason is not None:
+            findings.append((fixture, reason))
+        elif verbose:
+            sys.stderr.write(f"ok: {fixture.name}\n")
+
+    if findings:
+        prefix = "::error:: " if ci else ""
+        sys.stderr.write(f"\n{len(findings)} malformed conformance fixture(s):\n\n")
+        for fixture, reason in findings:
+            try:
+                rel = fixture.relative_to(REPO_ROOT).as_posix()
+            except ValueError:
+                rel = fixture.as_posix()
+            sys.stderr.write(f"  {prefix}{rel}: {reason}\n")
+        sys.stderr.write(
+            "\nFix: a conformance fixture must be ONE well-formed EDN form with "
+            "nothing after it. Both loaders use clojure.edn/read-string, which "
+            "returns the first form and ignores the rest — so a fixture in this "
+            "state loads, runs and reports as PASSING while the assertions "
+            "outside the first form are never executed. (rf2-x91a, rf2-5mr6)\n"
+        )
+    elif verbose:
+        sys.stderr.write(
+            f"all {n_scanned} conformance fixture(s) are one well-formed EDN form.\n"
+        )
+
+    return n_scanned, len(findings)
+
+
+# --------------------------------------------------------------------------
+# Self-tests — synthetic fixture dirs exercising both directions.
+# --------------------------------------------------------------------------
+
+# The real shape, reduced: a map whose value is a vector of assertion maps.
+_GOOD = """;; a conformance fixture
+{:kind :routing
+ :given {:url "/garbage/path"}
+ :trace-emissions
+ [{:operation :rf.error/no-such-handler
+   :tags {:url "/garbage/path" :kind :route}}
+  {:operation :rf.event/run-start}]}
+"""
+
+# rf2-5mr6 exactly: one closing brace too many, so the top-level form ends
+# early and the assertions after it fall outside it.
+_EXTRA_BRACE = """;; a conformance fixture
+{:kind :routing
+ :given {:url "/garbage/path"}}
+
+ :trace-emissions
+ [{:operation :rf.error/no-such-handler}]}
+"""
+
+# Balanced, but two top-level forms: read-string returns only the first. A
+# depth-only check passes this file.
+_TRAILING_FORM = """{:kind :routing
+ :given {:url "/garbage/path"}}
+{:trace-emissions [{:operation :rf.event/run-start}]}
+"""
+
+# Brackets that appear only inside a string or as char literals must NOT be
+# counted — otherwise the gate reds the corpus for no reason.
+_TRICKY_BUT_VALID = """;; brackets in }} comments {{ are ignored
+{:kind :routing
+ :url "a string with }}} and {{{ and a \\" quote"
+ :chars [\\{ \\} \\( \\)]
+ :note "trailing ; is not a comment inside a string"}
+"""
+
+_UNCLOSED = """{:kind :routing
+ :given {:url "/x"}
+"""
+
+_UNTERMINATED_STRING = """{:kind :routing
+ :url "never closed}
+"""
+
+_ONLY_COMMENTS = """;; nothing but commentary
+;; and more of it
+"""
+
+
+def _run_self_tests(verbose: bool = False) -> int:
+    cases: list[tuple[str, str, int]] = [
+        # (fixture name, text, expected defect count)
+        ("ok_well_formed.edn", _GOOD, 0),
+        ("ok_brackets_in_strings_and_chars.edn", _TRICKY_BUT_VALID, 0),
+        ("bad_extra_closing_brace.edn", _EXTRA_BRACE, 1),
+        ("bad_trailing_second_form.edn", _TRAILING_FORM, 1),
+        ("bad_unclosed_form.edn", _UNCLOSED, 1),
+        ("bad_unterminated_string.edn", _UNTERMINATED_STRING, 1),
+        ("bad_no_form_at_all.edn", _ONLY_COMMENTS, 1),
+    ]
+
+    failures = 0
+    for name, text, expected in cases:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "fixtures"
+            root.mkdir()
+            (root / name).write_text(text, encoding="utf-8")
+
+            saved = sys.stderr
+            sys.stderr = _DevNull()
+            try:
+                _, got = check(root, verbose=False, ci=False)
+            finally:
+                sys.stderr = saved
+
+            if got == expected:
+                if verbose:
+                    reason = _defect_reason(scan_edn(text))
+                    sys.stderr.write(
+                        f"self-test PASS: {name} (defects={got})"
+                        + (f" — {reason}\n" if reason else "\n")
+                    )
+            else:
+                sys.stderr.write(
+                    f"self-test FAIL: {name} expected {expected}, got {got}\n"
+                )
+                failures += 1
+
+    # The gate must NAME the offending file: a defect count with no filename
+    # is not actionable, and this is the half a count-only assertion misses.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "fixtures"
+        root.mkdir()
+        (root / "bad_named.edn").write_text(_EXTRA_BRACE, encoding="utf-8")
+        buf = _Capture()
+        saved = sys.stderr
+        sys.stderr = buf
+        try:
+            check(root, verbose=False, ci=False)
+        finally:
+            sys.stderr = saved
+        if "bad_named.edn" not in buf.text:
+            sys.stderr.write(
+                "self-test FAIL: names_the_file — the finding did not name "
+                "bad_named.edn\n"
+            )
+            failures += 1
+        elif verbose:
+            sys.stderr.write("self-test PASS: names_the_file\n")
+
+    if failures:
+        sys.stderr.write(f"\n{failures} self-test failure(s).\n")
+        return 1
+    if verbose:
+        sys.stderr.write(f"all {len(cases) + 1} self-tests passed.\n")
+    return 0
+
+
+class _DevNull:
+    def write(self, *_args, **_kwargs) -> int:  # noqa: D401
+        return 0
+
+    def flush(self) -> None:  # pragma: no cover
+        return None
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.text = ""
+
+    def write(self, s: str) -> int:
+        self.text += s
+        return len(s)
+
+    def flush(self) -> None:  # pragma: no cover
+        return None
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify every conformance fixture is one well-formed EDN form with "
+            "nothing after it (rf2-x91a)."
+        ),
+    )
+    parser.add_argument(
+        "--fixtures-root",
+        default=None,
+        help="Path to the fixtures root. Defaults to <repo>/spec/conformance/fixtures.",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true")
+    parser.add_argument(
+        "--ci",
+        action="store_true",
+        help="CI mode: ::error:: prefixed findings, exit non-zero on any.",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run the bundled synthetic-fixture self-tests and exit.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _run_self_tests(verbose=args.verbose)
+
+    fixtures_root = (
+        Path(args.fixtures_root).resolve() if args.fixtures_root else FIXTURES_ROOT
+    )
+    if not fixtures_root.is_dir():
+        sys.stderr.write(f"error: {fixtures_root} is not a directory.\n")
+        return 2
+
+    n_scanned, n_defects = check(
+        fixtures_root, verbose=args.verbose and not args.ci, ci=args.ci
+    )
+    if n_scanned == 0:
+        sys.stderr.write(f"error: no .edn fixtures found under {fixtures_root}.\n")
+        return 2
+    return 0 if n_defects == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_skill_package_refs.py
+++ b/scripts/check_skill_package_refs.py
@@ -16,15 +16,26 @@ The invariant this gate enforces — in-package link resolution (rf2-deo2zp):
     doc (SKILL.md / README.md / references/**.md) MUST resolve to a file the
     package.json `files` allow-list ships.
 
+"Intra-package" is decided by where a link RESOLVES, not by how it is spelled
+(rf2-kgw8z). A `../` from a nested doc usually lands back inside the package —
+`references/README.md` -> `../spec/design.md` is the reported case, and
+`references/x.md` -> `../SKILL.md` is the common one — so treating the literal
+`../` prefix as "escapes the package" left those links unexamined.
+
 The defect this prevents: a shipped doc links to a sibling support doc
 (`docs/LOCAL_DEV.md`, `STATUS.md`, `RELEASING.md`, ...) that the `files`
 allow-list omits, so a packaged install resolves the link to a missing file at
-exactly the point a user is configuring the skill. Links that escape the
-package (`../`) point at the monorepo, not the tarball, and are out of scope
-here — the repo-wide docs link gate (`scripts/check_doc_slugs.py`) fails any
-such link whose target does not exist in the repo, which is what retires a
+exactly the point a user is configuring the skill. Links that genuinely RESOLVE
+outside the package point at the monorepo, not the tarball, and stay out of
+scope here — the repo-wide docs link gate (`scripts/check_doc_slugs.py`) fails
+any such link whose target does not exist in the repo, which is what retires a
 reintroduced `../shared/`-style dependency. npm always ships `package.json`,
 the README, and LICENSE/LICENCE regardless of `files`.
+
+This gate is NOT an existence checker, and must not become one: a link to a
+path that matches the `files` allow-list but does not exist on disk passes here
+by design, and `check_doc_slugs.py` owns that question. What is checked is
+allow-list membership — a packaging question.
 
 Exit code:
     0  no findings
@@ -168,20 +179,23 @@ def _broken_package_links(skill_dir: Path) -> list[str]:
                 target = raw.split("#", 1)[0].split("?", 1)[0]
                 if not target:
                     continue
-                # Links escaping the package (../) point at the monorepo, not
-                # the tarball — out of scope for this allow-list check; the
-                # repo-wide docs link gate (check_doc_slugs.py) validates their
-                # targets exist in the repo.
-                if target.startswith("../"):
-                    continue
                 # Resolve relative to the linking doc's directory, then make it
-                # package-root-relative.
+                # package-root-relative. Scope is decided by where a link
+                # RESOLVES, never by how it is spelled (rf2-kgw8z): a `../`
+                # from a nested doc very often lands back INSIDE the package
+                # — `references/README.md` -> `../spec/design.md` is the
+                # reported case — and skipping on the literal prefix left
+                # every such link unexamined, which is the allow-list question
+                # this gate exists to answer.
                 resolved = (doc.parent / target).resolve()
                 try:
                     rel_target = resolved.relative_to(skill_dir.resolve())
                 except ValueError:
-                    # Resolves outside the package despite no literal ../ prefix
-                    # (symlink, etc.) — treat as out of scope.
+                    # Genuinely escapes the package: points at the monorepo,
+                    # not the tarball, so it is out of scope for this
+                    # allow-list check. The repo-wide docs link gate
+                    # (check_doc_slugs.py) validates that its target exists in
+                    # the repo.
                     continue
                 rel_str = rel_target.as_posix()
                 if _is_shipped(rel_str, allow):
@@ -252,8 +266,9 @@ def _make_skill(
     package: bool,
     files: list[str] | None = None,  # package.json `files`; None -> ["SKILL.md"]
     skill_link: str | None = None,   # an intra-package link to embed in SKILL.md
+    ref_link: str | None = None,     # a link to embed in references/lens.md
     create_docs: bool = False,       # create docs/SETUP.md on disk
-    monorepo_only: bool = False,     # mark the skill_link line monorepo-only
+    monorepo_only: bool = False,     # mark the link's line monorepo-only
 ) -> None:
     d = root / name
     if package:
@@ -262,14 +277,23 @@ def _make_skill(
             d / "package.json",
             '{"name": "@day8/%s", "files": %s}' % (name, json.dumps(allow)),
         )
+    suffix = (
+        " (not in the published package; run from a monorepo clone)"
+        if monorepo_only
+        else ""
+    )
     skill_body = "# skill\n"
     if skill_link is not None:
-        suffix = " (not in the published package; run from a monorepo clone)" if monorepo_only else ""
         skill_body += f"See [setup]({skill_link}){suffix}.\n"
     if create_docs:
         _write(d / "docs" / "SETUP.md", "# setup\n")
     _write(d / "SKILL.md", skill_body)
-    _write(d / "references" / "lens.md", "# refs\n")
+    # references/lens.md sits one level down, so a `../` link from it resolves
+    # back INSIDE the package — the rf2-kgw8z shape.
+    ref_body = "# refs\n"
+    if ref_link is not None:
+        ref_body += f"See [design]({ref_link}){suffix}.\n"
+    _write(d / "references" / "lens.md", ref_body)
     _write(d / "README.md", "# readme\n")
 
 
@@ -313,7 +337,7 @@ def _run_self_tests(verbose: bool = False) -> int:
             ),
             0,
         ),
-        # link escaping the package (../) is out of scope here (the repo-wide
+        # link RESOLVING outside the package is out of scope here (the repo-wide
         # docs link gate validates its target exists in the repo)      -> 0
         (
             "ok_parent_escape_out_of_scope",
@@ -321,6 +345,53 @@ def _run_self_tests(verbose: bool = False) -> int:
                 package=True,
                 files=["SKILL.md", "README.md"],
                 skill_link="../../tools/foo/README.md",
+            ),
+            0,
+        ),
+        # rf2-kgw8z — a `../` link from a NESTED doc that resolves back INSIDE
+        # the package, at a path `files` omits. Spelled like an escape, but it
+        # is an intra-package link and is exactly the reported improver case
+        # (references/README.md -> ../spec/design.md).                  -> 1
+        (
+            "bad_parent_reentry_unshipped",
+            dict(
+                package=True,
+                files=["SKILL.md", "README.md", "references/"],
+                ref_link="../spec/design.md",
+            ),
+            1,
+        ),
+        # the same `../` re-entry shape, but the target IS shipped      -> 0
+        (
+            "ok_parent_reentry_shipped",
+            dict(
+                package=True,
+                files=["SKILL.md", "README.md", "references/"],
+                ref_link="../SKILL.md",
+            ),
+            0,
+        ),
+        # the same `../` re-entry to an unshipped path, but the LINE documents
+        # it as a deliberate monorepo-only reference                    -> 0
+        (
+            "ok_parent_reentry_marked",
+            dict(
+                package=True,
+                files=["SKILL.md", "README.md", "references/"],
+                ref_link="../spec/design.md",
+                monorepo_only=True,
+            ),
+            0,
+        ),
+        # NOT an existence checker: a `../` re-entry to a path that is SHIPPED
+        # by the allow-list but does not exist on disk stays green — existence
+        # is check_doc_slugs.py's question, not this gate's.            -> 0
+        (
+            "ok_shipped_but_absent_is_not_our_question",
+            dict(
+                package=True,
+                files=["SKILL.md", "README.md", "references/", "docs/"],
+                ref_link="../docs/NEVER-CREATED.md",
             ),
             0,
         ),

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -1204,6 +1204,18 @@ run "gate-scheduling audit self-test" "python scripts/check_gate_scheduling.py -
 run "gate-scheduling audit (rf2-6ckzl)" "python scripts/check_gate_scheduling.py --verbose" \
   python "$spine_root/scripts/check_gate_scheduling.py" --verbose
 
+# Conformance-corpus EDN well-formedness (rf2-x91a).  Always-on rather than
+# tiered: `spec/conformance/fixtures/*.edn` is not an `.md` path so it never
+# arms the documentation tier, and the classifier routes it only to the heavy
+# JVM/CLJS lanes.  A stdlib bracket scan over 247 small files costs
+# milliseconds, so it runs on every diff, mirroring its always-on step in the
+# invariant job.
+run "conformance fixture EDN gate self-test" "python scripts/check_conformance_fixture_edn.py --self-test --verbose" \
+  python "$spine_root/scripts/check_conformance_fixture_edn.py" --self-test --verbose
+
+run "conformance fixture EDN gate (rf2-x91a)" "python scripts/check_conformance_fixture_edn.py --verbose" \
+  python "$spine_root/scripts/check_conformance_fixture_edn.py" --verbose
+
 # The last three are `verify-readme-links`', not the invariant job's.  Note that
 # CI runs `check_readme_links --ci` ALWAYS-ON while this spine runs it in the
 # documentation tier; only the self-test arm is added here, so the live scan


### PR DESCRIPTION
Two gates that did not check what they were believed to check. Same defect class from opposite ends: a control returning a clean answer without having inspected its subject.

- **rf2-x91a** (P2) — the conformance corpus had no EDN well-formedness gate.
- **rf2-kgw8z** (P4) — `check_skill_package_refs.py` skipped every `../` link.

Four files: one new script, one rewritten predicate, two wiring lines. **No new job key.**

---

## 1. Fixture count and defect count, measured

| corpus | fixtures | defects |
|---|---|---|
| live corpus at this PR's base | 247 | **0** |
| pre-fix `routing-not-found.edn`, recovered from `a54088ee7e^` | 1 | **1** |

Both numbers re-measured here rather than carried over from the bead. 247 tracked `.edn` files under `spec/conformance/fixtures/`, and `git ls-files` agrees with the scanner's own count.

The historical defect is the strongest available control, because it is a real one. Run against the pre-fix file the scanner reports:

```
routing-not-found.edn: unbalanced brackets — a closing bracket at line 60 closes
more than is open, so the form ends early and every assertion after it is
discarded by read-string (final-depth=-1 min-depth=-1 top-level-forms=2)
```

`final-depth=-1` and line 60 match the measurement recorded on the bead exactly. The bead recorded `top-level-forms=1`; this scanner counts **2**, which is the more accurate reading — after the early close, `:trace-emissions [...]` genuinely is a second top-level form. The file is a defect on two independent axes either way.

**No hollow fixture was found in the live corpus**, so nothing was turned on and the conformance runner's before/after is not in play.

## 2. The new gate's self-test, both directions

`python scripts/check_conformance_fixture_edn.py --self-test --verbose` → **exit 0**, 8/8. Two passing cases, five failing cases, one that pins the finding *names the file*:

```
PASS ok_well_formed.edn (defects=0)
PASS ok_brackets_in_strings_and_chars.edn (defects=0)
PASS bad_extra_closing_brace.edn (defects=1)
     — unbalanced brackets — a closing bracket at line 6 closes more than is
       open ... (final-depth=-1 min-depth=-1 top-level-forms=4)
PASS bad_trailing_second_form.edn (defects=1)
     — trailing text after the first form — a second top-level form begins at
       line 3, and read-string returns only the FIRST, so everything after it
       is silently discarded (final-depth=0 min-depth=0 top-level-forms=2)
PASS bad_unclosed_form.edn (defects=1)
     — unbalanced brackets — 1 unclosed at end of file (final-depth=1 ...)
PASS bad_unterminated_string.edn (defects=1)
     — unterminated string opened at line 2
PASS bad_no_form_at_all.edn (defects=1)
     — no top-level EDN form
PASS names_the_file
```

**Both halves of the check are load-bearing, and the self-test proves it separately.** `bad_trailing_second_form` is perfectly balanced — `final-depth=0 min-depth=0` — so a bracket-balance check alone passes it while `read-string` still discards everything after the first form. `bad_extra_closing_brace` is the converse. Neither check subsumes the other.

### Planted fault on a real fixture (the bead's acceptance criterion)

The bead asks for red from a planted fault, not green on a clean corpus. Planted into `routing-not-found.edn` in the working tree, twice, on the final rebased base:

| plant | scanner verdict | captured exit |
|---|---|---|
| one extra `}` | `a closing bracket at line 60 closes more than is open` — `final-depth=-1` | **1** |
| a *balanced* second top-level form appended | `a second top-level form begins at line 62` — `final-depth=0` | **1** |
| restored | no findings | **0** |

The second plant is the sharper one: it is balanced, so only the top-level-form half catches it.

Each plant's anchor match count was read as exactly 1 *before* the run, and each restore was verified by git blob hash against the committed object (`7200be9e65…`), not by reading a diff — a patch that never applied and an unchanged file produce the same diff. The working tree is clean and the fixture is byte-identical to the committed blob.

## 3. Job-key discriminator

```
git diff origin/main...HEAD -- .github/workflows/ | grep -cE '^\+  [a-z][a-z0-9_-]*:[[:space:]]*$'
```

| target | two-space form | unindented form |
|---|---|---|
| **this PR's diff** | **0** | 0 |
| control `366e4fca79` (added job `provenance-pins-corpus`) | **1** | **0** |
| negative control `4cf4d711a2` (added no job) | 0 | — |

The instrument was proven to bite before it was believed. The unindented form reads 0 on the commit that genuinely added a job — a constant zero that would have answered every question reassuringly.

A second, independent check: every added line in `.github/workflows/` that is a bare key at **any** indent → **0 matches**. The workflow diff is two `- name:` steps and nothing else.

## 4. Where item 1 is wired, and why that is the honest home

Two steps in the **existing** `verify-skill-mcp-drift` job in `test.yml` ("Repo invariant checks"), plus an always-on lane in the fast-PR spine.

That job is the honest home on three counts:

- **It is where the comparable gates already live** — `check_retired_spellings.py`, `check_inject_cofx_residue.py`, `check_keyword_catalogue_drift.py` and ~34 others, each wired as a self-test step plus a live-scan step.
- **It is unconditional and stdlib-only.** The scanner imports nothing outside the stdlib, which preserves the job's stated defining property: it installs no pip packages, and that is what keeps it costing seconds.
- **There is no cheap surface flag to ride.** The classifier's `spec/conformance/fixtures/*` arm sets only `implementation_jvm`, `cljs_node_test`, `cljs_browser` and `cljs_prod` — four heavy JVM/Node/Chromium lanes. Gating a millisecond bracket scan behind one of those, or widening the surface, is the trade the neighbouring inject-cofx gate declined in a comment for exactly this reason.

The spine lane is required, not optional: `check_fast_pr_gap.py` set-differences CI's checker invocations against the spine's, and a CI step with no spine lane is reported as a gap.

Three meta-gates police this wiring and all pass:

| gate | exit |
|---|---|
| `check_ci_reproduce_commands.py --check` (id/mode/single-line-run contract) | 0 |
| `check_fast_pr_gap.py` | 0 |
| `check_gate_scheduling.py` | 0 |
| `check_workflow_yaml.py` | 0 |

The first one lists both new steps by id, so it saw them rather than skipping them.

## 5. Item 2 — the `../` skip, confirmed at source

`_broken_package_links` carried, verbatim:

```python
# Links escaping the package (../) point at the monorepo, not
# the tarball — out of scope for this allow-list check; ...
if target.startswith("../"):
    continue
```

The skip was real, and its stated premise is what fails: **a `../` from a nested doc usually does not escape the package.** Scope is now decided by where a link *resolves*, not by how it is spelled. A target that genuinely resolves outside the package root stays out of scope, unchanged and for the reason the docstring already gave.

Classified across all nine published skills, every `../`-shaped link:

| where it resolves | count | treatment |
|---|---|---|
| outside the package root | 398 | out of scope (unchanged) |
| inside the package, shipped | 52 | now checked, passes |
| inside the package, **unshipped** | 3 | now checked — all three carry a monorepo-only marker |

So the fix moves **55 links from unexamined to examined** and the tree stays green.

**The reported example is real but already marked.** `skills/re-frame2-improver/references/README.md` does link `../spec/design.md` (three times), and `spec/` is genuinely absent from that package's `files` array. But all three sit on lines reading "not shipped in the package" / "reach it from a monorepo clone", which are existing `_MONOREPO_ONLY_MARKERS`. Per the bead's own acceptance — *"the improver case is either fixed or marked"* — it is **marked**. The gate simply never got far enough to consult the marker.

### It did not become an existence checker

Confirmed, and pinned by a self-test case: `ok_shipped_but_absent_is_not_our_question` links `../docs/NEVER-CREATED.md` where `docs/` **is** in `files` — the file does not exist and the gate stays green. Allow-list membership is a packaging question; existence belongs to `check_doc_slugs.py`. No filesystem existence test was added; `Path.resolve()` is non-strict and never requires the target to exist.

Four self-test cases added, `--self-test` → **exit 0**, 11/11. The new cases discriminate: re-inserting the old `../` skip into a scratch copy fails `bad_parent_reentry_unshipped` (expected 1, got 0) and exits **1**.

---

## Gates

Run in the foreground, unfiltered, exit codes captured on the same command line as the redirect and quoted from that capture.

| gate | captured exit |
|---|---|
| `check_conformance_fixture_edn.py --self-test --verbose` | 0 |
| `check_conformance_fixture_edn.py` (live, 247 fixtures) | 0 |
| `check_skill_package_refs.py --self-test` | 0 |
| `check_skill_package_refs.py` (live, 9 packages) | 0 |
| `check_ci_reproduce_commands.py --check` | 0 |
| `check_fast_pr_gap.py` | 0 |
| `check_gate_scheduling.py` | 0 |
| `check_workflow_yaml.py` | 0 |

All re-run on the final rebased base; a pre-rebase green is evidence about a tree that no longer exists.

`sh scripts/test-fast-pr.sh` — `--plan` reports `docs=true jvm=true node=true`, `PLAN-SELFTEST run`, `PLAN-KONDO skip`, reason **"spine self-change (every tier)"**: every tier arms because the diff touches `test-fast-pr.sh` itself, not because it touches any documentation or JS. The run printed `gate root: …/gates-a`, confirming it read this branch's checkout.

**Captured exit 1, from one lane: `FAIL CLJS node integration`.** 77 of 78 lanes green, including `mkdocs --strict build`, `JVM implementation/core`, the README link/anchor validator and the JS harness self-tests. That single failure is `compile-node-test: could not resolve shadow-cljs: Cannot find module 'shadow-cljs/cli/runner.js'` — `implementation/node_modules` is not installed in this worktree. **This is a no-verdict for that tier, not a red on this change**: the diff is four Python/shell/YAML files and touches no JS, no `package.json` and no shadow-cljs config, so it cannot create or remove a dependency tree. CI owns that lane. No dependency link into a shared tree was created, deliberately — an installer run through one rewrites the shared target.

No markdown changed, so `check_doc_slugs.py` is not this diff's gate; the docs tier ran anyway under the spine-self rule and passed.

## Findings returned, filed rather than actioned

- **398 links in shipped skill docs resolve outside their own package** and are broken in the published tarball — `references/README.md` → `../../re-frame2/patterns/managed-http.md` and similar, across all nine packages. Each skill publishes as its own npm package and its own plugin, so there is no sibling to resolve against. This is deliberate existing behaviour with a documented rationale, it is far larger than either bead, and turning it red is a ruling rather than a worker's call. Filed, not actioned.
- **rf2-x91a prefers shape (b)** — make the loaders themselves refuse trailing text — which lands in `implementation/**`, outside this dispatch's fence. Filed as a follow-up. The bead estimates "the two host-specific loaders"; there are in fact **seven** files doing `slurp` + `edn/read-string` over this corpus, across core, flows, machines, schemas and ssr. That makes (b) materially larger than estimated, and it is also why the corpus scanner is the right primary gate: one scanner covers every loader, and it additionally catches a fixture whose capabilities are out of claim, which the runner skips and no load-time check can ever see.

Closes rf2-x91a. Closes rf2-kgw8z.
