### PR TITLE
fix(core): unregistrable dead-frame sentinel, two false resolve-resource-scope docstrings, three latent suite orderings (rf2-g1vu, rf2-rlrd, rf2-djqm)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/infinite_feed_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/infinite_feed_example_cljs_test.cljs
@@ -103,12 +103,29 @@
    re-register it that way, re-install the example's `:resource` registration
    the reset hook wiped, reset routing counters, re-publish the late-bound
    routing integration, and stub the managed-HTTP + url-push fx so route entry's
-   page-0 ensure + navigation are deterministic without a fetch / browser."
+   page-0 ensure + navigation are deterministic without a fetch / browser.
+
+   THE ORDER MATTERS, AND THE FRAME IS MADE LAST (rf2-djqm, prophylactic —
+   the shape rf2-k4oe repaired in the LinearLite suite). A `:url-bound?` frame
+   performs a synchronous initial URL sync AT CONSTRUCTION — `make-frame` ->
+   `frame/upsert-frame!`'s post-create hook -> routing's
+   `:routing/on-frame-registered!` -> `reconcile-url-listener!` — and under
+   Node that URL is `\"/\"`. So a route registered at `\"/\"` has its route-entry
+   resource plan run INSIDE `make-frame`. Construct the frame before the
+   `registrar/register!` loop below and that plan sees the `:resource` kind
+   still EMPTY (the shared reset hook cleared it), records `:transition :error`
+   / `:rf.error/resource-route-plan` on the routing slice, and — because the
+   suite's own navigation never re-plans — the error is STICKY.
+
+   This suite is green either way TODAY only because its `\"/\"` route declares
+   no BLOCKING resource; add one and it reproduces rf2-k4oe exactly, silently.
+   Registering everything first and making the frame last removes the
+   dependence entirely, and matches the committed pilot baseline
+   (`docs/design/hicasso/product/pilots/baseline/linearlite/baseline_test.cljs`,
+   which documents \"the frame is made last\")."
   []
   (test-support/reinstate-app-registration! not-found-route-row)
   (reset! last-managed-args nil)
-  (rf/make-frame {:id :rf/default :url-bound? true
-                  :doc "infinite-feed-example default app frame."})
   ;; rf2-h1vqa4: reinstate through `registrar/register!` — NOT a raw
   ;; registrar-atom swap. Image-loaded frames resolve through the SOURCE
   ;; STORE (the default image is assembled from it), and the reset hook's
@@ -122,7 +139,12 @@
   ;; Capturing no-op: the reply is replayed explicitly by the test so the
   ;; 3-element internal reply event matches what the live transport produces.
   (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil)))
