### PR TITLE
fix(error-emit): the dev console prints the error message, not the record's JS fields (rf2-6sqv, rf2-02w1)

### DIFF
--- a/implementation/core/src/re_frame/core_artefact.cljc
+++ b/implementation/core/src/re_frame/core_artefact.cljc
@@ -59,6 +59,40 @@
   | `:apply`           | same as `:delegate` but `(apply f args)` — for variadic arglists |
   | `[expr expr ...]`  | recursion form — emits `(<name> expr expr ...)`                  |
 
+  ### A hook value MUST be a FUNCTION, never a COMPONENT
+
+  Both direct body kinds CALL the hook value — `:delegate` emits `(f a b)`,
+  `:apply` emits `(apply f args)` — so whatever the producing namespace
+  publishes is invoked as an ordinary function. That is correct for every
+  hook in the table, and it is a real constraint rather than a stylistic one:
+  a component that is CALLED never becomes a component. On Reagent it runs
+  inside its CALLER's component instance, so it reads that instance's React
+  context rather than its own, and any `:contextType` its head carries is
+  inert.
+
+  Nothing enforces this and nothing can warn about it. The failure is silent
+  at registration, silent at call, and surfaces only when something
+  downstream needs the context — in a real browser, since a unit suite that
+  calls the render fn under `rf/with-frame` is answered by the dynamic-var
+  tier and stays green.
+
+  **The worked instance is rf2-nvcp.** `rf/route-link` is a `defwrapper` over
+  `:routing/route-link`, and routing published the registered `:route/link`
+  view head straight into it. The head was called rather than mounted, so
+  `(.-context cmp)` answered React's empty default and the render-time
+  `require-current-frame!` raised `:rf.error/no-frame-context` on FIRST
+  render — every routed application blank, for about two and a half months,
+  behind a fully green suite.
+
+  The repair belongs at the PUBLICATION side, not here: publish a function
+  that EMITS AN ELEMENT (`(fn [& args] (into [(views/view-head :route/link)]
+  args))`) and the substrate componentizes the head exactly as it does a
+  `reg-view` view. `defwrapper` is deliberately NOT taught a second calling
+  convention for this — the `:apply` / `:delegate` arities are correct for
+  functions, which is what every hook value is, and a component-aware body
+  kind would fork a hot path to accommodate one case already fixed upstream
+  of it.
+
   ### `artefact-info` map shape
 
   ```
@@ -155,6 +189,14 @@
      Shape: `(defwrapper name docstring-or-attr-map spec & arity-forms)`.
      Each arity-form is `(arglist body-kind)` where body-kind is
      `:delegate`, `:apply`, or `[recursion-args ...]`.
+
+     The hook value MUST be a FUNCTION. Both `:delegate` and `:apply` CALL
+     it, and a component that is called never becomes a component — it
+     renders inside its caller's instance and reads the caller's React
+     context, leaving any `:contextType` inert. A component-valued hook
+     therefore publishes an element-EMITTING fn instead. See the ns
+     docstring §A hook value MUST be a FUNCTION, never a COMPONENT; rf2-nvcp
+     is the worked instance.
 
      When `:where` is omitted from the spec, it defaults to
      `'rf/<name>` — the common case. Wrappers whose public-facing

--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -152,13 +152,63 @@
 ;; Per-category ownership, sink discovery, a formatter, deduplication and a
 ;; suppression setting all stay REJECTED as premature.
 ;;
+;; A READABLE LINE LEADS THE RECORD (rf2-6sqv). Passing the record as a
+;; value is right, and it stays — but it was the ONLY thing passed, and a
+;; CLJS map is not a JS object: Chrome renders its interior fields, so an
+;; ordinary page load showed
+;;
+;;     [re-frame2] {meta: null, cnt: 7, arr: Array(14), __hash: null, …}
+;;
+;; and nothing else. `cnt: 7` is the seven-key record itself. That teaches a
+;; reader that re-frame2's errors are unreadable — the exact opposite of what
+;; the error text achieves — and it is the first place a reader looks, before
+;; any tool is installed (Spec 009 / pilot outcome 5).
+;;
+;; So [[console-summary]] now leads with a STRING built from what the record
+;; already carries, and the record + exception follow as their own arguments
+;; exactly as before. Text first, structure still expandable, nothing lost to
+;; a structured consumer. It composes NO new error prose: every byte of the
+;; line already existed on the record or on its exception.
+;;
 ;; Everything is try/catch wrapped: observability must never abort the drain.
