### PR TITLE
fix(api-manifest,ssr-node): wire the orphaned roster-completeness gate, and two docs-truth repairs on the crossing (rf2-8arzr.7, rf2-m65l, rf2-8arzr.8)

### DIFF
--- a/docs/ssr/concepts.md
+++ b/docs/ssr/concepts.md
@@ -591,6 +591,29 @@ allowlist vocabulary cannot express a projection, `:render-state` also accepts
 
 ### 5. Start the sidecar, and mind the skew
 
+**Where the sidecar comes from.** There is no published artefact. The
+sidecar is not on npm, it has no Clojars coordinate, and none is planned as
+of this writing — this repository publishes JVM artefacts only, and its
+package manifest is marked private, so there is nothing to `npm install` by
+name. You obtain it from a checkout of the repository, and that is the
+supported route rather than a stopgap: the package is `implementation/ssr-node`,
+self-contained CommonJS that declares no dependencies of any kind. Either
+install it into the host from that directory —
+
+```bash
+npm install /path/to/re-frame2/implementation/ssr-node
+```
+
+— or a `file:` entry in the host's `package.json` to the same effect, which
+puts the `re-frame2-ssr-node` command in the host's `node_modules/.bin`; or
+copy the directory onto the deployment host and run `node bin/serve.cjs`
+with the flags below, which is the same program. Because the manifest
+resolves nothing, copying the tree *is* the install — there is no download
+step to fail in a locked-down network, and the version you run is the
+checkout you copied. Pin that checkout the way you pin the JVM artefacts:
+the sidecar and the server bundle must move together, which is what the
+build id in this step exists to catch.
+
 ```bash
 re-frame2-ssr-node --module /srv/my-app/out/my-app-server/server.js
 ```

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -102,6 +102,19 @@
     re-frame.http
     re-frame.ssr
     re-frame.ssr.ring
+    ;; The two JVM-loadable namespaces of the ssr-node crossing (rf2-8arzr.7).
+    ;; Both are requires-directly host-adapter surfaces that nothing
+    ;; re-exports: `re-frame.ssr.ring.node` provides `renderer`, the one
+    ;; non-local `:renderer` the reference ships (the JVM→Node adapter over
+    ;; the bounded sidecar at implementation/ssr-node), and
+    ;; `re-frame.ssr.render-state` is the render-visible projection that seam
+    ;; runs. spec/API.md §Namespaces places them at the `:implementation`
+    ;; tier "on the same footing as `re-frame.ssr.ring`'s own vars", so they
+    ;; are rowed here and NOT rowed as var-rows in spec/API.md. They shipped
+    ;; unenrolled — public vars, no `^:no-doc`, zero manifest rows — which is
+    ;; the hole the roster-completeness gate below now closes.
+    re-frame.ssr.render-state
+    re-frame.ssr.ring.node
     re-frame.epoch
     ;; The Hicasso view substrate's public door. A `.cljc` whose `:clj` arm
     ;; is the three authoring macros (`defview` / `event` / `defhost`) and
@@ -160,6 +173,210 @@
                            (str/replace "\\" "/"))))
                 (keep source-file->ns-sym))
           (file-seq root))))
