### PR TITLE
fix(routing): rf/route-link renders as a component, not a call (rf2-nvcp)

### DIFF
--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -433,6 +433,43 @@
                         (assoc (source-coords/merge-coords {})
                                :handler-fn link/route-link-render-ssr)))
 
+#?(:cljs
+   (defn ^:no-doc route-link-element
+     "The value published to the `:routing/route-link` hook — what
+     `rf/route-link` becomes at a call site (rf2-nvcp).
+
+     Returns the HICCUP ELEMENT `[<component-head> props & children]` rather
+     than calling the render fn. That distinction is the whole of this fn, and
+     it is a correctness requirement, not a style choice.
+
+     `rf/route-link` is a `defwrapper` (`re-frame.core-routing`), so its body
+     is `(apply <hook-fn> args)` — an ordinary function call. A user writes
+     `[rf/route-link {:to …} \"Articles\"]`, and the component the substrate
+     mounts is therefore `rf/route-link` ITSELF: a plain fn, carrying no
+     `{:contextType frame-context}` meta. Publishing the registered view head
+     directly made that head run INSIDE that plain-fn component instead of
+     becoming a component of its own, so the React-context tier had nothing to
+     read it from: `re-frame.views.provider/current-frame` saw React's empty
+     default on `(.-context cmp)`, resolved nil, and `route-link-render`'s
+     render-time `require-current-frame!` (rf2-o3nam4) raised
+     `:rf.error/no-frame-context` on FIRST RENDER — blanking every routed
+     application, however correctly it mounted its `frame-root`.
+
+     Emitting the element instead hands the head to the substrate as an
+     element TYPE, so it is componentized exactly as a `reg-view` view is
+     (`[home-page]` and `[rf/route-link …]` now take the same path) and the
+     enclosing `frame-root` / `frame-provider` context reaches it.
+
+     The head is resolved through `views/view-head` per render rather than
+     closed over: the head is a property of (registration × installed
+     substrate), and `view-head` re-derives it against the adapter installed
+     NOW and memoizes (rf2-8mkmb). Closing over the `reg-view*` return value
+     would pin the SEED head — derived at ns-load, before `rf/init!` seats any
+     adapter — which is right for Reagent and wrong for any substrate that
+     publishes `:adapter/componentize-view`."
+     [& args]
+     (into [(views/view-head :route/link)] args)))
+
 ;; ---- late-bind hook registration ------------------------------------------
 ;; Core must not require this optional artefact. Late-bound hooks publish the
 ;; integration points without reversing that dependency.
@@ -507,8 +544,13 @@
 #?(:cljs (late-bind/set-fn! :routing/reset-url-listener!  history/remove-url-listener!))
 
 ;; route-link is exposed on both platforms so .cljc render trees
-;; resolve identically server- and client-side.
-#?(:cljs (late-bind/set-fn! :routing/route-link route-link)
+;; resolve identically server- and client-side. On CLJS the hook carries the
+;; ELEMENT-emitting `route-link-element`, not the registered head itself — see
+;; its docstring (rf2-nvcp): `rf/route-link` is a `defwrapper`, so whatever
+;; this hook holds is CALLED rather than mounted, and a head that is called
+;; never becomes a component that can read the frame context. SSR has no React
+;; context to read, so the JVM side keeps rendering the anchor directly.
+#?(:cljs (late-bind/set-fn! :routing/route-link route-link-element)
    :clj  (late-bind/set-fn! :routing/route-link route-link-render-ssr))
 
 ;; The substrate-neutral link seam consumed by an optional view artefact's own