+
+(defn- console-summary
+  "The readable line that LEADS the dev console fallback (rf2-6sqv): the
+  category, then the human sentence the framework ALREADY composed — the
+  carried exception's `ex-message` when the category throws one, else the
+  record's own `:reason` slot.
+
+  Composes NO new error prose. Every byte comes off the record or its
+  exception; the categories that carry neither (`:rf.error/no-such-handler`
+  and its kin) yield the bare category keyword, which is still the
+  greppable discriminator a reader looks up. Leading with the keyword is
+  deliberate: `:reason` sentences do not carry the bracketed catalogue
+  token — `re-frame.error/throw-error!` appends that when it builds a THROWN
+  message — so without it a `:reason`-only line would name no category at
+  all.
+
+  Never throws: `ex-message` is guarded because `:exception` is whatever the
+  failing code threw, which need not be an `Error`. Returns a string."
+  [record]
+  (let [ex   (:exception record)
+        text (or (when (some? ex)
+                   (try (ex-message ex) (catch #?(:clj Throwable :cljs :default) _ nil)))
+                 (:reason record))]
+    (if (seq text)
+      (str (:error record) " — " text)
+      (str (:error record)))))
 
 (defn- report-unowned-error!
   "Print `record` to the browser console when NOTHING owns it. Dev builds
   only, browser hosts only, and only while the corpus-wide `:errors`
   listener registry is EMPTY — see §Unowned-error dev console fallback
   above for why each of those three conditions is load-bearing.
+
+  Arguments are `[\"[re-frame2]\" <summary-line> <record>]`, plus the
+  original `<exception>` when the category carries one. The summary leads so
+  a reader sees TEXT first (rf2-6sqv); the record and exception still ride as
+  their own arguments, so the host inspector renders the structure and the
+  real stack survives untouched.
 
   A no-op on the JVM, on Node-targeted CLJS (and CLJS SSR), and in any
   `goog.DEBUG=false` build, where the whole body constant-folds away.
@@ -172,9 +222,10 @@
                     (exists? js/document)
                     (exists? js/console)
                     (fn? (.-error js/console)))
-           (if-some [ex (:exception record)]
-             (.error js/console "[re-frame2]" record ex)
-             (.error js/console "[re-frame2]" record)))
+           (let [summary (console-summary record)]
+             (if-some [ex (:exception record)]
+               (.error js/console "[re-frame2]" summary record ex)
+               (.error js/console "[re-frame2]" summary record))))
          (catch :default _ nil))
        nil)))
 

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1112,7 +1112,11 @@
   "Surface `:rf.error/bad-frame-provider-arg` through the always-on error
   axis AND the dev-only trace surface, then return the payload. Mirrors
   `emit-no-frame-context!`: production-survivable so a bad provider arg is
-  observable where the dev trace is elided."
+  observable where the dev trace is elided — including carrying the
+  payload's own `:reason` / `:recovery` onto the record (rf2-6sqv), which
+  this category needs for exactly the reason its sibling does: it passes no
+  `:exception`, so without them the always-on record holds no message at all
+  and the dev console can only print the bare category."
   [payload]
   (when-let [dispatch-on-error! (late-bind/get-fn :error-emit/dispatch-on-error)]
     (dispatch-on-error!
@@ -1122,7 +1126,9 @@
       nil                                ;; no frame — the supplied target is invalid
       nil                                ;; no exception — invalid arg, not a throw
       0                                  ;; elapsed-ms
-      (interop/now-ms)))                 ;; time
+      (interop/now-ms)                   ;; time
+      {:reason   (:reason payload)
+       :recovery (:recovery payload)}))
   (trace/emit-error! :rf.error/bad-frame-provider-arg payload)
   payload)
 

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -915,7 +915,21 @@
   This is the EMISSION half; callers that must also halt the operation use
   `require-current-frame!` (which emits then throws). Detection-only
   callers (frame pickers, tooling) read the nil from `current-frame` /
