### PR TITLE
gate(conformance,spine): the EDN scanner sees mismatched pairs, the loaders refuse trailing text, and the spine comment stops asserting a refuted claim (rf2-x91a, rf2-98ni, rf2-4cbx)

### DIFF
--- a/implementation/core/test/re_frame/conformance_fixtures.clj
+++ b/implementation/core/test/re_frame/conformance_fixtures.clj
@@ -33,26 +33,44 @@
       (throw (ex-info "conformance fixtures dir not found"
                       {:tried [(.getPath nested) (.getPath legacy)]})))))
 
+(defn- read-one-form
+  "Read `text` as EXACTLY ONE top-level EDN form, or throw. See
+  `re-frame.conformance-test/read-one-form` for the full rationale
+  (rf2-98ni).
+
+  This is the CLJS arm's seam, and it is the loudest of the seven: the
+  macro below runs on the JVM at CLJS COMPILE time, so a malformed
+  fixture fails the build outright rather than reaching a runner that
+  could classify it as a skip."
+  [text fixture-name]
+  (let [forms (edn/read-string (str "[\n" text "\n]"))]
+    (when-not (= 1 (count forms))
+      (throw (ex-info (str "conformance fixture " fixture-name
+                           " must hold exactly ONE top-level EDN form, found "
+                           (count forms)
+                           " — clojure.edn/read-string returns only the first"
+                           " and silently discards the rest (rf2-98ni,"
+                           " rf2-5mr6)")
+                      {:fixture/file  fixture-name
+                       :fixture/forms (count forms)})))
+    (first forms)))
+
 (defn- load-fixture-from-file
   "Read one EDN fixture file, applying the same `::name` rewrite the
   JVM runner uses so `clojure.edn/read-string` (which has no reader
   resolver) accepts auto-resolved keywords."
   [file]
-  (try
-    (let [raw   (slurp file)
-          ;; Rewrite ONLY a standalone auto-resolved keyword `::name` (one
-          ;; beginning a token — preceded by `(` / `[` / `{` / whitespace).
-          ;; The lookbehind keeps the rewrite from corrupting a `::` INSIDE a
-          ;; value, e.g. the CEDN-1 keyword token `"k::answer"` in an EP-0012
-          ;; `:expect` string (rf2-qyb9l1). Mirror of the JVM runner's
-          ;; load-fixture rewrite.
-          fixed (str/replace raw
-                             #"(?<=[\s(\[{])::([a-zA-Z][a-zA-Z0-9_-]*)"
-                             ":rf.machine.timer/$1")]
-      (edn/read-string fixed))
-    (catch Throwable e
-      {:fixture/load-error (.getMessage e)
-       :fixture/file       (.getName file)})))
+  (let [raw   (slurp file)
+        ;; Rewrite ONLY a standalone auto-resolved keyword `::name` (one
+        ;; beginning a token — preceded by `(` / `[` / `{` / whitespace).
+        ;; The lookbehind keeps the rewrite from corrupting a `::` INSIDE a
+        ;; value, e.g. the CEDN-1 keyword token `"k::answer"` in an EP-0012
+        ;; `:expect` string (rf2-qyb9l1). Mirror of the JVM runner's
+        ;; load-fixture rewrite.
+        fixed (str/replace raw
+                           #"(?<=[\s(\[{])::([a-zA-Z][a-zA-Z0-9_-]*)"
+                           ":rf.machine.timer/$1")]
+    (read-one-form fixed (.getName file))))
 
 (defn- load-all-fixtures
   "Return a sorted-by-filename vector of `[filename fixture-data]`

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -84,9 +84,10 @@
         .getCanonicalFile)))
 
 (defn read-one-form
-  "Read `text` as EXACTLY ONE top-level EDN form, or throw. The canonical
-  copy of this rationale; the sibling artefacts' runners carry the same
-  three lines and cite this one (rf2-98ni).
+  "Read `text` as EXACTLY ONE top-level EDN form, or throw. Six sibling
+  runners carry the same body — no artefact puts `core/test` on another's
+  classpath, so there is no shared home for it below `src/` — and each
+  cites this docstring rather than restating it (rf2-98ni).
 
   WHY NOT `edn/read-string` DIRECTLY. It returns the FIRST form and
   silently ignores everything after it. So a fixture whose expectation

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -83,21 +83,57 @@
         (io/file "spec" "conformance" "fixtures")
         .getCanonicalFile)))
 
