### PR TITLE
docs(pilots): fix the three package defects the rehearsal found (rf2-f22y, rf2-lpfz, rf2-dc0c)

### DIFF
--- a/docs/design/hicasso/product/pilots/brief-linearlite.md
+++ b/docs/design/hicasso/product/pilots/brief-linearlite.md
@@ -2,9 +2,9 @@
 
 Copy the block below into `<pilot-root>/BRIEF.md`. Everything inside it is written *to the pilot agent* and is the only thing that agent is given, alongside the blank friction log and the workspace itself.
 
-The brief is deliberately free of in-tree references: no bead ids, no spec sections, no repository paths except the ones the published documentation itself tells a reader to use. That is not tidiness. A brief that leaks in-tree knowledge does not bend a rule, it invalidates the evidence the pilot exists to produce, and the leak is invisible in the output.
+The brief is deliberately free of in-tree references: no bead ids, no spec sections, no repository paths except the ones the published documentation itself tells a reader to use, and one added since: `docs/core/hicasso/` inside the checkout, which is where the published documentation is kept until a site exists (`rf2-lpfz`). Naming it is what makes the pilot's only reference reachable at all. That is not tidiness. A brief that leaks in-tree knowledge does not bend a rule, it invalidates the evidence the pilot exists to produce, and the leak is invisible in the output.
 
-Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the sentence naming the test command, under `rf2-xkhul`. Assemble the workspace first, per [`workspace.md`](workspace.md).
+Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the sentence naming the test command, under `rf2-xkhul`; the address of the published documentation in the read rules, under `rf2-lpfz`. Assemble the workspace first, per [`workspace.md`](workspace.md).
 
 **Why this pilot is shaped differently from [Pilot 1](brief-realworld.md), and it matters that it is.** Pilot 1 translates two screens that already exist, which measures whether the documentation supports *porting*. This one ports one screen and grows a second that does not exist yet, which measures whether the documentation supports *authoring* — reaching for a form you have never written, from the guide alone. Those are different failure modes and the two pilots are chosen to cover both, so the card detail is a shipped screen rather than a stretch goal and must not be softened into one when the brief is handed over.
 
@@ -56,7 +56,10 @@ produce. Only you can tell us.
 
 - The published Hicasso documentation, in full. It is your reference for
   everything: what to type, what things are called, why something broke, how
-  to test, how to build for production.
+  to test, how to build for production. It has not been put on a website yet,
+  so your copy of it is the one inside the checkout beside your project, at
+  `re-frame2/docs/core/hicasso/`. Those pages are the documentation; reading
+  them is not reading the checkout.
 - Everything in `app/`. That is your codebase. Its README explains what the
   application does and which patterns it is built from — read it freely.
 - Ordinary error output: compiler messages, stack traces, browser console.
@@ -65,19 +68,22 @@ produce. Only you can tell us.
 **You may not read:**
 
 - The `re-frame2/` checkout sitting beside your project, for anything other
-  than the two mechanical uses below. Not its source, not its internal design
-  notes, not its other example applications, not its history.
+  than the documentation named above and the two mechanical uses below. Not
+  its source, not its internal design notes, not its other example
+  applications, not its history.
 - Any file your app's README links to outside `app/`. The README is yours; the
   things it points at are not.
 - Any source file named in a stack trace. Knowing that a complaint came from
   some internal file is diagnosis and is fine. Opening that file is research
   and is not.
 
-**The `re-frame2/` checkout is a build input, not a reference work.** Two uses
-of it are expected and correct, because the published documentation itself
-tells you to make them: your `deps.edn` resolves the library from it, and the
-migration tool the documentation opens with is run from a path inside it. Both
-are the documented setup. Neither is licence to browse.
+**The `re-frame2/` checkout is a build input, not a reference work.** The
+documentation above is the one exception, and only because it has nowhere else
+to live yet. Two further uses of it are expected and correct, because the
+published documentation itself tells you to make them: your `deps.edn` resolves
+the library from it, and the migration tool the documentation opens with is run
+from a path inside it. Both are the documented setup. Neither is licence to
+browse.
 
 There is no trick here and you are not being tested for compliance. If you
 read something you should not have, write it down in the log's attestation and

--- a/docs/design/hicasso/product/pilots/brief-realworld.md
+++ b/docs/design/hicasso/product/pilots/brief-realworld.md
@@ -2,9 +2,9 @@
 
 Copy the block below into `<pilot-root>/BRIEF.md`. Everything inside it is written *to the pilot agent* and is the only thing that agent is given, alongside the blank friction log and the workspace itself.
 