+  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
+  ;; LAST — see the ordering note in the docstring. Everything the frame's
+  ;; construction-time URL sync needs (the reinstated `:resource` rows, the
+  ;; routing integration, the stubbed fx) is registered above.
+  (rf/make-frame {:id :rf/default :url-bound? true
+                  :doc "infinite-feed-example default app frame."}))
 
 (defn- isolate-trace-bus-fixture
   "OUTER fixture: keep this resource-registering suite from leaking trace

--- a/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_resources_cljs_test.cljs
@@ -171,7 +171,27 @@
    (`:url-bound? true`); re-register it that way, re-install the example's
    resource / mutation / scope registrations the reset hook wiped, reset routing
    counters, re-publish the late-bound routing integration, and stub managed-HTTP
-   + url-push so ensure / navigation are deterministic without a fetch / browser."
+   + url-push so ensure / navigation are deterministic without a fetch / browser.
+
+   THE ORDER MATTERS, AND THE FRAME IS MADE LAST (rf2-djqm, prophylactic —
+   the shape rf2-k4oe repaired in the LinearLite suite). A `:url-bound?` frame
+   performs a synchronous initial URL sync AT CONSTRUCTION — `make-frame` ->
+   `frame/upsert-frame!`'s post-create hook -> routing's
+   `:routing/on-frame-registered!` -> `reconcile-url-listener!` — and under
+   Node that URL is `\"/\"`. So a route registered at `\"/\"` has its route-entry
+   resource plan run INSIDE `make-frame`. Construct the frame before the
+   `registrar/register!` loop below and that plan sees the `:resource` /
+   `:mutation` kinds still EMPTY (the shared reset hook cleared them), records
+   `:transition :error` / `:rf.error/resource-route-plan` on the routing slice,
+   and — because the suite's own navigation never re-plans — the error is
+   STICKY.
+
+   This suite is green either way TODAY only because its `\"/\"` route declares
+   no BLOCKING resource; add one and it reproduces rf2-k4oe exactly, silently.
+   Registering everything first and making the frame last removes the
+   dependence entirely, and matches the committed pilot baseline
+   (`docs/design/hicasso/product/pilots/baseline/linearlite/baseline_test.cljs`,
+   which documents \"the frame is made last\")."
   []
   ;; rf2-h1vqa4: re-scrub the sibling app's rows per test — the merge-form
   ;; store restore preserves slots this suite's baseline does not know
@@ -181,8 +201,6 @@
   (test-support/reinstate-app-registration! not-found-route-row)
   (reset! last-managed-args nil)
   (reset! managed-args-log [])
-  (rf/make-frame {:id :rf/default :url-bound? true
-                  :doc "realworld-resources default app frame."})
   ;; Re-install the example's ns-load resource/mutation/scope registrations.
   ;; rf2-h1vqa4: reinstate through `registrar/register!` — NOT a raw
   ;; registrar-atom swap. Image-loaded frames resolve through the SOURCE
@@ -199,7 +217,12 @@
                                 (reset! last-managed-args args)
                                 (swap! managed-args-log conj args)
                                 nil))
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil)))
+  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
+  ;; LAST — see the ordering note in the docstring. Everything the frame's
+  ;; construction-time URL sync needs (the reinstated `:resource` / `:mutation`
+  ;; rows, the routing integration, the stubbed fx) is registered above.
+  (rf/make-frame {:id :rf/default :url-bound? true
+                  :doc "realworld-resources default app frame."}))
 
 (def ^:private isolate-trace-bus-fixture
   "OUTER fixture: keep this resource/mutation-registering suite from leaking

--- a/implementation/adapters/reagent/test/re_frame/resources_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/resources_example_cljs_test.cljs
@@ -110,12 +110,29 @@
    it that way, re-install the example's `:resource` registrations the reset hook
    wiped, reset the routing counters, re-publish the late-bound routing
    integration, and stub the managed-HTTP + url-push fx so route entry's ensure
-   + navigation are deterministic without a fetch / browser."
+   + navigation are deterministic without a fetch / browser.
+
+   THE ORDER MATTERS, AND THE FRAME IS MADE LAST (rf2-djqm, prophylactic —
+   the shape rf2-k4oe repaired in the LinearLite suite). A `:url-bound?` frame
+   performs a synchronous initial URL sync AT CONSTRUCTION — `make-frame` ->
+   `frame/upsert-frame!`'s post-create hook -> routing's
+   `:routing/on-frame-registered!` -> `reconcile-url-listener!` — and under
+   Node that URL is `\"/\"`. So a route registered at `\"/\"` has its route-entry
+   resource plan run INSIDE `make-frame`. Construct the frame before the
+   `registrar/register!` loop below and that plan sees the `:resource` kind
+   still EMPTY (the shared reset hook cleared it), records `:transition :error`
+   / `:rf.error/resource-route-plan` on the routing slice, and — because the
+   suite's own navigation never re-plans — the error is STICKY.
+
+   This suite is green either way TODAY only because its `\"/\"` route declares
+   no BLOCKING resource; add one and it reproduces rf2-k4oe exactly, silently.
+   Registering everything first and making the frame last removes the
+   dependence entirely, and matches the committed pilot baseline
+   (`docs/design/hicasso/product/pilots/baseline/linearlite/baseline_test.cljs`,
+   which documents \"the frame is made last\")."
   []
   (test-support/reinstate-app-registration! not-found-route-row)
   (reset! last-managed-args nil)
-  (rf/make-frame {:id :rf/default :url-bound? true
-                  :doc "resources-example default app frame."})
   ;; Re-install the example's ns-load resource registrations (wiped post-dispose).
   ;; rf2-h1vqa4: reinstate through `registrar/register!` — NOT a raw
   ;; registrar-atom swap. Image-loaded frames resolve through the SOURCE
@@ -130,7 +147,12 @@
   ;; Capturing no-op: the reply is replayed explicitly by the test so the
   ;; 3-element internal reply event matches what the live transport produces.
   (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil)))