+(defn read-one-form
+  "Read `text` as EXACTLY ONE top-level EDN form, or throw. The canonical
+  copy of this rationale; the sibling artefacts' runners carry the same
+  three lines and cite this one (rf2-98ni).
+
+  WHY NOT `edn/read-string` DIRECTLY. It returns the FIRST form and
+  silently ignores everything after it. So a fixture whose expectation
+  block closes one brace early still loads, still runs, and still reports
+  as PASSING — with every assertion that fell outside the block discarded.
+  That is exactly what `routing-not-found.edn` did (rf2-5mr6). Reading
+  `[<text>]` instead makes the reader see the whole file: trailing text
+  becomes a second element, and a stray closing delimiter becomes an
+  unmatched-delimiter error.
+
+  WHY IT THROWS, and why the `try`/`catch` that used to wrap this is gone.
+  The catch turned any load failure into a `{:fixture/load-error ...}` map,
+  and `conformance-runner/run-corpus` classifies that map as `:skipped?
+  true` while `machines-conformance-test` filters those fixtures out
+  altogether. A caught parse error would therefore be exactly as silent as
+  the defect it is meant to catch — the fixture would stop passing
+  falsely and start vanishing quietly instead. Corpus malformation is a
+  repository defect, not a per-fixture runtime condition, so it fails the
+  run.
+
+  The corpus scanner (`scripts/check_conformance_fixture_edn.py`, rf2-x91a)
+  is the complementary half: it sees fixtures whose capabilities are
+  unclaimed, which this check never loads at all."
+  [text fixture-name]
+  (let [forms (edn/read-string (str "[\n" text "\n]"))]
+    (when-not (= 1 (count forms))
+      (throw (ex-info (str "conformance fixture " fixture-name
+                           " must hold exactly ONE top-level EDN form, found "
+                           (count forms)
+                           " — clojure.edn/read-string returns only the first"
+                           " and silently discards the rest (rf2-98ni,"
+                           " rf2-5mr6)")
+                      {:fixture/file  fixture-name
+                       :fixture/forms (count forms)})))
+    (first forms)))
+
 (defn- load-fixture [file]
-  (try
-    ;; A handful of fixtures use `::name` (auto-resolved keyword) which pure
-    ;; clojure.edn cannot read without a *reader-resolver*. Rewrite ONLY a
-    ;; standalone auto-resolved keyword `::name` (one that begins a token) to
-    ;; a stable namespace so the fixture loads (rf2-lu3f). The lookbehind keeps
-    ;; the rewrite from corrupting a `::` INSIDE a value (e.g. a CEDN-1 token
-    ;; string `"k::answer"`).
-    (let [raw   (slurp file)
-          fixed (string/replace raw #"(?<=[\s(\[{])::([a-zA-Z][a-zA-Z0-9_-]*)"
-                                ":rf.machine.timer/$1")]
-      (edn/read-string fixed))
-    (catch Throwable e
-      {:fixture/load-error (.getMessage e)
-       :fixture/file       (.getName file)})))
+  ;; A handful of fixtures use `::name` (auto-resolved keyword) which pure
+  ;; clojure.edn cannot read without a *reader-resolver*. Rewrite ONLY a
+  ;; standalone auto-resolved keyword `::name` (one that begins a token) to
+  ;; a stable namespace so the fixture loads (rf2-lu3f). The lookbehind keeps
+  ;; the rewrite from corrupting a `::` INSIDE a value (e.g. a CEDN-1 token
+  ;; string `"k::answer"`).
+  (let [raw   (slurp file)
+        fixed (string/replace raw #"(?<=[\s(\[{])::([a-zA-Z][a-zA-Z0-9_-]*)"
+                              ":rf.machine.timer/$1")]
+    (read-one-form fixed (.getName file))))
 
 (defn all-fixtures []
   (->> (file-seq fixtures-dir)

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -190,19 +190,35 @@
         (io/file "spec" "conformance" "fixtures")
         .getCanonicalFile)))
 
+(defn- read-one-form
+  "Read `text` as EXACTLY ONE top-level EDN form, or throw. `read-string`
+  returns only the FIRST and silently discards the rest, so a fixture whose
+  expectation block closes early passes having verified less than it claims
+  (rf2-5mr6). Throws rather than returning `:fixture/load-error`, which the
+  runner classifies as a SKIP — as silent as the defect. Full rationale on
+  `re-frame.conformance-test/read-one-form` (rf2-98ni)."
+  [text fixture-name]
+  (let [forms (edn/read-string (str "[\n" text "\n]"))]
+    (when-not (= 1 (count forms))
+      (throw (ex-info (str "conformance fixture " fixture-name
+                           " must hold exactly ONE top-level EDN form, found "
+                           (count forms)
+                           " — clojure.edn/read-string returns only the first"
+                           " and silently discards the rest (rf2-98ni,"
+                           " rf2-5mr6)")
+                      {:fixture/file  fixture-name
+                       :fixture/forms (count forms)})))
+    (first forms)))
+
 (defn- load-fixture
   "Read one EDN fixture, applying the same `::name` rewrite the core
   runner uses so `clojure.edn/read-string` (no reader resolver) accepts
   auto-resolved keywords. Per rf2-lu3f."
   [file]
-  (try
-    (let [raw   (slurp file)
-          fixed (str/replace raw #"::([a-zA-Z][a-zA-Z0-9_-]*)"
-                             ":rf.machine.timer/$1")]
-      (edn/read-string fixed))
-    (catch Throwable e
-      {:fixture/load-error (.getMessage e)
-       :fixture/file       (.getName file)})))
+  (let [raw   (slurp file)
+        fixed (str/replace raw #"::([a-zA-Z][a-zA-Z0-9_-]*)"
+                           ":rf.machine.timer/$1")]
+    (read-one-form fixed (.getName file))))
 
 (defn- all-flow-fixtures
   "Every fixture file whose name matches `flow-*.edn`. Returns

--- a/implementation/machines/test/re_frame/machines_conformance_test.clj
+++ b/implementation/machines/test/re_frame/machines_conformance_test.clj
@@ -80,20 +80,37 @@
         (io/file "spec" "conformance" "fixtures")
         .getCanonicalFile)))
 
+(defn- read-one-form
+  "Read `text` as EXACTLY ONE top-level EDN form, or throw. `read-string`
+  returns only the FIRST and silently discards the rest, so a fixture whose
+  expectation block closes early passes having verified less than it claims
+  (rf2-5mr6). Throws rather than returning `:fixture/load-error`, which
+  `all-machine-transition-fixtures` below FILTERS OUT — quieter still than
+  the skip the core runner would give it. Full rationale on
+  `re-frame.conformance-test/read-one-form` (rf2-98ni)."
+  [text fixture-name]
+  (let [forms (edn/read-string (str "[\n" text "\n]"))]
+    (when-not (= 1 (count forms))
+      (throw (ex-info (str "conformance fixture " fixture-name
+                           " must hold exactly ONE top-level EDN form, found "
+                           (count forms)
+                           " — clojure.edn/read-string returns only the first"
+                           " and silently discards the rest (rf2-98ni,"
+                           " rf2-5mr6)")
+                      {:fixture/file  fixture-name
+                       :fixture/forms (count forms)})))
+    (first forms)))
+
 (defn- load-fixture [file]
-  (try
-    ;; A handful of fixtures use `::name` (auto-resolved keyword) which
-    ;; pure `clojure.edn` cannot read without a *reader-resolver*. Match
-    ;; the core runner's translation so the fixture loads as bare data:
-    ;; rewrite `::name` → `:rf.machine.timer/name` (the only use in the
-    ;; corpus today, for synthetic timer events).
-    (let [raw   (slurp file)
-          fixed (str/replace raw #"::([a-zA-Z][a-zA-Z0-9_-]*)"
-                             ":rf.machine.timer/$1")]
-      (edn/read-string fixed))
-    (catch Throwable e
-      {:fixture/load-error (.getMessage e)
-       :fixture/file       (.getName file)})))
+  ;; A handful of fixtures use `::name` (auto-resolved keyword) which
+  ;; pure `clojure.edn` cannot read without a *reader-resolver*. Match
+  ;; the core runner's translation so the fixture loads as bare data:
+  ;; rewrite `::name` → `:rf.machine.timer/name` (the only use in the
+  ;; corpus today, for synthetic timer events).
+  (let [raw   (slurp file)
+        fixed (str/replace raw #"::([a-zA-Z][a-zA-Z0-9_-]*)"
+                           ":rf.machine.timer/$1")]
+    (read-one-form fixed (.getName file))))
 
 (def machine-call-ops
   "The Mode-B `:call` ops this artefact's runner executes:

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -115,6 +115,26 @@
         (io/file "spec" "conformance" "fixtures")
         .getCanonicalFile)))
 