-The brief is deliberately free of in-tree references: no bead ids, no spec sections, no repository paths except the ones the published documentation itself tells a reader to use. That is not tidiness. A brief that leaks in-tree knowledge does not bend a rule, it invalidates the evidence the pilot exists to produce, and the leak is invisible in the output.
+The brief is deliberately free of in-tree references: no bead ids, no spec sections, no repository paths except the ones the published documentation itself tells a reader to use, and one added since: `docs/core/hicasso/` inside the checkout, which is where the published documentation is kept until a site exists (`rf2-lpfz`). Naming it is what makes the pilot's only reference reachable at all. That is not tidiness. A brief that leaks in-tree knowledge does not bend a rule, it invalidates the evidence the pilot exists to produce, and the leak is invisible in the output.
 
-Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the sentence naming the test command, under `rf2-xkhul`. Assemble the workspace first, per [`workspace.md`](workspace.md).
+Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the sentence naming the test command, under `rf2-xkhul`; the address of the published documentation in the read rules, under `rf2-lpfz`. Assemble the workspace first, per [`workspace.md`](workspace.md).
 
 ---
 
@@ -40,7 +40,10 @@ afterwards from the code you produce. Only you can tell us.
 
 - The published Hicasso documentation, in full. It is your reference for
   everything: what to type, what things are called, why something broke, how
-  to test, how to build for production.
+  to test, how to build for production. It has not been put on a website yet,
+  so your copy of it is the one inside the checkout beside your project, at
+  `re-frame2/docs/core/hicasso/`. Those pages are the documentation; reading
+  them is not reading the checkout.
 - Everything in `app/`. That is your codebase. Its README explains what the
   application does and which patterns it is built from — read it freely.
 - Ordinary error output: compiler messages, stack traces, browser console.
@@ -49,19 +52,22 @@ afterwards from the code you produce. Only you can tell us.
 **You may not read:**
 
 - The `re-frame2/` checkout sitting beside your project, for anything other
-  than the two mechanical uses below. Not its source, not its internal design
-  notes, not its other example applications, not its history.
+  than the documentation named above and the two mechanical uses below. Not
+  its source, not its internal design notes, not its other example
+  applications, not its history.
 - Any file your app's README links to outside `app/`. The README is yours; the
   things it points at are not.
 - Any source file named in a stack trace. Knowing that a complaint came from
   some internal file is diagnosis and is fine. Opening that file is research
   and is not.
 
-**The `re-frame2/` checkout is a build input, not a reference work.** Two uses
-of it are expected and correct, because the published documentation itself
-tells you to make them: your `deps.edn` resolves the library from it, and the
-migration tool the documentation opens with is run from a path inside it. Both
-are the documented setup. Neither is licence to browse.
+**The `re-frame2/` checkout is a build input, not a reference work.** The
+documentation above is the one exception, and only because it has nowhere else
+to live yet. Two further uses of it are expected and correct, because the
+published documentation itself tells you to make them: your `deps.edn` resolves
+the library from it, and the migration tool the documentation opens with is run
+from a path inside it. Both are the documented setup. Neither is licence to
+browse.
 
 There is no trick here and you are not being tested for compliance. If you
 read something you should not have, write it down in the log's attestation and