+  (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil))
+  ;; LAST — see the ordering note in the docstring. Everything the frame's
+  ;; construction-time URL sync needs (the reinstated `:resource` rows, the
+  ;; routing integration, the stubbed fx) is registered above.
+  (rf/make-frame {:id :rf/default :url-bound? true
+                  :doc "resources-example default app frame."}))
 
 (defn- isolate-trace-bus-fixture
   "OUTER fixture: keep this resource-registering suite from leaking trace

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1571,9 +1571,13 @@
 (def ^{:doc "Resolver helper: resolve the named resolver `scope-id` against
   the supplied `db` value, returning a canonical concrete scope or nil — a
   plain function over the resolver registry, NOT an effect (no app-state /
-  dispatch side effects). It is not a pure data helper, though: like every
-  resolution site it emits `:rf.resource/scope-resolved` dev-time trace
-  evidence. Canonical use is the logout idiom (resolve the concrete old scope
+  dispatch side effects). It is a PURE data helper (rf2-ru73k6 F3): it routes
+  through the trace-free `resolve-scope*-pure` evaluator and so does NOT emit
+  `:rf.resource/scope-resolved` — a passive read advertised as pure carries no
+  observability side effect. The CAUSAL resolution boundaries that DO carry
+  that trace evidence (a resource event's `{:from-db …}` scope, route entry,
+  mutation settle) run the traced `resolve-scope*` wrapper instead. Canonical
+  use is the logout idiom (resolve the concrete old scope
   from the handler's coeffect db and pass it to `:rf.resource/clear-scope`
   concretely). Per Spec 016 §`clear-scope` resolves the concrete scope from
   the coeffect db (EP-0016 issue 7). Implementation ships in

--- a/implementation/core/src/re_frame/derivation/egress.cljc
+++ b/implementation/core/src/re_frame/derivation/egress.cljc
@@ -257,9 +257,23 @@
   fail-closed branch (`frame/frame` returns nil ⇒ whole value redacted to
   `:rf/redacted`). We therefore stamp this sentinel as the `:frame` opt when
   no live governing frame is known, so the walker fails closed on its own
-  dead-frame branch rather than resolving an ambient frame. The keyword is
-  namespaced into this ns so it can never collide with a real frame id."
-  ::no-egress-frame)
+  dead-frame branch rather than resolving an ambient frame.
+
+  It has to be a value NO frame can be registered under, and a keyword is not
+  one: `make-frame` validates no `:id` type and the registry is keyed by
+  whatever id it is handed, so every keyword — however it is namespaced — is
+  a public id an app can spell. This was `::no-egress-frame`, i.e.
+  `:re-frame.derivation.egress/no-egress-frame`; a live frame registered
+  under that literal made the stamp RESOLVE, so the walker took its
+  live-frame branch and shipped the graph's value-bearing fields raw under
+  that frame's empty declaration registry (rf2-g1vu — the same defect class
+  the rf2-7htk7 third pass fixed for Xray's `::no-frame`). A fresh host
+  object is an IDENTITY rather than a datum — nothing outside this var can
+  produce an equal value — so no registration can match it, and
+  `frame/frame` misses on it exactly as on a destroyed id. Pinned by the
+  derivation-conformance collision arm
+  `g-graph-egress-nil-frame-fails-closed-under-sentinel-id-collision`."
+  #?(:clj (Object.) :cljs (js/Object.)))
 
 (defn- project-resource-node-identity
   "Project ONE live resource node's secret-bearing identity fields:

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -627,7 +627,7 @@
    {:key         :resources/resolve-resource-scope
     :producer-ns 're-frame.resources
     :design-bead "rf2-hls77w"
-    :description "Resolver helper: resolve a named scope resolver against a SUPPLIED db value, returning the canonical scope or nil — a plain function over the resolver registry, NOT an effect (no app-state / dispatch side effects). Not a pure data helper, though: like every resolution site it emits :rf.resource/scope-resolved dev-time trace evidence. Canonical use is the logout/account-switch idiom (resolve the concrete old scope from the handler's coeffect db, then pass it to :rf.resource/clear-scope concretely). Per Spec 016 §clear-scope resolves the concrete scope from the coeffect db (EP-0016 issue 7)."}
+    :description "Resolver helper: resolve a named scope resolver against a SUPPLIED db value, returning the canonical scope or nil — a plain function over the resolver registry, NOT an effect (no app-state / dispatch side effects). It IS a pure data helper (rf2-ru73k6 F3): it routes through the trace-free resolve-scope*-pure evaluator and so does NOT emit :rf.resource/scope-resolved — a passive read advertised as pure carries no observability side effect. The CAUSAL resolution boundaries that DO carry that trace evidence (a resource event's {:from-db …} scope, route entry, mutation settle) run the traced resolve-scope* wrapper instead. Canonical use is the logout/account-switch idiom (resolve the concrete old scope from the handler's coeffect db, then pass it to :rf.resource/clear-scope concretely). Per Spec 016 §clear-scope resolves the concrete scope from the coeffect db (EP-0016 issue 7)."}
    {:key         :resources/project-scope-resolved-egress
     :producer-ns 're-frame.resources
     :design-bead "rf2-84l82t"

--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -1299,28 +1299,37 @@
         (is (not (contains-secret? top-wid))
             "no raw secret survives in the projected work-id")))))
 
