### PR TITLE
docs+skills(client-root): finish the adoption sweep and settle two discharged bead markers (rf2-k5r9t, rf2-pd9b, rf2-fgwf)

### DIFF
--- a/docs/core/25-from-re-frame-v1.md
+++ b/docs/core/25-from-re-frame-v1.md
@@ -139,6 +139,8 @@ Fix at the root: ensure a frame and scope the tree to it. The usual shape is `fr
 
 ```clojure
 ;; Prefer: named seed event(s) on frame-root (same pipeline as every later change)
+;; `app-root` is the client-root handle; `main-view` is your application's
+;; root view — two different things, so give them two different names.
 (defonce app-root (reagent-adapter/client-root))
 (def el (js/document.getElementById "app"))
 
@@ -146,7 +148,7 @@ Fix at the root: ensure a frame and scope the tree to it. The usual shape is `fr
   [rf/frame-root {:id :app/main
                   :initial-events [[:app/initialise]   ;; reg-event that returns {:db …}
                                    [:boot]]}
-   [app-root]]
+   [main-view]]
   el)
 
 ;; Also fine: pre-create, then scope — e.g. when boot is outside React
@@ -154,7 +156,7 @@ Fix at the root: ensure a frame and scope the tree to it. The usual shape is `fr
                 :initial-events [[:app/initialise] [:boot]]})
 (reagent-adapter/render! app-root
   [rf/frame-provider {:frame :app/main}
-   [app-root]]
+   [main-view]]
   el)
 ```
 

--- a/docs/design/hicasso/studio/hframe-design.md
+++ b/docs/design/hicasso/studio/hframe-design.md
@@ -263,10 +263,17 @@ Hicasso arm error id is catalogued there**: `git grep 'rf.error/hicasso' -- spec
 is empty, which is what HD-017's bench-lane residence implies. So no catalogue
 row is owed, and the question reopens if and when the arm graduates.
 
-**The provisional id did not leak.** `:rf.error/ambient-frame-refused` is written
-in exactly one place in the new work — nowhere. The carry rows pin *"the same id
-an ambient read gets"*, taken live from a sibling row, so `rf2-k0rbk`'s rename
-touches the one pre-existing anchor rather than five new sites.
+**The provisional id did not leak, and the id is now settled.**
+`:rf.error/ambient-frame-refused` is written in exactly one place in the new
+work — nowhere. The carry rows pin *"the same id an ambient read gets"*, taken
+live from a sibling row. That indirection was first argued as rename economy,
+against a rename `rf2-k0rbk` might have ordered; `rf2-k0rbk` closed on
+2026-08-06 confirming the spelling stands, so no rename is coming and that
+argument is discharged. The indirection stays on the reason that outlives it:
+these rows assert that a carry and a read refuse *identically*, so reading the
+id live from the sibling row is what makes the agreement the property under
+test — two independent literals would assert two constants and could not see
+them drift apart. §9 item 2 records the settled contract.
 
 **W7 could not be built when this record was first written, and that was not a
 shortfall.** The row needs the `[:>]` value-first door, and `front/codec.cljs`
@@ -308,10 +315,14 @@ is `rf2-nqj22`. It is also how the SSR rows were grounded: the shared test fixtu
 root-binds `*current-frame*` to `:rf/default`, so the SSR witnesses opt out with
 `:ambient-frame nil` rather than measure the fixture.
 
-**Spec 009's catalogue row for the refusal is behind the code** — it enumerates
-`:operation` as `(:dispatch / :subscribe)`, and at least `:capture-frame` and
-`:current-frame-id` also reach `require-current-frame!`. Filed as `rf2-e28wl`,
-to sequence with `rf2-k0rbk`.
+**Spec 009's catalogue row for the refusal was behind the code, and has caught
+up.** It enumerated `:operation` as `(:dispatch / :subscribe)` when at least
+`:capture-frame` and `:current-frame-id` also reach `require-current-frame!`.
+Filed as `rf2-e28wl`, closed 2026-08-05 and fixed in PR #7533: the row now
+states the rule instead of a list — the category is defined by the DOOR, and
+`:operation` is documented as an OPEN set rather than a closed pair. Nothing is
+left to sequence against `rf2-k0rbk`, which closed the following day leaving the
+id unchanged.
 
 **The guide half is still owed.** §10's guide bullet was fenced out of the
 implementation PR — a rename was landing in `draft-guide/` at the time — so the