+(defn- read-one-form
+  "Read `text` as EXACTLY ONE top-level EDN form, or throw. `read-string`
+  returns only the FIRST and silently discards the rest, so a fixture whose
+  expectation block closes early passes having verified less than it claims
+  (rf2-5mr6). Throws rather than returning `:fixture/load-error`, which the
+  runner classifies as a SKIP — as silent as the defect. Full rationale on
+  `re-frame.conformance-test/read-one-form` (rf2-98ni)."
+  [text fixture-name]
+  (let [forms (edn/read-string (str "[\n" text "\n]"))]
+    (when-not (= 1 (count forms))
+      (throw (ex-info (str "conformance fixture " fixture-name
+                           " must hold exactly ONE top-level EDN form, found "
+                           (count forms)
+                           " — clojure.edn/read-string returns only the first"
+                           " and silently discards the rest (rf2-98ni,"
+                           " rf2-5mr6)")
+                      {:fixture/file  fixture-name
+                       :fixture/forms (count forms)})))
+    (first forms)))
+
 (defn- load-fixture
   "Read one EDN fixture. The corpus does not use auto-resolved keywords
   in schema fixtures (the `::name` rewrite the machines / ssr runners
@@ -122,14 +142,10 @@
   same rewrite here for symmetry — a no-op on the schemas subset, but
   the runner stays robust if a future fixture grows a `::` form."
   [file]
-  (try
-    (let [raw   (slurp file)
-          fixed (str/replace raw #"::([a-zA-Z][a-zA-Z0-9_-]*)"
-                             ":rf.machine.timer/$1")]
-      (edn/read-string fixed))
-    (catch Throwable e
-      {:fixture/load-error (.getMessage e)
-       :fixture/file       (.getName file)})))
+  (let [raw   (slurp file)
+        fixed (str/replace raw #"::([a-zA-Z][a-zA-Z0-9_-]*)"
+                           ":rf.machine.timer/$1")]
+    (read-one-form fixed (.getName file))))
 
 (defn- schema-fixture-file?
   "True for the schemas-relevant fixture filenames:

--- a/implementation/ssr/test/re_frame/ssr_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_conformance_test.clj
@@ -197,19 +197,35 @@
         (io/file "spec" "conformance" "fixtures")
         .getCanonicalFile)))
 