+(defn- egress-sensitive-value-contributors
+  "The `egress-live-contributors` fixture plus a value-bearing live sub node
+  sitting at the frame-sensitive `[:cart :items]` path, so one graph exercises
+  BOTH egress leak channels: the value-path walk and the frame-independent
+  resource-identity projection."
+  []
+  (assoc (egress-live-contributors)
+         :subs
+         {:live-shape :map
+          :static-fn  (constantly {})
+          :live-fn    (constantly
+                        {[:cart/items]
+                         {:id      [:cart/items] :kind :derivation :rf/family :subs
+                          :inputs  [] :output [:fact [:cart/items]]
+                          :storage :ephemeral :evaluation :on-demand
+                          :lifecycle :subscription-cache-entry
+                          :value   {:cart {:items secret-token}}}})}))
+
+(defn- classify-egress-frame-sensitive!
+  "Install the `[:cart :items]` sensitive classification on `egress-frame`
+  through the same runtime-db effect the commit plane uses."
+  []
+  (frame/swap-runtime-db! egress-frame
+    (fn [rt] (elision/apply-classification-effects rt {:sensitive [[:cart :items]]}))))
+
 (deftest g-graph-egress-for-unknown-frame-fails-closed
   ;; An unreachable frame has no usable value policy, so value-bearing fields
   ;; fail closed. Resource identity projection is independent of that policy.
   (rf/make-frame {:id egress-frame})
-  ;; Install the classification through the same runtime-db effect used by the
-  ;; commit plane.
-  (frame/swap-runtime-db! egress-frame
-    (fn [rt] (elision/apply-classification-effects rt {:sensitive [[:cart :items]]})))
-  ;; a value-bearing live sub node at a frame-sensitive path, alongside the
-  ;; sensitive resource identity.
-  (let [contributors
-        (assoc (egress-live-contributors)
-               :subs
-               {:live-shape :map
-                :static-fn  (constantly {})
-                :live-fn    (constantly
-                              {[:cart/items]
-                               {:id      [:cart/items] :kind :derivation :rf/family :subs
-                                :inputs  [] :output [:fact [:cart/items]]
-                                :storage :ephemeral :evaluation :on-demand
-                                :lifecycle :subscription-cache-entry
-                                :value   {:cart {:items secret-token}}}})})
+  (classify-egress-frame-sensitive!)
+  (let [contributors (egress-sensitive-value-contributors)
         raw (graph/live-derivation-graph egress-frame contributors)]
     (testing "the raw graph carries the secret in value and identity positions"
       (is (contains-secret? raw)))
@@ -1349,6 +1358,49 @@
             "the classified [:cart :items] leaf is redacted")
         (is (= :derivation (:kind sub)) "the sub node is still present + classified")
         (is (not (contains-secret? redacted)))))))