@@ -341,8 +352,15 @@ tip, as its own entry now records; (3) stands.*
    stability rule in `implementation/hicasso/spec/complaints.md` closes the
    question outright: an id names one refusal and is never re-spelled or reused.
    Guide text naming it is no longer blocked. *(This item previously held the id
-   PROVISIONAL pending a rename under `rf2-k0rbk`; no such bead exists in the
-   tracker, and the rename it anticipated is one the stability rule forbids.)*
+   PROVISIONAL pending a rename under `rf2-k0rbk`. That marker was a DISCHARGED
+   promise, not a dangling one: `rf2-k0rbk` — "confirm or rename the provisional
+   error id" — was a real bead, and it closed on 2026-08-06 answering
+   **confirm**, so the rename never came. It has since been garbage-collected
+   out of the live tracker, which is why `bd show rf2-k0rbk` now finds nothing;
+   absence from the tracker is not evidence a bead never existed, and existence
+   is decidable in the git history of `.beads/issues.jsonl` rather than in the
+   tracker. The rename it anticipated is in any case one the stability rule
+   forbids.)*
 3. **The name `h/frame` is unfrozen**, as `h/root!` is.
 4. **A diagnostic gap `rf2-2rtt6.122` opened, which is arguably a small bug of its
    own.** The arm's refusal detail is written for the two doors it was aimed at —

--- a/skills/re-frame-migration/references/guided-handlers-state.md
+++ b/skills/re-frame-migration/references/guided-handlers-state.md
@@ -191,37 +191,41 @@ Present the categorisation per site; confirm with the author; only then apply. F
 
 ## M-42 — React-19-removed Reagent surfaces (bridge *and* slim)
 
-**Trigger**: fires on **both** Reagent paths, because the render call site breaks on the React-19 floor both adapters target. On the **bridge**, stock Reagent 2.x still ships the `reagent.dom/render` Var — but React 19 removed `react-dom/render` underneath it, so the Var warns and no-ops at runtime; the call site must be rewritten to `reagent.dom.client/create-root` + `render`. On **slim**, the legacy `reagent.dom` render surface is absent entirely (the render API lives at `reagent2.dom.client`), so the same call site fails at **compile** time with an unresolved-var error. Either way the render call site needs a createRoot+render **rewrite**; only the **target namespace** differs. The *other* legacy symbols (`dom-node`, `force-update-all`, `unmount-component-at-node`) are **absent on slim** (a compile-time unresolved-var, not a runtime shim throw) but **unchanged on the bridge** (stock Reagent has not removed them — only the React-DOM `render`/`createRoot` floor moved).
+**Trigger**: fires on **both** Reagent paths, because the render call site breaks on the React-19 floor both adapters target. On the **bridge**, stock Reagent 2.x still ships the `reagent.dom/render` Var — but React 19 removed `react-dom/render` underneath it, so the Var warns and no-ops at runtime. On **slim**, the legacy `reagent.dom` render surface is absent entirely, so the same call site fails at **compile** time with an unresolved-var error. Either way the render call site needs a **rewrite** — and the rewrite target is the **adapter's own client root** (`re-frame.adapter.reagent/client-root` + `render!`), not a caller-owned `create-root`. The *other* legacy symbols (`dom-node`, `force-update-all`, `unmount-component-at-node`) are **absent on slim** (a compile-time unresolved-var, not a runtime shim throw) but **unchanged on the bridge** (stock Reagent has not removed them — only the React-DOM `render`/`createRoot` floor moved).
 
