### PR TITLE
docs(records): correct three records that misdescribe what shipped (rf2-l1hh, rf2-v0rw, rf2-0d1w)

### DIFF
--- a/docs/design/hicasso/draft-guide/REWRITE-NOTES.md
+++ b/docs/design/hicasso/draft-guide/REWRITE-NOTES.md
@@ -141,7 +141,8 @@ implementation confirmation:
 - `h/as-component`
 - `n/memo` and `n/lazy`
 - overlay heads and option names
-- `motion/presence` with `::h/mounting` / `::h/unmounting` (not `::motion/*`)
+- `motion/presence` (the marker spelling is settled: `::motion/mounting` /
+  `::motion/unmounting`, naming-ledger row 31, executed under `rf2-hg3q`)
 - `forms/buffered-field` and its control options
 - resource `:demand true`
 - route-link's generated `::h/navigate` carrier
@@ -194,8 +195,9 @@ The following older draft ideas are not restored:
 - pre-React-19 ref contracts
 - the retired `h/fn` spelling (the product form is `h/event`, renamed under
   `rf2-hic-066`)
-- `::motion/*` override keys (shipped markers remain `::h/mounting` /
-  `::h/unmounting`)
+- the retired `::h/mounting` / `::h/unmounting` marker spelling (the shipped
+  override keys are `::motion/mounting` / `::motion/unmounting`, respelled
+  under `rf2-hg3q`)
 
 The current guide teaches `h/event` as the one callback form,
 `(rf/capture-frame (h/frame))` at foreign edges, app-db state ownership, CSS

--- a/docs/design/hicasso/studio/hframe-design.md
+++ b/docs/design/hicasso/studio/hframe-design.md
@@ -325,7 +325,8 @@ it was fenced out of `rf2-zllp8` for the same reason it was fenced out of
 
 ## 9. What is NOT settled here — flagged for a ruling
 
-*Written before the implementation. §8a resolves (1) and (4); (2) and (3) stand.*
+*Written before the implementation. §8a resolves (1) and (4); (2) is settled at
+tip, as its own entry now records; (3) stands.*
 
 1. **The error id.** The design pass proposed
    `:rf.error/hicasso-frame-outside-boundary`; the synthesis comment wrote
@@ -334,10 +335,14 @@ it was fenced out of `rf2-zllp8` for the same reason it was fenced out of
    **`-outside-boundary` is the spelling that matches the tree** and is the
    recommendation — but the implementer should have it confirmed rather than pick
    silently, because error ids are catalogued in Spec 009.
-2. **`:rf.error/ambient-frame-refused` is PROVISIONAL.** `rf2-k0rbk` may rename
-   it. Nothing in this design may be built on that spelling; `h/frame` does not
-   depend on it, and the guide text that names it must be written after
-   `rf2-k0rbk` settles.
+2. **`:rf.error/ambient-frame-refused` is SETTLED**, and this design may be
+   built on that spelling. It is rowed in `spec/009-Instrumentation.md`'s error
+   catalogue and raised by `re-frame.frame/emit-ambient-frame-refused!`, and the
+   stability rule in `implementation/hicasso/spec/complaints.md` closes the
+   question outright: an id names one refusal and is never re-spelled or reused.
+   Guide text naming it is no longer blocked. *(This item previously held the id
+   PROVISIONAL pending a rename under `rf2-k0rbk`; no such bead exists in the
+   tracker, and the rename it anticipated is one the stability rule forbids.)*
 3. **The name `h/frame` is unfrozen**, as `h/root!` is.
 4. **A diagnostic gap `rf2-2rtt6.122` opened, which is arguably a small bug of its
    own.** The arm's refusal detail is written for the two doors it was aimed at —

--- a/spec/View-Hierarchy-Capture.md
+++ b/spec/View-Hierarchy-Capture.md
@@ -43,7 +43,7 @@ The walker is also dev-only by classpath: Xray's preload is `:devtools/preloads`
 
 ## React-version regression check
 
