### PR TITLE
conformance loaders: close the early-] escape; playground: drop the retired machine-has-tag? (rf2-98ni, rf2-wd0h)

### DIFF
--- a/docs/tools/playground/README.md
+++ b/docs/tools/playground/README.md
@@ -15,12 +15,16 @@ by the SCI bundle namespace, which fires the artefact's `:machines/*`
 late-bind hook installs at bundle init and registers the
 `:rf/machine` / `:rf.machine/has-tag?` framework subs +
 `:rf.machine/spawn` / `:rf.machine/destroy` (and others) reserved fxs from
-its top-level forms. The `re-frame.core` aliases `sci/copy-ns` already
-exposes (`reg-machine*` / `make-machine-handler` / `machine-transition`
-/ `machine-has-tag?` / `machines` / `machine-meta` /
-`machine-by-system-id` / `dispatch-to-system`) become live, and the SCI
-namespace also binds `reg-machine` to the `reg-machine*` fn-alias so
-cells write the same `(rf/reg-machine ...)` they would in real code.
+its top-level forms. Those hook installs are what make the machine
+helpers live — `reg-machine*` / `make-machine-handler` /
+`machine-transition` / `machines` / `machine-meta` /
+`machine-by-system-id`. They sit on `re-frame.machines`, NOT on the
+`re-frame.core` façade: the front-porch shrink (rf2-wad2fl) left the
+façade's machine surface as the `reg-machine` / `defmachine` macros
+alone, and `reg-machine` is a JVM-only macro (per-element source-coord
+stamping at expansion time). So the SCI namespace binds `reg-machine` to
+the `re-frame.machines/reg-machine*` fn-alias, and cells write the same
+`(rf/reg-machine ...)` they would in real code.
 Used by ch12 of the guide to demo a real `reg-machine` +
 `subscribe [:rf/machine …]` turnstile.
 
@@ -121,7 +125,7 @@ The Phase-3 re-frame2 eval bundle (`sci/`) pins:
 | `org.babashka/sci` | 0.11.51 (git) | the SCI interpreter — the re-frame2 cells' eval engine |
 | `day8/re-frame2` (core) | `:local/root` | the public API exposed to cells (`re-frame.core` v2) |
 | `day8/reagent-slim` | `:local/root` | reagent2 (the render substrate) + the `reagent-slim` adapter |
-| `day8/re-frame2-machines` | `:local/root` | Spec 005 state-machine artefact (rf2-ldgpd) — activates `reg-machine` / `subscribe [:rf/machine …]` / `machine-has-tag?` for ch12 live cells |
+| `day8/re-frame2-machines` | `:local/root` | Spec 005 state-machine artefact (rf2-ldgpd) — activates `reg-machine` / `subscribe [:rf/machine …]` (and the `[:rf.machine/has-tag? …]` sub) for ch12 live cells |
 | `react` + `react-dom` | 19.2.0 | **bundled** into `playground-rf2.js` (React 19 has no UMD) |
 | `shadow-cljs` | 3.4.10 | the CLJS → `:advanced` browser bundler |
 

--- a/docs/tools/playground/sci/deps.edn
+++ b/docs/tools/playground/sci/deps.edn
@@ -16,8 +16,8 @@
 ;;     (rf2-ldgpd). `:require`d by the SCI bundle namespace so the
 ;;     `:machines/*` late-bind hooks register at bundle init: the
 ;;     `reg-machine*` / `make-machine-handler` / `machine-transition`
-;;     / `machine-has-tag?` aliases on `re-frame.core`
-;;     (which `sci/copy-ns` already exposes) become live, and the
+;;     helpers on `re-frame.machines` (the façade no longer re-exports
+;;     them — front-porch shrink, rf2-wad2fl) become live, and the
 ;;     `:rf/machine` / `:rf.machine/has-tag?` framework subs +
 ;;     `:rf.machine/spawn` / `:rf.machine/destroy` fxs register from
 ;;     `re-frame.machines`'s top-level forms. Live cells in the

--- a/implementation/core/test/re_frame/conformance_fixtures.clj
+++ b/implementation/core/test/re_frame/conformance_fixtures.clj
@@ -43,17 +43,25 @@
   fixture fails the build outright rather than reaching a runner that
   could classify it as a skip."
   [text fixture-name]
