### PR TITLE
api-manifest: enrol implementation/routing/src + implementation/resources/src in roster-covered-roots — 51 namespaces, all internal (rf2-hjj4)

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -227,6 +227,22 @@
 ;; Widening to the remaining artefacts is a per-tree decision with a per-tree
 ;; cost; the point of the data-driven shape below is that each is a root plus
 ;; its classifications, never another mechanism.
+;;
+;; ROUTING AND RESOURCES joined under rf2-hjj4, executing step 2 of the
+;; rf2-qvhx ruling, and their result is worth recording because it points the
+;; OTHER WAY from hicasso's. They were chosen on blast radius — the two trees
+;; judged most likely to hide a public authoring surface an application
+;; requires directly. Fifty-one namespaces were unaccounted (routing 28,
+;; resources 23) and ALL FIFTY-ONE classified internal: no new manifest row, no
+;; new documentation page, `:var-count` unchanged. The reason the two trees
+;; differ from hicasso is structural rather than lucky. Both are FAÇADE
+;; artefacts — one enrolled door re-exporting what an app may call (27 rows for
+;; routing, 21 for resources), with the siblings holding handler bodies,
+;; `*-meta` registration maps, cofx constructors, `*-sub-fn` bodies and
+;; host-side caches. Hicasso is the opposite shape: its optional modules are
+;; separately requirable BECAUSE they are opt-in, so its door could not
+;; re-export them. That distinction is the useful predictor for the remaining
+;; trees, and it is what rf2-hjj4's verdict rests on.
 ;; ---------------------------------------------------------------------------
 
 (def roster-covered-roots
@@ -236,22 +252,32 @@
    beneath it (see this section's header)."
   ["implementation/ssr/src"
    "implementation/ssr-ring/src"
-   "implementation/hicasso/src"])
+   "implementation/hicasso/src"
+   "implementation/routing/src"
+   "implementation/resources/src"])
 
 (def internal-namespaces
   "Source namespaces under `roster-covered-roots` that are deliberately NOT a
   supported surface: SSR pipeline internals, host-adapter plumbing and
-  emitters, and the Hicasso runtime beneath its door. Nothing here is
-  published, documented or rowed in the manifest — being on this list is the
-  RECORD of that decision, not a consequence of it.
+  emitters, the Hicasso runtime beneath its door, and the per-concern siblings
+  the routing and resources façades compose. Nothing here is published,
+  documented or rowed in the manifest — being on this list is the RECORD of
+  that decision, not a consequence of it.
 
   This is not a synonym for `^:no-doc`. NONE of these carry that metadata
   (the SSR trees use it nowhere at all), so the marker cannot be the
   classifier — which is precisely why the roster is written down instead of
-  derived. The public doors of these three artefacts are `re-frame.ssr`,
-  `re-frame.ssr.ring` and `re-frame.hicasso`, plus the two crossing surfaces
-  rf2-8arzr.7 enrolled and the Hicasso modules rf2-3ne8 enrolled; everything
-  below is reached only from inside them."
+  derived. The public doors of these five artefacts are `re-frame.ssr`,
+  `re-frame.ssr.ring`, `re-frame.hicasso`, `re-frame.routing` and
+  `re-frame.resources`, plus the two crossing surfaces rf2-8arzr.7 enrolled and
+  the Hicasso modules rf2-3ne8 enrolled; everything below is reached only from
+  inside them.
+
+  READ THE GROUPING COMMENTS AS THE CLASSIFICATION. Each names what the group
+  is and the checkable reason it is not a surface — most often the artefact's
+  own docstring, a spec section, or the fact that the door already rows the
+  var. A bare name here with no reason above it would be a rubber stamp, which
+  is worse than an unenrolled tree because it looks like a decision."
   '#{;; --- implementation/ssr/src -------------------------------------------
      ;; Boot, install and the shared constant/hash/manifest plumbing.
      re-frame.ssr.boot
@@ -333,7 +359,197 @@
      re-frame.hicasso.impl.portal
      re-frame.hicasso.impl.presence
      re-frame.hicasso.impl.presence-react
-     re-frame.hicasso.impl.route-link})
+     re-frame.hicasso.impl.route-link
+     ;; --- implementation/routing/src ---------------------------------------
+     ;; The door is `re-frame.routing`, enrolled above, and it says so in its
+     ;; own docstring: "This namespace is the public boot point and facade for
+     ;; the routing artefact: apps load it with `(:require [re-frame.routing])`
+     ;; … The implementation lives in per-concern namespaces". TWENTY-FIVE of
+     ;; the twenty-eight below repeat that verbatim in their own docstrings —
+     ;; "Internal namespace; the public facade is `re-frame.routing`" — so this
+     ;; roster records the artefact's OWN published boundary rather than a
+     ;; judgement invented here. Exactly three lack that sentence —
+     ;; `readiness`, `tooling` and `test-support` — and each is given its own
+     ;; reason at its group below.
+     ;;
+     ;; What the façade re-exports is ALREADY rowed under `re-frame.routing`
+     ;; (27 rows spanning :advanced / :tooling / :implementation). Every
+     ;; remaining public below is an intra-artefact seam the façade composes:
+     ;; `*-handler` fns, their `*-meta` registration maps, `*-cofx`
+     ;; constructors, host-side cache accessors (`reset-cache!`,
+     ;; `release-frame!`) and pure projectors. None is an authoring surface,
+     ;; and none is named by spec/API.md, docs/ or skills/ as one.
+     ;;
+     ;; URL, pattern and address primitives — pure parsing/encoding beneath
+     ;; `match-url` / `route-url`, which the façade rows at :advanced.
+     re-frame.routing.address
+     re-frame.routing.match
+     re-frame.routing.resolve
+     re-frame.routing.url
+     ;; Registration and the projection-relative data classification lowered
+     ;; at route registration. `reg-route` / `route-ids` / `route-meta` are the
+     ;; façade's rows; these are the validators and the route-table cache.
+     re-frame.routing.classification
+     re-frame.routing.registry
+     ;; Navigation planning and commit: the pre-commit planning seam, the
+     ;; leave/entry decisions, the commit-time readiness projector, the shared
+     ;; nav-event helpers, and the two commands that reuse the standing plan.
+     ;; `readiness` carries no "internal namespace" sentence, but its only
+     ;; public (`project-at-commit`) takes the `:routing/on-route-entry` hook
+     ;; result and is called by the commit assembler — the façade lists it as a
+     ;; per-concern namespace, and Spec 012 §Route readiness names the
+     ;; projection, never a var.
+     re-frame.routing.decisions
+     re-frame.routing.events
+     re-frame.routing.plan
+     re-frame.routing.prefetch
+     re-frame.routing.readiness
+     re-frame.routing.replan
+     ;; Nav tokens, the monotonic host-side allocators, and the `:rf.nav/*` fx
+     ;; legs with their Malli args schemas. The consumer surface here is the
+     ;; event/fx/cofx vocabulary (`:rf.route/with-nav-token`, `:rf.nav/push-url`),
+     ;; registered by the façade; these namespaces supply the handler bodies.
+     re-frame.routing.navigate
+     re-frame.routing.nav-counters
+     re-frame.routing.nav-fx
+     re-frame.routing.nav-fx-schemas
+     re-frame.routing.nav-token
+     re-frame.routing.url-bound
+     re-frame.routing.url-change
+     ;; History strategy and scroll restoration. The two SHIPPED strategy maps
+     ;; and `with-base-path` are façade rows at :advanced and documented on
+     ;; docs/api/re-frame.routing.md; a CUSTOM strategy is a five-key map the
+     ;; app writes itself (Spec 012 §URL strategies), so the encode/decode legs
+     ;; and `url-strategy-from-config` are those maps' internals, not a
+     ;; compose-your-own kit — spec/009-Instrumentation.md's only mention of
+     ;; the latter calls it a dev-only tripwire.
+     re-frame.routing.history
+     re-frame.routing.scroll
+     re-frame.routing.strategy
+     ;; Reads: the framework-shipped subs, their off-box egress projection, and
+     ;; the `:route/link` registered view. The consumer names are the sub ids
+     ;; and the `:route/link` view id, both registered by the façade.
+     re-frame.routing.link
+     re-frame.routing.sub-egress
+     re-frame.routing.subs
+     ;; Async lowering onto the shared reply envelope. Its own docstring is
+     ;; explicit that this is "internal lowering only" and that "the PUBLIC
+     ;; routing API … is unchanged".
+     re-frame.routing.reply
+     ;; The bundle-isolated tooling sibling. Its ENTIRE public surface — both
+     ;; algebra views — is already rowed at :tooling under `re-frame.routing`
+     ;; via the JVM façade aliases, and documented on
+     ;; docs/api/re-frame.routing.md, which names the CLJS call form too.
+     ;; Enrolling the namespace as well would row the same two fns twice.
+     ;; spec/Derivations.md §Routes expose algebra views is the authority for
+     ;; the disposition: this exposure "is *internal registration metadata* …
+     ;; it ships **no public accessor**", with the public name deferred to a
+     ;; stated graduation gate.
+     re-frame.routing.tooling
+     ;; The test-only fixture namespace. REQUIRED DIRECTLY by test suites — the
+     ;; skill corpus tells authors to `(:require [re-frame.routing.test-support])`
+     ;; — but required for its LOAD EFFECT: the require registers
+     ;; `:rf.test/simulate-http-resolution`, and the consumer-facing name is
+     ;; that event id, not the one public var (`simulate-http-resolution-handler`,
+     ;; the handler body nobody calls). The manifest is one row per public VAR,
+     ;; so there is nothing here to row; see the sibling note under resources.
+     re-frame.routing.test-support
+     ;; --- implementation/resources/src -------------------------------------
+     ;; The door is `re-frame.resources`, enrolled above, whose docstring calls
+     ;; it "the **public boot point and façade** for the resources artefact:
+     ;; apps boot it with `(:require [re-frame.resources])`. Doing so
+     ;; transitively loads every concern sibling under `re-frame.resources.*`".
+     ;; Unlike routing, the siblings here carry NO per-file "internal
+     ;; namespace" sentence, so each group below states its own reason.
+     ;;
+     ;; The consumer surface is `reg-resource` / `reg-mutation` /
+     ;; `reg-resource-scope`, the `:rf.resource/*` + `:rf.mutation/*` event and
+     ;; sub vocabularies, and the registry introspection accessors — 21 rows
+     ;; already carried under `re-frame.resources`. Every public below is a
+     ;; runtime seam: durable-shape constructors and path fns, `*-handler` /
+     ;; `*-meta` pairs, `*-sub-fn` bodies, host-side cache accessors and pure
+     ;; projectors. Spec 016 names the events, subs and registration fns; it
+     ;; names none of these vars.
+     ;;
+     ;; Runtime-db paths and the durable entry / instance shapes every sibling
+     ;; agrees on. `state`'s own docstring: "the paths and shapes are pinned
+     ;; here so every sibling agrees on one home".
+     re-frame.resources.mutation-runtime
+     re-frame.resources.state
+     ;; Registration: the three registrar kinds, the shared params
+     ;; validate+canonicalize pipeline, and the durable classification lowered
+     ;; at registration. The `reg-*` / `clear-*` / `*-ids` / `*-meta` surfaces
+     ;; are the façade's rows; these hold the validators, the registrar-kind
+     ;; keywords and the scope resolvers behind them.
+     re-frame.resources.classification
+     re-frame.resources.mutation-registry
+     re-frame.resources.params
+     re-frame.resources.registry
+     re-frame.resources.scope-registry
+     ;; The causal write surface: the `:rf.resource/*` and `:rf.mutation/*`
+     ;; event handlers plus the framework-internal `*.internal/*` replies. Spec
+     ;; 016 §Public API §Events documents the EVENT IDS; these namespaces are
+     ;; the handler bodies the façade registers.
+     re-frame.resources.events
+     re-frame.resources.mutation-events
+     ;; The passive read surface: the `:rf/resource` / `:rf/mutation` sub
+     ;; families. Again the consumer names are the sub ids; the publics here
+     ;; are `*-sub-fn` bodies and their registration entry points.
+     re-frame.resources.mutation-subs
+     re-frame.resources.subs
+     ;; Async lowering and the frame work ledger: the uniform reply envelope,
+     ;; the shared stale-suppression substrate above it, the ledger records and
+     ;; host-side handles, and the transport seam. The artefact ships ONE
+     ;; built-in transport (`:rf.http/managed`); transport-neutrality is a
+     ;; design property of the core, not a published extension API — no doc,
+     ;; spec, skill or example names `managed-http-transport`,
+     ;; `default-transport` or `assert-managed-transport!`.
+     re-frame.resources.reply
+     re-frame.resources.reply-handlers
+     re-frame.resources.transport
+     re-frame.resources.transport.http
+     re-frame.resources.work-ledger
+     ;; Host-side scheduling: the stale / GC / poll timer side-table and the
+     ;; window-focus / network-reconnect listeners. Both are installed and
+     ;; torn down by the façade and by frame lifecycle; the app-facing controls
+     ;; are the policy keys on a resource spec and the two
+     ;; `install-` / `remove-revalidation-listeners!` façade rows.
+     re-frame.resources.revalidate-listeners
+     re-frame.resources.timers
+     ;; The two LATE-BOUND cross-artefact integrations. Resources never
+     ;; statically requires routing or ssr; these publish the hooks those
+     ;; artefacts resolve. `install-routing-integration!` /
+     ;; `install-ssr-integration!` are called by the façade at load (and again
+     ;; by tests after a registrar reset, the same `:reload` re-wiring the
+     ;; façade docstring describes) — never by application code.
+     re-frame.resources.route
+     re-frame.resources.ssr
+     ;; The OFF-BOX trace-row egress projector. Production-reachable rather
+     ;; than tool-only (the façade requires it on both runtimes so the
+     ;; `:resources/project-resource-trace-egress` hook is always published),
+     ;; but consumed only through that hook by the epoch tool pair.
+     re-frame.resources.trace-egress
+     ;; The bundle-isolated tooling sibling — same disposition as routing's,
+     ;; and the same authority: spec/Derivations.md §Resources expose process
+     ;; nodes says this exposure "is *internal registration metadata* … it
+     ;; ships **no public accessor**", the public name deferred to the
+     ;; graduation gate. Its two algebra views are already rowed at :tooling
+     ;; under `re-frame.resources` via the JVM façade aliases; its five other
+     ;; publics (`resource-superkind`, `resource-refined-kind`,
+     ;; `resource-storage`, `resource-lifecycle`, `resource-evaluation`) are
+     ;; module-level classification CONSTANTS read only by the two view
+     ;; builders in that same file — public by omission beside the `^:private`
+     ;; `resource-selectors` directly below them, not a surface.
+     re-frame.resources.tooling
+     ;; The test-only fixture namespace, the sibling of
+     ;; `re-frame.routing.test-support` above (its docstring names the family:
+     ;; routing, resources and http). Required directly by test suites, again
+     ;; for the LOAD EFFECT: the require publishes the
+     ;; `:resources/reset-resources!` late-bind hook, and the consumer-facing
+     ;; name is `re-frame.test-support/make-reset-runtime-fixture` — already
+     ;; rowed at :testing with a docs/api page — which FIRES the one public var
+     ;; here. No consumer calls `reset-resources!` itself.
+     re-frame.resources.test-support})
 
 (defn- repo-file
   "Resolve a `/`-joined repo-relative path against `repo-root`, portably."


### PR DESCRIPTION
Step 2 of the rf2-qvhx widening. One file changed: the api-manifest generator.

**The headline: both trees are entirely internal. No public authoring surface, no new manifest row, no new documentation page, no nav entry. That is the opposite of what hicasso yielded, and §5 argues it is structural rather than luck.**

## 1. Namespace counts, and how I derived them

Derived with the generator's own `namespaces-under`, not a file count — `(gen/namespaces-under (io/file gen/repo-root "implementation/routing/src"))`, whose printed `ROOT=` named this worktree.

| tree | total namespaces | accounted before | unaccounted |
|---|---:|---:|---:|
| `implementation/routing/src` | 29 | 1 (`re-frame.routing`, in `jvm-namespaces`) | **28** |
| `implementation/resources/src` | 24 | 1 (`re-frame.resources`) | **23** |
| | 53 | 2 | **51** |

The bead's 28 / 23 (measured at `375d5dd899`) are the *unaccounted* counts, and they reproduce exactly at my base. Neither tree has any `:cljs-only` sidecar row and neither had any prior `internal-namespaces` entry, so the 51 is the whole obligation. I re-derived it by running the reconciliation directly rather than by subtracting.

## 2. The full classification — all 51, internal

Every one is recorded in `internal-namespaces` under a grouping comment giving a checkable reason. The reasons are not my paraphrase of the code; they are mostly the artefact's own published boundary.

**Routing (28). 25 of them say it themselves.** A census of the sentence "Internal namespace; the public facade is re-frame.routing" returns 25 hits — run twice, line-oriented and again over whitespace-flattened text (identical results, so no line-broken instance is hiding), with a control needle that returned 1. The three without that sentence are handled individually:

- **`readiness`** — no marker, but its one public (`project-at-commit`) takes the `:routing/on-route-entry` hook result and is called by the commit assembler; the façade docstring lists it among the per-concern namespaces, and Spec 012 §Route readiness names the projection, never a var.
- **`tooling`** — see §3.
- **`test-support`** — see §3.

Grouped as: URL/pattern/address primitives (`url`, `match`, `address`, `resolve`) · registration + classification (`registry`, `classification`) · planning and commit (`decisions`, `events`, `plan`, `prefetch`, `readiness`, `replan`) · nav tokens, allocators and the fx legs (`navigate`, `nav-counters`, `nav-fx`, `nav-fx-schemas`, `nav-token`, `url-bound`, `url-change`) · history strategy and scroll (`history`, `scroll`, `strategy`) · reads (`link`, `sub-egress`, `subs`) · async lowering (`reply`) · `tooling` · `test-support`.

**Resources (23). No such marker exists in that tree** — the census returns zero there, and I did not read that zero as "nothing to find": resources simply phrases its boundary only in the façade docstring ("the **public boot point and façade** … Doing so transitively loads every concern sibling"). So each group carries its own reason.

Grouped as: runtime-db paths and durable shapes (`state`, `mutation-runtime`) · registration (`classification`, `mutation-registry`, `params`, `registry`, `scope-registry`) · causal write handlers (`events`, `mutation-events`) · passive subs (`subs`, `mutation-subs`) · reply envelope, work ledger and transport (`reply`, `reply-handlers`, `transport`, `transport.http`, `work-ledger`) · host-side scheduling (`revalidate-listeners`, `timers`) · the two late-bound integrations (`route`, `ssr`) · off-box egress (`trace-egress`) · `tooling` · `test-support`.

**The evidence behind "internal", stated as a measurement rather than an impression.** I listed every public var of all 51 namespaces via `ns-publics` and asked which are already carried by a manifest row under the enrolled door. The doors carry 27 rows (routing) and 21 (resources). Everything not so carried is `*-handler` fns, their `*-meta` registration maps, `*-cofx` constructors, `*-sub-fn` bodies, registrar-kind keywords, host-side cache accessors (`reset-cache!`, `release-frame!`) and pure projectors. Not one is named as a surface by `spec/API.md`, `docs/`, `skills/` or `examples/` — checked by grep, each with a control needle that returned non-zero.

Two spot-checks worth recording because they were the plausible counter-examples:

- **`routing.strategy`** publishes 12 vars, and a custom URL strategy is a real authoring concept. But the two shipped strategy maps plus `with-base-path` are *already* façade rows at `:advanced`, documented on `docs/api/re-frame.routing.md`; a custom strategy is a five-key map the app writes itself (Spec 012 §URL strategies). The encode/decode legs are those maps' internals. The only doc mention of `url-strategy-from-config` is `spec/009-Instrumentation.md` calling it a dev-only tripwire.
- **`resources.transport`** — Spec 016 says the artefact is "transport-NEUTRAL" and another transport "can be added". That is a property of the core, not a published extension API: `managed-http-transport`, `default-transport` and `assert-managed-transport!` return **zero** hits across `docs/`, `spec/`, `skills/` and `examples/`, against a control (the word "transport" appears 42 times in `spec/016-Resources.md`) proving the search works.

## 3. The two namespaces that genuinely resisted classification — named, per the bead

**The `.tooling` siblings.** Both are require-me-directly on CLJS, which looks like an authoring surface. They are not, and the authority is `spec/Derivations.md` (§Routes expose algebra views, §Resources expose process nodes), which grades this exposure "*internal registration metadata* … it ships **no public accessor**", with the public name **deferred** to a stated graduation gate. Mechanically they are also already accounted for: `routing.tooling`'s two algebra views and `resources.tooling`'s two are rowed at `:tooling` under the doors via the JVM façade aliases, and `docs/api/re-frame.routing.md` documents them *and names the CLJS call form*. Enrolling the namespaces too would row the same functions twice. `resources.tooling`'s five other publics (`resource-superkind`, `resource-refined-kind`, `resource-storage`, `resource-lifecycle`, `resource-evaluation`) are module-level classification constants read only by the two view builders in that same file — public by omission beside the `^:private` `resource-selectors` immediately below them.

**The `.test-support` siblings, and this is the one I want a second opinion on.** `skills/re-frame2/references/tooling/routing.md:180` tells app authors, in shipped consumer-facing text, to write `(:require [re-frame.routing.test-support])`. That is a documented direct require, which is exactly the hicasso signature. I still classified both internal, because the require is for its **load effect**, not for a var:

- `routing.test-support` publishes one var, `simulate-http-resolution-handler`; the require registers `:rf.test/simulate-http-resolution`, and the consumer-facing name is that **event id**. Nobody calls the handler.
- `resources.test-support` publishes one var, `reset-resources!`; the require publishes the `:resources/reset-resources!` late-bind hook, and the consumer-facing name is `re-frame.test-support/make-reset-runtime-fixture` — already rowed `:testing` with a docs/api page — which *fires* it.

The manifest is one row per public **var**, and neither var is one. So there is nothing here to row, and inventing a "require-for-effect namespace" vocabulary to express it would be exactly the over-engineering the stance rules out. But the tension is real and I have not hidden it: the record now says "not a supported surface" about a namespace the skills tell people to require. If that reads wrong, the fix is a tier on these two, not a change to the gate — and I would rather it be ruled than assumed.

## 4. Manifest var count, and the nav question

**528 before, 528 after** — `gen --check` exit 0 and "in sync" at both. A classification adds no row, which is the whole point: these namespaces contribute no public var. `doc_api_check` coverage is unchanged at **182 eligible manifest vars each with a page and a member heading**.

**Item 3 answered early and it collapsed:** no `docs/api` page is required, because no namespace reached an eligible tier (`:front-porch` / `:advanced` / `:adapter` / `:testing`, verified at `doc_api_check.clj:144-148` rather than taken from the brief). No page means **no `mkdocs.yml` nav entry**, so the parity question PR #9057 settled for the hicasso five does not arise here. `mkdocs.yml` is untouched.

**`^:no-doc` was not used anywhere, and the gate was not weakened.** The only change to gate behaviour is two more roots inside it.

## 5. Verdict on the tail: **STOP after these two, and re-ask before spending more.**

The ruling said the measurement decides, and the measurement came back empty: 51 namespaces, 51 internal, zero findings. On the ruling's own terms that is the stop signal.

But I want to give the *reason* rather than just the arithmetic, because the reason is what should govern the remaining trees — and it is not "routing and resources happened to be tidy".

**Both are façade artefacts.** One enrolled door re-exports everything an app may call; the siblings are the concerns it composes. Hicasso is the opposite shape: its five modules are separately requirable *because* they are opt-in, so its door structurally could not re-export them, and that is why five surfaces could hide. So the predictor for a tree is **not its size** — it is whether the artefact has a single re-exporting door.

By that test, the remaining trees look like routing and resources, not like hicasso: `machines`, `http`, `schemas`, `flows`, `epoch` and `core` each publish one façade namespace already enrolled in `jvm-namespaces`. **My recommendation is therefore to stop enrolling trees on a schedule, and instead enrol a tree when it acquires a second requirable door** — the condition that actually produces findings. I have written that reasoning into the generator's own section header so the next person meets it where the decision is made, rather than only on a bead.

Two caveats I would not want swallowed by that recommendation. The gate still has value on these trees *going forward*: it now refuses a new unclassified namespace under either, which is the "we forgot" to "the build refuses" conversion the ruling wanted, and that is worth the 51 lines regardless of the zero findings today. And `adapters/*` are the one part of the tail I would not assume — adapters are requirable by definition, so if any tree is enrolled next, that is where I would look first.

This is a recommendation, not a decision I have taken: rf2-qvhx stays open as the parent question.

## 6. Gates — every one foregrounded or polled to completion in-turn, exit codes captured by me on the command's own line, re-run on the final rebased base (`53c2799b49`)

| gate | exit |
|---|---|
| `clojure -M -m re-frame.api-manifest.gen --check` | **0** — in sync, 528 public vars |
| `clojure -M:test` (api-manifest suite) | **0** — 91 tests, 189 assertions, 0 failures, 0 errors |
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_readme_links.py --ci` | **0** |
| `python -m mkdocs build --strict` | **0** — 0 WARNING, 0 ERROR |
| `sh scripts/test-fast-pr.sh` | **0** — 50 gates, no FAIL line |

91 tests matches the count after #9053, so this change adds no test and breaks none.

`--plan` on this diff: `docs=false jvm=false node=true`, reason `classified`, clj-kondo run, spine self-test skipped (spine unchanged). **The documentation tier is skipped for this diff** — correctly, since it contains no markdown at all — so the three doc gates above are reported as standalone runs, not as spine coverage. Both spine runs printed `gate root: …/roster-a`, and the CLJS stack frames in the log resolve inside this worktree, so each is shown to have read the intended checkout.

**The roster gate was proven to bite on this tree.** I committed first, then deleted the single line `re-frame.routing.reply` from `internal-namespaces` (anchor match count read as **1** before planting, **0** after) and re-ran `gen --check`: exit **2**, failing by name with "Unaccounted public-API source namespace(s) … re-frame.routing.reply" and the two ways to answer for it. That fault existed only in this worktree, so a run that had wandered into a sibling's would have come back green — the red *is* the discrimination. Restored and verified by git **blob** hash equality (`09eb587535d6d8a88e8d9259c5a07d429b2f7140` before the plant and after the restore).

**What no gate here inspected.** This diff is one `.clj` file and contains no markdown, so `check_doc_slugs.py` and `mkdocs build --strict` inspected nothing I changed; their greens are baseline facts about the repo, not evidence about this change. The gate that does cover it is the api-manifest suite, whose `roster_completeness_test` drives `assert-roster-complete!` — and that is the one I sabotaged above. The new content is 200-odd lines of Clojure comment prose carrying no links; I checked by hand that the two file references in it (`docs/api/re-frame.routing.md`, `spec/Derivations.md`) resolve as real files, since they are comment text no link validator reads.

**One environmental note.** A fresh worktree has no `implementation/node_modules`, which the spine's node tier needs. I confirmed at source that neither `test:scripts` nor `test:cljs` runs an installer (no `npm ci` / `npm install` in `implementation/package.json`'s scripts or in `test-fast-pr.sh`), junctioned the mayor's tree, ran, then removed the junction and re-checked: **103 entries before and 103 after**.

Rebased once onto `53c2799b49` (four commits had landed, none touching `implementation/scripts/api-manifest/`, either source tree, or either manifest file). The merge-base diff (`origin/main...HEAD`) is one file; its nine deleted lines are all lines this commit rewrites in place — the roster's closing bracket and the `internal-namespaces` docstring sentences widened from "three artefacts" to "five". It reverts nothing a sibling landed.

Closes rf2-hjj4.