+(defn- read-one-form
+  "Read `text` as EXACTLY ONE top-level EDN form, or throw. `read-string`
+  returns only the FIRST and silently discards the rest, so a fixture whose
+  expectation block closes early passes having verified less than it claims
+  (rf2-5mr6). Throws rather than returning `:fixture/load-error`, which the
+  runner classifies as a SKIP — as silent as the defect. Full rationale on
+  `re-frame.conformance-test/read-one-form` (rf2-98ni)."
+  [text fixture-name]
+  (let [forms (edn/read-string (str "[\n" text "\n]"))]
+    (when-not (= 1 (count forms))
+      (throw (ex-info (str "conformance fixture " fixture-name
+                           " must hold exactly ONE top-level EDN form, found "
+                           (count forms)
+                           " — clojure.edn/read-string returns only the first"
+                           " and silently discards the rest (rf2-98ni,"
+                           " rf2-5mr6)")
+                      {:fixture/file  fixture-name
+                       :fixture/forms (count forms)})))
+    (first forms)))
+
 (defn- load-fixture
   "Read one EDN fixture, applying the same `::name` rewrite the JVM core
   runner uses so `clojure.edn/read-string` (no reader resolver) accepts
   auto-resolved keywords. Per rf2-lu3f."
   [file]
-  (try
-    (let [raw   (slurp file)
-          fixed (str/replace raw #"::([a-zA-Z][a-zA-Z0-9_-]*)"
-                             ":rf.machine.timer/$1")]
-      (edn/read-string fixed))
-    (catch Throwable e
-      {:fixture/load-error (.getMessage e)
-       :fixture/file       (.getName file)})))
+  (let [raw   (slurp file)
+        fixed (str/replace raw #"::([a-zA-Z][a-zA-Z0-9_-]*)"
+                           ":rf.machine.timer/$1")]
+    (read-one-form fixed (.getName file))))
 
 (defn- all-ssr-fixtures
   "Every fixture file whose name matches `ssr-*.edn`. Returns

--- a/implementation/ssr/test/re_frame/ssr_streaming_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_conformance_test.clj
@@ -83,10 +83,31 @@
 
 (use-fixtures :each reset+reg-fixture-handlers)
 
+(defn- read-one-form
+  "Read `text` as EXACTLY ONE top-level EDN form, or throw. `read-string`
+  returns only the FIRST and silently discards the rest, so a fixture whose
+  expectation block closes early passes having verified less than it claims
+  (rf2-5mr6). Unlike the corpus-walking runners this namespace names its two
+  fixtures directly, so there is no `:fixture/load-error` datum here — but
+  the silent-truncation hazard is identical. Full rationale on
+  `re-frame.conformance-test/read-one-form` (rf2-98ni)."
+  [text fixture-name]
+  (let [forms (edn/read-string (str "[\n" text "\n]"))]
+    (when-not (= 1 (count forms))
+      (throw (ex-info (str "conformance fixture " fixture-name
+                           " must hold exactly ONE top-level EDN form, found "
+                           (count forms)
+                           " — clojure.edn/read-string returns only the first"
+                           " and silently discards the rest (rf2-98ni,"
+                           " rf2-5mr6)")
+                      {:fixture/file  fixture-name
+                       :fixture/forms (count forms)})))
+    (first forms)))
+
 (defn- load-streaming-fixture []
   (let [raw   (slurp (io/file "../../spec/conformance/fixtures/ssr-streaming.edn"))
         fixed (str/replace raw #"::([a-zA-Z][a-zA-Z0-9_-]*)" ":rf.machine.timer/$1")]
-    (edn/read-string fixed)))
+    (read-one-form fixed "ssr-streaming.edn")))
 
 (deftest streaming-fixture-shell-walk-matches-pin
   (testing "render-shell emits the shell HTML + 2 continuations the fixture pins"
@@ -164,8 +185,9 @@
 ;; ===========================================================================
 
 (defn- load-nested-fixture []
-  (edn/read-string
-    (slurp (io/file "../../spec/conformance/fixtures/ssr-streaming-nested.edn"))))
+  (read-one-form
+    (slurp (io/file "../../spec/conformance/fixtures/ssr-streaming-nested.edn"))
+    "ssr-streaming-nested.edn"))
 
 (defn- reg-nested-fixture-handlers! []
   (rf/reg-view ^{:rf/id :streaming-nested.test/inner-section} _ni []

--- a/scripts/check_conformance_fixture_edn.py
+++ b/scripts/check_conformance_fixture_edn.py
@@ -15,16 +15,21 @@ is what `routing-not-found.edn` did: one extra `}` at line 46, two
 `:trace-emissions` assertions never executed, green for however long it sat
 there.
 
-BOTH HALVES OF THE CHECK ARE LOad-BEARING, and neither alone is enough:
+EVERY HALF OF THE CHECK IS LOAD-BEARING, and none alone is enough:
 
   * A "does it read without error" check catches NOTHING here — reading
     without error on a malformed file is precisely what `read-string` does.
   * A bracket-balance check alone misses trailing text that happens to
     balance: `{:a 1} {:b 2}` is perfectly balanced and still hides the
     second form from every loader.
+  * A DEPTH-ONLY balance check — one counter for all three delimiter kinds —
+    misses a mismatched pair, because the two errors cancel: `{:a [1 2)}`
+    ends at depth 0, never goes negative, and holds one top-level "form",
+    yet is not EDN at all. That was this gate's own false green (rf2-x91a).
 
-So this scans for three things: bracket depth that never goes negative, a
-final depth of zero, and exactly one top-level form.
+So this scans for four things: each closer matching the delimiter kind it
+closes, bracket depth that never goes negative, a final depth of zero, and
+exactly one top-level form.
 
 WHY A SCANNER AND NOT A PARSER. Python has no EDN reader in the stdlib, and
 this gate must run in the fast-PR spine with no dependency to install. The
@@ -75,6 +80,9 @@ for _stream in (sys.stdout, sys.stderr):
 
 _OPEN = "([{"
 _CLOSE = ")]}"
+# The closer each opener requires. Aggregate depth cannot see this: `[1 2)`
+# and `[1 2]` move the counter identically.
+_CLOSER_FOR = {"(": ")", "[": "]", "{": "}"}
 # EDN treats a comma as whitespace.
 _WS = " \t\r\f\v,"
 
@@ -89,6 +97,8 @@ class Scan:
         "top_level_forms",
         "second_form_line",
         "unterminated_string_line",
+        "mismatch",
+        "unclosed_opener",
     )
 
     def __init__(self) -> None:
@@ -98,6 +108,12 @@ class Scan:
         self.top_level_forms = 0
         self.second_form_line: int | None = None
         self.unterminated_string_line: int | None = None
+        # (closer_found, closer_line, opener_char, opener_line) for the first
+        # closer that does not match the delimiter it closes, else None.
+        self.mismatch: tuple[str, int, str, int] | None = None
+        # (opener_char, opener_line) for the outermost delimiter still open at
+        # end of file, else None.
+        self.unclosed_opener: tuple[str, int] | None = None
 
     @property
     def ok(self) -> bool:
@@ -106,6 +122,7 @@ class Scan:
             and self.first_negative_line is None
             and self.top_level_forms == 1
             and self.unterminated_string_line is None
+            and self.mismatch is None
         )
 
     def summary(self) -> str:
@@ -123,8 +140,18 @@ def scan_edn(text: str) -> Scan:
     forms are semantically valid EDN. It answers exactly the two questions
     `clojure.edn/read-string` will not — is it balanced, and is there anything
     after the first form.
+
+    Balance is tracked with an opener STACK, not an aggregate depth counter.
+    A counter is blind to `{:a [1 2)}`: the `)` and the `}` each move it by
+    one, so the two errors cancel and the file scans clean (rf2-x91a). The
+    stack knows which delimiter each closer is closing, so it does not.
     """
     s = Scan()
+    # Openers still awaiting a closer, innermost last: (char, line).
+    stack: list[tuple[str, int]] = []
+    # Kept alongside the stack so the reported depth stays a signed number:
+    # the stack bottoms out at empty, but depth goes NEGATIVE on a closer
+    # with nothing open, which is the rf2-5mr6 signature.
     depth = 0
     line = 1
     in_string = False
@@ -187,6 +214,7 @@ def scan_edn(text: str) -> Scan:
             continue
 
         if ch in _OPEN:
+            stack.append((ch, line))
             depth += 1
             i += 1
             continue
@@ -197,6 +225,10 @@ def scan_edn(text: str) -> Scan:
                 s.min_depth = depth
             if depth < 0 and s.first_negative_line is None:
                 s.first_negative_line = line
+            if stack:
+                opener_ch, opener_line = stack.pop()
+                if _CLOSER_FOR[opener_ch] != ch and s.mismatch is None:
+                    s.mismatch = (ch, line, opener_ch, opener_line)
             if depth <= 0:
                 # The form closed: anything after this, even with no
                 # whitespace between, is a NEW top-level form.
@@ -208,6 +240,8 @@ def scan_edn(text: str) -> Scan:
 
     if in_string:
         s.unterminated_string_line = string_start_line
+    if stack:
+        s.unclosed_opener = stack[0]
     s.final_depth = depth
     return s
 
@@ -219,6 +253,14 @@ def _defect_reason(s: Scan) -> str | None:
             f"unterminated string opened at line {s.unterminated_string_line} "
             f"({s.summary()})"
         )
+    if s.mismatch is not None:
+        found, found_line, opener_ch, opener_line = s.mismatch
+        return (
+            f"mismatched delimiters — the '{found}' at line {found_line} "
+            f"closes the '{opener_ch}' opened at line {opener_line}, which "
+            f"needs '{_CLOSER_FOR[opener_ch]}'. Aggregate depth cannot see "
+            f"this: the two errors cancel ({s.summary()})"
+        )
     if s.first_negative_line is not None:
         return (
             f"unbalanced brackets — a closing bracket at line "
@@ -227,9 +269,15 @@ def _defect_reason(s: Scan) -> str | None:
             f"read-string ({s.summary()})"
         )
     if s.final_depth != 0:
+        where = ""
+        if s.unclosed_opener is not None:
+            where = (
+                f", the outermost being the '{s.unclosed_opener[0]}' opened "
+                f"at line {s.unclosed_opener[1]}"
+            )
         return (
-            f"unbalanced brackets — {s.final_depth} unclosed at end of file "
-            f"({s.summary()})"
+            f"unbalanced brackets — {s.final_depth} unclosed at end of file"
+            f"{where} ({s.summary()})"
         )
     if s.top_level_forms == 0:
         return f"no top-level EDN form ({s.summary()})"
@@ -331,6 +379,24 @@ _TRICKY_BUT_VALID = """;; brackets in }} comments {{ are ignored
  :note "trailing ; is not a comment inside a string"}
 """
 
+# The rf2-x91a false green, reduced to its smallest form. Aggregate depth
+# ends at 0, never goes negative, and counts one top-level form — so a
+# depth-only scanner calls this well-formed EDN. It is not EDN at all.
+_MISMATCHED_PAIR = """{:a [1 2)}
+"""
+
+# The same defect at fixture scale: the assertion VECTOR is closed with a
+# brace, and the outer map is then closed with the vector's bracket. Every
+# aggregate number here is identical to the well-formed file's —
+# final-depth=0, min-depth=0, top-level-forms=1 — which is exactly why this
+# case, and none of the ones above it, discriminates the two scanners.
+_MISMATCHED_IN_FIXTURE = """;; a conformance fixture
+{:kind :routing
+ :given {:url "/garbage/path"}
+ :trace-emissions
+ [{:operation :rf.error/no-such-handler}}]
+"""
+
 _UNCLOSED = """{:kind :routing
  :given {:url "/x"}
 """
@@ -350,6 +416,8 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("ok_well_formed.edn", _GOOD, 0),
         ("ok_brackets_in_strings_and_chars.edn", _TRICKY_BUT_VALID, 0),
         ("bad_extra_closing_brace.edn", _EXTRA_BRACE, 1),
+        ("bad_mismatched_pair.edn", _MISMATCHED_PAIR, 1),
+        ("bad_mismatched_in_fixture.edn", _MISMATCHED_IN_FIXTURE, 1),
         ("bad_trailing_second_form.edn", _TRAILING_FORM, 1),
         ("bad_unclosed_form.edn", _UNCLOSED, 1),
         ("bad_unterminated_string.edn", _UNTERMINATED_STRING, 1),
@@ -405,11 +473,36 @@ def _run_self_tests(verbose: bool = False) -> int:
         elif verbose:
             sys.stderr.write("self-test PASS: names_the_file\n")
 
+    # A defect COUNT of 1 on the mismatched cases is not enough: if they were
+    # caught by the depth rule instead, they would not discriminate an
+    # opener stack from the aggregate counter that shipped the false green.
+    # Assert the reason, and assert the aggregate numbers are the clean
+    # file's, so a regression to depth-only counting fails here.
+    for name, text in (
+        ("mismatch_pair", _MISMATCHED_PAIR),
+        ("mismatch_in_fixture", _MISMATCHED_IN_FIXTURE),
+    ):
+        s = scan_edn(text)
+        reason = _defect_reason(s)
+        if (
+            reason is None
+            or not reason.startswith("mismatched delimiters")
+            or s.summary() != "final-depth=0 min-depth=0 top-level-forms=1"
+        ):
+            sys.stderr.write(
+                f"self-test FAIL: {name}_is_invisible_to_depth — expected a "
+                f"'mismatched delimiters' defect over clean aggregate "
+                f"numbers, got {reason!r} with {s.summary()}\n"
+            )
+            failures += 1
+        elif verbose:
+            sys.stderr.write(f"self-test PASS: {name}_is_invisible_to_depth\n")
+
     if failures:
         sys.stderr.write(f"\n{failures} self-test failure(s).\n")
         return 1
     if verbose:
-        sys.stderr.write(f"all {len(cases) + 1} self-tests passed.\n")
+        sys.stderr.write(f"all {len(cases) + 3} self-tests passed.\n")
     return 0
 
 

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -1319,12 +1319,30 @@ if [ "$run_docs" = true ]; then
   # tier already ~28s (mkdocs --strict dominates).  The NINTH is excluded and
   # named below.
   #
-  # They are not subject to the trap PR #7496 found in the mkdocs build — that
-  # gate reads `docs/`, and docs.yml stages `cp -r spec docs/spec` first, so a
-  # bare local run exits 0 having read nothing of a spec edit.  Each of these
-  # scans the TRACKED `spec/` tree and explicitly excludes the staged
-  # `docs/spec/` mirror (`_EXCLUDE_REL_PREFIXES`), so running them here reads
-  # exactly what CI reads, with no staging step to forget.
+  # These read the TRACKED `spec/` tree.  The mkdocs build reads a STAGED COPY
+  # of it: `mkdocs_hooks.py`'s `on_pre_build` hook mirrors `spec/` into
+  # `docs/spec` and `migration/` into `docs/migration` before MkDocs scans a
+  # single file, on EVERY invocation — build, serve, --strict, local or CI.
+  # docs.yml keeps its own `cp -r spec docs/spec` step, which the hook's
+  # docstring calls redundant belt-and-braces.
+  #
+  # So both trees are present during a build, and each of these sweeps
+  # explicitly excludes the staged `docs/spec/` mirror
+  # (`_EXCLUDE_REL_PREFIXES`) rather than counting every finding twice.
+  # Running them here reads exactly what CI reads, with no staging step to
+  # forget.
+  #
+  # An earlier version of this comment said the mkdocs gate reads only
+  # `docs/`, so "a bare local run exits 0 having read nothing of a spec edit".
+  # That was false when written (rf2-4cbx): the hook landed 2026-05-19 in
+  # b2e622c316, the comment 2026-08-05.  MEASURED on a checkout where
+  # `docs/spec` and `docs/migration` did not exist at all — a bare
+  # `python -m mkdocs build --strict`, with no staging step, recreated both
+  # and built 52 spec pages at exit 0; a broken `../../docs/` link planted in
+  # `spec/conformance/README.md` then took the same bare run to exit 1 naming
+  # the file and the unresolvable target.  A bare local strict build DOES
+  # cover a spec edit.  See also the `mkdocs --strict build` block below,
+  # which describes the staged copies correctly.
   run "inject-cofx residue self-test" "python scripts/check_inject_cofx_residue.py --self-test --verbose" \
     python "$spine_root/scripts/check_inject_cofx_residue.py" --self-test --verbose
 


### PR DESCRIPTION
Three items, one defect class: **a control that is wrong about its own subject**, reached through three doors — a scanner that cannot see the malformation it claims to catch, loaders that accept text they claim to reject, and a gate-runner comment that misdescribes a sibling gate.

Every number below is measured on this branch, with the exit code captured on the runner's own command line. Both plants were restored and the restores verified by `git hash-object` **blob** equality.

---

## Item 1 — rf2-x91a: the scanner tracked aggregate depth, so mismatched pairs cancelled

**Reproduced at my base (`1b64fd6396`) before changing anything.** The audit's finding holds exactly:

```
BEFORE  scan_edn("{:a [1 2)}")  ->  ok=True   final-depth=0 min-depth=0 top-level-forms=1
                                    _defect_reason = None
AFTER   scan_edn("{:a [1 2)}")  ->  ok=False  final-depth=0 min-depth=0 top-level-forms=1
        "mismatched delimiters — the ')' at line 1 closes the '[' opened at line 1,
         which needs ']'. Aggregate depth cannot see this: the two errors cancel"
```

The fix is the specified one and nothing more: `scan_edn` keeps a small **opener stack** of `(char, line)` and requires each closer to match the delimiter it closes. Still stdlib-only, still lexical — no EDN parser, no semantic validation. A signed `depth` is kept alongside the stack so `final-depth` can still go negative, which is the rf2-5mr6 signature.

**Planted-fault red on a live fixture.** A *cancelling* mismatch was planted in `spec/conformance/fixtures/routing-not-found.edn` (`}}]}}` → `}}}]}`, anchor match count read as 1 before the run):

| runner | exit | result |
|---|---|---|
| scanner at `HEAD` (pre-fix) | **0** | false green on the live corpus |
| scanner on this branch | **1** | `::error:: spec/conformance/fixtures/routing-not-found.edn: mismatched delimiters — the '}' at line 60 closes the '[' opened at line 49, which needs ']'` |

That red is also the proof the gate read *my* worktree: the fault existed only here, so a run that had wandered into a sibling checkout would have come back green.

Restore verified: blob `7200be9e6536eb9a61dc79c34990ee08d1f28478` before and after.

**"The gate runs unconditionally" — checked at source, and it holds.** Both steps sit in `test.yml`'s invariant-checks job with no path filter. They carry `continue-on-error: true`, which looks at first like the gate cannot fail CI; it can — the job's "Report every failing invariant check" step reads `toJSON(steps)`, selects any `outcome == 'failure'`, and exits 1. So the false green was reaching a gate that would genuinely have blocked, which is what made it worth fixing. No workflow edit was needed, and none was made.

**Corpus counts either side — unchanged, as required.** 247 fixtures / 0 defects, exit 0, both before and after the opener-stack change. The count on disk is also 247, and `spec/conformance/` holds exactly one corpus (`fixtures/`), so the number is unambiguous.

**The self-test was the other half, and it is now armed in both directions.** It exercised extra, missing and trailing delimiters but no mismatched pair — which is how the gate shipped green. Added two regressions whose aggregate numbers are *identical to a clean file's* (`final-depth=0 min-depth=0 top-level-forms=1`), so only an opener stack can tell them apart:

- `bad_mismatched_pair.edn` — `{:a [1 2)}`, the audit's own case
- `bad_mismatched_in_fixture.edn` — the same defect at fixture scale, an assertion vector closed with `}` and the outer map closed with `]`

Both are asserted on their **reason**, not just a defect count of 1 — a count alone would pass if they were caught by the depth rule instead, which would not discriminate. Self-test: **12/12, exit 0**. Sabotaged (mismatch rule disabled with `if False and …`): **4 failures, exit 1**, naming all four. Sabotage restored, scanner blob hash equal.

**One discrepancy with the bead.** rf2-x91a records the pre-fix `routing-not-found.edn` as `top-level-forms=1`; recovered from `a54088ee7e^` and scanned with the *committed* scanner it reads `top-level-forms=2`. `final-depth=-1` and `neg-at-line=60` match exactly, and the defect verdict is driven by the negative depth, so nothing turns on it — the bead's number came from the ad-hoc scanner used to measure rf2-5mr6, not this one.

---

## Item 2 — rf2-98ni: the loaders now refuse trailing text — and there are seven

### My own census

The brief offered 12 candidates from a `read-string`/`PushbackReader` grep and warned they were "a starting point and not an answer". **Seven are corpus loaders; five are not.** The bead's count of seven is correct.

**How I told them apart:** a corpus loader *names the fixtures directory in code* **and** parses EDN from a file it read. A `read-string` grep is the wrong instrument here — it matches `(read-string (pr-str x))` round-trips of in-memory values and markdown scanners over `spec/009-Instrumentation.md`.

The five non-loaders, with what they actually read:

| file | what it really does |
|---|---|
| `egress_chokepoint_conformance_test.clj` | slurps repo **source** for a text scan; its own comment says "a text scan rather than `read-string`" |
| `error_catalogue_channel_conformance_test.clj` | slurps `spec/009-Instrumentation.md` + `spec/Spec-Schemas.md` |
| `destroyed_reason_channel_conformance_test.clj` | slurps spec markdown + repo source |
| `timer_probe_conformance_cljs_test.cljc` | `(read-string (pr-str wid))` — no file at all |
| `reply_vocab_conformance_cljs_test.cljc` | `(read-string (pr-str x))` — no file at all |

**Control that bites.** A plain path grep is not sufficient, because five of the seven build the path from *segments* — `(io/file "spec" "conformance" "fixtures")` — which no `conformance/fixtures` substring search finds in the code. I ran the census line-oriented *and* over whitespace-flattened text; the flattened pass surfaced five files the line-oriented one missed, and the segment control matched exactly those five, proving the instrument sees the form that would otherwise be invisible.

The seven: `core/…/conformance_fixtures.clj`, `core/…/conformance_test.clj`, `flows_conformance_test.clj`, `machines_conformance_test.clj`, `schemas_conformance_test.clj`, `ssr_conformance_test.clj`, `ssr_streaming_conformance_test.clj` (two read sites).

### The mechanism — and why the obvious one would not have worked

Each loader now reads `(str "[" text "]")` and requires exactly one element, so trailing text becomes a second element and a stray closer becomes an unmatched-delimiter error. A trailing `\n` before the `]` keeps a final `;;` comment from swallowing it.

**The load-bearing discovery: adding the assertion in the obvious place would have produced no red.** Every loader wrapped its read in `(catch Throwable e {:fixture/load-error …})`, and that datum is not a failure:

- `conformance_runner.cljc:1670` classifies it as **`:skipped? true`**
- `machines_conformance_test.clj:121` **filters those fixtures out** of the corpus entirely

So a thrown EOF assertion would have been caught and converted into a silent skip — the fixture would have stopped passing falsely and started *vanishing quietly instead*, which is not louder. The check therefore **throws, and the `try`/`catch` is gone with it**. Corpus malformation is a repository defect, not a per-fixture runtime condition. On a clean corpus this changes nothing; it only changes what a broken corpus does.

### Proof it bites

A trailing second form (`{:fixture/id :planted-trailing-form}`) was appended to `spec/conformance/fixtures/routing-not-found.edn`.

| runner | exit | result |
|---|---|---|
| old read path, same file | — | `(edn/read-string text)` returned the map, id `:routing/not-found`, **no exception, no warning**, planted form gone |
| new read path, same file | — | form count **2**, second form `#:fixture{:id :planted-trailing-form}` |
| `core` conformance suite | **1** | `ERROR in (run-conformance-corpus)` … `conformance fixture routing-not-found.edn must hold exactly ONE top-level EDN form, found 2` |
| `machines` conformance suite | **1** | same error — the loader that previously *filtered* load errors is now loud |
| CLJS macro seam, planted | **3** | `MACRO SEAM THREW (CLJS build would fail)` |
| CLJS macro seam, clean | **0** | `MACRO EXPANDED OK, fixtures inlined = 247` |

Restore verified: blob `7200be9e6536eb9a61dc79c34990ee08d1f28478`.

**The CLJS macro seam: reached, and it is the loudest of the seven.** It is `re-frame.conformance-fixtures/all-fixtures`, a `.clj` macro that runs on the JVM at CLJS *compile* time. Expanding it is exactly what the CLJS compiler does, and with the plant in place it throws — a malformed fixture fails the build rather than reaching a runner that could skip it.

### Clean-corpus suites, all foreground, exit codes captured

| suite | exit | result |
|---|---|---|
| `core` `re-frame.conformance-test` | 0 | 5 tests, 18 assertions |
| `flows` `re-frame.flows-conformance-test` | 0 | 2 tests, 9 assertions |
| `machines` `re-frame.machines-conformance-test` | 0 | 1 test, 3 assertions |
| `schemas` `re-frame.schemas-conformance-test` | 0 | 1 test, 3 assertions |
| `ssr` both conformance namespaces | 0 | 8 tests, 54 assertions |

### Shared helper vs duplication

**Duplicated honestly, seven times, and here is why.** Five of the seven are shaped near-identically, so shape was not the blocker — *classpath reach* was. No sibling artefact puts `../core/test` on its test classpath (verified: the only match is a comment in core's own `deps.edn`), so a helper in `core/test` is invisible to flows, machines, schemas and ssr. The only homes reachable from all seven are `implementation/*/src/**` — **out of this dispatch's fence** — or a new namespace inside the `test-quiet` runner artefact, which exists for test-running mechanics and would be a new namespace invented to justify the abstraction. The body is eight lines; the full rationale lives once on `re-frame.conformance-test/read-one-form` and the other six cite it.

### The contended file

`egress_chokepoint_conformance_test.clj` — **not touched, and it needed no touching**: it is not a corpus loader (it slurps repo source for a text scan). `git diff` against my merge base confirms zero file overlap with the 18 files that landed on `origin/main` while I worked, and nothing in that range touched it either. No follow-on bead needed.

---

## Item 3 — rf2-4cbx: the comment's claim, measured myself including the negative

**The line numbers in the bead are stale.** At tip the comment is at **`scripts/test-fast-pr.sh:1322-1327`**; lines 1310-1312 are now the `else`/`printf`/`fi` of the provenance-pins block. The *content* claim is exactly as described.

**My own measurement, both directions.** This worktree was fresh, so `docs/spec` and `docs/migration` **did not exist at all** — the negative did not have to be manufactured by deleting them, and no staging step of mine was run:

| run | exit | result |
|---|---|---|
| bare `python -m mkdocs build --strict`, staged dirs absent | **0** | hook recreated `docs/spec` (52 md) and `docs/migration` (8 md); **52 spec pages built into `site/`** |
| same bare run, broken `../../docs/` link planted in `spec/conformance/README.md` | **1** | `WARNING - Doc file 'spec/conformance/README.md' contains a link '../../docs/no-such-page-gates-b.md', but the target … is not found` / `Aborted with 1 warnings in strict mode!` |

So a bare local strict build demonstrably **does** read a spec edit. Dates confirmed at source: the hook landed `b2e622c316` **2026-05-19**; the comment is `1a1521f1f4` **2026-08-05** — already false when written. `#7496` appears nowhere else in `scripts/`, `.github/`, `docs/` or `spec/`.

Restore verified: blob `c834b520b11543f31376778335e17935f19782b1`.

**The paragraph's point survives, and it is kept.** It is that these sweeps read the *tracked* `spec/` tree and exclude the staged `docs/spec/` mirror, so a local run reads what CI reads. The correction now *rests* on the staging fact instead of contradicting it, and points at the `mkdocs --strict build` block below that always described the staged copies correctly. Nothing the script runs was changed.

---

## Gates

- `check_conformance_fixture_edn.py` corpus — **exit 0**, 247 fixtures / 0 defects (unchanged from the previous pass's 247 / 0)
- `--self-test` — **exit 0**, 12/12; sabotaged **exit 1**, 4 failures
- Five artefacts' conformance suites — all **exit 0** (see table); planted fixture drives core and machines to **exit 1**
- `mkdocs build --strict` bare — **exit 0** clean / **exit 1** planted
- `scripts/test-fast-pr.sh --plan` — `reason: spine self-change (every tier)`; docs, spine self-test, JVM (core, schemas, machines, flows, ssr), node/CLJS and clj-kondo all armed. Its `gate root:` line printed this worktree. The **edited** script was run.

**Full spine, run on the rebased base — captured exit 1, with one failure, and it is environmental.** Everything it actually executed was green:

| tier | result |
|---|---|
| docs tier + `mkdocs --strict` | pass, built in 29.36s |
| clj-kondo (pinned, CI's command) | `errors: 0`, warnings 2085 (fail-level error) |
| JVM `implementation/core` | 2175 tests / 11144 assertions, 0 failures, 0 errors |
| JVM `implementation/schemas` | 372 / 19221, 0/0 |
| JVM `implementation/machines` | 1241 / 4495, 0/0 |
| JVM `implementation/flows` | 250 / 6102, 0/0 |
| JVM `implementation/ssr` | 621 / 3168, 0/0 |
| implementation JS harness self-tests | fail 0 |
| **CLJS node integration** | **FAIL — `could not resolve shadow-cljs: Cannot find module 'shadow-cljs/cli/runner.js'`** |

That is a **no-verdict, not a red**: this worktree had no `implementation/node_modules`. Rather than junction to the coordinator's tree — an installer run against a link rewrites the shared target — I installed my own from the lockfile (`npm ci`, exit 0) and re-ran the tier:

- `npm run test:cljs` — **exit 0**, **11191 tests / 55778 assertions, 0 failures, 0 errors**, which is the run that compiles `conformance_corpus_cljs_test.cljs` through the macro seam for real.

The installed tree is a **real directory**, not a junction (`realpath` resolves inside this worktree), so worktree cleanup has no link to follow; the coordinator's `node_modules` was verified intact at 103 entries afterwards.

A late docstring correction (`read-one-form`'s "same three lines" → the real reason it is duplicated) landed after the spine, so core's conformance suite was re-run on the final tree: **exit 0**, 5 tests / 18 assertions.

One measurement note: for the spine run the harness reported "exit code 0" while the exit code I captured on the runner's own command line was **1**. The captured number is the one quoted throughout.

`mkdocs` is not on PATH in these worktrees (bare `mkdocs` measured **exit 127**); `python -m mkdocs` was used throughout — a command not on PATH is a no-verdict, not a pass.

Rebased onto `origin/main` (`70c961b17f`) and the gates re-run on the final base, since a pre-rebase green is evidence about a tree that no longer exists.

## Anything that contradicts the brief

1. **The loader count was right but the candidate list was not** — 5 of the 12 suggested files are not corpus loaders at all. Detailed above.
2. **The bead's and brief's line numbers for item 3 are stale** — the comment is at 1322-1327, not 1310-1312.
3. **The bead's `top-level-forms=1` for the pre-fix fixture measures as 2** with the committed scanner. Immaterial to the verdict.
4. **The obvious mechanism for item 2 would have produced no red**, because the existing `catch` turns a load error into a skip. This is the same shape as the brief's own warning about planting somewhere the gate does not read.
5. **`check_doc_slugs.py` also went red on my planted link** (exit 1). My plant was broken repo-relative *and* in the built site, so it does **not** discriminate the two gates — I am not claiming complementarity from it.
