### PR TITLE
docs(ssr)+fix(xray): two records that described something other than what ships (rf2-8arzr.6, rf2-amz1)

### DIFF
--- a/docs/ssr/concepts.md
+++ b/docs/ssr/concepts.md
@@ -455,12 +455,21 @@ browser, and because the body is rendered before any shell is assembled, there
 is no partial page to serve.
 
 The worked example is
-[`substrates/hicasso/login`](../../examples/substrates/hicasso/login):
-`server.cljs` is a real render module, and the test suite drives the real
-views and registrations through it. Read its `host.clj` as annotated wiring
-rather than as a server you can start — that example's model is
-ClojureScript-only today, so a JVM host cannot yet load it. The code below is
-the shape to copy; it is not transcribed from a running deployment.
+[`substrates/hicasso/login`](../../examples/substrates/hicasso/login), and both
+halves of it run. `server.cljs` is a real render module and `host.clj` is a real
+Ring handler — the shared `login.model` is `.cljc`, so the JVM holds the
+application's state the same way the browser does. Two suites drive them:
+`re-frame.hicasso.login-server-crossing-ssr-dom-cljs-test` renders the real
+views and registrations through the published entry table, and
+`re-frame.ssr.ring.login-host-crossing-test` spawns the real launcher on an
+ephemeral port and drives the handler across it.
+
+One leg is covered by neither on its own: the compiled server bundle running
+under the sidecar in a single process. The JVM suite stands a fixture render
+module in for it, deliberately — compiling the bundle inside a JVM test would
+put shadow-cljs on that lane for nothing the ClojureScript suite does not
+already hold. Read the two together and every step below has a witness behind
+it; read either alone and it does not.
 
 ### 1. Build both bundles
 
@@ -485,9 +494,29 @@ step 5 exists to catch.
 
 ### 2. Write the render module
 
+Two files, and the split is load-bearing. The **policy** — the entry id and the
+per-partition key lists — goes in its own `.cljc` namespace, because the render
+module is ClojureScript, the Ring host in step 3 is Clojure, and a `.cljc`
+namespace is the only file both compilers read:
+
+```clojure
+(ns my-app.policy)
+
+(def root-entry "my-app/root")
+
+(def render-state-policy
+  {:app-db     [:todos :session]
+   :runtime-db [:rf.runtime/routing :rf.runtime/machines]})
+```
+
+Write those lists once. Two hand-kept copies drift, and the direction the
+sidecar **cannot** refuse is the safe-looking one: a host asking for *more* than
+the entry allows is refused by name, while a host asking for *less* is served a
+page rendered from incomplete state, with nothing anywhere to notice.
+
 The sidecar renders nothing itself; it loads your bundle. The module publishes
-a build id, an **entry table**, a once-per-isolate `boot` and a per-request
-`render`:
+a build id, an **entry table** derived from that policy, a once-per-isolate
+`boot` and a per-request `render`:
 
 ```clojure
 (ns my-app.server
@@ -495,17 +524,17 @@ a build id, an **entry table**, a once-per-isolate `boot` and a per-request
             [re-frame.hicasso.server :as server]
             [re-frame.hicasso.substrate :as substrate]
             [re-frame.ssr.render-state :as render-state]
+            ;; The one policy, shared with the host in step 3.
+            [my-app.policy :as policy]
             [my-app.views :as views]))
 
 ;; The development default. A release build overrides it — see step 5.
+;; This one stays in the bundle rather than the shared namespace: `goog-define`
+;; is a ClojureScript form, and the id is this bundle's own identity.
 (goog-define build-id "my-app-dev")
 
-(def render-state-policy
-  {:app-db     [:todos :session]
-   :runtime-db [:rf.runtime/routing :rf.runtime/machines]})
-
 (defn- allowlist [slot]
-  (into-array (map pr-str (get render-state-policy slot))))
+  (into-array (map pr-str (get policy/render-state-policy slot))))
 
 (defn- boot! []
   (rf/init! substrate/adapter)
@@ -524,7 +553,7 @@ a build id, an **entry table**, a once-per-isolate `boot` and a per-request
 (def module
   #js {:protocol 1
        :buildId  build-id
-       :entries  (js-obj "my-app/root"
+       :entries  (js-obj policy/root-entry
                          #js {:stateAllowlist   (allowlist :app-db)
                               :runtimeAllowlist (allowlist :runtime-db)})
        :boot     boot!
@@ -546,28 +575,34 @@ One construction opt. Nothing else about the handler moves:
 ```clojure
 (ns my-app.host
   (:require [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.ring.node :as node]))
