### PR TITLE
fix(xray): dead-frame sentinel collision + three spec/docstring truthings (rf2-ws60, rf2-2oug, rf2-9vm0, rf2-rn3u)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1753,6 +1753,21 @@ The launch pill doesn't render in production builds (per Spec 009 §
 Production builds — `goog.DEBUG=false` elides the entire surface).
 `Ctrl+Shift+C` does nothing. CI verifies via `npm run test:elision`.
 
+> **Status (rf2-2oug): the posture banner below is normative-future —
+> nothing in `tools/xray/src` implements it.** The paragraph is retained as
+> the design, not as a description of a shipped surface. Census at tip over
+> `tools/xray/src`: zero hits for the banner text both line-oriented and
+> whitespace-collapsed, against a `dismiss` control returning 43.
+>
+> It is deliberately not built. The posture question it answers is already
+> answered by the elision gate above — a production build carries no Xray
+> surface at all, and `npm run test:elision` holds that in CI — so the
+> banner is a dev-build courtesy rather than a privacy control, and
+> building it speculatively to make this sentence true would be the wrong
+> direction of causation. The `skills/re-frame2-xray` reference
+> `references/launch-lifecycle.md` §Production posture records the same
+> status in the same words; the two carriers must stay in step.
+
 In a non-elided dev build running in production-like conditions,
 Xray shows a yellow top banner: "Xray is enabled in this build.
 Disable for production." Single-click dismiss, remembered for the

--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -415,6 +415,29 @@ Constraints inherited from the `window.opener` posture:
   garbage-collected. Pop-out re-bootstraps on opener reload by
   re-reading `window.opener.xrayRuntime`.
 
+> **Status (rf2-9vm0): the `window.opener.xrayRuntime` handle in the last
+> bullet is normative-future — nothing in `tools/xray/src` sets or reads
+> it.** This marker is scoped to that HANDLE alone and to nothing else in
+> this section. Pop-out itself **ships**, by the mechanism stated above:
+> `window.open` plus same-JS-realm reads and dispatches against the
+> opener's runtime atoms, with no `postMessage`, `BroadcastChannel`,
+> shared worker or query-param layer. That description is accurate and
+> normative — see `mount.cljs` `popout!`, `install-opener-gone-overlay!`
+> and `start-opener-gone-watchdog!`. Census at tip over `tools/xray/src`:
+> zero hits for `xrayRuntime` both line-oriented and whitespace-collapsed,
+> against an `opener` control returning 79 and a `popout` control
+> returning 165.
+>
+> **The bullet's second claim is a real gap, not drift, and is tracked
+> rather than marked away (rf2-uong).** With no handle there is no
+> re-bootstrap, and `opener-gone?` is `(or (nil? opener) (.-closed
+> opener))` — a same-origin hard reload leaves `window.opener` live and
+> `.closed` false, so the watchdog never fires and the opener-gone overlay
+> never shows. The pop-out keeps rendering against the previous realm's
+> atoms: silently stale rather than visibly broken. Whether the fix is to
+> widen the predicate, to build the re-bootstrap, or to declare the reload
+> case out of scope is open on that bead.
+
 Solves the "I want Xray on a second monitor while the app runs
 full-screen" use case.
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/local_render.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/local_render.cljc
@@ -117,10 +117,28 @@
   `:rf/redacted`, unless the caller explicitly waived sensitive redaction).
   We therefore stamp this sentinel as the `:frame` opt when no live governing
   frame is known, so the walker fails closed on its own dead-frame branch
