### PR TITLE
docs(pilots): step 1 sets the pin; the PRE-PILOT header is stamped at collection (rf2-zmhn, rf2-yqtr)

### DIFF
--- a/docs/design/hicasso/product/pilots/workspace.md
+++ b/docs/design/hicasso/product/pilots/workspace.md
@@ -4,7 +4,7 @@ The operator's page. It says what a pilot workspace contains, how to assemble on
 
 A pilot agent is never sent here — this page sits inside the repository the pilot is blinded to. What the agent gets is `BRIEF.md` and `FRICTION-LOG.md`, both of which land in the workspace by the procedure below.
 
-Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the `_shared/` line in both source manifests, under `rf2-f22y`; the documentation row in the read fence and the docs line in the layout block, under `rf2-lpfz`; the rehearsal variant of outcome 7, under `rf2-dc0c`; step 6 naming the fenced block rather than the file, under `rf2-lh7b`; pilot 2's distinct `:dev-http` port and step 5's identity check, under `rf2-v6l6`.
+Authorized by `rf2-v04s` under [`rf2-hic-063`](README.md#what-governs-this-directory)'s ratification; the `_shared/` line in both source manifests, under `rf2-f22y`; the documentation row in the read fence and the docs line in the layout block, under `rf2-lpfz`; the rehearsal variant of outcome 7, under `rf2-dc0c`; step 6 naming the fenced block rather than the file, under `rf2-lh7b`; pilot 2's distinct `:dev-http` port and step 5's identity check, under `rf2-v6l6`; step 1 setting the pin rather than reading it back, under `rf2-zmhn`; the `PRE-PILOT` header being stamped at collection, under `rf2-yqtr`.
 
 ## Layout
 
@@ -28,7 +28,7 @@ The published installation chapter tells a reader to clone the monorepo *beside*
 
 `app/deps.edn` sits one level under `<pilot-root>`, which is what makes every `:local/root "../re-frame2/…"` in the published documentation resolve without modification. Do not flatten it.
 
-**Pin the checkout.** Record the commit the workspace was built at in the log's header and do not update it mid-pilot. A pilot that silently moves onto a newer tree is measuring two things at once, and outcome 7 — upgrade across the RC — is the one place a deliberate second pin belongs. On a rehearsal there is no second pin to belong there, and outcome 7 is [recorded `BLOCKED`](#rehearsal-runs-outcome-7-is-blocked) instead.
+**Pin the checkout.** Record the commit the workspace was built at in the log's header and do not update it mid-pilot. A pilot that silently moves onto a newer tree is measuring two things at once, and outcome 7 — upgrade across the RC — is the one place a deliberate second pin belongs. On a rehearsal there is no second pin to belong there, and outcome 7 is [recorded `BLOCKED`](#rehearsal-runs-outcome-7-is-blocked) instead. Both pilots take the same pin, which is why [step 1](#assemble-a-workspace) sets it explicitly instead of reading back whatever the clone landed on.
 
 ## The read fence
 
@@ -66,8 +66,11 @@ Six steps, the fifth in two halves. Run them from anywhere; `<pilot-root>` and `
 ```bash
 mkdir -p <pilot-root> && cd <pilot-root>
 git clone https://github.com/day8/re-frame2.git
-git -C re-frame2 rev-parse HEAD    # record this in the log header
+git -C re-frame2 checkout --detach <sha>   # the one sha, chosen before you start
+git -C re-frame2 rev-parse HEAD            # verifies the line above; record it in the log header
 ```
+
+**The sha is chosen, not discovered, and `rev-parse` checks the choice rather than reporting an accident.** Without the `checkout --detach` line each workspace lands on whatever `main` happened to be at the instant its own clone ran, and nothing downstream notices: two clones issued in the same tick during the rehearsal assembly came out six commits apart, two of those commits runtime changes under `implementation/`. Each pin was recorded faithfully into its own log header, which is exactly where the divergence is invisible — a header is read for what it says, not against the other pilot's. [`rf2-hic-063`](README.md#what-governs-this-directory)'s method permits the two pilots to run in parallel, and the point of running two is two independent readings of the *same* product; on different commits they read two products, and the logs are then comparable neither with each other nor against the counted run they are read beside. So pick one sha before assembling either workspace, use that same sha in both, and treat the `rev-parse HEAD` line as the check that you did — it must print the sha you chose. Added under `rf2-zmhn`.
 
 **2. Copy the application source**, preserving the namespace-to-path mapping. In the repository these files are flat under a source root; in the workspace they take their namespace path under `app/src/`.
 
@@ -152,6 +155,8 @@ Checkout pin: <sha>
 ```
 
 Both replacements are written to be read alone. Neither names a rehearsal, a counted run, or this page, so the pilot meets one instruction rather than a choice between two. Added under `rf2-dc0c`.
+
+**The `PRE-PILOT — NOT §13 EVIDENCE` header is stamped at collection, and it is the operator who stamps it.** The blank log the pilot receives carries no such header, and none is added to [`friction-log.md`](friction-log.md)'s template: it would tell a blinded pilot that it is inside an experiment whose evidence status is contested, and a pilot that knows it is rehearsing reports differently. The label is for the later reader — an auditor, or the [§13](../specification.md#13-definition-of-done) checkpoint — so write it at the top of each log when the log comes back, before the log is filed with the run's findings. That keeps the archived artefact marked and the pilot blinded, which the two orderings do not trade off: adding the line afterwards is one line of work, and un-blinding a pilot cannot be undone at all. Added under `rf2-yqtr`.
 
 ## The four project files
 


### PR DESCRIPTION
Two beads, one file: `docs/design/hicasso/product/pilots/workspace.md`. Both are corrections to the operator-facing pilot assembly procedure, found during the live rehearsal assembly for `rf2-t4jpz`.

## rf2-zmhn — step 1 recorded a pin but never set one

Step 1 cloned and then read `HEAD` back, so each workspace landed on whatever `main` happened to be at the instant its own clone ran. Two clones issued in the same tick during the rehearsal assembly came out six commits apart, two of those commits runtime changes under `implementation/`. Each pin was then recorded faithfully into its own log header, which is precisely where the divergence is invisible — a header is read for what it says, not against the other pilot's.

Step 1 now takes an operator-chosen sha and checks it out in both workspaces:

```
git -C re-frame2 checkout --detach <sha>   # the one sha, chosen before you start
git -C re-frame2 rev-parse HEAD            # verifies the line above; record it in the log header
```

The surrounding prose says the operator picks one sha for both pilots and that `rev-parse HEAD` is now a verification rather than a discovery. The Layout section's existing **Pin the checkout** paragraph gains one clause pointing at step 1, so the two do not read against each other.

The sha is written as the `<sha>` placeholder, matching the placeholder the rehearsal section's attestation block already uses. A hex literal would be wrong twice over: the operator chooses the sha, and a literal authored head with no landed anchor beside it is exactly what the provenance gate refuses.

## rf2-yqtr — record the stamping mechanism in the package

This bead is already ruled. The ruling's last paragraph is the only outstanding work: record the mechanism in the package so the next operator does not re-derive it and does not leave the artefact unmarked.

Added to the rehearsal section: the blank friction log carries no `PRE-PILOT — NOT §13 EVIDENCE` header, and the operator stamps it when the log is collected, before filing. One clause on why — the pilot is blinded, and a pilot that knows it is rehearsing reports differently.

The blinding is unchanged, no header is added to any template, and the two operator-applied replacement blocks are untouched.

## Quality gates

`mkdocs build --strict` does **not** cover this page and is not cited as evidence for it: `mkdocs.yml`'s `exclude_docs` block lists `design/hicasso/`. The two gates that do cover it were run directly, and each was proven to read this worktree by a planted fault.

| Gate | Result | Captured exit |
| --- | --- | --- |
| `python scripts/check_doc_slugs.py --self-test --verbose` | all 146 self-tests passed | 0 |
| `python scripts/check_doc_slugs.py --verbose` | 762 files across 11 roots, no broken links | 0 |
| `python scripts/check_provenance_pins.py --self-test --verbose` | all 68 self-tests passed | 0 |
| `python scripts/check_provenance_pins.py --changed-since origin/main --verbose` | 1 page inspected, 0 cited pins, 0 findings | 0 |
| `sh scripts/test-fast-pr.sh` | PASS fast PR spine (documentation tier ran) | 0 |

Both link gates were re-run on the final rebased base; the greens above are that tree's.

**Sabotage runs — each gate proven to bite on this page.** Neither gate prints the root it read, so the proof is red from a planted fault, since the fault exists only in this worktree.

- Planted a broken anchor on the line this PR adds: `check_doc_slugs.py` returned **exit 1**, `BROKEN ANCHOR: ...workspace.md:159 -> ../specification.md#13-definition-of-done-PLANTEDFAULTA`. This also empirically confirms the slug gate covers `docs/design/hicasso/`, a tree `exclude_docs` hides from the strict build.
- Planted an unaccompanied stranded pin in the same paragraph: `check_provenance_pins.py` returned **exit 1**, one `[UNRESOLVABLE]` finding naming the file and token.

Both faults were reverted and the restore verified by git blob hash against the committed object, not by reading a diff.

## Verified by hand

No automated gate validates this page's prose, its tables, or whether the procedure works.

- **Command sequence runs correctly in order.** Executed the documented step-1 sequence end to end against a throwaway repository: `git clone`, then `git -C re-frame2 checkout --detach <sha>`, then `git -C re-frame2 rev-parse HEAD`. `rev-parse` printed exactly the chosen sha and the working tree was at that commit's content — so the verification line verifies, and the files step 2 copies come from the pinned tree. The clone is a full clone, so any commit on `main` is present to check out.
- **Table column counts unchanged.** Every table row in the file is byte-identical to the pre-change version; the read-fence table keeps 2 columns and the outcome-7 row keeps 4. Only line numbers moved.
- **Anchors resolve.** `#assemble-a-workspace` and `#rehearsal-runs-outcome-7-is-blocked` are headings in this file; `README.md#what-governs-this-directory` exists; `friction-log.md` exists; `../specification.md#13-definition-of-done` resolves to `## 13. Definition of done`, and is the same target the sibling README already links. All are covered by the slug gate, which the sabotage run proves bites on this page.
- **The template really carries no header.** Searched `friction-log.md` for `PRE-PILOT` line-oriented and again over whitespace-collapsed text: zero both ways, against a control (`Checkout pin`) that returns 5 both ways. So the "no header on the template" half of the ruling already holds and no template change was needed.
- **Fence contents checked.** In this tree a doc link inside a fenced block is itself reported; the fence this PR edits contains no doc links, only a git URL and comments.