### PR TITLE
docs+spec+hicasso: client-root snippets, the test-kit coordinate, and the skills distribution paragraph (rf2-pd9b, rf2-luo6, rf2-yhbei)

### DIFF
--- a/docs/core/25-from-re-frame-v1.md
+++ b/docs/core/25-from-re-frame-v1.md
@@ -139,18 +139,23 @@ Fix at the root: ensure a frame and scope the tree to it. The usual shape is `fr
 
 ```clojure
 ;; Prefer: named seed event(s) on frame-root (same pipeline as every later change)
-(rdc/render root
+(defonce app-root (reagent-adapter/client-root))
+(def el (js/document.getElementById "app"))
+
+(reagent-adapter/render! app-root
   [rf/frame-root {:id :app/main
                   :initial-events [[:app/initialise]   ;; reg-event that returns {:db …}
                                    [:boot]]}
-   [app-root]])
+   [app-root]]
+  el)
 
 ;; Also fine: pre-create, then scope — e.g. when boot is outside React
 (rf/make-frame {:id :app/main
                 :initial-events [[:app/initialise] [:boot]]})
-(rdc/render root
+(reagent-adapter/render! app-root
   [rf/frame-provider {:frame :app/main}
-   [app-root]])
+   [app-root]]
+  el)
 ```
 
 Inside that tree, bare `dispatch` / `subscribe` resolve the frame ambiently *once the view can read the provider*. A `reg-view` can; a plain (unregistered) Reagent fn that dispatches or subscribes cannot, and fails with `:rf.error/no-frame-context` ([Views render under a frame scope](#views-render-under-a-frame-scope)). Rootless call sites also need attention: async callbacks that lost scope, top-level boot with no provider — the wrong-frame cases v1 swallowed. The skill rewrites bare top-level call sites into a root provider and flags async callbacks for explicit capture (next).

--- a/docs/core/frames.md
+++ b/docs/core/frames.md
@@ -70,8 +70,7 @@ Inside a `reg-view`, `dispatch` and `subscribe` arrive as injected functions —
 
 ```clojure
 (ns my-app.core
-  (:require [reagent.dom.client :as rdc]
-            [re-frame.core :as rf]
+  (:require [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]))
 
 (rf/reg-event :app/initialise
@@ -83,14 +82,14 @@ Inside a `reg-view`, `dispatch` and `subscribe` arrive as injected functions —
 (rf/reg-view main-view []
   [:h1 "Screen: " (name @(subscribe [:screen]))])
 
-(defonce react-root
-  (rdc/create-root (js/document.getElementById "app")))
+(defonce app-root (reagent-adapter/client-root))
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)        ;; install the adapter (creates no frame)
-  (rdc/render react-root
+  (reagent-adapter/render! app-root
     [rf/frame-root {:id :app :initial-events [[:app/initialise]]}
-     [main-view]]))
+     [main-view]]
+    (js/document.getElementById "app")))
 ```
 
 Two forms do the work. `init!` installs the [substrate](glossary.md#substrate) [adapter](glossary.md#adapter) — the one-time hookup between re-frame2 and your rendering library (Reagent here) — and creates *no* frame. Then `frame-root {:id :app …}` **ensures** the `:app` frame: it creates the frame the first time the view mounts (running its `:initial-events`) and establishes it for everything underneath, so inside that subtree every `dispatch` and `subscribe` resolves to `:app` without ever naming it.
@@ -162,9 +161,10 @@ Here's the split pane, end to end. Watch how little changes from the one-frame c
    [rf/frame-root {:id :pane/right :initial-events [[::init]]} [counter-panel "Right"]]])
 
 ;; At boot — after (rf/init! ...) — the root boundary ensures the app frame.
-(rdc/render react-root
+(reagent-adapter/render! app-root
   [rf/frame-root {:id :app}
-   [split-screen]])
+   [split-screen]]
+  (js/document.getElementById "app"))
 ```
 
 Notice what *isn't* there: no pane id threaded through the view, no atom per pane, no "which counter am I" argument on the handler. The view is identical to one you'd write for a single counter. Boundaries nest — each pane's `frame-root` overrides the root scope for its own subtree.

--- a/docs/core/hicasso/15-testing.md
+++ b/docs/core/hicasso/15-testing.md
@@ -43,7 +43,8 @@ the [`:local/root` setup](00-installation.md#add-the-dependencies):
  {:shadow {:extra-deps {thheller/shadow-cljs {:mvn/version "3.4.10"}}}
 
   ;; The test kit, from the same checkout the artifact resolves from.
-  :test   {:extra-paths ["../re-frame2/implementation/hicasso/test_kit/src"]}}}
+  :test   {:extra-deps {day8/re-frame2-hicasso-test-kit
+                        {:local/root "../re-frame2/implementation/hicasso/test_kit"}}}}}
 ```
 
 Then select that alias in the build, beside the one that puts the compiler on the
@@ -56,13 +57,15 @@ not named here is not on it:
 ```
 
 The path is relative to *your* `deps.edn`, exactly as the artifact coordinates
-above are. It also reaches outside your project root, and the Clojure CLI names
-that on every invocation: `WARNING: Use of :paths external to the project has
-been deprecated`. Nothing fails — the root goes on the classpath and `ht` and
-`hm` resolve — and the warning belongs to this route rather than to your project.
-It is the cost of a checkout that is not yet a published coordinate, and it goes
-away with the checkout: resolve Hicasso from a coordinate and the kit arrives in
-the jar with nothing to add and no path to escape.
+above are. It is a coordinate rather than a source path on purpose. The kit
+carries its own `deps.edn`, so the source root it contributes sits inside *that*
+project's boundary and the Clojure CLI has nothing to deprecate. Naming
+`test_kit/src` as an `:extra-paths` entry resolves `ht` and `hm` just as well,
+but that path escapes your project root, and the CLI says so on every
+invocation: `WARNING: Use of :paths external to the project has been
+deprecated`. Both routes work today; only one of them is quiet, and only one of
+them survives a CLI that decides to refuse the escape. When Hicasso is
+published, the kit arrives inside the jar and this alias goes away entirely.
 
 Which build target the tests then run under is a choice per level, and
 the ladder below is the guide to it: L0–L2 are browser-free and need no DOM, while

