### PR TITLE
api-manifest: routing.test-support is internal because no VAR is public, not because the name is unsupported (rf2-sy1l)

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -446,13 +446,20 @@
      ;; it ships **no public accessor**", with the public name deferred to a
      ;; stated graduation gate.
      re-frame.routing.tooling
-     ;; The test-only fixture namespace. REQUIRED DIRECTLY by test suites — the
-     ;; skill corpus tells authors to `(:require [re-frame.routing.test-support])`
-     ;; — but required for its LOAD EFFECT: the require registers
-     ;; `:rf.test/simulate-http-resolution`, and the consumer-facing name is
-     ;; that event id, not the one public var (`simulate-http-resolution-handler`,
-     ;; the handler body nobody calls). The manifest is one row per public VAR,
-     ;; so there is nothing here to row; see the sibling note under resources.
+     ;; The test-only fixture namespace, and the ONE name in these two groups
+     ;; that documented guidance tells an author to type:
+     ;; skills/re-frame2/references/tooling/routing.md says of the
+     ;; `:rf.test/simulate-http-resolution` fixture event that it "is test-only,
+     ;; so `(:require [re-frame.routing.test-support])` to register it (it is
+     ;; NOT wired into the production `re-frame.routing` façade)". That require
+     ;; is wanted for its LOAD EFFECT — it registers the event — and nobody
+     ;; calls the one public var (`simulate-http-resolution-handler`, the
+     ;; handler body). One row per public VAR therefore leaves nothing here to
+     ;; row, which is why the tier is internal; but the NAMESPACE NAME is
+     ;; load-bearing all the same, because a name authors are instructed to
+     ;; require is part of the contract even when none of its vars are. Rename
+     ;; it and that skill page breaks. The resources sibling below is NOT this
+     ;; case — see its note.
      re-frame.routing.test-support
      ;; --- implementation/resources/src -------------------------------------
      ;; The door is `re-frame.resources`, enrolled above, whose docstring calls
@@ -548,7 +555,10 @@
      ;; `:resources/reset-resources!` late-bind hook, and the consumer-facing
      ;; name is `re-frame.test-support/make-reset-runtime-fixture` — already
      ;; rowed at :testing with a docs/api page — which FIRES the one public var
