### PR TITLE
fix(xray): single-use dead-frame sentinel + opener-reload announcement for the pop-out (rf2-ws60, rf2-uong)

### DIFF
--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -412,8 +412,25 @@ Constraints inherited from the `window.opener` posture:
   overlay is also torn down by `teardown-popout-state!` (test path)
   and on the popout's own `pagehide` / `unload`.
 - The pop-out can't survive a hard reload of the opener — atoms get
-  garbage-collected. Pop-out re-bootstraps on opener reload by
-  re-reading `window.opener.xrayRuntime`.
+  garbage-collected, and so does everything else Xray runs for the
+  pop-out, because it ALL lives in the opener's JS realm: the render
+  tree, the `popout-state` atom, and the watchdog timer above (its
+  `setInterval` is registered on the OPENER's window). Re-bootstrapping
+  on opener reload by re-reading `window.opener.xrayRuntime` remains
+  normative-future (see the status note below): the pop-out does NOT
+  re-bootstrap today. It announces instead. Per `rf2-uong`
+  `popout!` registers a `pagehide` listener on the OPENER window
+  (`register-opener-reload-announcer!`) which reveals the same
+  opener-gone overlay while the opener's realm is still alive and
+  still holds the pop-out's DOM handle. The reveal persists because
+  the pop-out's own document is not reloaded. The user closes the
+  stale pop-out and opens a fresh one.
+
+  The announcer is `pagehide` ONLY — never `unload` / `beforeunload`,
+  which would make the DEVELOPER'S OWN APPLICATION WINDOW ineligible
+  for the back/forward cache. It ignores a `persisted` pagehide (a
+  bfcache freeze a back-navigation can resume) and guards on pop-out
+  window identity, as the external-close cleanup below does.
 
 > **Status (rf2-9vm0): the `window.opener.xrayRuntime` handle in the last
 > bullet is normative-future — nothing in `tools/xray/src` sets or reads
@@ -428,15 +445,32 @@ Constraints inherited from the `window.opener` posture:
 > against an `opener` control returning 79 and a `popout` control
 > returning 165.
 >
-> **The bullet's second claim is a real gap, not drift, and is tracked
-> rather than marked away (rf2-uong).** With no handle there is no
-> re-bootstrap, and `opener-gone?` is `(or (nil? opener) (.-closed
-> opener))` — a same-origin hard reload leaves `window.opener` live and
-> `.closed` false, so the watchdog never fires and the opener-gone overlay
-> never shows. The pop-out keeps rendering against the previous realm's
-> atoms: silently stale rather than visibly broken. Whether the fix is to
-> widen the predicate, to build the re-bootstrap, or to declare the reload
-> case out of scope is open on that bead.
+> **The bullet's second claim — the re-bootstrap — is RESOLVED, and not
+> the way it was written (rf2-uong).** The reload case was real: with no
+> handle there is no re-bootstrap, and `opener-gone?` is `(or (nil?
+> opener) (.-closed opener))` — a same-origin hard reload leaves
+> `window.opener` live (a WindowProxy survives navigation, now fronting
+> the NEW realm) and `.closed` false, so the watchdog never fired and the
+> pop-out kept rendering against the previous realm's atoms: silently
+> stale rather than visibly broken.
+>
+> **Widening the predicate would not have fixed it, which is why the
+> shipped answer is neither of the two shapes first proposed.** The
+> watchdog does not survive the event it would be asked to detect: its
+> `setInterval` timer is registered on the OPENER's window, so the reload
+> that makes the pop-out stale also destroys the watchdog. After the
+> reload nothing of Xray's is left running to evaluate any predicate.
+> Detecting it after the fact would require Xray code in the POP-OUT's own
+> realm, which today runs none — the pop-out document is opened blank and
+> rendered into from the opener — so it would mean injecting a `<script>`.
+>
+> **What ships instead is an opener-side announcement**, described in the
+> bullet above: the opener reveals the existing overlay at `pagehide`,
+> while its realm is still alive and still holds the pop-out's DOM handle.
+> No new pop-out-realm surface, no re-bootstrap machinery, and the
+> overlay's copy now names a reload as well as a close. The
+> `window.opener.xrayRuntime` handle stays normative-future per the marker
+> above; nothing in the shipped behaviour depends on it.
 
 Solves the "I want Xray on a second monitor while the app runs
 full-screen" use case.

--- a/tools/xray/src/day8/re_frame2_xray/mount.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/mount.cljs
@@ -1026,14 +1026,23 @@
 
 (defn- teardown-popout-state!
   "Internal: tear down the popout singleton if present. Invokes the
-  substrate unmount, clears the opener-gone watchdog, attempts to
-  close the popout window, and clears the singleton. All steps run
-  inside swallow-errors guards — this is a last-chance cleanup (test
+  substrate unmount, clears the opener-gone watchdog, detaches the
+  opener-side `pagehide` announcer, attempts to close the popout
+  window, and clears the singleton. All steps run inside
+  swallow-errors guards — this is a last-chance cleanup (test
   fixture, opener-side unload), not a contract-checking call site."
   []
-  (when-let [{:keys [window unmount watchdog-id]} @popout-state]
+  (when-let [{:keys [window unmount watchdog-id
+                     opener-window opener-pagehide-handler]} @popout-state]
     (when watchdog-id
       (try (js/clearInterval watchdog-id) (catch :default _ nil)))
+    ;; rf2-uong — drop the opener-side `pagehide` announcer. Unlike the
+    ;; watchdog (a timer owned by this realm) the listener would otherwise
+    ;; accumulate across repeated popout open/close cycles in ONE opener
+    ;; realm, each survivor closing over a now-detached overlay node.
+    (when (and opener-window opener-pagehide-handler)
+      (try (.removeEventListener opener-window "pagehide" opener-pagehide-handler)
+           (catch :default _ nil)))
     (when unmount
       (try (unmount) (catch :default _ nil)))
     (when window
@@ -1253,10 +1262,17 @@
       (set! (.-fontSize s)    "20px")
       (set! (.-fontWeight s)  "600")
       (set! (.-marginBottom s) "12px"))
+    ;; rf2-uong — the overlay now also fires on an opener RELOAD, so the
+    ;; copy must not assert "closed": a reloaded opener is still on screen,
+    ;; and a message contradicting what the user can see reads as a bug in
+    ;; Xray rather than an explanation. Name the cause generically and say
+    ;; what to do; "no longer connected to the running runtime" is the true
+    ;; statement common to closed, navigated-away and reloaded openers.
     (set! (.-textContent hint)
-          (str "The host application window has been closed. "
-               "This Xray pop-out is no longer connected to a "
-               "running runtime — close this window."))
+          (str "The host application window was closed or reloaded. "
+               "This Xray pop-out is no longer connected to the "
+               "running runtime — close this window and open a "
+               "fresh pop-out."))
     (let [s (.-style hint)]
       (set! (.-color s)      opener-gone-overlay-secondary)
       (set! (.-fontSize s)   "14px")
@@ -1318,6 +1334,76 @@
         id      (js/setInterval tick 500)]
     (reset! id-atom id)
     id))
+
+;; ---- popout opener-RELOAD announcer (rf2-uong) ---------------------------
+;;
+;; The watchdog above cannot see an opener RELOAD, and widening its
+;; predicate would not help — the watchdog does not survive the event it
+;; would be asked to detect.
+;;
+;; Everything Xray runs for the popout lives in the OPENER's JS realm:
+;; `popout!` is called from the opener, `substrate-adapter/render` paints
+;; the popout's DOM from there, `popout-state` is an opener-realm atom, and
+;; `start-opener-gone-watchdog!`'s `js/setInterval` registers its timer on
+;; the OPENER's window. A hard reload of the opener discards that realm and
+;; every timer, closure and atom it owned. So after the reload there is no
+;; tick left to evaluate any predicate, however widened — and meanwhile
+;; `window.opener` still resolves (a WindowProxy survives navigation,
+;; now fronting the NEW realm) with `.closed` false, so even a surviving
+;; watchdog would read "opener fine".
+;;
+;; Detecting it AFTER the fact would therefore need Xray code running in
+;; the POPOUT's own realm, which today runs none — the popout document is
+;; opened blank and rendered into from the opener. That means injecting a
+;; `<script>`: real new surface, for a case the opener can simply announce.
+;;
+;; So the opener announces its own death on the way out. At `pagehide` the
+;; opener's realm is still alive and still holds the direct DOM handle to
+;; the popout's overlay node (same-origin, no serialisation layer — the
+;; popout's whole posture), so revealing the overlay is the SAME
+;; `show-opener-gone-overlay!` the watchdog calls, reached from a different
+;; edge. The mutation lands in the popout's document, which is NOT reloaded,
+;; so it persists after the opener realm is gone.
+;;
+;; `pagehide` fires for reload, cross-document navigation AND close, so this
+;; also backstops the cases the watchdog already covers.
+
+(defn- register-opener-reload-announcer!
+  "Reveal the popout's opener-gone overlay when the OPENER window unloads —
+  the hard-reload case `opener-gone?` structurally cannot observe (rf2-uong).
+  Returns the registered handler so `teardown-popout-state!` can detach it,
+  or nil when no listener could be registered.
+
+  `opener-win` is passed rather than read from `js/window` so the dependency
+  is explicit and a test can drive the listener against a stub.
+
+  `pagehide` ONLY, deliberately — never `unload`/`beforeunload`. This
+  listener goes on the DEVELOPER'S OWN APPLICATION WINDOW, and an `unload`
+  or `beforeunload` handler makes a page ineligible for the back/forward
+  cache in every major browser. Xray is a devtool: it must not degrade the
+  navigation behaviour of the app it is inspecting to report on itself.
+  `pagehide` is the specified replacement and carries no such penalty.
+
+  Two guards:
+
+  - **`persisted`** — a persisted `pagehide` is a bfcache FREEZE, not a
+    teardown, and a back-navigation can resume the very realm (and popout
+    render tree) that is being suspended. Announcing there would cry wolf
+    over a popout about to work again, so only a non-persisted pagehide
+    reveals.
+  - **window identity** — mirrors `register-popout-unload-cleanup!`: a
+    stale handler must not paint over a popout that a fresh `popout!` has
+    since replaced."
+  [opener-win win overlay-node]
+  (when (and (some? opener-win) (.-addEventListener opener-win))
+    (let [handler (fn opener-pagehide-handler [event]
+                    (when (and (not (.-persisted event))
+                               (some-> @popout-state :window (identical? win)))
+                      (show-opener-gone-overlay! overlay-node)))]
+      (try
+        (.addEventListener opener-win "pagehide" handler)
+        handler
+        (catch :default _ nil)))))
 
 ;; ---- popout stylesheet hand-off (rf2-czcg5) -----------------------------
 ;;
@@ -1388,7 +1474,15 @@
   watchdog reveals the spec'd 'opener gone — close this window'
   overlay so the popout is not left in a frozen-or-broken state
   with no UI signal as to the cause. See `install-opener-gone-
-  overlay!` + `start-opener-gone-watchdog!` for the contract."
+  overlay!` + `start-opener-gone-watchdog!` for the contract.
+
+  Per rf2-uong that pair is joined by an opener-side `pagehide`
+  announcer, because the watchdog covers only the cases in which
+  the OPENER'S REALM OUTLIVES the event. A hard reload of the
+  opener destroys the realm that owns the watchdog's timer, so no
+  widening of `opener-gone?` could catch it; instead the opener
+  reveals the overlay itself on its way out, while it still holds
+  the popout's DOM handle. See `register-opener-reload-announcer!`."
   []
   (if-let [state @popout-state]
     state
@@ -1429,13 +1523,19 @@
                                        node nil)
                         overlay-node (install-opener-gone-overlay! doc)
                         watchdog-id  (start-opener-gone-watchdog! win overlay-node)
+                        ;; rf2-uong — the reload case the watchdog cannot
+                        ;; see, because the reload destroys the watchdog.
+                        announcer    (register-opener-reload-announcer!
+                                       js/window win overlay-node)
                         state        {:ok?          true
                                       :window       win
                                       :node         node
                                       :unmount      unmount
                                       :mode         :popout
                                       :overlay-node overlay-node
-                                      :watchdog-id  watchdog-id}]
+                                      :watchdog-id  watchdog-id
+                                      :opener-window           js/window
+                                      :opener-pagehide-handler announcer}]
                     (reset! popout-state state)
                     (register-popout-unload-cleanup! win)
                     state)))))))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/local_render.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/local_render.cljc
@@ -103,10 +103,11 @@
   explicit operator act, never a process-global toggle."
   :rf.egress/local-raw)
 
-(def ^:private dead-frame-sentinel
-  "A frame id that can NEVER resolve to a live frame, stamped as the `:frame`
-  opt to FAIL CLOSED a nil / unreachable egress frame WITHOUT borrowing the
-  ambient scope.
+(defn- fresh-dead-frame-sentinel
+  "Mint a FRESH frame id that can never resolve to a live frame, stamped as the
+  `:frame` opt to FAIL CLOSED a nil / unreachable egress frame WITHOUT borrowing
+  the ambient scope. A new identity PER CALL — see §Why per-call below, which is
+  the half a shared singleton got wrong.
 
   `rf/elide-wire-value` resolves its governing frame as `(or (:frame opts)
   (frame/resolve-current-frame))` — so a nil `:frame` opt (or no `:frame` at
@@ -127,17 +128,49 @@
   `:day8.re-frame2-xray.panels.local-render/no-egress-frame`; a live frame
   registered under that id made the stamp RESOLVE, took the walker's LIVE-frame
   branch, and shipped the value RAW under that frame's empty declaration
-  registry — the fail-CLOSED stamp becoming fail-OPEN (rf2-ws60). A fresh host
-  object is an IDENTITY rather than a datum — nothing outside this var can
-  produce an equal value — so no registration can match it, and `frame/frame`
-  misses on it exactly as on a destroyed id.
+  registry — the fail-CLOSED stamp becoming fail-OPEN (rf2-ws60, first pass). A
+  host object is an IDENTITY rather than a datum — nothing can *spell* an equal
+  value — so no registration a caller writes by hand can match it, and
+  `frame/frame` misses on it exactly as on a destroyed id.
+
+  ## Why per-call, and not one shared private singleton (rf2-ws60, second pass)
+
+  Making the identity private is NECESSARY AND NOT SUFFICIENT. The second pass
+  bound one `(Object.)` to a `^:private def` and claimed 'no frame can be
+  registered under it' — but the PUBLIC `local-render-opts` RETURNS that value
+  in `:frame` for every nil / unreachable target, so a caller never had to
+  manufacture an equal object: it was HANDED the identical one. Registering a
+  frame under the value it received made every SUBSEQUENT unreachable
+  projection resolve to that live frame and ship the secret raw — the same
+  fail-OPEN outcome as the keyword, reached through the return value instead of
+  through the spelling. Reproduced on the JVM lane at the merged commit:
+  `{:same-sentinel? true, :registered? true, :rendered {:auth {:token \"…\"}}}`.
+
+  So the discriminating question is NOT 'is the definition private' but **does
+  any PUBLIC fn RETURN a structure containing it** — and here one does, by
+  design, because `local-render-opts` is the seam's opts builder. Minting a
+  FRESH identity per call answers it without withdrawing that seam: the value
+  governing any one projection is created inside that call and is not
+  observable by anyone before the walk consumes it, so there is no longer a
+  durable identity to poison. What a direct caller of `local-render-opts`
+  receives is a single-use id that governs nothing else — registering a frame
+  under it cannot affect any other projection.
+
+  Contrast the two sibling carriers, which are clean for the OTHER reason
+  available: in `day8.re-frame2-xray.egress` and `re-frame.derivation.egress`
+  the sentinel is consumed by a walk whose caller only ever receives the
+  PROJECTED VALUE / TRANSFORMED GRAPH, so it has no public exit at all.
 
   Mirrors the off-box derivation-graph fix (rf2-udkj69); applied to
-  local-render by rf2-cra0nq. Third carrier of the sentinel class fixed at
+  local-render by rf2-cra0nq. Third carrier of the sentinel class, alongside
   `day8.re-frame2-xray.egress/no-frame` (rf2-7htk7) and
   `re-frame.derivation.egress` (rf2-g1vu); this file is `.cljc` and IS read on
   the JVM (its test namespace runs under `clojure -M:test`), so the substitute
-  takes the reader-conditional form rather than a bare `(js/Object.)`."
+  takes the reader-conditional form rather than a bare `(js/Object.)`.
+
+  Allocation note: the call sits on the UNREACHABLE branch of an `if`, so a
+  live-frame render — the hot path — mints nothing."
+  []
   #?(:clj (Object.) :cljs (js/Object.)))
 
 (defn local-render-profile
@@ -156,16 +189,25 @@
     the per-(tool,frame) `raw?` grain (default `:rf.egress/local-redacted`).
   - **`:frame`** — ALWAYS stamped: the named `frame-id` when it is LIVE
     (`rf/frame-ids`); otherwise (nil id, a destroyed / never-registered
-    frame) the `dead-frame-sentinel`. We must NOT omit / leave `:frame` nil
-    for an unreachable frame: an absent / nil `:frame` opt lets the walker
-    fall through to the AMBIENT dynamically-bound frame
+    frame) a FRESHLY MINTED dead-frame sentinel. We must NOT omit / leave
+    `:frame` nil for an unreachable frame: an absent / nil `:frame` opt lets
+    the walker fall through to the AMBIENT dynamically-bound frame
     (`frame/resolve-current-frame`) and ship value-bearing fields RAW under
     that borrowed frame's policy — the exact ambient-borrow leak this seam
-    abolishes (rf2-cra0nq, mirroring rf2-udkj69). The sentinel is a non-nil
-    value that NO frame can be registered under (rf2-ws60 — a namespaced
-    keyword was one, and collided), so the walker takes its
+    abolishes (rf2-cra0nq, mirroring rf2-udkj69). So the walker takes its
     unresolvable-frame fail-closed branch (redact the whole value) rather
     than borrow another frame's policy.
+
+    **The sentinel this returns is SINGLE-USE, and that is load-bearing
+    rather than incidental (rf2-ws60).** This fn is PUBLIC and hands the
+    stamped `:frame` straight to its caller, so any sentinel it returned
+    twice would be an id the caller could register a live frame under —
+    making every later unreachable projection resolve to that frame and
+    egress raw, which is exactly how the first two passes at this bug
+    stayed fail-OPEN (a namespaced keyword, then a shared private
+    singleton). Because each call mints a new identity instead, the value
+    you receive governs this opts map only: registering a frame under it
+    cannot affect any other projection. Do not cache, intern, or hoist it.
   - **`:rf.size/include-large? true`** — the on-box 'keep large' override
     (EP-0015 §10: `local-redacted` *suppresses sensitive display*; the
     local operator IS entitled to large values — Xray's own size-bounding
@@ -191,7 +233,7 @@
    (let [reachable? (and (some? frame-id) (contains? (rf/frame-ids) frame-id))]
      {:rf.egress/profile      (local-render-profile raw?)
       :rf.size/include-large? true
-      :frame                  (if reachable? frame-id dead-frame-sentinel)})))
+      :frame                  (if reachable? frame-id (fresh-dead-frame-sentinel))})))
 
 ;; ---------------------------------------------------------------------------
 ;; The projection seam.

