### PR TITLE
feat(examples): the Hicasso login JVM host actually runs, and a gate drives it (rf2-8arzr.5)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -152,7 +152,7 @@ Both apps share read-only helpers (avatars, markdown rendering) from `real-apps/
 
 ## Substrates
 
-The same dataflow, rendered through a different view layer — the proof the adapter swaps cleanly. **[`substrates/README.md`](substrates/README.md) is the entry point**: it sorts these into the two comparisons they actually make (same authoring language / different package, versus one model / three view languages) and says what each holds constant. The headline is the **login triple** — Reagent, UIx and Hicasso over one substrate-free [`login.model`](core/login/model.cljs), where diffing any two entry points shows the view layer and nothing else.
+The same dataflow, rendered through a different view layer — the proof the adapter swaps cleanly. **[`substrates/README.md`](substrates/README.md) is the entry point**: it sorts these into the two comparisons they actually make (same authoring language / different package, versus one model / three view languages) and says what each holds constant. The headline is the **login triple** — Reagent, UIx and Hicasso over one substrate-free [`login.model`](core/login/model.cljc), where diffing any two entry points shows the view layer and nothing else.
 
 | Example | What it demonstrates |
 |---|---|

--- a/examples/TESTING.md
+++ b/examples/TESTING.md
@@ -108,7 +108,7 @@ copies of the `:auth.login/*` dataflow, the three login examples — Reagent
 (`examples/login`), UIx (`examples/login-uix`) and Hicasso
 (`examples/login-hicasso`) — all `:require`
 **one** substrate-free model namespace,
-[`login.model`](core/login/model.cljs) — the single owner of every shared
+[`login.model`](core/login/model.cljc) — the single owner of every shared
 `auth.login` schema, fx, machine, event, and sub (rf2-ppbvav, extended to the
 Hicasso arm by rf2-fmns2). So the ids aren't
 merely *shared*, they're registered from *one source*; each `core.cljs` adds only

--- a/examples/core/login/README.md
+++ b/examples/core/login/README.md
@@ -8,7 +8,7 @@ Read this when you've seen the smaller examples and you want to know how the pie
 
 Everything in the feature shares one prefix: `:auth.login/*`. The machine, the events, the subscriptions — all of it. (The registered views are the one exception: their ids come from the file's namespace, for example `:login.core/root-view`.) That prefix marks the unit you'd lift into its own folder in a real codebase (more on that below).
 
-The whole substrate-free half of that feature — the machine, schemas, events, subs, demo HTTP stub, and frame config — lives in one place: [`model.cljs`](model.cljs), the namespace `login.model`. It is the single owner of the `auth.login` dataflow. This `core.cljs`, its [UIx twin](../../substrates/uix/login/) and its [Hicasso twin](../../substrates/hicasso/login/) each `:require` that model and add only their own views + mount. So the model you read below lives once, not three times — one owner, three view layers. [`examples/substrates/README.md`](../../substrates/README.md) lays the comparison out.
+The whole substrate-free half of that feature — the machine, schemas, events, subs, demo HTTP stub, and frame config — lives in one place: [`model.cljc`](model.cljc), the namespace `login.model`. It is the single owner of the `auth.login` dataflow. This `core.cljs`, its [UIx twin](../../substrates/uix/login/) and its [Hicasso twin](../../substrates/hicasso/login/) each `:require` that model and add only their own views + mount. So the model you read below lives once, not three times — one owner, three view layers. [`examples/substrates/README.md`](../../substrates/README.md) lays the comparison out.
 
 ## What this demonstrates
 
@@ -58,13 +58,13 @@ This is the canonical cross-view-layer base. The exact same login feature — th
 
 The substrate here is stock Reagent (not reagent-slim). This is the reference example, so it sits on the reference substrate. If it's the stock-vs-slim contrast you want, that's a different pair: `counter` / `counter_slim_and_fast`.
 
-A note on layout (this is example layout, not production layout). The substrate-free half already lives in its own file, `model.cljs` — the seam a real codebase draws first. In a larger app you'd split `model.cljs` further along the seams the `:auth.login/*` slice implies — `login/schema.cljc | events.cljs | subs.cljs | machines.cljs`. Here the model is one file so you can read it whole; each `core.cljs` keeps only the views + mount.
+A note on layout (this is example layout, not production layout). The substrate-free half already lives in its own file, `model.cljc` — the seam a real codebase draws first. In a larger app you'd split `model.cljc` further along the seams the `:auth.login/*` slice implies — `login/schema.cljc | events.cljs | subs.cljs | machines.cljs`. Here the model is one file so you can read it whole; each `core.cljs` keeps only the views + mount.
 
 ## Files
 
 ```
 login/
-  model.cljs           — THE substrate-free owner: schema + fx + machine +
+  model.cljc           — THE substrate-free owner: schema + fx + machine +
                          events + subs + frame config. Shared, id for id, by
                          all three login examples (Reagent / UIx / Hicasso).
   core.cljs            — the Reagent HALF: reg-view views + adapter init + mount.

--- a/examples/core/login/core.cljs
+++ b/examples/core/login/core.cljs
@@ -3,7 +3,7 @@
 
    The whole login model — the state machine, the schemas, the form-slice
    events and subs, the demo HTTP stub, and the shared frame config — lives in
-   the substrate-free [`login.model`](model.cljs) namespace, required below for
+   the substrate-free [`login.model`](model.cljc) namespace, required below for
    its side-effecting registrations. That namespace is the ONE owner of the
    `auth.login` dataflow; read it for the ideas (the five-state login machine,
    the machine + slice split, the three password-egress boundaries).
@@ -28,7 +28,7 @@
             ;; The substrate-free model owner. Requiring it registers every
             ;; shared `auth.login` schema, fx, machine, event, and sub, and
             ;; hands us `model/frame-config` for the mount below. It names no
-            ;; substrate — see model.cljs.
+            ;; substrate — see model.cljc.
             [login.model :as model]
             [re-frame.adapter.reagent :as reagent-adapter]))
 

--- a/examples/core/login/model.cljc
+++ b/examples/core/login/model.cljc
@@ -57,8 +57,16 @@
    because all three builds import it, any adapter/view library it dragged in
    would leak into the two login bundles it doesn't belong in.
 
-   In a real codebase you'd split this across login/schema.cljc, events.cljs,
-   subs.cljs, and machines.cljs. It lives in one namespace here so you can read
+   SUBSTRATE-FREE AND PLATFORM-NEUTRAL. It is `.cljc`, not `.cljs`, and the
+   second half of that is load-bearing rather than tidy: the Hicasso arm
+   server-renders through a JVM Ring host
+   (`examples/substrates/hicasso/login/host.clj`), and a JVM host has to hold
+   the application's state — so every `auth.login` schema, fx, machine, event
+   and sub has to be loadable from Clojure. One handler body needs a platform,
+   the `localStorage` write in `:auth.session/store`, and it says so in place.
+
+   In a real codebase you'd split this across login/schema.cljc, events.cljc,
+   subs.cljc, and machines.cljc. It lives in one namespace here so you can read
    the whole model top to bottom in one sitting."
   ;; re-frame2 ships its bigger features opt-in. You pay for what you use, and
   ;; you say so by requiring it. Each `re-frame.*` require here is a feature
@@ -199,7 +207,16 @@
 (rf/reg-fx :auth.session/store
   {:doc       "Stash the session token in localStorage so the login
                 survives a refresh. Client-only — localStorage is a
-                browser thing, so `:platforms` keeps it off the server."
+                browser thing, so `:platforms` keeps it off the server.
+
+                This is the ONE handler body in this namespace that is not
+                platform-neutral, and it is why the file is `.cljc` rather
+                than `.cljs`. `:platforms #{:client}` already keeps the
+                effect from RUNNING on a server; a reader conditional is
+                what keeps `js/globalThis` from being READ there, so a JVM
+                host can load the shared model at all. The two are
+                different boundaries — one runtime, one compile-time — and
+                a server-side host needs both."
    ;; The token is a credential, and fx args are a transient payload with their
    ;; OWN egress owner — separate from the event that produced them. So this
    ;; registration classifies its `:token` arg `:sensitive`: the per-effect
@@ -211,8 +228,13 @@
    :sensitive [[:token]]
    :platforms #{:client}}
   (fn fx-auth-session-store [_m {:keys [token]}]
-    (when-let [ls (.-localStorage js/globalThis)]
-      (.setItem ls "auth/token" token))))
+    #?(:cljs (when-let [ls (.-localStorage js/globalThis)]
+               (.setItem ls "auth/token" token))
+       ;; Unreachable on the JVM — `:platforms #{:client}` refuses the
+       ;; effect before a handler body runs. Present so the namespace
+       ;; READS on a Clojure classpath, which is what a JVM SSR host needs.
+       :clj  (throw (ex-info "auth.session/store is client-only"
+                             {:token-present? (some? token)})))))
 
 (rf/reg-fx :auth.login.demo/managed-stub
   {:doc       "Our stand-in backend. It reads the URL and request body and

--- a/examples/substrates/README.md
+++ b/examples/substrates/README.md
@@ -19,7 +19,7 @@ the difference is entirely in what ships.
 One substrate-free model namespace, three view layers over it. This is the
 comparison the login example exists to make.
 
-[`login.model`](../core/login/model.cljs) is the ONE owner of the `auth.login`
+[`login.model`](../core/login/model.cljc) is the ONE owner of the `auth.login`
 dataflow — every schema, the demo HTTP fx, the five-state machine, the
 form-slice events, the named subs, and the shared frame config. It names no
 substrate. The three entry points below each `:require` that identical
@@ -58,24 +58,21 @@ build (`examples/login-hicasso-server`) that publishes the render module the
 dials it — the shape of a native Hicasso root rendered on Node while the JVM
 keeps the request, the `<head>`, the payload and the shell (`rf2-8arzr`).
 
-**Read the two files differently, because only one of them runs.**
-`server.cljs` is real and exercised: the CLJS product witness
-(`re-frame.hicasso.login-server-crossing-ssr-dom-cljs-test`) drives the real
-views, the real `login.model` registrations and this module's own published
-entry table through the sidecar's own request validator, simulating only the
-transport. `host.clj` is **annotated wiring rather than a running server** — it
-comments out its `login.model` require, because a JVM host must load the
-application's model and that model is ClojureScript-only today, so nothing
-starts this handler and no gate drives it. Its own docstring says so and says
-why. The transport half of the crossing is witnessed separately, by the
-`jvm-node-crossing` CI job over a real socket.
+**Both files run, and a gate drives each.** `server.cljs` is exercised by the
+CLJS product witness (`re-frame.hicasso.login-server-crossing-ssr-dom-cljs-test`),
+which drives the real views, the real `login.model` registrations and this
+module's own published entry table through the sidecar's own request validator,
+simulating only the transport. `host.clj` is exercised by
+`re-frame.ssr.ring.login-host-crossing-test` (`implementation/ssr-ring/test/`,
+CI's `jvm-node-crossing` job): requiring the namespace is the compile gate, and
+its `:crossing` tests spawn the real launcher on a real socket and drive the
+handler this host constructs.
 
-What the pair is still the clearest illustration of is **why render state is a
-policy distinct from the hydration payload**: the server notice the page
-renders is deliberately in one and not the other. Note that `host.clj` today
-spells its `:render-state` map out literally rather than reading
-`server.cljs`'s `render-state-policy`, so the two halves are not yet one list
-with two readers — that, and the host's runnability, are open on `rf2-8arzr.5`.
+What the pair is the clearest illustration of is **why render state is a policy
+distinct from the hydration payload**: the server notice the page renders is
+deliberately in one and not the other. Both halves read that policy from one
+place — `policy.cljc`, a `.cljc` namespace, because neither neighbour can be
+read by the other's compiler and a copy in either would be a copy that drifts.
 
 The recipe these two files illustrate is
 [Render on Node](../../docs/ssr/concepts.md#render-on-node).

--- a/examples/substrates/hicasso/login/README.md
+++ b/examples/substrates/hicasso/login/README.md
@@ -15,7 +15,7 @@ layer, instead of Reagent.
 Everything below the view layer stays the same, because it is literally the same
 source. The schemas, the five-state machine, the form-slice events, the named
 subscriptions and the canned HTTP stub all live in one substrate-free namespace,
-`login.model` ([`examples/core/login/model.cljs`](../../../core/login/model.cljs)),
+`login.model` ([`examples/core/login/model.cljc`](../../../core/login/model.cljc)),
 which this example `:require`s and both twins import unchanged. Only the views
 and the boot are written differently.
 
@@ -103,12 +103,13 @@ login/
   core.cljs    — the Hicasso HALF: h/defview views + adapter init + frame + boot.
   server.cljs  — the SERVER bundle: the entry table the ssr-node sidecar loads.
   host.clj     — the JVM half: one ssr-handler wired to the Node renderer.
+  policy.cljc  — the render-state list and the entry id, read by BOTH of those.
   index.html   — minimal host page.
 ```
 
 The substrate-free half — schemas, machine, events, subs, HTTP stub, frame
 config — is not in this folder: it is the shared
-[`login.model`](../../../core/login/model.cljs) namespace this `core.cljs`
+[`login.model`](../../../core/login/model.cljc) namespace this `core.cljs`
 `:require`s.
 
 ## How to run
@@ -123,7 +124,7 @@ example on a free local port, and prints the URL to open. Add `--no-watch` for a
 one-shot compile-and-serve.
 
 No backend ships. The login runs against the canned HTTP stub in
-[`login.model`](../../../core/login/model.cljs), so the password
+[`login.model`](../../../core/login/model.cljc), so the password
 `correct-horse` succeeds and anything else fails the way the machine expects.
 
 ## Rendering it on the server
@@ -149,19 +150,43 @@ either direction.
 
 There are two allowlists, and reading them as one is the mistake worth
 avoiding. `:payload` answers *what may the browser see?*; `:render-state`
-answers *what does the render need?* They differ in both directions:
+answers *what does the render need?* They differ in both directions — and they
+are opts on two different constructors, because the thing that projects is the
+renderer:
 
 ```clojure
-:payload      [:auth]                                   ;; the browser's
+;; on ssr-handler — the browser's
+:payload      [:auth]
+;; on the renderer — the render's
 :render-state {:app-db     [:auth :auth.login/server-notice]
-               :runtime-db [:rf.runtime/machines]}      ;; the render's
+               :runtime-db [:rf.runtime/machines]}
 ```
+
+That map is not written twice. It is
+[`policy.cljc`](policy.cljc)'s `render-state-policy`, and `host.clj` and
+`server.cljs` both read it — one list, two readers, one file. It has to be its
+own namespace because neither neighbour can be read by the other's compiler,
+so a policy written in either is a policy the other has to copy. The sidecar
+refuses a host that asks for **more** than the entry table allows; nothing can
+notice a host that asks for **less**, which is the direction a hand-kept copy
+actually drifts in.
 
 `:rf.runtime/machines` is in the render's list and not the browser's *shape*
 because the two partitions are different places: the `:auth.login/flow`
 machine's snapshot lives in runtime-db, and it is what decides whether the page
-shows the form, the welcome or the locked panel. Leave it out and the server
+shows the form, the welcome or the locked panel. A host that restores a session
+and drives the flow to `:authed` needs that snapshot to cross, or the server
 renders a signed-in visitor a login form.
+
+This host drives nothing, and the consequence is worth knowing before you copy
+the file: the machine is **self-seeding** — it materialises a snapshot the first
+time it is dispatched at or subscribed to — and neither happens on the JVM,
+because the rendering happens in Node. So the runtime partition crosses empty
+and Node's own per-request frame seeds `:idle`, which draws the form. That is
+the right page, and both halves of it are measured in
+`re-frame.ssr.ring.login-host-crossing-test`: the shipped configuration crosses
+with an empty runtime partition, and the same page with one machine event added
+to `:initial-events` crosses carrying `:submitting`.
 
 `:auth.login/server-notice` runs the other way: a deployment notice the host
 resolves per request, which the render may read and the browser never receives.
@@ -202,15 +227,27 @@ Then serve `host.clj`'s `handler` from any Ring adapter, with
 client boots through the same `core.cljs` either way: it looks for
 `__rf_payload`, and hydrates when it finds one instead of mounting.
 
-**One thing is not done yet, and the JVM host cannot run without it.** A JVM
-host has to hold the application's state, so `login.model` — the owner of every
+**The host runs**, and two gates say so rather than this paragraph. A JVM host
+has to hold the application's state, so `login.model` — the owner of every
 `auth.login` schema, fx, machine, event and sub — has to be loadable from
-Clojure, and it is `model.cljs` today. The single line keeping it there is a
-`localStorage` write in the demo session effect. Making it `.cljc` is a change
-to a file all three login arms share and is not made here; until it is,
-`host.clj` is the wiring rather than a running server. The crossing itself is
-exercised end to end, against the real sidecar contract, by
-`implementation/hicasso/test/re_frame/hicasso/login_server_crossing_ssr_dom_cljs_test.cljs`.
+Clojure; it is
+[`model.cljc`](../../../core/login/model.cljc), platform-neutral but for one
+reader conditional around the demo session effect's `localStorage` write.
+
+The crossing is witnessed from both ends:
+
+- `implementation/hicasso/test/re_frame/hicasso/login_server_crossing_ssr_dom_cljs_test.cljs`
+  — the **render** half, in CLJS: the real views, the real `login.model`
+  registrations and this module's published entry table, through the sidecar's
+  own request validator.
+- `implementation/ssr-ring/test/re_frame/ssr/ring/login_host_crossing_test.clj`
+  — the **host** half, on the JVM. Requiring `hicasso.login.host` is itself the
+  compile gate (before it, a compile error here passed everything silently);
+  its `:crossing` tests spawn the real `serve.cjs` launcher on a port-0 socket
+  and drive this file's `make-handler`, asserting the complete JVM-owned
+  document, the projection under `policy.cljc`'s list, and the sidecar's refusal
+  of a host that reaches past it. `clojure -M:crossing-test` from
+  `implementation/ssr-ring/`; CI runs it as `jvm-node-crossing`.
 
 ## Copying this into your own app
 

--- a/examples/substrates/hicasso/login/core.cljs
+++ b/examples/substrates/hicasso/login/core.cljs
@@ -4,7 +4,7 @@
    The same feature runs on Reagent (`login.core`) and on UIx
    (`uix.login.core`), and that is the point of this file. All three
    `:require` the identical substrate-free
-   [`login.model`](../../../core/login/model.cljs) namespace — the ONE owner of
+   [`login.model`](../../../core/login/model.cljc) namespace — the ONE owner of
    the `auth.login` schemas, demo fx, five-state machine, form-slice events and
    named subs — and each adds only its own view layer and boot. Diff this
    `core.cljs` against either twin and the diff is the view layer, whole and
@@ -33,7 +33,7 @@
    contract suite (`npm run test:cljs`) and the framework gates, not by a test
    alongside this file."
   (:require [re-frame.core :as rf]
-            ;; The substrate-free model owner (examples/core/login/model.cljs).
+            ;; The substrate-free model owner (examples/core/login/model.cljc).
             ;; Requiring it registers every shared `auth.login` schema, fx,
             ;; machine, event and sub, and hands us `model/frame-config` for the
             ;; boot below. It names no substrate — the Hicasso code lives only

--- a/examples/substrates/hicasso/login/host.clj
+++ b/examples/substrates/hicasso/login/host.clj
@@ -25,29 +25,31 @@
   ## The two policies, and why there are two
 
   `:payload` answers *what may the BROWSER see?*; `:render-state` answers
-  *what does the RENDER need?* They differ in both directions, and this
-  handler is where that is declared. The render-state policy is
-  `hicasso.login.server/render-state-policy` — the SAME map the bundle
-  derives its entry allowlists from, so one list is read by both halves and
-  a host that reaches past it is refused by the sidecar rather than served.
+  *what does the RENDER need?* They differ in both directions, and they
+  are also opts on two DIFFERENT constructors — `:payload` on
+  `ssr-handler`, `:render-state` on the renderer, which is what does the
+  projecting. The render-state list is
+  `hicasso.login.policy/render-state-policy`: the same Var the server
+  bundle derives its entry allowlists from, so one list is read by both
+  halves and a host that reaches past it is refused by the sidecar rather
+  than served.
 
   ## Running it
 
-  See the example README. There is one thing this file cannot do on its
-  own, and it is worth knowing before you try: a JVM host has to hold the
-  application's state, so the shared `login.model` — the owner of every
-  `auth.login` schema, fx, machine, event and sub — has to be loadable from
-  Clojure. It is `examples/core/login/model.cljs` today, ClojureScript
-  only, and the single line that keeps it there is a `localStorage` write
-  in the demo session fx. Making it `.cljc` is a separate change to a file
-  three example arms share, so it is not made here; until it is, this
-  namespace is the WIRING rather than a running server, and the crossing it
-  describes is exercised end to end by
-  `re-frame.hicasso.login-server-crossing-ssr-dom-cljs-test`."
+  See the example README. This namespace loads and runs on a plain Clojure
+  classpath — the shared `login.model` is `.cljc`, so the JVM holds the
+  application's state the same way the browser does — and it is driven,
+  over a real socket against the real sidecar launcher, by
+  `re-frame.ssr.ring.login-host-crossing-test`
+  (`implementation/ssr-ring/test/`, tagged `:crossing`)."
   (:require [re-frame.ssr.ring :as ssr-ring]
             [re-frame.ssr.ring.node :as node]
-            ;; The application, on the JVM. See §Running it above.
-            #_[login.model]))
+            ;; The one render-state list, shared with `server.cljs`.
+            [hicasso.login.policy :as policy]
+            ;; The application, on the JVM: every `auth.login` schema, fx,
+            ;; machine, event and sub. Requiring it is what makes
+            ;; `:initial-events` below name something that exists.
+            [login.model :as model]))
 
 (def build-id
   "The bundle this host was deployed against.
@@ -69,31 +71,42 @@
   remote one is the operator's network and transport to secure."
   (or (System/getenv "LOGIN_HICASSO_SSR_NODE") node/default-endpoint))
 
-(def handler
-  "The Ring handler. One `ssr-handler`, one `:renderer`.
+(defn make-handler
+  "Build the Ring handler against ONE sidecar. `handler` below is this
+  called with the deployment's own `endpoint` / `build-id`; a test calls it
+  with the ephemeral ones a spawned sidecar reported.
 
-  `:render-state` and `:payload` are the two policies; `:initial-events`
-  seeds the form slice before the first render exactly as the browser boot
-  does, so the two halves render the same page from the same events."
+  One `ssr-handler`, one `:renderer`.
+
+  `:payload` is the browser's allowlist; `:render-state` — an opt on the
+  RENDERER, since the renderer is what projects — is
+  `policy/render-state-policy`. `:initial-events` and `:fx-overrides` come
+  from the shared `model/frame-config`, so the server seeds and stubs the
+  frame exactly as the browser boot does and the two halves render the
+  same page from the same events."
+  [{:keys [endpoint build-id]}]
   (ssr-ring/ssr-handler
-    {:initial-events [[:auth.login/initialise-form]]
+    {:initial-events (:initial-events model/frame-config)
+     ;; The demo HTTP stub, remapped for this frame exactly as the browser
+     ;; mount remaps it. No request is issued during a server render, but
+     ;; the frame is configured the same either way.
+     :fx-overrides   (:fx-overrides model/frame-config)
      ;; What the BROWSER may see: the form slice, and nothing else.
      :payload        [:auth]
-     ;; What the RENDER may see. Read from the bundle's own map when it is
-     ;; on this classpath; spelled here otherwise, and the sidecar refuses
-     ;; the difference rather than serving it.
-     :render-state   {:app-db     [:auth :auth.login/server-notice]
-                      :runtime-db [:rf.runtime/machines]}
      ;; No `:root-view` — only the default JVM-local renderer reads one.
      :renderer       (node/renderer
                        {:endpoint     endpoint
-                        :entry        "hicasso.login/root"
+                        :entry        policy/root-entry
                         :build-id     build-id
-                        ;; The same two policies the seam projects under.
-                        :render-state {:app-db     [:auth :auth.login/server-notice]
-                                       :runtime-db [:rf.runtime/machines]}
+                        ;; The one list. `server.cljs` publishes the same
+                        ;; keys as the entry's per-partition allowlists.
+                        :render-state policy/render-state-policy
                         :timeout-ms   1000})
      ;; The client bundle, and the element it adopts. `hicasso.login.core/run`
      ;; reads `__rf_payload`, finds one, and HYDRATES rather than mounting.
      :app-element-id "app"
      :script-src     "/js/main.js"}))
+
+(def handler
+  "The Ring handler this deployment serves. Hand it to any Ring adapter."
+  (make-handler {:endpoint endpoint :build-id build-id}))

--- a/examples/substrates/hicasso/login/policy.cljc
+++ b/examples/substrates/hicasso/login/policy.cljc
@@ -1,0 +1,57 @@
+(ns hicasso.login.policy
+  "The login arm's RENDER-STATE POLICY — one list, two readers, one file.
+
+  `server.cljs` (Node) derives the sidecar entry's per-partition
+  allowlists from it; `host.clj` (JVM) hands it to the Node renderer as
+  `:render-state`. The two processes are deployed separately, so nothing
+  can MAKE them agree at run time — but they cannot DRIFT in source,
+  because there is only one list to edit.
+
+  That is the whole reason this is a `.cljc` namespace of its own rather
+  than a `def` in either neighbour. `server.cljs` cannot be read by
+  Clojure and `host.clj` cannot be read by ClojureScript, so a policy
+  written in either is a policy the other has to copy — and a copy that
+  drifts the SAFE way is silent. The sidecar refuses a host that asks for
+  MORE than the entry allows (its state-key-not-allowed refusal); a host
+  that asks for LESS is served a page rendered from incomplete state, with
+  no refusal to notice. The second is the direction a hand-kept copy
+  actually fails in.
+
+  ## What the render is allowed to see
+
+  It is DISTINCT from the host's `:payload` policy — *what may the BROWSER
+  see?* — and deliberately so:
+
+    `:auth`                      the form slice at `[:auth :login-form]` —
+                                 the draft the inputs are bound to. Also in
+                                 the payload, because the client needs it to
+                                 re-render the same controlled inputs. The
+                                 draft PASSWORD is classified `:sensitive`
+                                 by the shared model, so the projection
+                                 redacts it on both wires: the render cannot
+                                 print a secret it was never handed.
+    `:auth.login/server-notice`  a deployment notice the host resolves per
+                                 request. NOT in the payload — the browser
+                                 never receives it. A key in this position
+                                 must not change the markup; see the note
+                                 beside the sub in `core.cljs`.
+    `:rf.runtime/machines`       the machine snapshots. `:auth.login/flow`
+                                 is what decides which of the page's three
+                                 faces renders, so without this partition
+                                 the server would render the form for an
+                                 authenticated visitor. It lives in
+                                 runtime-db, which is exactly why the render
+                                 state is TWO partitions and not one.")
+
+(def root-entry
+  "The entry identifier the sidecar's entry table is keyed by and the JVM
+  host names in its renderer opts. One root, one entry; a bigger
+  application publishes one per server-rendered route. Here for the same
+  reason the policy is: two processes, one spelling."
+  "hicasso.login/root")
+
+(def render-state-policy
+  "The one list. `{:app-db [<top-level keys>] :runtime-db [<top-level keys>]}`,
+  the map shape `re-frame.ssr.render-state` validates and both halves read."
+  {:app-db     [:auth :auth.login/server-notice]
+   :runtime-db [:rf.runtime/machines]})

--- a/examples/substrates/hicasso/login/server.cljs
+++ b/examples/substrates/hicasso/login/server.cljs
@@ -27,15 +27,18 @@
   declares no list for a partition cannot be rendered at all — absence is a
   refusal, never a licence to read everything.
 
-  They are derived from `render-state-policy` below, which is also the map
-  `host.clj` hands `ssr-handler` as `:render-state`. ONE list, two readers.
-  The two processes are deployed separately, so nothing can MAKE them agree
-  — but nothing has to: a host that asks for a key this table does not name
-  is refused with the sidecar's state-key-not-allowed refusal, and a host
-  built against a different bundle with its build-identity one. Both codes
-  are the sidecar's vocabulary, spelled in its protocol rather than
-  restated here. Drift is loud on the first request, not silent on the
-  thousandth.
+  They are derived from `hicasso.login.policy/render-state-policy` — the
+  SAME Var `host.clj` hands the Node renderer as `:render-state`, in a
+  `.cljc` namespace precisely so both halves can read it. ONE list, two
+  readers, one file. The two processes are deployed separately, so nothing
+  can MAKE them agree at run time — but nothing has to: a host that asks
+  for a key this table does not name is refused with the sidecar's
+  state-key-not-allowed refusal, and a host built against a different
+  bundle with its build-identity one. Both codes are the sidecar's
+  vocabulary, spelled in its protocol rather than restated here. Drift is
+  loud on the first request, not silent on the thousandth — and a host
+  built from this repository cannot drift in the first place, because
+  there is one list to edit.
 
   ## The render module contract
 
@@ -52,6 +55,8 @@
             ;; The views, the SSR coordinates and every `auth.login`
             ;; registration (the model rides in through this one require).
             [hicasso.login.core :as views]
+            ;; The one render-state list, shared with `host.clj`.
+            [hicasso.login.policy :as policy]
             [login.model :as model]))
 
 ;; ---------------------------------------------------------------------------
@@ -76,48 +81,22 @@
 ;; ---------------------------------------------------------------------------
 ;; The render-state policy — the one list both halves read
 ;; ---------------------------------------------------------------------------
-
-(def render-state-policy
-  "What the render is allowed to see. `host.clj` passes this map to
-  `ssr-handler` as `:render-state`; `entries` below publishes the same keys
-  as the sidecar's per-partition allowlists.
-
-  It is DISTINCT from the host's `:payload` policy, and deliberately so:
-
-    `:auth`                   the form slice at `[:auth :login-form]` — the
-                              draft the inputs are bound to. Also in the
-                              payload, because the client needs it to
-                              re-render the same controlled inputs. The
-                              draft PASSWORD is classified `:sensitive` by
-                              the shared model, so the projection redacts it
-                              on both wires: the render cannot print a
-                              secret it was never handed.
-    `:auth.login/server-notice`  a deployment notice the host resolves per
-                              request. NOT in the payload — the browser
-                              never receives it. See the note beside the
-                              sub in `core.cljs` for the rule that comes
-                              with that choice.
-    `:rf.runtime/machines`    the machine snapshots. `:auth.login/flow` is
-                              what decides which of the page's three faces
-                              renders, so without this partition the server
-                              would render the form for an authenticated
-                              visitor. It lives in runtime-db, which is
-                              exactly why the render state is TWO
-                              partitions and not one."
-  {:app-db     [:auth :auth.login/server-notice]
-   :runtime-db [:rf.runtime/machines]})
+;;
+;; It is NOT written here. `hicasso.login.policy/render-state-policy` owns it,
+;; in a `.cljc` namespace both this bundle and the JVM `host.clj` require, and
+;; that namespace's docstring is where the per-key reasoning lives.
 
 (def root-entry
-  "The entry identifier a JVM host names in its renderer opts. One root, one
-  entry; a bigger application publishes one per server-rendered route."
-  "hicasso.login/root")
+  "The entry identifier a JVM host names in its renderer opts — from the
+  shared policy namespace, for the same reason the allowlists are."
+  policy/root-entry)
 
 (defn- allowlist
-  "The EDN text of each key in one slot of `render-state-policy` — the
-  spelling the protocol's key grammar admits (`:foo`, `:foo/bar`), and the
-  same spelling `render-state/serialize` puts on the wire."
+  "The EDN text of each key in one slot of `policy/render-state-policy` —
+  the spelling the protocol's key grammar admits (`:foo`, `:foo/bar`), and
+  the same spelling `render-state/serialize` puts on the wire."
   [slot]
-  (into-array (map pr-str (get render-state-policy slot))))
+  (into-array (map pr-str (get policy/render-state-policy slot))))
 
 ;; ---------------------------------------------------------------------------
 ;; The module

--- a/examples/substrates/uix/login/README.md
+++ b/examples/substrates/uix/login/README.md
@@ -15,7 +15,7 @@ Everything below the [view](../../../../docs/core/glossary.md#view) layer stays
 the same — the same schemas, the same machine, the same named subscriptions,
 the same canned HTTP stub — because it is literally the same source. All of it
 lives in one substrate-free namespace, `login.model`
-([`examples/core/login/model.cljs`](../../../core/login/model.cljs)), which this
+([`examples/core/login/model.cljc`](../../../core/login/model.cljc)), which this
 example `:require`s and both twins — Reagent and
 [Hicasso](../../hicasso/login/) — import unchanged. Only the
 views are written differently. That's the idea worth taking away: swapping the
@@ -123,7 +123,7 @@ login/
 
 The substrate-free half — schemas, machine, events, subs, HTTP stub, frame
 config — is not in this folder: it is the shared
-[`login.model`](../../../core/login/model.cljs) namespace this `core.cljs`
+[`login.model`](../../../core/login/model.cljc) namespace this `core.cljs`
 `:require`s.
 
 ## How to run

--- a/examples/substrates/uix/login/core.cljs
+++ b/examples/substrates/uix/login/core.cljs
@@ -5,7 +5,7 @@
 
    Everything below the views — the state machine, the schemas, the form-slice
    events and subs, the managed-HTTP effect — lives in the substrate-free
-   [`login.model`](../../../core/login/model.cljs) namespace, the ONE owner of
+   [`login.model`](../../../core/login/model.cljc) namespace, the ONE owner of
    the `auth.login` dataflow. This file `:require`s it (registering everything at
    ns-load) and adds only the UIx view layer + mount. The Reagent twin
    (`login.core`) imports the identical model. Same data, two doorways: here a
@@ -23,7 +23,7 @@
   (:require [uix.core :as uix :refer [$ defui]]
             [uix.dom  :as uix-dom]
             [re-frame.core :as rf]
-            ;; The substrate-free model owner (examples/core/login/model.cljs).
+            ;; The substrate-free model owner (examples/core/login/model.cljc).
             ;; Requiring it registers every shared `auth.login` schema, fx,
             ;; machine, event, and sub, and hands us `model/frame-config` for the
             ;; mount below. It names no substrate — the UIx code lives only here.

--- a/implementation/core/test/re_frame/example_login_form_slice_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_login_form_slice_cljs_test.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.example-login-form-slice-cljs-test
   "Framework-tree regression for the login feature's FORM SLICE + password
-   PRIVACY — the `:auth.login/*` events owned by examples/core/login/model.cljs,
+   PRIVACY — the `:auth.login/*` events owned by examples/core/login/model.cljc,
    the substrate-free model shared across the Reagent/UIx login examples
    (rf2-ppbvav). rf2-t83ail + the password-classification fix rf2-3fc89f.33.
 

--- a/implementation/core/test/re_frame/example_login_stub_fx_args_redaction_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_login_stub_fx_args_redaction_cljs_test.cljs
@@ -1,7 +1,7 @@
 (ns re-frame.example-login-stub-fx-args-redaction-cljs-test
   "Framework-tree security regression for the login example's DEMO HTTP STUB —
    the `:auth.login.demo/managed-stub` reg-fx owned by
-   examples/core/login/model.cljs (rf2-a6zmmu).
+   examples/core/login/model.cljc (rf2-a6zmmu).
 
    These belong in the framework test tree, NOT under examples/ (examples stay
    test-free per rf2-8cevm). The ns requires the login model owner

--- a/implementation/core/test/re_frame/example_login_success_token_cljs_test.cljs
+++ b/implementation/core/test/re_frame/example_login_success_token_cljs_test.cljs
@@ -1,7 +1,7 @@
 (ns re-frame.example-login-success-token-cljs-test
   "Framework-tree regression for the login feature's SUCCESS-TOKEN privacy — the
    `:auth.login/succeeded` reply event and the `:auth.session/store` persistence
-   fx owned by examples/core/login/model.cljs, the substrate-free model shared
+   fx owned by examples/core/login/model.cljc, the substrate-free model shared
    across the Reagent/UIx login examples (rf2-ppbvav / rf2-j538f7.30).
 
    These belong in the framework test tree, NOT under examples/ (examples stay

--- a/implementation/hicasso/test/re_frame/hicasso/login_server_crossing_ssr_dom_cljs_test.cljs
+++ b/implementation/hicasso/test/re_frame/hicasso/login_server_crossing_ssr_dom_cljs_test.cljs
@@ -85,6 +85,7 @@
             ;; entry table, and the substrate-free model every `auth.login`
             ;; registration lives in.
             [hicasso.login.core :as views]
+            [hicasso.login.policy :as app-policy]
             [hicasso.login.server :as app-server]
             [login.model :as model]))
 
@@ -119,7 +120,7 @@
 
 (def ^:private payload-policy-opts
   "What the HOST lets the browser see — `[:auth]`, the form slice, and
-  nothing else. Narrower than `app-server/render-state-policy` on purpose:
+  nothing else. Narrower than `app-policy/render-state-policy` on purpose:
   that is the whole claim of §3."
   {:payload [:auth]})
 
@@ -212,7 +213,7 @@
   parses it into."
   [wire {:keys [build-id entry state]}]
   #js {:protocol 1
-       :entry    (or entry app-server/root-entry)
+       :entry    (or entry app-policy/root-entry)
        :state    (clj->js (or state (:rf/app-db wire)))
        :runtime  (clj->js (:rf/runtime-db wire))
        :buildId  (or build-id (.-buildId module))})
@@ -222,7 +223,7 @@
   policy and serialize both partitions to per-key EDN text."
   [frame-id]
   (render-state/serialize
-    (render-state/project frame-id {:render-state app-server/render-state-policy})))
+    (render-state/project frame-id {:render-state app-policy/render-state-policy})))
 
 (defn- hand-to-module!
   "Hand the module the frozen call shape `worker.cjs` builds, and answer
@@ -307,7 +308,7 @@
 
 (deftest the-server-bundle-satisfies-the-render-module-contract
   (testing "the entry table, which every lane can read"
-    (let [entry (aget (.-entries module) app-server/root-entry)]
+    (let [entry (aget (.-entries module) app-policy/root-entry)]
       (is (some? entry) "the module publishes the entry a host names")
       (is (= [":auth" ":auth.login/server-notice"] (vec (.-stateAllowlist entry)))
           "both allowlists, in the EDN spelling the protocol's key grammar admits")

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -704,7 +704,7 @@ const ARTEFACTS = [
 //       the artefact; assert every sentinel is PRESENT (count > 0). The
 //       strongest form (the perf-bundle template): it proves the sentinel is a
 //       live literal that survives `:advanced` compilation into a real
-//       production bundle. `login` (examples/core/login/model.cljs) requires
+//       production bundle. `login` (examples/core/login/model.cljc) requires
 //       the schemas / machines / http artefacts, so its bundle carries their
 //       sentinels — empirically 1+ each (rf2-e6qmxk validation).
 //

--- a/implementation/scripts/check-login-bundle-isolation.cjs
+++ b/implementation/scripts/check-login-bundle-isolation.cjs
@@ -7,7 +7,7 @@
  * The three login examples — Reagent (`login.core`), UIx
  * (`uix.login.core`) and Hicasso (`hicasso.login.core`) — share ONE
  * substrate-free model owner,
- * `login.model` (examples/core/login/model.cljs): the single source for every
+ * `login.model` (examples/core/login/model.cljc): the single source for every
  * `auth.login` schema, fx, machine, event, sub, and the frame config. Each
  * example `:require`s that model and adds only its own views + mount.
  *
@@ -286,7 +286,7 @@ function main() {
     if (r.ok) continue;
     if (!r.foreignOk) {
       console.error(`${r.name}: a FOREIGN view runtime leaked into the bundle.`);
-      console.error('  The shared substrate-free login.model (examples/core/login/model.cljs)');
+      console.error('  The shared substrate-free login.model (examples/core/login/model.cljc)');
       console.error('  appears to have pulled in a view library / adapter — the isolation');
       console.error('  claim (rf2-ppbvav) is broken. Likely cause: a `:require` on');
       console.error('  `reagent.*` / `uix.*` / `re-frame.hicasso.*` or `re-frame.adapter.*`');

--- a/implementation/ssr-ring/deps.edn
+++ b/implementation/ssr-ring/deps.edn
@@ -28,7 +28,18 @@
  {:test {;; The local fixture combines core's public reset fixture with the
          ;; SSR per-request side-channel resets available through the
          ;; production SSR dependency.
-         :extra-paths ["test"]
+         ;;
+         ;; The two `../../examples` roots are the login arm's JVM host
+         ;; witness (rf2-8arzr.5, `login_host_crossing_test.clj`): it
+         ;; requires `hicasso.login.host` (examples/substrates) which
+         ;; requires the shared `login.model` (examples/core). Loading the
+         ;; namespace is half the witness — before this, a compile error in
+         ;; that host passed every gate silently. Same shape as
+         ;; implementation/core/deps.edn's `:test`, which puts the example
+         ;; buckets on the classpath for `re-frame.examples-test`.
+         :extra-paths ["test"
+                       "../../examples/core"
+                       "../../examples/substrates"]
          ;; Mirrors implementation/ssr/deps.edn :test alias — schemas /
          ;; flows / routing / machines load at ns-load time and the
          ;; reset-runtime fixture reloads them after registrar/clear-all!.
@@ -36,6 +47,9 @@
                        day8/re-frame2-flows      {:local/root "../flows"}
                        day8/re-frame2-routing    {:local/root "../routing"}
                        day8/re-frame2-machines   {:local/root "../machines"}
+                       ;; `login.model` turns on managed HTTP and its
+                       ;; canned-reply stubs (the example's demo backend).
+                       day8/re-frame2-http       {:local/root "../http"}
                        ;; Resource payload tests require the optional hooks
                        ;; without adding them to the published adapter.
                        day8/re-frame2-resources  {:local/root "../resources"}
@@ -53,11 +67,17 @@
 
   ;; Nightly/rigorous gate: includes only tests excluded by `:test`.
   :slow-test
-  {:extra-paths ["test"]
+  {:extra-paths ["test"
+                 ;; Every lane that scans `test/` loads every namespace in
+                 ;; it, the login host witness included — so the classpath
+                 ;; the `:test` alias explains is needed here too.
+                 "../../examples/core"
+                 "../../examples/substrates"]
    :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
                  day8/re-frame2-flows      {:local/root "../flows"}
                  day8/re-frame2-routing    {:local/root "../routing"}
                  day8/re-frame2-machines   {:local/root "../machines"}
+                 day8/re-frame2-http       {:local/root "../http"}
                  day8/re-frame2-resources  {:local/root "../resources"}
                  day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                  ring/ring-jetty-adapter {:mvn/version "1.12.1"}}
@@ -71,11 +91,16 @@
   ;; (`jvm-node-crossing` in .github/workflows/test.yml); the default `:test`
   ;; alias never touches Node.
   :crossing-test
-  {:extra-paths ["test"]
+  {:extra-paths ["test"
+                 ;; The login arm's JVM host and the model it holds — the
+                 ;; product half of the crossing (rf2-8arzr.5).
+                 "../../examples/core"
+                 "../../examples/substrates"]
    :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
                  day8/re-frame2-flows      {:local/root "../flows"}
                  day8/re-frame2-routing    {:local/root "../routing"}
                  day8/re-frame2-machines   {:local/root "../machines"}
+                 day8/re-frame2-http       {:local/root "../http"}
                  day8/re-frame2-resources  {:local/root "../resources"}
                  day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                  ring/ring-jetty-adapter {:mvn/version "1.12.1"}}

--- a/implementation/ssr-ring/test/fixtures/node/login_host.cjs
+++ b/implementation/ssr-ring/test/fixtures/node/login_host.cjs
@@ -1,0 +1,62 @@
+'use strict';
+// THE LOGIN-HOST FIXTURE — the render module the login arm's JVM host
+// witness (`re-frame.ssr.ring.login-host-crossing-test`) spawns the sidecar
+// on.
+//
+// It carries NO policy of its own. The entry id, the build id and both
+// per-partition allowlists arrive in the environment, and the test sets them
+// from `hicasso.login.policy` — the same Vars `examples/substrates/hicasso/
+// login/server.cljs` derives the real bundle's entry table from. So the
+// sidecar in this witness enforces the application's own list rather than a
+// second copy of it, and a host that drifted off that list is refused here
+// exactly as it would be against the shipped bundle.
+//
+// What it is NOT is the login application's render. That is a Hicasso render
+// on React, witnessed in CLJS by
+// `re-frame.hicasso.login-server-crossing-ssr-dom-cljs-test`, which drives
+// the real views, the real `login.model` registrations and this module's
+// published entry table. What THIS module witnesses is the other half — the
+// JVM host: that `hicasso.login.host` loads on a Clojure classpath, that its
+// handler projects the settled frame under the shared policy, and that a
+// complete JVM-owned document comes back around Node's body bytes over a
+// real socket.
+//
+// So it echoes what it was handed, and decodes nothing: the values arrive as
+// EDN TEXT, per key, exactly as `re-frame.ssr.render-state/serialize` put
+// them on the wire, and what the JVM reads back out of the document is
+// byte-for-byte what it sent.
+
+const text = (s) =>
+  String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const list = (name) => {
+  const raw = process.env[name];
+  if (!raw) return [];
+  return JSON.parse(raw);
+};
+
+const entry = process.env.RF2_LOGIN_ENTRY || 'hicasso.login/root';
+
+module.exports = {
+  protocol: 1,
+  buildId: process.env.RF2_LOGIN_BUILD_ID || 'login-hicasso-dev',
+  entries: {
+    [entry]: {
+      stateAllowlist: list('RF2_LOGIN_STATE_ALLOWLIST'),
+      runtimeAllowlist: list('RF2_LOGIN_RUNTIME_ALLOWLIST'),
+    },
+  },
+
+  async render({ entry, state, runtime }, emit) {
+    const keys = (o) => Object.keys(o ?? {}).sort().join(' ');
+    emit(
+      `<main data-entry="${text(entry)}">` +
+        `<div class="login-state-keys">${text(keys(state))}</div>` +
+        `<div class="login-runtime-keys">${text(keys(runtime))}</div>` +
+        `<div class="login-draft">${text(state[':auth'])}</div>` +
+        `<div class="login-notice">${text(state[':auth.login/server-notice'])}</div>` +
+        `<div class="login-machines">${text(runtime[':rf.runtime/machines'])}</div>` +
+        `</main>`,
+    );
+  },
+};

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/login_host_crossing_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/login_host_crossing_test.clj
@@ -1,0 +1,378 @@
+(ns re-frame.ssr.ring.login-host-crossing-test
+  "rf2-8arzr.5 — THE LOGIN ARM'S JVM HOST WITNESS.
+
+  Slice E shipped `examples/substrates/hicasso/login/` as the native-Hicasso
+  PRODUCT witness for the ssr-node crossing, and the merged-PR audit found
+  that half of it did not run: `host.clj` commented out its `login.model`
+  require because the shared model was ClojureScript-only, the example
+  README said in so many words that the JVM host could not run, and no gate
+  loaded the namespace or drove the advertised Ring handler. A compile error
+  in it passed every gate silently.
+
+  This namespace is the gate that was missing, in two tiers.
+
+  UNTAGGED — runs in the default `:test` lane, no Node. Loading this
+  namespace requires `hicasso.login.host`, which requires the shared
+  `login.model` on a plain Clojure classpath. That is the compile witness:
+  the namespace cannot rot without a red gate. The untagged tests then
+  assert the things that hold without a sidecar — that the handler
+  constructed at all, that the model's registrations are really in the
+  registrar, and that the render-state policy is ONE source both halves of
+  the deployment read.
+
+  `:crossing` — runs under `clojure -M:crossing-test` (CI's
+  `jvm-node-crossing` job; Node 24 on PATH). Each spawns
+  implementation/ssr-node's serve launcher on `test/fixtures/node/
+  login_host.cjs`, over a real socket on port 0, and drives
+  `hicasso.login.host/make-handler` — the same constructor the shipped
+  `handler` Var is built from, pointed at the ephemeral endpoint the
+  spawned sidecar reported. The fixture is configured FROM
+  `hicasso.login.policy`, so the sidecar enforces the application's own
+  entry allowlists rather than a second copy of them.
+
+  ## What this witnesses, and what it does not
+
+  It witnesses the JVM half of the documented build -> sidecar -> Ring page
+  path: the host loads, `ssr-handler` drains `:initial-events` against real
+  `auth.login` registrations, the renderer projects the settled frame under
+  the shared policy, the bytes cross a real socket to the real sidecar
+  launcher, and a complete JVM-owned document comes back with Node's body
+  inserted verbatim.
+
+  It does NOT re-witness the Hicasso render itself — that is React on Node,
+  and `re-frame.hicasso.login-server-crossing-ssr-dom-cljs-test` drives the
+  real views, the real registrations and the real published entry table
+  against the sidecar's own request validator. Compiling the login server
+  bundle inside a JVM test would buy nothing that test does not already
+  hold, and would put shadow-cljs on this lane.
+
+  ## The fail-open the audit named, proved closed
+
+  The sidecar refuses a host that asks for MORE than the entry allows. It
+  cannot refuse one that asks for LESS — that host is served a page
+  rendered from incomplete state, with nothing to notice. Two copies of one
+  list drift both ways; one Var cannot. `render-state-is-one-source`
+  asserts the single owner, and `a-widened-host-is-refused` proves the
+  other direction still bites at the seam."
+  (:require [clojure.data.json :as json]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            [re-frame.ssr.ring :as ssr-ring]
+            [re-frame.ssr.ring.node :as node]
+            [re-frame.ssr.ring.test-support :as ts]
+            ;; THE SUBJECT. Requiring it is half the witness.
+            [hicasso.login.host :as host]
+            [hicasso.login.policy :as policy])
+  (:import [java.util.concurrent TimeUnit]))
+
+;; ===========================================================================
+;; The runtime reset, plus the application's registrations
+;; ===========================================================================
+
+(defn- with-login-app
+  "`ts/reset-runtime` wipes the registrar before each test, which drops the
+  `auth.login` registrations `login.model` installed at namespace load —
+  and Clojure's `require` is idempotent, so a plain re-require would not
+  re-fire them. Reload the framework namespaces whose own load-time
+  registrations the model leans on, then the model itself. Same pattern,
+  and same reason, as `re-frame.examples-test`'s fixture."
+  [f]
+  (ts/reset-runtime
+    (fn []
+      (require 're-frame.cofx :reload)
+      (require 're-frame.http.managed :reload)
+      (require 're-frame.http.test-support :reload)
+      (require 're-frame.machines :reload)
+      (require 'login.model :reload)
+      (f))))
+
+;; ===========================================================================
+;; The sidecar — slice B's launcher on the login fixture, port 0
+;; ===========================================================================
+
+(def ^:private launcher
+  (.getCanonicalPath (io/file "../ssr-node/bin/serve.cjs")))
+
+(def ^:private fixture-module
+  (.getCanonicalPath (io/file "test/fixtures/node/login_host.cjs")))
+
+(def ^:private boot-timeout-ms 30000)
+
+(defn- pump-lines!
+  [stream on-line on-eof]
+  (doto (Thread. (fn []
+                   (try
+                     (with-open [r (io/reader stream)]
+                       (doseq [line (line-seq r)] (on-line line)))
+                     (finally (on-eof))))
+                 "rf2-login-host-sidecar-pump")
+    (.setDaemon true)
+    (.start)))
+
+(defn- entry-env
+  "The environment the fixture module reads its entry table out of — the
+  application's OWN policy, JSON-encoded for a CommonJS module to parse.
+  Nothing in the fixture spells a key; this is where they come from, and
+  it is the same Var `server.cljs` derives the shipped bundle's
+  `stateAllowlist` / `runtimeAllowlist` from."
+  []
+  {"RF2_LOGIN_ENTRY"             policy/root-entry
+   "RF2_LOGIN_BUILD_ID"          host/build-id
+   "RF2_LOGIN_STATE_ALLOWLIST"   (json/write-str
+                                   (mapv pr-str (:app-db policy/render-state-policy)))
+   "RF2_LOGIN_RUNTIME_ALLOWLIST" (json/write-str
+                                   (mapv pr-str (:runtime-db policy/render-state-policy)))})
+
+(defn- spawn-sidecar!
+  "Spawn `node bin/serve.cjs --module <login fixture> --port 0 …` and wait
+  for the launcher's ONE ready line. Returns `{:process :url :stderr}`."
+  []
+  (let [pb     (ProcessBuilder. ^java.util.List
+                                ["node" launcher
+                                 "--module" fixture-module
+                                 "--port" "0"
+                                 "--isolates" "2"
+                                 "--timeout-ms" "1000"
+                                 "--admission-ms" "250"])
+        _      (doto (.environment pb)
+                 (.putAll ^java.util.Map (entry-env)))
+        p      (.start pb)
+        stderr (StringBuilder.)
+        ready  (promise)]
+    (pump-lines! (.getInputStream p)
+                 (fn [line]
+                   (when-not (realized? ready)
+                     (when-let [m (try (json/read-str line) (catch Exception _ nil))]
+                       (when (= "ready" (get m "rf.ssr-node"))
+                         (deliver ready m)))))
+                 #(deliver ready ::eof))
+    (pump-lines! (.getErrorStream p)
+                 (fn [line] (locking stderr (.append stderr line) (.append stderr "\n")))
+                 (fn []))
+    (let [m (deref ready boot-timeout-ms ::timeout)]
+      (when-not (map? m)
+        (.destroyForcibly p)
+        (throw (ex-info (str "the sidecar produced no ready line (" (name m) ")"
+                             "\nstderr:\n" stderr)
+                        {:launcher launcher :module fixture-module})))
+      {:process p :url (get m "url") :stderr stderr})))
+
+(defn- stop-sidecar! [{:keys [^Process process]}]
+  (.destroy process)
+  (when-not (.waitFor process 5 TimeUnit/SECONDS)
+    (.destroyForcibly process)))
+
+(def ^:private sidecar
+  "Spawned by the first `:crossing` test that asks, never by namespace
+  load, so the default lane loading this ns costs nothing."
+  (atom nil))
+
+(defn- sidecar! []
+  (or @sidecar (reset! sidecar (spawn-sidecar!))))
+
+(defn- with-sidecar [f]
+  (try
+    (f)
+    (finally
+      (when-let [s @sidecar]
+        (reset! sidecar nil)
+        (stop-sidecar! s)))))
+
+(use-fixtures :once with-sidecar)
+(use-fixtures :each with-login-app)
+
+;; ===========================================================================
+;; The request, and small readers over the response body
+;; ===========================================================================
+
+(def ^:private request
+  {:uri "/login" :request-method :get :headers {}})
+
+(defn- marked
+  "The text of the fixture's `<div class=\"<mark>\">…</div>` echo — what
+  Node was actually handed, read back out of the document the JVM built
+  around it."
+  [body mark]
+  (second (re-find (re-pattern (str "<div class=\"" mark "\">(.*?)</div>")) body)))
+
+(defn- payload-edn-of [body]
+  (second (re-find #"<script id=\"__rf_payload\"[^>]*>(.*?)</script>" body)))
+
+;; ===========================================================================
+;; UNTAGGED — no Node. The compile witness and its neighbours.
+;; ===========================================================================
+
+(deftest the-jvm-host-loads-and-constructs
+  (testing "the namespace this test requires is the deployment's own host"
+    (is (fn? host/handler)
+        "hicasso.login.host/handler — constructed at namespace load, on a
+         plain Clojure classpath, with the shared model required")
+    (is (fn? (host/make-handler {:endpoint "http://127.0.0.1:8148"
+                                 :build-id "login-hicasso-dev"}))
+        "make-handler builds one against any endpoint — the seam this
+         witness drives, and the constructor `handler` itself is built from"))
+
+  (testing "the shared model really is in the registrar, not merely on the
+            classpath — `:initial-events` names a registration that exists"
+    (is (some? (registrar/lookup :event :auth.login/initialise-form))
+        ":auth.login/initialise-form — the host's one boot event")
+    (is (some? (registrar/lookup :fx :auth.login.demo/managed-stub))
+        ":auth.login.demo/managed-stub — the demo backend the host's
+         :fx-overrides remaps :rf.http/managed to")
+    (is (some? (registrar/lookup :sub :auth.login/draft))
+        ":auth.login/draft — a named sub the server-rendered view reads")))
+
+(deftest render-state-is-one-source
+  (testing "the policy is a Var in a .cljc namespace, and it is the ONLY
+            place the login arm spells the render-state keys"
+    (is (= {:app-db     [:auth :auth.login/server-notice]
+            :runtime-db [:rf.runtime/machines]}
+           policy/render-state-policy)
+        "hicasso.login.policy/render-state-policy — the one list")
+    (is (= "hicasso.login/root" policy/root-entry)
+        "and the one entry id"))
+
+  (testing "neither reader keeps a copy. host.clj is Clojure and server.cljs
+            is ClojureScript, so neither can be read by the other's compiler
+            — which is exactly why a copy in either would be silent. Read
+            them as TEXT and assert they name the Var instead."
+    (doseq [f ["../../examples/substrates/hicasso/login/host.clj"
+               "../../examples/substrates/hicasso/login/server.cljs"]]
+      (let [src (slurp (io/file f))
+            ;; The forms in `policy.cljc`'s own docstring do not appear
+            ;; here; what would appear in a COPY is the key vector itself.
+            copies (count (re-seq #"\[:auth :auth\.login/server-notice\]" src))]
+        (is (str/includes? src "policy/render-state-policy")
+            (str f " reads the shared Var"))
+        (is (zero? copies)
+            (str f " keeps no copy of the app-db key list (found "
+                 copies " — a second copy can drift the SAFE way, which "
+                 "the sidecar cannot refuse)"))))))
+
+;; ===========================================================================
+;; :crossing — the real launcher, a real socket, the advertised handler
+;; ===========================================================================
+
+(deftest ^:crossing the-login-host-renders-a-page
+  (let [{:keys [url]} (sidecar!)
+        h             (host/make-handler {:endpoint url :build-id host/build-id})
+        {:keys [status headers body]} (h request)]
+
+    (testing "a complete JVM-owned document"
+      (is (= 200 status))
+      (is (str/includes? body "<!DOCTYPE html>") "shell: JVM-built")
+      (is (str/includes? body "<div id=\"app\"")
+          "shell: the #app root the client hydrator adopts by id")
+      (is (str/includes? body "src=\"/js/main.js\"")
+          "shell: the client bundle the example's README names")
+      ;; The host names no `:content-type`, so the handler emits none and
+      ;; leaves the header to the runtime — asserted as measured rather
+      ;; than as assumed.
+      (is (nil? (get headers "Content-Type"))
+          "no Content-Type override: the host does not declare one"))
+
+    (testing "Node's body markup, inserted verbatim, for the login entry"
+      (is (str/includes? body (str "<main data-entry=\"" policy/root-entry "\">"))
+          "the entry the host named is the entry the sidecar dispatched to"))
+
+    (testing "the render-state projection crossed under the shared policy"
+      ;; `select-keys` omits an absent key, so the state partition carries
+      ;; the policy keys the settled app-db HAS. `:auth` is seeded by the
+      ;; boot event; `:auth.login/server-notice` is deliberately unset in
+      ;; this deployment (the README's rule: a render-state key the payload
+      ;; does not carry must not change the markup).
+      (is (= ":auth" (marked body "login-state-keys"))
+          "the app-db partition Node received")
+      (is (str/includes? (str (marked body "login-draft")) ":login-form")
+          "and it carried the form slice the inputs are bound to")
+      (is (str/includes? (str (marked body "login-draft")) ":rf/redacted")
+          "with the draft password redacted at the projection — the render
+           cannot print a secret it was never handed")
+      ;; MEASURED, and worth stating because the prose used to imply
+      ;; otherwise: the runtime partition is EMPTY on this deployment. The
+      ;; `:auth.login/flow` machine is self-seeding — it materialises a
+      ;; snapshot the first time it is dispatched at or subscribed to — and
+      ;; the shipped host does neither, because the render happens in Node.
+      ;; So Node's own frame seeds `:idle` and renders the form, which is
+      ;; the right page. `the-machine-snapshot-crosses-when-the-host-drives-it`
+      ;; below proves the partition is live rather than decorative.
+      (is (= "" (marked body "login-runtime-keys"))
+          "nothing in the runtime partition: the host never drives the machine")
+      (println (format "[rf2-8arzr.5] login host render-state: app-db keys %s / runtime-db keys %s"
+                       (pr-str (marked body "login-state-keys"))
+                       (pr-str (marked body "login-runtime-keys")))))
+
+    (testing "render-state is NOT the payload"
+      (let [payload (payload-edn-of body)]
+        (is (some? payload) "__rf_payload — JVM-built, from the JVM app-db")
+        (is (str/includes? payload ":auth") "the browser gets the form slice")
+        (is (not (str/includes? payload ":auth.login/server-notice"))
+            "and never the server-only notice key")))))
+
+(deftest ^:crossing the-machine-snapshot-crosses-when-the-host-drives-it
+  (testing "`:rf.runtime/machines` is on the render-state list because a host
+            that HAS driven the flow — a session-restoring one, say — must
+            hand the render the state that decides which of the page's three
+            faces it draws. The shipped host drives nothing, so nothing
+            crosses; drive the machine from `:initial-events` and the
+            snapshot rides the runtime partition."
+    (let [{:keys [url]} (sidecar!)
+          h (ssr-ring/ssr-handler
+              {:initial-events [[:auth.login/initialise-form]
+                                ;; `:idle` -> `:submitting`, action
+                                ;; `:clear-error`. A pure data transition —
+                                ;; the HTTP request is fired by
+                                ;; `submit-form`, not by the machine.
+                                [:auth.login/flow [:auth.login/submit]]]
+               :payload        [:auth]
+               :renderer       (node/renderer
+                                 {:endpoint     url
+                                  :entry        policy/root-entry
+                                  :build-id     host/build-id
+                                  :render-state policy/render-state-policy
+                                  :timeout-ms   1000})})
+          {:keys [status body]} (h request)]
+      (is (= 200 status))
+      (is (= ":rf.runtime/machines" (marked body "login-runtime-keys"))
+          "the machine partition crossed")
+      (is (str/includes? (str (marked body "login-machines")) ":submitting")
+          "carrying the state the JVM drove the flow into")
+      (is (not (str/includes? (str (payload-edn-of body)) ":rf.runtime/machines"))
+          "and it is render state, not payload: the browser's allowlist is
+           app-db keys and names none of this"))))
+
+(deftest ^:crossing a-widened-host-is-refused
+  (testing "a host that asks for a key the entry does not allow is refused
+            by the sidecar rather than served — the direction that CAN be
+            caught at the seam, and the reason the other direction is
+            closed by construction instead"
+    ;; The widened key has to be PRESENT in app-db, or the projection's
+    ;; `select-keys` omits it and the sidecar never sees the overreach.
+    (rf/reg-event :login-host-test/seed-extra
+      {:platforms #{:server}}
+      (fn [{:keys [db]} _]
+        {:db (assoc db :auth.login/not-on-the-list "widened")}))
+    (let [{:keys [url]} (sidecar!)
+          widened (ssr-ring/ssr-handler
+                    {:initial-events [[:auth.login/initialise-form]
+                                      [:login-host-test/seed-extra]]
+                     :payload        [:auth]
+                     :renderer       (node/renderer
+                                       {:endpoint     url
+                                        :entry        policy/root-entry
+                                        :build-id     host/build-id
+                                        :render-state (update policy/render-state-policy
+                                                              :app-db conj
+                                                              :auth.login/not-on-the-list)
+                                        :timeout-ms   1000})
+                     :error-view     (fn [{:keys [code]}]
+                                       [:main#login-error [:p (str "projected:" (name code))]])})
+          {:keys [status body]} (widened request)]
+      (is (>= status 500) (str "a refusal is a projected 5xx, got " status))
+      (is (str/includes? body "projected:")
+          "the error view rendered, so the refusal reached the projector")
+      (is (not (str/includes? body "<main data-entry="))
+          "and no partial page was served"))))


### PR DESCRIPTION
Closes the merged-PR audit on rf2-8arzr.5. Slice E shipped
`examples/substrates/hicasso/login/` as the native-Hicasso PRODUCT witness for
the ssr-node crossing, and half of it did not run: `host.clj` commented out its
`login.model` require, the README said in so many words that the JVM host could
not run, its `:initial-events` named registrations the host never loaded, and no
gate required the namespace or drove the advertised Ring handler. A compile
error in that file passed every gate silently.

## 1. Why `login.model` was commented out, and how it is loadable now

**The reason was real and it was one line.** `login.model` is
`examples/core/login/model.cljs`, shared by all three login arms, and the single
non-portable thing in it is the `localStorage` write in the demo session effect:

```clojure
(when-let [ls (.-localStorage js/globalThis)]
  (.setItem ls "auth/token" token))
```

`js/globalThis` is a *read-time* problem, not a run-time one — the registration
already carries `:platforms #{:client}`, so the effect could never have RUN on a
server. Those are two different boundaries, and a JVM host needs both.

So the file is now `model.cljc` with a reader conditional around that one body,
and the `:clj` arm throws (it is unreachable — `:platforms` refuses the effect
first — and present so the namespace READS on a Clojure classpath). **Nothing is
duplicated: the three login arms still share exactly one model.** Verified by
loading it standalone on `implementation/core`'s `:test` classpath before
anything else was written.

Every reference to the old path moved with it (five markdown files, four source
comments, two `implementation/scripts/*.cjs` message strings).

## 2. The smoke: what it drives, and its red against the un-required model

`implementation/ssr-ring/test/re_frame/ssr/ring/login_host_crossing_test.clj`,
in two tiers.

**Untagged** (default `:test` lane, no Node). Requiring `hicasso.login.host`
*is* the compile gate — that is the exact hole the audit named. It then asserts
`handler` and `make-handler` constructed, and that the model's registrations
(`:auth.login/initialise-form`, `:auth.login.demo/managed-stub`,
`:auth.login/draft`) are really in the registrar rather than merely on the
classpath.

**`:crossing`** (CI's `jvm-node-crossing` job; `clojure -M:crossing-test`).
Spawns the real `implementation/ssr-node/bin/serve.cjs` launcher on a port-0
socket and drives `hicasso.login.host/make-handler`:

- a complete JVM-owned document — doctype, `<div id="app">`, `/js/main.js` —
  around Node's body bytes inserted verbatim, for the entry the host named;
- the render-state projection under the shared policy, with the draft password
  arriving `:rf/redacted`;
- render-state distinct from `__rf_payload`: the browser gets `:auth`, never
  `:auth.login/server-notice`;
- the machine snapshot crossing the runtime partition as `:submitting` when the
  host drives the flow from `:initial-events`;
- a **widened** host — one asking for a key the entry table does not allow —
  refused by the sidecar and projected as a 5xx with no partial page.

Its fixture module (`test/fixtures/node/login_host.cjs`) carries no policy of
its own. The entry id, the build id and both per-partition allowlists are handed
to it in the environment, from the same application Vars the shipped bundle
derives its entry table from, so the sidecar in this witness enforces the
application's own list rather than a second copy of it.

**What it does not do** is re-witness the Hicasso render itself — that is React
on Node, and `re-frame.hicasso.login-server-crossing-ssr-dom-cljs-test` already
drives the real views, the real registrations and the real published entry table
against the sidecar's own request validator. Compiling the login server bundle
inside a JVM test would buy nothing that test does not hold, and would put
shadow-cljs on this lane.

**The red.** Planted the exact slice-E state — `#_[login.model :as model]` at
`host.clj`'s require (single-line anchor, match count read as 1 before the run)
— and ran the untagged lane:

```
SABOTAGE EXIT=1
Syntax error compiling at (hicasso\login\host.clj:89:22).
No such namespace: model
```

Restored with `git checkout HEAD --`; the file's git blob hash was equal before
and after the plant, and the lane came back green.

`ssr-ring/deps.edn` puts `examples/core` + `examples/substrates` on all three
test lanes' classpaths — the same shape `implementation/core/deps.edn` already
uses for `re-frame.examples-test` — plus `day8/re-frame2-http`, which
`login.model` needs.

## 3. The twice-repeated render-state policy

It was worse than repeated: **the first copy was dead.** `ssr-handler` has no
`:render-state` opt at all (it is a RENDERER opt — the renderer is what
projects), so `host.clj`'s top-level `:render-state` was inert while reading
exactly like the live policy. The second copy, on the renderer, was the only one
that did anything; `server.cljs` derived the sidecar's allowlists from a third
spelling of the same list.

`examples/substrates/hicasso/login/policy.cljc` is now the single owner of both
the render-state map and the entry id, and `host.clj` and `server.cljs` each
require it. **"One list, two readers" is now true**, and mechanically so rather
than by convention: a `.cljc` namespace is the only place both a Clojure and a
ClojureScript compiler can read, which is precisely why a copy in either
neighbour could only ever be kept in step by hand.

The direction that matters is the one the sidecar cannot catch. It refuses a
host asking for MORE than the entry allows; it has nothing to say about a host
asking for LESS, which is served a page rendered from incomplete state. One Var
closes that by construction. An untagged test also reads both files as text and
asserts neither keeps a copy of the key vector, and the `:crossing` widening arm
proves the refusal still bites in the other direction.

The dead top-level opt is gone, and `make-handler` now takes `:initial-events`
AND `:fx-overrides` from the shared `model/frame-config` rather than restating
one and dropping the other.

## 4. Already done in the bead's description, by commit

The description's `## Scope (fence)` and `## Do` sections describe landed work.
Nothing in them was redone, and `implementation/shadow-cljs.edn` is untouched:

- `bbc97a5678` — `re-frame.hicasso.server/render-body`, the body-only entry.
- `ae858bf329` — the login arm's server bundle, JVM host wiring and CLJS witness.
- `ff6698f794` — the `:examples/login-hicasso-server` `:node-library` build.
- `a4e1d6f5e6` — the out+init invariant scoped to `:browser` builds.

Also stale on the bead, checked at source rather than taken from the note:
**rf2-8arzr.9 is CLOSED** (PR #9024), so the appended "fold it in" offer does not
apply. The newest note by mutation time is that stale one; the live instruction
is the audit note beneath it.

## A finding for slice F (rf2-8arzr.6)

Measured, not assumed: **on the shipped configuration the runtime partition
crosses EMPTY.** `:auth.login/flow` is self-seeding — it materialises a snapshot
the first time it is dispatched at or subscribed to — and the JVM host does
neither, because the rendering happens in Node. So Node's own per-request frame
seeds `:idle` and draws the form, which is the right page, but the README's
justification for `:rf.runtime/machines` ("leave it out and the server renders a
signed-in visitor a login form") describes a host that has driven the flow, not
this one. Both halves are now asserted: the shipped page crosses with an empty
runtime partition, and the same page with one machine event added crosses
carrying `:submitting`. The README says so in place.

## Gates

Every run foregrounded or polled to completion in the same turn, exit code
captured on the same line as the redirect, artefacts named per worktree and
attempt. `scripts/assert-worker-worktree.sh` ran and exited 0; the fast-PR plan
printed this worktree as its gate root, and shadow-cljs named this worktree's
`shadow-cljs.edn`. **Every row below was re-run after the rebase onto the
current trunk** — main had moved 26 commits, including `hicasso/server.cljs`
(rf2-ypom) and `scripts/test-fast-pr.sh`, so the pre-rebase greens were about a
tree that no longer existed.

| gate | result |
|---|---|
| `sh scripts/test-fast-pr.sh` | exit 0 — docs tier, clj-kondo, JVM core 2175/11144, ssr-ring 231/1163, hicasso 3/92, CLJS node 11193/55792, all 0 failures |
| `sh scripts/test-fast-pr.sh --plan` | docs / JVM / node all armed; JVM tier = core + ssr-ring + hicasso |
| `:node-test-hicasso` (compile + run) | exit 0 — 1177 tests, 4393 assertions, 0 failures; 527 files, 0 warnings |
| `implementation/ssr-ring` `clojure -M:test` | exit 0 — 231 tests, 1163 assertions, 0 failures |
| `implementation/ssr-ring` `clojure -M:crossing-test` (the whole `:crossing` lane, slice D's six plus these three) | exit 0 — 9 tests, 95 assertions, 0 failures |
| the focused witness against the planted fault | exit 1, naming `host.clj:89:22 No such namespace: model` |
| `scripts/check_readme_links.py --ci` | exit 0; control: a planted broken link went exit 1 naming file and target, restored to an equal blob hash |
| `npx shadow-cljs compile` — all six login builds (`login`, `login-uix`, `login-hicasso`, `login-hicasso-server`, `login-with-stories`, `login-form`) | exit 0, **0 warnings** on each: the `.cljc` rename does not disturb any arm |

Left to CI: `test:examples-compile`, `test:bundle-isolation`,
`check_optional_module_reachability.py`.

## Hand verification

`mkdocs build --strict` is not the gate for this diff — nothing under `docs/` or
the staged `spec/` / `migration/` trees is touched. Markdown link targets are
covered by `check_readme_links.py --ci` (green, and shown to bite). No table
column counts changed; the one table in the Hicasso login README is untouched.
