### PR TITLE
fix(conformance,bench): enforce the exactly-one classification op-map contract; retire two discharged markers (rf2-7yth0, rf2-fgwf, rf2-cu5h)

### DIFF
--- a/bench/hicasso/src/re_frame/bench/hicasso/arm1/ambient_refusal_cljs_test.cljs
+++ b/bench/hicasso/src/re_frame/bench/hicasso/arm1/ambient_refusal_cljs_test.cljs
@@ -312,13 +312,19 @@
 ;; refuses, and each spelling that still carries is proved on its own.
 ;;
 ;; THE ERROR ID IS NOT REPEATED IN THESE ROWS, deliberately.
-;; `:rf.error/ambient-frame-refused` is PROVISIONAL (rf2-k0rbk may rename
-;; it), so a carry's refusal is pinned as *the same id an ambient read
-;; gets*, taken live from [[refusal-id]]. The literal is anchored ONCE in
-;; this file — by `ambient-subscribe-inside-a-body-refuses-by-name` above —
-;; so a rename touches one row rather than five, and these rows go on
-;; saying the thing that is actually interesting: that a carry and a read
-;; refuse identically.
+;; `:rf.error/ambient-frame-refused` is SETTLED: it is rowed in
+;; `spec/009-Instrumentation.md`'s error catalogue, it is raised by
+;; `re-frame.frame/emit-ambient-frame-refused!`, and the stability rule in
+;; `implementation/hicasso/spec/complaints.md` closes the question outright
+;; — an id names one refusal, and it is never re-spelled or reused.
+;;
+;; So the indirection below is not waiting on a rename; it earns its place
+;; on its own. What these rows assert is the AGREEMENT — a carry's refusal
+;; is pinned as *the same id an ambient read gets*, taken live from
+;; [[refusal-id]]. Two independent literals would assert two constants and
+;; could not see the two drift apart; one live read is what makes "refuse
+;; identically" the property under test rather than a coincidence. The
+;; rows above that pin the spelling BY NAME are where the literal belongs.
 
 (defn- refusal-id
   "The id core raises for an ambient READ refused inside a body. Taken

--- a/implementation/core/test/re_frame/conformance_runner.cljc
+++ b/implementation/core/test/re_frame/conformance_runner.cljc
@@ -504,6 +504,14 @@
           ;; derive-fn). `flow-meta` is the reflection metadata middle slot.
           (rf/reg-flow flow-id flow-meta output-fn))))))
 