--- a/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/mount_cljs_test.cljs
@@ -1612,10 +1612,30 @@
      :listeners listeners
      :closed?   closed?}))
 
+(defn- mk-stub-opener-window-with-listeners
+  "An opener stub that records `addEventListener` / `removeEventListener`
+  calls, so a test can fire the rf2-uong `pagehide` announcer directly and
+  assert the teardown detach."
+  []
+  (let [listeners (atom {})
+        {:keys [window closed?]} (mk-stub-opener-window)]
+    (set! (.-addEventListener window)
+          (fn [event-name handler]
+            (swap! listeners update event-name (fnil conj []) handler)
+            nil))
+    (set! (.-removeEventListener window)
+          (fn [event-name handler]
+            (swap! listeners update event-name
+                   (fn [hs] (vec (remove #(identical? % handler) hs))))
+            nil))
+    {:window window :listeners listeners :closed? closed?}))
+
 (defn- opener-gone?* [win] ((deref #'mount/opener-gone?) win))
 (defn- install-opener-gone-overlay!* [doc] ((deref #'mount/install-opener-gone-overlay!) doc))
 (defn- start-opener-gone-watchdog!* [win overlay-node]
   ((deref #'mount/start-opener-gone-watchdog!) win overlay-node))
+(defn- register-opener-reload-announcer!* [opener-win win overlay-node]
+  ((deref #'mount/register-opener-reload-announcer!) opener-win win overlay-node))
 
 (deftest opener-gone?-true-when-opener-closed
   (testing "rf2-h3ekl: opener-gone? reads window.opener.closed and
@@ -1758,6 +1778,114 @@
         (finally
           (set! (.-setInterval js/globalThis) prior-set)
           (set! (.-clearInterval js/globalThis) prior-clear))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-uong — the OPENER-RELOAD case the watchdog structurally cannot observe.
+;;
+;; `opener-gone?` is `(or (nil? opener) (.-closed opener))`, and a same-origin
+;; hard reload leaves `window.opener` live (a WindowProxy survives navigation)
+;; with `.closed` false — so the predicate reads "opener fine". Widening it
+;; would not help: the watchdog's `setInterval` timer is registered on the
+;; OPENER's window, so the reload that makes the popout stale also destroys
+;; the watchdog. Nothing of Xray's is left running in the popout's realm to
+;; evaluate any predicate at all.
+;;
+;; So the opener announces on its way out, at `pagehide`, while it still holds
+;; the popout's DOM handle. These arms pin that edge.
+;; ---------------------------------------------------------------------------
+
+(deftest opener-gone?-is-false-across-a-reload--why-the-announcer-exists
+  (testing "rf2-uong: the PREMISE. A reloaded opener is neither nil nor
+            .closed, so opener-gone? reads false and the watchdog would
+            never reveal the overlay — this is the gap the announcer fills,
+            not a bug in the predicate"
+    (let [{opener :window} (mk-stub-opener-window)
+          {popout :window} (mk-stub-popout-window-with-opener opener)]
+      (is (false? (opener-gone?* popout))
+          "a live-but-reloaded opener reads as NOT gone — .closed is false
+           and the reference is non-nil, exactly as after a hard reload"))))
+
+(deftest opener-reload-announcer-reveals-overlay-on-pagehide
+  (testing "rf2-uong: the opener's own pagehide reveals the popout overlay,
+            so a hard reload of the host app stops presenting stale panels
+            as live data"
+    (let [{opener :window listeners :listeners} (mk-stub-opener-window-with-listeners)
+          {popout :window} (mk-stub-popout-window-with-opener opener)
+          doc              (.-document popout)
+          overlay          (install-opener-gone-overlay!* doc)]
+      (seed-popout-state! {:window popout})
+      (try
+        (let [handler (register-opener-reload-announcer!* opener popout overlay)]
+          (is (some? handler) "announcer returns its handler for teardown")
+          (is (= [handler] (get @listeners "pagehide"))
+              "the announcer registers on the OPENER window's pagehide")
+          (is (nil? (get @listeners "unload"))
+              "NEVER unload — an unload listener would make the developer's
+               own application window ineligible for the back/forward cache")
+          (is (nil? (get @listeners "beforeunload"))
+              "NEVER beforeunload — same bfcache penalty")
+          (is (= "none" (.-display (.-style overlay)))
+              "overlay hidden before the opener goes away")
+          (handler (js-obj "persisted" false))
+          (is (= "flex" (.-display (.-style overlay)))
+              "a non-persisted opener pagehide reveals the overlay"))
+        (finally
+          (reset! @#'mount/popout-state nil))))))
+
+(deftest opener-reload-announcer-ignores-a-persisted-pagehide
+  (testing "rf2-uong: a persisted pagehide is a bfcache FREEZE a
+            back-navigation can resume — the opener realm, and the popout
+            render tree with it, come back alive. Announcing there would cry
+            wolf over a popout that is about to work again"
+    (let [{opener :window} (mk-stub-opener-window-with-listeners)
+          {popout :window} (mk-stub-popout-window-with-opener opener)
+          doc              (.-document popout)
+          overlay          (install-opener-gone-overlay!* doc)]
+      (seed-popout-state! {:window popout})
+      (try
+        (let [handler (register-opener-reload-announcer!* opener popout overlay)]
+          (handler (js-obj "persisted" true))
+          (is (= "none" (.-display (.-style overlay)))
+              "a persisted (bfcache) pagehide must NOT reveal the overlay"))
+        (finally
+          (reset! @#'mount/popout-state nil))))))
+
+(deftest opener-reload-announcer-guards-on-popout-window-identity
+  (testing "rf2-uong: a stale announcer whose popout window is no longer the
+            registered :window slot must not paint over the popout a fresh
+            popout! has since installed — mirrors the watchdog's guard"
+    (let [{opener :window} (mk-stub-opener-window-with-listeners)
+          {popout :window} (mk-stub-popout-window-with-opener opener)
+          doc              (.-document popout)
+          overlay          (install-opener-gone-overlay!* doc)]
+      ;; popout-state references a DIFFERENT window than the announcer's.
+      (seed-popout-state! {:window (:window (mk-stub-popout-window-with-opener opener))})
+      (try
+        (let [handler (register-opener-reload-announcer!* opener popout overlay)]
+          (handler (js-obj "persisted" false))
+          (is (= "none" (.-display (.-style overlay)))
+              "the identity guard suppressed the reveal on a superseded popout"))
+        (finally
+          (reset! @#'mount/popout-state nil))))))
+
+(deftest teardown-popout-state!-detaches-the-opener-announcer
+  (testing "rf2-uong: teardown removes the opener-side pagehide listener, so
+            repeated popout open/close cycles in ONE opener realm do not
+            accumulate handlers closing over detached overlay nodes"
+    (let [{opener :window listeners :listeners} (mk-stub-opener-window-with-listeners)
+          {popout :window} (mk-stub-popout-window-with-opener opener)
+          doc              (.-document popout)
+          overlay          (install-opener-gone-overlay!* doc)]
+      (seed-popout-state! {:window popout})
+      (let [handler (register-opener-reload-announcer!* opener popout overlay)]
+        (is (= [handler] (get @listeners "pagehide")) "registered before teardown")
+        (swap! @#'mount/popout-state assoc
+               :opener-window opener
+               :opener-pagehide-handler handler)
+        ((deref #'mount/teardown-popout-state!))
+        (is (empty? (get @listeners "pagehide"))
+            "teardown detached the opener-side announcer")
+        (is (nil? @@#'mount/popout-state) "singleton cleared")))))
 
 (deftest teardown-popout-state!-clears-watchdog-interval
   (testing "rf2-h3ekl: when popout-state carries a :watchdog-id slot,

--- a/tools/xray/test/day8/re_frame2_xray/panels/local_render_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/local_render_cljs_test.cljc
@@ -313,3 +313,84 @@
       (finally
         ;; Never leave the colliding id live for a sibling test.
         (rf/destroy-frame! colliding-sentinel-id)))))
+
+;; ---------------------------------------------------------------------------
+;; 7b. THE CALLER-VISIBLE ARM (rf2-ws60, SECOND pass — the audit of PR #9044).
+;;
+;; §7 above registers the RETIRED KEYWORD and then asserts STRUCTURALLY that the
+;; replacement is not a keyword. That is a test about the SHAPE of the sentinel,
+;; and it is why the first repair passed its own regression while still leaking:
+;; making the identity `^:private` is NECESSARY AND NOT SUFFICIENT, because the
+;; PUBLIC `local-render-opts` RETURNS the stamped `:frame` to its caller. Nobody
+;; had to manufacture an equal object — they were handed the identical one, and
+;; a frame registered under it made the next unreachable projection resolve to
+;; that live frame and ship the secret RAW.
+;;
+;; So these arms exercise the value A REAL CALLER RECEIVES, never the definition:
+;; take `(:frame (local-render-opts nil))`, register a live frame under THAT
+;; EXACT VALUE, and assert an unreachable projection still redacts. Against the
+;; pre-fix code this failed with
+;;   {:same-sentinel? true, :registered? true,
+;;    :rendered {:auth {:token "secret-session-jwt-abc123"}}}
+;;
+;; The discriminator this pins is not "is the def private" but "does any PUBLIC
+;; fn RETURN a structure containing it" — answered here by minting a FRESH
+;; identity per call, so the escaped value governs nothing else.
+;; ---------------------------------------------------------------------------
+
+(deftest local-render-fails-closed-when-a-frame-is-registered-under-the-handed-out-sentinel
+  (testing "rf2-ws60 — an app registers a live frame under the sentinel the
+            PUBLIC local-render-opts handed it. A nil / unreachable observed
+            frame MUST still redact the whole value"
+    (let [handed-out (:frame (local-render/local-render-opts nil))]
+      (rf/make-frame {:id handed-out})
+      (try
+        (testing "a NIL observed frame fails closed despite the registration"
+          (let [rendered (local-render/local-render-value app-db-value nil)]
+            (is (= :rf/redacted rendered)
+                (str "nil observed frame must redact WHOLE even with a live "
+                     "frame registered under the sentinel local-render-opts "
+                     "returned. got: " (pr-str rendered)))
+            (is (not= "secret-session-jwt-abc123" (get-in rendered [:auth :token]))
+                "the session token leaked through the handed-out sentinel")))
+
+        (testing "an UNREACHABLE observed frame likewise fails closed"
+          (let [rendered (local-render/local-render-value app-db-value
+                                                          :app/does-not-exist)]
+            (is (= :rf/redacted rendered)
+                (str "unreachable observed frame must redact WHOLE. got: "
+                     (pr-str rendered)))))
+
+        (testing "the PATH-AWARE sibling shares the seam, so it fails closed too"
+          (let [rendered (local-render/local-render-value-at
+                           (:auth app-db-value) nil [:auth])]
+            (is (= :rf/redacted rendered)
+                (str "local-render-value-at must redact WHOLE under the same "
+                     "registration. got: " (pr-str rendered)))))
+
+        (finally
+          (rf/destroy-frame! handed-out))))))
+
+(deftest dead-frame-sentinel-is-single-use-per-projection
+  (testing "rf2-ws60 — the property that makes the handed-out value harmless:
+            each call MINTS A FRESH identity, so a sentinel a caller obtained
+            (and could register a frame under) governs no other projection. A
+            shared singleton is the defect, so assert the values are DISTINCT"
+    (let [a (:frame (local-render/local-render-opts nil))
+          b (:frame (local-render/local-render-opts nil))
+          c (:frame (local-render/local-render-opts :app/does-not-exist))]
+      (is (some? a) "the sentinel is still stamped, never nil/absent")
+      (is (not (identical? a b))
+          (str "two nil-frame opts must NOT share one dead-frame sentinel — a "
+               "reusable identity is registrable by whoever receives it. got: "
+               (pr-str a)))
+      (is (not= a b)
+          "the two sentinels must not be equal either (identity, not a datum)")
+      (is (not (identical? a c))
+          "the nil-frame and unreachable-frame sentinels must differ too")))
+
+  (testing "a LIVE frame is still carried verbatim — minting applies only to the
+            unreachable branch, so the reachable hot path is unchanged"
+    (is (= secure-frame (:frame (local-render/local-render-opts secure-frame))))
+    (is (identical? secure-frame
+                    (:frame (local-render/local-render-opts secure-frame))))))


### PR DESCRIPTION
Two Xray fixes: a security repair that did not hold, and a pop-out that goes silently stale.

## Item 1 — rf2-ws60: the dead-frame sentinel is handed out, so making it private was not enough

### The leak, reproduced at my base before changing anything

PR #9044 replaced the `dead-frame-sentinel` keyword in
`tools/xray/src/day8/re_frame2_xray/panels/local_render.cljc` with a private identity
value. The audit's finding is correct and I reproduced it on the JVM lane at my base
(`146ee34b85`, which contains #9044's `8258cb5d70`) with the source untouched: take
`(:frame (local-render-opts nil))` — the value a real caller receives — register a frame
under that exact value, then project with a nil observed frame.

```
{:same-sentinel? true, :registered? true,
 :rendered {:auth {:token "secret-session-jwt-abc123", :user-id 42}}}
```

Captured exit 1. The secret ships raw; the fail-CLOSED branch is fail-OPEN.

`local-render-opts` is public and returns the singleton in `:frame` for every nil or
unreachable target, so nobody has to manufacture an equal object — they are handed the
identical one. A private definition is necessary and not sufficient.

### The fix

`dead-frame-sentinel` (a shared `def`) becomes `fresh-dead-frame-sentinel` (a `defn-`),
minting a new identity per call. The value governing any one projection is created inside
that call and is not observable before the walk consumes it, so there is no longer a
durable identity to poison: what a direct caller receives is single-use and governs nothing
else. The call sits on the unreachable branch of an `if`, so a live-frame render — the hot
path — mints nothing, and `frame/frame` is a plain registry `get` with no interning or
per-id caching, so fresh identities are immediately garbage.

I kept `local-render-opts` public: it has no production callers outside its own namespace
(only `local-render-value` / `local-render-value-at`, which consume the opts immediately),
and the alternative — returning `:frame nil` for an unreachable target — is the
ambient-borrow shape the whole seam exists to abolish.

### The regression, written against the caller-visible value

The #9044 test registered only the retired keyword and then asserted *structurally* that
the replacement is not a keyword — a test about the SHAPE of the sentinel, which is why it
passed while the code leaked. Two new arms in `local_render_cljs_test.cljc` exercise the
value a real caller receives:

- `local-render-fails-closed-when-a-frame-is-registered-under-the-handed-out-sentinel` —
  takes `(:frame (local-render-opts nil))`, registers a live frame under **that exact
  value**, and asserts nil, unreachable and path-aware (`local-render-value-at`)
  projections all still redact whole.
- `dead-frame-sentinel-is-single-use-per-projection` — asserts two calls do not share one
  identity (the property that makes the escape harmless), and that a live frame is still
  carried verbatim.

**Proof they bite**: I restored the pre-fix source from my base by `git checkout`, verified
the plant by blob-hash equality with the base blob (`3d540bcd82…`), and re-ran the
namespace. Captured **exit 1, 7 failures**, both new tests red. The pre-existing #9044
collision test stayed **green** under the same plant — which is the whole point: it was
blind to this. Restore verified by blob-hash equality (`93810892d5…`).

### Answer on `tools/xray/src/day8/re_frame2_xray/egress.cljs` — CLASS CLOSED

**No fourth instance.** That namespace has exactly one public fn, `egress-value`. It builds
its opts map *inline* as the argument to `rf/elide-wire-value` and returns that walker's
result — the projected value, never the opts map. `no-frame` is `^:private`, never returned,
and consumed only inside the `cond->` that is immediately passed to the walker. Nothing
outside can obtain the identity, so nothing can register a frame under it. Census: only
`egress-value` is required elsewhere (7 files), and nothing reaches `no-frame`.

Same structural shape as carrier 2 — in `re-frame.derivation.egress` the sentinel is bound
into `walk-opts` inside `project-graph`'s `let` and `project-graph` returns the transformed
graph, never the opts map. I re-verified that at the rebased tip, where rf2-g1vu's identity
fix has now landed (`4944195bff`); it was still the keyword at my original base, and the
escape-route verdict is the same either way.

So the discriminator to carry is **not** "is the definition private" but **"does any PUBLIC
fn RETURN a structure containing it"**. Carriers 1 and 2 answer no because the value has no
public exit; carrier 3 answers yes by design, and is repaired by making what escapes
single-use. That is written into the `fresh-dead-frame-sentinel` docstring so the next pass
does not have to re-derive it.

## Item 2 — rf2-uong: the pop-out goes silently stale on an opener reload

### Both source readings verified

1. **No re-bootstrap.** `xrayRuntime` census over `tools/xray/src`: **0** line-oriented and
   **0** whitespace-collapsed, against controls `opener` = 79, `popout` = 165, `.-opener` = 1
   flattened. Matches the bead.
2. **`opener-gone?` does not fire.** It is verbatim
   `(or (nil? opener) (.-closed opener))` with a defensive catch. A same-origin hard reload
   leaves `window.opener` non-nil (a WindowProxy survives navigation, now fronting the new
   realm) and `.closed` false, so the predicate reads "opener fine".

### A third reading, which changes the disposition

**Widening the predicate could not have worked, because the watchdog does not survive the
event it would be asked to detect.** Everything Xray runs for the pop-out lives in the
OPENER's JS realm: `popout!` is called from there, `substrate-adapter/render` paints the
pop-out's DOM from there, `popout-state` is an opener-realm atom, and
`start-opener-gone-watchdog!`'s `js/setInterval` registers its timer on the **opener's**
window. A hard reload discards that realm and every timer, closure and atom it owned — so
after the reload there is no tick left to evaluate any predicate, however widened.

Detecting it after the fact would need Xray code running in the **pop-out's** own realm,
which today runs none (the pop-out document is opened blank and rendered into from the
opener). That means injecting a `<script>`: real new surface.

### The shape I chose, and why

Neither (a) nor (b) from the bead. **The opener announces its own death on the way out.** At
`pagehide` the opener's realm is still alive and still holds the direct DOM handle to the
pop-out's overlay node (same-origin, no serialisation layer — the pop-out's whole posture),
so revealing the overlay is the *existing* `show-opener-gone-overlay!`, reached from a
different edge. The mutation lands in the pop-out's document, which is not reloaded, so it
persists after the opener realm is gone.

This is what the bead's (a) wanted — reuse the built machinery, tell the truth, no new
surface — and unlike (a) it actually works. `pagehide` also fires on navigation and close,
so it backstops the cases the watchdog already covers; the watchdog stays for the
closed / reference-nulled cases.

Two deliberate constraints:

- **`pagehide` only — never `unload` / `beforeunload`.** This listener goes on the
  *developer's own application window*, and an unload handler makes a page ineligible for
  the back/forward cache in every major browser. A devtool must not degrade the navigation
  behaviour of the app it inspects in order to report on itself.
- **Ignore a `persisted` pagehide.** That is a bfcache freeze a back-navigation can resume,
  bringing the opener realm and the pop-out's render tree back alive; announcing there
  would cry wolf.

Plus a window-identity guard mirroring `register-popout-unload-cleanup!`, and detachment in
`teardown-popout-state!` so repeated open/close cycles in one opener realm do not accumulate
handlers.

I also corrected the overlay copy: it said "has been closed", which is false for a reload
(the window is still on screen) and would read as a bug in Xray rather than an explanation.
It now says "was closed or reloaded … close this window and open a fresh pop-out". The copy
is pinned by neither the spec nor any test.

Five new arms in `mount_cljs_test.cljs` pin the premise (`opener-gone?` reads false across a
reload), the reveal, the `persisted` guard, the identity guard, and teardown detachment.

### 011 now describes what ships

`tools/xray/spec/011-Launch-Modes.md` §Pop-out: the constraint bullet now states that the
pop-out does not re-bootstrap and announces instead, names
`register-opener-reload-announcer!`, and records the `pagehide`-only / bfcache reasoning.
The status note records why widening the predicate was not the answer. **The rf2-9vm0
normative-future marker on the `window.opener.xrayRuntime` handle is untouched and keeps its
referent** — I deliberately left the handle sentence in the bullet rather than deleting it,
so that settled ruling is not orphaned.

## `tools/xray/spec/*`

Updated — `011-Launch-Modes.md`, as above. No spec change was needed for item 1: the
sentinel is an internal implementation detail of the local-render seam and no `tools/xray/spec`
page states its representation (the invariant it must satisfy is now documented at the
definition instead).

## Gates — every one foreground, unfiltered, exit code captured by me

Re-run on the final rebased base (`origin/main` = `3009c45058`), which moved 13 commits under me.

| Gate | Captured exit | Result |
| --- | --- | --- |
| `tools/xray` JVM (`clojure -M:test`) | 0 | **1315 tests / 6227 assertions**, 0 failures |
| `npm run test:cljs` | 0 | **11203 tests / 55820 assertions**, 0 failures |
| `python scripts/lint_kondo.py` | 0 | errors: 0; zero findings on any of my 4 changed source files |
| `check_readme_links.py --ci` | 0 | |
| `check_doc_slugs.py` | 0 | |
| `check_ep_status_sync.py` | 0 | |
| `check_runtime_subsystem_grading.py` | 0 | |
| `check_inject_cofx_residue.py` | 0 | |
| `check_failure_corpus_residue.py` | 0 | |
| `check_retired_composition_vocab.py` | 0 | |
| `check_retired_image_keys.py` (`--self-test`, then live) | 0, 0 | |
| `python -m mkdocs build --strict` | 0 | |

The JVM count is `+2` tests / `+10` assertions against #9044's measured 1313 / 6217 — exactly
my two new deftests.

**Gate-provenance checks.** `scripts/test-fast-pr.sh --plan` printed
`gate root: …/xrayleak-a` and the CLJS build printed my worktree's `shadow-cljs.edn` path, so
both read this worktree. Two planted faults confirmed the gates bite rather than merely pass:

- Renaming `"pagehide"` to `"unload"` in `mount.cljs` turned `npm run test:cljs` **red**
  (exit 1, 3 failures naming my new tests) — a *rename*, not a move, so a substring-matching
  assertion would not have caught it. Restored, blob-hash verified (`f873ede26f…`). That
  plant also proves the runtime saw the change, not merely the source: the file is in the
  build's module graph, so the red is evidence about the compiled tree.
- A broken anchor planted in `011-Launch-Modes.md` turned `check_doc_slugs.py` **red**
  (exit 1, naming file, line 427 and the anchor). Restored, blob-hash verified
  (`0d97fa813a…`).

**`test-fast-pr.sh --plan` says my diff arms**: documentation gates = run, node/CLJS = run,
clj-kondo = run, JVM tier = skip, spine self-test = skip. I ran the spine's components
individually rather than as one script — the compound run exceeded my harness ceiling — and
every component is in the table above. As the plan's own note says, *no browser, bundle,
adapter, Xray, MCP or tool-JVM gate is in any tier*, so the spine says little here; the
`tools/xray` JVM suite, which is where both items' regressions live, was run directly.

**`npm run test:xray-feature-gate`**: not run. #9044's caveat still holds and I confirmed it
— no feature-gate scenario mounts an unreachable frame, so it does not exercise item 1's
changed branch. It likewise has no pop-out opener-reload scenario, so it does not exercise
item 2's.

`npm ci` was run into this worktree's own `node_modules`; no junction into the mayor's tree
was created, and the mayor's `node_modules` was verified intact (101 entries) afterwards.