-**Each React major bump (16 → 17 → 18 → 19 → …) MUST run a smoke test that confirms the walker still reads parent/child correctly.** The smoke test stubs a minimal Fiber-shaped object graph that mirrors the React version's published structure. It is **not yet written** — it lands with the Fiber-walker itself (rf2-l1hh), and until then this MUST has no home. If the smoke breaks, the choice is binary:
+**Each React major bump (16 → 17 → 18 → 19 → …) MUST run a smoke test that confirms the walker still reads parent/child correctly.** The smoke test stubs a minimal Fiber-shaped object graph that mirrors the React version's published structure. It was **written once and retired with the walker** — it shipped as `tools/causa/test/day8/re_frame2_causa/views/fiber_walker_cljs_test.cljs` and was deleted by the Reactive-panel rebuild (see the Ownership table below), so this MUST currently has no home in the CLJS reference. A conformant React-backed port still owes it. If the smoke breaks, the choice is binary:
 
 1. **Ship a fix** — update the walker to the new Fiber slot names / shape. This is the expected path when React renames a slot but keeps the structural model.
 2. **Fall back to data-attribute tagging** — each `reg-view` mutates its first element's attribute map to include `data-rf-view="<name>"`; the walker queries `document.querySelectorAll('[data-rf-view]')` and infers parent ⊃ children by DOM containment. This is the React-version-independent escape hatch.
@@ -99,25 +99,35 @@ This capability unlocks:
 
 ## Ownership + cross-references
 