--- a/implementation/routing/test/re_frame/route_link_frame_context_dom_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/route_link_frame_context_dom_cljs_test.cljs
@@ -1,0 +1,219 @@
+(ns re-frame.route-link-frame-context-dom-cljs-test
+  "`[rf/route-link …]` RENDERS, MOUNTED THE WAY AN APPLICATION MOUNTS IT
+  (rf2-nvcp).
+
+  ## The gap this file closes
+
+  Every other route-link suite in the tree calls `routing/route-link-render`
+  — the bare render fn — directly, and every one of them establishes the
+  frame with `rf/with-frame`. That is the DYNAMIC-VAR tier, tier 1 of the
+  three-tier chain `frame/resolve-current-frame` reads, and it answers
+  whoever asks, from anywhere. So those suites can be green for a component
+  that no application can render.
+
+  They were. `rf/route-link` reaches a call site through a `defwrapper`
+  (`re-frame.core-routing`), whose body CALLS the value on the
+  `:routing/route-link` hook rather than mounting it. The component the
+  substrate actually mounted was therefore `rf/route-link` itself — a plain
+  fn, carrying no `{:contextType frame-context}` — so `(.-context cmp)` was
+  React's empty default, the REACT-CONTEXT tier (tier 2, the only tier a
+  real application's `frame-root` establishes) resolved nil, and
+  `route-link-render`'s render-time `require-current-frame!` raised
+  `:rf.error/no-frame-context` on first render. Three shipped examples
+  mounted nothing at all — `#app` innerHTML length 0, a blank page — while
+  the unit suites stayed green.
+
+  So the rows below are deliberately NOT unit calls on the render fn:
+
+    * they mount through the Reagent adapter into a real document, so the
+      component boundary the bug lives at is genuinely constructed; and
+    * they establish the frame ONLY through a React-context boundary — a
+      `frame-provider` (SCOPE) in one row, a `frame-root` (ENSURE, the
+      applications' own shape) in the other — with `:ambient-frame nil` on
+      the fixture so no `with-frame` scope can answer in its place.
+
+  A row that passes because tier 1 answered would prove nothing, which is
+  exactly what the pre-existing coverage did.
+
+  ## What a failure looks like
+
+  A route-link that cannot resolve its frame THROWS during render, and
+  React discards the whole subtree — so the failure shows up as an absent
+  anchor, not a wrong one. Each row therefore reports the container's actual
+  innerHTML on failure, and reports any error that escaped the mount,
+  because 'the anchor is missing' on its own does not say why.
+
+  Per Spec 012 §Linking from views and Spec 002 §Frame target resolution.
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test` discovers it;
+  `:node-test` loads it too, where the rows degrade to a STATED skip."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            ["react-dom" :as react-dom]
+            [reagent.dom.client :as rdc]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.core :as rf]
+            [re-frame.routing :as routing]
+            [re-frame.test-support :as test-support]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- skip! [why]
+  (is true (str "a route-link render witness needs a real browser — " why)))
+
+;; ---------------------------------------------------------------------------
+;; The application under test — one route, one view, one link
+;; ---------------------------------------------------------------------------
+
+(def ^:private root-id "rf2-route-link-frame-context-root")
+
+(def ^:private link-testid "rf2-route-link-under-context")
+
+(def articles-route ::articles)
+
+(def ^:private articles-url "/rf2-route-link-ctx/articles")
+
+(defn- register-routes!
+  "Register this witness's single route.
+
+  A function rather than an ns-load effect: the reset fixture restores the
+  registrar to a baseline captured when `use-fixtures` was evaluated, so a
+  route registered at load is rolled back before the first row runs. The
+  `/rf2-route-link-ctx` leading segment keeps the path out of every other
+  namespace's match table in the shared bundle (TESTING.md §Test authoring
+  policy)."
+  []
+  (routing/reg-route articles-route {:doc "The article list."} articles-url)
+  nil)
+
+(rf/reg-view* ::app
+  (fn app []
+    ;; A route-link and nothing else. The point of the row is the link's own
+    ;; render, so anything else on the page would only be somewhere for a
+    ;; failure to hide.
+    [:main
+     [rf/route-link {:to           articles-route
+                     :data-testid  link-testid}
+      "See the articles"]]))
+
+;; ---------------------------------------------------------------------------
+;; The lane
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       reagent-adapter/adapter
+     ;; THE LOAD-BEARING LINE. With an ambient frame bound, tier 1 answers
+     ;; every resolution and both rows below pass without the React-context
+     ;; tier ever being consulted — which is precisely the blind spot that
+     ;; let the regression ship.
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+                      (routing/reset-counters!)
+                      (register-routes!))}))
+
+;; ---------------------------------------------------------------------------
+;; Mount / teardown
+;; ---------------------------------------------------------------------------
+
+(defn- mount!
+  "Create a root element, append it to the document, and commit `tree`
+  synchronously. Returns `{:container :root :error}` — `:error` holds
+  anything the first render threw, so a row can name the cause rather than
+  only reporting an absent anchor."
+  [tree]
+  (let [container (.createElement js/document "div")]
+    (.setAttribute container "id" root-id)
+    (.appendChild js/document.body container)
+    (let [root  (rdc/create-root container)
+          error (try
+                  (react-dom/flushSync (fn [] (rdc/render root tree)))
+                  nil
+                  (catch :default e e))]
+      {:container container :root root :error error})))
+
+(defn- teardown!
+  "Unmount, detach the root, and drop the frame. Runs on the success and
+  failure paths alike, so a row that threw cannot make the next row wrong."
+  [{:keys [container root]} frame-id]
+  (try (.unmount root) (catch :default _ nil))
+  (try (.remove container) (catch :default _ nil))
+  (try (rf/destroy-frame! frame-id) (catch :default _ nil))
+  nil)
+
+(defn- anchor
+  "The rendered `<a>`, or nil. Selected by the link's own passthrough
+  `:data-testid` rather than by tag, so a stray anchor from anything else on
+  the shared test page cannot answer for it."
+  [{:keys [container]}]
+  (.querySelector container (str "a[data-testid=\"" link-testid "\"]")))
+
+(defn- describe-failure
+  "What the container actually holds, plus whatever the mount threw — the
+  two facts that turn 'no anchor' into a diagnosis."
+  [{:keys [container error]}]
+  (str "container innerHTML = " (pr-str (.-innerHTML container))
+       (when error
+         (str "; the render threw " (pr-str (ex-data error))
+              " :: " (.-message error)))))
+
+(defn- assert-link-rendered!
+  "The whole contract, asserted the same way for both boundaries: the mount
+  did not throw, and the anchor is on the page carrying the route's href."
+  [m label]
+  (is (nil? (:error m))
+      (str label " — the first render must not throw. " (describe-failure m)))
+  (let [a (anchor m)]
+    (is (some? a)
+        (str label " — the route-link must render an <a>. " (describe-failure m)))
+    (when (some? a)
+      (is (= articles-url (.getAttribute a "href"))
+          (str label " — the anchor's href must be the route's URL."))
+      (is (= "See the articles" (.-textContent a))
+          (str label " — the anchor must carry the link's children.")))))
+
+;; ---------------------------------------------------------------------------
+;; Rows
+;; ---------------------------------------------------------------------------
+
+(deftest route-link-renders-under-a-frame-provider-rf2-nvcp
+  (testing "a route-link inside a frame-provider — the SCOPE boundary — resolves
+           its frame from the React-context tier and renders its anchor"
+    (if-not (browser?)
+      (skip! "frame context is a React-context read on a mounted component")
+      (async done
+        (let [frame-id ::provider-frame]
+          (rf/make-frame {:id frame-id :doc "route-link render witness (SCOPE)."})
+          (let [m (mount! [rf/frame-provider {:frame frame-id}
+                           [(rf/view ::app)]])]
+            (assert-link-rendered! m "frame-provider")
+            (teardown! m frame-id)
+            (done)))))))
+
+(deftest route-link-renders-under-a-frame-root-rf2-nvcp
+  (testing "a route-link inside a frame-root — the ENSURE boundary, and the exact
+           shape every failing example mounted — renders its anchor"
+    (if-not (browser?)
+      (skip! "frame context is a React-context read on a mounted component")
+      (async done
+        (let [frame-id ::root-frame
+              ;; `frame-root` ENSUREs in a client `useLayoutEffect`, so the
+              ;; first render emits no descendant subtree and the children
+              ;; render on the pass after the commit. Poll for the anchor
+              ;; rather than counting frames: a deadline reports which render
+              ;; never arrived, a frame count reports only that a line was
+              ;; false.
+              m        (mount! [rf/frame-root {:id  frame-id
+                                               :doc "route-link render witness (ENSURE)."}
+                                [(rf/view ::app)]])]
+          (-> (test-support/poll-until
+                #(some? (anchor m))
+                {:label "the route-link's anchor under a frame-root"})
+              (.then  (fn [_] (assert-link-rendered! m "frame-root")))
+              (.catch (fn [_]
+                        ;; The poll timing out IS the regression's signature —
+                        ;; report it as the assertion the row is about, with the
+                        ;; render's own error when one escaped.
+                        (assert-link-rendered! m "frame-root")))
+              (.then  (fn [_] (teardown! m frame-id) (done)))))))))


### PR DESCRIPTION
Closes rf2-nvcp (P0). `rf/route-link` raised `:rf.error/no-frame-context` on first
render, so every routed application mounted **nothing** — blank page, `#app`
innerHTML length 0.

## 1. Which mechanism it was, and how I established it

The brief offered two candidates: **(a)** `frame-root` no longer establishes the
dynamic scope descendants read, or **(b)** `require-current-frame!`'s admission
changed so a scope that IS established no longer satisfies it. **It was neither,
and both are refuted by the reproduction itself.**

`:examples/routing`'s `root-view` is a `reg-view` whose body is
`@(subscribe [:rf.route/id])` — an **ambient** subscribe with no explicit frame —
and it renders *before* any route-link. The thrown error names
`:operation :route-link`, `:where re-frame.routing.link/route-link-render`, not a
subs site. So `root-view`'s ambient resolution had already **succeeded** through
the React-context tier that `frame-root` establishes. The scope was present,
established, and readable — refuting (a) — and `require-current-frame!` admitted
it for every `reg-view` in the tree — refuting (b).

The actual mechanism is structural, and it sits one level up from both:

`rf/route-link` is a `defwrapper` (`re-frame.core-routing`), so its body is
`(apply <hook-fn> args)` — an **ordinary function call**. The
`:routing/route-link` hook carried the registered `:route/link` view **head**, so
that head ran *inside* the component the substrate mounted for `rf/route-link`
itself rather than becoming a component of its own. A plain Reagent fn carries no
`{:contextType frame-context}`, so `(.-context cmp)` was React's empty default,
`views.provider/current-frame` resolved nil, and `route-link-render`'s
render-time `require-current-frame!` (rf2-o3nam4) raised. This is the exact
failure mode `re-frame.views.provider/current-frame`'s own docstring describes —
"Plain Reagent fns lack this wiring … a public frame-scoped operation reading nil
then fails loudly" — reached by a component nobody had noticed was a plain fn.

**The fix** publishes an element-emitting shim: the hook now returns
`[(views/view-head :route/link) props & children]`, so the head reaches the
substrate as an element **type** and is componentized exactly as a `reg-view`
view is. `[rf/route-link …]` and `[home-page …]` now take the same path. The head
is resolved per render through `view-head` rather than closed over, because it is
a property of (registration × installed substrate) and the `reg-view*` seed is
taken at ns-load, before `rf/init!` seats any adapter (rf2-8mkmb). SSR is
untouched: the JVM has no React context to read.

I did **not** wrap any call site in a frame context. All three failing
applications were already correct.

## 2. Bisect — the brief's pointer was wrong, and not marginally

**`aa9e90af7f` is not the cause.** The break is **`fda84bb117`** (2026-06-16),
*"fix(routing): route-link click carries the render-time frame (rf2-o3nam4)"* —
the commit that introduced the render-time `require-current-frame!` into
`link.cljc`. `aa9e90af7f` is 2026-08-30, roughly two and a half months later.

A `-S` pickaxe over `require-current-frame!` scoped to `link.cljc` returns
**exactly one** commit, and the symbol count goes 0 → 2 across it. Measured in the
browser at both ends, with `:examples/login` as the control at every step (the
example lived at `examples/reagent/routing/` before the #4999 reorg):

| commit | `:examples/routing` | `:examples/login` (control) |
|---|---|---|
| `1e443dde7a` (`fda84bb117^`) | **BOOTS** — `#app` 267, "Welcome / See the articles →", 0 page errors | BOOTS — `#app` 627, 0 errors |
| `fda84bb117` | **FAILS** — `#app` 0, 1 page error, `:rf.error/no-frame-context :operation :route-link :where re-frame.routing.link/route-link-render` | BOOTS — `#app` 627, 0 errors |

One commit, control alive on both sides, and the error at `fda84bb117` is
identical to the one reported at tip. Before that commit route-link made no frame
demand at render time, so it could not raise from that site.

Worth recording: `examples/capabilities/routing/routing/` did not exist at
`fda84bb117` under that path, and `realworld_http` / `linearlite` did not exist at
all. The routing example was **born into a tree that already had the defect**.

## 3. The four browser measurements

Headless Chromium, static file server, `npx shadow-cljs compile` from
`implementation/`, zero failed requests on every run.

| app | | `#app` innerHTML | page errors | console errors | failed requests |
|---|---|---|---|---|---|
| `:examples/routing` | **before** | **0** (blank) | 1 (`:rf.error/no-frame-context`) | 2 | 0 |
| `:examples/routing` | **after** | **268** ("Welcome / See the articles →") | 0 | 0 | 0 |
| `:examples/login` (control) | **before** | 643 ("Sign in") | 0 | 0 | 0 |
| `:examples/login` (control) | **after** | 643 ("Sign in") | 0 | 0 | 0 |

The control's 643 / "Sign in" / 0 errors matches the filer's number exactly,
before and after — the instrument stayed alive at every step.

Beyond the required four, since the bead's severity is about the pilots:

* `:examples/realworld` (pilot 1) — `#app` **2350**, renders the Conduit navbar
  (the route-link-bearing surface that blocked *every* screen), 0 errors.
* `:examples/linearlite` (pilot 2) — `#app` **3535**, 0 errors.
* The bead's decisive pair, one bundle / one server / two URLs: linearlite
  `/index.html` falls through to `not-found-page` and renders its single
  route-link — `#app` **274**, "Not found / Back to the board", 0 errors
  (`#app` 0 with 1 page error before).
* The link also **navigates**: clicking "See the articles" moves `/` → `/articles`
  and re-renders the list, 0 page errors — so rf2-o3nam4's render-time frame
  capture, the thing `fda84bb117` was fixing, still works.

## 4. The durable regression, and its red

`implementation/routing/test/re_frame/route_link_frame_context_dom_cljs_test.cljs`
— two rows in the `:browser-test` lane (`npm run test:browser`, an unguarded
PR-time job in `test.yml`).

The class the bead names is "a control that cannot catch its own case", and the
reason here is precise: **every** pre-existing route-link suite calls
`routing/route-link-render` directly and establishes the frame with
`rf/with-frame` — the dynamic-var tier, which answers from anywhere. Not one
mounts `[rf/route-link …]` through a substrate. So they were green about a
component no application could render.

The new rows mount through the Reagent adapter into a real document, with
`:ambient-frame nil` on the fixture, establishing the frame **only** through a
React-context boundary: `frame-provider` (SCOPE) in one row, `frame-root`
(ENSURE, the failing applications' own shape) in the other.

**Proven to bite.** Reverting only `routing.cljc` to its pre-fix blob
(`10c10592845eddd2f1c4efb8f4fc384bcd7c71b6`), keeping the new test, and re-running
the browser suite: **exit 1, 2 failures**, both of them the new rows, both
reporting `container innerHTML = ""` — the blank-page signature. Nothing else in
the 776-test suite moved. The fix was then restored and verified against its
committed blob hash (`d83425c64017c1a0cb5c2f1a03c09a57d7a3d7c8`).

## Gates — every exit code captured from the runner, not reported about it

Re-run on the final rebased base (`origin/main` @ `90924be249`).

| gate | result | exit |
|---|---|---|
| `npm run test:browser` (post-fix) | Ran **776** tests / **4211** assertions, 0 failures, 0 errors | 0 |
| `npm run test:browser` (pre-fix, sabotage) | Ran 776 tests / 4207 assertions, **2 failures**, 0 errors | 1 |
| `implementation/routing` `clojure -M:test` | Ran **554** tests / **3454** assertions, 0 failures, 0 errors | 0 |
| `npm run test:cljs` | Ran **11193** tests / **55780** assertions, 0 failures, 0 errors | 0 |
| `sh scripts/test-fast-pr.sh` | core 2175/11144, routing 554/3454, node 11193/55780 — all 0F/0E | 0 |
| `npx shadow-cljs compile` (browser-test + 4 example builds) | 0 warnings | 0 |

`--plan` for this diff: `PLAN docs=false jvm=true node=true`, JVM artefacts
`implementation/core implementation/routing`, kondo run, docs tier and spine
self-test skipped. **The plan's own note restates the bead's point: "No browser,
bundle, adapter, Xray, MCP or tool-JVM gate is in any tier."** The spine cannot
see this class of bug, which is why the acceptance test here is the browser
reproduction and why the new regression lives in the browser lane.

Both the fast-PR spine and the browser-test runner print their root, and both
named this worktree.

## 5. Left undone because of the fence

* **`implementation/core/src/re_frame/core_routing.cljc`** (not in the allowed
  list) holds the `defwrapper` whose `:apply` shape is the underlying sharp edge:
  any late-bound hook whose value is a *component* gets invoked as a *function*,
  so the component identity is lost. `route-link` is the only such hook today,
  and it is fixed at the publication side. Whether `defwrapper` should grow a
  component-shaped arity is a design question, not a fix for this P0.
* **`implementation/core/src/re_frame/late_bind/directory.cljc`** (held, cluster
  `code-a`) — its `:routing/route-link` description reads "Reagent / SSR
  `[rf/route-link ...]` view component renderer", which stays accurate under this
  change. Checked; no edit needed.
* **No spec change.** The rendered `<a>`, its href synthesis and the whole click
  law are unchanged; Spec 012's observable contract never described the broken
  behaviour, so there is nothing in `spec/` that this corrects.
* **rf2-6sqv obstructed the diagnosis exactly as the brief predicted** — the
  framework logs `ExceptionInfo` to `console.error` as a raw CLJS object, so the
  first reproduction showed only `{meta: null, cnt: 7, arr: Array(14), …}`. I
  worked around it locally by `pr-str`-ing the object inside the measurement
  harness (which lives outside the repo and is not committed) to recover the
  error id and `:where`. Not fixed, not touched.
