### PR TITLE
skill+scripts+nav: testing leaves compose on CLJS, a SKILL.md description gate, five nav entries (rf2-519x5, rf2-w9p2, rf2-9f6h)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -329,6 +329,11 @@ nav:
     - "re-frame.adapter.reagent": api/re-frame.adapter.reagent.md
     - "re-frame.adapter.uix": api/re-frame.adapter.uix.md
     - "re-frame.hicasso": api/re-frame.hicasso.md
+    - "re-frame.hicasso.substrate": api/re-frame.hicasso.substrate.md
+    - "re-frame.hicasso.forms": api/re-frame.hicasso.forms.md
+    - "re-frame.hicasso.overlay": api/re-frame.hicasso.overlay.md
+    - "re-frame.hicasso.motion": api/re-frame.hicasso.motion.md
+    - "re-frame.hicasso.native": api/re-frame.hicasso.native.md
     - "re-frame.test-support": api/re-frame.test-support.md
     - "re-frame.test-helpers": api/re-frame.test-helpers.md
 

--- a/scripts/check_skill_description_budget.py
+++ b/scripts/check_skill_description_budget.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python3
+"""Guard the two SKILL.md description limits Claude Code actually ENFORCES (rf2-w9p2).
+
+WHY THIS EXISTS, and why it does not check the number everybody quotes.
+
+rf2-cupfi observed that six of nine `skills/*/SKILL.md` descriptions exceeded
+1,024 characters and asked whether that truncates at runtime.  It ruled: *do not
+add a gate unless truncation is confirmed*.  A worker then confirmed truncation
+against the SHIPPED runtime rather than against documentation, and found the
+1,024 figure is **not the enforced one**:
+
+  * 1,024 is the Agent Skills PACKAGING spec's figure.  Claude Code's SKILL.md
+    frontmatter validator checks only that `description` is a string ("description
+    must be a string, got <type>.  At runtime this value is dropped.") and applies
+    NO length check whatsoever.  The one enforced 1,024 in the runtime is a
+    `.max(1024)` on the *plugin marketplace manifest* description — a different
+    field on a different surface, and this repo's nine `plugin.json` descriptions
+    run 146-418 characters, nowhere near it.
+
+  * The enforced per-description cap is **1,536** (`skillListingMaxDescChars`),
+    applied as a HARD SLICE — `.slice(0, 1536)`, no ellipsis, no warning in the
+    listing the model reads, and the cut lands mid-word.  So the TAIL is always
+    what is lost.
+
+  * A SECOND mechanism has no per-skill spelling at all: the listing carries a
+    TOTAL budget, and past it Claude Code stops trimming tails and starts dropping
+    ENTIRE descriptions, lowest-priority first, rendering those skills as a bare
+    `- name` with NOTHING for the model to route on.
+
+A gate written against 1,024 would therefore red six descriptions that are fine
+and miss the mechanism that actually degrades this family.  This gate is written
+against what is enforced.
+
+THE RUNTIME MECHANISM, transcribed from the shipped bundle (Claude Code 2.1.258,
+`claude.exe`; the listing planner and its renderer):
+
+    var z2o = 0.01,        // skillListingBudgetFraction default
+        cjn = 4,           // bytes per token
+        q2o = 200000;      // default context window
+    var V2o = 1536;        // skillListingMaxDescChars default
+
+    budget      = floor((contextWindow ?? 200000) * 4 * 0.01)          // = 8000
+    resolved(s) = s.whenToUse ? `${s.description} - ${s.whenToUse}` : s.description
+    entryLen(s) = s.name.length + 4 + min(resolved(s).length, 1536)
+    total       = sum(entryLen) + (entryCount - 1)
+
+    if total <= budget      -> "fits";  every description renders in full (to 1536)
+    else                    -> "priority" mode: every non-exempt entry is costed at
+                               its bare `- name` floor, the remaining budget is
+                               spent on descriptions in DESCENDING priority order,
+                               and every entry that no longer fits renders as
+                               `- name` alone.
+
+    Skills BUNDLED with Claude Code (type "prompt", source "bundled") are EXEMPT
+    from that dropping pass.  Consumer-installed skills — every skill in this
+    repo — are NOT.
+
+WHAT THIS GATE CHECKS, and why each is the severity it is.
+
+  C1  PER-DESCRIPTION CAP (hard fail).  Every skill's resolved description must
+      be <= 1,536 characters.  This is a real cliff, it is local, and its remedy
+      is local: shorten or reorder ONE description.  All nine currently pass, so
+      the gate lands green and stays a regression guard rather than a backlog.
+
+  C2  FAMILY LISTING FOOTPRINT (hard fail, RATCHETED — not the absolute).  The
+      family's contribution to the listing is computed with the runtime's own
+      formula and compared against a pinned ceiling.
+
+      The absolute 8,000 budget is NOT the fail threshold, deliberately.  The
+      family already costs 10,727 characters — 134% of the entire listing budget
+      — before the consumer installs a single skill of their own and before
+      Claude Code's own bundled commands take their share.  Failing at 8,000
+      would red this repo on day one with no in-repo remedy, because the remedy
+      is not "shorten a description": nine skills averaging ~1,200 characters
+      cannot all fit in 8,000 no matter how they are written.  That is a product
+      decision (ship fewer skills, or accept that the lowest-priority ones render
+      bare), and a gate cannot make it.
+
+      What a gate CAN do here is stop the family getting worse, so C2 is a
+      ratchet against the measured footprint, in the idiom this repo already uses
+      for `check-ai-tracking-ratchet.sh`.  The absolute comparison against 8,000
+      is PRINTED on every run, passing or failing, so the number is never lost
+      behind a green tick.
+
+WHAT THIS GATE DOES NOT CHECK — stated because a gate's silence reads as coverage.
+
+  DISQUALIFIER-FIRST ORDERING IS NOT MECHANICALLY CHECKABLE HERE, and pretending
+  otherwise would be worse than omitting it.  Ordering is the half that makes a
+  truncation survivable — whatever is last is what the slice removes, which is
+  why PR #9051 moved re-frame2-xray's "**Do not use** ... re-frame2-pair" clause
+  to the FRONT.  But detecting the two halves requires agreed markers, and there
+  are none: measured across the nine live descriptions, only six contain any
+  "trigger" marker at all, only eight contain any recognisable disqualifier
+  phrasing (spelled variously "Do not use", "Not for", "Never", "Activates only
+  on explicit pull", "... instead"), and among the six carrying both, the
+  disqualifier follows the trigger list in five.  A mechanical assertion would
+  red four to five compliant descriptions on a heuristic nobody agreed to.
+
+  What IS mechanical, and what this gate prints instead, is HEADROOM: how many
+  characters each description has before the slice starts eating its tail.  That
+  is the actionable form of the same concern — reagent-migration currently sits
+  49 characters from the cliff — and it needs no guess about phrasing.
+
+CAVEAT, carried deliberately.  1,536 and 0.01 are DEFAULTS of user-configurable
+settings (`skillListingMaxDescChars`, `skillListingBudgetFraction`), and the
+budget also scales with the context window and can be overridden outright by
+`SLASH_COMMAND_TOOL_CHAR_BUDGET`.  Both were read out of ONE shipped version,
+pinned below with that version cited.  They are the documented defaults, not
+constants of the platform; re-measure before trusting them against a new release.
+
+Author-facing prose for the same mechanism lives in `skills/README.md`
+"§SKILL.md frontmatter description — the cap that actually bites".  This script
+is only the machine-checked half.
+
+Usage:
+
+    python scripts/check_skill_description_budget.py                # check
+    python scripts/check_skill_description_budget.py --verbose      # + the table
+    python scripts/check_skill_description_budget.py --ci           # ::error:: lines
+    python scripts/check_skill_description_budget.py --self-test    # built-in fixtures
+
+`--verbose` prints the repo root the gate resolved, so a run can be shown to have
+read the intended checkout rather than a sibling worktree's copy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - CI installs requirements.txt
+    print(
+        "ERROR: PyYAML is required (it arrives with mkdocs via requirements.txt).\n"
+        "       Install it with: python -m pip install -r requirements.txt",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+
+# ---------------------------------------------------------------------------
+# Pinned runtime constants.  Read from the shipped bundle, not from docs.
+# ---------------------------------------------------------------------------
+
+#: Version of Claude Code these numbers were read out of.
+PINNED_RUNTIME_VERSION = "2.1.258"
+
+#: `skillListingMaxDescChars` default.  Applied as a hard `.slice(0, N)`.
+LISTING_MAX_DESC_CHARS = 1536
+
+#: `skillListingBudgetFraction` default.
+LISTING_BUDGET_FRACTION = 0.01
+
+#: Bytes-per-token the listing planner assumes.
+BYTES_PER_TOKEN = 4
+
+#: Context window the listing planner falls back to.
+DEFAULT_CONTEXT_WINDOW = 200_000
+
+#: `"- "` + `": "` — the fixed per-entry overhead around name and description.
+ENTRY_OVERHEAD_CHARS = 4
+
+#: Ratchet ceiling for the family's listing footprint (see C2 above).
+#: Measured 2026-09-03 over the nine live SKILL.md files at 10,727.  LOWER this
+#: when descriptions shrink; RAISING it is a deliberate act that says the family
+#: now costs the listing more, and wants a reason in the commit message.
+FAMILY_FOOTPRINT_CEILING = 10_727
+
+
+def listing_budget(context_window: int = DEFAULT_CONTEXT_WINDOW) -> int:
+    """The whole-listing character budget, by the runtime's own formula."""
+    return max(1, int(context_window * BYTES_PER_TOKEN * LISTING_BUDGET_FRACTION))
+
+
+# ---------------------------------------------------------------------------
+# Reading the family.
+# ---------------------------------------------------------------------------
+
+_FRONTMATTER_RE = re.compile(r"\A---\r?\n(.*?)\r?\n---\r?\n", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class SkillEntry:
+    """One SKILL.md, costed the way the listing planner costs it."""
+
+    path: Path
+    name: str
+    resolved: str
+
+    @property
+    def resolved_len(self) -> int:
+        return len(self.resolved)
+
+    @property
+    def capped_len(self) -> int:
+        return min(self.resolved_len, LISTING_MAX_DESC_CHARS)
+
+    @property
+    def entry_len(self) -> int:
+        return len(self.name) + ENTRY_OVERHEAD_CHARS + self.capped_len
+
+    @property
+    def over_cap(self) -> bool:
+        return self.resolved_len > LISTING_MAX_DESC_CHARS
+
+    @property
+    def headroom(self) -> int:
+        """Characters left before the hard slice starts removing the tail."""
+        return LISTING_MAX_DESC_CHARS - self.resolved_len
+
+    @property
+    def rel(self) -> str:
+        try:
+            return self.path.relative_to(REPO_ROOT).as_posix()
+        except ValueError:
+            return self.path.as_posix()
+
+
+def _resolve_description(frontmatter: dict) -> str:
+    """Reproduce the runtime's `resolved(s)`.
+
+    `description`, or `"<description> - <when_to_use>"` when a when-to-use field
+    is present.  Both spellings are accepted because the packaging spec uses the
+    snake_case one and the runtime reads it as `whenToUse`.
+    """
+    description = frontmatter.get("description")
+    if not isinstance(description, str):
+        raise ValueError(
+            f"description must be a string, got "
+            f"{'array' if isinstance(description, list) else type(description).__name__}"
+        )
+    when_to_use = frontmatter.get("when_to_use") or frontmatter.get("whenToUse")
+    if isinstance(when_to_use, str) and when_to_use:
+        return f"{description} - {when_to_use}"
+    return description
+
+
+def read_skill(path: Path) -> SkillEntry:
+    """Parse one SKILL.md into a costed listing entry."""
+    text = path.read_text(encoding="utf-8")
+    match = _FRONTMATTER_RE.match(text)
+    if match is None:
+        raise ValueError("no YAML frontmatter block")
+    frontmatter = yaml.safe_load(match.group(1))
+    if not isinstance(frontmatter, dict):
+        raise ValueError("frontmatter must be a YAML mapping (key: value pairs)")
+    name = frontmatter.get("name")
+    if not isinstance(name, str) or not name:
+        raise ValueError("frontmatter has no string `name`")
+    return SkillEntry(path=path, name=name, resolved=_resolve_description(frontmatter))
+
+
+def collect_skills(skills_dir: Path) -> tuple[list[SkillEntry], list[str]]:
+    """Read every `*/SKILL.md` under `skills_dir`.  Returns (entries, errors)."""
+    entries: list[SkillEntry] = []
+    errors: list[str] = []
+    for path in sorted(skills_dir.glob("*/SKILL.md")):
+        try:
+            entries.append(read_skill(path))
+        except (ValueError, yaml.YAMLError) as exc:
+            rel = path.relative_to(skills_dir.parent).as_posix()
+            errors.append(f"{rel}: {exc}")
+    return entries, errors
+
+
+def family_footprint(entries: Iterable[SkillEntry]) -> int:
+    """Total listing cost of these entries, by the runtime's own formula."""
+    entries = list(entries)
+    if not entries:
+        return 0
+    return sum(e.entry_len for e in entries) + (len(entries) - 1)
+
+
+# ---------------------------------------------------------------------------
+# Checking.
+# ---------------------------------------------------------------------------
+
+
+def check(entries: list[SkillEntry], ceiling: int = FAMILY_FOOTPRINT_CEILING) -> list[str]:
+    """Return a list of failure messages; empty means clean."""
+    failures: list[str] = []
+
+    # C1 - per-description hard cap.
+    for entry in sorted(entries, key=lambda e: e.name):
+        if entry.over_cap:
+            lost = entry.resolved_len - LISTING_MAX_DESC_CHARS
+            failures.append(
+                f"{entry.rel}: resolved description is {entry.resolved_len} chars, "
+                f"over the enforced {LISTING_MAX_DESC_CHARS}-char cap "
+                f"(skillListingMaxDescChars, Claude Code {PINNED_RUNTIME_VERSION}). "
+                f"The listing hard-slices it, so the LAST {lost} char"
+                f"{'' if lost == 1 else 's'} are dropped mid-word with no ellipsis "
+                f"and no warning. Shorten it, or move whatever must survive "
+                f"(a disqualifier clause especially) ahead of the cut."
+            )
+
+    # C2 - family footprint ratchet.
+    total = family_footprint(entries)
+    if total > ceiling:
+        failures.append(
+            f"skills/: the family's listing footprint is {total} chars, over the "
+            f"pinned ceiling of {ceiling}. This is a RATCHET, not the absolute "
+            f"budget: the listing drops ENTIRE descriptions past "
+            f"{listing_budget()} chars (lowest priority first, rendering a skill "
+            f"as a bare '- name' with nothing to route on), and consumer-installed "
+            f"skills are not exempt from that pass. Shrink a description, or raise "
+            f"FAMILY_FOOTPRINT_CEILING in scripts/check_skill_description_budget.py "
+            f"deliberately and say in the commit message why the family should cost "
+            f"the listing more."
+        )
+
+    return failures
+
+
+def render_table(entries: list[SkillEntry]) -> str:
+    """The per-skill measurement table."""
+    lines = [
+        f"{'skill':<24} {'resolved':>8} {'capped':>7} {'entry':>6} {'headroom':>9}",
+        f"{'-' * 24} {'-' * 8} {'-' * 7} {'-' * 6} {'-' * 9}",
+    ]
+    for entry in sorted(entries, key=lambda e: -e.resolved_len):
+        flag = "  OVER CAP" if entry.over_cap else ""
+        lines.append(
+            f"{entry.name:<24} {entry.resolved_len:>8} {entry.capped_len:>7} "
+            f"{entry.entry_len:>6} {entry.headroom:>9}{flag}"
+        )
+    return "\n".join(lines)
+
+
+def render_summary(entries: list[SkillEntry], ceiling: int = FAMILY_FOOTPRINT_CEILING) -> str:
+    """The family-level summary.  Always names the absolute budget."""
+    total = family_footprint(entries)
+    budget = listing_budget()
+    pct = (100.0 * total / budget) if budget else 0.0
+    over = total > budget
+    return "\n".join(
+        [
+            f"family entries              : {len(entries)}",
+            f"family listing footprint    : {total} chars",
+            f"pinned ratchet ceiling      : {ceiling} chars",
+            f"whole-listing budget        : {budget} chars "
+            f"({DEFAULT_CONTEXT_WINDOW} window x {BYTES_PER_TOKEN} bytes/token "
+            f"x {LISTING_BUDGET_FRACTION})",
+            f"family share of that budget : {pct:.1f}%"
+            + (
+                "  <- OVER: past this, whole descriptions are dropped, "
+                "lowest priority first"
+                if over
+                else ""
+            ),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Self-test.  Both directions, on synthetic fixtures.
+# ---------------------------------------------------------------------------
+
+
+def _write_skill(root: Path, name: str, description: str, when_to_use: str | None = None) -> None:
+    d = root / name
+    d.mkdir(parents=True, exist_ok=True)
+    lines = ["---", f"name: {name}", f"description: {description!r}"]
+    if when_to_use is not None:
+        lines.append(f"when_to_use: {when_to_use!r}")
+    lines += ["---", "", "# body", ""]
+    (d / "SKILL.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def run_self_test() -> int:
+    """Exercise every rule in BOTH directions.  Returns 0 when all cases hold."""
+    failures: list[str] = []
+
+    def expect(label: str, condition: bool, detail: str = "") -> None:
+        if condition:
+            print(f"  ok   {label}")
+        else:
+            print(f"  FAIL {label}{(': ' + detail) if detail else ''}")
+            failures.append(label)
+
+    print(f"self-test: check_skill_description_budget (repo root {REPO_ROOT})")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp) / "skills"
+        root.mkdir()
+
+        # --- C1 negative: a compliant description passes. -------------------
+        _write_skill(root, "compliant", "x" * (LISTING_MAX_DESC_CHARS - 1))
+        entries, errors = collect_skills(root)
+        expect("C1 fixture parses", not errors and len(entries) == 1, str(errors))
+        expect(
+            "C1 PASSES a description one char under the cap",
+            check(entries, ceiling=10**9) == [],
+        )
+
+        # --- C1 positive: one char over the cap reds it. --------------------
+        _write_skill(root, "compliant", "x" * (LISTING_MAX_DESC_CHARS + 1))
+        entries, _ = collect_skills(root)
+        failures_seen = check(entries, ceiling=10**9)
+        expect(
+            "C1 FAILS a description one char over the cap",
+            len(failures_seen) == 1 and "over the enforced" in failures_seen[0],
+            str(failures_seen),
+        )
+        expect(
+            "C1 boundary: exactly AT the cap passes",
+            (
+                _write_skill(root, "compliant", "x" * LISTING_MAX_DESC_CHARS),
+                check(collect_skills(root)[0], ceiling=10**9),
+            )[1]
+            == [],
+        )
+
+        # --- when_to_use is folded into the measured length. ----------------
+        _write_skill(root, "compliant", "x" * 1000, when_to_use="y" * 600)
+        entries, _ = collect_skills(root)
+        entry = entries[0]
+        expect(
+            "resolved length includes ' - ' + when_to_use",
+            entry.resolved_len == 1000 + 3 + 600,
+            f"got {entry.resolved_len}",
+        )
+        expect(
+            "C1 FAILS on description+when_to_use crossing the cap",
+            check(entries, ceiling=10**9) != [],
+        )
+
+        # --- entry/footprint arithmetic matches the runtime formula. --------
+        _write_skill(root, "compliant", "x" * 100)
+        entries, _ = collect_skills(root)
+        entry = entries[0]
+        expect(
+            "entryLen == len(name) + 4 + min(desc, 1536)",
+            entry.entry_len == len("compliant") + ENTRY_OVERHEAD_CHARS + 100,
+            f"got {entry.entry_len}",
+        )
+        _write_skill(root, "second", "y" * 200)
+        entries, _ = collect_skills(root)
+        expected_total = (
+            (len("compliant") + 4 + 100) + (len("second") + 4 + 200) + 1
+        )  # + (n-1) separators
+        expect(
+            "footprint == sum(entryLen) + (n - 1)",
+            family_footprint(entries) == expected_total,
+            f"got {family_footprint(entries)} want {expected_total}",
+        )
+
+        # --- C2 both directions against an explicit ceiling. ----------------
+        total = family_footprint(entries)
+        expect("C2 PASSES at the ceiling", check(entries, ceiling=total) == [])
+        red = check(entries, ceiling=total - 1)
+        expect(
+            "C2 FAILS one char over the ceiling",
+            len(red) == 1 and "listing footprint" in red[0],
+            str(red),
+        )
+
+        # --- capping is a slice, not a rejection: over-cap entries still
+        #     cost only 1536 toward the footprint. -------------------------
+        _write_skill(root, "huge", "z" * 5000)
+        entries, _ = collect_skills(root)
+        huge = next(e for e in entries if e.name == "huge")
+        expect(
+            "an over-cap entry costs the listing only the capped length",
+            huge.entry_len == len("huge") + 4 + LISTING_MAX_DESC_CHARS,
+            f"got {huge.entry_len}",
+        )
+
+        # --- malformed frontmatter is reported, not silently skipped. ------
+        bad = root / "broken"
+        bad.mkdir()
+        (bad / "SKILL.md").write_text("no frontmatter here\n", encoding="utf-8")
+        _, errors = collect_skills(root)
+        expect(
+            "malformed SKILL.md is reported as an error",
+            any("broken/SKILL.md" in e for e in errors),
+            str(errors),
+        )
+
+        # --- a non-string description is reported (the one thing the
+        #     runtime validator itself checks). ---------------------------
+        listy = root / "listy"
+        listy.mkdir()
+        (listy / "SKILL.md").write_text(
+            "---\nname: listy\ndescription:\n  - a\n  - b\n---\n\n# body\n",
+            encoding="utf-8",
+        )
+        _, errors = collect_skills(root)
+        expect(
+            "a non-string description is reported",
+            any("listy/SKILL.md" in e and "must be a string" in e for e in errors),
+            str(errors),
+        )
+
+    # --- the pinned budget arithmetic. -------------------------------------
+    expect("listing budget is 8000 at a 200K window", listing_budget() == 8000)
+
+    print()
+    if failures:
+        print(f"self-test FAILED: {len(failures)} case(s): {', '.join(failures)}")
+        return 1
+    print("self-test PASSED")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def _is_ci() -> bool:
+    return os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+def main(argv: Iterable[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Guard the enforced SKILL.md description limits: the 1,536-char "
+            "per-description hard slice, and the family's listing footprint "
+            "against a pinned ratchet (rf2-w9p2)."
+        ),
+    )
+    parser.add_argument("--verbose", "-v", action="store_true",
+                        help="Print the repo root, the per-skill table and the summary.")
+    parser.add_argument("--ci", action="store_true",
+                        help="Emit GitHub-Actions ::error:: lines (auto-on under GITHUB_ACTIONS).")
+    parser.add_argument("--self-test", action="store_true",
+                        help="Run built-in fixtures and exit.")
+    args = parser.parse_args(list(argv))
+
+    if args.self_test:
+        return run_self_test()
+
+    ci = args.ci or _is_ci()
+
+    if not SKILLS_DIR.is_dir():
+        msg = f"skills directory not found: {SKILLS_DIR}"
+        print(f"::error::{msg}" if ci else f"ERROR: {msg}", file=sys.stderr)
+        return 2
+
+    entries, errors = collect_skills(SKILLS_DIR)
+
+    if errors:
+        for err in errors:
+            msg = f"unreadable SKILL.md frontmatter: {err}"
+            print(f"::error::{msg}" if ci else f"ERROR: {msg}", file=sys.stderr)
+        return 2
+
+    if not entries:
+        msg = f"no skills/*/SKILL.md found under {SKILLS_DIR}"
+        print(f"::error::{msg}" if ci else f"ERROR: {msg}", file=sys.stderr)
+        return 2
+
+    if args.verbose:
+        print(f"repo root: {REPO_ROOT}")
+        print(f"scanned {len(entries)} SKILL.md file(s) under {SKILLS_DIR.name}/")
+        print()
+        print(render_table(entries))
+        print()
+        print(render_summary(entries))
+        print()
+
+    failures = check(entries)
+    if failures:
+        print(
+            f"SKILL.md description budget: {len(failures)} "
+            f"failure{'' if len(failures) == 1 else 's'}.",
+            file=sys.stderr,
+        )
+        for line in failures:
+            print(f"::error::{line}" if ci else f"ERROR: {line}", file=sys.stderr)
+        if not args.verbose:
+            print(render_summary(entries), file=sys.stderr)
+        return 1
+
+    if args.verbose:
+        print(
+            f"OK: all {len(entries)} descriptions are within the "
+            f"{LISTING_MAX_DESC_CHARS}-char cap, and the family footprint is "
+            f"within the pinned ceiling."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/re-frame2/references/cross-cutting/testing-views.md
+++ b/skills/re-frame2/references/cross-cutting/testing-views.md
@@ -25,7 +25,8 @@ This is the dominant shape for an app-developer e2e view test: one frame, one in
 
 (use-fixtures :each
   (ts/make-reset-runtime-fixture {:adapter counter/test-adapter   ;; your substrate adapter
-                                  :init-fn counter/setup!}))       ;; reg-event / reg-sub / reg-view
+                                  :init-fn counter/setup!         ;; reg-event / reg-sub / reg-view
+                                  :async?  true}))                ;; the CLJS (async done …) row below needs it
 
 ;; Synchronous — dispatch-sync drains before the assertion, so walk the
 ;; re-rendered view directly.
@@ -35,6 +36,8 @@ This is the dominant shape for an app-developer e2e view test: one frame, one in
 ```
 
 `make-reset-runtime-fixture` installs the `:adapter`, seats `:rf/default` as the ambient frame for each test (so `dispatch-sync` / `subscribe` resolve to it without a `{:frame …}` opt), and runs `:init-fn` inside that scope. Its registrations land in the global registrar and roll back around each test. `h/testid` is the **authoring** helper — standardise the `:data-testid` fragment at the view call site (`[:span (h/testid "n") @(rf/subscribe [:counter/n])]`); `find-by-testid` locates it, `text-content` reads its text, `invoke-handler` fires an attached handler.
+
+**Why `:async? true` sits on that one fixture.** The CLJS row further down is an `(async done …)` test, and `cljs.test` hard-errors on a fn-form fixture for an async row (*"Async tests require fixtures to be specified as maps"*); the opt selects the `{:before :after}` map-form, whose `:before` establishes the ambient frame with a persistent `set!` that survives the async boundary. On the JVM it is **inert** — `clojure.test` has no async rows and no map-fixture support — so one plain `:async? true` serves a `.cljc` suite on both hosts, with no reader conditional at the call site. Full contract: [`testing.md` §Async (`cljs.test`) suites](testing.md#async-cljstest-suites--async-true).
 
 For an async settle, poll the re-rendered view with `ts/poll-until` until it matches:
 

--- a/skills/re-frame2/references/cross-cutting/testing.md
+++ b/skills/re-frame2/references/cross-cutting/testing.md
@@ -46,8 +46,11 @@ Do **not** call `(registrar/clear-all!)` from a fixture — under CLJS, framewor
 A suite with `(async done …)` tests cannot use the fn-form fixture: `cljs.test` HARD-ERRORS with *"Async tests require fixtures to be specified as maps"*. The reason is structural — the fn-form establishes the body's ambient frame scope with a dynamic `binding`, and that binding unwinds the instant the fixture fn returns, which for an async test is *before* the body resumes on a later tick. Pass `:async? true` to get the `{:before :after}` map-form instead:
 
 ```clojure
+;; `substrate` is the alias bound by §The single import above — on CLJS it resolves
+;; to the Reagent adapter. (`plain-atom` is named only inside the JVM-only variant,
+;; and `async` is CLJS-only, so this suite is assembled from the single import.)
 (use-fixtures :each
-  (ts/make-reset-runtime-fixture {:adapter plain-atom/adapter :async? true}))
+  (ts/make-reset-runtime-fixture {:adapter substrate/adapter :async? true}))
 
 (deftest drains-across-the-async-boundary
   (async done


### PR DESCRIPTION
Three beads, one PR: the fourth pass on the testing leaves, the SKILL.md description gate whose precondition finally resolved, and five nav entries.

## 1. rf2-519x5 — the testing leaves, fourth pass (MATCHED, not re-derived)

Worked the newest text-bearing note, ordered by `bd history --json` walking adjacent snapshots to the item's beginning: **18 real text/status changes across 856 history entries**, newest at 2026-09-03 04:38:15 (the mayor's fence-cleared note). The description is generation-one and stale, as that note warns.

**What `spec/008-Testing.md` says now.** PR #9048 landed as commit `3f42785a32`, rewriting the `#### poll-until example` CLJS fence to the docstring's prescribed shape: assertion in `.then`, a `.catch` that reports and returns `nil` ("report and RELEASE — no done here"), then **one trailing `.then` that calls `done`** ("ONE trailing done, shared by both paths"), plus a paragraph giving the `cljs.test/run-block` reason.

**The leaf matches it.** I compared the two fenced chains structurally rather than by eye alone — same skeleton (`(async done` → `ts/poll-until` → `.then` → `.catch` → `is false` → `.then` → `(done)`), 1 `(done)` site each, 2 `.then` each, 1 `.catch` each, the sole `(done)` inside the last `.then` in both, and **no `(done)` inside the `.catch` arm** in either. The comments are verbatim identical. The only textual difference is that the spec's prose carries one extra explanatory clause ("re-forcing `run-block`'s unrealized delay and re-running the offending namespace") that the leaf's tighter rendering omits; the rule, the shape and the mechanism are the same. I did not re-derive anything from the `poll-until` docstring.

**The one-trailing-`done` property checked BY EYE as well as by reader**, because the #9048 worker's caveat is right: a Clojure reader proves **balance only**, and the pre-edit fence read cleanly too — a reader cannot see that `done` is called twice on different promise arms. Read by eye at `testing-views.md:63-75`: the `.then` at 69 asserts and returns without `done`; the `.catch` at 72 reports and returns `nil`; the `.then` at 75 is the only `(done)`. The sibling `testing.md` async row is a single `js/setTimeout` callback with one `done` and no chain.

**The two defects generation four actually asked for**, both verified at source first:

1. `testing-views.md` installed `make-reset-runtime-fixture` with **no `:async? true`**, then placed an `(async done …)` row under that same single fixture. `implementation/core/src/re_frame/test_support.cljc` is explicit: on `:cljs` the opt selects the `{:before :after}` map-form, "the only shape `cljs.test` will run an `(async done …)` row under"; on `:clj` it is **INERT** — the fn-form is returned regardless, because `clojure.test` has no map-fixture support at all and a map fixture there composes to a key lookup returning nil, silently running zero tests. The docstring's own conclusion: "a `.cljc` suite with async CLJS rows writes a plain `:async? true` — no reader conditional at the call site." Added exactly that, with the reason in prose.
2. `testing.md`'s async recipe named **`plain-atom/adapter`**, an alias introduced only inside the preceding **JVM-only `.clj`** variant. `async` is CLJS-only, so that suite is assembled from §The single import, where the adapter is bound as `substrate` (`re-frame.adapter.reagent` on `:cljs`, `re-frame.substrate.plain-atom` on `:clj`). Now `substrate/adapter`, with an in-fence comment saying why. Confirmed at source that `re-frame.adapter.reagent` ships only as `reagent.cljs`.

## 2. rf2-w9p2 — `scripts/check_skill_description_budget.py`

**Re-verified against the shipped runtime, not the bead.** Read out of Claude Code **2.1.258**'s bundle:

```
var z2o = 0.01, cjn = 4, q2o = 200000;   var V2o = 1536;
budget      = floor((ctx ?? 200000) * 4 * 0.01)              // = 8000
resolved(s) = s.whenToUse ? `${s.description} - ${s.whenToUse}` : s.description
entryLen(s) = s.name.length + 4 + min(resolved(s).length, 1536)
total       = sum(entryLen) + (n - 1)
```

- **1,024 is not enforced on a SKILL.md description.** The frontmatter validator checks only the type ("description must be a string, got …. At runtime this value is dropped."). **One refinement the bead did not have:** 1,024 *is* enforced somewhere — a `.max(1024)` on the **plugin marketplace manifest** description, a different field on a different surface. This repo's nine `plugin.json` descriptions run 146–418 chars, so it does not bite here.
- **1,536 is enforced**, as `.slice(0, 1536)` — hard, no ellipsis, no warning, cut lands mid-word, tail is what is lost.
- **The listing budget is 8,000 exactly** at a 200K window. Past it the planner stops trimming tails and drops **entire** descriptions in ascending priority order, rendering a skill as a bare `- name`. Bundled skills (`type === "prompt" && source === "bundled"`) are exempt from that pass; consumer-installed ones are not.

**Measured family state** (all nine within the cap; footprint by the runtime's own formula):

| skill | resolved | entry | headroom |
|---|---:|---:|---:|
| reagent-migration | 1487 | 1508 | 49 |
| re-frame2-xray | 1482 | 1500 | 54 |
| re-frame2 | 1251 | 1264 | 285 |
| re-frame2-pair-retro | 1203 | 1227 | 333 |
| re-frame2-implementor | 1186 | 1211 | 350 |
| re-frame2-improver | 1150 | 1172 | 386 |
| re-frame2-setup | 1068 | 1087 | 468 |
| re-frame-migration | 963 | 985 | 573 |
| re-frame2-pair | 747 | 765 | 789 |

**Family footprint 10,727 chars = 134.1% of the entire 8,000 budget**, before the consumer installs anything of their own and before Claude Code's bundled commands take their share.

**Which limit the gate guards, and why.** Both, in one script, at different severities:

- **C1, the 1,536 cap — hard fail.** Local, actionable, remedy is one description. All nine pass, so it lands green as a regression guard rather than a backlog.
- **C2, the family footprint — hard fail against a pinned RATCHET, not against the absolute 8,000.** Failing at 8,000 would red the repo on day one with no in-repo remedy: nine skills averaging ~1,200 chars cannot fit in 8,000 however they are written. That is a product decision (ship fewer skills, or accept the lowest-priority ones rendering bare), and a gate cannot make it. The ratchet stops the family getting worse — the repo's own idiom, as in `check-ai-tracking-ratchet.sh` — and **the absolute comparison is printed on every run, green or red**, so the 134% is never lost behind a tick.

**Ordering is NOT mechanically checkable, and the gate does not pretend it is.** Measured across the nine live descriptions: only **six** carry any `trigger` marker at all, only **eight** carry any recognisable disqualifier phrasing (spelled variously "Do not use", "Not for", "Never", "Activates only on explicit pull", "… instead"), and among the six carrying both, **the disqualifier follows the trigger list in five** — re-frame2-xray, the one PR #9051 fixed, is the single exception. An assertion would red four to five compliant descriptions on a heuristic nobody agreed to. The gate prints **headroom** instead, which is the guess-free form of the same concern: reagent-migration is 49 chars from the cliff.

**Both directions proved.**

- `--self-test`: **14 cases, exit 0** — C1 passes one char under the cap, fails one char over, passes exactly at it; the `when_to_use` fold is counted; `entryLen` and footprint arithmetic match the runtime formula; C2 passes at the ceiling and fails one char over it; an over-cap entry still costs only the capped length; malformed and non-string-description frontmatter are reported rather than skipped.
- Live run over the nine SKILL.md files: **exit 0**.
- **Planted-fault run on the live family**: 60 chars appended to `skills/reagent-migration/SKILL.md`'s description → **exit 1**, C1 naming the file and the exact 40-char overflow (1576 vs 1536) and C2 catching the footprint move to 10,776. **Plant restored and verified by `git hash-object` blob equality** (`ae4ea10dc9435a3ffb23a6500e45fd31464c6489` before and after); the anchor's match count was read as 1 before planting. That file is unchanged in this diff.

**NOT ARMED IN CI — filed as rf2-bn5f.** Every sibling `check_skill_*.py` is wired into `.github/workflows/test.yml` as a self-test step plus a `--verbose --ci` step, but `.github/**` was outside this dispatch's allowed paths and `.github/workflows/*` is hot-zone with live workers. rf2-bn5f carries the two step bodies verbatim plus the matching `test-fast-pr.sh` documentation-tier lanes, and notes that `check_fast_pr_gap.py` will correctly report the checker as having no local lane the moment the CI half lands alone. Same shape as rf2-4m9x, filed when `spec/` sat outside a fence.

## 3. rf2-9f6h — five nav entries

Premise confirmed: the five pages exist (`docs/api/re-frame.hicasso.{forms,motion,native,overlay,substrate}.md`) and none appeared in `mkdocs.yml`'s nav.

Placed to match the grouping `docs/api/README.md` already uses — the door, then its own substrate adapter (that README pairs those two in one table), then the four opt-in authoring modules in its order: forms, overlay, motion, native. Flat, beside the existing `api/` entries. **The nav is not restructured**; the diff is +5 lines.

**The bead's severity measurement reproduced rather than contradicted.** `python -m mkdocs build --strict` is **exit 0 both before and after** — an unnavigated page does not red the build, because `validation.nav.omitted_files` is INFO, `mkdocs.yml` sets no `validation.nav` key, and `--strict` promotes WARNING but not INFO. **100 pages remain in the omitted list either way**, matching the bead's "roughly 100" baseline exactly. **The five left that list**: zero hits for any of them in the build log, against a control confirming the omitted-list section is present in that same log (so the zero is a real zero, not a missing section), and all five are present in `site/api/` and named in the built nav HTML.

## 4. Which edits sit inside fenced blocks that no gate inspected

**Most of item 1.** `check_doc_slugs.py` strips fenced code blocks before it reads a link, so its exit 0 says nothing whatever about these, and `mkdocs build --strict` does not build `skills/` at all:

- `testing-views.md` — the `:async?  true` line added inside the `use-fixtures` fence.
- `testing.md` — the `substrate/adapter` change and the three-line comment above it, inside the async fence.

These were verified instead by **a real Clojure reader** (all 26 `clojure` fences across the two leaves, 48 top-level forms, `:read-cond :allow`, **exit 0**, with an **unbalanced control that bit** — "EOF while reading" — so the zero is earned) and, for the one-trailing-`done` property the reader structurally cannot see, **by eye plus a structural comparison against the spec**.

**The one item-1 edit that IS gated** is the new prose paragraph in `testing-views.md`, because it sits outside any fence. Its cross-file anchor link was proved covered rather than assumed: planting `#async-cljstest-suites-PLANTED-BROKEN` made `check_doc_slugs.py` **exit 1**, naming the file, line 40 and the anchor; restored and verified by `git hash-object` blob equality (`0474eb4b6693d4777d3058f1f6f7a148e4b2c6af` before and after).

`mkdocs.yml` (item 3) and the new script (item 2) are not in fences and are covered by the strict build and the gate's own self-test respectively.

## Gates — exit codes captured on the command's own line, re-run on the final rebased base (`cfcc30ae93`)

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_readme_links.py --ci` | 0 |
| `python -m mkdocs build --strict` | 0 |
| all **15** `scripts/check_skill_*.py --verbose --ci` (14 pre-existing + the new one) | 0 each |
| `python scripts/check_skill_description_budget.py --self-test` | 0 (14 cases) |
| Clojure reader over 26 fences, unbalanced control | 0 (control bit) |
| `sh scripts/test-fast-pr.sh` | 0 — `PASS fast PR spine` |

The 15 skill gates enumerated: `description_budget`, `eval_docs`, `eval_packaging`, `implementor_order`, `implementor_partition_drift`, `mcp_drift`, `migration_cites`, `migration_contract_drift`, `migration_o1617_router_drift`, `package_refs`, `pair_authoring_drift`, `re_frame2_drift`, `redirect_anchors`, `setup_counter_drift`, `xray_tab_inventory_drift`.

`scripts/test-fast-pr.sh --plan` arms **the documentation tier only** — `documentation gates: run`, JVM / node / clj-kondo all `skip`, reason `classified`, spine self-test skipped (spine unchanged). Both the spine and the new gate printed their resolved root as this worktree, so each is shown to have read the intended checkout.

Rebased once (a beads checkpoint had landed); the merge-base diff (`origin/main...HEAD`) is four files — `mkdocs.yml`, the new script, and the two leaves — and reverts nothing a sibling landed.

Closes rf2-519x5, rf2-w9p2, rf2-9f6h. Follow-up rf2-bn5f arms the new gate in CI.