-  `resolve-current-frame` and never reach here."
+  `resolve-current-frame` and never reach here.
+
+  THE RECORD CARRIES THE PAYLOAD'S OWN `:reason` (rf2-6sqv). This category
+  passes no `:exception` — the operation is invalid, nothing threw — so
+  before this the always-on record was seven slots of pure metadata
+  (`{:error :event :event-id :frame :time :exception :elapsed-ms}`) and the
+  composed recovery ladder `no-frame-context-payload` had just built reached
+  the always-on axis NOWHERE. Measured, not inferred: an ordinary page load
+  printed `[re-frame2] {meta: null, cnt: 7, arr: Array(14), …}` to the
+  console and the ladder was not inside it, so no console formatter could
+  have recovered it. `:reason` / `:recovery` ride the EXISTING `attrs`
+  attribution seam `dispatch-on-error!` already provides for
+  category-specific slots — the same seam flow-eval uses — and match the
+  non-event union records (the frame-teardown report carries both). An
+  off-box shipper gains the sentence too."
   [payload]
   (let [event-id (:event-id payload)]
     ;; Always-on listener registry (survives prod elision).
@@ -929,7 +943,11 @@
         nil                              ;; no frame — that is the whole point
         nil                              ;; no exception — invalid op, not a throw
         0                                ;; elapsed-ms
-        (interop/now-ms)))               ;; time
+        (interop/now-ms)                 ;; time
+        ;; The composed ladder + machine-readable repair the payload already
+        ;; holds; nil-valued slots are dropped by the attribution merge.
+        {:reason   (:reason payload)
+         :recovery (:recovery payload)}))
     ;; Dev-only trace path — DCEs under `:advanced` + `goog.DEBUG=false`.
     (trace/emit-error! :rf.error/no-frame-context payload)
     payload))

--- a/implementation/core/test/re_frame/error_emit_dev_console_dom_cljs_test.cljs
+++ b/implementation/core/test/re_frame/error_emit_dev_console_dom_cljs_test.cljs
@@ -11,14 +11,29 @@
   the contract:
 
     - with an EMPTY registry a promoted refusal reaches the console exactly
-      once, as `[\"[re-frame2]\" <record> <exception>]` — the structured
-      record and the ORIGINAL exception as separate console ARGUMENTS, never
-      a rendered string (console presentation is implementation-defined);
+      once, as `[\"[re-frame2]\" <summary> <record> <exception>]` — a readable
+      SUMMARY LINE first, then the structured record and the ORIGINAL
+      exception as separate console ARGUMENTS;
     - with ANY `:errors` listener attached the fallback is SILENT — that is
       what stops it being the nag-diagnostic the ruling avoided. Ownership
       is corpus-wide and implicit: a listener that ignores the category, or
       one that itself throws, still owns the stream. Dropping the last
       listener resumes the fallback.
+
+  ## The summary argument (rf2-6sqv)
+
+  The record rides as a VALUE, and that is right — but for a while it was
+  the ONLY thing passed, and a CLJS map is not a JS object. Chrome renders
+  its interior fields, so an ordinary page load of a routed example showed
+  `[re-frame2] {meta: null, cnt: 7, arr: Array(14), __hash: null, …}` and no
+  message at all. Measured in headless Chromium, not asserted in a unit test.
+
+  So a readable line now LEADS, and the assertions below pin both halves of
+  that: the summary is text and names the category, AND the record and
+  exception still ride as their own arguments so a structured consumer and
+  the DevTools inspector are unaffected. The summary composes no new error
+  prose — it is the exception's `ex-message`, else the record's `:reason`,
+  else the bare category keyword.
 
   And, in every case, ZERO `reportError` calls. `reportError` reports \"in
   the same fashion as an unhandled exception\" (HTML Standard), which