+            [re-frame.ssr.ring.node :as node]
+            ;; The same policy the render module reads.
+            [my-app.policy :as policy]))
 
 (def handler
   (ssr-ring/ssr-handler
     {:initial-events [[:app/init]]
-     ;; What the BROWSER may see.
+     ;; What the BROWSER may see — an `ssr-handler` opt.
      :payload        [:todos]
-     ;; What the RENDER may see.
-     :render-state   {:app-db     [:todos :session]
-                      :runtime-db [:rf.runtime/routing :rf.runtime/machines]}
      ;; No :root-view — only the default JVM-local renderer reads one.
      :renderer       (node/renderer
                        {:endpoint     "http://127.0.0.1:8148"
-                        :entry        "my-app/root"
+                        :entry        policy/root-entry
                         ;; Must equal the server bundle's `build-id` — the
                         ;; development default here, a stamped id in a release.
                         :build-id     "my-app-dev"
-                        :render-state {:app-db     [:todos :session]
-                                       :runtime-db [:rf.runtime/routing
-                                                    :rf.runtime/machines]}
+                        ;; What the RENDER may see — a RENDERER opt, because
+                        ;; the renderer is what projects.
+                        :render-state policy/render-state-policy
                         :timeout-ms   1000})}))
 ```
+
+**`:render-state` sits on the renderer, not on `ssr-handler`.** A copy written
+at the top level beside `:payload` reads exactly like the live policy and is
+silently ignored — `ssr-handler` has no such opt to read — so the render
+projects under whatever the renderer was actually given. It is the same reason
+step 2's entry table and this step's `:render-state` read one shared Var rather
+than two literals that happen to agree today.
 
 `:renderer` is validated at construction, so a misconfigured deployment fails
 at boot rather than at the first request. Omitting it keeps the JVM-local
@@ -579,15 +614,25 @@ streaming renders its shell and every continuation from a server-resolved
 
 `:payload` answers *what may the browser see?* `:render-state` answers *what
 does the render need?* They are separate because the answers genuinely differ
-in both directions.
+in both directions — and, as step 3 shows, they are opts on two different
+constructors, because the thing that projects is the renderer.
 
 A server-only value — a deployment notice, an internal flag, an entitlement —
 belongs in `:render-state` and must stay out of `:payload`. Deriving one from
 the other would either leak it to the browser or render `nil` where the page
 expects content. Meanwhile the route slice and machine snapshots live in
 **runtime-db**, not app-db, which is why render state is a two-partition
-envelope `{:rf/app-db {…} :rf/runtime-db {…}}` rather than one map. A page
-whose face is chosen by a machine renders the wrong face without it.
+envelope `{:rf/app-db {…} :rf/runtime-db {…}}` rather than one map.
+
+Whether that second partition carries anything is a property of the **host**
+rather than of the page. A host that has driven a machine — one restoring a
+session, say — must hand the render the snapshot that decides which face to
+draw, or it renders a signed-in visitor a login form. A host that neither
+dispatches at the machine nor subscribes to it sends the partition across
+empty, and a self-seeding machine then materialises its initial state in the
+render's own per-request frame, which is the right page. Name the key either
+way: the list is the deployment's ceiling, not a promise that something fills
+it. Both directions are measured in the login example's crossing suite.
 
 Both policies are fail-closed allowlists of top-level keys, and both project
 the same EDN wire domain the hydration payload already uses. Where the

--- a/tools/xray/src/day8/re_frame2_xray/views/view_walker.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/view_walker.cljs
@@ -38,11 +38,22 @@
         and reconstructs parent ⊃ children purely from DOM containment.
         No React internals; no Fiber slot reads; no version-coupling.
 
-  It is ACTIVE under the canonical install, not dormant: with no Fiber-walker
-  at HEAD there is nothing for it to stand in for. It is also the path that
-  survives the two cases the Fiber design does not cover — a React-version
-  regression that breaks Fiber slot reads, and a non-React substrate (none
-  today; Reagent and UIx both mount through React).
+  Being the only implementation present is NOT the same as being invoked, and
+  running the two together is what `rf2-amz1` was filed against. This namespace
+  is UNWIRED at HEAD: nothing under `tools/xray/src` or `tools/xray/test`
+  requires it, and `walk!` and `tagged-elements` have no caller outside this
+  file and its own DOM test. It is dormant unless a consumer explicitly
+  requires the namespace and calls it.
+
+  One live consumer is easy to mistake for a caller. The Views panel's
+  hover-highlight resolves a single `[data-rf-view='<view-id>']` selector to
+  stamp a class (`panels/reactive-panel-view`). That reads the same ATTRIBUTE,
+  but it is an element lookup by id rather than a hierarchy walk: it calls
+  nothing in this namespace, and it captures no tree.
+
+  What this path does hold is the coverage the Fiber design does not — a
+  React-version regression that breaks Fiber slot reads, and a non-React
+  substrate (none today; Reagent and UIx both mount through React).
 
   ## Fidelity gaps (documented edge cases)
 


### PR DESCRIPTION
Two records that described something other than what ships. One PR, two beads:
**rf2-8arzr.6** (left OPEN — see *What remains*) and **rf2-amz1** (complete).

Base `172c8f8b35`. Two files, +87/-31: `docs/ssr/concepts.md` and
`tools/xray/src/day8/re_frame2_xray/views/view_walker.cljs`.

---

## 1. rf2-8arzr.6 — the Render on Node recipe now has a witness, and stops over-claiming

rf2-8arzr.5 merged in #9054 at `5209470588` (verified an ancestor of this base, and
`implementation/ssr-ring/test/re_frame/ssr/ring/login_host_crossing_test.clj` is present).
All three corrections were re-verified against the landed example rather than taken from
the bead.

**(a) The worked-example paragraph was false.** It said *"that example's model is
ClojureScript-only today, so a JVM host cannot yet load it"* and told the reader to treat
`host.clj` as annotated wiring. At source: the shared model is `examples/core/login/model.cljc`
— `.cljc`, loadable on the JVM — and `host.clj` is a real Ring handler. Replaced with what
runs, naming both witnesses (`re-frame.hicasso.login-server-crossing-ssr-dom-cljs-test` for
the render half, `re-frame.ssr.ring.login-host-crossing-test` for the host half) and, per the
bead's newest note, the one leg **neither** drives alone: the compiled server bundle under the
sidecar in a single process, for which the JVM suite stands a fixture module in deliberately.
The recipe no longer claims end-to-end coverage it does not have.

**(b) `:render-state` is a RENDERER opt, not an `ssr-handler` opt.** The recipe carried a
top-level `:render-state` beside `:payload` *and* the live one inside `node/renderer` — exactly
the dead key the bead says `host.clj` used to carry. Measured at source:
`implementation/ssr-ring/src/re_frame/ssr/ring.clj` contains **zero** occurrences of
`render-state` (grep exit 1; control needle `ssr-handler` = 9 hits, exit 0), while
`.../ring/node.clj:207` marks `:render-state` **REQUIRED**. The top-level copy is removed and
a short paragraph says why the shape is a trap — it reads exactly like the live policy and is
silently ignored.

**(c) The policy moves to a `.cljc` namespace.** The recipe wrote the key lists twice (render
module and host) and the entry id twice. It now teaches one `my-app.policy` `.cljc` namespace
owning `root-entry` and `render-state-policy`, required by both — matching the landed
`examples/substrates/hicasso/login/policy.cljc`, and for the reason that file's own docstring
gives: a `.cljc` namespace is the only file both compilers read. `goog-define build-id` stays
in the bundle (it is a ClojureScript form and the id is the bundle's own identity), which is
what the landed `server.cljs` does.

**Also corrected — the runtime partition.** §4 flatly said *"A page whose face is chosen by a
machine renders the wrong face without it."* The witness measures both directions
(`login_host_crossing_test.clj:302` asserts the runtime partition crosses **empty** on the
shipped configuration; `:339` asserts it carries `:submitting` once the host drives the flow).
The page now says whether that partition carries anything is a property of the **host**, not the
page: a host that never dispatches at nor subscribes to a self-seeding machine sends it empty and
the render's own frame seeds the initial state — the correct page.

### What remains on rf2-8arzr.6 (bead deliberately left OPEN)

The narrow guard that fails when the recipe's paired build-id literals diverge. Its natural home
is `implementation/ssr/test/` (beside the existing `ssr_doc_example_*` tests that already read
`docs/`), **and** arming it needs a row in `.github/scripts/report-changed-surfaces.sh`'s
*"PROSE THAT A test.yml SUITE PINS"* block, because `docs/ssr/concepts.md` is not in that roster
today. Both paths are outside this dispatch's fence (`.github/**` is hot-zone and held), so
neither was touched.

### 2. Cross-references into `spec/` — reported, not edited

Checked at source; `spec/` is outside this fence.

- **`spec/011-SSR.md` is accurate.** `render-state` appears exactly once (`:409`) and correctly
  describes `:render-state` as a `node/renderer` construction opt. The recipe's
  "Full normative contract: Spec 011" pointer is sound. No drift.
- **`spec/009-Instrumentation.md` — the brief's premise does NOT hold.** It claimed the
  `:rf.error/ssr-render-failed` row "now names the second emitter slice E added
  (`re-frame.hicasso.server/render-body`)". It does not. Three passes (line-oriented, `-F` alone,
  whitespace-flattened) all return **0** for `hicasso.server/render-body`, with live controls in
  each pass (`render-body` = 2 — both unrelated prose; `hicasso` = 86; `build-full-response` = 1).
  The row at `:2123` names only `re-frame.ssr.ring.pipeline/build-full-response`. The emitter is
  real: `implementation/hicasso/src/re_frame/hicasso/server.cljs:240` raises
  `:rf.error/ssr-render-failed`, and its own docstring says it is "raised from the hosts that have
  to raise it by hand". So spec/009 is one emitter short. Reported for a spec-fenced follow-up.
- **`examples/README.md` — the premise half-holds.** `examples/substrates/README.md` is corrected
  (it names the server build and both witnesses at `:53-66`). `examples/README.md:162` still
  carries the same falsehood this PR removed from the recipe: *"annotated wiring rather than a
  runnable server — this example's model is ClojureScript-only today"*, and names no witness.
  Outside this fence; reported.

---

## 3. rf2-amz1 — "ACTIVE under the canonical install" is not true

### The census, re-run with controls

Scope `tools/xray/src` + `tools/xray/test`, **345 files / 7,984,189 bytes**, excluding the
namespace's own file and `view_walker_dom_cljs_test.cljs`. Four passes, because neither result is
a superset of the others:

| Needle | P1 line | P2 `-F` alone | P3 flattened | P4 hyphen-rejoined |
|---|---|---|---|---|
| `view-walker` | 0 | 0 | 0 | 0 |
| `view_walker` | 0 | — | 0 | 0 |
| `walk!` | 0 | 0 | 0 | 0 |
| `tagged-elements` | 0 | 0 | 0 | 0 |
| `day8.re-frame2-xray.views.view-walker` | — | — | 0 | 0 |
| **CONTROL** `local-render` (hyphenated) | **107** | **107** | **139** | **139** |
| **CONTROL** `re-frame2-xray` (hyphenated) | **1499** | — | **1498** | **1498** |
| **CONTROL** `init!` (bang-final) | **202** | **202** | **203** | **203** |
| **CONTROL** `reg-sub` (hyphenated) | **243** | — | **243** | **243** |

Pass 4 exists because flattening inserts a space where a hyphen-wrapped token broke, which would
hide `view-walker` and `tagged-elements` from passes 1 *and* 3 — both are that shape. Controls are
shape-matched: hyphenated needles get hyphenated controls, `walk!` gets the punctuation-final
`init!`.

**The `-F`/`-i` trap is real on this build** and was reproduced with my own control before relying
on any zero: GNU grep 3.0, `grep -rni local-render` = **109**, `grep -rnFi local-render` = **0**.
No pass above combines them.

**Result: zero call sites.** The Views panel does use the `data-rf-view` *attribute*
(`panels/reactive_panel_view.cljs:248`) — but for a single-element hover-highlight lookup
(`querySelectorAll("[data-rf-view='<id>']")`), not a hierarchy walk. It requires nothing from the
walker namespace and captures no tree. That distinction is now recorded in the docstring, because
it is the thing most likely to be mistaken for a caller next time.

### Both records now say the same narrower thing

The docstring's claim — *"It is ACTIVE under the canonical install, not dormant: with no
Fiber-walker at HEAD there is nothing for it to stand in for"* — is a non-sequitur: being the only
implementation present is not being invoked. It now says it is the only hierarchy-capture
implementation present **and** unwired and dormant unless a consumer requires the namespace and
calls it.

**A premise refinement worth flagging:** the bead asks to correct "the source docstring AND the
Ownership-table wording together". Measured, the Ownership table did **not** need the dormancy
correction — `spec/Ownership.md:46` already reads "the shipped-and-dormant `data-rf-view`
fallback", and `spec/View-Hierarchy-Capture.md:51` already reads "The fallback is **shipped and
dormant**". The docstring was the sole outlier contradicting them. With it corrected the two
records agree on the narrower statement, which is what the bead was filed to achieve.

Two residual spec-side framing points, **reported not edited** (`spec/` is fenced, and both edge
on rf2-2vpm, which is left strictly alone — no implementation is added or proposed):

- `spec/Ownership.md:46` col-4 calls `tools/xray/spec/012-Views.md` "the Views panel that consumes
  the captured tree". Nothing consumes a captured view-hierarchy tree at HEAD.
- `spec/View-Hierarchy-Capture.md:51` closes "consumers should default to the Fiber walker" —
  advice to default to a path with no implementation at HEAD.

### `tools/xray/spec/*` unchanged, because measured

Per the standing rule that a dispatch touching `tools/xray/` updates `tools/xray/spec/*` or says
why not: **no `tools/xray/spec/` document describes the walker or its wiring status.** Census over
that tree: `view-walker` 0, `view_walker` 0, `walk!` 0, `tagged-elements` 0 (controls `panel` 1670,
`re-frame2-xray` 127, `app-db` 329). The two `data-rf-view` hits there
(`021-Dynamic-Panel-Designs.md:507`, `Conventions.md:148`) are about the hover-highlight and the
adapter's attribute stamping — both still accurate. The contract for this path is pinned in
repo-root `spec/View-Hierarchy-Capture.md`, outside this fence.

---

## 4. Which of my edits no gate inspected

**Both link gates strip fenced blocks before reading a link, and I measured that on my own edits
rather than citing it.** Identical broken link `[nope](./no-such-page-truthing-a.md)`, planted
twice into `docs/ssr/concepts.md`, each plant preceded by a match-count read and each restore
verified against the committed git **blob** hash `c9fd42f93b9974acd3e63102b65edf8e04df091f`:

- in **prose** (§3) → `check_doc_slugs.py` **exit 1**, naming `docs\ssr\concepts.md:600 -> ./no-such-page-truthing-a.md`
- inside a **fenced** `clojure` block (the new `my-app.policy` fence) → **exit 0**, log empty

The red also discharges the discrimination question: the fault existed only in this worktree, so a
run that had wandered into a sibling checkout would have come back green.

So the following edits were **not** inspected by any gate and were checked by hand:

- the `my-app.policy` `.cljc` fence (step 2) — new
- the `my-app.server` fence (step 2) — require added, local `render-state-policy` removed,
  `allowlist` and `:entries` repointed at `policy/…`
- the `my-app.host` fence (step 3) — require added, top-level `:render-state` removed,
  `:entry` / `:render-state` repointed at `policy/…`

Checked by hand: every symbol in those fences resolves against the landed example
(`policy.cljc` / `server.cljs` / `host.clj`); `node/renderer`'s opts match
`.../ring/node.clj:207` and its own docstring example at `:366-375`; the build id remains one
value written twice (`"my-app-dev"` in the `goog-define` and in `:build-id`), unchanged by this PR.
No heading was touched anywhere in the file — all anchors are as they were.

Prose edits (the worked-example paragraph, the `:render-state` note, the §4 host/page paragraph)
*were* inspected: `check_doc_slugs.py` and `mkdocs build --strict` both read them.

---

## Gates — foreground, unfiltered, exit codes captured and quoted from my own capture

All re-run on the **final rebased base** `172c8f8b35`; pre-rebase greens are not quoted.

| Gate | Captured exit | Result |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | clean |
| `python scripts/check_readme_links.py --ci` | **0** | clean |
| `python -m mkdocs build --strict` | **0** | built in 29.5s; log names this worktree as its root |
| `tools/xray` JVM suite (`clojure -M:test`) | **0** | **1315 tests / 6227 assertions, 0 failures, 0 errors** |
| `sh scripts/test-fast-pr.sh --no-docs` | **0** | gate root names this worktree; 0 `FAIL` lines; clj-kondo **errors: 0** (2087 pre-existing warnings, `--fail-level error`); CLJS 11203 tests / 55820 assertions |

`--plan` for this diff: `documentation gates: run`, `spine self-test: skip (spine unchanged)`,
`JVM tier: skip`, `node/CLJS suite: run`, `clj-kondo: run`, `reason: classified` —
`PLAN docs=true jvm=false node=true`. The docs tier was armed by the classifier and run as the
three gates above (the spine run itself used `--no-docs` purely to split it under the runtime
ceiling; nothing was skipped overall). Worth recording from the plan's own output: **"No browser,
bundle, adapter, Xray, MCP or tool-JVM gate is in any tier"** — the spine contains no Xray gate, so
the `tools/xray` JVM suite above was run directly.

**Two honest limits on the xray numbers.** The `tools/xray` JVM suite does not cover the edited
file — `view_walker.cljs` is ClojureScript and the JVM runner does not load it — and my diff
touches no `.clj`/`.cljc` at all, so that suite is a regression check on the rest of the package
rather than evidence about this change. What does cover it: **clj-kondo, which lints `tools/xray`
and reports errors 0**, and a reader check confirming the `ns` form still parses (docstring 4998
chars, no double-quote introduced by the edit). The suite read 1313/6217 on the pre-rebase base and
1315/6227 after rebasing — the difference is two xray commits that landed in the interval, not
anything in this diff.

`npm ci` was run into this worktree's own `implementation/` rather than junctioning to a shared
tree; the coordinator's `node_modules` was verified at 101 entries before and after.
