### PR TITLE
docs(skills): the dense teaching leaf is a second shape passing the token test (rf2-wh25)

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -251,10 +251,39 @@ Single source of truth for the per-leaf size ceiling — per-skill
   one trigger (the retro's pattern-check step) and is scanned whole to
   classify an unknown friction, so a reader cannot know in advance which half
   holds their case and a split would load both.
+- dense teaching leaves may exceed it on that same test, for a different
+  reason. A catalogue is scanned whole because it is *unordered*; a teaching
+  leaf is read whole because it is a *single arc*.
+  `re-frame2/references/state-machines/reg-machine.md` is recorded exempt on
+  that test: it is not a bag of entries but one declaration taught end to
+  end, from mental model through declaration shape to gotchas, and the second
+  half loads on the same trigger as the first — so a split raises
+  tokens-per-session, and costs `SKILL.md` routing rows besides. The overrun
+  here is density, not duplication: 68 prose lines carry 20 KB and code
+  fences are only 13% of the file, which is exactly the long-unwrapped-prose
+  load the byte ceiling exists to catch — a true positive with no split
+  available.
+
+Recorded exempt on the token test, so the next author cites this list rather
+than re-deriving it. Line counts and LF-normalised bytes, measured
+2026-09-03:
+
+- catalogue-shaped — `re-frame2-pair/references/ops.md` 220 L / 46,461 B;
+  `re-frame2-pair/references/recipes.md` 424 L / 46,086 B;
+  `re-frame2-pair-retro/references/known-frictions.md` 242 L / 16,752 B
+- dense teaching — `re-frame2/references/state-machines/reg-machine.md`
+  208 L / 20,599 B; `re-frame2/references/state-machines/spawn.md`
+  199 L / 19,236 B; `re-frame-migration/references/guided-views-m11.md`
+  261 L / 39,701 B
 
 The ceilings are grounded in a May 2026 corpus audit (max 203 L, p95
 148 L, median 88 L); leaves that have since outgrown them are refactor
-targets unless they pass the catalogue test above.
+targets unless they pass the test above. The exemption is narrow, and the
+ceiling is not unreachable in general: de-duplication brought
+`re-frame2/references/fundamentals/cofx.md` (16,115 B) and
+`re-frame2/patterns/forms.md` (16,105 B) back inside both ceilings, and
+`re-frame2/references/cross-cutting/testing.md` was genuinely split, carving
+out `testing-views.md`. Try both before recording an exception.
 
 ### `SKILL.md` frontmatter `description` — the cap that actually bites
 


### PR DESCRIPTION
`skills/README.md` §Leaf size discipline already carves out catalogue-shaped
leaves on a real test — *would splitting reduce total tokens loaded per
session?* Four beads have since reached the same answer for a **different**
shape and recorded it on their own bead, where the next author will not find
it. The page that owns the rule did not carry the answer, so each author
re-derived it from scratch.

This widens that carve-out to name the **dense teaching leaf** as a second
shape passing the *unchanged* test. A catalogue is scanned whole because it is
unordered; a teaching leaf is read whole because it is a single arc —
`reg-machine.md` is not a bag of entries but one declaration taught end to end,
and its second half loads on the same trigger as its first. Same test, same
answer, second shape.

It also records the measured exempt leaves with their figures, so the next
author cites the record instead of re-deriving it, and keeps the honest
qualifier that the ceiling is **not** unreachable in general.

The 250-line and 16 KB figures are unchanged, no gate is added, and no leaf
file is touched. One file, +30/-1.

### Why no gate

There is none today, and adding one would convert a judgement into a refusal
on a rule whose whole content is "apply this test". Verified at source: a
fixed-string search for `16 KB`, `16384` and `16_384` across `scripts/`,
`implementation/scripts/` and `.github/` returns zero files (controls in the
same shape fire: `1,536 characters` finds 1 file, and per-tree controls return
42 / 77 / 11). The one `LEAF-SIZE` check in the repo,
`check_skill_migration_o1617_router_drift.py`, is a different rule with a
different number — a 60-line "no shadow guide" cap bound to two named O-16/O-17
router leaves, none of them listed here.

## Quality gates

Each run foreground, exit code captured on the same command line as the
redirect, on the final rebased base (`origin/main` @ c8eddc1302).

| gate | invocation | result | exit |
| --- | --- | --- | --- |
| doc slugs (self-test) | `python scripts/check_doc_slugs.py --self-test --verbose` | 146/146 self-tests passed | **0** |
| doc slugs | `python scripts/check_doc_slugs.py --verbose` | 762 markdown files across 11 roots (170 under `skills`); no broken links | **0** |
| skill package refs (self-test) | `python scripts/check_skill_package_refs.py --self-test --verbose` | 11/11 self-tests passed | **0** |
| skill package refs | `python scripts/check_skill_package_refs.py --verbose --ci` | all 9 packaged skills resolve their in-package links | **0** |
| readme links | `python scripts/check_readme_links.py --ci` | no findings | **0** |

**Which gate covers this file, and how it was established.** `skills/README.md`
falls to `check_doc_slugs.py`, not `check_readme_links.py`. Established from
both sides at source — `DEFAULT_ROOTS` in `check_doc_slugs.py` contains
`skills`, and `check_readme_links.py`'s `DOCS_GATE_ROOTS` excludes it
explicitly ("no double-coverage") — and then confirmed empirically by planting
a broken link target in this file's new prose: `check_doc_slugs.py` returned
exit 1 naming `skills/README.md:286 -> ./no-such-leaf-rf2wh25.md`, while
`check_readme_links.py --ci` returned exit 0 and never mentioned it. The plant
also proves the gate read this worktree, since the fault existed nowhere else.
It was reverted before the final runs and the restore verified byte-identical
by blob hash (`ad770af24a81bb9d7517aac09cdc040bd8c02ba7`), not by reading a
diff.

`mkdocs build --strict` is **not** nominated: `docs_dir` is `docs`, and
`skills/` sits outside it, so it was never a candidate for `exclude_docs` and
its absence from that block is not evidence of coverage.

### Verified by hand (nothing validates markdown prose, tables or rendering)

- **Not in a fence.** Both link gates strip fenced code blocks before reading a
  link, so a fenced edit would be invisible to them. Checked programmatically:
  no line of the edited region (235–290) is inside a fence, and the file's
  fences balance at EOF. The edit is entirely prose and list items.
- **Tables.** None touched — zero diff lines contain a table pipe, so no column
  count changed.
- **Anchors.** None cited, and no heading added or renamed, so no anchor and no
  routing row moves.
- **Paths.** All 10 paths named in the new prose exist on disk. They are written
  as inline code spans, not links — matching the style of the existing
  catalogue bullet, and inert to the packaging gate (which scans only docs
  *inside* packaged skill dirs, and checks links, not code spans).
- **Figures re-measured**, LF-normalised, from git blobs at the final rebased
  tip rather than quoted from the bead: all eight match what the page now
  states — `ops.md` 220 L / 46,461 B, `recipes.md` 424 L / 46,086 B,
  `known-frictions.md` 242 L / 16,752 B, `reg-machine.md` 208 L / 20,599 B,
  `spawn.md` 199 L / 19,236 B, `guided-views-m11.md` 261 L / 39,701 B,
  `cofx.md` 16,115 B, `forms.md` 16,105 B.
- **The density claim** in the new bullet is measured, not inherited:
  `reg-machine.md` carries 68 prose lines and its code fences are 13% of the
  file (2,778 B of 20,599 B).
- **Wrap** matches the file at ≤77 columns.

Closes rf2-wh25.