--- a/docs/core/how-to/index.md
+++ b/docs/core/how-to/index.md
@@ -10,7 +10,7 @@ The recipes are grouped by where they sit in the life of an app — **build it**
 
 !!! note "If your views are Hicasso"
 
-    The view code in these recipes is written on a React substrate adapter and registered `reg-view` views — `rdc/create-root` to mount, `@(subscribe …)` to read, `^{:key}` metadata on list items, and Form-2 views where a value has to stay stable across renders. [Hicasso](../hicasso/index.md) accepts none of those spellings, so a recipe's view code will not run as written. What does carry over is everything below the view: the events, effects, subscriptions and frames are ordinary re-frame2 on either. For the view and the mount, read [Installation](../hicasso/00-installation.md) and [Views and reads](../hicasso/02-views-and-reads.md); for the debugging recipes, [Diagnostics](../hicasso/16-diagnostics.md) and [Performance](../hicasso/19-performance.md).
+    The view code in these recipes is written on a React substrate adapter and registered `reg-view` views — the adapter's `client-root` / `render!` to mount, `@(subscribe …)` to read, `^{:key}` metadata on list items, and Form-2 views where a value has to stay stable across renders. [Hicasso](../hicasso/index.md) accepts none of those spellings, so a recipe's view code will not run as written. What does carry over is everything below the view: the events, effects, subscriptions and frames are ordinary re-frame2 on either. For the view and the mount, read [Installation](../hicasso/00-installation.md) and [Views and reads](../hicasso/02-views-and-reads.md); for the debugging recipes, [Diagnostics](../hicasso/16-diagnostics.md) and [Performance](../hicasso/19-performance.md).
 
 ## Build it
 

--- a/docs/design/hicasso/product/pilots/workspace.md
+++ b/docs/design/hicasso/product/pilots/workspace.md
@@ -112,7 +112,7 @@ npx shadow-cljs watch app     # then open http://localhost:8080
 cd app && npm test > ../baseline-reagent.log 2>&1; echo "baseline exit $?"    # the number goes in the log header
 ```
 
-The runner's closing line is the count to expect — as of `rf2-xkhul` the RealWorld baseline reports `Ran 4 tests containing 123 assertions.` and the LinearLite baseline `Ran 10 tests containing 51 assertions.`, both with `0 failures, 0 errors.` — and it is the exit status that is recorded, not the count. The compile also prints a handful of `:infer-warning` lines from the framework's own source and a Clojure CLI deprecation notice about the test kit's external path; neither fails the run, and both are the framework's to log, not the operator's to hide. Added under `rf2-xkhul`.
+The runner's closing line is the count to expect — as of `rf2-xkhul` the RealWorld baseline reports `Ran 4 tests containing 123 assertions.` and the LinearLite baseline `Ran 10 tests containing 51 assertions.`, both with `0 failures, 0 errors.` — and it is the exit status that is recorded, not the count. The compile also prints a handful of `:infer-warning` lines from the framework's own source; they do not fail the run, and they are the framework's to log, not the operator's to hide. (Before `rf2-luo6` gave the test kit its own `deps.edn`, a Clojure CLI deprecation notice about the kit's external path printed here too; the coordinate route above no longer emits it.) Added under `rf2-xkhul`.
 
 **6. Copy the brief and the blank log** into `<pilot-root>/`, from [`brief-realworld.md`](brief-realworld.md) or [`brief-linearlite.md`](brief-linearlite.md), and from [`friction-log.md`](friction-log.md)'s template section.
 
@@ -139,12 +139,14 @@ Pilot 1 — RealWorld/Conduit:
 
  :aliases
  {:shadow {:extra-deps {thheller/shadow-cljs {:mvn/version "3.4.10"}}}
-  :test   {:extra-paths ["test" "../re-frame2/implementation/hicasso/test_kit/src"]}}}
+  :test   {:extra-paths ["test"]
+           :extra-deps  {day8/re-frame2-hicasso-test-kit
+                         {:local/root "../re-frame2/implementation/hicasso/test_kit"}}}}}
 ```
 
 Pilot 2 — LinearLite: the same file with the `machines`, `flows`, `schemas`, `ssr` and `markdown` rows dropped and `day8/re-frame2-resources {:local/root "../re-frame2/implementation/resources"}` added.
 
-The `:test` alias follows the published testing chapter's `:local/root` route, where the Hicasso test kit lives on its own source root outside the artefact's `:paths` and has to be named explicitly. Both pilots need it from the first hour, because outcome 1 is to preserve the app's behavioural tests. `"test"` on the same alias is the app's own test root: the baseline lands there in step 2, and the tests the pilot ports or adds go beside it.
+The `:test` alias follows the published testing chapter's `:local/root` route, where the Hicasso test kit lives on its own source root outside the artefact's `:paths` and has to be named explicitly — as a second `:local/root` coordinate, which is what keeps it inside a project boundary and off the Clojure CLI's external-path deprecation. Both pilots need it from the first hour, because outcome 1 is to preserve the app's behavioural tests. `"test"` on the same alias is the app's own test root: the baseline lands there in step 2, and the tests the pilot ports or adds go beside it.
 
 ### `app/shadow-cljs.edn`
 