-  rather than resolving an ambient frame. The keyword is namespaced into this
-  panel so it can never collide with a real frame id. Mirrors the off-box
-  derivation-graph fix (rf2-udkj69); applied to local-render by rf2-cra0nq."
-  ::no-egress-frame)
+  rather than resolving an ambient frame.
+
+  It has to be a value NO frame can be registered under, and a keyword is not
+  one: `make-frame` validates no `:id` type and the registry is keyed by
+  whatever id it is handed, so every keyword — however it is namespaced — is a
+  public id an app can spell. Earlier passes used `::no-egress-frame`, which
+  expands to the ordinary public keyword
+  `:day8.re-frame2-xray.panels.local-render/no-egress-frame`; a live frame
+  registered under that id made the stamp RESOLVE, took the walker's LIVE-frame
+  branch, and shipped the value RAW under that frame's empty declaration
+  registry — the fail-CLOSED stamp becoming fail-OPEN (rf2-ws60). A fresh host
+  object is an IDENTITY rather than a datum — nothing outside this var can
+  produce an equal value — so no registration can match it, and `frame/frame`
+  misses on it exactly as on a destroyed id.
+
+  Mirrors the off-box derivation-graph fix (rf2-udkj69); applied to
+  local-render by rf2-cra0nq. Third carrier of the sentinel class fixed at
+  `day8.re-frame2-xray.egress/no-frame` (rf2-7htk7) and
+  `re-frame.derivation.egress` (rf2-g1vu); this file is `.cljc` and IS read on
+  the JVM (its test namespace runs under `clojure -M:test`), so the substitute
+  takes the reader-conditional form rather than a bare `(js/Object.)`."
+  #?(:clj (Object.) :cljs (js/Object.)))
 
 (defn local-render-profile
   "Resolve the egress profile a local panel render should project under,
@@ -144,7 +162,8 @@
     (`frame/resolve-current-frame`) and ship value-bearing fields RAW under
     that borrowed frame's policy — the exact ambient-borrow leak this seam
     abolishes (rf2-cra0nq, mirroring rf2-udkj69). The sentinel is a non-nil
-    id that resolves to no live frame, so the walker takes its
+    value that NO frame can be registered under (rf2-ws60 — a namespaced
+    keyword was one, and collided), so the walker takes its
     unresolvable-frame fail-closed branch (redact the whole value) rather
     than borrow another frame's policy.
   - **`:rf.size/include-large? true`** — the on-box 'keep large' override

--- a/tools/xray/src/day8/re_frame2_xray/views/view_walker.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/view_walker.cljs
@@ -1,12 +1,33 @@
 (ns day8.re-frame2-xray.views.view-walker
-  "Fallback runtime view-hierarchy walker — `data-rf-view` attribute path
-  (rf2-01il5).
+  "Runtime view-hierarchy walker — the `data-rf-view` attribute path (built by
+  commit `da39b0c0f8`, PR #1780).
 
-  ## Status: FALLBACK SAFETY NET only
+  ## Status: the ONLY runtime view-hierarchy capture path the reference ships
 
-  The primary path for runtime view-hierarchy capture is the Fiber-walker
-  (rf2-mxkq7) — see [View-Hierarchy-Capture.md](../../../../../spec/View-Hierarchy-Capture.md).
-  This namespace ships the **data-attribute fallback**:
+  A React Fiber-walker was built beside this one and later RETIRED. Added by
+  commit `fe4ff001b9` (PR #1533, 2026-05-19) at
+  `tools/causa/src/day8/re_frame2_causa/views/fiber_walker.cljs`; deleted by
+  commit `9781aa4e24` (PR #1741, 2026-05-20), the Reactive-panel rebuild, which
+  took the group-by-tree renderer, the Views toggle wiring and the
+  React-version regression smoke with it. Those files never lived under
+  `tools/xray/` — the Causa → Xray rename (`731188b1fb`, PR #2067) landed four
+  days after the deletion.
+
+  Nothing implements a Fiber-walker at HEAD, so this namespace is NOT a safety
+  net standing beside a live primary path: it is the whole of runtime
+  view-hierarchy capture in the CLJS reference. Whether the Fiber-walker
+  returns is an open product question owned by `rf2-2vpm`.
+
+  Commits and PRs are cited above because they are durable. The ids these lines
+  used to carry — `rf2-01il5` for this walker and `rf2-mxkq7` for the
+  Fiber-walker — are NOT beads and resolve to nothing; they survive only in the
+  commit subjects named here.
+
+  The CONTRACT this path answers to, including the Fiber slots a React-backed
+  port MUST read, stays pinned in
+  [View-Hierarchy-Capture.md](../../../../../../spec/View-Hierarchy-Capture.md).
+
+  This namespace ships the **data-attribute** capture:
 
       - Each re-frame2 adapter (Reagent / UIx) tags the rendered
         root DOM element of every registered view with
@@ -17,16 +38,15 @@
         and reconstructs parent ⊃ children purely from DOM containment.
         No React internals; no Fiber slot reads; no version-coupling.
 
-  Activate this walker when:
-
-      1. A future React-version regression breaks the Fiber-walker.
-      2. A non-React substrate is ever wired in (none today — Reagent,
-         and UIx all mount through React, so the data-attribute
-         path is dormant under the canonical install).
+  It is ACTIVE under the canonical install, not dormant: with no Fiber-walker
+  at HEAD there is nothing for it to stand in for. It is also the path that
+  survives the two cases the Fiber design does not cover — a React-version
+  regression that breaks Fiber slot reads, and a non-React substrate (none
+  today; Reagent and UIx both mount through React).
 
   ## Fidelity gaps (documented edge cases)
 
-  The fallback is a **lossy approximation** of the Fiber-walker. Per
+  This path is a **lossy approximation** of what a Fiber walk would see. Per
   Spec 006 §View tagging contract §Documented edge cases:
 
       - Fragment root (`:<>`) — invisible to the walker (no DOM
@@ -60,7 +80,7 @@
        :node-key  <integer>}                 ;; stable hash of the DOM node
 
   In document order — mirrors the Fiber-walker's output shape per
-  [View-Hierarchy-Capture.md §Output shape](../../../../../spec/View-Hierarchy-Capture.md#output-shape)
+  [View-Hierarchy-Capture.md §Output shape](../../../../../../spec/View-Hierarchy-Capture.md#output-shape)
   so consumer code is path-agnostic. `:node-key` substitutes for the
   Fiber-walker's `:fiber-key` — same role (stable React key for tree-row
   rendering across re-walks)."
@@ -79,8 +99,9 @@
   Alias of the canonical `re-frame.source-coords/parse-view-id` (the source-
   coord contract owner) — the inverse of `format-view-id`. This parser used to
   be reimplemented inline here and in the re-frame2-pair preload runtime's
-  `view-entity`; rf2-ztxnm8 collapsed both onto the one canonical impl in core
-  (the data-rf-view analogue of rf2-nr7vf2's `parse-source-coord` work). See
+  `view-entity`; commit `49c566370c` collapsed both onto the one canonical impl
+  in core (the data-rf-view analogue of the `parse-source-coord` dedup in
+  commit `04ab2d3d3b`). See
   that fn for the value format (Spec 006 §View tagging contract §Attribute
   value format / Spec-Schemas §`:rf/view-id-attr`) and the Tool-Pair opacity
   caveat (downstream callers MUST NOT depend on the parsed shape's stability

--- a/tools/xray/test/day8/re_frame2_xray/panels/local_render_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/local_render_cljs_test.cljc
@@ -250,3 +250,66 @@
           {:keys [top]} (h/current-state-sections projected nil)]
       (is (= "secret-session-jwt-abc123" (get-in top [:auth :token]))
           "no sensitive decl ⇒ section model is unredacted"))))
+
+;; ---------------------------------------------------------------------------
+;; 7. THE SENTINEL-COLLISION ARM (rf2-ws60) — the dead-frame substitute must be
+;;    a value NO app can register a frame under.
+;;
+;; Third carrier of the class fixed at `day8.re-frame2-xray.egress/no-frame`
+;; (rf2-7htk7 third pass, PR #8987 commit 449bfd21c7) and at
+;; `re-frame.derivation.egress` (rf2-g1vu). A `::`-namespaced keyword reads as
+;; private but expands to an ORDINARY PUBLIC keyword — here
+;; `:day8.re-frame2-xray.panels.local-render/no-egress-frame` — and the frame
+;; registry is keyed by whatever `:id` `make-frame` is handed. So an app CAN
+;; register a live frame under the literal. The stamp then RESOLVES, the walker
+;; takes its LIVE-frame branch, and that frame's (empty) declaration registry
+;; ships the value RAW: the fail-CLOSED stamp becomes fail-OPEN.
+;;
+;; Modelled on `copy-value-with-no-observed-frame-fails-closed-under-id-collision`
+;; in `app_db_diff_cljs_test.cljs`.
+;; ---------------------------------------------------------------------------
+
+(def ^:private colliding-sentinel-id
+  "The id the `::no-egress-frame` sentinel literal expanded to before rf2-ws60.
+  Spelled out in full ON PURPOSE: `::no-egress-frame` here would read as this
+  namespace's keyword, not the panel's, and the point of the test is that the
+  literal is a public id any app can spell."
+  :day8.re-frame2-xray.panels.local-render/no-egress-frame)
+
+(deftest local-render-fails-closed-under-sentinel-id-collision
+  (testing "rf2-ws60 — an app registers a LIVE frame under the public keyword
+            the dead-frame sentinel used to expand to. A nil / unreachable
+            observed frame MUST still redact the whole value: a substitute that
+            is itself a registrable frame id resolves to that live frame, takes
+            the walker's live-frame branch, and its empty declaration registry
+            ships the secret RAW"
+    (rf/make-frame {:id colliding-sentinel-id})
+    (try
+      (testing "a NIL observed frame fails closed despite the collision"
+        (let [rendered (local-render/local-render-value app-db-value nil)]
+          (is (= :rf/redacted rendered)
+              (str "nil observed frame must redact WHOLE even with a live frame "
+                   "registered under the sentinel's id. got: " (pr-str rendered)))
+          (is (not= "secret-session-jwt-abc123" (get-in rendered [:auth :token]))
+              "the session token leaked through the colliding sentinel frame")))
+      (testing "an UNREACHABLE observed frame likewise fails closed"
+        (let [rendered (local-render/local-render-value app-db-value
+                                                        :app/does-not-exist)]
+          (is (= :rf/redacted rendered)
+              (str "unreachable observed frame must redact WHOLE under the "
+                   "collision. got: " (pr-str rendered)))
+          (is (not= "secret-session-jwt-abc123" (get-in rendered [:auth :token]))
+              "the session token leaked through the colliding sentinel frame")))
+      (testing "the stamped :frame is NOT a value the app could have registered
+                — the structural half of the fix, so a future re-spelling as a
+                keyword is caught even if the projection happens to redact"
+        (let [stamped (:frame (local-render/local-render-opts nil))]
+          (is (some? stamped) "the sentinel is still stamped, never nil/absent")
+          (is (not (keyword? stamped))
+              (str "the dead-frame sentinel must not be a keyword — every "
+                   "keyword is an id an app can register. got: " (pr-str stamped)))
+          (is (not= colliding-sentinel-id stamped)
+              "the sentinel must not be the colliding public keyword")))
+      (finally
+        ;; Never leave the colliding id live for a sibling test.
+        (rf/destroy-frame! colliding-sentinel-id)))))


### PR DESCRIPTION
Four `tools/xray/` beads. Two carried mayor rulings; both were followed. Every
premise was checked at source before acting, and two of them did not hold as
written — those are called out below.

## Item 1 — rf2-ws60 (P2): dead-frame sentinel was a registrable keyword

**Premise holds, and it was REPRODUCED before it was fixed.**
`panels/local_render.cljc:106` defined `dead-frame-sentinel` as
`::no-egress-frame`, which expands to the ordinary public keyword
`:day8.re-frame2-xray.panels.local-render/no-egress-frame`. The frame registry
is keyed by whatever `:id` `make-frame` is handed, so an app can register a live
frame under that literal.

Reproduction, against the unmodified definition: register a live frame under the
literal, then render with a nil / unreachable observed frame. Captured **exit 1,
6 failing assertions** — the value egressed as
`{:auth {:token "secret-session-jwt-abc123", :user-id 42}, ...}` raw instead of
`:rf/redacted`. The fail-CLOSED stamp was fail-OPEN.

**Fix form: carrier 2's reader-conditional `#?(:clj (Object.) :cljs (js/Object.))`,
not carrier 1's bare `(js/Object.)`** — because I checked which platforms this
file is read on rather than assuming. It is `.cljc`, and `clojure -M:test` in
`tools/xray` loads it on the JVM (the existing `local_render_cljs_test.cljc`
runs there: 6 tests / 30 assertions before this change). A bare `(js/Object.)`
would not read on that lane.

**The docstring is fixed**, which is the part that made this class recur. All
three carriers claimed "The keyword is namespaced into this panel so it can
never collide with a real frame id." That sentence is replaced with what is
actually true of the replacement: a fresh host object is an identity rather than
a datum, nothing outside the var can produce an equal value, so no registration
can match it, and `frame/frame` misses on it exactly as on a destroyed id.

**Planted-fault proof that the new regression bites — twice, on both lanes.**

* JVM: the new test failed **exit 1 / 6 failures** against the pre-fix
  definition and passes **exit 0** after. Same test, same file.
* CLJS: reverted only the `:cljs` arm to the colliding keyword
  (`#?(:clj (Object.) :cljs ::no-egress-frame)`) and re-ran the node suite. It
  went **exit 1 with 6 failures naming
  `local-render-fails-closed-under-sentinel-id-collision` at
  `local_render_cljs_test.cljc:290/293/298/301`**. Tally was **11190 tests /
  55781 assertions on both the control and the sabotage run**, so the plant
  crashed no namespace and skipped nothing. A `:cljs`-only plant going red is
  also positive evidence that the CLJS lane actually executes this test through
  the `:cljs` reader branch, not merely that it compiles it.

Both plants restored and verified by **git blob-hash equality** against the
committed object, not by eyeball.

The regression also asserts the *structural* half — the stamped `:frame` must
not be a `keyword?` — so a future re-spelling as a keyword is caught even if the
projection happens to redact for some other reason.

On blast radius, as the bead asked: `local-render-opts` does pass
`:rf.size/include-large? true` always, and `:rf.egress/local-raw` (via `raw?`)
includes sensitive. Confirmed the leak arm is the **local-redacted default** —
under `local-raw` the operator has explicitly waived redaction and the opt-out
branch precedes the fail-closed redact, which the existing
`local-render-fails-closed-under-bound-ambient-frame` test already pins. Not
widened into the profile logic.

## Item 2 — rf2-2oug (P3): production-posture banner, marked normative-future

**Census re-run at tip, and the instrument had to be fixed first.** My initial
line-oriented pass reported 0 for the banner text *and 0 for the `dismiss`
control* — a control that must be non-zero. Cause: on this grep build `-F`
combined with `-i` silently returns 0 (`grep -ri` gives 43, `grep -rFi` gives
0). With `-F` alone the instrument is sound.

Validated result over `tools/xray/src`, four probes
(`Xray is enabled`, `Disable for production`, `is enabled in this build`,
`yellow top banner`):

* line-oriented: **0** for all four
* whitespace-collapsed: **0** for all four
* control `dismiss`: **40** plus `Dismiss` **3** = **43**, matching the filing
  worker's recorded 43; 12 files on the flattened pass

Both passes agree: the banner does not ship. The ruling stands and is applied.

**Marker spelling matched, not invented.** There was no existing
`normative-future` token inside `tools/xray/spec/`, but there *is* an
established form: a blockquote status notice, at
`004-App-DB-Diff.md:738` (`> **Status (rf2-g7zayk): the operator reveal act is
not yet wired.**`) and `006-Hydration-Debugger.md:15`. I matched that shape and
included the literal phrase "normative-future" so 007 and the skill agree word
for word. **Not a deletion** — `$Production posture` keeps its heading and its
design paragraph verbatim; the notice sits above it.

007 and the skill now agree:
`skills/re-frame2-xray/references/launch-lifecycle.md` §Production posture
already said "There is no in-build 'Xray is enabled' warning banner ... it is
normative-future".

One self-correction worth recording: I first wrote a cross-reference to
"§Wired hotkeys", copying the skill's phrasing. That heading exists in the
**skill**, not in `tools/xray/spec/`, so the reference was false. Removed rather
than repointed.

## Item 3 — rf2-9vm0 (P3): pop-out handle — branch (b), and a bug filed

**Census both ways, and they agreed this time**, over `tools/xray/src`:

* `xrayRuntime`: **0** line-oriented, **0** whitespace-collapsed
* controls: `opener` **79**, `popout` **165**

The filing worker's single flattened hit did not reproduce at tip. The one
near-miss I did find, `make-xray-runtime-fixture` in `test_support.cljs`, is an
unrelated test fixture and is cleared.

**The pop-out question landed in branch (b): pop-out SHIPS, using another
mechanism.** Establishing that at source was the point of the check-me clause,
and marking the whole section normative-future would have left 011 silent about
a substantially implemented feature. `mount.cljs` ships `popout!`,
`install-opener-gone-overlay!`, `start-opener-gone-watchdog!`, `opener-gone?`,
`style-popout-document!`, `register-popout-unload-cleanup!` and
`teardown-popout-state!`. The mechanism is the one **011 already describes
correctly**: `window.open` plus same-JS-realm reads and dispatches against the
opener's runtime atoms, with no `postMessage`, `BroadcastChannel`, shared worker
or query param (`mount.cljs`: "same JS realm; no postMessage layer").

So the marker is scoped to the `window.opener.xrayRuntime` **handle alone**, and
the blockquote says so explicitly.

**Part of it is branch (c) territory, so it is filed rather than marked away —
`rf2-uong` (P3).** The bullet carrying the handle also promises a recovery
behaviour that does not happen, and nothing else supplies it. `opener-gone?` is
`(or (nil? opener) (.-closed opener))`; a same-origin hard reload of the opener
leaves `window.opener` live and `.closed` false, so the 500ms watchdog never
fires and the opener-gone overlay never shows. With no re-bootstrap either, the
pop-out keeps rendering against the previous realm's atoms — silently stale
rather than visibly broken, which is the exact failure the rf2-h3ekl overlay was
introduced to abolish, reached by a route its predicate does not detect. I did
**not** reproduce this in a browser; it is read from source plus `window.opener`
semantics, and the bead says so and names a browser repro as step one. The
disposition (widen the predicate / build the re-bootstrap / declare the reload
case out of scope) is left open on the bead, not pre-empted here.

## Item 4 — rf2-rn3u (P4): docstring asserting a deleted primary path

**`rf2-01il5` is in exactly the same state as `rf2-mxkq7`: a phantom.** `bd show`
exits **1** for both against a control (`rf2-rn3u`) that exits **0**, and both
are absent from all **477** issue ids in the export while the control returns 1.

**Two more phantoms in the same file**, found while checking: `rf2-ztxnm8` and
`rf2-nr7vf2`, both `bd show` exit 1. Four phantom ids in one docstring.

**The built-then-retired history is true, verified at commit level rather than
taken from the brief:** `fe4ff001b9` (PR #1533, 2026-05-19) added
`tools/causa/src/day8/re_frame2_causa/views/fiber_walker.cljs` (+129) and
`9781aa4e24` (PR #1741, 2026-05-20) deleted it (-129) together with
`group_by_tree.cljs`, `views_view.cljs` and their tests. Those paths never lived
under `tools/xray/` — the Causa to Xray rename (`731188b1fb`, PR #2067) landed
four days after the deletion.

Durable coordinates written in place of the phantoms: `da39b0c0f8` / PR #1780
for this walker, `fe4ff001b9` / PR #1533 and `9781aa4e24` / PR #1741 for the
Fiber-walker, `49c566370c` and `04ab2d3d3b` for the parse-view-id dedup. The
contract pointer to `spec/View-Hierarchy-Capture.md` is kept, and `rf2-2vpm`
(which does resolve, exit 0) is named as the owner of whether the walker
returns. No editorialising about the future beyond that pointer.

**Two broken links fixed, in a place no gate reads.** Both relative links to
`spec/View-Hierarchy-Capture.md` were one `../` short and resolved to
`tools/spec/...`, which does not exist. `check_doc_slugs.py`'s roots do not
include `tools/xray/src`, and `check_readme_links.py` covers `README.md` and
tracked non-README markdown beside source — a `.cljs` docstring is neither, so
nothing would have caught these. Verified by resolving both forms on disk: six
levels resolves, five does not.

The "Activate this walker when" block was corrected too: it described this path
as dormant and conditional on a Fiber-walker regression, which is not true when
no Fiber-walker exists.

I changed the `## Status:` line inside the docstring, having first checked it is
not an anchor anyone links to — the only hits for "FALLBACK SAFETY NET" outside
the file itself are bead text in the tracker export. It was the false assertion
the bead was filed about.

## A brief premise that did NOT hold

The brief stated that `View-Hierarchy-Capture.md`'s Ownership table "now carries
the full built-then-retired record". **It did not, at my base
(`1b64fd6396`) or at `origin/main` when I checked (`70f6cea39b`)**: the table
still read "**Not yet shipped**" four times with no retirement record, because
its PR **#9041 was still OPEN** on `worker/records-a`. The history itself was
true, which is why item 4 was still completable — I cited the commits rather
than depending on the spec's wording.

That PR merged mid-session (`357ab8ad59`) and my rebase picked it up. The table
now says "**Retired**" with the same commits and PRs I wrote into the docstring,
so the two records agree. Minor residue, not fixed here because repo-root
`spec/` is outside this write surface: that table's fallback-walker row still
says the docstring "records its fallback status", which is now only partly how
the docstring reads.

## Gates

All foreground, unfiltered, to completion, exit codes captured on the same
command line as the redirect. **All re-run on the final post-rebase base.**

| Gate | Exit | Result |
|---|---|---|
| `tools/xray` JVM suite (`clojure -M:test`) | **0** | 1313 tests, 6217 assertions, 0 failures, 0 errors |
| `npm run test:cljs` (node/CLJS) | **0** | 11192 tests, 55785 assertions, 0 failures, 0 errors |
| `python scripts/check_doc_slugs.py` | **0** | covers `tools/*/spec` — items 2 and 3 |
| `npm run test:xray-feature-gate` | **0** | 16 scenarios, 0 failures, 13 matrix rows |
| `sh scripts/test-fast-pr.sh --plan` | **0** | see below |

The CLJS lane is the right one for this diff because `../tools/xray/src` and
`../tools/xray/test` are both in the `:node-test` build's source paths.

**`--plan` output** for this diff: `PLAN docs=true jvm=false node=true`,
kondo run, reason `classified`. It prints `gate root:
.../re-frame2-worktrees/xray-b`, which is how I verified it read this worktree.
Note its own footnote: *"No browser, bundle, adapter, Xray, MCP or tool-JVM gate
is in any tier"* — so the fast-PR spine does **not** cover the `tools/xray`
suite, which is why that suite was run directly rather than leaned on.

**Feature gate: armed, and run.** It is not default CI, but the diff touches
`local_render.cljc`, which is on the App-DB panel render path, and the matrix
covers a `Redaction, Sensitive, and Large Values` row. Worth being precise about
what it proved: no scenario mounts against a destroyed or unselected frame, so
none exercises the branch this fix changes — the discriminating coverage for
that is the CLJS planted-fault run above. The feature gate's value here is
compile-and-load over the changed namespace, and it was green.

**`mkdocs build --strict` deliberately NOT nominated**, verified by reading
`mkdocs.yml` and `mkdocs_hooks.py` rather than trusting the brief: `docs_dir` is
`docs`, and `_STAGE` maps only `spec` to `docs/spec` and `migration` to
`docs/migration`. `tools/xray/spec/` is staged by neither, and no `docs/` path is
in this diff.

**Fenced-code check.** None of my edits sit inside a fenced code block. Both
spec edits are blockquote prose, so `check_doc_slugs.py` genuinely read them —
proven rather than assumed: a broken anchor planted in my own added text in
`011-Launch-Modes.md` took the gate to **exit 1** naming
`tools/xray/spec/011-Launch-Modes.md:429 -> #rf2-sabotage-anchor-does-not-exist`.
The fault existed only in this worktree, so the red is also the proof of which
tree the gate read. Restored and verified by blob-hash equality.

Anchors and table columns checked by hand: I added no tables and no markdown
links, and the one heading anchor relied on
(`View-Hierarchy-Capture.md#output-shape`) exists as `## Output shape`. Every
heading is unchanged in both spec files.

## Spec updates per the standing rule

* Item 1 (rf2-ws60): **spec unchanged because** the sentinel is a `^:private`
  implementation detail of the fail-closed stamp. `tools/xray/spec/` specifies
  that an unreachable frame must fail closed, which is unchanged and now better
  enforced; it does not specify the substitute's representation.
* Item 2 (rf2-2oug): `tools/xray/spec/007-UX-IA.md` updated.
* Item 3 (rf2-9vm0): `tools/xray/spec/011-Launch-Modes.md` updated.
* Item 4 (rf2-rn3u): **spec unchanged because** the defect was a source
  docstring asserting a path the spec never claimed shipped; the owning spec
  record (`spec/View-Hierarchy-Capture.md`) was corrected separately by #9041,
  and this docstring now agrees with it.

## Beads

Closing rf2-ws60, rf2-2oug, rf2-9vm0, rf2-rn3u. Filed rf2-uong (P3,
`discovered-from` rf2-9vm0) for the pop-out opener-reload gap.