@@ -44,6 +59,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.error-emit :as error-emit]
+            [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
 
@@ -109,9 +125,19 @@
         (is (= 1 (count console))
             (str "exactly one console.error for one refusal; got "
                  (pr-str (mapv first console))))
-        (let [[prefix record ex] (first console)]
+        (let [[prefix summary record ex] (first console)]
           (is (= "[re-frame2]" prefix) "the stable prefix leads")
-          (is (map? record) "the structured record rides as its OWN argument")
+          (is (string? summary)
+              "a READABLE line comes before the record (rf2-6sqv) — without it
+               Chrome renders the CLJS map's interior fields and the reader
+               sees no message at all")
+          (is (re-find #"^:rf\.error/handler-exception\b" summary)
+              (str "the summary names the category first — the greppable "
+                   "discriminator; got " (pr-str summary)))
+          (is (re-find #"kaboom" summary)
+              (str "and carries the exception's OWN message, not a synthesised "
+                   "one; got " (pr-str summary)))
+          (is (map? record) "the structured record still rides as its OWN argument")
           (is (= :rf.error/handler-exception (:error record)))
           (is (= :fu75.console/throws (:event-id record)))
           (is (= [:fu75.console/throws] (:event record)))
@@ -127,22 +153,29 @@
       (let [{:keys [console report-error]}
             (capture-console #(rf/dispatch-sync [:fu75.console/foreign-fx]))]
         (is (= 1 (count console)))
-        (is (= "[re-frame2]" (ffirst console)))
-        (is (= :rf.error/effect-map-shape (:error (second (first console)))))
+        (let [[prefix summary record] (first console)]
+          (is (= "[re-frame2]" prefix))
+          (is (re-find #"^:rf\.error/effect-map-shape\b" summary))
+          (is (= :rf.error/effect-map-shape (:error record))))
         (is (zero? report-error))))
 
-    (testing "an unregistered event id — the typo case, and it carries NO
-              exception, so the diagnostic is two arguments not three"
+    (testing "an unregistered event id — the typo case. It carries NO
+              exception, so there is no fourth argument; the summary still
+              names the category, which is what a reader greps"
       (let [{:keys [console report-error]}
             (capture-console #(rf/dispatch-sync [:fu75.console/nothing-here]))]
         (is (= 1 (count console)))
         (let [args (first console)]
-          (is (= 2 (count args))
-              (str "prefix + record only — nothing synthesised to stand in for "
-                   "the absent exception; got " (count args) " arguments"))
+          (is (= 3 (count args))
+              (str "prefix + summary + record — nothing synthesised to stand in "
+                   "for the absent exception; got " (count args) " arguments"))
           (is (= "[re-frame2]" (first args)))
-          (is (= :rf.error/no-such-handler (:error (second args))))
-          (is (nil? (:exception (second args)))))
+          (is (= ":rf.error/no-such-handler" (second args))
+              (str "no exception and no :reason on this category, so the summary "
+                   "is the bare category keyword — never an empty string, never "
+                   "invented prose; got " (pr-str (second args))))
+          (is (= :rf.error/no-such-handler (:error (nth args 2))))
+          (is (nil? (:exception (nth args 2)))))
         (is (zero? report-error))))))
 
 (deftest unowned-diagnostic-does-not-change-control-flow
@@ -175,12 +208,76 @@
                     :where :safe-call-hook!}]
                   1234)))]
         (is (= 1 (count console)))
-        (let [args (first console)]
-          (is (= 2 (count args)))
-          (is (= "[re-frame2]" (first args)))
-          (is (= :rf.error/frame-teardown-failed (:error (second args))))
-          (is (= 1 (count (:hook-failures (second args))))))
+        (let [[prefix summary record] (first console)]
+          (is (= 3 (count (first console))))
+          (is (= "[re-frame2]" prefix))
+          (is (re-find #"^:rf\.error/frame-teardown-failed\b" summary))
+          (is (re-find #"teardown step\(s\) threw" summary)
+              (str "this union record carries no top-level :exception but DOES "
+                   "carry a composed :reason — the summary must fall back to it "
+                   "rather than stopping at the category; got " (pr-str summary)))
+          (is (= :rf.error/frame-teardown-failed (:error record)))
+          (is (= 1 (count (:hook-failures record)))))
         (is (zero? report-error))))))
+
+;; ===========================================================================
+;; NO-FRAME-CONTEXT — the category the rf2-6sqv measurement was OF
+;; ===========================================================================
+;;
+;; This is the one that motivated the bead, and it is the one a summary-only
+;; fix could NOT have repaired. `emit-no-frame-context!` passes no exception
+;; (nothing threw — the operation is invalid), so before rf2-6sqv the record
+;; was seven slots of pure metadata and the recovery ladder
+;; `no-frame-context-payload` had just composed reached the always-on axis
+;; nowhere at all. The console printed `{meta: null, cnt: 7, arr: Array(14),
+;; …}` — `cnt: 7` being exactly that record — and no formatter reading only
+;; the record could have recovered the sentence, because it was not there.
+;;
+;; So both halves are asserted here: the ladder is ON THE RECORD (the emit
+;; site carries it through `dispatch-on-error!`'s existing attribution seam),
+;; and it REACHES THE CONSOLE LINE.
+
+(deftest no-frame-context-carries-its-ladder-to-the-console
+  (when (browser?)
+    (let [payload (frame/no-frame-context-payload :subscribe
+                                                  {:where 'rf/subscribe})]
+      (is (string? (:reason payload))
+          "premise: the payload composes the ladder in the first place")
+
+      (testing "the always-on record carries the payload's OWN :reason and
+                :recovery — this category throws nothing, so without them the
+                record holds no message anywhere"
+        (let [seen (atom [])]
+          (rf/register-listener! :errors :fu75/ladder
+                                 (fn [record] (swap! seen conj record)))
+          (frame/emit-no-frame-context! payload)
+          (rf/unregister-listener! :errors :fu75/ladder)
+          (let [record (first @seen)]
+            (is (= :rf.error/no-frame-context (:error record)))
+            (is (= (:reason payload) (:reason record))
+                "the composed ladder, verbatim — not a re-derivation")
+            (is (= :supply-frame (:recovery record))
+                "and the machine-readable repair beside it"))))
+
+      (testing "and the console line leads with the category and the ladder,
+                so a reader who opens devtools sees the text FIRST"
+        (error-emit/clear-error-listeners!)
+        (let [{:keys [console report-error]}
+              (capture-console #(frame/emit-no-frame-context! payload))]
+          (is (= 1 (count console)))
+          (let [args (first console)
+                [prefix summary record] args]
+            (is (= 3 (count args))
+                (str "prefix + summary + record; no exception on this "
+                     "category. Got " (count args)))
+            (is (= "[re-frame2]" prefix))
+            (is (re-find #"^:rf\.error/no-frame-context\b" summary))
+            (is (re-find #"no frame context" summary)
+                (str "the ladder itself reaches the line — this is the exact "
+                     "text the rf2-6sqv page load could not show; got "
+                     (pr-str summary)))
+            (is (map? record) "and the record still rides for the inspector"))
+          (is (zero? report-error)))))))
 
 ;; ===========================================================================
 ;; OWNED — a listener suppresses the fallback, on BOTH fan-out sites

--- a/implementation/core/test/re_frame/error_emit_dev_console_dom_cljs_test.cljs
+++ b/implementation/core/test/re_frame/error_emit_dev_console_dom_cljs_test.cljs
@@ -279,6 +279,27 @@
             (is (map? record) "and the record still rides for the inspector"))
           (is (zero? report-error)))))))
 
+(deftest bad-frame-provider-arg-carries-its-reason-too
+  (when (browser?)
+    (testing "`emit-bad-frame-provider-arg!` says it MIRRORS
+              `emit-no-frame-context!`, and it has the same shape for the
+              same reason — no exception, a composed :reason on the payload.
+              Pinned so the two cannot drift into one carrying its message
+              and the other not"
+      (error-emit/clear-error-listeners!)
+      (let [payload (frame/bad-frame-provider-arg-payload
+                      "not-a-frame" {:where 'rf/frame-provider})
+            {:keys [console]}
+            (capture-console #(frame/emit-bad-frame-provider-arg! payload))]
+        (is (= 1 (count console)))
+        (let [[_ summary record] (first console)]
+          (is (re-find #"^:rf\.error/bad-frame-provider-arg\b" summary))
+          (is (re-find #"must be a frame id keyword" summary)
+              (str "the payload's own sentence reaches the line; got "
+                   (pr-str summary)))
+          (is (= (:reason payload) (:reason record))
+              "and verbatim onto the record for an off-box shipper"))))))
+
 ;; ===========================================================================
 ;; OWNED — a listener suppresses the fallback, on BOTH fan-out sites
 ;; ===========================================================================


### PR DESCRIPTION
Closes rf2-6sqv (P2) and rf2-02w1 (P3) — the two sharp edges the rf2-nvcp P0 exposed.

**Read the "What contradicts the brief" section first.** Three of the briefing premises did not
hold at source, and one of them changes what the fix had to be.

---

## Item 1 — rf2-6sqv: the framework's errors reached the console as opaque objects

### Reproduced in a real browser, before and after

Measured with headless Chromium driving the `:examples/linearlite` dev build over an ordinary
page load, reading CDP `Runtime.consoleAPICalled` previews — what the DevTools console panel
actually renders, not Playwright's `JSHandle@object` shorthand. The route that renders
`[rf/route-link …]` is the `not-found-page`, reached by any unmatched URL.

**BEFORE** (at the branch point, where the rf2-nvcp P0 was still live on main):

```
[re-frame2] {meta: null, cnt: 7, arr: Array(14), __hash: null, cljs$lang$protocol_mask$partition0$: 16647951, …}
```

Two such lines, two arguments each. `cnt: 7` is the seven-key error record itself.

**AFTER**, same page, same build, same instrument:

```
[re-frame2] :rf.error/no-frame-context — a frame-scoped route-link ran with no frame context —
no carried frame stamp and no established scope. Frame identity is carried, not found. If this
fired from an :on-* handler, a timer, a promise or any other deferred callback, the scope it was
WRITTEN inside had already unwound by the time it RAN: the repair is to carry the frame across
that boundary, not to establish a second scope there. In a view, use the dispatch / subscribe the
reg-view macro injects — they are render-time captures; elsewhere hold (:dispatch
(rf/capture-frame)) while the scope is still live. Otherwise establish a scope one of three
distinct ways (do not combine 1 and 2): (1) create a frame with rf/make-frame, then scope the
operation inside it with with-frame or a frame-provider (which SCOPES an existing frame); (2) let
a frame-root ENSURE the frame (create-if-absent) without pre-creating it; or (3) pass an explicit
{:frame <id>}. Per Spec 002 §The error and its ladder.
{meta: null, cnt: 9, root: Object, has_nil_QMARK_: false, nil_val: null, …}
```

Three arguments: prefix, summary, record.

rf2-nvcp merged part-way through this work, so linearlite no longer raises that error at all on
the current base. The AFTER line above was re-confirmed on the **final** tree by inducing a
genuine `:rf.error/no-frame-context` in the same live page — identical readable output.

### What the channel did, and why it changed the way it did

`re-frame.error-emit/report-unowned-error!` (the rf2-fu75 unowned-error dev console fallback) did:

```clojure
(.error js/console "[re-frame2]" record ex)   ;; or without ex
```

Passing the record **as a value** is deliberate and correct — the surrounding comment block gives
the reason (the host inspector renders the structure, the real stack survives, no flattening to a
string). That reason still holds, so **the record and the exception both still ride as their own
arguments, unchanged**. A structured consumer and DevTools object inspection are unaffected; the
only change is that a readable string now goes *in front* of them.

What the comment did not account for is that a CLJS map is not a JS object. Chrome renders
`PersistentArrayMap`'s interior fields — `meta`, `cnt`, `arr`, `__hash` — so the record arrived as
machine noise and the reader saw no message at all.

`console-summary` builds that leading line from **what already exists**: the carried exception's
`ex-message`, else the record's own `:reason`, else the bare category keyword. It composes no new
error prose. Leading with the category is deliberate — `:reason` sentences carry no bracketed
catalogue token (`re-frame.error/throw-error!` appends that only when building a *thrown*
message), so a `:reason`-only line would name no category to grep for.

### The half that a console-side fix alone could not reach

`:rf.error/no-frame-context` is the category the bead was measured on, and its record carried
**neither** an exception nor a reason — `emit-no-frame-context!` passes `nil` for the exception
(nothing threw; the operation is invalid) and dropped the payload's `:reason` on the floor. The
recovery ladder it had just composed reached the always-on axis nowhere. Measured, not inferred:

```clojure
;; the logged record, pr-str'd in-page, BEFORE
{:error :rf.error/no-frame-context, :event :rf/redacted, :event-id nil,
 :frame nil, :time 334.3, :exception nil, :elapsed-ms 0}
```

No formatter reading only that record could have recovered the sentence, because it was not there.
So the emit site now threads `:reason` / `:recovery` through `dispatch-on-error!`'s **existing**
`attrs` attribution seam — the same seam flow-eval already uses for category-specific slots, and
the same pair the non-event union records already carry (the frame-teardown report carries both).
An off-box shipper gains the sentence too.

`emit-bad-frame-provider-arg!` had the identical shape and its docstring says it *mirrors*
`emit-no-frame-context!`, so it got the same one-line treatment rather than being left as a
half-fixed sibling.

**This is the one place I went past the brief's literal scope** ("find the console channel and fix
the rendering there"). The brief's premise for that scoping — "the message exists and is
reachable... only the console rendering loses it" — is false for this category, and a console-only
fix would have closed the bead while leaving its own measured evidence unreadable. Flagging it
explicitly so it can be split out if that call is wrong.

### Coverage

`error_emit_dev_console_dom_cljs_test.cljs` pinned the old argument shape (`(= 2 (count args))`)
and is updated. Its assertions now pin **both** halves: the summary is text and names the
category, **and** the record and exception still ride as their own arguments. Two new tests cover
the no-frame-context ladder reaching the line, and the mirrored sibling's symmetry. No assertion
was weakened or deleted.

---

## Item 2 — rf2-02w1: `defwrapper` calls a hook whose value may be a component

### The full census — every `defwrapper` hook, classified

**How it was run.** A Clojure script reading every `.clj/.cljs/.cljc` file under `implementation/`
with the **Clojure reader** (`read` with `:read-cond :allow`), collecting forms whose head symbol
is `defwrapper`. A text scan is unsafe here — the ns docstring contains a worked `(defwrapper
clear-flow …)` example, which a grep counts and a reader correctly ignores as string content.

**Controls.** (a) The known needle `:routing/route-link` is present in the output. (b) The script
reports read **failures** explicitly rather than silently skipping them; 187 files failed on `#js`
/ `#queue` tags and `::alias` keywords. That hole was closed separately: a plain text search for
`(defwrapper ` returns exactly **9** files, and **none** of them is in the failure list — so no
file that could carry a wrapper went unparsed. (c) `grep -F` was never combined with `-i` (that
combination silently returns zero on this build).

**Result: 58 `defwrapper` forms, 58 distinct hooks, in 8 files.**

| Artefact | Hooks | Value classification |
|---|---|---|
| `:epoch/*` | 10 | FUNCTION (all `defn`, published via one `set-fns!` block) |
| `:flows/*` | 2 | FUNCTION |
| `:http/*` | 3 | FUNCTION |
| `:resources/*` | 15 | FUNCTION |
| `:routing/reg-route` | 1 | FUNCTION |
| `:routing/route-link` | 1 | **COMPONENT on CLJS** — see below |
| `:schemas/*` | 10 | FUNCTION |
| `:ssr/*` | 9 | FUNCTION |
| `:test/*` (test fixtures) | 7 | FUNCTION (all literal `(fn [] …)`) |

**57 FUNCTION, 1 COMPONENT.** The one is `:routing/route-link` — the known rf2-nvcp instance, and
nothing else.

That was confirmed from the other direction too, which is the stronger instrument: the only
component-*producing* expressions anywhere in the seven artefact source trees are
`views/reg-view* :route/link` and `registrar/register! :view :route/link`, both in
`routing.cljc`. There is no second component in any artefact to publish. (Control: the same search
for `contextType` finds seven files in `core/src`, so it bites.)

### Which branch of the ruling

**The "census finds none" branch** — no *other* component-valued hook exists. So per the ruling the
constraint is recorded where the next author meets it: `defwrapper`'s own docstring in
`core_artefact.cljc`, with rf2-nvcp named as the worked instance and the publication-side
element-emitting shim named as the repair. **No runtime check was built** — zero live violations.
`defwrapper`'s emission shape is unchanged.

### One correction to how the constraint is stated

The bead and brief both frame this as an **`:apply`** hazard. That framing is too narrow, and
writing the docstring that way would have been actively misleading:

- `:apply` emits `(apply f args)` — **1** wrapper uses it (`route-link`).
- `:delegate` emits `(f a b …)` — **57** wrappers use it.

Both **call**. A docstring saying "an `:apply` hook value must be a function" would have exempted
57 of the 58 wrappers from a constraint that binds every one of them. The docstring is written
against both direct body kinds.

---

## What contradicts the brief

1. **"That is now fixed and merged (PR #9050)" — was not true when this started.** At dispatch,
   PR #9050 was **OPEN** (`mergedAt: null`), so the P0 was still live on `main` and every routed
   page still blanked. It merged part-way through this work. This is the "beads close on PR-open,
   so closed ≠ on main" trap: rf2-nvcp showed as closed while its fix was not on the trunk. It
   also means `:routing/route-link` was *still* a component-valued hook at the branch point — the
   census answer would have read differently a few hours either side.

2. **"That is a raw `cljs.core/ExceptionInfo` (or its ex-data map)" — it is neither.** It is the
   `error-emit` **record** map. `cnt: 7` is its seven keys; an ExceptionInfo has three fields.

3. **"The message exists and is reachable... the same run's `window` error event carried the full
   text" — refuted on both halves.** The message was *not* in the logged object (`:exception nil`,
   no `:reason`), and the `pageerror` message string was **23 characters**: `cljs$core$ExceptionInfo`.
   Not the ladder. This is what forced the emit-site half of the fix.

4. Minor: linearlite's `rf/route-link` lives on `not-found-page`, so `/` alone does not reproduce
   the defect — an unmatched URL is needed. Worth knowing for anyone re-measuring.

---

## Gates

Every gate run in the foreground to completion, unfiltered, exit code captured by the runner
itself (never the harness's report) and quoted here.

| Gate | Baseline (branch point) | This branch | Exit |
|---|---|---|---|
| `npm run test:cljs` | 11193 tests / 55792 assertions | **11197 / 55794** | **0** |
| `implementation/core` JVM (`clojure -M:test`) | 2175 tests / 11144 assertions | **2175 / 11144** | **0** |
| `npm run test:browser` | — | **778 tests / 4233 assertions** | **0** |
| `sh scripts/test-fast-pr.sh` | — | full spine, clj-kondo `errors: 0` | **0** |

No counts dropped. The node/CLJS baseline was taken at the branch point, so its `+4 / +2` delta
mixes this change with the commits that landed in between; the browser suite is where this
change's own assertions live (`+1 test / +4 assertions` across the two runs on this branch).

**Does the diff arm `test:browser`?** Yes — it touches a `-dom-cljs-test` namespace, which is on
the `:browser-test` build. It was run, and it is the gate that matters here.

**`test-fast-pr.sh --plan`** reports `documentation gates: skip`, `JVM tier: run`
(`implementation/core`), `node/CLJS suite: run`, `clj-kondo: run` — and confirms the P0 worker's
observation verbatim: *"No browser, bundle, adapter, Xray, MCP or tool-JVM gate is in any tier."*
So the green spine says nothing about item 1, which is why the browser measurement above is the
load-bearing evidence rather than a supplement to it.

**Worktree verification.** `test-fast-pr.sh` and the browser runner both print their root, and both
named this worker's worktree. Independently, the new tests assert behaviour that exists only on
this branch and pass — a run that had wandered into a sibling checkout could not have produced
that.