-     ;; here. No consumer calls `reset-resources!` itself.
+     ;; here. No consumer calls `reset-resources!` itself. And unlike routing's,
+     ;; THIS name is not itself in the contract: no page under skills/, docs/,
+     ;; spec/ or migration/ instructs the require, so authors reach the reset
+     ;; only through that rowed fixture. The two reasons differ on purpose.
      re-frame.resources.test-support})
 
 (defn- repo-file


### PR DESCRIPTION
Closes rf2-sy1l.

One file, comment-only: `implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj`.

## The contradiction

`internal-namespaces`' own docstring says to **read the grouping comments as the
classification** — each names the group and "the checkable reason it is not a
surface". The reason covering `re-frame.routing.test-support` was checkable, and
it did not check out.

**BEFORE** (as merged by #9063):

```clojure
;; The test-only fixture namespace. REQUIRED DIRECTLY by test suites — the
;; skill corpus tells authors to `(:require [re-frame.routing.test-support])`
;; — but required for its LOAD EFFECT: the require registers
;; `:rf.test/simulate-http-resolution`, and the consumer-facing name is
;; that event id, not the one public var (`simulate-http-resolution-handler`,
;; the handler body nobody calls). The manifest is one row per public VAR,
;; so there is nothing here to row; see the sibling note under resources.
```

The false clause is **"the consumer-facing name is that event id"** — a definite,
exclusive claim. It contrasts the event id against the one public var and stops
there, leaving out the third name a consumer actually types. Its own preceding
clause already contradicts it: an author told to write
`(:require [re-frame.routing.test-support])` is typing the *namespace name*, so
that name is consumer-facing too. As written the comment argued past the one
record standing against it, and it cited that record only as "the skill corpus",
with no path — so the next reader had to rediscover the conflict rather than
follow a link to it.

**What the skill page actually says** — `skills/re-frame2/references/tooling/routing.md:180`,
quoted verbatim, the sole mention of this namespace anywhere in `skills/`,
`docs/`, `spec/` or `migration/`:

> Tests can simulate via `[:rf.test/simulate-http-resolution {:on-success-event [...] :carried-nav-token "nav-3"}]` — this fixture event is test-only, so `(:require [re-frame.routing.test-support])` to register it (it is NOT wired into the production `re-frame.routing` façade).

That is not vague and not incidental: it names the namespace, instructs the
require, and explains why it sits off the façade.

**AFTER**:

```clojure
;; The test-only fixture namespace, and the ONE name in these two groups
;; that documented guidance tells an author to type:
;; skills/re-frame2/references/tooling/routing.md says of the
;; `:rf.test/simulate-http-resolution` fixture event that it "is test-only,
;; so `(:require [re-frame.routing.test-support])` to register it (it is
;; NOT wired into the production `re-frame.routing` façade)". That require
;; is wanted for its LOAD EFFECT — it registers the event — and nobody
;; calls the one public var (`simulate-http-resolution-handler`, the
;; handler body). One row per public VAR therefore leaves nothing here to
;; row, which is why the tier is internal; but the NAMESPACE NAME is
;; load-bearing all the same, because a name authors are instructed to
;; require is part of the contract even when none of its vars are. Rename
;; it and that skill page breaks. The resources sibling below is NOT this
;; case — see its note.
```

**They no longer contradict.** The skill page says *require this namespace by
name*; the comment now says *its name is part of the contract, and here is the
page that makes it so* — while still giving the checkable reason the tier is
internal, which is that the manifest is one row per public var and this
namespace has no public var a consumer calls. Both records are now right about
the same things.

## What did not change, deliberately

- **The tier.** `re-frame.routing.test-support` stays in `internal-namespaces`.
- **No test namespace is rowed** in the public manifest.
- **No new tier** was invented for a population of two.
- **`skills/**` is untouched.** The skill page is correct; it is one half of the
  evidence, not the defect.

## Sibling search

"Bounded repair bounds the change, not the search." A whitespace-collapsed sweep
of all 1102 tracked files under `skills/`, `docs/`, `spec/` and `migration/`,
against all 50 namespaces in the two grouping comments (control: the
`re-frame.routing` door hits 42 files):

- `re-frame.routing.test-support` — **exactly one** mention, the skill page above.
- `re-frame.resources.test-support` — **zero**. No page instructs its require.
- The 31 other namespaces that appear in prose do so in
  `spec/009-Instrumentation.md`'s trace-producer catalogue and similar — named
  as producers, never as an authoring surface. The group header's claim ("none
  is named by spec/API.md, docs/ or skills/ *as one*") survives that.

So there is exactly **one** namespace with this defect shape, and it is the one
fixed here.

The resources sibling is therefore **not** given a matching comment. Its note
now records the measured asymmetry instead, so a later reader does not
symmetrise the two by reflex:

```clojure
;; here. No consumer calls `reset-resources!` itself. And unlike routing's,
;; THIS name is not itself in the contract: no page under skills/, docs/,
;; spec/ or migration/ instructs the require, so authors reach the reset
;; only through that rowed fixture. The two reasons differ on purpose.
```

One further blanket claim in the resources group was checked and **holds**: no
doc, spec, skill or example names `managed-http-transport`, `default-transport`
or `assert-managed-transport!` (search exit 1; control on `reg-resource` fires).

## Quality gates

Run from the branch **after** the rebase onto `264e47aad5`. Every number below is
the runner's own exit code, captured with `echo $?` on the same command line as
the redirect — never a pipeline status and never the harness's report. (The
harness and the captured file disagreed once here: on the first spine run the
harness reported exit 0 for a run whose captured code was 1.)

**Which gate.** `implementation/scripts/api-manifest` is on **neither**
`scripts/test-jvm-tools.sh` nor `scripts/test-jvm-implementation.sh` (grep for
`scripts/api-manifest` across both exits 1; the control `implementation/routing`
hits the impl roster at line 22). Its gate is `lint.yml`'s **`api-manifest`
job**, and `implementation/*` lights that workflow's `lint_surface`, so this PR
runs it. All eight of that job's commands were run locally:

| Gate | Captured exit | Result |
| --- | --- | --- |
| `clojure -M -m re-frame.api-manifest.gen --check` | **0** | in sync, 528 public vars — no regeneration |
| `clojure -M -m re-frame.api-manifest.api-md-check` | **0** | 177 var-rows |
| `clojure -M -m re-frame.api-manifest.story-spec-check` | **0** | 68 refs |
| `clojure -M -m re-frame.api-manifest.xray-spec-check` | **0** | 23 refs |
| `clojure -M -m re-frame.api-manifest.skills-check` | **0** | 572 refs |
| `clojure -M -m re-frame.api-manifest.doc-guide-check` | **0** | 793 refs |
| `clojure -M -m re-frame.api-manifest.doc-api-check` | **0** | 182 vars |
| `clojure -M:test` | **0** | 91 tests, 189 assertions, 0 failures, 0 errors |
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`, no FAIL line |

**The drift-check stayed green with no regeneration**, so the comment is not
load-bearing output and `spec/api-manifest.edn` is untouched.

**Planted-fault control.** The drift-check prints no root line, so a green alone
would not prove it read this worktree. Renaming the single roster entry to
`re-frame.routing.test-supportZZZ` (match count asserted as exactly 1 before
running — the naive `\n`-anchored probe matched 0, because the file is CRLF)
turned it **red, exit 2**, naming `re-frame.routing.test-support` as unaccounted.
The fault existed only here, so the red is the discrimination. Restored with
`git checkout HEAD --` and verified by blob hash against the committed object
(`e0cb93e9…`, identical), not by reading a diff. The spine prints its root and
named this worktree.

**Gap.** `python scripts/check_fast_pr_gap.py --brief` (exit 0) reports 97
required checks the spine does not decide, and names `api-manifest` among
`lint.yml`'s four jobs with **no lane in the spine at all** — which is exactly
why the eight commands above were run by hand. The spine additionally skipped
the documentation tier and the JVM artefact suites (both surfaces unchanged;
`report-changed-surfaces.sh` returns `implementation_jvm=false` for this diff).

**No gate validates a comment's truthfulness** — that is this PR's whole
subject, so the verification is the by-hand quotation above: the skill page's
instruction and the corrected comment are set side by side, and they no longer
contradict.