-  (let [forms (edn/read-string (str "[\n" text "\n]"))]
-    (when-not (= 1 (count forms))
-      (throw (ex-info (str "conformance fixture " fixture-name
-                           " must hold exactly ONE top-level EDN form, found "
-                           (count forms)
-                           " — clojure.edn/read-string returns only the first"
-                           " and silently discards the rest (rf2-98ni,"
-                           " rf2-5mr6)")
-                      {:fixture/file  fixture-name
-                       :fixture/forms (count forms)})))
-    (first forms)))
+  (let [eof  (Object.)
+        rdr  (java.io.PushbackReader. (java.io.StringReader. text))
+        fail (fn [why data]
+               (throw (ex-info (str "conformance fixture " fixture-name " " why
+                                    " (rf2-98ni, rf2-5mr6)")
+                               (assoc data :fixture/file fixture-name))))
+        rd   (fn []
+               (try (edn/read {:eof eof} rdr)
+                    (catch Exception e
+                      (fail (str "is not readable EDN: " (.getMessage e))
+                            {:fixture/reader-error (.getMessage e)}))))
+        form (rd)]
+    (when (identical? eof form)
+      (fail "holds no top-level EDN form" {:fixture/forms 0}))
+    (when-not (identical? eof (rd))
+      (fail (str "must hold exactly ONE top-level EDN form — a plain read"
+                 " returns the first and silently discards the rest")
+            {:fixture/forms :more-than-one}))
+    form))
 
 (defn- load-fixture-from-file
   "Read one EDN fixture file, applying the same `::name` rewrite the

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -93,10 +93,22 @@
   silently ignores everything after it. So a fixture whose expectation
   block closes one brace early still loads, still runs, and still reports
   as PASSING — with every assertion that fell outside the block discarded.
-  That is exactly what `routing-not-found.edn` did (rf2-5mr6). Reading
-  `[<text>]` instead makes the reader see the whole file: trailing text
-  becomes a second element, and a stray closing delimiter becomes an
-  unmatched-delimiter error.
+  That is exactly what `routing-not-found.edn` did (rf2-5mr6).
+
+  WHY NOT WRAP THE TEXT AS `[<text>]` EITHER, which is what this fn did
+  when the check first landed. Counting the elements of a SYNTHETIC vector
+  is a guard the guarded text can walk straight out of: a fixture that
+  closes the envelope itself with an early `]` yields a ONE-element vector,
+  so the count check passes and everything after that `]` is discarded in
+  silence — recreating the exact truncation class the check exists to
+  remove. Measured on the merged code: the text `{:fixture/id :first}`,
+  newline, `] {:fixture/id :silently-hidden}` returned `#:fixture{:id
+  :first}` without throwing.
+
+  SO READ THE ORIGINAL TEXT — no envelope, hence nothing to escape from —
+  and PROVE EOF behind the first form with a second read against a
+  sentinel. `one-form-guard-rejects-early-close-bracket` below pins both
+  directions.
 
   WHY IT THROWS, and why the `try`/`catch` that used to wrap this is gone.
   The catch turned any load failure into a `{:fixture/load-error ...}` map,
@@ -106,23 +118,33 @@
   the defect it is meant to catch — the fixture would stop passing
   falsely and start vanishing quietly instead. Corpus malformation is a
   repository defect, not a per-fixture runtime condition, so it fails the
-  run.
+  run. The `catch` in the body below is NOT that catch and must not be
+  read as its return: it RE-THROWS, and exists only so a reader error
+  arrives naming the fixture it came out of.
 
   The corpus scanner (`scripts/check_conformance_fixture_edn.py`, rf2-x91a)
   is the complementary half: it sees fixtures whose capabilities are
   unclaimed, which this check never loads at all."
   [text fixture-name]
-  (let [forms (edn/read-string (str "[\n" text "\n]"))]
-    (when-not (= 1 (count forms))
-      (throw (ex-info (str "conformance fixture " fixture-name
-                           " must hold exactly ONE top-level EDN form, found "
-                           (count forms)
-                           " — clojure.edn/read-string returns only the first"
-                           " and silently discards the rest (rf2-98ni,"
-                           " rf2-5mr6)")
-                      {:fixture/file  fixture-name
-                       :fixture/forms (count forms)})))
-    (first forms)))
+  (let [eof  (Object.)
+        rdr  (java.io.PushbackReader. (java.io.StringReader. text))
+        fail (fn [why data]
+               (throw (ex-info (str "conformance fixture " fixture-name " " why
+                                    " (rf2-98ni, rf2-5mr6)")
+                               (assoc data :fixture/file fixture-name))))
+        rd   (fn []
+               (try (edn/read {:eof eof} rdr)
+                    (catch Exception e
+                      (fail (str "is not readable EDN: " (.getMessage e))
+                            {:fixture/reader-error (.getMessage e)}))))
+        form (rd)]
+    (when (identical? eof form)
+      (fail "holds no top-level EDN form" {:fixture/forms 0}))
+    (when-not (identical? eof (rd))
+      (fail (str "must hold exactly ONE top-level EDN form — a plain read"
+                 " returns the first and silently discards the rest")
+            {:fixture/forms :more-than-one}))
+    form))
 
 (defn- load-fixture [file]
   ;; A handful of fixtures use `::name` (auto-resolved keyword) which pure
@@ -219,6 +241,43 @@
 
 (deftest run-conformance-corpus
   (runner/run-corpus (all-fixtures) host "JVM"))
+
+;; ---- rf2-98ni acceptance: the one-form guard cannot be escaped ------------
+;;
+;; The FIRST case is the discriminating one. Its trailing text opens with `]`,
+;; which is what the previous `[<text>]` implementation could not survive: the
+;; fixture closed the synthetic vector itself, `read-string` returned a
+;; one-element vector, the count check passed, and the second map vanished. A
+;; regression whose trailing text were an ordinary form would have passed
+;; against that implementation too and pinned nothing.
+
+(deftest one-form-guard-rejects-early-close-bracket
+  (is (thrown? clojure.lang.ExceptionInfo
+               (read-one-form "{:fixture/id :first}\n] {:fixture/id :hidden}"
+                              "early-close.edn"))
+      (str "a fixture that closes the reader's envelope itself with an early ] "
+           "MUST fail to load — under the [<text>] implementation this returned "
+           "the first form and discarded the second in silence (rf2-98ni)"))
+
+  (is (thrown? clojure.lang.ExceptionInfo
+               (read-one-form "{:fixture/id :first}\n{:fixture/id :second}"
+                              "two-forms.edn"))
+      "ordinary trailing text must still be refused (rf2-5mr6)")
+
+  (is (thrown? clojure.lang.ExceptionInfo
+               (read-one-form "\n;; only a comment\n" "empty.edn"))
+      "a fixture holding no top-level form must fail rather than load as nil")
+
+  ;; The other direction: a well-formed fixture, and one with the trailing
+  ;; whitespace and comments real corpus files carry, must still load.
+  (is (= {:fixture/id :ok}
+         (read-one-form "{:fixture/id :ok}" "clean.edn"))
+      "a single well-formed form must load unchanged")
+
+  (is (= {:fixture/id :ok}
+         (read-one-form "\n;; leading comment\n{:fixture/id :ok}\n;; trailing\n"
+                        "commented.edn"))
+      "comments and surrounding whitespace are not trailing FORMS"))
 
 ;; ---- rf2-xurchk acceptance self-tests -------------------------------------
 ;;

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -198,17 +198,25 @@
   runner classifies as a SKIP — as silent as the defect. Full rationale on
   `re-frame.conformance-test/read-one-form` (rf2-98ni)."
   [text fixture-name]
-  (let [forms (edn/read-string (str "[\n" text "\n]"))]
-    (when-not (= 1 (count forms))
-      (throw (ex-info (str "conformance fixture " fixture-name
-                           " must hold exactly ONE top-level EDN form, found "
-                           (count forms)
-                           " — clojure.edn/read-string returns only the first"
-                           " and silently discards the rest (rf2-98ni,"
-                           " rf2-5mr6)")
-                      {:fixture/file  fixture-name
-                       :fixture/forms (count forms)})))
-    (first forms)))
+  (let [eof  (Object.)
+        rdr  (java.io.PushbackReader. (java.io.StringReader. text))
+        fail (fn [why data]
+               (throw (ex-info (str "conformance fixture " fixture-name " " why
+                                    " (rf2-98ni, rf2-5mr6)")
+                               (assoc data :fixture/file fixture-name))))
+        rd   (fn []
+               (try (edn/read {:eof eof} rdr)
+                    (catch Exception e
+                      (fail (str "is not readable EDN: " (.getMessage e))
+                            {:fixture/reader-error (.getMessage e)}))))
+        form (rd)]
+    (when (identical? eof form)
+      (fail "holds no top-level EDN form" {:fixture/forms 0}))
+    (when-not (identical? eof (rd))
+      (fail (str "must hold exactly ONE top-level EDN form — a plain read"
+                 " returns the first and silently discards the rest")
+            {:fixture/forms :more-than-one}))
+    form))
 
 (defn- load-fixture
   "Read one EDN fixture, applying the same `::name` rewrite the core

--- a/implementation/machines/test/re_frame/machines_conformance_test.clj
+++ b/implementation/machines/test/re_frame/machines_conformance_test.clj
@@ -89,17 +89,25 @@
   the skip the core runner would give it. Full rationale on
   `re-frame.conformance-test/read-one-form` (rf2-98ni)."
   [text fixture-name]
-  (let [forms (edn/read-string (str "[\n" text "\n]"))]
-    (when-not (= 1 (count forms))
-      (throw (ex-info (str "conformance fixture " fixture-name
-                           " must hold exactly ONE top-level EDN form, found "
-                           (count forms)
-                           " — clojure.edn/read-string returns only the first"
-                           " and silently discards the rest (rf2-98ni,"
-                           " rf2-5mr6)")
-                      {:fixture/file  fixture-name
-                       :fixture/forms (count forms)})))
-    (first forms)))
+  (let [eof  (Object.)
+        rdr  (java.io.PushbackReader. (java.io.StringReader. text))
+        fail (fn [why data]
+               (throw (ex-info (str "conformance fixture " fixture-name " " why
+                                    " (rf2-98ni, rf2-5mr6)")
+                               (assoc data :fixture/file fixture-name))))
+        rd   (fn []
+               (try (edn/read {:eof eof} rdr)
+                    (catch Exception e
+                      (fail (str "is not readable EDN: " (.getMessage e))
+                            {:fixture/reader-error (.getMessage e)}))))
+        form (rd)]
+    (when (identical? eof form)
+      (fail "holds no top-level EDN form" {:fixture/forms 0}))
+    (when-not (identical? eof (rd))
+      (fail (str "must hold exactly ONE top-level EDN form — a plain read"
+                 " returns the first and silently discards the rest")
+            {:fixture/forms :more-than-one}))
+    form))
 
 (defn- load-fixture [file]
   ;; A handful of fixtures use `::name` (auto-resolved keyword) which

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -123,17 +123,25 @@
   runner classifies as a SKIP — as silent as the defect. Full rationale on
   `re-frame.conformance-test/read-one-form` (rf2-98ni)."
   [text fixture-name]
-  (let [forms (edn/read-string (str "[\n" text "\n]"))]
-    (when-not (= 1 (count forms))
-      (throw (ex-info (str "conformance fixture " fixture-name
-                           " must hold exactly ONE top-level EDN form, found "
-                           (count forms)
-                           " — clojure.edn/read-string returns only the first"
-                           " and silently discards the rest (rf2-98ni,"
-                           " rf2-5mr6)")
-                      {:fixture/file  fixture-name
-                       :fixture/forms (count forms)})))
-    (first forms)))
+  (let [eof  (Object.)
+        rdr  (java.io.PushbackReader. (java.io.StringReader. text))
+        fail (fn [why data]
+               (throw (ex-info (str "conformance fixture " fixture-name " " why
+                                    " (rf2-98ni, rf2-5mr6)")
+                               (assoc data :fixture/file fixture-name))))
+        rd   (fn []
+               (try (edn/read {:eof eof} rdr)
+                    (catch Exception e
+                      (fail (str "is not readable EDN: " (.getMessage e))
+                            {:fixture/reader-error (.getMessage e)}))))
+        form (rd)]
+    (when (identical? eof form)
+      (fail "holds no top-level EDN form" {:fixture/forms 0}))
+    (when-not (identical? eof (rd))
+      (fail (str "must hold exactly ONE top-level EDN form — a plain read"
+                 " returns the first and silently discards the rest")
+            {:fixture/forms :more-than-one}))
+    form))
 
 (defn- load-fixture
   "Read one EDN fixture. The corpus does not use auto-resolved keywords

--- a/implementation/ssr/test/re_frame/ssr_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_conformance_test.clj
@@ -205,17 +205,25 @@
   runner classifies as a SKIP — as silent as the defect. Full rationale on
   `re-frame.conformance-test/read-one-form` (rf2-98ni)."
   [text fixture-name]
-  (let [forms (edn/read-string (str "[\n" text "\n]"))]
-    (when-not (= 1 (count forms))
-      (throw (ex-info (str "conformance fixture " fixture-name
-                           " must hold exactly ONE top-level EDN form, found "
-                           (count forms)
-                           " — clojure.edn/read-string returns only the first"
-                           " and silently discards the rest (rf2-98ni,"
-                           " rf2-5mr6)")
-                      {:fixture/file  fixture-name
-                       :fixture/forms (count forms)})))
-    (first forms)))
+  (let [eof  (Object.)
+        rdr  (java.io.PushbackReader. (java.io.StringReader. text))
+        fail (fn [why data]
+               (throw (ex-info (str "conformance fixture " fixture-name " " why
+                                    " (rf2-98ni, rf2-5mr6)")
+                               (assoc data :fixture/file fixture-name))))
+        rd   (fn []
+               (try (edn/read {:eof eof} rdr)
+                    (catch Exception e
+                      (fail (str "is not readable EDN: " (.getMessage e))
+                            {:fixture/reader-error (.getMessage e)}))))
+        form (rd)]
+    (when (identical? eof form)
+      (fail "holds no top-level EDN form" {:fixture/forms 0}))
+    (when-not (identical? eof (rd))
+      (fail (str "must hold exactly ONE top-level EDN form — a plain read"
+                 " returns the first and silently discards the rest")
+            {:fixture/forms :more-than-one}))
+    form))
 
 (defn- load-fixture
   "Read one EDN fixture, applying the same `::name` rewrite the JVM core

--- a/implementation/ssr/test/re_frame/ssr_streaming_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_conformance_test.clj
@@ -92,17 +92,25 @@
   the silent-truncation hazard is identical. Full rationale on
   `re-frame.conformance-test/read-one-form` (rf2-98ni)."
   [text fixture-name]
-  (let [forms (edn/read-string (str "[\n" text "\n]"))]
-    (when-not (= 1 (count forms))
-      (throw (ex-info (str "conformance fixture " fixture-name
-                           " must hold exactly ONE top-level EDN form, found "
-                           (count forms)
-                           " — clojure.edn/read-string returns only the first"
-                           " and silently discards the rest (rf2-98ni,"
-                           " rf2-5mr6)")
-                      {:fixture/file  fixture-name
-                       :fixture/forms (count forms)})))
-    (first forms)))
+  (let [eof  (Object.)
+        rdr  (java.io.PushbackReader. (java.io.StringReader. text))
+        fail (fn [why data]
+               (throw (ex-info (str "conformance fixture " fixture-name " " why
+                                    " (rf2-98ni, rf2-5mr6)")
+                               (assoc data :fixture/file fixture-name))))
+        rd   (fn []
+               (try (edn/read {:eof eof} rdr)
+                    (catch Exception e
+                      (fail (str "is not readable EDN: " (.getMessage e))
+                            {:fixture/reader-error (.getMessage e)}))))
+        form (rd)]
+    (when (identical? eof form)
+      (fail "holds no top-level EDN form" {:fixture/forms 0}))
+    (when-not (identical? eof (rd))
+      (fail (str "must hold exactly ONE top-level EDN form — a plain read"
+                 " returns the first and silently discards the rest")
+            {:fixture/forms :more-than-one}))
+    form))
 
 (defn- load-streaming-fixture []
   (let [raw   (slurp (io/file "../../spec/conformance/fixtures/ssr-streaming.edn"))


### PR DESCRIPTION
Two unrelated beads, paired only because both surfaces were free.

## Item 1 — rf2-98ni: the one-form guard could be escaped by the fixture it guards

**The escape, reproduced at my base (69b33ca474) before changing anything.** All
seven loaders wrapped the fixture text as `[` / `<text>` / `]` and required the
returned vector to hold one element. Calling the merged
`re-frame.conformance-test/read-one-form` directly with

```
{:fixture/id :first}
] {:fixture/id :silently-hidden}
```

returned `#:fixture{:id :first}` **without throwing** — the fixture closed the
synthetic vector itself, so the count check passed and the second map was
discarded in silence. That is the truncation class the guard existed to remove.
A control with ordinary trailing text (no early `]`) threw correctly, so the
hole is specific to the early `]`.

**The repair.** Read the ORIGINAL text through a `PushbackReader` and prove EOF
behind the first form with a second `edn/read` against a sentinel. With no
envelope there is nothing for a fixture to close. A reader error is re-thrown as
`ex-info` so it still names the fixture — the old body's one genuinely useful
property, which a bare reader exception would have lost.

**Seven sites changed**, the full set, each matching exactly once (match counts
read before writing, since a silent zero-match is this edit's failure mode):

- `implementation/core/test/re_frame/conformance_fixtures.clj` (the CLJS arm's
  compile-time macro seam)
- `implementation/core/test/re_frame/conformance_test.clj` (the public owner)
- `implementation/{flows,machines,schemas}/test/re_frame/*_conformance_test.clj`
- `implementation/ssr/test/re_frame/{ssr,ssr_streaming}_conformance_test.clj`

`implementation/core/test/re_frame/conformance_runner.cljc` is untouched.

**The classpath claim is confirmed, not assumed.** The flows artefact's own
`:test` classpath (`clojure -A:test -Spath`) carries `implementation/core/src`
but not `core/test`, so `re-frame.conformance-test` is unreachable from a
sibling's suite and the seven small copies remain the honest shape. One nuance
worth recording: the aggregate `implementation/deps.edn` `:test` alias *does*
put `core/test` and every sibling test tree on one classpath — but that alias
documents itself as REPL convenience ("Production CI runs each artefact's :test
alias separately"), so it gives no artefact suite a shared home. No new shared
production namespace was added.

**The regression is discriminating.** `one-form-guard-rejects-early-close-bracket`
leads with trailing text that opens with `]`. A regression using ordinary
trailing text would have passed against the old body and pinned nothing. It also
covers the empty-fixture case and both must-still-load directions (a clean form,
and one wrapped in comments and whitespace).

**Proved to bite in both directions on a real corpus fixture.** Appending
`] {:fixture/id :rf.test/planted-hidden}` to
`spec/conformance/fixtures/machine-actor-isolation.edn`:

| | old body (as merged) | new body |
|---|---|---|
| planted fixture | **accepted**, returned `:machine/actor-isolation`, planted map discarded silently | **throws**, naming the fixture |
| core conformance suite | — | **exit 1** naming `machine-actor-isolation.edn` |
| machines conformance suite | — | **exit 1** naming the same |
| `check_conformance_fixture_edn.py` | — | **exit 1** (the scanner does catch this one, as the bead said) |

The fixture was restored and the restore verified by `git hash-object` blob
equality against the committed object, not by reading a diff.

**Clean corpus unmoved: 247 fixtures**, and stronger than a count — every
fixture's parsed data is IDENTICAL under the old and new bodies.
`check_conformance_fixture_edn.py --verbose` reads 247 / 0 defects, unchanged.

That the scanner also rejects this shape does not make the loaders' contract
true on its own, which is the audit's point: a targeted artefact suite can
accept a malformed fixture without ever running the scanner. The loaders now
hold by themselves.

## Item 2 — rf2-wd0h: two docs presented a retired fn as a live surface

**Re-measured census at tip**, three passes over the same tracked-file roster
(excluding `.beads`), because none is a superset of the others — plus controls,
since a zero from a broken pattern reads exactly like a clean result:

| needle | pass 1 line-oriented | pass 2 flattened | pass 3 de-hyphenated |
|---|---|---|---|
| `machine-has-tag?` (target) | 9 files / 129 lines | 9 files / 133 occ. | 9 files / 133 occ. |
| `has-tag?` (control, present, same shape: hyphenated, ends in `?`) | 81 files / 388 | 81 files / 415 | 81 files / 415 |
| `machine-has-tag-that-does-not-exist?` (control, absent) | 0 | 0 | 0 |

No file was visible only to pass 2 or pass 3. The 129 to 133 gap is a
lines-vs-occurrences metric difference, not a missed site: counting occurrences
per line and after flattening both give 133, so there are **zero** line-spanning
hits and the hyphen-wrap trap did not fire on this needle — checked rather than
assumed. The `-F`/`-i` trap did reproduce here: GNU grep 3.0, `-rnFi` returns 0
where `-rn`, `-rni` and `-rnF` all return 7.

Nine files, not the bead's eight: `scripts/check_retired_spellings.py` is the
gate PR #9042 added *after* that census was taken (the bead names #9042 itself).
It is the rule implementing the retirement — legitimate, and left alone.

**Both real carriers fixed; the six legitimate sites untouched.**

**What the playground actually activates** — measured with `ns-resolve` rather
than read off the prose. The `re-frame.core` façade's entire machine surface is
`reg-machine` and `defmachine`. **None** of the eight names the README listed as
"`re-frame.core` aliases `sci/copy-ns` already exposes" is a `re-frame.core`
public. `machine-has-tag?` resolves nowhere at all; `dispatch-to-system` does
not exist either (the real name is `dispatch-to-system-fx`); the remaining six
live on `re-frame.machines`, moved there by the front-porch shrink (rf2-wad2fl).

So the roster is corrected rather than holed — deleting only the one name would
have left a sentence still false about the other seven. The bundle's own source
(`sci/src/rf2_playground/sci.cljs`) already had this right and reaches
`re-frame.machines/reg-machine*` directly; the README and `sci/deps.edn` had
simply not followed.

The dependency-table row now names the `[:rf.machine/has-tag? …]` subscription,
which the machines artefact really does register, in place of the retired fn.
The short-form roster moved with it, in the same edit. For the record, the ch12
live cell (`docs/machines/concepts.md`) uses `reg-machine`, `reg-view`,
`frame-root` and `subscribe [:rf/machine :turnstile/flow]` — no tag surface at
all.

## Gates

Every gate run in the foreground, unfiltered, to completion, with the exit code
captured in the same shell as the redirect and quoted from that capture.

| gate | captured exit |
|---|---|
| `sh scripts/test-fast-pr.sh` (final base) | **0** — `PASS fast PR spine` |
| core / flows / machines / schemas / ssr conformance suites | **0** each |
| `python scripts/check_conformance_fixture_edn.py --verbose` | **0** — 247 / 0 |
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_retired_spellings.py` | **0** |
| `python scripts/check_readme_links.py --ci` | **0** |
| `python -m mkdocs build --strict` | **0** |

`--plan` armed documentation + JVM + node/CLJS + clj-kondo tiers, with the JVM
artefact list `core schemas machines flows ssr` — exactly the five whose loaders
this PR touches. The spine was re-run from scratch after rebasing onto
`8b510f7e8c`, because PR #9052's `conformance_runner.cljc` landed in the
interval along with `mkdocs.yml` and `spec/api-manifest-metadata.edn`; a
pre-rebase green would have been evidence about a tree that no longer exists.
The escape reproduction and the 247-fixture equivalence were re-measured on that
final base too. `npm ci` was installed into this worktree; no junction into any
shared `node_modules`.

### Which gate inspected which edit — one nomination did not hold

**`mkdocs build --strict` does NOT cover `docs/tools/playground/`.**
`exclude_docs` in `mkdocs.yml` lists `tools/playground/` as its FIRST entry.
Measured rather than inferred: the built site has no `site/tools/playground`
directory, the strict build's output never mentions the tree, and a broken prose
link planted in `docs/tools/playground/README.md` left `mkdocs build --strict`
**green at exit 0** — while `check_doc_slugs.py` went **red at exit 1** naming
the file and line on the identical plant. `check_doc_slugs.py` is the gate for
this path, and it is the one that ran.

**Fence-stripping confirmed in both directions on this very file**: the same
broken link exits 1 in prose and **exits 0 inside a fenced block**.

**Edits no gate inspected:**

- `docs/tools/playground/sci/deps.edn` — EDN, not markdown: outside
  `check_doc_slugs.py` and outside `check_readme_links.py`, and inside an
  `exclude_docs` tree for mkdocs. **No doc gate reads it at all.** The edit is a
  comment line; checked by hand.
- `docs/tools/playground/README.md` — `check_doc_slugs.py` does reach it (proved
  by the planted red above), but my edits there contain no links and no anchors,
  only prose and inline code spans, so the gate validated nothing I changed.
  Prose, the table column count (3 columns, unchanged) and every backticked
  symbol were checked by hand — `ns-resolve` is what settled the symbols.
- No headings were touched anywhere in this PR.

None of the item-1 edits sit inside fenced blocks.