--- a/docs/resources/tutorial/01-pages-and-state.md
+++ b/docs/resources/tutorial/01-pages-and-state.md
@@ -237,8 +237,7 @@ Now for `core.cljs`. You're replacing the whole file from setup: the placeholder
 ;; src/conduit/core.cljs
 ;; Adapted from examples/capabilities/routing/routing/core.cljs
 (ns conduit.core
-  (:require [reagent.dom.client :as rdc]
-            [re-frame.core :as rf]
+  (:require [re-frame.core :as rf]
             ;; Loading re-frame.routing once at boot is what makes
             ;; reg-route, route-link, and the :rf.route/* events and
             ;; subs available through re-frame.core.
@@ -349,8 +348,7 @@ One verb, `dispatch`, whether the user clicked a link, pressed Back, or your han
 Finish `core.cljs` with the boot function your build invokes:
 
 ```clojure
-(defonce root
-  (rdc/create-root (js/document.getElementById "app")))
+(defonce app-root (reagent-adapter/client-root))
 
 (defn run []
   (rf/init! reagent-adapter/adapter)
@@ -359,9 +357,10 @@ Finish `core.cljs` with the boot function your build invokes:
                   :url-bound? true})
   (rf/with-frame :rf/default
     (rf/dispatch-sync [:app/initialise]))
-  (rdc/render root
-              [rf/frame-provider {:frame :rf/default}
-               [root-view]]))
+  (reagent-adapter/render! app-root
+    [rf/frame-provider {:frame :rf/default}
+     [root-view]]
+    (js/document.getElementById "app")))
 ```
 
 Reading it top to bottom:

--- a/docs/resources/tutorial/index.md
+++ b/docs/resources/tutorial/index.md
@@ -136,8 +136,7 @@ Your page owns the layout; Xray owns only the content inside `[data-rf-xray-host
 ;; Adapted from examples/core/counter and examples/real-apps/realworld_http
 ;; in the re-frame2 repo.
 (ns conduit.core
-  (:require [reagent.dom.client       :as rdc]
-            [re-frame.core            :as rf]
+  (:require [re-frame.core            :as rf]
             [re-frame.adapter.reagent :as reagent-adapter])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -178,17 +177,17 @@ Your page owns the layout; Xray owns only the content inside `[data-rf-xray-host
    [banner]])
 
 ;; --- Mount: the only impure corner of the file ---
-(defonce root
-  (rdc/create-root (js/document.getElementById "app")))
+(defonce app-root (reagent-adapter/client-root))
 
 (defn run []
   (rf/init! reagent-adapter/adapter)        ;; 1. install the Reagent substrate
   (rf/make-frame {:id :rf/default})             ;; 2. establish this app's one frame
   (rf/with-frame :rf/default
     (rf/dispatch-sync [:app/initialise]))   ;; 3. seed app-db before first render
-  (rdc/render root
+  (reagent-adapter/render! app-root
     [rf/frame-provider {:frame :rf/default} ;; 4. the whole tree runs in this frame
-     [shell]]))
+     [shell]]
+    (js/document.getElementById "app")))
 ```
 
 The events, subs, and views here are just the quickstart's pipeline again — an [event](../../core/glossary.md#event) updates [app-db](../../core/glossary.md#app-db) (your app's single state map), a [subscription](../../core/glossary.md#subscription) reads from it, and a [view](../../core/glossary.md#view) renders that read. Two bits of syntax look new only because the browser cells smoothed them over:
@@ -204,7 +203,7 @@ What's genuinely new beyond syntax is the **boot**, the part the quickstart's br
 
 **Move 3 — `with-frame` + `dispatch-sync` seeds state.** Out here, outside the rendered tree, there's no provider in scope, so `with-frame` scopes the dispatch lexically to `:rf/default`. And it's [`dispatch-sync`](../../core/glossary.md#dispatch-sync) — a dispatch that runs the [event pipeline](../../core/glossary.md#event-pipeline) immediately rather than queuing it — because plain [`dispatch`](../../core/glossary.md#dispatch) would let the first render race it and paint an empty app-db. Seeding synchronously at the boot boundary is one of the handful of legitimate uses of `dispatch-sync`; the others are tests and REPL exploration. What they share is that they all run *outside* any handler — `dispatch-sync` from inside a running handler is rejected with `:rf.error/dispatch-sync-in-handler`, because the pipeline is already draining synchronously and a second one would convey nothing.
 
-**Move 4 — `frame-provider` wraps the tree.** The [provider](../../core/glossary.md#frame-provider) carries the already-registered `:rf/default` frame down through React context, so every bare `dispatch` / `subscribe` inside a `reg-view` body resolves to it without naming it. The `{:frame …}` config shape is the one that matters: handed a `:frame` key, the provider **scopes** the tree to a frame that already exists (you registered it in Move 2). It creates nothing and destroys nothing — it only routes ambient calls. It's the React-side counterpart to `with-frame`, which can't reach across React's render boundary because a child renders *after* the `with-frame` form has already returned. (`defonce` guards the root because a hot reload must not call `create-root` twice on the same element.)
+**Move 4 — `frame-provider` wraps the tree.** The [provider](../../core/glossary.md#frame-provider) carries the already-registered `:rf/default` frame down through React context, so every bare `dispatch` / `subscribe` inside a `reg-view` body resolves to it without naming it. The `{:frame …}` config shape is the one that matters: handed a `:frame` key, the provider **scopes** the tree to a frame that already exists (you registered it in Move 2). It creates nothing and destroys nothing — it only routes ambient calls. It's the React-side counterpart to `with-frame`, which can't reach across React's render boundary because a child renders *after* the `with-frame` form has already returned. (`defonce` keeps the same client-root handle across hot reloads, and the handle keeps the same React root: the first `render!` through it creates the root, every later one updates it.)
 
 That's the whole boot. Four moves: install the substrate, register the frame, seed it, scope the tree to it.
 

--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -629,7 +629,6 @@ Copy-paste shape (pages and loaders are stubs — fill in as the tutorial does):
 (ns app.routes
   (:require [re-frame.core :as rf]
             [re-frame.routing]
-            [reagent.dom.client :as rdc]
             [re-frame.adapter.reagent :as reagent-adapter]))
 
 (rf/reg-route :app/home {} "/")
@@ -649,11 +648,14 @@ Copy-paste shape (pages and loaders are stubs — fill in as the tutorial does):
     :rf.route/not-found [not-found-page]
     [not-found-page]))
 
+(defonce app-root (reagent-adapter/client-root))
+
 (defn run []
   (rf/init! reagent-adapter/adapter)
-  (rdc/render (rdc/create-root (js/document.getElementById "app"))
-              [rf/frame-root {:id :rf/default :url-bound? true}
-               [root-view]]))
+  (reagent-adapter/render! app-root
+    [rf/frame-root {:id :rf/default :url-bound? true}
+     [root-view]]
+    (js/document.getElementById "app")))
 ```
 
 ## Troubleshooting

--- a/docs/routing/tutorial.md
+++ b/docs/routing/tutorial.md
@@ -43,13 +43,15 @@ so you can watch every step from here on:
     [:h1 "Nothing here yet"]))   ;; any URL we haven't routed — Step 5 retires this
 
 ;; 3. Mount — standard Quickstart mount, plus one routing flag Step 6 explains.
-;;    (Also requires: [reagent.dom.client :as rdc]
-;;     [re-frame.adapter.reagent :as reagent-adapter])
+;;    (Also requires: [re-frame.adapter.reagent :as reagent-adapter])
+(defonce app-root (reagent-adapter/client-root))
+
 (defn run []
   (rf/init! reagent-adapter/adapter)
-  (rdc/render (rdc/create-root (js/document.getElementById "app"))
-              [rf/frame-root {:id :rf/default :url-bound? true}  ;; ← this flag
-               [root-view]]))
+  (reagent-adapter/render! app-root
+    [rf/frame-root {:id :rf/default :url-bound? true}  ;; ← this flag
+     [root-view]]
+    (js/document.getElementById "app")))
 ```
 
 `@(subscribe [:rf.route/id])` is the id of the route that matches the current URL.
@@ -241,10 +243,11 @@ Step 1's mount flag is what makes Back, refreshes, and shared links work:
 ```clojure
 (defn run []
   (rf/init! reagent-adapter/adapter)
-  (rdc/render (rdc/create-root (js/document.getElementById "app"))
-              [rf/frame-root {:id         :rf/default
-                              :url-bound? true}  ;; ← this frame owns the address bar
-               [root-view]]))
+  (reagent-adapter/render! app-root
+    [rf/frame-root {:id         :rf/default
+                    :url-bound? true}  ;; ← this frame owns the address bar
+     [root-view]]
+    (js/document.getElementById "app")))
 ```
 
 `:url-bound? true` says *this* [frame](../core/frames.md) owns the browser URL. When

--- a/docs/ssr/concepts.md
+++ b/docs/ssr/concepts.md
@@ -184,7 +184,9 @@ The client's job is to land in the state the server finished in, without redoing
 
 ```clojure
 ;; Adapted from examples/capabilities/ssr/ssr/core.cljc — requires, alongside rf and ssr:
-;;   [reagent.dom.client :as rdc]  [re-frame.adapter.reagent :as reagent-adapter]
+;;   [re-frame.adapter.reagent :as reagent-adapter]
+(defonce app-root (reagent-adapter/client-root))
+
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)          ;; installs the adapter — creates no frame
   (rf/make-frame {:id :app :platform :client})
@@ -192,23 +194,22 @@ The client's job is to land in the state the server finished in, without redoing
         payload (ssr/hydrate! {:frame          :app
                                :render-tree-fn (fn [] ((rf/view :app/root)))})
         tree    [rf/frame-provider {:frame :app} [(rf/view :app/root)]]]
-    (if payload
-      ;; Server-rendered: ADOPT the existing DOM. `hydrate-root` reconciles
-      ;; React against the server markup — same nodes, listeners attached, no
-      ;; re-paint. (`create-root` + `render` would throw the server HTML away.)
-      (rdc/hydrate-root el tree)
-      ;; No payload script — a client-only first load. Fresh root, fresh render.
-      (do
-        (rf/dispatch-sync [:app/client-bootstrap] {:frame :app})
-        (rdc/render (rdc/create-root el) tree)))))
+    (when-not payload
+      ;; No payload script — a client-only first load, so seed before rendering.
+      (rf/dispatch-sync [:app/client-bootstrap] {:frame :app}))
+    ;; One `render!` either way. `:hydrate? true` ADOPTS the existing DOM: React
+    ;; reconciles against the server markup — same nodes, listeners attached, no
+    ;; re-paint. `:hydrate? false` mounts a fresh root, which would throw the
+    ;; server HTML away — right only for the client-only branch.
+    (reagent-adapter/render! app-root tree el {:hydrate? (some? payload)})))
 ```
 
 `hydrate!` does the **state** half — read, install, verify — and returns the payload
 it applied (or `nil`). It deliberately does *not* touch the DOM mount. Adopting the
 server's painted DOM is the **substrate's** job and a separate call: hand the existing
-container to the adapter's `hydrate-root` (React's `hydrateRoot`), *not* `create-root`
-+ `render`. The latter discards the server markup and mounts fresh — correct only for
-the no-payload, client-only branch.
+container to the adapter's `render!` with `{:hydrate? true}` (React's `hydrateRoot`
+underneath). Without that option the same call mounts a fresh root, discarding the
+server markup — correct only for the no-payload, client-only branch.
 
 Two rules to hold onto:
 
@@ -397,7 +398,6 @@ the server's DOM.
             [re-frame.ssr :as ssr]
             [re-frame.ssr.ring :as ssr-ring]
             [re-frame.http.managed]
-            #?(:cljs [reagent.dom.client :as rdc])
             #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])
             #?(:clj  [ring.adapter.jetty :as jetty])))
 
@@ -419,6 +419,8 @@ the server's DOM.
         :root-view      [(rf/view :app/root)]                 ;; hiccup vector or 0-arity fn
         :payload        [:articles :session-user]})))  ;; required allowlist
 
+#?(:cljs (defonce app-root (reagent-adapter/client-root)))
+
 #?(:cljs
    (defn ^:export run []
      (rf/init! reagent-adapter/adapter)
@@ -427,10 +429,10 @@ the server's DOM.
            payload (ssr/hydrate! {:frame          :app
                                   :render-tree-fn (fn [] ((rf/view :app/root)))})
            tree    [rf/frame-provider {:frame :app} [(rf/view :app/root)]]]
-       (if payload
-         (rdc/hydrate-root el tree)                      ;; server-rendered: adopt the DOM
-         (do (rf/dispatch-sync [:app/client-bootstrap] {:frame :app})
-             (rdc/render (rdc/create-root el) tree)))))) ;; client-only: fresh root
+       (when-not payload                                 ;; client-only: seed first
+         (rf/dispatch-sync [:app/client-bootstrap] {:frame :app}))
+       ;; payload ⇒ adopt the server's DOM; no payload ⇒ fresh root
+       (reagent-adapter/render! app-root tree el {:hydrate? (some? payload)}))))
 ```
 
 Same `:frame` on `hydrate!` and `frame-provider`. Full walk-through:

--- a/docs/ssr/streaming.md
+++ b/docs/ssr/streaming.md
@@ -93,6 +93,8 @@ On the client, opt in with `ssr/streaming-install!` (same carried `:frame` as
 `hydrate!`), and **hydrate from its `:on-ready` callback**:
 
 ```clojure
+(defonce app-root (reagent-adapter/client-root))
+
 (ssr/streaming-install!
   {:frame    :app/main
    :on-ready (fn [_outcomes]
@@ -100,10 +102,9 @@ On the client, opt in with `ssr/streaming-install!` (same carried `:frame` as
                      el      (js/document.getElementById "app")
                      tree    [rf/frame-provider {:frame :app/main}
                               [(rf/view :article/page)]]]
-                 (if payload
-                   (reset! react-root (rdc/hydrate-root el tree))
-                   (do (reset! react-root (rdc/create-root el))
-                       (rdc/render @react-root tree)))))})
+                 ;; payload ⇒ adopt the streamed markup; nil ⇒ fresh root
+                 (reagent-adapter/render! app-root tree el
+                   {:hydrate? (some? payload)})))})
 ```
 
 The runtime materialises the inert fallback `<template>`s into visible mounts,
@@ -122,9 +123,10 @@ re-renders it, and you pay for streaming without getting any.
 !!! warning "Don't guess at readiness"
 
     Don't poll for `__rf_payload`, don't hydrate on a timer, and above all don't
-    fall through to `create-root` because the payload "hasn't arrived yet" — on a
-    live stream that is true for most of the page's life, and `create-root`
-    throws away the markup the server streamed. The protocol is: progressive
+    fall through to a fresh mount — a `render!` without `:hydrate?` — because the
+    payload "hasn't arrived yet". On a live stream that is true for most of the
+    page's life, and a fresh root throws away the markup the server streamed. The
+    protocol is: progressive
     pre-hydration paint, then **one** ordinary whole-root hydration, triggered by
     readiness.
 

--- a/docs/ssr/tutorial.md
+++ b/docs/ssr/tutorial.md
@@ -188,8 +188,9 @@ The browser now has painted HTML and a payload sitting in the page. The client's
 ```clojure
 ;; cf. examples/capabilities/ssr/ssr/core.cljc — the client entry point
 ;; client-side requires, alongside rf and ssr:
-;;   #?(:cljs [reagent.dom.client :as rdc])
 ;;   #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])
+#?(:cljs (defonce app-root (reagent-adapter/client-root)))
+
 #?(:cljs
    (defn run []
      (rf/init! reagent-adapter/adapter)      ;; the browser substrate this time
@@ -198,19 +199,17 @@ The browser now has painted HTML and a payload sitting in the page. The client's
            payload (ssr/hydrate! {:frame          :app
                                   :render-tree-fn (fn [] ((rf/view :app/root)))})
            tree    [rf/frame-provider {:frame :app} [(rf/view :app/root)]]]
-       (if payload
-         ;; server-rendered ⇒ ADOPT the painted DOM with hydrate-root
-         (rdc/hydrate-root el tree)
-         ;; nil ⇒ nobody server-rendered this page — a plain client-only load:
-         ;; seed, then mount a fresh root
-         (do
-           (rf/dispatch-sync [:app/client-bootstrap] {:frame :app})
-           (rdc/render (rdc/create-root el) tree))))))
+       (when-not payload
+         ;; nil ⇒ nobody server-rendered this page — a plain client-only load,
+         ;; so seed before the first render
+         (rf/dispatch-sync [:app/client-bootstrap] {:frame :app}))
+       ;; payload ⇒ ADOPT the painted DOM; nil ⇒ mount a fresh root
+       (reagent-adapter/render! app-root tree el {:hydrate? (some? payload)}))))
 ```
 
 `hydrate!` does three steps in a fixed order: **read** the `__rf_payload` script, **hydrate** — dispatch `[:rf/hydrate payload]` before the first render, installing the server's app-db *and* its runtime-db slice in one atomic move — and **verify** (Step 5). It returns the payload it applied, or `nil` when there wasn't one, which is how the code above answers "was this page server-rendered?" without sniffing the DOM.
 
-Those three steps are all **state**: `hydrate!` never touches the DOM mount. Adopting the server's painted markup is a *separate* call — `rdc/hydrate-root` (React's `hydrateRoot`), which reconciles against the existing DOM. `rdc/create-root` + `render` would discard that markup and mount fresh, so it's right only for the client-only branch. That split is the whole point of the `if` above: a server-rendered page hydrates the DOM it was handed; a cold client load builds a fresh root.
+Those three steps are all **state**: `hydrate!` never touches the DOM mount. Adopting the server's painted markup is a *separate* call — `reagent-adapter/render!` with `{:hydrate? true}` (React's `hydrateRoot` underneath), which reconciles against the existing DOM. Without that option the same call discards that markup and mounts fresh, so it's right only for the client-only branch. That's the whole point of `{:hydrate? (some? payload)}` above: a server-rendered page hydrates the DOM it was handed; a cold client load builds a fresh root.
 
 **What you see:** the page was already painted before your JS loaded. When `run` finishes, nothing flashes — the client's first render matches the HTML, the articles are in app-db without any re-fetch, and clicking things dispatches events like any other re-frame2 app. (To see it live without wiring a build: the worked example ships a hand-authored `index.html` — a frozen snapshot of what its `handle-request` serves — and its `run` hydrates it exactly this way.)
 
@@ -310,7 +309,7 @@ Everything above, as the two halves you ship:
 | Half | Surface | You supply |
 |---|---|---|
 | Server | `ssr-ring/ssr-handler` | `:initial-events`, `:root-view`, **`:payload` allowlist** |
-| Client | `ssr/hydrate!` then `hydrate-root` (fresh `create-root` when there's no payload) | Same `:frame` as `frame-provider`; `:render-tree-fn` that *calls* the root view |
+| Client | `ssr/hydrate!` then `reagent-adapter/render!` with `{:hydrate? (some? payload)}` | Same `:frame` as `frame-provider`; `:render-tree-fn` that *calls* the root view |
 
 Hand-rolled lifecycle (Steps 2–3) is still the right mental model when something
 misbehaves — the adapter is that sequence, packaged. Full copy-paste with both

--- a/implementation/hicasso/test_kit/deps.edn
+++ b/implementation/hicasso/test_kit/deps.edn
@@ -1,0 +1,38 @@
+;; The Hicasso test kit, as a resolvable :local/root coordinate.
+;;
+;; WHY THIS FILE EXISTS. The published testing chapter
+;; (docs/core/hicasso/15-testing.md) tells a reader to put this kit on a test
+;; alias. Spelled as an external :extra-paths entry —
+;;   :test {:extra-paths ["../re-frame2/implementation/hicasso/test_kit/src"]}
+;; — the path escapes the consuming project's root, and the Clojure CLI names
+;; that on EVERY invocation:
+;;   WARNING: Use of :paths external to the project has been deprecated,
+;;   please remove: ../re-frame2/implementation/hicasso/test_kit/src
+;; Nothing fails today, but a future CLI may refuse it, and a pilot following
+;; the published route meets the warning on their first build.
+;;
+;; A :local/root coordinate pointing HERE is inside the project boundary of
+;; THIS root, so it warns about nothing. That only works if the target carries
+;; a manifest: without this file the same coordinate is a HARD failure,
+;; "Error building classpath. Manifest file not found for
+;; day8/re-frame2-hicasso-test-kit in coordinate ..." — measured on CLI
+;; 1.12.4.1618, which is why the chapter's line could not simply change shape
+;; and this file had to land with it (rf2-luo6).
+;;
+;; WHAT THIS DOES NOT CHANGE. test_kit/src stays deliberately OFF the Hicasso
+;; artefact's own :paths, so an application that writes no test still carries
+;; none of the kit — see the header of implementation/hicasso/deps.edn, which
+;; spends several paragraphs on why :paths and :clein/build :src-dirs are not
+;; the same lever. This file adds a SECOND coordinate; it does not put
+;; test_kit/src on the artefact. Reachability, not packaging, is still what
+;; keeps the kit out of a production bundle.
+;;
+;; Deliberately NO :aliases here, and specifically no :clein/build. The
+;; publishable-artefact discovery in
+;; implementation/scripts/lib/publishable-runtimes.cjs walks
+;; implementation/<name>/<sub> probing for a deps.edn and enrols a directory
+;; only when it declares a :clein/build alias. Adding one here would enrol the
+;; test kit as a publishable runtime, which would then have to be added to
+;; .github/scripts/verify-version-lockstep.sh's ARTEFACT_PATHS/ARTEFACTS table.
+;; The kit ships inside the Hicasso jar, not as its own artefact.
+{:paths ["src"]}

--- a/skills/README.md
+++ b/skills/README.md
@@ -226,10 +226,11 @@ Each skill subdir contains, at minimum:
 
 Skills release through re-frame2's own pipeline (no skill-local CI
 workflows). Deterministic structural tests for
-`re-frame2-pair/`, `re-frame2-setup/` and `re-frame2-pair-retro/` run in
-`.github/workflows/test.yml` when those skill paths change;
-behavioural replay fixtures remain manual/diagnostic and are not required
-PR coverage.
+`re-frame2-pair/`, `re-frame2-setup/`, `re-frame2-pair-retro/` and
+`reagent-migration/` run in `.github/workflows/test.yml` when those skill
+paths change; `reagent-migration`'s cold-start fixture is required PR
+coverage, and the remaining behavioural replay fixtures stay
+manual/diagnostic.
 
 ### Leaf size discipline
 

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -178,10 +178,14 @@ CLJS hosts that ship Reagent on the browser AND need SSR on the JVM use the appr
 
 ```clojure
 ;; .cljc shared between JVM (server) and CLJS (browser):
+#?(:cljs (defonce app-root (reagent-adapter/client-root)))
+
 #?(:cljs
    (defn ^:export run []
      (rf/init! reagent-adapter/adapter)
-     (rdc/render react-root [(rf/view :app/root)])))
+     (reagent-adapter/render! app-root
+       [(rf/view :app/root)]
+       (js/document.getElementById "app"))))
 
 #?(:clj
    (defn ssr-handler [request]
@@ -421,9 +425,11 @@ The CLJS reference ships it as `re-frame.ssr/hydrate!` (re-exported from the fa√
      ;; it into the React tree rather than ensuring a new one; per EP-0024).
      (let [payload (ssr/hydrate! {:frame          :app/main
                                   :render-tree-fn #((rf/view :app/root))})]
-       (rdc/render react-root
+       (reagent-adapter/render! app-root
          [rf/frame-provider {:frame :app/main}
-          [(rf/view :app/root)]])
+          [(rf/view :app/root)]]
+         (js/document.getElementById "app")
+         {:hydrate? (some? payload)})
        payload)))
 ```
 


### PR DESCRIPTION
Three documentation-truth beads: `rf2-pd9b`, `rf2-luo6`, `rf2-yhbei`.

Worker worktree guard ran and exited 0 before any edit.

---

## Item 1 — rf2-pd9b: raw client-root snippets outside the rf2-k5r9t sweep

**The premise holds, and the bead's file list was accurate but not complete.**

### The replacement shape, taken from the sweep rather than invented

rf2-k5r9t's own landed commits define it — `cd6fd08587` (examples) and `73de07ddf8`
(docs/API). Ordinary mount:

```clojure
(defonce app-root (reagent-adapter/client-root))
(reagent-adapter/render! app-root [rf/frame-root {...} [view]] el)
```

Hydrating mount, from `examples/capabilities/ssr/ssr/mount.cljs`: one `render!`
carrying `{:hydrate? (some? payload)}`, replacing the hydrate-or-create `if`.
Signature confirmed against `docs/api/re-frame.adapter.reagent.md`:
`(render! handle render-tree mount-point [opts])`.

### The census, re-measured at my base (both forms, with a control that bites)

Over every tracked file under `docs/` plus `spec/011-SSR.md`:

| needle | line-oriented | whitespace-stripped | disagreement |
|---|---|---|---|
| `reagent.dom.client` | 13 files | 13 files | none |
| `create-root` | 16 files | 16 files | none |
| `rdc/create-root` | 10 files | 10 files | none |
| `rdc/render` | 12 files | 12 files | none |

**The control is the load-bearing part.** A collapse-to-space flattener does *not*
see a token broken across a line — it leaves a space in the middle. A planted
control containing both an intact and a line-broken `reagent.dom.client` proved
this: line-oriented found 1, collapse-to-space found 1, strip-all-whitespace found
2. The table above therefore uses **strip-all-whitespace**, the form the control
showed actually bites. Both forms agreeing here is evidence, not luck.

Two further measurement notes:

- **`reagent-dom-client`, the spelling in the bead's own title, returns 0 in both
  forms.** It does not appear anywhere in the tree; the real token is
  `reagent.dom.client`. A search on the title's spelling would have reported
  "already fixed".
- **`create-root` alone would have missed `spec/011-SSR.md`.** Its two raw snippets
  spell the mount `(rdc/render react-root …)` with no `create-root` on the line.
  The `rdc/` needle found them. Same mechanism caught a *second* site in
  `docs/core/frames.md` and sites in `docs/core/25-from-re-frame-v1.md`.

### What changed

`docs/core/frames.md` (2 sites), `docs/core/25-from-re-frame-v1.md` (2),
`docs/core/how-to/index.md` (1 prose), `docs/routing/concepts.md`,
`docs/routing/tutorial.md` (2), `docs/resources/tutorial/index.md`,
`docs/resources/tutorial/01-pages-and-state.md`, `docs/ssr/concepts.md` (2),
`docs/ssr/tutorial.md`, `docs/ssr/streaming.md`, `spec/011-SSR.md` (2).

`docs/ssr/streaming.md`'s snippet also loses a `react-root` binding the page never
defined anywhere.

### Deliberately NOT changed, with reasons

- **`docs/EP/EP-0002-frame-target-resolution.md`** — `Status: final`, and its own
  ledger says "EP-0002's decisions froze before the repo-wide migration finished".
  Rewriting a frozen decision record would falsify it.
- **`docs/api/re-frame.adapter.reagent.md`, `docs/core/how-to/boot-and-mount-an-app.md`**
  — these *teach* the new shape and name `reagent.dom.client` to say never touch it.
- **UIx sites** (`use-uix-or-slim.md`, `core/testing/views.md`) — `uix.dom/create-root`
  is how UIx mounts; UIx entrypoints own their own root and were deliberately
  outside rf2-k5r9t.
- **`spec/011-SSR.md:1649`** — normative prose about React root *ownership*, naming
  `create-root`/`hydrate-root` as React concepts. Not a copyable snippet.
- **`docs/design/**` studio pages and `docs/tools/playground/`** — benchmark records
  and the playground's own source; also excluded from the built site.

### Which edits no gate inspected — the honest number

Of **101 added lines, 85 sit inside fenced code blocks and 16 are prose.**
`check_doc_slugs.py` and `check_readme_links.py` share one extractor that strips
fences *before* reading a link, so **a green from either inspected 16 of my 101
lines.** `mkdocs --strict` renders fences but validates nothing inside them.

So the fenced 85 were verified by hand instead, and here is what that verification
actually was rather than an assurance:

- Every edited `clojure` fence paren/bracket-balanced: **14 blocks, all 0/0.**
- Every file that lost its `rdc` require checked for a surviving `rdc/` reference:
  **0 in all 11 files**, with `reagent-adapter/` present in each.
- Every `render!` call checked against the documented arity and argument order.
- The one markdown table I touched re-counted column by column: 3/3/3/3.

## Item 2 — rf2-luo6: the fix is a `deps.edn`, not prose

**All three of PR #9023's measurements reproduce at my base**, on the CLI the bead
names (1.12.4.1618), each exit code captured from the runner itself:

| variant | exit | result |
|---|---|---|
| `:extra-paths ["../kit/src"]` | **0** | warning reproduced verbatim: `WARNING: Use of :paths external to the project has been deprecated, please remove: ../kit/src`; root on the classpath. **The control — it bites.** |
| `:local/root`, no `deps.edn` in target | **1** | `Error building classpath. Manifest file not found for day8/kit in coordinate …` |
| `:local/root` + target `deps.edn {:paths ["src"]}` | **0** | **no warning at all**, `kit/src` on the classpath |

Re-run with `-Sforce` and `.cpcache` cleared, so V3's silence is a real resolution
and not a cache hit.

**Then measured again against the real kit, which is the measurement that matters:**

- old `:extra-paths` spelling → exit 0, warning fires (control bites on the real tree)
- new coordinate + the new `deps.edn` → exit **0**, **0 deprecation warnings**, `test_kit/src` on the classpath
- new coordinate with the new `deps.edn` **moved aside** → exit **1**, `Manifest file not found`

That last row is the point: **the doc change alone would have broken the published
route**, which is exactly why PR #9023 landed prose and left this open. So the fix is
two files, and this PR lands both.

### Consumer consequence

A consumer's `:test` alias changes shape from an external source path to a second
`:local/root` coordinate:

```clojure
:test {:extra-deps {day8/re-frame2-hicasso-test-kit
                    {:local/root "../re-frame2/implementation/hicasso/test_kit"}}}
```

The deprecation warning goes away, and the route survives a future CLI that refuses
external `:paths` rather than merely warning. `docs/core/hicasso/15-testing.md` and
the pilot workspace page's mirrored `deps.edn` both move together, and the
option-(3) paragraph naming the warning as expected is removed — PR #9023 said it
would go "when the coordinate arrives".

### What it does NOT change, checked rather than assumed

`test_kit/src` stays deliberately **off** the Hicasso artefact's own `:paths`
(rf2-rxf49), so an app that writes no test still carries none of the kit. Verified:
`clojure -Spath` in `implementation/hicasso` exits 0, emits no warning, and
`test_kit` is **absent** from that classpath. This adds a second coordinate, not a
path on the artefact — which is why option (2) stays rejected.

### Gate/roster check for a new file under `implementation/`

One mechanism really does read the new file:
`implementation/scripts/lib/publishable-runtimes.cjs` does a bounded
`implementation/<name>/<sub>` walk probing for `deps.edn`. It enrols a directory
only when that file declares a **`:clein/build` alias** — `{:paths ["src"]}`
declares none, so its output is unchanged and
`.github/scripts/verify-version-lockstep.sh`'s roster is untouched. The new file
carries a comment saying so, because adding `:clein/build` later would silently
enrol the kit as a publishable artefact.

Everything else was checked and is unperturbed: `report-changed-surfaces.sh` and its
mirror classify by changed-path patterns that already sweep `test_kit/*` in with
`hicasso/*` (`implementation_jvm` stays `false`, as
`_changed-surfaces.test.cjs` pins); `check_jvm_lane_rosters.py`,
`check_test_lane_bijection.py`, `check_readme_inventories.py`,
`_release-dag-policy.test.cjs`, `check_production_erasure.cjs` and the hicasso
scripts all use fixed paths naming `implementation/hicasso`, never `test_kit`.
The one real side effect is cosmetic: several CI cache keys hash
`implementation/**/deps.edn`, so the next run takes a one-time cache miss.

## Item 3 — rf2-yhbei: the one recorded sentence, and nothing else

The remainder PR #9036 recorded **still reproduced**: `skills/README.md`'s
distribution paragraph said deterministic structural tests run only for
`re-frame2-pair`, `re-frame2-setup` and `re-frame2-pair-retro`, and that behavioural
replay fixtures "remain manual/diagnostic and are not required PR coverage" — while
the roster later in the *same file* lists `reagent-migration/tests/` as the fourth
qualifying skill.

Verified at source before asserting it: `.github/workflows/test.yml:5994` defines
`reagent-migration-fixture-cold-start`, and `all-required-passed` lists it under
`needs:` with the comment "rf2-bbe91 — required, mirroring its pair sibling above".

The edit is one paragraph. **`git diff --stat skills/README.md` is a single hunk,
5 insertions / 4 deletions**; the roster, the test-fixture-discipline section and
every other part of the family contract are untouched. No heading changed anywhere
in this PR.

### A correction to that bead's own GATE line

The bead says `check_readme_links.py --ci` "covers … `skills/README.md`, which the
docs gate does not". **That is inverted.** Measured by planting a broken link in
`skills/README.md`:

- `check_doc_slugs.py` → **exit 1**, naming the planted target
- `check_readme_links.py --ci` → **exit 0**

`skills/` is in `check_doc_slugs.py`'s roots. Restore verified by git blob hash
(identical to pre-plant), and that red is also the proof the gate read this
worktree — the fault existed nowhere else.

---

## Gates

All run in the foreground, unfiltered, exit codes captured from the runner itself
and re-run on the **final rebased base** (the branch was rebased once mid-work;
`origin/main` moved twice).

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_readme_links.py --ci` | 0 |
| `python -m mkdocs build --strict` | 0, 0 WARNINGs |
| `python scripts/check_provenance_pins.py` | 0 (153 pages, 0 findings) |
| `sh scripts/test-fast-pr.sh` | 0 — `PASS fast PR spine`, 0 FAIL lines |

`--plan` reports `docs=true jvm=true node=true`, `reason: classified`, JVM suites
`implementation/core implementation/hicasso` — so the documentation tier genuinely
ran rather than being skipped by the classifier, and the new `implementation/` file
armed the node and kondo tiers too. The spine prints its `gate root`, and it named
this worktree on every run.

`check_provenance_pins.py` is included because
`docs/design/hicasso/product/pilots/workspace.md` sits under a tree `mkdocs.yml`'s
`exclude_docs` hides from the strict build; it was also read by hand.

Two earlier spine attempts died at the harness time limit leaving **no exit-code
file** — recorded here as no verdict rather than as passes. Their failures were
environmental and are worth naming so nobody re-reads them as real: this worktree
had no `implementation/node_modules` (installed from the lockfile, not linked), and
the residual failures carried `0xC0000142` / `fork: Resource temporarily
unavailable` — Windows process-creation failures under machine contention, one of
them on `git ls-files -- implementation/machines/deps.edn`, a file this branch never
touches. After the install, the same JS harness suite passes at exit 0 with zero
failures.
