### PR TITLE
test(ssr): guard the Node recipe's paired build-id literals (rf2-8arzr.6)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -1512,6 +1512,8 @@ else
       #                                                              → jvm-core
       #   docs/api/re-frame.ssr.md           ssr_doc_example_projector_test.clj
       #                                                              → jvm-ssr
+      #   docs/ssr/concepts.md               ssr_doc_example_node_build_id_
+      #                                        test.clj              → jvm-ssr
       #   docs/design/hicasso/product/       recipes/async_nav_doc_test.clj
       #     async-routing-recipes.md                                 → jvm-routing
       #   spec/000-Vision.md                 scope_ensure_authority_test.clj
@@ -1587,6 +1589,19 @@ else
         # pages' worth of edits into a 22-job JVM tier when 23 of them have no
         # JVM pin at all is the "coarse rules clutter the matrix" TESTING.md
         # warns about. Add the page here when a new JVM suite names one.
+        implementation_jvm=true
+        ;;
+      docs/ssr/concepts.md)
+        # One named file, NOT `docs/ssr/*` — the same narrowing the two
+        # `docs/api` pages above get, for the same reason: exactly one page in
+        # this ten-page tree is read by a test.yml suite.
+        # `ssr_doc_example_node_build_id_test.clj` (jvm-ssr) reads the "Render
+        # on Node" recipe's fences and fails when its paired build-id literals
+        # diverge — the bundle's `goog-define`, the host's `:build-id` renderer
+        # opt and the launcher transcript that echoes them. The other nine
+        # pages carry no JVM pin, and the tree's own coverage is docs.yml plus
+        # check_doc_slugs.py, neither of which reads inside a fence. Add a page
+        # here when a new JVM suite names one (rf2-8arzr.6).
         implementation_jvm=true
         ;;
       docs/design/hicasso/product/async-routing-recipes.md)

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -282,7 +282,8 @@ test('Spec-only .md change fires implementation_jvm but NOT cljs (rf2-f79t8, rf2
 
 test('Docs prose with NO pinning suite still skips jvm-core + cljs (rf2-f79t8, rf2-61ar)', () => {
   // rf2-61ar armed the docs trees a test.yml suite reads (docs/machines, two
-  // docs/api pages, one docs/design page) and left every other docs page
+  // docs/api pages, one docs/design page, and since rf2-8arzr.6
+  // docs/ssr/concepts.md) and left every other docs page
   // classifying exactly as it did before. That asymmetry IS the bead's
   // narrowing, so this case keeps its original control — a docs/core page
   // reaches none of the armed trees. Since rf2-7v5vx that holds for the WHOLE
@@ -428,7 +429,7 @@ test('unpinned PROSE reads implementation_jvm false — the render-law census re
   // The seventh walk's domain is `git ls-files`, not a directory: every tracked
   // `.md` / `.clj` / `.cljc` / `.cljs` in the repo. rf2-61ar armed
   // `implementation_jvm` for the prose a test.yml suite PINS — nearly all of
-  // `spec/*`, `docs/machines/*`, three named pages — and deliberately left the
+  // `spec/*`, `docs/machines/*`, four named pages — and deliberately left the
   // rest of `docs/` arming nothing. So the census outruns the arm, and a
   // retired render-law claim landing on an unpinned page merged green.
   for (const p of [
@@ -5490,6 +5491,7 @@ const PROSE_PINS_ARMING_JVM = [
   ['docs/machines/concepts.md', 'transition_geometry_terminology_jvm_test.clj', 'jvm-machines'],
   ['docs/api/re-frame.adapter.uix.md', 'scope_ensure_authority_test.clj', 'jvm-core'],
   ['docs/api/re-frame.ssr.md', 'ssr_doc_example_projector_test.clj', 'jvm-ssr'],
+  ['docs/ssr/concepts.md', 'ssr_doc_example_node_build_id_test.clj', 'jvm-ssr'],
   ['docs/design/hicasso/product/async-routing-recipes.md', 'recipes/async_nav_doc_test.clj', 'jvm-routing'],
   ['spec/000-Vision.md', 'scope_ensure_authority_test.clj', 'jvm-core'],
   ['spec/005-StateMachines.md', 'transition_geometry_terminology_jvm_test.clj', 'jvm-machines'],
@@ -5524,6 +5526,12 @@ test('prose no suite reads still arms NOTHING — the narrowing (rf2-61ar)', () 
     'docs/hicasso/concepts.md',
     'docs/core/intro.md',
     'docs/api/re-frame.core.md', // 23 of the 25 docs/api pages carry no JVM pin
+    // The same narrowing one tree over (rf2-8arzr.6): `concepts.md` carries
+    // the Node recipe whose build-id literals ssr_doc_example_node_build_id_
+    // test.clj holds together, and the other nine pages in docs/ssr/ carry no
+    // JVM pin at all. The arm is the PAGE, not the tree — this is the verdict
+    // that says so.
+    'docs/ssr/testing.md',
     // A docs/design/** exemplar, which is what the count beside it measures --
     // so this one does NOT follow the guide to docs/core/hicasso/. The chapter
     // it used to name left the tree under rf2-0yp7w; REWRITE-NOTES.md is the
@@ -6072,7 +6080,15 @@ const DECLARED_NO_SURFACE_OUTPUT = {
   'docs/routing': DOCS_YML,
   'docs/scripts': DOCS_YML,
   'docs/skills': DOCS_YML,
-  'docs/ssr': DOCS_YML,
+  // `docs/ssr` is DELIBERATELY ABSENT since rf2-8arzr.6, and the ratchet below
+  // is what makes that a requirement rather than a tidy-up: the tree used to
+  // be DOCS_YML, and then `docs/ssr/concepts.md` gained a test.yml pin
+  // (ssr_doc_example_node_build_id_test.clj, jvm-ssr) and an arm to schedule
+  // it. One armed file arms the tree, so the declaration became stale and had
+  // to go — leaving it would have told the next reader this tree is ungated
+  // months after it stopped being. The other nine pages are still covered by
+  // docs.yml + check_doc_slugs.py exactly as DOCS_YML says; that is a
+  // statement about pages, and this table is keyed by tree.
   'docs/story': DOCS_YML,
   'docs/stylesheets': DOCS_YML,
   'docs/the-mayor-method': DOCS_YML,

--- a/implementation/ssr/test/re_frame/ssr_doc_example_node_build_id_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_doc_example_node_build_id_test.clj
@@ -1,0 +1,171 @@
+(ns re-frame.ssr-doc-example-node-build-id-test
+  "rf2-8arzr.6 ACCEPTANCE — the \"Render on Node\" recipe in
+  `docs/ssr/concepts.md` writes ONE build id in THREE places, and this
+  suite fails when they diverge.
+
+  WHY THIS SUITE EXISTS. The recipe is a paste-and-run deployment
+  procedure, and the sidecar checks build skew in both directions: the
+  service refuses a request whose `buildId` is not the loaded module's,
+  and the adapter refuses an answer whose `x-rf-ssr-build` is not the
+  `:build-id` it was configured with (`:rf.error/ssr-node-build-skew`).
+  That check is exactly why the page leaves the bundle's `goog-define`
+  and the adapter's `:build-id` at the same development default, and the
+  page says so in its own words — \"the two literals above are one value
+  written twice\". A reader who pastes both fences gets a page; a reader
+  who pastes a recipe whose two literals have drifted apart gets a
+  refusal on EVERY request, and the refusal names the skew rather than
+  the edit that caused it.
+
+  Nothing was checking that. `mkdocs build --strict` renders the page and
+  `scripts/check_doc_slugs.py` validates its links and anchors; neither
+  reads inside a fence, let alone compares two of them. So the one defect
+  this recipe can carry that breaks every request for the reader was
+  invisible to every gate the page had — the same blind spot
+  `re-frame.ssr-doc-example-projector-test` and
+  `re-frame.ssr-doc-example-form-action-test` were written for, reached
+  through a different kind of drift: theirs is code that stops working,
+  this one is two literals that stop agreeing.
+
+  WHY THREE PLACES AND NOT TWO. The page also prints the launcher's
+  `ready` line, and its `buildId` is not a fourth decision — it is the
+  sidecar reporting the id of the module it loaded, so it is the SAME
+  value a third time. An edit that updates the two fences and leaves the
+  sample output behind publishes a transcript that no run of the recipe
+  can produce.
+
+  WHAT IS DELIBERATELY NOT PINNED. The value. `\"my-app-dev\"` is the
+  page's development default and the page is free to change it; the
+  invariant is AGREEMENT, not the string, so a rename that moves all
+  three together stays green. Each fence is located by a needle that must
+  match exactly one block, so a rewrite that removes a step fails loudly
+  here rather than silently pinning nothing.
+
+  POSTURE-INDEPENDENT. Every assertion is text read off a Markdown file:
+  no frame, no dispatch, no trace bus, no `debug-enabled?` read. The
+  namespace therefore executes identically under
+  `scripts/test-ssr-prod-gate.sh`'s real `-Dre-frame.debug=false` gate and
+  in the ordinary lane."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]))
+
+;; ---------------------------------------------------------------------------
+;; Reading the recipe out of the page
+;; ---------------------------------------------------------------------------
+
+(def ^:private concepts-page
+  "`docs/ssr/concepts.md`, anchored to a CLASSPATH RESOURCE rather than the
+  working directory (rf2-ywrwkl; the same anchoring
+  `re-frame.ssr-doc-example-projector-test` uses for the API page). A
+  `(io/file \"../../docs/...\")` form would resolve correctly under the
+  per-artefact gate run from `implementation/ssr/` and silently MIS-SCOPE
+  under the combined `implementation/deps.edn :test` alias. This namespace's
+  own source is on the test classpath, so five parents
+  (`…_test.clj → re_frame → test → ssr → implementation → repo root`) reach
+  the repo root from wherever the JVM was started."
+  (let [res (io/resource "re_frame/ssr_doc_example_node_build_id_test.clj")]
+    (assert res
+            (str "ssr-doc-example-node-build-id-test cannot locate its own "
+                 "source on the classpath — the ssr test/ dir must be on the "
+                 "test classpath for the concepts page to be found."))
+    (-> (io/file res)  ; …/ssr/test/re_frame/ssr_doc_example_node_build_id_test.clj
+        .getParentFile .getParentFile .getParentFile .getParentFile .getParentFile
+        (io/file "docs" "ssr" "concepts.md")
+        .getCanonicalFile)))
+
+(defn- fence
+  "The text of the one ```<lang> fence on the concepts page containing
+  `needle`. Hard-errors on zero or many matches, so a rewritten page fails
+  loudly rather than silently pinning nothing.
+
+  Line endings are normalised first: the page is stored LF but checks out
+  CRLF on a Windows dev box (`core.autocrlf`), and a `\\n`-only fence regex
+  matches zero blocks there while passing on the Linux CI runner."
+  [lang needle]
+  (let [md   (str/replace (slurp concepts-page) "\r\n" "\n")
+        hits (->> (re-seq (re-pattern (str "(?s)```" lang "\n(.*?)```")) md)
+                  (map second)
+                  (filter #(str/includes? % needle)))]
+    (assert (= 1 (count hits))
+            (str "expected EXACTLY ONE ```" lang " fence in " concepts-page
+                 " containing " (pr-str needle) ", found " (count hits)
+                 " — the pin has lost its anchor."))
+    (first hits)))
+
+(defn- only-capture
+  "The one capture group `re` finds in `text`. Hard-errors on zero or many,
+  for the same reason `fence` does: an ambiguous anchor pins nothing, and a
+  vanished one must say so rather than compare `nil` to `nil`."
+  [re what text]
+  (let [hits (map second (re-seq re text))]
+    (assert (= 1 (count hits))
+            (str "expected EXACTLY ONE " what " in the fence, found "
+                 (count hits) " — the pin has lost its anchor."))
+    (first hits)))
+
+(def ^:private bundle-build-id
+  "Step 2's server bundle: `(goog-define build-id \"…\")`. This is the id the
+  compiled module publishes as its `:buildId`, and the one the sidecar
+  answers with in `x-rf-ssr-build`."
+  (delay
+    (only-capture #"\(goog-define\s+build-id\s+\"([^\"]*)\"\)"
+                  "(goog-define build-id \"…\") form"
+                  (fence "clojure" "(goog-define build-id"))))
+
+(def ^:private adapter-build-id
+  "Step 3's JVM host: the `:build-id` opt handed to `node/renderer`. The
+  adapter refuses any answer whose `x-rf-ssr-build` is not this string."
+  (delay
+    (only-capture #":build-id\s+\"([^\"]*)\""
+                  ":build-id \"…\" renderer opt"
+                  (fence "clojure" "node/renderer"))))
+
+(def ^:private ready-line-build-id
+  "Step 5's launcher transcript: the `buildId` on the one `ready` line the
+  sidecar writes to stdout. Reported BY the service ABOUT the module it
+  loaded, so it is the bundle's id observed from outside."
+  (delay
+    (only-capture #"\"buildId\"\s*:\s*\"([^\"]*)\""
+                  "\"buildId\" field on the ready line"
+                  (fence "json" "\"rf.ssr-node\":\"ready\""))))
+
+;; ===========================================================================
+;; (1) THE GUARD: the two paired literals are one value written twice
+;; ===========================================================================
+
+(deftest the-paired-build-id-literals-do-not-diverge
+  (testing "rf2-8arzr.6: the recipe's server bundle and its JVM host name the
+            same build id. They are checked against each other at RUN time by
+            the sidecar and the adapter, in both directions, so a page whose
+            two literals disagree is a recipe that refuses every request the
+            moment it is pasted — and the refusal names the skew rather than
+            the edit. The page states this rule itself; this is the assertion
+            that holds it."
+    (is (seq @bundle-build-id)
+        "step 2 still declares a non-empty build id on the server bundle")
+    (is (seq @adapter-build-id)
+        "step 3 still hands the renderer a non-empty :build-id")
+    (is (= @bundle-build-id @adapter-build-id)
+        (str "the recipe's build-id literals have DIVERGED: the server "
+             "bundle's `goog-define build-id` is " (pr-str @bundle-build-id)
+             " and the host's `:build-id` renderer opt is "
+             (pr-str @adapter-build-id) ". A reader who pastes both fences "
+             "gets :rf.error/ssr-node-build-skew on every request. They are "
+             "one value written twice — change both or neither."))))
+
+;; ===========================================================================
+;; (2) The printed launcher transcript is one a run of the recipe produces
+;; ===========================================================================
+
+(deftest the-ready-line-transcript-reports-the-bundles-build-id
+  (testing "rf2-8arzr.6: the sample `ready` line is the sidecar reporting the
+            loaded module's own id, not a third independent choice. An edit
+            that moves the two fences and leaves the transcript behind
+            publishes output no run of this recipe can produce — and the
+            transcript is precisely what an operator greps for to confirm the
+            right bundle is serving."
+    (is (= @bundle-build-id @ready-line-build-id)
+        (str "the printed ready line reports "
+             (pr-str @ready-line-build-id) " while the server bundle "
+             "declares " (pr-str @bundle-build-id)
+             " — the sample output is stale."))))


### PR DESCRIPTION
Completes the remainder of rf2-8arzr.6. The docs half merged as #9062; the bead stayed open for the guard and its arm, which were outside that slice's docs fence.

## What this is

`docs/ssr/concepts.md`'s "Render on Node" recipe writes ONE build id in THREE places — the server bundle's `goog-define build-id`, the JVM host's `:build-id` renderer opt, and the launcher's `ready`-line transcript that echoes them. The sidecar refuses a request whose `buildId` is not the loaded module's, and the adapter refuses an answer whose `x-rf-ssr-build` is not the `:build-id` it was configured with (`:rf.error/ssr-node-build-skew`). So a page whose literals have drifted apart is a recipe that refuses every request the moment a reader pastes it — and the refusal names the skew rather than the edit that caused it.

Nothing could see that. `mkdocs build --strict` renders the page and `check_doc_slugs.py` validates its links and anchors; neither reads inside a fence, let alone compares two of them.

**1. The guard.** `implementation/ssr/test/re_frame/ssr_doc_example_node_build_id_test.clj` reads the three fences out of the page at run time and asserts they agree — the idiom of the two `ssr_doc_example_*` suites beside it: classpath-anchored page (not a working-directory-relative path, which mis-scopes under the combined `implementation/deps.edn :test` alias), needles that must match exactly one fence, hard error on a lost anchor, CRLF normalised. Two deftests, four assertions. The VALUE is deliberately not pinned — the invariant is agreement, so a rename that moves all three together stays green. Pure text, so it is posture-independent and joins `scripts/test-ssr-prod-gate.sh`'s lane by default (verified below).

**2. The arm.** `docs/ssr/concepts.md` was in no roster, so a prose-only edit to it could red the new suite and merge green — the rf2-61ar hole exactly. `.github/scripts/report-changed-surfaces.sh` gains a named `docs/ssr/concepts.md` arm for `implementation_jvm`, plus its roster row. A named page rather than `docs/ssr/*`: the other nine pages in that tree carry no JVM pin.

**Why one commit.** The arm changes what the classifier OUTPUTS, and `implementation/scripts/_changed-surfaces.test.cjs` pins those outputs — the CLAUDE.md one-toucher pair. The mirror gains the roster row, a negative-direction verdict (`docs/ssr/testing.md` still arms nothing, so the arm is the page rather than the tree), and one deletion its own ratchet requires: `docs/ssr` was declared in `DECLARED_NO_SURFACE_OUTPUT`, one armed file arms the tree, and `staleDeclarations` fails on a declaration that outlives its hole.

## Quality gates

Every exit code below is the runner's own `$?`, captured on the same command line as its redirect and never through a filter. Every gate was invoked by absolute path. All were re-run on the final rebased base (`681ff410cd`).

| Gate | Result | Exit |
|---|---|---|
| `node implementation/scripts/_changed-surfaces.test.cjs` (baseline, pre-change) | 335 passed | 0 |
| `node implementation/scripts/_changed-surfaces.test.cjs` (post-change) | 335 passed | 0 |
| `clojure -M:test` from `implementation/ssr/` | 623 tests, 3172 assertions, 0 failures, 0 errors | 0 |
| `bash scripts/test-ssr-prod-gate.sh` (`-Dre-frame.debug=false`, whole suite) | 625 tests, 2999 assertions, 0 failures, 0 errors | 0 |
| `clojure -M:test -n` the three repo-source-walk namespaces that read test trees and tracked prose | 8 tests, 27 assertions, 0 failures | 0 |
| `sh scripts/test-fast-pr.sh` | PASS fast PR spine | 0 |
| `python scripts/check_fast_pr_gap.py --brief` | 97 required checks named as outside the spine | 0 |

Inside the spine: clj-kondo 2026.04.15 (CI's pin, CI's own command) errors 0 / warnings 2087; JVM `implementation/core` 2176 tests / 11149 assertions; JVM `implementation/ssr` 623 / 3172; changed-surfaces 335 passed; CLJS `:node-test` 11206 tests / 55823 assertions. The documentation tier was SKIPPED — it is classifier-gated and this diff touches no page, so the spine's green says nothing about the doc gates and none is claimed. `mkdocs build --strict` is deliberately not cited: no page changed.

**The changed-surfaces total did NOT move: 335 before and 335 after.** The new coverage lands as rows inside existing `test(...)` blocks (the roster array, the negative-direction list), not as new blocks, so an unchanged total is the expected reading — a lower one would have meant a case was removed.

### The guard exercised in both directions

A guard only ever seen green has not been shown to guard anything. Three faults were planted in `docs/ssr/concepts.md` one at a time, each anchored to a single line with the match count read before the run (1 in every case), and each restored with the page's blob hash verified equal to the committed object (`c9fd42f93b`) rather than by reading a diff:

1. **The adapter literal diverges.** `:build-id "my-app-dev"` → `"my-app-PLANTED"`. RED, exit 1: `the-paired-build-id-literals-do-not-diverge` fails naming both values — `(not (= "my-app-dev" "my-app-PLANTED"))`.
2. **The printed transcript goes stale.** The ready line's `"buildId":"my-app-dev"` → `"my-app-STALE"`. RED, exit 1: `the-ready-line-transcript-reports-the-bundles-build-id` fails — `(not (= "my-app-dev" "my-app-STALE"))`.
3. **The anchor is lost.** `(goog-define build-id …)` → `(def build-id …)`. RED, exit 1, three errors: `expected EXACTLY ONE ```clojure fence … containing "(goog-define build-id", found 0 — the pin has lost its anchor.` This is the failure mode that would otherwise let a rewritten page pin nothing while staying green.

After the third restore: blob hash equal, `git status` clean, suite GREEN at exit 0 (2 tests, 4 assertions). The planted faults existed only in this worktree, and the assertion text named this worktree's own copy of the page — so the runs were reading the tree under test, not a sibling's.