-> **Do not read "apps on the bridge are unaffected" (MIGRATION.md §M-42) as "the bridge needs no render change."** That sentence is about the legacy Vars still *existing* on the bridge (stock Reagent 2.x has not removed them). But the **render call site still needs the createRoot rewrite on the bridge too**: the `reagent.dom/render` Var survives, yet React 19 removed the `react-dom/render` it delegated to, so it warns and no-ops at runtime. The bridge just targets a different namespace (`reagent.dom.client`) than slim.
+> **Do not read "apps on the bridge are unaffected" (MIGRATION.md §M-42) as "the bridge needs no render change."** That sentence is about the legacy Vars still *existing* on the bridge (stock Reagent 2.x has not removed them). But the **render call site still needs the rewrite on the bridge too**: the `reagent.dom/render` Var survives, yet React 19 removed the `react-dom/render` it delegated to, so it warns and no-ops at runtime.
 
-**The adapter-keyed render-namespace table** (the render rewrite is the same shape — `create-root` + `render` around the same `container` — only the namespace changes):
+**The rewritten boot namespace is the same on both coordinates.** The published `day8/reagent-slim` artefact ships its adapter at the canonical `re-frame.adapter.reagent` ns, and both artefacts publish the same `client-root` / `render!` / `unmount!` trio — so the migrated file compiles unchanged against either. The app never requires `reagent.dom.client` *or* `reagent2.dom.client`: the adapter owns the React root, and the coordinate is chosen in `deps.edn`, not in the boot line.
 
-| Adapter the app boots | Render namespace (createRoot + render) | Coord |
+| Adapter the app boots | Boot namespace it requires | Coord |
 |---|---|---|
-| **classic bridge** (stock Reagent 2.x + `re-frame.adapter.reagent`) | `reagent.dom.client` | `day8/re-frame2-reagent` |
-| **slim rewrite** (`re-frame.adapter.reagent-slim`) | `reagent2.dom.client` | `day8/reagent-slim` |
+| **classic bridge** (stock Reagent 2.x) | `re-frame.adapter.reagent` | `day8/re-frame2-reagent` |
+| **slim rewrite** | `re-frame.adapter.reagent` | `day8/reagent-slim` |
 
 ```clojure
 ;; v1 (both paths) — reagent.dom/render no-ops under React 19 (bridge) / is absent (slim)
 (reagent.dom/render [app] (.getElementById js/document "app"))
 
-;; bridge — create-root + render via reagent.dom.client
-(defonce root (rdc/create-root (.getElementById js/document "app"))) ; [reagent.dom.client :as rdc]
-(rdc/render root [app])
+;; v2 (both paths, byte-identical) — the adapter owns the root.
+;; [re-frame.adapter.reagent :as reagent-adapter]
+;;
+;; `client-root` allocates an inert handle: no DOM work at namespace load, so
+;; the `defonce` is safe to evaluate on every hot reload. The first `render!`
+;; through the handle creates the React root; every later one renders into
+;; that same root, which is what makes `^:dev/after-load` re-render rather
+;; than mount a second, fighting root.
+(defonce app-root (reagent-adapter/client-root))
 
-;; slim — identical shape, reagent2.dom.client target
-(defonce root (rdc/create-root (.getElementById js/document "app"))) ; [reagent2.dom.client :as rdc]
-(rdc/render root [app])
+(reagent-adapter/render! app-root [app] (.getElementById js/document "app"))
 ```
 
-Pick the row by the **adapter artefact M-0 committed** — that disambiguates the namespace without inspecting the substrate source.
+M-0's committed artefact still decides the **coordinate**, but it no longer changes a line of the boot namespace — which is the point of the adapter-owned root, and the reason there is no namespace to disambiguate here any more.
 
 **Identify**: grep for call sites of `render` (`reagent.dom/render`, `reagent.core/render`), plus — *on slim only* — the other removed symbols: `unmount-component-at-node`, `dom-node`, `force-update-all`, plus the `reagent.dom.server` surface per the MIGRATION.md list.
 
 **Risk + decision shape — split by symbol**:
 
