### PR TITLE
test(bundle-isolation): durable co-load controls for both rf2-k4oe repairs, and the fourth client-root site (rf2-k4oe, rf2-phtp)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs
@@ -40,6 +40,11 @@
             [re-frame.frame :as frame]
             [re-frame.fx :as fx]
             [re-frame.registrar :as registrar]
+            ;; the provenance store behind the registrar — section 0's control
+            ;; reads it to find WHICH namespace owns each rival "/" route row,
+            ;; so it can sequester them through the provenance-safe pairing
+            ;; rather than by a raw registrar write.
+            [re-frame.source-store :as source-store]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
             [re-frame.views]
@@ -240,6 +245,87 @@
   (rf/dispatch-sync [:rf.route/navigate {:to :linearlite.app/board}])
   (reply-success! demo-board)
   (reset! last-managed-args nil))
+
+;; ============================================================================
+;; 0. CO-LOAD ISOLATION CONTROL (rf2-k4oe) — the witness this suite lacked
+;; ============================================================================
+
+;; EVERY test below section 0 is green in this bundle whether or not `init!`
+;; makes the frame last. Seven co-loaded example apps also register a route at
+;; "/", so one of THEM answers the URL sync `make-frame` performs at
+;; construction and this app's blocking board resource is never planned there.
+;; That is the false green rf2-k4oe was filed for, and it survived the fix:
+;; measured on the pre-#9027 ordering in the consolidated `:node-test` bundle,
+;; sections 1-9 still read 10 tests / 51 assertions / 0 failures. Moving
+;; `make-frame` back up left CI green.
+;;
+;; This test is the missing witness, and it does NOT build a second bundle —
+;; the fifteen single-app builds that found the defect were audit evidence, too
+;; expensive to keep. It reproduces IN PROCESS the two facts a single-app bundle
+;; would have supplied:
+;;
+;;   (1) "/" is answered by THIS app's board route ALONE. Every rival row is
+;;       sequestered through the same provenance-safe pairing the suite already
+;;       uses for `:rf.route/not-found`, and reinstated in a `finally`.
+;;   (2) The `:resource` / `:mutation` kinds are EMPTY when `init!` starts —
+;;       the state the shared fixture's post-dispose reset hook really leaves,
+;;       and which refilling is `init!`'s whole job.
+;;
+;; It then runs the REAL `init!` against a cleared frame registry, so
+;; `make-frame` genuinely CONSTRUCTS and its post-create URL sync really runs.
+;; Register-then-make-frame lands `:linearlite.app/board` with its board
+;; resource planned; make-frame-then-register lands `:transition :error` /
+;; `:rf.error/resource-route-plan`. Calling `init!` itself rather than a copy of
+;; it is the point: a refactor that puts the frame back in front of the
+;; registrar reinstatement, by any route, fails HERE.
+;;
+;; The first assertion is the control's own positive control. If the
+;; sequestering ever silently stops working — a route row that moves, a `:path`
+;; key that is renamed — the URL sync lands on a sibling's route id and this
+;; test fails LOUD, rather than passing while checking nothing.
+
+(defn- root-path-rivals
+  "The `[route-id provenance-ns]` source slots of every OTHER app that also owns
+   \"/\" in this consolidated bundle."
+  []
+  (for [[id metadata] (registrar/registrations :route)
+        :when         (and (= "/" (:path metadata))
+                           (not= :linearlite.app/board id))
+        provenance-ns (keys (source-store/descriptors-for :route id))]
+    [id provenance-ns]))
+
+(deftest init-refills-the-registrar-before-it-makes-the-url-bound-frame
+  (testing "examples/capabilities/resources/linearlite — with \"/\" owned by this app alone and
+            the :resource/:mutation kinds cleared (a single-app bundle's two
+            conditions, reproduced in process), init!'s construction-time URL
+            sync plans the blocking :linearlite/board resource cleanly. This is
+            the assertion the consolidated bundle cannot make for itself"
+    (let [sequestered (atom [])]
+      (try
+        (doseq [[id provenance-ns] (root-path-rivals)]
+          (when-let [row (test-support/sequester-app-registration! :route id provenance-ns)]
+            (swap! sequestered conj row)))
+        (registrar/clear-kind! :resource)
+        (registrar/clear-kind! :mutation)
+        (reset! frame/frames {})
+        (init!)
+        (let [slice (get-in (runtime-db) [:rf.runtime/routing :current])]
+          (is (= :linearlite.app/board (:route-id slice))
+              "POSITIVE CONTROL: the rival \"/\" rows really are gone, so the
+               frame's construction-time URL sync lands on THIS app's board
+               route — the single-app condition the rest of this test needs")
+          (is (not= :error (:transition slice))
+              "the construction-time route-entry resource plan SUCCEEDED: init!
+               refilled the :resource registrar before it made the :url-bound?
+               frame (rf2-k4oe). A :transition :error here means make-frame ran
+               first and the plan found the kind empty")
+          (is (nil? (:rf.error/id (:error slice)))
+              "and no :rf.error/resource-route-plan is stuck on the slice — the
+               error is STICKY, which is why the suite's own navigate never
+               clears it"))
+        (finally
+          (run! test-support/reinstate-app-registration! @sequestered)
+          (reset! frame/frames {}))))))
 
 ;; ============================================================================
 ;; 1. ROUTE ENTRY ensures the board resource (the route OWNS the read)

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -1268,6 +1268,234 @@ function assertCanonicalInventoryCovered(required = discoverBrowserOptionalRunti
   };
 }
 
+// ----- example ns-load co-load isolation (rf2-k4oe) --------------------------
+
+// Every check above this line asks whether an artefact's body reached a bundle
+// it should be absent from. This one asks the ns-LOAD question underneath that,
+// and it is the question the consolidated `:node-test` bundle structurally
+// cannot answer about itself: does each example app load on its OWN, or only
+// because a SIBLING app happened to be co-loaded beside it?
+//
+// THE DEFECT THIS EXISTS FOR (rf2-k4oe). examples/capabilities/resources/resources/core.cljs
+// called `rf/reg-machine` while requiring neither `re-frame.machines` nor
+// anything pulling it in. Machines are an OPTIONAL artefact whose façade export
+// resolves through the late-bind hook table, so the call succeeds exactly when
+// some other namespace has already loaded the artefact. In the consolidated
+// bundle one always had. Alone, the example's ns-load threw
+// `:rf.error/machines-artefact-missing` before a single test ran. Every gate in
+// the repo was GREEN across that defect, and — the part that made it worth a
+// permanent control rather than a one-off fix — every gate would be green again
+// the moment somebody deleted the require that fixed it. The fifteen single-app
+// builds that found it were audit evidence, far too expensive to keep.
+//
+// WHY THIS IS A SOURCE CHECK AND NOT AN EMITTED-ARTEFACT ONE, since the roster
+// comment above rightly insists on the emitted module for every claim it makes:
+// the claim here is not about a bundle's CONTENTS, it is about an ns FORM. A
+// missing `:require` is invisible in any bundle that contains the artefact for
+// some other reason, which is precisely the co-load being ruled out — so the
+// only artefact that could witness it is a single-app build, and that is the
+// cost the audit forbade. The ns form is the honest subject, so the ns form is
+// what is read.
+//
+// THE RULE. An example that CALLS an optional artefact's registration façade
+// must `:require` that artefact in its OWN ns form. Load-time hook registration
+// is what the `:require` buys — not the Maven dep, and not a sibling's require
+// (`skills/re-frame-migration/references/auto-cross-cutting.md` states the same
+// rule for migrating apps: "Add the dep AND the `:require` in every namespace
+// that uses the surface").
+const OPTIONAL_ARTEFACT_FACADES = [
+  { call: 'reg-machine',    artefact: 're-frame.machines',  absentError: 'rf.error/machines-artefact-missing' },
+  { call: 'defmachine',     artefact: 're-frame.machines',  absentError: 'rf.error/machines-artefact-missing' },
+  { call: 'reg-route',      artefact: 're-frame.routing',   absentError: 'rf.error/routing-artefact-missing' },
+  { call: 'reg-resource',   artefact: 're-frame.resources', absentError: 'rf.error/resources-artefact-missing' },
+  { call: 'reg-mutation',   artefact: 're-frame.resources', absentError: 'rf.error/resources-artefact-missing' },
+  { call: 'reg-flow',       artefact: 're-frame.flows',     absentError: 'rf.error/flows-artefact-missing' },
+  { call: 'reg-app-schema', artefact: 're-frame.schemas',   absentError: 'rf.error/schemas-artefact-missing' },
+];
+
+const EXAMPLES_DIR = path.resolve(ROOT, '..', 'examples');
+
+// Reduce a source file to the text that is CODE: line comments removed, string
+// bodies blanked (delimiters and newlines kept, so paren balance and line
+// structure survive). Both halves are load-bearing, and each was established by
+// a fixture in the sibling self-test rather than assumed:
+//
+//   - a `;` inside a string does not start a comment, and `\;` is a character
+//     literal, so a naive line strip mangles real code;
+//   - a façade named in a comment or a docstring is PROSE, not a call. This
+//     file's own subject, resources/core.cljs, writes `rf/reg-machine` in a
+//     comment two lines above the genuine call, and blanking string bodies is
+//     what stops `(def doc "call (rf/reg-flow …)")` from demanding a require.
+//
+// Blanking rather than deleting keeps the ns-form reader's paren balance intact
+// through a docstring containing an unbalanced bracket.
+function stripCommentsAndStringBodies(source) {
+  let out = '';
+  let inString = false;
+  for (let i = 0; i < source.length; i += 1) {
+    const ch = source[i];
+    if (inString) {
+      if (ch === '\\' && i + 1 < source.length) {
+        out += source[i + 1] === '\n' ? '  \n' : '  ';
+        i += 1;
+        continue;
+      }
+      if (ch === '"') { out += ch; inString = false; continue; }
+      out += ch === '\n' ? '\n' : ' ';
+      continue;
+    }
+    if (ch === '"') { inString = true; out += ch; continue; }
+    if (ch === '\\') {
+      // character literal, e.g. \; or \" — copy it whole so it can neither open
+      // a string nor start a comment.
+      out += ch;
+      if (i + 1 < source.length) { out += source[i + 1]; i += 1; }
+      continue;
+    }
+    if (ch === ';') {
+      while (i < source.length && source[i] !== '\n') i += 1;
+      out += '\n';
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+// The `(ns …)` form, read by paren balance over comment-stripped source (the
+// form spans many lines and carries `;` comments between requires, so neither a
+// line-oriented read nor a raw brace count survives it).
+function nsForm(strippedSource) {
+  const start = strippedSource.indexOf('(ns ');
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  for (let i = start; i < strippedSource.length; i += 1) {
+    const ch = strippedSource[i];
+    if (inString) {
+      if (ch === '\\') { i += 1; } else if (ch === '"') { inString = false; }
+      continue;
+    }
+    if (ch === '"') { inString = true; continue; }
+    if (ch === '\\') { i += 1; continue; }
+    if (ch === '(' || ch === '[' || ch === '{') depth += 1;
+    else if (ch === ')' || ch === ']' || ch === '}') {
+      depth -= 1;
+      if (depth === 0) return strippedSource.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+// Namespaces this file requires ITSELF, in any of the shapes the tree uses:
+// `[re-frame.machines]`, `[re-frame.routing :as r]`, or a bare symbol.
+function requiredNamespaces(nsFormText) {
+  if (!nsFormText) return new Set();
+  const found = new Set();
+  for (const m of nsFormText.matchAll(/[[\s]([a-z][a-z0-9.*+!_'?<>=-]*\.[a-z][a-z0-9.*+!_'?<>=-]*)/g)) {
+    found.add(m[1]);
+  }
+  return found;
+}
+
+// Call sites of `<call>` in the file BODY (outside the ns form), as an actual
+// call — a `(` immediately before the symbol, optionally alias-qualified. Prose
+// naming the symbol in backticks is not a call and does not count.
+function facadeCallSites(bodyText, call) {
+  const escaped = call.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`\\((?:[A-Za-z0-9.*+!_'?<>=-]+/)?${escaped}(?=[\\s()\\[\\]{}])`, 'g');
+  return (bodyText.match(re) || []).length;
+}
+
+function listExampleSources(dir, acc = []) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch (_e) {
+    return acc;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'out' || entry.name === '.shadow-cljs') continue;
+      listExampleSources(full, acc);
+    } else if (/\.clj[sc]$/.test(entry.name)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+// Returns { ok, violations, callSitesByCall, requireSitesByArtefact, filesScanned }.
+//
+// NON-VACUITY IS BUILT IN, on both halves and for the same reason the emitted
+// positive controls above exist. A roster row whose façade was renamed would
+// find zero call sites and silently stop checking anything; an ns-form reader
+// that stopped working would report zero requires and turn every row into a
+// vacuous pass. So the contract also requires each row to FIND its call sites
+// and to find its artefact genuinely required somewhere — either reading zero
+// fails the gate LOUD.
+function assertExampleCoLoadIsolation(files = listExampleSources(EXAMPLES_DIR)) {
+  const violations = [];
+  const callSitesByCall = new Map();
+  const requireSitesByArtefact = new Map();
+  for (const row of OPTIONAL_ARTEFACT_FACADES) {
+    callSitesByCall.set(row.call, 0);
+    requireSitesByArtefact.set(row.artefact, 0);
+  }
+
+  for (const file of files) {
+    let source;
+    try {
+      source = fs.readFileSync(file, 'utf8');
+    } catch (_e) {
+      continue;
+    }
+    const stripped = stripCommentsAndStringBodies(source);
+    const ns = nsForm(stripped);
+    const requires = requiredNamespaces(ns);
+    const body = ns ? stripped.replace(ns, '') : stripped;
+
+    for (const artefact of new Set(OPTIONAL_ARTEFACT_FACADES.map((r) => r.artefact))) {
+      if (requires.has(artefact)) {
+        requireSitesByArtefact.set(artefact, requireSitesByArtefact.get(artefact) + 1);
+      }
+    }
+
+    for (const row of OPTIONAL_ARTEFACT_FACADES) {
+      const hits = facadeCallSites(body, row.call);
+      if (hits === 0) continue;
+      callSitesByCall.set(row.call, callSitesByCall.get(row.call) + hits);
+      if (!requires.has(row.artefact)) {
+        violations.push({
+          file: path.relative(path.resolve(ROOT, '..'), file).replace(/\\/g, '/'),
+          call: row.call,
+          artefact: row.artefact,
+          absentError: row.absentError,
+          hits,
+        });
+      }
+    }
+  }
+
+  const deadRows = OPTIONAL_ARTEFACT_FACADES
+    .filter((row) => callSitesByCall.get(row.call) === 0)
+    .map((row) => row.call);
+  const unprovenArtefacts = [...requireSitesByArtefact.entries()]
+    .filter(([, count]) => count === 0)
+    .map(([artefact]) => artefact);
+
+  return {
+    ok: violations.length === 0 && deadRows.length === 0 && unprovenArtefacts.length === 0,
+    violations,
+    deadRows,
+    unprovenArtefacts,
+    callSitesByCall,
+    requireSitesByArtefact,
+    filesScanned: files.length,
+  };
+}
+
 // ----- main ------------------------------------------------------------------
 
 function main() {
@@ -1306,9 +1534,14 @@ function main() {
   // so an artefact omitted from every internal table cannot be defined away.
   const coverage = assertCanonicalInventoryCovered();
 
+  // ns-load co-load isolation (rf2-k4oe): an example that CALLS an optional
+  // artefact's façade must `:require` that artefact itself, rather than loading
+  // only because a sibling app in the consolidated bundle already did.
+  const coLoad = assertExampleCoLoadIsolation();
+
   const ctx = makePositiveContext();
 
-  let allOk = completeness.ok && coverage.ok;
+  let allOk = completeness.ok && coverage.ok && coLoad.ok;
   const failures = [];
   const positiveFailures = [];
   let internalChecked = 0;
@@ -1346,6 +1579,9 @@ function main() {
         `${positiveChecked} emitted positive-control sentinels present; ` +
         `${coverage.required.length} canonical browser-optional runtimes covered ` +
         `(${coverage.genericCount} generic, ${coverage.dedicatedCount} dedicated); ` +
+        `${coLoad.filesScanned} example sources co-load isolated ` +
+        `(${[...coLoad.callSitesByCall.values()].reduce((a, b) => a + b, 0)} optional-façade ` +
+        `call sites, each backed by its own :require); ` +
         `bundle=${bundleDir} (${blob.length} chars)`
     );
     process.exit(0);
@@ -1416,6 +1652,33 @@ function main() {
       console.error('  with a reason.');
       console.error('');
     }
+    if (!coLoad.ok) {
+      console.error('Example ns-load co-load isolation (rf2-k4oe):');
+      for (const v of coLoad.violations) {
+        console.error(`  - ${v.file} calls ${v.call} (${v.hits} site(s)) but does not`);
+        console.error(`    :require ${v.artefact} in its own ns form.`);
+        console.error(`    Optional artefacts resolve through the late-bind hook table, so`);
+        console.error(`    that call succeeds ONLY while some co-loaded sibling namespace has`);
+        console.error(`    already loaded ${v.artefact}. Built alone, this example's ns-load`);
+        console.error(`    throws :${v.absentError} before a single test runs — and the`);
+        console.error(`    consolidated bundle stays green either way, which is the whole`);
+        console.error(`    reason this check reads the ns form. Fix: add [${v.artefact}] to`);
+        console.error(`    this file's :require. Never delete the call to reach green.`);
+      }
+      if (coLoad.deadRows.length) {
+        console.error(`  Façade row(s) with ZERO call sites anywhere under examples/: ${coLoad.deadRows.join(', ')}`);
+        console.error('    The rule would silently check nothing. Either the façade was');
+        console.error('    renamed (re-derive the row from the current re-frame.core export)');
+        console.error('    or the last example using it went away (drop the row).');
+      }
+      if (coLoad.unprovenArtefacts.length) {
+        console.error(`  Artefact(s) never seen REQUIRED by any example: ${coLoad.unprovenArtefacts.join(', ')}`);
+        console.error('    The ns-form reader can no longer see requires it should see, so');
+        console.error('    every row above it had degraded to a vacuous pass. Fix the reader,');
+        console.error('    never the roster.');
+      }
+      console.error('');
+    }
     if (positiveFailures.length) {
       console.error('Positive control FAILED — a sentinel is no longer PRESENT where');
       console.error('it should be (rf2-e6qmxk). The sentinel string has DRIFTED (most');
@@ -1460,4 +1723,12 @@ module.exports = {
   validateDedicatedGate,
   readPackageScripts,
   assertCanonicalInventoryCovered,
+  OPTIONAL_ARTEFACT_FACADES,
+  stripCommentsAndStringBodies,
+  nsForm,
+  requiredNamespaces,
+  facadeCallSites,
+  listExampleSources,
+  assertExampleCoLoadIsolation,
+  EXAMPLES_DIR,
 };

--- a/implementation/scripts/check-bundle-isolation.test.cjs
+++ b/implementation/scripts/check-bundle-isolation.test.cjs
@@ -16,6 +16,8 @@ const {
   genericCoveragePaths,
   validateDedicatedGate,
   assertCanonicalInventoryCovered,
+  OPTIONAL_ARTEFACT_FACADES,
+  assertExampleCoLoadIsolation,
 } = require('./check-bundle-isolation.cjs');
 const { assertSentinelSet } = require('./lib/sentinel-scan.cjs');
 const { listPublishableRuntimes } = require('./lib/publishable-runtimes.cjs');
@@ -540,6 +542,148 @@ assert(/publishable-runtimes\.cjs/.test(LOCKSTEP),
 assert(!/grep\s+-qF\s+':clein\/build'/.test(LOCKSTEP),
   'lockstep must NOT rediscover publishability via a textual grep for the clein/build token (duplicated grep removed)');
 
+// ----- example ns-load co-load isolation (rf2-k4oe) --------------------------
+// The rule under test: an example calling an OPTIONAL artefact's registration
+// façade must `:require` that artefact ITSELF, rather than loading only because
+// a sibling app in the consolidated `:node-test` bundle already did.
+//
+// Every assertion below is a MUTATION, for the reason the whole file is written
+// this way: a rule that has only ever been seen green is indistinguishable from
+// a rule that reads nothing. resources/core.cljs was the real defect (its
+// `rf/reg-machine` call resolved only through a co-loaded sibling's
+// `re-frame.machines`), so the fixtures reproduce that exact shape rather than
+// an invented one.
+const CO_LOAD_FIXTURE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'rf2-coload-'));
+let coLoadMutations = 0;
+
+function coLoadFixture(name, source) {
+  const file = path.join(CO_LOAD_FIXTURE_DIR, name);
+  fs.writeFileSync(file, source, 'utf8');
+  return file;
+}
+
+const CO_LOAD_COMPLIANT = `(ns fixture.app
+  (:require [re-frame.core :as rf]
+            [re-frame.routing]
+            [re-frame.resources]
+            [re-frame.flows]
+            [re-frame.schemas]
+            ;; the reader machine below is why this require is here
+            [re-frame.machines]))
+(rf/reg-machine :fixture.app/reader {})
+(rf/defmachine fixture-machine {})
+(rf/reg-route :fixture.app/home {} "/")
+(rf/reg-resource :fixture/thing {})
+(rf/reg-mutation :fixture/write {})
+(rf/reg-flow {:id :fixture/flow})
+(rf/reg-app-schema :fixture/schema {})
+`;
+
+// The compliant fixture passes, and — the half that makes the rest meaningful —
+// it is seen to EXERCISE every roster row and every artefact.
+{
+  const file = coLoadFixture('compliant.cljs', CO_LOAD_COMPLIANT);
+  const res = assertExampleCoLoadIsolation([file]);
+  assert(res.ok, 'compliant fixture must pass the co-load isolation rule');
+  assert.deepStrictEqual(res.violations, []);
+  assert.deepStrictEqual(res.deadRows, [], 'every façade row must find a call site in the fixture');
+  assert.deepStrictEqual(res.unprovenArtefacts, [],
+    'every artefact must be seen REQUIRED — a reader that cannot see requires makes every row vacuous');
+  for (const row of OPTIONAL_ARTEFACT_FACADES) {
+    assert(res.callSitesByCall.get(row.call) > 0, `${row.call}: fixture must exercise this row`);
+  }
+}
+
+// Dropping any ONE require, leaving its call site in place, must be caught —
+// and must be caught by NAME, so the failure tells a maintainer which require
+// to restore rather than that "something" is wrong.
+for (const row of OPTIONAL_ARTEFACT_FACADES) {
+  const dropped = CO_LOAD_COMPLIANT
+    .split('\n')
+    .filter((line) => !new RegExp(`\\[${row.artefact.replace(/\./g, '\\.')}\\]`).test(line))
+    .join('\n');
+  assert(!dropped.includes(`[${row.artefact}]`), `fixture mutation must actually drop [${row.artefact}]`);
+  coLoadMutations += 1;
+  const res = assertExampleCoLoadIsolation([coLoadFixture(`missing-${row.call}.cljs`, dropped)]);
+  assert(!res.ok, `${row.call}: a call site with no [${row.artefact}] require must FAIL`);
+  assert(res.violations.some((v) => v.call === row.call && v.artefact === row.artefact),
+    `${row.call}: the violation must name the call and the artefact it needs`);
+}
+
+// A façade named only in PROSE is not a call site. Without this the rule would
+// demand a require for every doc comment mentioning the surface — and
+// resources/core.cljs, the real subject, names `rf/reg-machine` in a comment two
+// lines above the genuine call.
+{
+  coLoadMutations += 1;
+  const res = assertExampleCoLoadIsolation([coLoadFixture('prose-only.cljs', `(ns fixture.prose
+  (:require [re-frame.core :as rf]))
+;; This example does not use machines; \`rf/reg-machine\` and (rf/reg-route …)
+;; are named here only to explain what it does NOT do.
+(def doc "call (rf/reg-flow …) to register a flow")
+(rf/reg-event-db :fixture/noop (fn [db _] db))
+`)]);
+  assert.deepStrictEqual(res.violations, [],
+    'a façade named in a comment or a string is not a call site');
+}
+
+// And the converse, which is the one that would matter if the comment stripper
+// were ever made too eager: a REAL call sitting on the same line as a trailing
+// comment still counts.
+{
+  coLoadMutations += 1;
+  const res = assertExampleCoLoadIsolation([coLoadFixture('trailing-comment.cljs', `(ns fixture.trailing
+  (:require [re-frame.core :as rf]))
+(rf/reg-machine :fixture/m {}) ; the reader machine
+`)]);
+  assert(res.violations.some((v) => v.call === 'reg-machine'),
+    'a real call followed by a trailing comment must still be a call site');
+}
+
+// The two NON-VACUITY guards, each exercised in the direction that would
+// otherwise degrade the whole rule to a silent pass.
+{
+  coLoadMutations += 1;
+  const res = assertExampleCoLoadIsolation([coLoadFixture('no-calls.cljs', `(ns fixture.empty
+  (:require [re-frame.core :as rf]
+            [re-frame.machines]
+            [re-frame.routing]
+            [re-frame.resources]
+            [re-frame.flows]
+            [re-frame.schemas]))
+(rf/reg-event-db :fixture/noop (fn [db _] db))
+`)]);
+  assert(!res.ok, 'a corpus in which NO façade row finds a call site must fail, not pass vacuously');
+  assert.strictEqual(res.deadRows.length, OPTIONAL_ARTEFACT_FACADES.length);
+  assert.deepStrictEqual(res.unprovenArtefacts, [], 'requires were still readable here');
+}
+{
+  coLoadMutations += 1;
+  const res = assertExampleCoLoadIsolation([coLoadFixture('no-requires.cljs', `(ns fixture.bare)
+(fixture/reg-machine :x {})
+(fixture/defmachine y {})
+(fixture/reg-route :z {} "/")
+(fixture/reg-resource :r {})
+(fixture/reg-mutation :m {})
+(fixture/reg-flow {:id :f})
+(fixture/reg-app-schema :s {})
+`)]);
+  assert(!res.ok, 'a corpus in which no artefact is ever required must fail loud');
+  assert.strictEqual(res.unprovenArtefacts.length,
+    new Set(OPTIONAL_ARTEFACT_FACADES.map((r) => r.artefact)).size);
+}
+
+// The live tree must satisfy the rule — and be seen to be a real corpus, so a
+// walk that silently returned nothing cannot read as compliance.
+{
+  const live = assertExampleCoLoadIsolation();
+  assert(live.ok, `examples/ must satisfy co-load isolation: ${JSON.stringify(live.violations)}`);
+  assert(live.filesScanned > 20,
+    `co-load walk must reach the real examples corpus (scanned ${live.filesScanned})`);
+}
+
+fs.rmSync(CO_LOAD_FIXTURE_DIR, { recursive: true, force: true });
+
 console.log(
   `PASS check-bundle-isolation self-test: ${ARTEFACTS.length} artefacts; ` +
   `${sentinelMutations} sentinel-removal mutations; ` +
@@ -552,5 +696,9 @@ console.log(
   'unrelated-checker-for-new-runtime all rejected; nonexistent-root / subtree-EACCES / ' +
   'unreadable-deps.edn fail closed, missing-deps.edn is a normal non-candidate); ' +
   'lockstep consumes the shared EDN authority; ' +
-  'module-ownership and sentinel-ownership confusion rejected'
+  'module-ownership and sentinel-ownership confusion rejected; ' +
+  `${coLoadMutations} example co-load isolation mutations ` +
+  '(each dropped require caught by name; prose-only mention is not a call site; ' +
+  'trailing comment does not hide one; zero-call-site and zero-require corpora ' +
+  'fail loud rather than pass vacuously)'
 );

--- a/skills/re-frame-migration/references/auto-cross-cutting.md
+++ b/skills/re-frame-migration/references/auto-cross-cutting.md
@@ -352,12 +352,19 @@ The adapter value is the `adapter` Var from the substrate adapter ns (e.g. `(:re
 ```clojure
 (ns my-app.core
   (:require [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent]   ; the adapter ns (M-38)
-            [reagent.dom.client :as rdomc]))         ; React-19 createRoot path
+            [re-frame.adapter.reagent :as reagent])) ; the adapter ns (M-38) —
+                                      ; it owns the React root, so the app
+                                      ; requires NO reagent.dom.client
 
 (def app-frame :app/main)             ; pick an explicit app-frame id
                                       ; (a migration MAY use :rf/default —
                                       ;  but it is still registered, never inferred)
+
+(defonce app-root (reagent/client-root)) ; the client-root HANDLE. Inert until the
+                                      ; first render!, so the defonce is safe on
+                                      ; every hot reload. `app-root` is the handle;
+                                      ; `main-view` below is your application's root
+                                      ; VIEW — two different things, two names.
 
 (defn ^:export init []                ; the boot entry point
   (rf/init! reagent/adapter)          ; 1. ADD: install adapter (creates NO frame)
@@ -365,9 +372,10 @@ The adapter value is the `adapter` Var from the substrate adapter ns (e.g. `(:re
     {:id app-frame                    ;    via :initial-events — dispatch-sync'd into
      :initial-events [[:initialize-db]]}) ; the fresh frame; by the time make-frame
                                       ;    RETURNS, app-db already reflects the seed cascade.
-  (rdomc/render (rdomc/create-root el); 3. render LAST, UNDER the SCOPE-only frame-provider:
+  (reagent/render! app-root           ; 3. render LAST, UNDER the SCOPE-only frame-provider:
     [rf/frame-provider {:frame app-frame}  ; scope-only — frame already exists
-     [app-root]]))
+     [main-view]]
+    el))
 ```
 
 `:initial-events` are the single seed mechanism — **do not also `dispatch-sync` the same event** from a `with-frame` wrap. The framework dispatch-syncs each `:initial-events` step into the freshly-created frame at `make-frame` time and drains to fixed point, so by the time `make-frame` returns the seed has already committed (verified in [`spec/002-Frames.md` §make-frame config grammar](../../../spec/002-Frames.md)). Re-dispatching `[:initialize-db]` after `make-frame` runs the same handler **twice** — harmless for an idempotent seed, but a boot handler that emits effects, starts a machine, increments a counter, or stamps durable state then double-fires. To seed multiple events, list them directly in the `:initial-events` vector, in order (see the M-15 walkthrough in [`guided-handlers-state.md`](guided-handlers-state.md#m-15--top-level-app-db-seeding)); never repeat an `:initial-events` step in a separate boot dispatch.
@@ -382,12 +390,13 @@ The adapter value is the `adapter` Var from the substrate adapter ns (e.g. `(:re
      :initial-events [[:initialize-db]]}) ; seed runs here, once
   (rf/with-frame app-frame            ; establish a scope for ADDITIONAL boot work …
     (rf/dispatch-sync [:app/extra-boot-work]))  ; … a DISTINCT event, not :initialize-db
-  (rdomc/render (rdomc/create-root el)
+  (reagent/render! app-root
     [rf/frame-provider {:frame app-frame}
-     [app-root]]))
+     [main-view]]
+    el))
 ```
 
-Either way, **the render is wrapped in `frame-provider` (its `{:frame …}` SCOPE-only shape) for the app frame** so every bare `dispatch` / `subscribe` in the tree resolves against it. (The frame already exists from `make-frame`, so you scope it with `{:frame …}` rather than ensure it; the sibling `frame-root {:id …}` component *ensures* a named frame — create-if-absent, reuse-no-reseed — which this boot shape doesn't need because `make-frame` already created it.) If the v1 boot used `(reagent.dom/render …)`, that mount call is itself a React-19 rewrite (M-42 mount-path half → `react-dom/client` `createRoot` + `render`); the **ordering** rule and the provider wrap are independent of which mount API the app lands on.
+Either way, **the render is wrapped in `frame-provider` (its `{:frame …}` SCOPE-only shape) for the app frame** so every bare `dispatch` / `subscribe` in the tree resolves against it. (The frame already exists from `make-frame`, so you scope it with `{:frame …}` rather than ensure it; the sibling `frame-root {:id …}` component *ensures* a named frame — create-if-absent, reuse-no-reseed — which this boot shape doesn't need because `make-frame` already created it.) If the v1 boot used `(reagent.dom/render …)`, that mount call is itself a React-19 rewrite (M-42 mount-path half → the adapter's own `client-root` handle + `render!`, exactly as above — the migrated app requires neither `reagent.dom.client` nor `reagent2.dom.client`, because the adapter owns the React root and the coordinate is chosen in `deps.edn`); the **ordering** rule and the provider wrap are independent of which mount API the app lands on.
 
 > **The boot kick is the SYNCHRONOUS sibling of a larger no-frame-context class — the async one needs a DIFFERENT fix.** Wrapping the synchronous boot dispatch in `with-frame` works only because the dispatch runs *while the binding is live*. A bare `dispatch` / `subscribe` that runs **after** boot from an async callback registered outside any view — a module-level `addEventListener` (popstate / hashchange), a `setTimeout` / `setInterval` / `requestAnimationFrame` timer, a `window 'error'` handler, a JS-lib lifecycle callback — raises the same `:rf.error/no-frame-context`, but a registration-time `with-frame` does **not** survive into the callback; the frame must be re-established **inside** it. See [`guided-views-m11.md` §The async listener timer and error-handler class](guided-views-m11.md#the-async-listener-timer-and-error-handler-class).
 


### PR DESCRIPTION
Two unrelated beads, paired only because both surfaces were free.

## Item 1 — rf2-k4oe: the control PR #9027 never got

**The audit's premise holds, measured here rather than taken on trust.** I reproduced
the exact pre-#9027 tree (the resources plant restores blob `5e0060754f`, which is the
`index 5e0060754f..132a287c1e` the PR's own diff header records) and ran both subject
suites in the ordinary consolidated `:node-test` bundle:

| tree | result | captured exit |
|---|---|---|
| at tip (both fixes in) | Ran 19 tests containing 90 assertions. 0 failures | 0 |
| **both pre-fix states restored** | **Ran 19 tests containing 90 assertions. 0 failures** | **0** |

Identical. Moving `make-frame` back up and deleting the `machines` require leaves CI
green, exactly as the audit said.

### The audit asked for ONE control. It needs two, and that is a finding, not a shortcut.

The two repairs are different *kinds* of fact, so no single instrument reaches both:

* The LinearLite repair is an **ordering inside an adapter test fixture**. It never
  enters any app bundle, so no bundle grep can see it; only *executing* it under the
  isolated condition can.
* The resources repair is a **missing `:require` in an example's ns form**. It is
  invisible at runtime in any bundle that carries `re-frame.machines` for another
  reason — which is precisely the co-load being ruled out — so only a single-app build
  or the ns form itself can witness it.

Neither control builds a second bundle; together they cost milliseconds plus one
in-process test. The fifteen-build sweep is not institutionalised.

### Control A — LinearLite ordering (behavioural, in the suite it protects)

`implementation/adapters/reagent/test/re_frame/linearlite_example_cljs_test.cljs`
gains a section-0 test that reproduces **in process** the two conditions a single-app
bundle supplies — `"/"` owned by this app's board route alone (every rival row
sequestered through the provenance-safe pairing the suite already uses for
`:rf.route/not-found`, reinstated in a `finally`), and the `:resource` / `:mutation`
kinds cleared — then runs the **real `init!`** against a cleared frame registry so
`make-frame` genuinely constructs and its post-create URL sync really runs.

It calls `init!` itself rather than a copy, so a refactor that puts the frame back in
front of the registrar reinstatement *by any route* fails here — which is why this was
chosen over a source-order text check. A text check on a moving target degrades to a
vacuous pass, the failure mode this gate's own positive-control section exists to
prevent.

**Its first assertion is its own positive control**: if the sequestering ever silently
stops working, the URL sync lands on a sibling's route id and the test fails loud
rather than passing while checking nothing.

**Planted red (subject 1).** Pre-plant blob `31b1a879c4`; plant = `make-frame` moved
back above the `registrar/register!` loop.

```
FAIL init-refills-the-registrar-before-it-makes-the-url-bound-frame
  expected: (not= :error (:transition slice))     actual: (not (not= :error :error))
  expected: (nil? (:rf.error/id (:error slice)))  actual: (not (nil? :rf.error/resource-route-plan))
Ran 11 tests containing 54 assertions.  2 failures, 0 errors.       captured exit 1
```

Exactly the bead's mechanism — and the **other ten tests stayed green**, which is the
false green demonstrated directly. Positive control passed on that same run, so the
setup was real. Restore verified by blob hash: the `init!` region hashes
`88481e756e38c8867d6a6e186668342571b5a9d4` on both sides, and the whole-file diff
against HEAD is **86 additions / 0 deletions**.

### Control B — the resources `machines` require (ns-form rule, in the gate)

`check-bundle-isolation.cjs` gains a co-load isolation contract: **an example that
CALLS an optional artefact's registration façade must `:require` that artefact in its
own ns form**, because the `:require` — not the Maven dep, and not a sibling's require
— is what fires the load-time hook registrations.

Read on **source**, deliberately, and against the roster comment's own rule that every
claim be verified in the emitted artefact. That rule governs claims about a bundle's
*contents*; this claim is about an *ns form*, and the only artefact that could witness
it is the single-app build the audit ruled out on cost. Said so in the code.

Seven façade rows (`reg-machine`, `defmachine`, `reg-route`, `reg-resource`,
`reg-mutation`, `reg-flow`, `reg-app-schema`) over 82 example sources: **111 call
sites, each backed by its own `:require`, zero violations at tip**.

**Non-vacuity is built into the contract**, not left to a one-off plant: a façade row
that finds no call site anywhere, or an ns reader that stops seeing requires, fails the
gate. Both are exercised as mutations in `check-bundle-isolation.test.cjs`, which the
lane already runs first — 11 new mutations, so the rule is re-proven on every CI run
rather than once by me.

**Planted red (subject 2).** Deleting `[re-frame.machines]` from
`examples/capabilities/resources/resources/core.cljs` — blob `5e0060754f`, byte-identical
to the pre-#9027 state:

```
ok= false
[{"file":"examples/capabilities/resources/resources/core.cljs","call":"reg-machine",
  "artefact":"re-frame.machines","absentError":"rf.error/machines-artefact-missing","hits":1}]
```

One file named, no collateral. `hits: 1` and not 2 is itself evidence the comment
stripper works: that file names `rf/reg-machine` in a comment two lines above the real
call. Restored to blob `132a287c1e`.

**A self-test caught a real defect in my own checker mid-build**, which is the reason
the mutations are there: a façade named inside a *string* (`(def doc "call (rf/reg-flow …)")`)
counted as a call site. Fixed in the checker — string bodies are now blanked, not just
comments — rather than by relaxing the fixture.

**And one plant silently no-oped.** A `perl -0pi` patch left the blob hash unchanged
(CRLF) while reporting success; the hash check caught it before a run was spent on a
green that would have read as "the control does not bite".

### Confirming the control loads each subject without siblings — established, not assumed

* **Control A**: its passing positive control *is* that establishment — `(= :linearlite.app/board (:route-id slice))` can only hold once the rival `"/"` rows are gone, and it is asserted on the same run as the red.
* **Control B**: the roster is proven to *see* both halves by mutation — every dropped require is caught **by name**, and corpora with zero call sites or zero requires fail loud instead of passing.

### Scope held

Three merely-latent fixture orderings stay on rf2-djqm; the route-retry ruling stays on
rf2-ma8r. Neither widened. Nothing was weakened or deleted to reach green.

## Item 2 — rf2-phtp: the fourth client-root site

`skills/re-frame-migration/references/auto-cross-cutting.md`. Re-measured at tip: the
three hits are still at **:356, :368 and :385**, unmoved since filing.

**In class**, and the test applied rather than assumed: this is an ordinary app-boot
surface — a migrating v1 app's boot entry point — not focused low-level teaching and
not a deliberate foreign-root integration. No site on the page was judged out of class.

**Landed spelling matched, censused at tip in three passes with a present-control
beside the needle**: 46 sites bind the handle `app-root`
(44 `reagent-adapter/client-root`, 2 `reagent-slim-adapter/client-root`) and **zero**
bind any other name. The brief said 39; it is 46 now. So the handle is `app-root`, the
application view is renamed `main-view` (the `[app-root]` collision the bead flags), and
the boot requires neither `reagent.dom.client` nor `reagent2.dom.client`.

**The adapter `:as` alias was deliberately NOT changed.** This page already binds
`[re-frame.adapter.reagent :as reagent]`, which its surrounding M-40 prose depends on
(`reagent/adapter`, restated at :335). Across the corpus the alias is genuinely
per-file — 13 distinct spellings — so it is not what #9055 pinned; the *handle name*
is, and that is matched exactly. Renaming the alias here would have churned M-40 for
nothing.

The M-42 cross-reference at :399 said the rewrite target was `react-dom/client`
`createRoot` + `render`; #9055 landed the adapter-owned root as the target, so that
clause now says so. **The care-point-2 sentence survives verbatim** — the ordering rule
and the provider wrap remain stated as independent of the mount API.

## Gates — every one foreground, unfiltered, exit code captured by me

The trunk moved twice while I worked, so **every number below was re-measured after
the final rebase**, on merge base `4893d007b6`. That mattered: the incoming commits
touched `implementation/core/src/re_frame/frame.cljc` — which control A exercises —
renamed `examples/core/login/model.cljs` to `.cljc` inside the corpus control B walks,
and added a **15th** `check_skill_*.py`.

| gate | captured exit | what it read |
|---|---|---|
| `npm run test:bundle-isolation` | **0** | 23 artefacts; **40 internal sentinels absent / 40 positive-control present** (the brief's expected counts); + **83 example sources co-load isolated, 111 façade call sites** |
| gate self-test (`check-bundle-isolation.test.cjs`) | **0** | 40 sentinel mutations + **11 new co-load mutations** |
| reagent adapter suite — BEFORE | **0** | Ran 458 tests containing 2459 assertions. 0 failures |
| reagent adapter suite — AFTER | **0** | Ran 459 tests containing 2462 assertions. 0 failures |
| `python scripts/check_doc_slugs.py` | **0** | see below |
| `python scripts/check_readme_links.py --ci` | **0** | the other half of the split |
| all **15** `check_skill_*.py` | **0** each | enumerated below |
| `sh scripts/test-fast-pr.sh` | **0** | docs + JVM + node + kondo; CLJS **11206 tests / 55823 assertions, 0 failures, 0 errors** |

Adapter delta is exactly **+1 test / +3 assertions** — the one control. `node-test`
compiled 1893 files, **0 warnings**, on every run.

`--plan` on this diff arms: `documentation gates: run`, `JVM tier: run`
(`implementation/core` + `implementation/adapters/reagent`), `node/CLJS suite: run`,
`clj-kondo: run`; spine self-test skipped (spine unchanged); reason `classified`.
It arms no bundle, browser, adapter, Xray, MCP or tool-JVM gate — which is why
`test:bundle-isolation` was run separately rather than relied on through the spine.

**Both planted reds were re-proven on the final base**, not carried over: with
`make-frame` moved back up, `Ran 11 tests containing 54 assertions. 2 failures`,
captured exit **1**, both failures the control's; restored to blob
`f7c581dd8e8ec8d703b4456b6e58e5f13af1285a` and back to `Ran 20 tests containing 93
assertions. 0 failures`, exit **0**.

The spine log was checked for the spliced-artefact signature before being believed:
one `PASS fast PR spine` line, and zero NUL bytes (measured by byte-count delta across
`tr -d '\000'`, with a control file carrying one NUL reading delta 1 — my first attempt
at that check used a pattern that matched every line and would have reported a hole
that was not there).

**Every gate was verified to have read THIS worktree**, by the route each affords:
`test:bundle-isolation`, `test-fast-pr.sh --plan` and the shadow-cljs config line all
print a root, and each printed this worktree; the CLJS controls were proven by planted
reds that exist only here.

### All 15 skill gates — enumerated, and only 8 are `*_drift.py`

The brief said 14. It was 14 at my base and is **15** at the final base —
`check_skill_description_budget.py` landed in between (rf2-w9p2), which is exactly why
they were enumerated rather than counted:

`description_budget`, `eval_docs`, `eval_packaging`, `implementor_order`,
`implementor_partition_drift`, `mcp_drift`, `migration_cites`,
`migration_contract_drift`, `migration_o1617_router_drift`, `package_refs`,
`pair_authoring_drift`, `re_frame2_drift`, `redirect_anchors`, `setup_counter_drift`,
`xray_tab_inventory_drift`. All exit 0.

### Which edits no gate inspected — measured on this tree, both directions

Item 2's two rewritten blocks are entirely inside ```` ```clojure ```` fences. I planted
one broken link with a broken anchor and moved it four lines:

* **inside the fence** — `check_doc_slugs.py` **exit 0**, `check_readme_links.py --ci`
  exit 0, and the three migration skill gates exit 0. Silent.
* **the identical link in prose** — `check_doc_slugs.py` **exit 1**, naming file, line
  350 and target.

So the instrument bites and the fenced content is genuinely uninspected. Restored to
blob `69967570257c5cfe51ee3260334c46eb4d22687a`.

**So I checked the fences by hand**: all 11 `clojure` fences on the page paren-balance
(depth 0, no underflow), using the gate's own newly unit-tested comment/string stripper —
and that checker was itself controlled against a deliberately unbalanced fixture, where
it exits 1. No heading was touched; the diff contains no `#` line either way. No table
columns changed.

`mkdocs build --strict` does not cover this file at all — `skills/` is outside
`docs_dir` — so it is not nominated.