--- a/docs/design/hicasso/product/pilots/friction-log.md
+++ b/docs/design/hicasso/product/pilots/friction-log.md
@@ -4,7 +4,7 @@ The pilot's own record, kept as the work happens. It is the programme's delivera
 
 The format is built around [the seven outcomes](#part-1-the-seven-outcomes) rather than around a generic template, because those seven are what the ratification says the pilots prove. Two things follow: the log has a section per outcome and no free-floating "notes" bucket, and an outcome that was never attempted is a distinct verdict from one that failed.
 
-Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the template's `Baseline:` header line, which the operator fills in at [workspace step 5b](workspace.md#assemble-a-workspace), under `rf2-xkhul`. The blank template is [at the end](#the-blank-template); copy that into the workspace.
+Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the template's `Baseline:` header line, which the operator fills in at [workspace step 5b](workspace.md#assemble-a-workspace), under `rf2-xkhul`; the template's supplied `Docs read from:` answer, under `rf2-lpfz`; the checkout case in outcome 7's rule and in the attestation, under `rf2-dc0c`. The blank template is [at the end](#the-blank-template); copy that into the workspace.
 
 ## A short log is a bad sign, not a good one
 
@@ -47,7 +47,7 @@ Rules that make the row mean something:
 - **Outcome 1 is measured twice** — the suite passing before the migration is the baseline, and without it "the tests pass" says nothing.
 - **Outcome 5 induces the failure deliberately.** Pick a fault the published diagnostics chapter claims to cover, break it on purpose, and record whether the documented path actually reached it. A pilot that only diagnoses the bugs it happened to write has not tested the instrument.
 - **Outcome 6 checks the built page runs**, not merely that the build exited zero. Advanced compilation removes diagnostics and warning strings, and a bundle that compiles but does not boot is the failure this outcome exists to catch.
-- **Outcome 7 needs two pins**, and moving the checkout pin is what stands in for an upgrade until a release coordinate exists. Record both, and record what broke — a rename surfacing as a compile error at the call site is the promised behaviour, not a defect.
+- **Outcome 7 needs two pins**, and moving the checkout pin is what stands in for an upgrade until a release coordinate exists. Record both, and record what broke — a rename surfacing as a compile error at the call site is the promised behaviour, not a defect. **Where the run resolves the library from a checkout rather than from a released version there is no second pin, and the outcome is `BLOCKED`.** It is not simulated by repointing the checkout at a later commit: that yields a row which reads as upgrade evidence without being any, and a later counted run is read against this log. The operator applies that variant to the copied log during [assembly](workspace.md#rehearsal-runs-outcome-7-is-blocked), so the pilot meets one instruction rather than a choice. Amended under `rf2-dc0c`.
 
 ## Part 2: friction entries
 
@@ -96,6 +96,8 @@ Checkout pin at end:   <sha>
 
 **An empty list here is the expected value and must still be written.** The point is that somebody signed it: an absent attestation and a clean one are the same silence otherwise, and only one of them is evidence. A non-empty list is not a failed pilot — it is a pilot that reported accurately, and it lets the audit weigh the affected entries instead of discarding the whole log.
 
+The two pin lines belong to a run that has two pins. Where the library is resolved from a checkout and outcome 7 is `BLOCKED`, they collapse to the single pin the run actually had; the operator makes that replacement when copying the template, at [assembly](workspace.md#rehearsal-runs-outcome-7-is-blocked). Leaving them as a pair asks the pilot for something the run cannot produce, and a pilot will try to produce it. Amended under `rf2-dc0c`.
+
 ## Part 4: disposition
 
 The operator's section, written after the pilot ends and never by the pilot. Each entry gets a disposition — `fixed`, `filed`, `rejected`, or `not a defect` — with its bead. This is what `rf2-hic-063`'s acceptance means by the friction log being dispositioned, and it is the half that turns the log into work.
@@ -112,7 +114,8 @@ Agent:            <identifier>
 Workspace:        <pilot-root>
 Checkout pin:     <sha>
 Baseline:         npm test → exit <code>, with the app still on Reagent
-Docs read from:   <published site URL or local build>
+Docs read from:   re-frame2/docs/core/hicasso/ — the checkout's copy of the
+                  published documentation; there is no published site yet
 Started / ended:  <date> / <date>
 
 A near-empty log is suspect, not successful. Record every hesitation,

--- a/docs/design/hicasso/product/pilots/workspace.md
+++ b/docs/design/hicasso/product/pilots/workspace.md
@@ -4,7 +4,7 @@ The operator's page. It says what a pilot workspace contains, how to assemble on
 
 A pilot agent is never sent here — this page sits inside the repository the pilot is blinded to. What the agent gets is `BRIEF.md` and `FRICTION-LOG.md`, both of which land in the workspace by the procedure below.
 
-Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification.
+Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the `_shared/` line in both source manifests, under `rf2-f22y`; the documentation row in the read fence and the docs line in the layout block, under `rf2-lpfz`; the rehearsal variant of outcome 7, under `rf2-dc0c`.
 
 ## Layout
 
@@ -13,6 +13,8 @@ The published installation chapter tells a reader to clone the monorepo *beside*
 ```text
 <pilot-root>/
   re-frame2/            the checkout. A build input — see the read fence below
+    docs/core/hicasso/  the published Hicasso documentation, 29 pages. This is
+                        the pilot's reference; there is no published site yet
   app/                  the pilot's project. Everything here is the pilot's
     deps.edn
     shadow-cljs.edn
@@ -26,7 +28,7 @@ The published installation chapter tells a reader to clone the monorepo *beside*
 
 `app/deps.edn` sits one level under `<pilot-root>`, which is what makes every `:local/root "../re-frame2/…"` in the published documentation resolve without modification. Do not flatten it.
 
-**Pin the checkout.** Record the commit the workspace was built at in the log's header and do not update it mid-pilot. A pilot that silently moves onto a newer tree is measuring two things at once, and outcome 7 — upgrade across the RC — is the one place a deliberate second pin belongs.
+**Pin the checkout.** Record the commit the workspace was built at in the log's header and do not update it mid-pilot. A pilot that silently moves onto a newer tree is measuring two things at once, and outcome 7 — upgrade across the RC — is the one place a deliberate second pin belongs. On a rehearsal there is no second pin to belong there, and outcome 7 is [recorded `BLOCKED`](#rehearsal-runs-outcome-7-is-blocked) instead.
 
 ## The read fence
 
@@ -34,14 +36,16 @@ The published installation chapter tells a reader to clone the monorepo *beside*
 
 That is the whole rule, and it decides every case cleanly. Everything under `app/` is the pilot's own code, to read, run and rewrite. Hicasso — what it is, how it works, what to type, why it broke — comes from the published documentation and from nothing else.
 
-The checkout in `re-frame2/` exists because there is no published coordinate yet ([gap G1](README.md#what-the-published-documentation-does-not-answer)). It is a build input, not a reference work:
+The checkout in `re-frame2/` exists because there is no published coordinate yet ([gap G1](README.md#what-the-published-documentation-does-not-answer)). It is a build input, not a reference work — with one exception, which is that same gap wearing a second face: the published documentation has no address either. There is no site to send the pilot to, and the [installation page](../../../../core/hicasso/00-installation.md) says on its own face that nothing is published yet. Until one exists, the checkout's copy of those pages *is* the published documentation, and the pilot reads it as such. That is an exception about where the documentation is kept, not about what may be studied, and it leaves everything else on this page exactly where it was.
 
 | Allowed | Not allowed |
 | --- | --- |
-| Resolving dependencies from it via `:local/root` | Reading `implementation/` for how something works |
-| Running a tool a published page names, at the path that page gives — the migration reporter under `migration/reagent-to-hicasso/codemod` is the one that matters | Reading `spec/`, `docs/design/`, or any other example under `examples/` |
-| Reading error text and stack traces the build emits, including the file paths in them | Reading the tracker, `git log`, or any branch |
-| — | Opening a source file named in a stack trace to see what it does |
+| Reading the published documentation inside it — anything under `docs/` the site builds, which is where `docs/core/hicasso/`'s 29 pages live | Reading `implementation/` for how something works |
+| Resolving dependencies from it via `:local/root` | Reading `spec/`, `docs/design/`, or any other example under `examples/` |
+| Running a tool a published page names, at the path that page gives — the migration reporter under `migration/reagent-to-hicasso/codemod` is the one that matters | Reading the tracker, `git log`, or any branch |
+| Reading error text and stack traces the build emits, including the file paths in them | Opening a source file named in a stack trace to see what it does |
+
+**Which pages those are is decided by the site build, not by a list kept here.** Anything under `docs/` that the published site builds is documentation and is readable; anything the build leaves out is not. That is `mkdocs.yml`'s `docs_dir` minus its `exclude_docs` block, and it is worth stating as a mechanism rather than as an inventory, because an inventory drifts and this one would be read on every task. It also settles the awkward case without needing a second sentence: `docs/design/` — this page among them — is excluded from the site, so it stays out of bounds by the same rule that lets `docs/core/hicasso/` in. The repository's other trees are not under `docs/` at all and never enter the question.
 
 The last row is the one that will actually come up, and it is deliberately strict. Reading *that* a complaint came from `impl/slot.cljc` is diagnosis. Opening `impl/slot.cljc` is research, and it is the leak the programme is built to detect.
 
@@ -76,6 +80,7 @@ cp re-frame2/examples/real-apps/realworld_http/*.cljc   app/src/realworld_http/
 cp re-frame2/examples/real-apps/realworld_shared/*.cljs app/src/realworld_shared/
 cp re-frame2/examples/real-apps/realworld_http/default-avatar.svg app/public/
 cp re-frame2/examples/real-apps/realworld_http/index.html         app/public/
+cp -r re-frame2/examples/_shared                                  app/public/_shared
 cp re-frame2/examples/real-apps/realworld_http/README.md          app/
 cp re-frame2/docs/design/hicasso/product/pilots/baseline/realworld_http/baseline_test.cljs app/test/realworld_http/
 ```
@@ -86,11 +91,14 @@ Pilot 2 — LinearLite:
 mkdir -p app/src/linearlite app/public app/test/linearlite
 cp re-frame2/examples/capabilities/resources/linearlite/core.cljs  app/src/linearlite/
 cp re-frame2/examples/capabilities/resources/linearlite/index.html app/public/
+cp -r re-frame2/examples/_shared                                   app/public/_shared
 cp re-frame2/examples/capabilities/resources/linearlite/README.md  app/
 cp re-frame2/docs/design/hicasso/product/pilots/baseline/linearlite/baseline_test.cljs app/test/linearlite/
 ```
 
 The last line of each manifest is the app's behavioural baseline, and it is the one file that does not come from the app's own directory. The examples tree is test-free by policy, so each app's behavioural suite lives in the Reagent adapter's test tree and runs on the in-repo harness; [`baseline/`](baseline/README.md) carries the subset that exercises the nominated screens, rewritten as the app's own test namespace so that it stands on `cljs.test`, the core test support and the canned HTTP replies — all of which the `:local/root` route resolves — and on nothing the workspace cannot see. The pilot may read it, since it is under `app/`, which is why it names no in-tree path, bead or spec: the fence holds inside the test file as it does inside the brief. Added under `rf2-xkhul`.
+
+**The `_shared/` line is the one that is easy to leave out, and leaving it out is invisible until a browser draws the page.** Both `index.html` files link a stylesheet, a favicon and an OG image from a sibling `_shared/` directory that sits at the *root* of the examples tree, one level above each app's own folder — so a manifest written per app misses all three, and nothing in the repository ever notices, because the repository's own example runner stages that directory into each example's output as a whole-tree copy instead of serving it from where it lives. Copy the directory rather than the three files it is named for: `style.css` opens by importing `structure.css` beside it, which a file-by-file manifest drops silently and no page ever mentions. Omit the line and both workspaces serve an unstyled page — which reads as broken scaffolding, in the one place [step 5](#assemble-a-workspace) exists to stop that reading. Added under `rf2-f22y`.
 
 **3. Write the four project files** from the templates below.
 
@@ -115,6 +123,33 @@ cd app && npm test > ../baseline-reagent.log 2>&1; echo "baseline exit $?"    # 
 The runner's closing line is the count to expect — as of `rf2-xkhul` the RealWorld baseline reports `Ran 4 tests containing 123 assertions.` and the LinearLite baseline `Ran 10 tests containing 51 assertions.`, both with `0 failures, 0 errors.` — and it is the exit status that is recorded, not the count. The compile also prints a handful of `:infer-warning` lines from the framework's own source and a Clojure CLI deprecation notice about the test kit's external path; neither fails the run, and both are the framework's to log, not the operator's to hide. Added under `rf2-xkhul`.
 
 **6. Copy the brief and the blank log** into `<pilot-root>/`, from [`brief-realworld.md`](brief-realworld.md) or [`brief-linearlite.md`](brief-linearlite.md), and from [`friction-log.md`](friction-log.md)'s template section.
+
+### Rehearsal runs: outcome 7 is BLOCKED
+
+A rehearsal runs on `:local/root` against a checkout, where the library has one pin and no released version behind it. Outcome 7 — upgrade across the pin — therefore cannot be attempted, and it is recorded `BLOCKED` rather than simulated by moving the checkout to a later commit. The reason is substantive rather than clerical: an upgrade on a checkout is moving a git pin, not moving a version across a release candidate, so a simulated move produces a row that *looks* like upgrade evidence, and the counted run is later read against this log. `rf2-hic-063`'s ruling of 2026-09-02 closes that reading.
+
+The briefs and [`friction-log.md`](friction-log.md) are correct as written for the counted run on a published artefact, where two pins genuinely exist, and they stay as they are. A rehearsal's difference is applied by the operator, here, to the two copies step 6 has just made — never by the pilot, who is blinded and must not be asked to work out which kind of run it is in. Two edits, both to the copies and neither to the pages they came from:
+
+**In `BRIEF.md`**, replace outcome 7 in the definition of done with:
+
+```markdown
+7. **Not part of this run.** Your project resolves the library from the
+   checkout beside it rather than from a released version, so there is no
+   released version to upgrade across and nothing here to attempt. Record
+   outcome 7 as `BLOCKED` and move on — that is the expected verdict, not a
+   failure and not a finding. Do not stand in for it by repointing the
+   checkout at a different commit.
+```
+
+**In `FRICTION-LOG.md`**, pre-fill outcome 7's row so the pilot spends nothing reaching it, and replace the attestation's two pin lines — which presuppose the move — with the single pin that is true of the run:
+
+```markdown
+| 7 | Upgrade across the pin | `BLOCKED` | Not part of this run — the library is resolved from the checkout, not a released version |
+
+Checkout pin: <sha>
+```
+
+Both replacements are written to be read alone. Neither names a rehearsal, a counted run, or this page, so the pilot meets one instruction rather than a choice between two. Added under `rf2-dc0c`.
 
 ## The four project files
 


### PR DESCRIPTION
Closes the three pilots-package defects the pre-pilot rehearsal (`rf2-t4jpz`) found by executing `docs/design/hicasso/product/pilots/workspace.md` literally for the first time. All four changed files are inside `docs/design/hicasso/product/pilots/`; nothing else is touched.

## Item 1 — `rf2-f22y`: the manifest omits `examples/_shared/`

**Re-measured at tip.** Both `index.html` files still reference exactly three `_shared/` assets — `_shared/css/style.css`, `_shared/img/favicon.svg`, `_shared/img/og.png` — and `examples/_shared/css/style.css` is still 274 lines. But there is a **fourth, transitive asset the bead does not name**: `style.css` line 14 is `@import url('structure.css')`, a further 256 lines that own "reusable geometry and the inline-Xray layout". A three-file manifest would still have served a partly unstyled page.

**The dev-http cascade claim is REFUTED.** The bead says the repo "serves them through its dev-http root cascade rather than by copying". It does not. `examples/scripts/examples-staging.cjs` stages `_shared/` by **recursive copy** — `stageShared()` calls `copyDirRecursive(SHARED_SRC, outDir/_shared)` — invoked from `serve-example.cjs` and `serve-and-run-adapter-smokes.cjs`. `examples/README.md` says so directly, and warns that a bare `shadow-cljs watch <build-id>` "copies no `_shared/` assets". The dev-http entries corroborate the refutation: LinearLite's (port 8044) cascades two roots, the app's own source directory and `out/examples/linearlite`, and `_shared/` is in neither.

**The defect is real regardless** — only the stated mechanism was wrong. The omission is invisible in-repo because the runner copies the whole tree automatically, so nobody writing a per-app manifest ever meets the dependency.

**The fix** adds one line to each manifest, copying the *directory* rather than the three named files. That mirrors the repository's own staging contract and picks up the transitive `structure.css` for free.

**Proof — measured, both pilots, before and after.** Workspaces assembled exactly per step 2 (plus the documented script-tag change), served over HTTP:

| Request | RealWorld before | RealWorld after | LinearLite before | LinearLite after |
| --- | --- | --- | --- | --- |
| `index.html` | 200 | 200 | 200 | 200 |
| `default-avatar.svg` | 200 | 200 | 404 | 404 |
| `_shared/css/style.css` | **404** | **200** | **404** | **200** |
| `_shared/css/structure.css` | **404** | **200** | **404** | **200** |
| `_shared/img/favicon.svg` | **404** | **200** | **404** | **200** |
| `_shared/img/og.png` | **404** | **200** | **404** | **200** |
| `js/main.js` | 404 | 404 | 404 | 404 |

Two rows need saying plainly rather than being read as failures. `js/main.js` is 404 in **every** column because it is the shadow-cljs output of step 5's `watch`, not a file the step-2 manifest copies; this probe assembles only the manifest's static copy, so that row is 404 by construction and is outside what the fix touches. `default-avatar.svg` is 404 for LinearLite in both columns because LinearLite's `index.html` never references it and its source directory does not contain it — correct, not a defect.

## Item 2 — `rf2-lpfz`: the pilot's only reference had no address

**`exclude_docs` as I observed it** — `mkdocs.yml` line 32, verbatim, six entries, with `docs_dir: docs`:

```
tools/playground/
migration/from-re-frame-v1/codemod/
migration/reagent-to-hicasso/codemod/
design/freehand/
design/hicasso/
design/retirement/
```

I confirmed the reading **by running the build rather than by trusting the block**, as the ruling asks. `python -m mkdocs build --strict` exits 0 and `site/design` **does not exist**; `site/core/hicasso/` contains exactly **29** pages, matching both the bead's count and the checkout's 29 `.md` files. `docs/design/` holds exactly three subdirectories — `freehand`, `hicasso`, `retirement` — and all three are excluded, so the ruling's hard case holds precisely rather than approximately.

**One wrinkle worth recording, because it nearly leaked into the rule.** `mkdocs_hooks.py` stages the repo-root `spec/` and `migration/` trees into `docs_dir` before the scan, so the built site really does carry 52 `spec/` pages. A rule worded as "anything the built site serves" would therefore have permitted `spec/`, which the ruling forbids. It resolves cleanly because the rule is scoped to the **checkout's** `docs/` tree: root `spec/` is not under `docs/`, and `docs/spec/` is a gitignored build artefact absent from the fresh clone step 1 produces. The fence's existing Not-allowed row already names `spec/`, so the two columns now read as exact complements.

**The rule as written**, in the read fence: *"Anything under `docs/` that the published site builds is documentation and is readable; anything the build leaves out is not. That is `mkdocs.yml`'s `docs_dir` minus its `exclude_docs` block."* Stated as a mechanism rather than an inventory, and it settles `docs/design/` by the same sentence that permits `docs/core/hicasso/`.

**All three ruled places changed:** the read fence (new Allowed row, plus the honesty paragraph saying what the exception is and why — there is no site, and `00-installation.md` says `day8/re-frame2-hicasso` is "**not published**"); `friction-log.md`'s `Docs read from:` (now supplied rather than blank); and the workspace layout block (now names `docs/core/hicasso/`).

**One thing beyond the ruled three, flagged for review.** Both briefs also changed. The ruling's own test is that "a permission that the assembly steps do not realise is still a gap" — and the assembly delivers the **brief**, which told the pilot it may not read the checkout "for anything other than the two mechanical uses below". Left alone, the pilot receives the prohibition and never the permission, which is the bug restated. Each brief now names the documentation's address in "You may read", admits it in "You may not read", and calls it the one exception in the build-input paragraph. Outcome 7 in both briefs is **untouched**. Say the word and I will revert the brief half.

While adding the fence row I rebalanced the table: it previously carried an em-dash filler in the Allowed column, and the four Allowed entries now pair one-to-one with the four Not-allowed ones. No row was removed, and the "last row" the following paragraph discusses is still the stack-trace row.

## Item 3 — `rf2-dc0c`: outcome 7

**Mechanism chosen: a rehearsal variant applied by the operator, living in `workspace.md`'s assembly immediately after step 6.** The reasons come from the package's own conventions rather than from preference:

- `workspace.md` is the operator's page and the pilot is never sent to it (`README.md` says so), so a conditional placed there can never reach the pilot — which is exactly what rules out (c).
- Step 6 is where the two pilot-facing copies are made, so the delta sits against the step that produces the thing it changes.
- The package already expresses variants as *base plus delta* ("Pilot 2 — LinearLite: the same file with the … rows dropped"), so this reads in the existing idiom.
- A separate rehearsal page was rejected: `README.md`'s heading is `## The four pages`, and a fifth would force a heading change, which the scope fence forbids.

The counted-run instruction stays untouched in both briefs and in `friction-log.md`, ruling out (a). The variant replaces outcome 7 in `BRIEF.md` and, in `FRICTION-LOG.md`, pre-fills outcome 7's row as `BLOCKED` and collapses the attestation's two pin lines to one, ruling out (b).

**Result of reading the rehearsal text alone, with no knowledge of the ruling.** The pilot's outcome 7 becomes:

> **Not part of this run.** Your project resolves the library from the checkout beside it rather than from a released version, so there is no released version to upgrade across and nothing here to attempt. Record outcome 7 as `BLOCKED` and move on — that is the expected verdict, not a failure and not a finding. Do not stand in for it by repointing the checkout at a different commit.

Read cold it answers what to do, why, that it is expected rather than a finding, and forecloses the pin move a resourceful agent would otherwise invent for itself. The words "rehearsal" and "counted run" appear nowhere in it, so the pilot is never asked which kind of run it is in. Both facts it rests on are ones the pilot can check without leaving permitted material: its own `deps.edn` uses `:local/root`, and the published installation page says nothing is released.

I checked for residual contradiction rather than assuming none: **`pin` occurs exactly once in each brief** — outcome 7 itself — so after the replacement `BRIEF.md` carries no reference to moving a pin at all. In the blank template the only remaining pin line is the header's singular `Checkout pin:`, which is true of a rehearsal and stays.

## Gates

Every gate foreground, unfiltered, exit code captured on the runner's own command line and quoted from that capture. All re-run on the final base `58fc37ebdd` after the second rebase.

| Gate | Exit | Note |
| --- | --- | --- |
| `python scripts/check_doc_slugs.py` | **0** | silent |
| `python scripts/check_provenance_pins.py` | **0** | 153 pages, **821 cited pins**, 0 findings. In the spine's changed-pages mode: 4 pages, 0 pins, 0 findings |
| `python -m mkdocs build --strict` | **0** | see below — not the gate for this diff |
| `sh scripts/test-fast-pr.sh --plan` | **0** | `docs=true jvm=false node=false`, reason `classified` |
| `sh scripts/test-fast-pr.sh` (full) | **0** | `PASS fast PR spine` |

`mkdocs build --strict` **cannot see any file in this PR** — `site/design` does not exist after a successful build — so its green is not evidence about these edits. It was run for item 2, where the rule being written down is defined by what that build includes; there the observation is the deliverable, not the exit code. Both `test-fast-pr.sh` invocations print `gate root:` naming this worktree.

**Both gates that can see this diff were verified to read this worktree by planted faults, not by their colour.** A broken anchor planted at a line I had edited took `check_doc_slugs.py` to exit **1**, naming `workspace.md:31` and the planted anchor. A bare prose hex took `check_provenance_pins.py` to exit **1**, naming `workspace.md:129`, with the pin count moving 821 → 822 and findings 0 → 1. Each fault existed only in this worktree, so a run that had wandered into a sibling checkout would have come back green. Both were restored by checkout and the restore verified by hash rather than by reading a diff: the committed **blob** hash `d39dd615139700dbc5056453ed66ba66816a77c6` was identical before and after, `git diff --quiet HEAD` exited 0, and the provenance gate returned to exactly 821 pins / 0 findings.

## What no gate inspected

`check_doc_slugs.py` and `check_readme_links.py` share one extractor that **strips fenced code blocks before reading a single link**, and this package is mostly fences. These edits sit inside fences and were checked by hand:

- **`workspace.md`** — the ```text layout block (the new `docs/core/hicasso/` lines); both ```bash step-2 manifests (the two `_shared` lines); and both ```markdown blocks inside the new rehearsal section.
- **`brief-realworld.md` / `brief-linearlite.md`** — **every** edit in both files sits inside the single ```markdown block copied verbatim into `BRIEF.md`, except the two page-prose lines above it.
- **`friction-log.md`** — the ```markdown blank-template block (the `Docs read from:` answer).

Checked by hand, since nothing validates prose, tables, rendering or nav:

- **Table column counts**, measured mechanically across all five pages: read fence 4 data rows × 2 columns (was 3 rows plus an em-dash filler); `friction-log.md` resolution table 3 columns, Part 1 table 4 columns, blank-template Part 1 table 4 columns; `README.md` untouched. The pre-filled outcome-7 row I supply is **4 cells**, matching the template table it goes into.
- **Anchors** — `#rehearsal-runs-outcome-7-is-blocked` is a new heading targeted from two files; `#assemble-a-workspace` and the `00-installation.md` relative path reuse forms `README.md` already uses. The planted-anchor run above is positive evidence the anchor gate is live on this page.
- **Manifest alignment** — both new `cp -r` lines align their destination column with their neighbours (column 66 for RealWorld, 67 for LinearLite), verified by measurement rather than by eye.
- **Line endings** — these files are CRLF under `core.autocrlf=true`. All four remain CRLF with zero bare LF, and every scripted replacement asserted a match count of exactly 1 before writing.
- **Custody** — every amendment names its authorizing bead at the site, per the directory's custody rule. No bead id was placed inside a pilot-facing fence; the briefs' in-tree references stay in the page prose.

## Scope and concurrency

Only `docs/design/hicasso/product/pilots/**`. No example was edited and `rf2-nvcp` was not touched — item 1 is about the manifest that copies the examples, never the examples themselves. `README.md` and `baseline/` are unchanged.

PR #9047 also edits `workspace.md`. Measured rather than assumed: its two regions are the step-5 prose about what the compile prints (line 123 here) and Pilot 1's `:test` alias (line 177 here), and **this diff touches neither** — no added or removed line in this PR contains `deprecat`, `infer-warning`, `test_kit`, `extra-paths` or `extra-deps`, while those terms do match the untouched regions, so the zero is a control that bites rather than a pattern that missed. The nearest approach is my last hunk, which begins at the blank line immediately after the paragraph #9047 rewrites — adjacent but non-overlapping, so the two should apply in either order. Whoever rebases second should confirm rather than trust that. The three-dot diff against the merge base was read for reverts: nothing that landed on `main` since the base touches this subtree.