+
+;; ---------------------------------------------------------------------------
+;; Roster completeness (rf2-8arzr.7 — restoring the mechanism of rf2-o8xev).
+;;
+;; THE HOLE. `jvm-namespaces` above is an EXPLICIT roster, and `doc_api_check`
+;; derives ITS namespace roster from the rows that roster produces. So a
+;; namespace absent from the roster is not UNCLASSIFIED — it is UNSCANNED:
+;; `--check` stays green, no documentation-coverage check reaches it, and
+;; every public var in it is invisible to every manifest-derived gate at once.
+;; A completeness check keyed on the roster cannot see what the roster omits.
+;;
+;; WHY THIS IS BEING WRITTEN A SECOND TIME. It is not a new idea. rf2-o8xev
+;; built exactly this reconciliation for `implementation/freehand/src`, with
+;; a public roster, an internal roster and an assertion called FIRST in
+;; `build-manifest`. Freehand's retirement (rf2-0yp7w.6, commit c951808b47)
+;; deleted the tree and — correctly, since the gate refuses to build when a
+;; source namespace is named by neither roster — retired the rosters, the
+;; assertion and its call site with it. What it left behind was
+;; `namespaces-under` and `source-file->ns-sym`: the two pure helpers, with no
+;; caller. The gate was not forgotten, it was ORPHANED, and the orphan reads
+;; exactly like a live backstop to anyone grepping for one. Three namespaces
+;; then shipped unscanned through the gap (`re-frame.ssr.ring.node`,
+;; `re-frame.ssr.render-state`, `re-frame.hicasso.server`).
+;;
+;; THE GATE. It infers NOTHING about publicness: no namespace is
+;; auto-enrolled, no var is auto-published, and `^:no-doc` carve-outs behave
+;; exactly as before. It asserts only that every source namespace under a
+;; covered root has been ACCOUNTED FOR — named either in `jvm-namespaces`
+;; above (a supported surface, introspected and rowed), in the sidecar's
+;; `:cljs-only` rows (a surface the JVM cannot require), or in
+;; `internal-namespaces` below (plumbing nobody authors against). A newly
+;; shipped namespace is in none of the three, so it fails BY NAME with the
+;; ways to answer for it. Classification stays a human decision; only the
+;; OBLIGATION to make one is automated.
+;;
+;; WHY THESE ROOTS AND NOT EVERY TREE. Deliberately narrow, and the narrowness
+;; is the honest part of this fix rather than a shortcut. The SSR trees are
+;; where the class just recurred, and enrolling a tree is not free: every
+;; namespace in it must be classified by a human, once, and recorded below.
+;; `implementation/hicasso/src` is the KNOWN next one — `re-frame.hicasso.server`
+;; is the third unscanned namespace and would need a `:cljs-only` sidecar row,
+;; not a `jvm-namespaces` entry, since it is CLJS-only — but that tree was held
+;; by an open PR when this landed, so it is named here rather than half-done.
+;; Widening to the remaining artefacts is a per-tree decision with a per-tree
+;; cost; the point of the data-driven shape below is that each is a root plus
+;; its classifications, never another mechanism.
+;; ---------------------------------------------------------------------------
+
+(def roster-covered-roots
+  "Repo-relative source trees whose every namespace must be accounted for by
+   one of the three rosters. Adding a tree here is deliberate work, not a
+   free generalisation: it obliges a classification for every namespace
+   beneath it (see this section's header)."
+  ["implementation/ssr/src"
+   "implementation/ssr-ring/src"])
+
+(def internal-namespaces
+  "Source namespaces under `roster-covered-roots` that are deliberately NOT a
+  supported surface: SSR pipeline internals, host-adapter plumbing and
+  emitters. Nothing here is published, documented or rowed in the manifest —
+  being on this list is the RECORD of that decision, not a consequence of it.
+
+  This is not a synonym for `^:no-doc`. NONE of these carry that metadata
+  (the SSR trees use it nowhere at all), so the marker cannot be the
+  classifier — which is precisely why the roster is written down instead of
+  derived. The public doors of these two artefacts are `re-frame.ssr` and
+  `re-frame.ssr.ring`, plus the two crossing surfaces rf2-8arzr.7 enrolled;
+  everything below is reached only from inside them."
+  '#{;; --- implementation/ssr/src -------------------------------------------
+     ;; Boot, install and the shared constant/hash/manifest plumbing.
+     re-frame.ssr.boot
+     re-frame.ssr.constants
+     re-frame.ssr.hash
+     re-frame.ssr.install
+     re-frame.ssr.manifest
+     re-frame.ssr.substrate
+     ;; The render pipeline: request/response shaping, emission, the UI tree.
+     re-frame.ssr.emit
+     re-frame.ssr.html-helpers
+     re-frame.ssr.http-validation
+     re-frame.ssr.request
+     re-frame.ssr.response
+     re-frame.ssr.ui-tree
+     ;; `<head>` collection and emission.
+     re-frame.ssr.head
+     re-frame.ssr.head.emit
+     re-frame.ssr.head.registry
+     ;; Error capture and projection.
+     re-frame.ssr.error-listener
+     re-frame.ssr.error-projector
+     ;; Hydration, egress, payload policy and the server-fx schemas.
+     re-frame.ssr.egress
+     re-frame.ssr.hydrate
+     re-frame.ssr.payload-policy
+     re-frame.ssr.server-fx-schemas
+     re-frame.ssr.suspense
+     ;; Streaming internals (the client half is the browser-side reader).
+     re-frame.ssr.streaming
+     re-frame.ssr.streaming.client
+     re-frame.ssr.streaming.constants
+     ;; --- implementation/ssr-ring/src --------------------------------------
+     ;; Ring host-adapter plumbing beneath `re-frame.ssr.ring`'s own door.
+     re-frame.ssr.ring.cookie
+     re-frame.ssr.ring.headers
+     re-frame.ssr.ring.lifecycle
+     re-frame.ssr.ring.payload
+     re-frame.ssr.ring.pipeline
+     re-frame.ssr.ring.shell
+     re-frame.ssr.ring.streaming
+     re-frame.ssr.ring.trust})
+
+(defn- repo-file
+  "Resolve a `/`-joined repo-relative path against `repo-root`, portably."
+  [rel-path]
+  (apply io/file repo-root (str/split rel-path #"/")))
+
+(defn covered-source-namespaces
+  "The sorted set of every namespace under every root in
+   `roster-covered-roots`. Throws (via `namespaces-under`) when a root has
+   gone missing, rather than quietly reconciling an empty tree."
+  []
+  (into (sorted-set)
+        (mapcat #(namespaces-under (repo-file %)))
+        roster-covered-roots))
+
+(defn- cljs-only-namespaces
+  "Namespaces the sidecar carries `:cljs-only` rows for — accounted for, but
+   by the curated roster rather than by JVM introspection."
+  [sidecar]
+  (into #{} (map (comp symbol :namespace)) (:cljs-only sidecar)))
+
+(defn roster-drift
+  "Reconcile the three rosters against the live source tree. Returns
+   `{:unaccounted [...] :stale [...] :contradictory [...]}`:
+
+     :unaccounted   — a source namespace named by NO roster. The new surface
+                      that would otherwise ship unscanned.
+     :stale         — an INTERNAL roster entry with no source file left. The
+                      roster rots the same way the sidecar does, and is
+                      reconciled the same way.
+     :contradictory — a namespace claimed as BOTH a public surface and
+                      internal, which is not a classification but a
+                      contradiction.
+
+   `present` is the live set from `covered-source-namespaces`; passing it in
+   keeps the reconciliation pure and lets a test drive a synthetic tree
+   through it."
+  [present sidecar]
+  (let [present  (set present)
+        ;; Only the enrolled namespaces SOURCED FROM a covered root count as
+        ;; accounting for that root — `jvm-namespaces` spans every artefact,
+        ;; and the two SSR trees deliberately share one `re-frame.ssr` prefix
+        ;; (`re-frame.ssr.ring` lives in ssr-ring, `re-frame.ssr.render-state`
+        ;; in ssr), so a prefix filter would mis-assign both. Intersecting
+        ;; with what is actually on disk is exact and needs no per-tree rule.
+        enrolled (set/intersection (set jvm-namespaces) present)
+        public   (set/union enrolled
+                            (set/intersection (cljs-only-namespaces sidecar)
+                                              present))]
+    {:unaccounted   (vec (sort (set/difference present
+                                               (set/union public
+                                                          internal-namespaces))))
+     :stale         (vec (sort (set/difference internal-namespaces present)))
+     :contradictory (vec (sort (set/intersection public internal-namespaces)))}))
+
+(defn assert-roster-complete!
+  "Throw with an actionable message when `present` reveals roster drift.
+   Returns `present` unchanged when the rosters account for the tree exactly."
+  [present sidecar]
+  (let [{:keys [unaccounted stale contradictory]} (roster-drift present sidecar)]
+    (when (seq unaccounted)
+      (throw (ex-info
+              (str "Unaccounted public-API source namespace(s) — every "
+                   "namespace under a root in `roster-covered-roots` must be "
+                   "classified, or it ships UNSCANNED (no manifest rows, no "
+                   "documentation-coverage check, and this gate green). "
+                   "Classify each one of:\n  "
+                   (str/join "\n  " unaccounted)
+                   "\n\nEither (a) SUPPORTED SURFACE — add it to "
+                   "`jvm-namespaces` in this generator (or, if it is "
+                   "CLJS-only, add its rows under `:cljs-only` in "
+                   "spec/api-manifest-metadata.edn), and classify each public "
+                   "var there with :tier/:owner/:status; or (b) INTERNAL — add "
+                   "it to `internal-namespaces` in this generator, under the "
+                   "grouping comment that says what it is.")
+              {:unaccounted unaccounted})))
+    (when (seq stale)
+      (throw (ex-info
+              (str "Stale `internal-namespaces` entries — these are recorded "
+                   "as internal plumbing but no source file under "
+                   "`roster-covered-roots` answers to them any more (remove "
+                   "them from the roster in this generator):\n  "
+                   (str/join "\n  " stale))
+              {:stale stale})))
+    (when (seq contradictory)
+      (throw (ex-info
+              (str "Contradictory classification — these namespaces are BOTH "
+                   "enrolled as a public surface (`jvm-namespaces`, or a "
+                   "sidecar `:cljs-only` row) AND recorded as internal in "
+                   "`internal-namespaces`. A namespace is one or the other; "
+                   "remove the wrong entry:\n  "
+                   (str/join "\n  " contradictory))
+              {:contradictory contradictory})))
+    present))
 
 ;; ---------------------------------------------------------------------------
 ;; Derivation from live vars.
@@ -349,6 +566,13 @@
    spec/api-manifest.edn). Throws on missing / stale sidecar entries with
    an actionable message — that throw is what turns the drift-check red."
   [sidecar]
+  ;; ROSTER COMPLETENESS FIRST (rf2-8arzr.7). The reconciliations below all
+  ;; read `jvm-namespaces`, so they can only report on namespaces the roster
+  ;; already names — an unenrolled namespace is invisible to every one of
+  ;; them. Asserting the rosters account for the source tree BEFORE any of
+  ;; them run is what turns "a new public namespace shipped unscanned" from a
+  ;; green run into a named failure.
+  (assert-roster-complete! (covered-source-namespaces) sidecar)
   (let [[rows missing] (build-rows sidecar)
         stale          (stale-sidecar-entries sidecar)
         dups           (duplicate-rows rows)

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/roster_completeness_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/roster_completeness_test.clj
@@ -1,0 +1,192 @@
+(ns re-frame.api-manifest.roster-completeness-test
+  "Regression tests for the roster-completeness gate (rf2-8arzr.7).
+
+  THE BUG. `jvm-namespaces` is an EXPLICIT roster, and every downstream
+  projection (`doc_api_check` among them) derives its own namespace roster
+  from the rows that roster produces. So a namespace absent from the roster
+  was not UNCLASSIFIED — it was UNSCANNED: `--check` stayed green, no
+  documentation-coverage check reached it, and every public var in it was
+  invisible to every manifest-derived gate at once. The drift-check reported
+  `in sync (494 public vars)` while three public namespaces
+  (`re-frame.ssr.ring.node`, `re-frame.ssr.render-state`,
+  `re-frame.hicasso.server`) carried genuinely public vars, no `^:no-doc`
+  markers, and zero manifest rows. A completeness check keyed on the roster
+  cannot see what the roster omits.
+
+  THE HISTORY, because this is the second time. rf2-o8xev built exactly this
+  reconciliation over `implementation/freehand/src`. Freehand's retirement
+  (rf2-0yp7w.6, commit c951808b47) removed the tree and — correctly, since
+  the gate refuses to build when a source namespace is named by neither
+  roster — retired the rosters, the assertion and its call site with it,
+  leaving `namespaces-under` and `source-file->ns-sym` behind with no caller.
+  The gate was ORPHANED rather than forgotten, which is worse: the orphan
+  reads like a live backstop to anyone grepping for one. These tests exist so
+  the restored gate cannot be orphaned silently a second time — the live-tree
+  test below fails if the call site stops accounting for the real trees.
+
+  THE GATE. It infers nothing about publicness. It asserts only that every
+  source namespace under `roster-covered-roots` is ACCOUNTED FOR — by
+  `jvm-namespaces`, by a sidecar `:cljs-only` row, or by `internal-namespaces`
+  — and fails BY NAME with the ways to answer for it. These tests pin that
+  through `roster-drift` (pure, synthetic inputs, all three directions) plus
+  `assert-roster-complete!` (the throw), and assert the LIVE rosters account
+  for the LIVE trees exactly."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.api-manifest.gen :as gen]))
+
+;; ---------------------------------------------------------------------------
+;; roster-drift — pure reconciliation over synthetic inputs.
+;;
+;; `present` stands in for the live source tree, so these drive the three
+;; failure directions without touching disk. The sidecar argument supplies
+;; only `:cljs-only`, which is the third way a namespace can be accounted for.
+;; ---------------------------------------------------------------------------
+
+(def ^:private no-cljs-sidecar
+  "A sidecar carrying no `:cljs-only` rows — the common case for the JVM
+   trees, and the one that isolates the other two rosters."
+  {:cljs-only []})
+
+(deftest fully-accounted-tree-has-no-drift
+  (testing "a tree whose every namespace is enrolled or recorded internal
+            reports nothing in any of the three directions"
+    (let [present (into #{'re-frame.ssr 're-frame.ssr.ring}
+                        (take 3 gen/internal-namespaces))
+          drift   (gen/roster-drift present no-cljs-sidecar)]
+      (is (empty? (:unaccounted drift)))
+      (is (empty? (:contradictory drift)))
+      ;; Every internal entry NOT in this synthetic `present` reads as stale,
+      ;; which is the mechanism working; the live-tree test is what pins the
+      ;; real roster's staleness.
+      (is (seq (:stale drift))
+          "internal entries absent from the tree are reported stale"))))
+
+(deftest a-new-namespace-is-unaccounted
+  (testing "a namespace named by NO roster is reported by name — the new
+            public surface that would otherwise ship unscanned"
+    (let [present #{'re-frame.ssr 're-frame.ssr.brand-new}
+          drift   (gen/roster-drift present no-cljs-sidecar)]
+      (is (= '[re-frame.ssr.brand-new] (:unaccounted drift))))))
+
+(deftest enrolment-accounts-for-a-namespace
+  (testing "the same namespace, once enrolled in jvm-namespaces, is accounted
+            for — enrolment is what clears the finding, not a marker"
+    ;; `re-frame.ssr.ring.node` is enrolled (rf2-8arzr.7), so it must NOT be
+    ;; reported even though it is not on the internal roster.
+    (let [drift (gen/roster-drift #{'re-frame.ssr.ring.node} no-cljs-sidecar)]
+      (is (empty? (:unaccounted drift))))))
+
+(deftest a-cljs-only-sidecar-row-accounts-for-a-namespace
+  (testing "a namespace the JVM cannot require is accounted for by its
+            sidecar :cljs-only rows — the path a CLJS-only surface takes"
+    (let [present #{'re-frame.hicasso.server}
+          bare    (gen/roster-drift present no-cljs-sidecar)
+          carried (gen/roster-drift
+                    present
+                    {:cljs-only [{:namespace "re-frame.hicasso.server"
+                                  :var       "render-body"}]})]
+      (is (= '[re-frame.hicasso.server] (:unaccounted bare))
+          "unaccounted without the row")
+      (is (empty? (:unaccounted carried))
+          "accounted for with it"))))
+
+(deftest a-vanished-internal-entry-is-stale
+  (testing "an internal-roster entry whose source file is gone is reported —
+            the roster rots the way the sidecar does, and is reconciled the
+            same way"
+    (let [gone  (first (sort gen/internal-namespaces))
+          drift (gen/roster-drift
+                  (disj (set gen/internal-namespaces) gone)
+                  no-cljs-sidecar)]
+      (is (= [gone] (:stale drift))))))
+
+(deftest claiming-both-is-contradictory
+  (testing "a namespace enrolled as public AND recorded internal is a
+            contradiction, not a classification"
+    (let [both  (first (sort gen/internal-namespaces))
+          drift (gen/roster-drift
+                  #{both}
+                  {:cljs-only [{:namespace (name both) :var "x"}]})]
+      (is (= [both] (:contradictory drift))))))
+
+(deftest unaccounted-is-sorted
+  (testing "findings are sorted, so the failure message is stable across runs"
+    (let [drift (gen/roster-drift
+                  '#{re-frame.ssr.zzz re-frame.ssr.aaa re-frame.ssr.mmm}
+                  no-cljs-sidecar)]
+      (is (= '[re-frame.ssr.aaa re-frame.ssr.mmm re-frame.ssr.zzz]
+             (:unaccounted drift))))))
+
+;; ---------------------------------------------------------------------------
+;; assert-roster-complete! — the throw that turns drift red.
+;; ---------------------------------------------------------------------------
+
+(deftest assert-throws-on-unaccounted-and-names-it
+  (testing "the assertion throws, names the namespace, and carries it in
+            ex-data for a caller that wants the list"
+    (let [present '#{re-frame.ssr re-frame.ssr.brand-new}]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"re-frame\.ssr\.brand-new"
+                            (gen/assert-roster-complete! present no-cljs-sidecar)))
+      (is (= '[re-frame.ssr.brand-new]
+             (:unaccounted
+               (try (gen/assert-roster-complete! present no-cljs-sidecar)
+                    (catch clojure.lang.ExceptionInfo e (ex-data e)))))))))
+
+(deftest assert-message-names-both-remediation-paths
+  (testing "the failure tells the reader how to answer for the namespace —
+            enrol it, or record it internal. A gate that only says NO sends
+            people to the nearest silencer (a ^:no-doc marker), which is the
+            outcome this bead's fence forbids."
+    (let [msg (try (gen/assert-roster-complete! '#{re-frame.ssr.brand-new}
+                                                no-cljs-sidecar)
+                   (catch clojure.lang.ExceptionInfo e (ex-message e)))]
+      (is (re-find #"jvm-namespaces" msg))
+      (is (re-find #"internal-namespaces" msg))
+      (is (re-find #"cljs-only" msg)))))
+
+(deftest assert-returns-present-when-clean
+  (testing "a clean reconciliation returns `present` unchanged, so the
+            assertion composes in the caller. `present` must carry the whole
+            internal roster: an entry missing from the tree is STALE, which
+            is a throw of its own."
+    (let [present (conj (set gen/internal-namespaces) 're-frame.ssr.ring.node)]
+      (is (= present (gen/assert-roster-complete! present no-cljs-sidecar))))))
+
+;; ---------------------------------------------------------------------------
+;; The LIVE tree — the test that fails if the gate is orphaned again.
+;; ---------------------------------------------------------------------------
+
+(deftest covered-roots-are-non-empty
+  (testing "the gate reconciles at least one real tree; an empty root list
+            would make every assertion above vacuous"
+    (is (seq gen/roster-covered-roots))))
+
+(deftest live-rosters-account-for-the-live-trees
+  (testing "every namespace under every covered root is classified, with no
+            stale internal entries and no contradictions. This is the
+            assertion `build-manifest` makes on every run and every --check."
+    (let [drift (gen/roster-drift (gen/covered-source-namespaces)
+                                  (gen/read-sidecar))]
+      (is (empty? (:unaccounted drift))
+          (str "unaccounted: " (:unaccounted drift)))
+      (is (empty? (:stale drift))
+          (str "stale: " (:stale drift)))
+      (is (empty? (:contradictory drift))
+          (str "contradictory: " (:contradictory drift))))))
+
+(deftest the-crossing-namespaces-are-enrolled
+  (testing "the two JVM-loadable ssr-node crossing namespaces rf2-8arzr.7
+            found shipping unscanned are enrolled for introspection"
+    (is (contains? (set gen/jvm-namespaces) 're-frame.ssr.ring.node))
+    (is (contains? (set gen/jvm-namespaces) 're-frame.ssr.render-state))))
+
+(deftest covered-source-namespaces-reads-the-real-tree
+  (testing "the live scan returns the artefact doors it must contain — a
+            silently empty scan is the defect `namespaces-under` throws to
+            prevent, and this pins that it did not happen"
+    (let [present (gen/covered-source-namespaces)]
+      (is (contains? present 're-frame.ssr))
+      (is (contains? present 're-frame.ssr.ring))
+      (is (contains? present 're-frame.ssr.ring.node))
+      (is (contains? present 're-frame.ssr.render-state)))))

--- a/implementation/ssr-node/README.md
+++ b/implementation/ssr-node/README.md
@@ -589,6 +589,16 @@ The sidecar is a second production runtime, and the server-arm pricing is
 blunt that this is a real cost to a real operator. What it costs in
 practice:
 
+0. Get the package onto the host. There is no published artefact — this
+   package is not on npm, it has no Clojars coordinate, none is planned as
+   of this writing, and the repository publishes JVM artefacts only. It
+   comes from a checkout, by either route in [Using it](#using-it):
+   installed from its directory, or copied onto the host and run with
+   `node bin/serve.cjs`. Since the manifest resolves nothing, copying the
+   tree is the whole install, and the version deployed is the checkout it
+   came from — so pin that checkout as deliberately as the JVM artefact
+   versions in the same release.
+
 1. Build the server bundle with the application's own shadow-cljs
    build, targeting `:node-script` or `:node-library`, publishing the
    module contract above. It must be rebuilt and redeployed in the same
@@ -736,11 +746,34 @@ strength:
   it. There is still no allowance list — no path or string is forgiven, the
   needles were not widened by a character, and the refusal-code namespace
   `:rf.ssr-node/` keeps its absolute zero on a row of its own
-- it is on no build's source path. `implementation/shadow-cljs.edn`
-  names no build reaching it and the top-level `implementation/deps.edn`
-  has no entry for it, so it is in no module graph and there is no bundle
-  it could be in. The package also contains no `.clj`/`.cljs`/`.cljc` file
-  for a build to pick up if one ever did. This is the strong reading:
+- it is on no build's source path. `implementation/shadow-cljs.edn` and
+  the top-level `implementation/deps.edn` are read at their **loader
+  positions** — for an EDN config, the value form after each of
+  `:source-paths`, `:paths`, `:extra-paths`, `:replace-paths`, `:deps`,
+  `:extra-deps`, `:replace-deps`, `:local/root` and `:dependencies` — and
+  this package's path appears at none of them, so it is in no module graph
+  and there is no bundle it could be in. A `;;` comment is not one of
+  those keys, and `implementation/shadow-cljs.edn` does name the package
+  in one: a comment above the `:examples/login-hicasso-server` build says
+  which sidecar loads the module that build emits. That is prose about a
+  build, in the file where prose about a build belongs, and it is not a
+  way into one. This reading was once a raw-text scan of the two configs,
+  which made it a claim about *mentioning* rather than the claim its own
+  failure message states; it moved (`rf2-8arzr.9`) — the sibling of the
+  move Reading 1 made under `rf2-6ovv`, not a second and softer one.
+  Nothing was forgiven to achieve it: there is no allowance list, no path
+  or string is named as an exception, and the needles were not widened by
+  a character. The control plants a real `:source-paths` entry and a real
+  `:local/root` coordinate and requires both to be found, plants a comment
+  naming the package and requires it not to be, and then requires that
+  comment fixture to carry both needles — so the scoped scan is shown
+  walking past text a raw scan does hit, rather than passing on an empty
+  fixture. The row also fails closed on its own instrument: each config
+  must exist and must yield at least one loader position, so a missing,
+  unparseable or key-less file is not a clean scan. That is what this row
+  adds over Reading 1's repo-wide sweep, which cannot speak for a config
+  that has gone missing. The package also contains no `.clj`/`.cljs`/`.cljc`
+  file for a build to pick up if one ever did. This is the strong reading:
   absence from the graph is not a property anyone has to maintain by care
 - it adds no dependency. Every `require` in `src/` is a `node:` builtin
   or a sibling file here, and the package's own `package.json` declares no

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -1409,6 +1409,21 @@
   ["re-frame.ssr" "streaming-hydrate-delta-script"] {:tier :implementation :owner "011" :status "v1"}
 
   ;; =========================================================================
+  ;; re-frame.ssr.render-state — the ssr-node crossing's render-visible
+  ;; projection (day8/re-frame2-ssr, §011). `project` / `serialize` /
+  ;; `deserialize` / `restore!` over the two-partition envelope, plus the
+  ;; policy validator. Requires-directly and re-exported by nothing;
+  ;; spec/API.md §Namespaces places it at `:implementation` "on the same
+  ;; footing as `re-frame.ssr.ring`'s own vars" and does NOT row its vars.
+  ;; Enrolled by rf2-8arzr.7, which found it shipping unscanned.
+  ;; =========================================================================
+  ["re-frame.ssr.render-state" "validate-policy-opts!"] {:tier :implementation :owner "011" :status "v1"}
+  ["re-frame.ssr.render-state" "project"]               {:tier :implementation :owner "011" :status "v1"}
+  ["re-frame.ssr.render-state" "serialize"]             {:tier :implementation :owner "011" :status "v1"}
+  ["re-frame.ssr.render-state" "deserialize"]           {:tier :implementation :owner "011" :status "v1"}
+  ["re-frame.ssr.render-state" "restore!"]              {:tier :implementation :owner "011" :status "v1"}
+
+  ;; =========================================================================
   ;; re-frame.ssr.ring — Ring host-adapter (day8/re-frame2-ssr-ring), §011.
   ;; Internal host-adapter machinery the framework wires (the individual
   ;; `*-handler` / `default-*` fns are NOT rowed as supported var APIs in
@@ -1424,6 +1439,25 @@
   ["re-frame.ssr.ring" "default-on-error"]          {:tier :implementation :owner "011" :status "v1"}
   ["re-frame.ssr.ring" "cookie->set-cookie-header"] {:tier :implementation :owner "011" :status "v1"}
   ["re-frame.ssr.ring" "handler-defaults"]          {:tier :implementation :owner "011" :status "v1"}
+
+  ;; =========================================================================
+  ;; re-frame.ssr.ring.node — the JVM→Node adapter over the bounded sidecar
+  ;; at implementation/ssr-node (day8/re-frame2-ssr-ring, §011). `renderer`
+  ;; is the one non-local `:renderer` the reference ships; the `default-*` /
+  ;; `wire-margin-ms` vars are its published bound defaults and
+  ;; `validate-opts!` / `http-timeout-ms` its opts seam. Requires-directly
+  ;; and re-exported by nothing; spec/API.md §Namespaces places it at
+  ;; `:implementation` "on the same footing as `re-frame.ssr.ring`'s own
+  ;; vars" and does NOT row its vars. Enrolled by rf2-8arzr.7, which found it
+  ;; shipping unscanned.
+  ;; =========================================================================
+  ["re-frame.ssr.ring.node" "default-endpoint"]     {:tier :implementation :owner "011" :status "v1"}
+  ["re-frame.ssr.ring.node" "default-timeout-ms"]   {:tier :implementation :owner "011" :status "v1"}
+  ["re-frame.ssr.ring.node" "default-admission-ms"] {:tier :implementation :owner "011" :status "v1"}
+  ["re-frame.ssr.ring.node" "wire-margin-ms"]       {:tier :implementation :owner "011" :status "v1"}
+  ["re-frame.ssr.ring.node" "validate-opts!"]       {:tier :implementation :owner "011" :status "v1"}
+  ["re-frame.ssr.ring.node" "http-timeout-ms"]      {:tier :implementation :owner "011" :status "v1"}
+  ["re-frame.ssr.ring.node" "renderer"]             {:tier :implementation :owner "011" :status "v1"}
 
   ;; =========================================================================
   ;; re-frame.epoch — optional artefact (day8/re-frame2-epoch), §Tool-Pair.

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 494,
+ :var-count 506,
  :tier-vocab
  [:front-porch
   :advanced
@@ -362,6 +362,11 @@
   {:namespace "re-frame.ssr", :var "streaming-render-shell", :tier :advanced, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr", :var "streaming-resolved-template", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr", :var "verify-hydration!", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ssr.render-state", :var "deserialize", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ssr.render-state", :var "project", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ssr.render-state", :var "restore!", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ssr.render-state", :var "serialize", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ssr.render-state", :var "validate-policy-opts!", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr.ring", :var "cookie->set-cookie-header", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr.ring", :var "default-html-shell", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr.ring", :var "default-on-error", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
@@ -371,6 +376,13 @@
   {:namespace "re-frame.ssr.ring", :var "ssr-handler", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr.ring", :var "ssr-middleware", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr.ring", :var "stream-handler", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ssr.ring.node", :var "default-admission-ms", :tier :implementation, :kind :var, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ssr.ring.node", :var "default-endpoint", :tier :implementation, :kind :var, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ssr.ring.node", :var "default-timeout-ms", :tier :implementation, :kind :var, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ssr.ring.node", :var "http-timeout-ms", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ssr.ring.node", :var "renderer", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ssr.ring.node", :var "validate-opts!", :tier :implementation, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ssr.ring.node", :var "wire-margin-ms", :tier :implementation, :kind :var, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.story", :var "aggregate-verdict", :tier :tooling, :kind :fn, :owner "007", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.story", :var "all-kinds-with-counts", :tier :tooling, :kind :fn, :owner "007", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.story", :var "assert-deterministic", :tier :implementation, :kind :fn, :owner "007", :status "post-v1 lib", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
Three beads on the ssr-node crossing: `rf2-8arzr.7` (P2), `rf2-m65l` (P3), `rf2-8arzr.8` (P3, docs half only — see item 3).

All three were filed by workers who refused their own dispatch's premise. Every premise was re-checked at source before acting; two did not hold as written and are reported below.

---

## Item 1 — `rf2-8arzr.7`: the completeness gate was defined but never called

**The claim holds, and the cause is more specific than "nobody wired it".**

`git grep -F 'namespaces-under'` over `.clj/.cljc/.cljs` returns exactly one hit: its own definition at `gen.clj:141`. Controlled against `all-jvm-vars`, a same-shaped hyphenated symbol in the same file, which returns three hits including two call sites — so the instrument works and the one-hit result is real.

**Why it was orphaned.** This mechanism is not new. `rf2-o8xev` (commit `c504e47d11`) built exactly this three-way reconciliation over `implementation/freehand/src`, asserted first in `build-manifest`, with a 201-line test file. Freehand's retirement (`rf2-0yp7w.6`, commit `c951808b47`) deleted the tree and — correctly, since the gate refuses to build when a source namespace is named by neither roster — retired the rosters, the assertion and its call site with it. Its own commit message says they "retire together". What it left behind was `namespaces-under` and `source-file->ns-sym`: two pure helpers with no caller. **The gate was orphaned, not forgotten**, which is worse, because an orphan reads like a live backstop to anyone grepping for one.

**The wiring.** Restored data-driven rather than hardcoded to one tree, so widening is a root plus its classifications and never another mechanism:

- `roster-covered-roots` — the trees reconciled. Enrolled: `implementation/ssr/src`, `implementation/ssr-ring/src`.
- A namespace is accounted for by one of **three** rosters: `jvm-namespaces`, a sidecar `:cljs-only` row, or `internal-namespaces`. The `:cljs-only` arm is deliberate — it is the path the third namespace will need.
- `roster-drift` reports `:unaccounted` / `:stale` / `:contradictory`; `assert-roster-complete!` throws naming the namespace and both remediation paths; `build-manifest` calls it **first**, before the reconciliations that read `jvm-namespaces` and so cannot see past it.
- Enrolment intersects `jvm-namespaces` with what is actually on disk rather than filtering by prefix. The two SSR trees deliberately share the `re-frame.ssr` prefix across different artefacts (`re-frame.ssr.ring` lives in ssr-ring, `re-frame.ssr.render-state` in ssr), so a prefix filter would mis-assign both.

**What it reds on.** Within its covered roots, nothing now — all 37 namespaces are classified: 4 enrolled (`re-frame.ssr`, `re-frame.ssr.ring`, plus the two below) and 33 recorded internal. The two newly enrolled are `re-frame.ssr.render-state` (5 public vars) and `re-frame.ssr.ring.node` (7), exactly the vars and line numbers the bead names, verified at tip. Both are classified `:tier :implementation :owner "011" :status "v1"` — the tiering `spec/API.md` §Namespaces already states for them ("on the same footing as `re-frame.ssr.ring`'s own vars"), and `doc_api_check.clj:148` gates docs coverage on `#{:front-porch :advanced :adapter :testing}`, so `:implementation` adds no docs/api page obligation. Verified at source, not taken from the bead's hint. Manifest 494 → 506 vars.

**No `^:no-doc` was added anywhere.** The SSR trees contain zero `no-doc` markers of any kind, before or after this change.

**The deliberate-red demonstration.** A "before" green means nothing on its own, so the gate was made red on something it previously ignored entirely:

- **Before**, at the merge base: captured exit **0**, `OK: spec/api-manifest.edn in sync (494 public vars)` — green while three public namespaces were invisible.
- **Planted** a new public namespace `re-frame.ssr.roster-probe` under a covered root, exactly the case the gate exists for.
- **After**: captured exit **2**, failing by name — `Unaccounted public-API source namespace(s) … re-frame.ssr.roster-probe` — with both remediation paths in the message. That red exists only in this branch's tree, so a run that had wandered into another checkout would have come back green; the red *is* the discrimination.
- **Restored** and verified by git **blob** hash: working `gen.clj` `59dd06f93953ed0306ac35bfb75e7b585481a029`, identical to the committed object; planted file gone; `git status` clean.

**Fourteen tests** pin all three drift directions, the throw, the failure message (it must name both remediation paths — a gate that only says NO sends the reader to the nearest silencer), and the **live trees**, which is the test that fails if the gate is ever orphaned again. Suite 74 → 88 tests, 184 assertions.

**Two premises that did NOT hold**, reported rather than worked around:

1. The bead says `implementation/scripts/api-manifest/test/` "is empty". It is not — six tracked test files, including `gen_test.clj`. The new file is a seventh.
2. The bead says the manifest lives at `spec/api-manifest.edn`; confirmed, and `implementation/api-manifest.edn` indeed does not exist.

**Scope held.** `re-frame.hicasso.server` — the third namespace — is **not** addressed: `implementation/hicasso/**` was held by PR #9035, which merged into this branch's new base during the work. It is CLJS-only and needs a `:cljs-only` sidecar row rather than a `jvm-namespaces` entry; the gate's third roster arm is already built for it. Follow-up bead filed.

**The widening cost, measured** so the narrow scope is a stated decision rather than an omission: **276** namespaces under `implementation/` are unenrolled in total. This PR's two roots account for 33 of them. The remaining 243 sit under trees the gate does not yet cover — `core` 84, `machines` 33, `routing` 28, `hicasso` 25, `resources` 23, `http` 17, and smaller. Each is a per-tree decision obliging a human classification per namespace, which is why they are named here rather than half-done.

---

## Item 2 — `rf2-m65l`: Reading 2's prose predated #9024's rescope

**Verified at tip:** `implementation/shadow-cljs.edn` contains exactly one `ssr-node` hit — line 1629, inside a `;;` comment above `:examples/login-hicasso-server` explaining which sidecar loads that build's module. `implementation/deps.edn` contains none (control: the same grep returns exit 1 there and exit 0 on the hit). So the README's "`implementation/shadow-cljs.edn` names no build reaching it" was false as written: the file *does* name the package.

**What the row actually checks, read from the row itself** (`absence.test.cjs`, `no shadow-cljs build and no classpath entry reaches this package`):

1. For each of `BUILD_CONFIGS` — `implementation/shadow-cljs.edn` and `implementation/deps.edn` — it asserts the file **exists** (`readTracked` non-null), so a missing config cannot read as a clean scan.
2. It asserts each file yields **at least one loader position**, failing with "the scan has gone blind". That is a liveness check on the instrument itself, not on the subject — the row refuses to pass on an instrument that found nothing because it could no longer see.
3. It then collects hits **only at loader positions**. For `.edn` that is `valuesAfterKeys(text, EDN_LOAD_KEYS)` — the value form after each of `:source-paths`, `:paths`, `:extra-paths`, `:replace-paths`, `:deps`, `:extra-deps`, `:replace-deps`, `:local/root`, `:dependencies` — and asserts the result is empty.

So the claim is **not** "these files never mention the package"; it is "no classpath-or-source-path value in them names it". A `;;` comment is not one of those keys and cannot host a hit. The paired control plants a real `:source-paths` entry **and** a real `:local/root` coordinate and requires both to be found, plants a comment naming the package and requires it **not** to be, and then requires that comment fixture to carry both needles — so the scoped scan is shown walking past text a raw scan does hit, rather than passing on an empty fixture.

The bullet is rewritten from that reading, mirroring Reading 1's shape (the worked precedent in the same file): loader positions, a comment is not one, nothing forgiven and no allowance list, the `rf2-8arzr.9` rescope named as the sibling of Reading 1's own `rf2-6ovv` move — plus the fail-closed property, which is what this row adds over Reading 1's repo-wide sweep. No test changed.

---

## Item 3 — `rf2-8arzr.8`: the honest-docs half ONLY

**The three measurements, re-run at current tip. All three still hold; the ruling's premise has not moved.**

| # | Measurement | Result at tip |
|---|---|---|
| a | `implementation/ssr-node/package.json` `private` flag | `"private": true`, `@day8/re-frame2-ssr-node` 0.1.0, `bin` → `./bin/serve.cjs` — unchanged |
| b | `npm publish` / `NPM_TOKEN` / `registry.npmjs` across `.github/` and `scripts/` | **zero hits** (exit 1). Control: the same instrument over `CLOJARS_USERNAME|CLOJARS_PASSWORD` returns four workflow files, so the zero is real and not a broken pattern |
| c | What `release.yml` publishes | Jobs exactly `verify-version-lockstep`, `test`, `deploy-core`, `deploy-leaf`, `deploy-ssr-ring`, `deploy-hicasso`, `github-release`; the release body enumerates **14** `day8/re-frame2-*` Clojars coordinates and nothing else |

One thing the bead did not measure and this PR did: there are **four** release workflows, not one (`release.yml` plus `release-story`, `release-xray`, `release-machines-viz`). Measurement (b) spans all of `.github/`, so "no npm publishing path at all" is confirmed across all four rather than inferred from one.

**A premise that did not hold as stated.** The bead says "There is no documented way to get that binary onto a production host." The README's **Using it** section already documents one — private, "installed from its directory rather than a registry", `npm install <checkout>/implementation/ssr-node` or a `file:` entry — and it predates the bead (added by `4bab8df1ae`, an ancestor of the bead's base). What was genuinely missing is what the bead's **title** names, and that is what this PR fixes: the crossing recipe's §5 gave the bare command with no account of its provenance, the README's Deployment recipe named the binary at step 2 the same way, and **neither said that no published artefact exists**.

**The acquisition route documented**, in `docs/ssr/concepts.md` §Render on Node step 5 and `implementation/ssr-node/README.md` §Deployment: there is no published artefact; the package is not on npm; it has no Clojars coordinate; none is planned as of this writing; the repository publishes JVM artefacts only. The route that works today is a checkout — installed from the package directory, a `file:` entry to the same effect, or the tree copied onto the host and run with `node bin/serve.cjs`. Because the manifest resolves nothing, copying the tree *is* the install, and the version deployed is the checkout it came from, so pin that checkout as deliberately as the JVM artefact versions in the same release.

**No coordinate is invented and no package is implied.**

**The shippability half is NOT addressed and remains held for the operator.** `package.json` keeps `private: true`, no npm publish step is added, `release.yml` is untouched. The bead is closed on its docs half only and says so.

---

## Gates

| Gate | Captured exit | Result |
|---|---|---|
| `clojure -M -m re-frame.api-manifest.gen --check` (before, at merge base) | **0** | `in sync (494 public vars)` — the false green |
| same, with a new namespace planted | **2** | red **by name** on `re-frame.ssr.roster-probe` |
| same (after, post-rebase) | **0** | `in sync (506 public vars)`, roster gate live |
| `clojure -M:test` (api-manifest, post-rebase) | **0** | 88 tests, 184 assertions, 0 failures, 0 errors |
| `node implementation/ssr-node/test/run.cjs` (post-rebase) | **0** | 9 suites all green; `absence.test.cjs` 18/18 |
| `python scripts/check_doc_slugs.py` (post-rebase) | **0** | green; planted broken anchor → exit **1** naming `docs/ssr/concepts.md` |
| `python scripts/check_readme_links.py --ci` (post-rebase) | **0** | green; planted broken anchor → exit **1** naming `implementation/ssr-node/README.md` |
| `python -m mkdocs build --strict` (post-rebase) | **0** | built clean |
| `npm run test:cljs` | **0** | 11183 tests, 55720 assertions, 0 failures, 0 errors |

Every exit code above is one captured on the same command line as the run, never one reported about it. Both link gates were proven to bite by a planted fault in this branch's own tree and restored with the blob hashes verified equal.

`check_readme_links.py` is run because `implementation/ssr-node/README.md` is **its** surface, not `check_doc_slugs.py`'s — and the plants confirmed the split empirically: each gate caught only its own file.

### One gate produced a NO-VERDICT, named as such

`sh scripts/test-fast-pr.sh` **did not produce a verdict** and is not reported as a pass.

- First run: **captured exit 1**, failing at `CLJS node integration` with `Cannot find module 'shadow-cljs/cli/runner.js'` — this worktree had no `implementation/node_modules` at all. Environmental. Every other tier was green (classified `docs=true jvm=false node=true`), including the README link validator, the docs corpus anchor validator, `mkdocs --strict`, clj-kondo, and 122 JS harness self-tests.
- `npm ci --prefix implementation` then installed a **real** directory (101 top-level entries), not a junction. The mayor checkout's own `node_modules` was re-counted afterwards and is intact at 101 — no shared target was rewritten.
- Second run: the harness's 10-minute ceiling killed the shell mid-lane. The CLJS build completed (1890 files, 0 warnings, 66.92s), then the kill landed on `node out/node-test.js`. **No `.exit` file was written, so there is no verdict** — the `FAIL` line in that log is the kill, not a test result.
- The gate was then **split** rather than re-detached, using the spine's own repro line: `npm run test:cljs` alone, run to completion, **captured exit 0**, 11183 tests / 55720 assertions / 0 failures.

So the spine's only unresolved lane is green when run to completion; the spine as a whole exceeded the harness ceiling and has no captured exit code to quote.

---

## Fence

Untouched, as instructed: `implementation/hicasso/**` (PR #9035), `.beads/**`, `package.json`'s `private` flag, `release.yml`, and every heading. No `^:no-doc` added to any var. `spec/API.md` is outside the permitted file list and was not edited — see the follow-up beads.

Closes `rf2-8arzr.7`, `rf2-m65l`. Closes `rf2-8arzr.8` **on its docs half only**.