-The Fiber-walker design is **locked and wanted** (Decisions log below) but is
-**not yet built** in the CLJS reference. The only capture path that ships today
-is the `data-rf-view` fallback walker. Rows below say which is which: a row
-marked *not yet shipped* names a surface this contract still requires, not one
-that was withdrawn (rf2-l1hh).
+The Fiber-walker design is **locked and wanted** (Decisions log below). In the
+CLJS reference it was **built and then retired**: the walker, the group-by-tree
+renderer, the Views wiring and the React-version smoke all shipped in May 2026
+and were deleted a day later by the Reactive-panel rebuild. The only capture
+path that ships today is the `data-rf-view` fallback walker.
+
+Two things about the paths below are easy to get wrong, so they are stated
+plainly. First, none of the retired files ever lived under `tools/xray/` — they
+were written under `tools/causa/`, and the `causa` → `xray` rename
+(`731188b1fb`, PR #2067, 2026-05-24) landed four days after they were deleted,
+so a `tools/xray/…` path for any of them has never existed at any commit.
+Second, a row marked *retired* records what the CLJS reference withdrew; it does
+**not** withdraw the contract. This document is still a v1 MUST for
+React-backed ports, and the Fiber-walker is still its primary path.
 
 | Surface                                | Owner                                                                  |
 |----------------------------------------|------------------------------------------------------------------------|
-| Fiber-walker implementation (CLJS)     | **Not yet shipped** — no namespace implements it in the CLJS reference. Still the locked primary path (rf2-mxkq7). |
-| Group-by-tree renderer                 | **Not yet shipped** — depends on the Fiber-walker above.               |
-| Views panel toggle wiring              | **Not yet shipped** — Xray ships no Views panel today.                 |
-| React-version regression smoke         | **Not yet shipped** — see [§React-version regression check](#react-version-regression-check) for the MUST this owes. |
+| Fiber-walker implementation (CLJS)     | **Retired** — shipped as `tools/causa/src/day8/re_frame2_causa/views/fiber_walker.cljs` (`fe4ff001b9`, PR #1533, 2026-05-19), deleted by `9781aa4e24` (PR #1741, 2026-05-20). No namespace implements it today; it remains this contract's primary path. |
+| Group-by-tree renderer                 | **Retired** — shipped as `tools/causa/src/day8/re_frame2_causa/views/group_by_tree.cljs` at those same two commits. Neither the group-by-tree mode nor its toggle exists anywhere in `tools/xray` today. |
+| Views panel toggle wiring              | **Retired — the toggle only.** The Views panel itself **ships**: `tools/xray/src/day8/re_frame2_xray/panels/reactive_panel.cljs` registers the `:views` L4 tab labelled "Views". What was withdrawn is the group-by-tree toggle, whose host `tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs` (added `4664501065`, PR #1401) the same rebuild deleted. |
+| React-version regression smoke         | **Retired** — shipped as `tools/causa/test/day8/re_frame2_causa/views/fiber_walker_cljs_test.cljs` at those same two commits; see [§React-version regression check](#react-version-regression-check) for the MUST it owes. |
 | Fallback walker (`data-rf-view` path)  | `tools/xray/src/day8/re_frame2_xray/views/view_walker.cljs` — the only capture path that ships; its own docstring records its fallback status. |
 | Production DCE contract                | `implementation/scripts/check-bundle-isolation.cjs`                    |
 | Reactive-substrate adapter API         | [`006-ReactiveSubstrate.md`](006-ReactiveSubstrate.md) (Fiber is the *contract*, not an adapter-side surface) |
-| Xray Views panel                      | `tools/xray/spec/012-Views.md`                                        |
+| Xray Views panel                      | `tools/xray/spec/021-Dynamic-Panel-Designs.md` §3 — the normative design for the shipped panel. `tools/xray/spec/012-Views.md` is **superseded** by it and describes a richer surface that was never implemented. |
 
 ## Decisions log
 
 - **2026-05-19 ~14:55 AUSEST** — Mike LOCKS Fiber-reading for parent/child hierarchy capture. Per-component metadata reads STAY REJECTED. Comments 4–5 (data-attribute tagging as primary) deprecated to fallback status. (Findings doc §11 Comment 6, §12.)
 - **2026-05-19** — Walker implementation lands behind `interop/debug-enabled?` gate; React-version smoke test seeded for React 16 + 17+. Production DCE verified via `npm run test:bundle-isolation`.
-- **2026-09-03** — Bookkeeping correction (rf2-l1hh). The Ownership table asserted four `tools/xray` paths that do not exist (`fiber_walker.cljs`, `group_by_tree.cljs`, `views_view.cljs`, `fiber_walker_cljs_test.cljs`), and §React-version regression check asserted the smoke test already lived at the last of them. Verified at source: none of the four exists, the only capture path that ships is `views/view_walker.cljs` (the `data-rf-view` fallback, whose docstring names the Fiber-walker as primary), and `__rf2_view_id__` appears in no source file. The rows now say *not yet shipped* instead of naming files. **This corrects the record only — it does not revisit the 2026-05-19 lock, and the Fiber-walker remains the wanted primary path.** Whether to build it is open and tracked separately.
+- **2026-05-20** — **RETIRED.** `9781aa4e24` (PR #1741) rebuilt the Views panel around `reactive_panel.cljs` and deleted the Fiber-walker, the group-by-tree renderer, the `views_view.cljs` toggle wiring and the React-version smoke, naming them individually in its commit body. The `__rf2_view_id__` property went with them — it was defined in the walker as `view-id-prop` and appears in no source file today. The rebuilt panel **keeps** the `:views` tab (label "Views"); what went is the hierarchy / group-by-tree mode. The 2026-05-19 entry above stands: the walker did land. This entry records that it did not survive.
+- **2026-09-03** — Ownership-table correction (rf2-l1hh). The table cited four `tools/xray` source paths. None of those paths has ever existed — the files were real, but they lived under `tools/causa/`, and the `causa` → `xray` rename (`731188b1fb`, PR #2067) landed four days after they were deleted. A first pass replaced the rows with *not yet shipped*, which was wrong in the other direction: these surfaces were built and retired, not never built, and it also asserted that Xray ships no Views panel, which it does. The rows now record the built-then-retired lifecycle with its commits, and the Views row separates the shipped `:views` tab from the withdrawn group-by-tree mode. **This corrects the record only — it does not revisit the 2026-05-19 lock, and the Fiber-walker remains this contract's wanted primary path.** Whether to rebuild it in the CLJS reference is an open operator call, tracked at rf2-2vpm.

--- a/tools/xray/test/day8/re_frame2_xray/keybinding_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/keybinding_cljs_test.cljs
@@ -73,7 +73,9 @@
   (#'keybinding/palette-toggle-key? event))
 
 (defn- spine-key-id
-  "rf2-adve5 — the spine-binding predicate (Space / L / j / k / G).
+  "rf2-adve5 — the spine-binding predicate (Space / L / j / k / Shift+G /
+  `,` / s). `keybinding/spine-key-id`'s `cond` arms are the roster; read
+  them rather than any count restated here (rf2-v0rw).
   Returns the spine event id or nil."
   [event]
   (#'keybinding/spine-key-id event))
@@ -509,16 +511,19 @@
 
 ;; ---- (5) spine-key-id (rf2-adve5) ---------------------------------------
 ;;
-;; Per spec/018 §3 + §6 the five spine bindings are Space, L, j, k, G.
-;; The predicate is *unmodified* — modifier-held variants must not
-;; match (so Cmd+L → focus address bar still works inside Xray). The
-;; mapping table:
+;; Per spec/018 §3 + §6. `keybinding/spine-key-id`'s `cond` arms are the
+;; SOURCE OF TRUTH for the spine set — deliberately no count is stated
+;; here, because the wording that named one undercounted from the moment
+;; the `,` / s arms landed (rf2-v0rw). The predicate is *unmodified* —
+;; modifier-held variants must not match (so Cmd+L → focus address bar
+;; still works inside Xray). Today the arms are:
 ;;
-;;     Space   →  :rf.xray/toggle-live-pause
-;;     L       →  :rf.xray/follow-head      (snap-LIVE)
-;;     G       →  :rf.xray/follow-head      (Shift+G; vim 'Go to head')
-;;     j       →  :rf.xray/focus-event-prev
-;;     k       →  :rf.xray/focus-event-next
+;;     Space    →  :rf.xray/toggle-live-pause
+;;     L        →  :rf.xray/follow-head      (snap-LIVE)
+;;     G        →  :rf.xray/follow-head      (Shift+G; vim 'Go to head')
+;;     j        →  :rf.xray/focus-event-prev
+;;     k        →  :rf.xray/focus-event-next
+;;     `,` / s  →  :rf.xray/settings-toggle  (toggle Settings popup)
 
 (deftest spine-key-id-space-is-toggle-live-pause
   (is (= :rf.xray/toggle-live-pause
@@ -549,6 +554,22 @@
          (spine-key-id (mk-event {:key "k"}))))
   (is (= :rf.xray/focus-event-next
          (spine-key-id (mk-event {:code "KeyK"})))))
+
+(deftest spine-key-id-comma-is-settings-toggle
+  ;; rf2-v0rw — the `,` arm was unasserted, which is why the prose above
+  ;; could undercount the roster without anything going red.
+  (is (= :rf.xray/settings-toggle
+         (spine-key-id (mk-event {:key ","}))))
+  (is (= :rf.xray/settings-toggle
+         (spine-key-id (mk-event {:code "Comma"})))))
+
+(deftest spine-key-id-s-is-settings-toggle
+  ;; rf2-v0rw — `s` is the second door onto the Settings popup; per
+  ;; spec/007-UX-IA.md §Global shortcuts both `,` and `s` open the modal.
+  (is (= :rf.xray/settings-toggle
+         (spine-key-id (mk-event {:key "s"}))))
+  (is (= :rf.xray/settings-toggle
+         (spine-key-id (mk-event {:code "KeyS"})))))
 
 (deftest spine-key-id-c-is-unbound
   ;; rf2-y0z5b — Causality surface dropped entirely; `c` is now free


### PR DESCRIPTION
Three records that misdescribe what shipped. Closes rf2-l1hh, rf2-v0rw, rf2-0d1w.

Every premise was checked at source before acting. **Two of them did not hold** — see the two "premise refuted" notes below.

---

## Item 1 — rf2-l1hh: the Fiber hierarchy was RETIRED, not never built

The bead's audit note was right that the previous pass wrote the opposite error. Git history settles it. **All four names were real code, and all four were deliberately deleted.**

| Name | Added | Deleted | At HEAD |
|---|---|---|---|
| `fiber_walker.cljs` | `fe4ff001b9` (PR #1533, 2026-05-19) | `9781aa4e24` (PR #1741, 2026-05-20) | absent |
| `group_by_tree.cljs` | `fe4ff001b9` (PR #1533) | `9781aa4e24` (PR #1741) | absent |
| `views_view.cljs` | **`4664501065` (PR #1401, 2026-05-18)** — *not* `fe4ff001b9`, which only modified it | `9781aa4e24` (PR #1741) | absent |
| `fiber_walker_cljs_test.cljs` | `fe4ff001b9` (PR #1533) | `9781aa4e24` (PR #1741) | absent |

`9781aa4e24`'s commit body names the deletions individually — *"Old supporting files (views_view, views_subs, views_events, views_helpers, views_sub_diff, views_sub_diff_subs, views/group_by_tree, views/fiber_walker) + their tests removed."* That is an explicit retirement, not attrition.

**`__rf2_view_id__`** was real too: defined at `fiber_walker.cljs:84` as `(def ^:private ^:const view-id-prop "__rf2_view_id__")` and asserted on in the smoke test, removed by the same commit. Zero hits in any `.cljs/.cljc/.clj/.js` file at HEAD (control: the metachar-bearing fixed string `__reactFiber$` matches 2 lines, so the instrument works).

**A correction the audit note did not have.** None of the four ever lived under `tools/xray/`. They were written under `tools/causa/`, and the `causa` to `xray` rename (`731188b1fb`, PR #2067) landed **four days after** they were deleted. So the paths the table cited have never existed at any commit — right conclusion, wrong reason. The document now says so explicitly.

**What Xray's Views panel is today.** It ships. `tools/xray/src/day8/re_frame2_xray/panels/reactive_panel.cljs:76-87` registers `{:id :views :label "Views" :mnem "v" :order 2}`, with a comment citing the same rf2-wyvf2 rebuild. What is absent is the group-by-tree *mode* and its toggle: `group-by-tree` and `group_by_tree` both return **zero** hits across `tools/xray` (control: `group-by` alone matches 19+ files). So "Xray ships no Views panel" was false; the table row now separates the shipped panel from the withdrawn mode.

The normative product call — should the Fiber walker come back? — is **not** pre-empted here. It now has a durable owner, **rf2-2vpm**, because the acceptance criteria require any "tracked separately" claim to name a real one.

### Premise refuted (1): three cited bead ids do not exist

`rf2-mxkq7` and `rf2-wyvf2` are **not beads**. Neither is `rf2-k0rbk` (item 3). Verified against all 511 issue ids in the export and by `bd show` (exit 1, "no issue found") against a control that resolves. Each survives only as prose — in commit subjects, in a source docstring, and in the very beads complaining about them. **`rf2-wyvf2` is cited by rf2-l1hh's own audit note and by its acceptance criteria.** The document therefore cites the commits and PRs, which are durable and resolvable, rather than bead ids that resolve to nothing. All four SHAs cited are ancestors of `origin/main` (control: a local commit correctly reads NO).

**Table columns counted by hand: 2** (`| Surface | Owner |`), verified per-row across the header, separator and all 8 body rows — every row has exactly 3 pipes.

---

## Item 2 — rf2-v0rw: the count is seven, and one detail of the bead is off

**My count: seven keys, across SEVEN `cond` arms, mapping to five distinct event ids.**

How I counted: read `spine-key-id` in `keybinding.cljs` and enumerated the `cond` test/result pairs directly — Space, `l`, Shift+`G`, `j`, `k`, `,`, `s`. Five distinct ids (`toggle-live-pause`, `follow-head` twice, `focus-event-prev`, `focus-event-next`, `settings-toggle` twice), which is the likely origin of "five".

The bead says "seven keys across **six** cond arms, the last two sharing one arm". At current tip `,` and `s` are in **separate** arms — seven arms, not six. They share one *comment block*, which is probably where the six came from.

Fixed three sites, not the two the bead named: the helper docstring (`:76`), the section comment (`:512`), and **the mapping table beneath it, which listed only five rows** and omitted both settings-toggle bindings. Followed PR #9030's shape — name `spine-key-id` as the source of truth and state no count.

Also added the two `deftest`s for the `,` and `s` arms. The bead named this as the substantive version, and it is the reason the prose could drift silently: nothing asserted those arms, so nothing went red.

---

## Item 3 — rf2-0d1w: both records corrected, plus a third site

**`bd show rf2-k0rbk` returns `Error fetching rf2-k0rbk: no issue found matching "rf2-k0rbk"`, exit 1** (control: a real bead returns exit 0). Not renamed — absent. So the PROVISIONAL note was gated on nothing.

Dropped the PROVISIONAL wording rather than re-pointing it, because the id is settled on three independent grounds: it is fully rowed in `spec/009-Instrumentation.md:1991`, it is raised by `re-frame.frame/emit-ambient-frame-refused!`, and `implementation/hicasso/spec/complaints.md` §The stability rule forbids the rename it anticipated — *"An id is stable: it names one refusal, and it is never re-spelled or reused."* Updated the section's summary line, which still listed item (2) as standing.

**The real presence markers are `::motion/mounting` / `::motion/unmounting`.** `::h/mounting` has **zero** hits anywhere in `implementation/hicasso/src/` (control: `::motion/mounting` matches 8 sites across 4 files), and the shipped guide under `docs/core/hicasso/` teaches `::motion/*` exclusively. The `::h/…` spelling is the retired prototype form; naming-ledger row 31 ruled the respelling and **rf2-hg3q** executed it — a bead that *does* exist, and is closed.

Fixed a **third site the bead did not name**: `REWRITE-NOTES.md:144` carries the same inversion, claiming the guide spelling is `::h/mounting` "(not `::motion/*`)". Also corrected the bullet's subject at `:197`, not just its parenthetical — as written it listed `::motion/*` itself as a deliberate omission, which contradicts the code that ships it.

### Premise refuted (2): the doc-slug gate DOES cover this tree

rf2-0d1w states that "neither path is under `check_doc_slugs.py`'s roots". That is wrong. `docs` is in `DEFAULT_ROOTS`, and nothing in `EXCLUDE_DIR_NAMES` covers `design`. Proven, not just read: a planted broken anchor in `docs/design/hicasso/studio/hframe-design.md` made the gate go **red naming that exact file and line**. The bead is right about `mkdocs build --strict` — `exclude_docs` does contain `design/hicasso/`, which I read directly.

---

## Gates — all foreground, unfiltered, exit codes captured and quoted

Re-run on the **final post-rebase base** (the trunk moved 32 commits; the suite count rose 11185 to 11191, so the earlier green was about a different tree).

| Gate | Exit | Evidence it read this worktree |
|---|---|---|
| `check_doc_slugs.py` | **0** | Sabotage: two planted anchors produced **exit 1**, naming both files and lines |
| `check_provenance_pins.py` | **0** | 153 pages, 821 pins, 0 findings; scoped run reported exactly my 2 changed pages |
| `mkdocs build --strict` | **0** | Log names `spec\View-Hierarchy-Capture.md` (staged by `on_pre_build`) |
| CLJS `node-test` compile | **0** | Log names this worktree's own `shadow-cljs.edn` |
| CLJS `node-test` run | **0** | 11191 tests / 55778 assertions, 0 failures |

**Sabotage control on the CLJS lane**: a planted wrong expectation in the new comma test produced **exit 1** at `keybinding_cljs_test.cljs:561`, with `actual: (not (= :rf.xray/PLANTED-FAULT :rf.xray/settings-toggle))` — which independently confirms the `,` arm's real return value. Test and assertion counts were identical across the green and sabotaged runs, so the plant crashed no other namespace. Both plants were restored and verified by **git blob hash** against the committed objects, not by reading a diff.

`mkdocs` is not on `PATH` here (exit 127 — a no-verdict, not a pass); ran via `python -m mkdocs`. The CLJS lane needed dependencies this worktree lacked: installed its **own** `node_modules` from the lockfile rather than linking the shared tree, and the coordinator's tree was verified intact afterwards (101 entries, unchanged).

Verified by hand, since no gate covers it: the ownership table's column count, and that no trunk commit touched any of my four files (`origin/main...HEAD` against the merge base — nothing reverted).

## Follow-ups filed

- **rf2-2vpm** (P3) — the operator call: does the Fiber walker return as the reference's primary path? Cited by the corrected document.
- **rf2-rn3u** (P4) — `view_walker.cljs`'s docstring still calls the retired walker "the primary path" and cites the non-existent `rf2-mxkq7`. `tools/xray/src/**` was outside this dispatch's write surface.
- **rf2-fgwf** (P4) — the second PROVISIONAL site, in `bench/hicasso/…/ambient_refusal_cljs_test.cljs:315`. rf2-0d1w asked that both sites move together; `bench/**` was outside this dispatch's write surface, so only the design-tree half moved here.