-1. **`render` / `unmount-component-at-node` (Type A — mechanical, *both* adapters for `render`)**: rewrite to a `create-root` + `render` / `unmount` pair around the same `container`, in the adapter-appropriate namespace from the table above. Apply once the caller's `container` reference is identified — this half rides the normal Type A sweep with the sweep-level announcement (Cardinal rule 4). (`unmount-component-at-node` is only *removed* on slim; on the bridge it remains available, but the surrounding render rewrite usually makes the `create-root`-returned root's `unmount` the natural target anyway.)
+1. **`render` / `unmount-component-at-node` (Type A — mechanical, *both* adapters for `render`)**: rewrite to a `defonce` `client-root` handle plus `render!` / `unmount!` around the same `container`, on the canonical `re-frame.adapter.reagent` ns for either coordinate. Apply once the caller's `container` reference is identified — this half rides the normal Type A sweep with the sweep-level announcement (Cardinal rule 4). (`unmount-component-at-node` is only *removed* on slim; on the bridge it remains available, but the surrounding render rewrite makes the adapter's `unmount!` on that same handle the natural target anyway.)
 2. **`dom-node` (Type B — ask first; slim only)**: `findDOMNode` returned the underlying DOM node for a mounted component; the canonical React-19 replacement captures the node via `:ref` at the call site **of the parent**, not at the consumer. There is **no static-analysable rewrite** — the agent flags every `dom-node` site and the author supplies the parent ref ownership. (Available unchanged on the bridge.)
 3. **`force-update-all` (Type B — ask first; slim only)**: had no documented use beyond global-rebuild scripts. Flag every site and ask the maintainer whether it can be removed entirely; if not, file a GitHub issue (per the [`issue-filing.md`](issue-filing.md) recipe) rather than inventing a replacement. (Available unchanged on the bridge.)
 

--- a/skills/re-frame2-pair/tests/fixture/src/counter/core.cljs
+++ b/skills/re-frame2-pair/tests/fixture/src/counter/core.cljs
@@ -13,8 +13,7 @@
  `data-rf2-source-coord` attribute on every registered-view root, so it is
  present on the rendered DOM here — re-frame2-pair's DOM ↔ source bridge depends
  on it (Tool-Pair §Source-mapping, Spec 006 §Source-coord annotation)."
- (:require [reagent.dom.client :as rdc]
- [re-frame.core :as rf]
+ (:require [re-frame.core :as rf]
  [re-frame.views]
  [re-frame.adapter.reagent :as reagent-adapter])
  (:require-macros [re-frame.core :refer [reg-view]]))
@@ -63,8 +62,10 @@
 
 ;; -- Mount --------------------------------------------------------------------
 
-(defonce root
- (rdc/create-root (js/document.getElementById "app")))
+;; The adapter owns the React root. `client-root` allocates an inert handle —
+;; no DOM work at namespace load — and the first `render!` through it creates
+;; the root every later render reuses.
+(defonce app-root (reagent-adapter/client-root))
 
 (defn ^:export run []
  ;; Source-coord DOM annotation is automatic in debug builds (mandatory per
@@ -82,4 +83,6 @@
  (rf/make-frame {:id :rf/default})
  (rf/with-frame :rf/default
   (rf/dispatch-sync [:counter/initialise]))
- (rdc/render root [rf/frame-provider {:frame :rf/default} [counter-app]]))
+ (reagent-adapter/render! app-root
+  [rf/frame-provider {:frame :rf/default} [counter-app]]
+  (js/document.getElementById "app")))

--- a/skills/re-frame2/references/fundamentals/frames.md
+++ b/skills/re-frame2/references/fundamentals/frames.md
@@ -124,10 +124,17 @@ And establishing the app frame at boot (the runtime infers no frame, so you regi
    :fx-overrides {:rf.http/managed :auth.login.demo/managed-stub}})
 
 ;; ...then scope it at the root so bare dispatch/subscribe resolve to it