+(def classification-effect-axes
+  "The four EP-0025 commit-plane axes a `:fixture/classification-effects`
+  op-map may carry. An op carries EXACTLY ONE of them — see
+  `spec/Spec-Schemas.md` §`:rf/fixture-file` and
+  `spec/conformance/README.md` §The `:fixture/classification-effects`
+  harness step."
+  #{:sensitive :large :clear-sensitive :clear-large})
+
 (defn- realise-classification-effects!
   "Apply a fixture's `:fixture/classification-effects` declarations against
   the established frame scope.
@@ -514,7 +522,16 @@
   body, these ops are a TEST-ONLY shorthand writing the frame's durable
   elision registry EXACTLY as those effects would. `:sensitive` / `:large`
   are additive; `:clear-*` remove the named paths on their named axis ONLY.
-  Called AFTER `make-frame` and BEFORE `realise-flows!`."
+  Called AFTER `make-frame` and BEFORE `realise-flows!`.
+
+  Each op carries EXACTLY ONE of the four axes, and that is CHECKED here
+  before anything is applied (rf2-7yth0). The `cond` below is
+  priority-ordered, so without the check a multi-axis op would silently
+  apply only its first arm and an empty or unknown-key op would silently
+  apply nothing — a fixture author writing two axes would get one, with no
+  error. Same fail-loud posture as `unknown-expect-keys` above, and the
+  same reason: a setup key the harness ignores changes the scenario
+  without saying so."
   [fixture scope-frame]
   (letfn [(slot-for [axis]
             (case axis :sensitive :sensitive-declarations :large :declarations))
@@ -526,6 +543,15 @@
           (clear-paths [reg axis paths]
             (elision/remove-claims reg (slot-for axis) {:source :effect} (map vec paths)))]
     (doseq [op (or (:fixture/classification-effects fixture) [])]
+      (let [ks (set (keys op))]
+        (when-not (and (= 1 (count ks))
+                       (contains? classification-effect-axes (first ks)))
+          (throw (ex-info (str "unrecognised :fixture/classification-effects op-map — "
+                               "each op carries EXACTLY ONE of "
+                               (pr-str classification-effect-axes))
+                          {:fixture-id (:fixture/id fixture)
+                           :op         op
+                           :keys       ks}))))
       (cond
         (contains? op :sensitive)
         (elision/swap-elision-slot! scope-frame #(add-paths (or % {}) :sensitive (:sensitive op)))

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -4576,14 +4576,25 @@ The host-agnostic conformance fixture format. Per [conformance/README.md](confor
    ;; that ordering). Each op carries EXACTLY ONE of the four
    ;; commit-plane effect keys; each value is a vector of `:rf/path`
    ;; vectors. The harness applies them in order.
+   ;;
+   ;; EXACTLY ONE is ENFORCED, as a closed four-way `:or` of
+   ;; single-required-key maps rather than one open map of optional
+   ;; entries. The open form admitted `{}`, admitted several axes at once,
+   ;; and admitted arbitrary unknown keys — and the harness applies these
+   ;; ops through a PRIORITY-ORDERED `cond`, so a multi-axis op would have
+   ;; silently applied only its first arm while an empty or unknown-key op
+   ;; applied nothing at all. A fixture author writing two axes got one,
+   ;; with no error. Each arm is `{:closed true}`, which is what refuses
+   ;; the second axis and the unknown key; requiring the arm's own key is
+   ;; what refuses the empty map.
    [:fixture/classification-effects
     {:optional true}
     [:vector
-     [:map
-      [:sensitive       {:optional true} [:vector [:vector :any]]]
-      [:large           {:optional true} [:vector [:vector :any]]]
-      [:clear-sensitive {:optional true} [:vector [:vector :any]]]
-      [:clear-large     {:optional true} [:vector [:vector :any]]]]]]
+     [:or
+      [:map {:closed true} [:sensitive       [:vector [:vector :any]]]]
+      [:map {:closed true} [:large           [:vector [:vector :any]]]]
+      [:map {:closed true} [:clear-sensitive [:vector [:vector :any]]]]
+      [:map {:closed true} [:clear-large     [:vector [:vector :any]]]]]]]
 
    ;; `true` marks a fixture asserting a RUNTIME validation trace that a
    ;; statically-typed host claiming schemas through its type system

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -602,7 +602,7 @@ Each op-map carries exactly one of the four commit-plane effect keys — `:sensi
 
 The corpus is host-agnostic pure-data event/sub/fx semantics. Render-time observables — React-context propagation through `frame-provider`, Reagent reactivity, component lifecycle, and the like — are not currently expressible as fixtures because the corpus has no render capability and no harness side that mounts a component tree to capture what happens during render. These behaviours are verified by host-side unit tests instead (for example `runtime_cljs_test.cljs` covers `frame-provider`'s establish-context and nested-override behaviour for the CLJS reference).
 
-If a port (CLJS, JVM SSR, future hosts) needs to claim conformance for render-time behaviour, this README will grow a `:reagent/render` (or equivalent) capability tag and a host-side fixture runner that mounts the fixture's tree and captures the observable. Tracked as future work — see bead `` for context.
+If a port (CLJS, JVM SSR, future hosts) needs to claim conformance for render-time behaviour, this README will grow a `:reagent/render` (or equivalent) capability tag and a host-side fixture runner that mounts the fixture's tree and captures the observable. That is future work; no fixture in the corpus claims a render capability today.
 
 ## Cross-references
 


### PR DESCRIPTION
Three controls that constrained nothing: a `PROVISIONAL` marker, a schema stating a contract it could not enforce, and a tracker-side claim about phantom bead ids. Two are fixed. The third's premise does not hold, and the evidence is below.

Beads: rf2-7yth0 (closed), rf2-cu5h (closed), rf2-fgwf (**left open** — see item 1).

---

## Item 1 — rf2-fgwf: the `PROVISIONAL` marker

**The phantom, re-verified with controls.** `bd show rf2-k0rbk` → *no issue found*, exit 1; controls `rf2-fgwf` / `rf2-l1hh` / `rf2-0d1w` / `rf2-rn3u` all exit 0. Absent from all 539 ids in the live export.

**What the `docs/design/hicasso/` half was changed to**, read at tip rather than taken from a note. `hframe-design.md` §9 item 2 now opens **"`:rf.error/ambient-frame-refused` is SETTLED"** and rests on three grounds, each of which I confirmed at source:

| ground | verified at |
|---|---|
| rowed in the Spec 009 error catalogue | `spec/009-Instrumentation.md:1991` |
| raised by the emitter | `implementation/core/src/re_frame/frame.cljc:1035` |
| the rename is forbidden | `implementation/hicasso/spec/complaints.md:57-59` — *"An id is stable: it names one refusal, and it is never re-spelled or reused."* |

The bench comment now states the same three grounds in the same terms.

**Which way I went: KEPT the indirection, and rewrote the reason.** The old justification was rename economy — *"a rename touches one row rather than five"* — which dies with the rename. The reason that survives it is the one the bead itself names: these rows assert that a carry and a read refuse **identically**, so taking the id live from `[[refusal-id]]` is what makes the *agreement* the property under test. Two independent literals would assert two constants and could not see them drift apart.

**A stale claim in the old comment, corrected in passing.** It said the literal is *"anchored ONCE in this file"*. It is not — `:rf.error/ambient-frame-refused` appears at lines 19, 136, 153 and 186. The new wording makes no count claim.

**The "phantom" framing is wrong, and it changes what this fix *is*.** `rf2-k0rbk` was a real bead — *"rf2-2rtt6.122 follow-up: **confirm or rename the provisional error id**"* — **closed 2026-08-06**, whose close reason reads:

> Confirmed-as-implemented … `:rf.error/ambient-frame-refused` stands … **Remaining touch: the provisional stamps' removal is a one-line comment/docs touch**

That is precisely this edit. The marker is a **discharged promise**, not a pointer to nothing: the question was asked, answered *confirmed*, and the marker outlived the answer. See item 3 for how that was established.

**Why this bead stays OPEN.** `hframe-design.md:268` and `:313-314` still depend on the same two ids, and `:268` contradicts item 2 of its own document. `docs/**` was outside this dispatch's write surface — the same fence that split this bead off rf2-0d1w — so the two halves have now failed to move together **twice**. The remainder needs `docs/design/hicasso/` in scope.

---

## Item 2 — rf2-7yth0: the schema that could not enforce its contract

Worked the **newest note**, not the description (ordered by `bd history`: the description was never edited across 755 entries; the live instruction is the `#9032 REOPENED` note).

**The schema as written:**

```clojure
[:fixture/classification-effects
 {:optional true}
 [:vector
  [:or
   [:map {:closed true} [:sensitive       [:vector [:vector :any]]]]
   [:map {:closed true} [:large           [:vector [:vector :any]]]]
   [:map {:closed true} [:clear-sensitive [:vector [:vector :any]]]]
   [:map {:closed true} [:clear-large     [:vector [:vector :any]]]]]]]
```

`{:closed true}` refuses the second axis and the unknown key; requiring each arm's own key refuses the empty map. The ordered vector and the live corpus are unchanged.

**And a fail-loud seam in the runner, because the schema alone changes nothing here.** Measured: `FixtureFile` is referenced in **no code at all** — only in `spec/Spec-Schemas.md` — so it is a documented projection for foreign hosts, and fixing it alone would leave this repo's own harness still silently partial-applying. `realise-classification-effects!` now checks the same contract before applying, in the idiom of the `unknown-expect-keys` fail-loud floor already in that file (rf2-xurchk), and for the reason `spec/conformance/README.md:40` already states: *a harness that meets a key it does not implement fails the run naming the key.*

**The parse, with a control that must fail.** `check_doc_slugs.py` strips fences, so its green inspects nothing here. Instead the fence is **parsed** — the named `def` read out of the markdown as data, the repo's own `extract-def-form` pattern (`spawn_all_schema_extract.clj`) — and the element validated with Malli:

| control | result |
|---|---|
| `{}` (empty op-map) | refused ✔ |
| `{:sensitive … :large …}` (two axes) | refused ✔ |
| `{:bogus …}` (unknown key) | refused ✔ |
| `{:sensitive … :bogus …}` | refused ✔ |
| all four axes at once | refused ✔ |
| each of the four well-formed single-axis maps | accepted ✔ |

**Live corpus: 247 fixture files parsed, 8 carry `:fixture/classification-effects`, 12 op-maps, 0 refused.** (A `grep -l` says 9 files; one mentions the key only in prose. The parse is the instrument.)

**Sabotage, both halves.** Removing `{:closed true}` from the `:sensitive` arm turned the gate **red (exit 1)**, naming the three controls that then passed — proof it reads this worktree. Inverting the runner's check turned the JVM conformance suite **red (exit 1)** on exactly **8 fixtures**, which independently corroborates the parse's count of 8 carriers and is positive evidence the runtime observes the check. Both restored and verified by git blob hash.

**The key-roster half of the description is already done** — PR #9019 completed the 18-key roster (per this bead's own note); nothing of it remains.

---

## Item 3 — rf2-cu5h: the premise does not hold

**The boundary I counted, stated before counting.** A citation is in class iff **both**: (1) it sits in a *live conditional* — forward-looking marker vocabulary, or an empty citation slot; **and** (2) the referent resolves to nothing. A historical citation is out of class even when the id is absent — that is the 4,997/5,179 population that sank the earlier attempt.

**The population.**

| question | answer |
|---|---|
| dependency edges → absent id (fully decidable) | **0** |
| `acceptance_criteria` → absent id | **2**, both historical provenance naming a past PR, gating nothing |
| empty citation slots (`see bead ``` `` ```) | **1** — fixed here |
| tree sites: forward marker + absent id, same sentence | **292 sites / 204 ids / 172 files** |

**Then the finding that reframes all of it: not one of those ids was "never created".** Absence from the current tracker proves nothing, because the tracker has been **garbage-collected** — 10,444 rows on 2026-07-11, 2,149 on 2026-07-19, **539 today**, against **14,551 distinct ids ever exported** (union of 13 sampled snapshots across all 11,413 export commits). Of the 204: **200 verified present in sampled history**; the other 4 (`rf2-hic`, `rf2-ssr`, `rf2-abort`, `rf2-ede1h.3`) are my regex truncating longer tokens — `rf2-hic-065`, `rf2-ssr-streaming-`, the test name `rf2-abort-vs-decode`, and `rf2-ede1h`, which *is* in history. **Net: zero.**

Every id this bead names was real, and **every one was closed before being collected**:

| id | what it was | closed |
|---|---|---|
| `rf2-k0rbk` | confirm or rename the provisional error id | 2026-08-06 — *"the id stands"* |
| `rf2-e28wl` | Spec 009 `:operation` enumeration incomplete | 2026-08-05, PR #7533 |
| `rf2-wyvf2` | Causa Reactive panel rebuild | 2026-05-20, PR #1741 |
| `rf2-j9yf` | conformance render capability | 2026-05-12 |
| `rf2-04tx` | v1-shaped `:dispatch-later` dropped | 2026-08-12 |

So `rf2-wyvf2` in `rf2-l1hh`'s acceptance criteria — this bead's motivating "worst case" — is a **historical citation naming the PR that did the removal**. It gates nothing, and is out of class by this bead's own boundary.

**Mechanism — established, and it is neither hypothesis on the bead.** Not a failed `create`. Two real mechanisms: (1) **tracker GC** removing closed beads out from under prose that cites them; and (2) a **bulk bead-ref stripping sweep** — commit `2d64e1f7c2` (2026-05-27, *"strip bead refs … spec states what IS"*) replaced `rf2-j9yf` *inside* the backticks and left the sentence standing, producing `see bead `` for context`. Its commit message reports mkdocs, `check_doc_slugs` and `test-fast-pr` all green, because **no gate looks at this**.

**Judgement: no tooling.** A linter would flag 292 sites whose ids were all legitimately created and legitimately collected — signal zero, noise the whole corpus. **The rule worth recording, and now on the bead:** absence of a bead id from the tracker is *not* evidence it never existed. The tracker is a working set; `.beads/issues.jsonl` in git history is the archive. Resolve a suspect id against that history before calling it a phantom.

---

## Every census, with its control beside it

| census | reading | control |
|---|---|---|
| `grep -F` + `-i` on this build | **0** | `grep -ri "PROVISIONAL" spec/` → **25**; `-rnFi` → **0**, no error. GNU grep 3.0. Confirmed the brief's warning; `-F -i` avoided throughout. |
| tracker id set | 539 ids | `rf2-fgwf` present ✔ / `rf2-k0rbk` absent ✔ |
| fixture corpus | 247 files, 8 carriers | control needle `fixture/id` → 247 = total ✔ |
| census v1 (tree, 260-char window) | 1,187 "findings" | positive controls read **0** → **instrument rejected**; it also died on a cp1252 encode error after two findings, so its counts printed and its evidence did not |
| census v2 (same-sentence) | Q1 2 / Q2 0 / Q3 1 / Q4 497 | forward-marker control passed positive *and* negative ✔ |
| census v3 (`\b` boundaries) | — | **negative control FAILED** and stopped the run: `\bprovisional\b` still matched inside `provisional-horizon-ms`, because `-` is a non-word character |
| census v4 (non-identifier boundaries) | 292 / 204 / 172 | positive matches, identifier-substring does not ✔ |
| history union | 14,551 ids | `rf2-2rtt6` (real, GC'd) found ✔ · `rf2-k0rbk` found ✔ · `rf2-zzzzznotanid` not found ✔ |

`bd --json | jq` emits CRLF on this build; every read was piped through `tr -d '\r'` at the source.

---

## Gates

All run in the foreground, unfiltered, to completion, with exit codes captured by me — and **re-run on the final base after the rebase** (main moved 25 commits; none touched these four files).

| gate | exit | result |
|---|---|---|
| schema fence parse + Malli, post-rebase | **0** | 5 violating controls refused, 4 well-formed accepted; 247 fixtures / 8 carriers / 12 op-maps / 0 refused |
| ↳ *sabotage:* `{:closed true}` removed | **1** | red, naming the now-accepted controls |
| JVM `re-frame.conformance-test`, post-rebase | **0** | 5 tests / 18 assertions / 0 failures (identical before and after the change) |
| ↳ *sabotage:* runner check inverted | **1** | red on exactly **8** fixtures |
| `npm run test:cljs` (node-test), post-rebase | **0** | 11193 tests / 55792 assertions / 0 failures (pre-rebase: 11191 / 55778 — the trunk added two tests in the interval, which is why this was re-run) |
| JVM `implementation/core` (via spine) | **0** | 2175 tests / 11144 assertions / 0 failures |
| `npm run test:scripts` | **0** | 0 failures (it failed *inside* the spine under load; passes in isolation — contention, and it references none of these four files) |
| `python scripts/check_doc_slugs.py`, post-rebase | **0** | — |
| ↳ *probe in my changed fence* | **0** | **silent — the gate is blind here** |
| ↳ *probe in my changed prose* | **1** | red naming `spec/conformance/README.md:605` |
| `python -m mkdocs build --strict`, post-rebase | **0** | output names `spec\Spec-Schemas.md` and `spec\conformance\README.md` — the staging hook covers both |
| bench form-identity (no tier covers `bench/hicasso/`) | **0** | 32 forms / 22 deftests unchanged; printed-form sequences identical |

**Which of my edits `check_doc_slugs.py` did not inspect: the `spec/Spec-Schemas.md` schema change, entirely.** Proved rather than asserted — a broken link planted inside that fence returns exit 0 in silence, while the same class of fault in the README prose returns exit 1 naming file and line. The Spec-Schemas edit is covered by the parse gate above instead.

Two instrument faults of my own, recorded because each returned a confident wrong answer: the bench form check first reported *"forms differ"* because Clojure regex literals (`#"collector"`) have no value equality — five `deftest`s in that file contain one; and a conformance run reported `Ran 0 tests` from the wrong working directory, which the repo's own `RF2_MIN_TESTS` floor (rf2-qqzmf) correctly refused to call a pass.