+
+(deftest g-graph-egress-nil-frame-fails-closed-under-sentinel-id-collision
+  ;; rf2-g1vu — the fail-closed stamp `project-graph` applies when the
+  ;; governing frame is nil / unreachable must be a value NO app can register
+  ;; a frame under. It was `::no-egress-frame`, i.e. the ordinary public
+  ;; keyword `:re-frame.derivation.egress/no-egress-frame`: `make-frame`
+  ;; validates no `:id` type and the registry is keyed by whatever id it is
+  ;; handed, so an app registering a live frame under that literal turned the
+  ;; fail-CLOSED stamp into a live-frame walk under that frame's (empty)
+  ;; declaration registry, and the graph's value-bearing fields shipped RAW.
+  ;;
+  ;; Same defect class as Xray's `::no-frame`, fixed by the rf2-7htk7 third
+  ;; pass (commit 449bfd21c7) with the collision regression this arm mirrors:
+  ;; register a live frame under the literal id, leave the governing frame
+  ;; unselected, assert `:rf/redacted`.
+  (rf/make-frame {:id egress-frame})
+  (classify-egress-frame-sensitive!)
+  ;; The colliding frame: an ordinary public keyword any app can spell, and
+  ;; deliberately with no classification of its own — an empty declaration
+  ;; registry is what makes the leak observable.
+  (rf/make-frame {:id :re-frame.derivation.egress/no-egress-frame})
+  (try
+    (let [raw (graph/live-derivation-graph egress-frame
+                                           (egress-sensitive-value-contributors))]
+      (is (contains-secret? raw)
+          "the raw graph carries the secret in value and identity positions")
+      ;; An ambient frame is bound as well, so a pass here cannot be an
+      ;; accident of there being nothing to borrow.
+      (rf/with-frame :rf/default
+        (is (some? (frame/resolve-current-frame))
+            "an ambient frame is bound, making policy borrowing observable")
+        (let [redacted (egress/project-graph raw nil)
+              sub      (get-in redacted [:nodes [:sub [:cart/items]]])]
+          (is (= privacy/redacted-sentinel (:value sub))
+              "a nil governing frame must redact the whole value-bearing field
+               even with a live frame registered under the dead-frame
+               sentinel's former keyword id")
+          (is (not (contains-secret? redacted))
+              "no raw secret survives a nil-frame egress while a frame is live
+               under the dead-frame sentinel's former keyword id (rf2-g1vu)"))))
+    (finally
+      ;; Never leave the colliding id live for a sibling test.
+      (rf/destroy-frame! :re-frame.derivation.egress/no-egress-frame))))
 
 (deftest g-graph-egress-is-idempotent
   ;; Forwarders may project the same graph more than once. Full graph equality

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -495,13 +495,40 @@ const ARTEFACTS = [
   // loads it and Closure `:advanced` + goog.DEBUG=false DCE its body
   // wholesale. A non-zero hit means the egress ns got dragged into the counter
   // bundle (most likely a stray `:require` from a production-reachable ns, or
-  // an accidental re-export from the core facade). The sentinel is the live
-  // missing-frame marker produced by the egress projection.
+  // an accidental re-export from the core facade). The sentinel is the opaque
+  // resource-handle marker the egress projection MINTS: `opaque-handle` emits
+  // `[:rf.resource/opaque <digest>]` and `opaque-handle?` reads the same
+  // keyword back, both on the live path reached from `project-graph`, so the
+  // keyword's fully-qualified name is interned into this module's emitted JS.
+  //
+  // TWO literals were tried here before this one and BOTH are traps worth
+  // naming, because each is what reading the source alone would pick (rf2-fgco):
+  //
+  //   `re-frame.derivation.egress/no-egress-frame` — the old `::no-egress-frame`
+  //     dead-frame stamp. rf2-g1vu correctly replaced that keyword with a fresh
+  //     host object (`#?(:clj (Object.) :cljs (js/Object.))`) so no app-spellable
+  //     id can collide with it, and a keyword interns its name as a string where
+  //     an identity value interns nothing. The literal left the artefact and this
+  //     positive control went 0/1 — which is the whole point of rf2-e6qmxk, and
+  //     is how the drift was caught rather than shipped as a vacuous green.
+  //
+  //   `rf.derivation.egress/sentinel:rf2-mm3y49-2026-07-10:do-not-rename` — the
+  //     `defonce ^:private bundle-isolation-sentinel` still planted at the bottom
+  //     of egress.cljc. It reads like the obvious choice and it is NOT one: the
+  //     var is private and nothing consumes its value, so Closure `:advanced`
+  //     drops it and the emitted module carries 0 occurrences (measured on
+  //     out/bundle-isolation-positive-control/derivation-egress.js). That is why
+  //     4e43784ec7 moved this entry — and its `derivation-graph` sibling, onto
+  //     `rf/family` — off the planted strings when the controls became
+  //     emitted-module greps rather than source greps.
+  //
+  // The rule both traps teach: pick a literal a LIVE code path emits, and verify
+  // the count in the emitted module, never in the .cljc.
   {
     name: 'derivation-egress',
     internalSentinels: [
-      { source: 're-frame.derivation.egress missing-frame marker',
-        sentinel: 're-frame.derivation.egress/no-egress-frame' },
+      { source: 're-frame.derivation.egress opaque resource-handle marker',
+        sentinel: 'rf.resource/opaque' },
     ],
     consumerAllowList: null,
     expectedAllowListHits: 0,


### PR DESCRIPTION
Three implementation-side beads, one PR. Every premise was checked at source before
acting; two checks turned up carriers the beads did not name, filed as new beads
rather than fixed (both fell outside this dispatch's write fence).

## 1. rf2-g1vu — the dead-frame sentinel was registrable (RULED: option (a))

**The premise reproduces.** Before changing any source, I added the collision
regression and ran it against the unfixed tree. It failed exactly as the bead
predicted:

```
FAIL in (g-graph-egress-nil-frame-fails-closed-under-sentinel-id-collision)
expected: (= privacy/redacted-sentinel (:value sub))
  actual: (not (= :rf/redacted {:cart {:items "tenant-jwt-9f3a-SECRET"}}))
```

With a live frame registered under the literal
`:re-frame.derivation.egress/no-egress-frame`, `project-graph` with a nil frame-id
egressed the sensitive value **raw** instead of `:rf/redacted`. Captured exit 1,
2 failing assertions. The docstring's claim that namespacing makes the keyword
uncollidable was false, as the bead said.

**The fix, per the mayor's ruling — option (a).** `dead-frame-sentinel` is now a
private identity value, `#?(:clj (Object.) :cljs (js/Object.))`. Nothing outside
the var can produce an equal value, so no registration can match it, and
`frame/frame` misses on it exactly as on a destroyed id. (`frame/frame` is a plain
registry lookup — `(get @frames id)` — so a host object misses cleanly with no
validation path to throw. Checked before relying on it.)

**Commit followed: `449bfd21c7`** — "fix(xray): represent an explicit nil egress
frame as a private identity, not a registrable keyword (rf2-7htk7)", the PR #8987
fix for Xray's `::no-frame`. Its collision regression at
`tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs:559`
is the shape mine mirrors.

**The regression added:**
`g-graph-egress-nil-frame-fails-closed-under-sentinel-id-collision` in
`implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc`
(where `project-graph`'s tests live). It registers a live frame under the literal
id, leaves the governing frame nil, binds an ambient frame as well so a pass
cannot be an accident of there being nothing to borrow, and asserts `:rf/redacted`
plus a no-secret-anywhere sweep. The colliding frame is destroyed in a `finally`
so it never leaks to a sibling test.

Also extracted the shared fixture the sibling `g-graph-egress-for-unknown-frame-fails-closed`
duplicated (`egress-sensitive-value-contributors` / `classify-egress-frame-sensitive!`).
Pure extraction — the diff removes no assertion, and the count moved 22/522 to
23/526, which is exactly the four `is` forms of the one new test.

**FINDING — a third carrier of this class, not fixed (out of fence).**
`tools/xray/src/day8/re_frame2_xray/panels/local_render.cljc:106` defines its own
`dead-frame-sentinel` as `::no-egress-frame` and stamps it as the `:frame` opt at
`:175`, carrying the identical false docstring claim. Filed as **rf2-ws60** (P2)
with the reproduction recipe and fix shape. The bead's own point — that this
defect keeps recurring because each fix's scope was drawn too tight — now holds
for a third instance.

One near-miss was inspected and **cleared**: `implementation/core/src/re_frame/elision.cljc:1145`
passes `::no-frame` to `elide-against-frame`, but only on the branch where the
caller has explicitly waived sensitive redaction, and a colliding registry there
supplies `:large` declarations causing *more* elision. It fails closed, so it is
not this defect.

## 2. rf2-rlrd — two docstrings claimed a trace emission that does not happen

**All four readings verified at source**, not taken from the bead:

- `implementation/resources/src/re_frame/resources/scope_registry.cljc:587` — the
  public `resolve-resource-scope` body is
  `(resolve-scope*-pure scope-id spec db 'rf/resolve-resource-scope)`.
- Same file `:530` — `resolve-scope*-pure` is "PURE ... WITHOUT emitting any
  observability state (rf2-ru73k6 F3)".
- Same file `:550` — `resolve-scope*` is the TRACED wrapper for CAUSAL boundaries
  (resource events, route entry, mutation settle).
- `implementation/core/src/re_frame/core_resources.cljc:196` — the `defwrapper` is
  already correct, and is the wording both fixes follow.

Both named carriers corrected: the `re-frame.core` facade `def` and the
`:resources/resolve-resource-scope` late-bind directory `:description`.

### Census, instrument and control

The claim is **line-broken** in most carriers ("like every\n  resolution site it
emits"), so a line-oriented search for the sentence finds nothing. Two instruments
were used, and neither result is a superset of the other:

1. line-oriented `git grep -n "scope-resolved"` over tracked files — 30 files,
   narrowed to the 15 that also mention `resolve-resource-scope`;
2. per-file **whitespace-flattened** search (`tr '\n' ' ' | tr -s ' '`) for
   "not a pure data helper" / "like every resolution site it emits".

**Control, and it bit:** the flattened instrument run against
`git show HEAD:implementation/core/src/re_frame/core.cljc` (the pre-fix text)
returned the false sentence, so the pattern finds a known-present site. One blind
spot found and worked around: a window taken *after* the symbol name misses the
`core.cljc` site entirely, because there the docstring precedes the symbol in the
`(def ^{:doc ...} name value)` form. An early run of this census was also
truncated by a `head -40`, which is why the file list above is unbounded.

**FINDING — three more carriers, four sites, none fixed (all out of fence).**
The bead said "assume there may be a third"; there are three more. Filed as
**rf2-gfrv** (P3):

- `spec/Ownership.md:64` — the Named resource-scope resolvers row still says
  "emits `:rf.resource/scope-resolved` dev trace — not a pure data helper",
  contradicting `spec/016-Resources.md` and `spec/API.md`, which are both correct.
- `spec/api-manifest-metadata.edn` — **contradicts itself**: the `re-frame.core`
  row says "not a pure data helper", its `re-frame.resources` neighbour says
  "PURE ... emits no `:rf.resource/scope-resolved` trace".
- `docs/EP/EP-0016-resource-mutation-completion.md:976` and `:1356`.

`spec/**` was held by a live worker this tick and `docs/EP/**` was outside the
fence, so these are filed rather than edited. EP-0016 additionally needs a
judgment call rather than a fix: it is `Status: final` and its own header says
"This EP is now the rationale record; where it and the spec differ, the spec
governs", so its two sites are a design-time statement the implementation later
departed from deliberately.

Worth recording: the *behaviour* is already gated —
`implementation/resources/test/re_frame/resources_from_db_scope_cljs_test.cljc`
carries `resolve-resource-scope-emits-no-trace`. Only the prose drifted.

## 3. rf2-djqm — three suites shared the rf2-k4oe ordering

Applied the same reordering PR #9027 applied to LinearLite: everything registers
first, the `:url-bound?` frame is made **last**, with a docstring note in each
suite explaining why (the construction-time URL sync, the empty-registrar plan,
the sticky `:transition :error`, and the fact that each is green today only
because its `"/"` route declares no blocking resource) so the constraint cannot be
silently undone again.

### Before/after, single-app `:node-test` bundles, on the final rebased base

Each suite was built in a bundle containing only itself, via
**clear → compile → run → clear** (the dev bundle `SHADOW_IMPORT`s from the
build-cache directory at *run* time, so the cache must survive between compile and
run; `--test=<ns>` was not used, since it filters what runs while leaving siblings
loaded). Compile file counts (222 / 315 / 263 against 1891 for the full bundle)
confirm single-app isolation, and shadow-cljs printed this worktree's config path
on every run.

| suite | before | after |
|---|---|---|
| `infinite_feed_example_cljs_test` | 5 tests / 38 assertions, 0 failures, exit 0 | 5 tests / 38 assertions, 0 failures, exit 0 |
| `realworld_resources_cljs_test` | 33 tests / 286 assertions, 0 failures, exit 0 | 33 tests / 286 assertions, 0 failures, exit 0 |
| `resources_example_cljs_test` | 9 tests / 39 assertions, 0 failures, exit 0 | 9 tests / 39 assertions, 0 failures, exit 0 |

Identical throughout, and all three match the figures the bead recorded. Nothing
observable changed.

**PREMISE CORRECTION — PR #9027 was still OPEN when this work started.** The brief
described its fix as landed. On the original base (`8b617dd529`)
`resources_example_cljs_test` could not be built in a single-app bundle at all: it
died at ns load with

```
Error: rf/reg-machine requires day8/re-frame2-machines on the classpath [:rf.error/machines-artefact-missing]
```

— the exact defect PR #9027 fixes in `examples/capabilities/resources/resources/core.cljs`,
independently corroborated here. That is also why the bead's own measurement is
recorded as taken "on 690b99309f **+ the rf2-k4oe fixes**": the caveat is
load-bearing. The first before/after pass was therefore taken with that one-line
require planted temporarily (restore verified by git blob hash back to
`5e0060754f4a614a1ac1080594a958efc38c77b8`, tree clean). PR #9027 has since
merged, and **every number in the table above is from the rebased base with no
plant at all.**

## Gates

All run in the foreground or detached-and-polled to completion, unfiltered, with
the exit code captured on the runner's own command line. Every number below is the
captured one, and all are on the **final rebased base**.

| gate | result |
|---|---|
| `npm run test:cljs` (compile + run, split to stay foreground) | compile 1891 files / 0 warnings, exit 0; run **11190 tests / 55778 assertions, 0 failures**, exit 0 |
| `implementation/core` JVM (`clojure -M:test`) | 2175 tests / 11144 assertions, 0 failures, exit 0 |
| `implementation/derivation-conformance` JVM (`clojure -M:test`) | 23 tests / 526 assertions, 0 failures, exit 0 |
| three single-app `:node-test` bundles | see the table above, exit 0 each |
| `sh scripts/test-fast-pr.sh` | **PASS**, 0 `FAIL` lines, exit 0 |

`derivation-conformance` is the lane item 1 lives in, and it is a `.cljc` suite
that runs in **both** runtimes — the JVM alias exercises the `(Object.)` arm and
the `:node-test` bundle exercises `(js/Object.)`, so the collision regression is
the discriminator for both reader-conditional arms.

**Gate discrimination.** `test-fast-pr.sh` and the single-app runs both print the
root they resolved, and every run named this worktree. Beyond that, item 1's
regression is itself a planted-fault control that was measured **red before the
fix and green after** — a run that had wandered into a sibling checkout would have
come back green on the first attempt.

**One flake, named rather than folded into the pass.** An earlier spine run
(pre-rebase) failed at
`startLocalHttpServer proves readiness against loopback for a wildcard 0.0.0.0 bind`
with `AssertionError: a wildcard-bound server must be proven ready via 127.0.0.1`.
That is a Node HTTP-harness bind race with no CLJS in this diff able to reach it;
re-running `npm run test:scripts` alone returned exit 0 with zero failures, and
the two subsequent full spine runs both passed it. No gate is reported here as a
no-verdict.

## Fence

Diffed against the merge base (`origin/main...HEAD`): 7 files, +174/-37, exactly
the intended set. Nothing under `spec/**`, `implementation/hicasso/**`,
`skills/**`, `.beads/**`, or `docs/EP/**`. No assertion was weakened anywhere, and
rf2-djqm was not widened into the other apps registering `"/"`.