-;; (frame-provider {:frame …} — the frame already exists from make-frame above):
-(rdc/render root
+;; (frame-provider {:frame …} — the frame already exists from make-frame above).
+;; The adapter owns the React root: `client-root` hands back an inert handle
+;; (no DOM work at namespace load), and the first `render!` through it creates
+;; the root every later render reuses. `app-root` is that handle; `main-view`
+;; is your application's root view — two different things, two different names.
+(defonce app-root (reagent-adapter/client-root))
+
+(reagent-adapter/render! app-root
   [rf/frame-provider {:frame :app/login}
-   [app-root]])
+   [main-view]]
+  (js/document.getElementById "app"))
 ```
 
 ## Frame metadata — what goes in it


### PR DESCRIPTION
Three beads from one cluster: two audit reopenings of PR #9047 (one correctness, one completeness) and a remainder whose fence had failed twice.

## 1. rf2-pd9b — CORRECTNESS: the migration snippet shadowed the app view with the root handle

**Confirmed at source, including the "before".** In `docs/core/25-from-re-frame-v1.md` the sweep bound `(defonce app-root (reagent-adapter/client-root))` and then used `[app-root]` in **both** render trees. `git show` of the parent commit shows the pre-sweep text: the raw handle was named `root` and `[app-root]` **was** the application view. So the new `def` silently rebound the view symbol to the handle, and a reader copying the recipe handed Reagent the handle as a component.

**Which symbol I renamed, and why that way round.** The handle keeps the landed spelling `app-root`; the **view** is renamed `main-view`. The audit offered `client-root`/`app-root` as an example, but renaming the handle would have introduced a second spelling of the migration at 1 of 40 sites: a census of `(defonce … (reagent-adapter/client-root))` finds **39 other sites and every one of them names the handle `app-root`**. `main-view` is not invented either — it is the spelling in `docs/core/frames.md`, which the prose two lines above the snippet links to. A comment now names the two roles so the collision cannot be reintroduced.

**Surrounding prose checked**: `app-root` and `main-view` appear nowhere else on the page (grep over the whole file), so no prose moved. `main-view` was previously unused there.

**No gate inspected this fix** — see section 4.

## 2. rf2-k5r9t — COMPLETENESS: three raw-root sites survived a close that said "No REMAINDER"

### My own census, with every needle beside its control

Run over **4,164 git-tracked text files** in three independent passes — line-oriented, whitespace-flattened, and de-hyphenated-then-flattened — because none of the three is a superset of the others. Fixed-string matching throughout (Python `str.find`), so no shell/regex quoting hazard.

| needle | line files | line hits | flattened files | de-hyphenated files | role |
|---|---|---|---|---|---|
| `rdc/` | 86 | 406 | 86 | 86 | target |
| `create-root` | 136 | 353 | 136 | 136 | target |
| `reagent.dom.client` | 103 | 142 | 103 | 103 | target |
| `reagent-dom-client` | 0 | 0 | 0 | 0 | target (the false-negative needle) |
| `client-root` | 59 | 142 | 59 | 59 | **control — present** |
| `frame-root` | 153 | 746 | 153 | 153 | **control — present** |

Both controls read non-zero through the same pipeline and flags, so a zero from this instrument means absence rather than a broken pattern. `reagent-dom-client` — the spelling in this bead's own **earlier title** — reads **0 on all three passes**: searching the obvious needle reports "already fixed" with confidence. `create-root` alone also misses sites (it does not catch a bare `rdc/render`), which is why several needles were reconciled rather than one trusted.

**All three passes agreed on every needle** — no file was found only by the flattened or only by the de-hyphenated pass. That is a result the third pass was needed to establish, not a reason it was unnecessary.

**Both census traps reproduced independently on this machine (GNU grep 3.0):** `grep -rni 'rdc/'` gives **402**, `grep -rnF` gives **402**, `grep -rn` gives **402**, but `grep -rnFi` gives **0**. `-F` combined with `-i` returns zero silently.

### The landed replacement shape I matched, and where I found it

`examples/core/counter/core.cljs` (the file the pair fixture claims to mirror) and `skills/re-frame2-setup/references/first-counter.md:157`:

```clojure
(defonce app-root (reagent-adapter/client-root))
(reagent-adapter/render! app-root <tree> <dom-node>)
```

Arity verified against the adapter itself — `client-root` is 0-arity and `render!` is `(render! handle render-tree mount-point [opts])`, per `implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs` and the spine's `render-client-root!`.

### The three sites, all repaired

1. **`skills/re-frame2/references/fundamentals/frames.md`** — the "Canonical mini-example" mounted with `(rdc/render root …)`, where `rdc` and `root` were never defined in the snippet. It also used `[app-root]` as the view, so it carried the **same latent collision as item 1**; repaired the same way.
2. **`skills/re-frame-migration/references/guided-handlers-state.md` (M-42)** — prescribed caller-owned `create-root` + `render` keyed to a two-row per-adapter *render-namespace* table. **The premise that table rests on is refuted at source**: `implementation/adapters/reagent-slim/test/…/reagent_slim_surface_parity_cljs_test.cljs` states the published slim artefact ships its adapter at the canonical `re-frame.adapter.reagent` ns and **pins the `client-root` / `render!` / `unmount!` trio equal on both adapters**. So the migrated boot namespace is identical on either coordinate and requires neither `reagent.dom.client` nor `reagent2.dom.client`. The table now keys the **coordinate** (which still differs) rather than a namespace (which no longer does). M-42's heading, its anchor, and its Type A / Type B symbol split are unchanged; `unmount-component-at-node` now points at the adapter's `unmount!` on the same handle.
3. **`skills/re-frame2-pair/tests/fixture/src/counter/core.cljs`** — required `reagent.dom.client` and, worse, did **DOM work at namespace load** (`(defonce root (rdc/create-root (js/document.getElementById "app")))`), which is the precise anti-pattern the example it claims to mirror warns about. Now an inert `client-root` handle with the DOM lookup moved into `run`. Its "Mirrors `examples/core/counter/core.cljs`" claim is true again.

### A fourth in-class site I did NOT edit, and why

**`skills/re-frame-migration/references/auto-cross-cutting.md` (3 hits, lines ~356 / 368 / 385)** teaches a "Corrected canonical v2 boot order" using `rdomc/create-root` + `rdomc/render`. This is an **ordinary app-boot surface — not low-level, not deliberately foreign-root** — so it is genuinely in the adoption class. It is outside this dispatch's write surface, and rf2-k5r9t's own reopening note says "Keep the repair bounded to those three", so I left it and am reporting it instead. **It needs a follow-up bead.**

Sites deliberately left because they are correctly out of class: UIx entrypoints (`uix.dom/create-root` — UIx owns its own root by design, per the sweep's own commit message), `skills/reagent-migration/**` (the Reagent v1-to-v2 skill, including the SSR "before" example the audit calls intentional), `skills/re-frame2-setup/**` and `docs/core/how-to/boot-and-mount-an-app.md` prose that names `create-root` only to explain that the adapter now owns it, and `skills/re-frame2-setup/tests/setup_drift_test.clj` (a test pinning a troubleshooting row). The `docs/` teaching trees are otherwise clean of Reagent raw-root boot recipes.

## 3. rf2-fgwf — DISCHARGED PROMISES, verified in the export's git history

**The bead's description is refuted, and I verified the refutation myself rather than taking it on report.** The tracker is garbage-collected, so absence from `bd show` proves nothing. Existence is decidable in the git history of `.beads/issues.jsonl`:

- **`rf2-k0rbk` is real** — "rf2-2rtt6.122 follow-up: confirm or rename the provisional error id…", `closed_at 2026-08-06T01:22:51Z`, close reason: "…`:rf.error/ambient-frame-refused` stands… Remaining touch: the provisional stamps' removal is a one-line comment/docs touch."
- **`rf2-e28wl` is real** — `closed_at 2026-08-05T06:26:01Z`, "Fixed in PR #7533."

Method: `git show <2026-08-06 export commit>:.beads/issues.jsonl` (a 3,148-row export), then a fixed-string search for each `"id":"…"`. Run with **both controls**: a known-present id (`rf2-so3io`) gives 1, and a known-absent one (`rf2-ZZZZZ`) gives 0. So the instrument discriminates in both directions.

**Citations kept as provenance; resolutions recorded beside them.** Three sites in `docs/design/hicasso/studio/hframe-design.md` — one more than the bead's note named:

- **:266** — the rename-economy argument is marked discharged, and the indirection is re-justified on the reason that outlives the rename (a carry and a read must refuse *identically*, so a live read is what makes the agreement the property under test).
- **:311** — records that `rf2-e28wl` landed in PR #7533. **Verified at source**: the Spec 009 row no longer enumerates `:operation` as `(:dispatch / :subscribe)` (0 matches); it now states the rule — the category is defined by the DOOR and `:operation` is documented as an **OPEN set**.
- **:343 — a third site the bead's note did not name.** Section 9 item 2's parenthetical asserted "no such bead exists in the tracker". That is the refuted claim, sitting in the document as a positive statement. It now records that the bead was real, closed **confirm**, and was later garbage-collected — and that existence is decidable in the export's git history rather than in the tracker.

Both halves of this bead have now moved.

## 4. Which edits sit inside fenced blocks that no gate inspected

**Measured, not assumed — the same broken link planted twice in `docs/core/25-from-re-frame-v1.md`:**

| where | `check_doc_slugs.py` |
|---|---|
| in prose (line 138) | **exit 1**, naming file, line and target |
| inside the fenced snippet (line 144) | **exit 0**, silent |

So `check_doc_slugs.py` inspected **none** of the following, which are all inside fences: the item-1 snippet, the skills `frames.md` mini-example, M-42's code block, and the whole of the `.cljs` fixture. Those were verified by reading, plus the arity check against the adapter source above.

The `mkdocs build --strict` non-coverage was measured the same way: a broken link planted in `docs/core/` gives **exit 1** naming it; the identical fault planted in `docs/design/hicasso/studio/hframe-design.md` **and** `skills/re-frame2/references/fundamentals/frames.md` gives **exit 0**, with the planted target appearing nowhere in the log. So mkdocs is the gate for item 1 only, exactly as briefed.

Table column counts and headings were checked by hand: every changed markdown file's heading set is **byte-identical to its base version** (diff of `^#` lines), and the rewritten M-42 table is 3 columns across header, delimiter and both rows.

## Gates — all foreground, unfiltered, exit codes captured on the runner's own command line

Re-run on the **final rebased base** (`origin/main` cfcc30a; 12 commits had landed, **none touching these five files**, so nothing here reverts a sibling):

| gate | exit | evidence it read this worktree |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | planted fault gives exit 1 naming file and line |
| `python -m mkdocs build --strict` | **0** | planted fault gives exit 1 naming the link |
| `python scripts/check_provenance_pins.py` | **0** | 153 pages, 821 pins, 0 findings; planted stranded pin gives exit 1, pins 821 to 822, findings 0 to 1, naming `hframe-design.md:266` |
| all **14** `scripts/check_skill_*.py` (8 are `*_drift.py`) | **0** each | `check_skill_re_frame2_drift.py` with planted residue gives exit 1 naming `frames.md:102` |
| `bb tests/prompts/…` + `tests/runtime/*_test.clj` (the `skills-structural` job) | **0** | see the caveat below |
| `sh scripts/test-fast-pr.sh` | **0** | prints `gate root: …/clientroot-a`; 74 gates |

`sh scripts/test-fast-pr.sh --plan` reports **`docs=true jvm=false node=false (classified)`** — the documentation tier only.

**One honest negative result.** The `skills-structural` suite passed **with an unresolvable var planted in the fixture** (`reagent-adapter/THIS-VAR-DOES-NOT-EXIST`), so it does **not** compile or read the fixture source; its green says nothing about item 2 site 3. The surface classifier (run on **paths**, its documented input, not revisions) shows the fixture arms `mcp_conformance`, `mcp_live` and `skills_structural`, and the first two are CI-only compiles. Exercised in both directions: `implementation/core/src/re_frame/frame.cljc` arms 16 surfaces, `README.md` arms none, and of these five files only the fixture arms anything. So the fixture's real gate is **CI's `mcp-conformance-re-frame2-pair` / `re-frame2-pair-fixture-pure`** — please read those on this PR. Locally I substituted what I could: the file **reads cleanly with the Clojure reader** at the same top-level form count as its base version (10 forms), with the reader exercised against a deliberately unbalanced copy to confirm it exits 1.

All sabotage plants were restored and **each restore verified by git blob hash** against the pre-plant value (`core.autocrlf=true` here, so a byte digest of the working file would have been the wrong instrument).

Closes rf2-pd9b, rf2-k5r9t, rf2-fgwf.
