### PR TITLE
fix(derivation): drop graph.cljc's dead bundle-isolation sentinel (rf2-f8fo)

### DIFF
--- a/implementation/core/src/re_frame/derivation/graph.cljc
+++ b/implementation/core/src/re_frame/derivation/graph.cljc
@@ -815,22 +815,3 @@
                 (present-families contributors))
          selector-targets (get-in contributors [:machines :selector-targets])]
      (assemble :live nodes contributors selector-targets {:frame frame-id}))))
-
-;; ---- bundle-isolation sentinel ------------------------------------------
-;;
-;; Per rf2-2axssk / rf2-eiiifu / rf2-gn9juw / rf2-s8w3nw / rf2-bmzq0 /
-;; rf2-qwm0a (the five algebra-view siblings + the trace.tooling split
-;; pattern): `implementation/scripts/check-bundle-isolation.cjs` greps the
-;; counter bundle for this exact string. The string lives ONLY in this
-;; file's source body — no other namespace, no docstring, no test fixture
-;; references it — so its presence in the production counter bundle proves
-;; this graph-inspection composer's body got pulled in (most likely via a
-;; stray `:require` from a production-reachable ns). This composer is
-;; consumed only by dev tools (Xray) + the conformance fixtures, which
-;; `:require` it directly; the counter example never does. The string
-;; survives `:advanced` because string literals are not renamed; it sits
-;; outside any `interop/debug-enabled?` gate so DCE cannot drop the literal
-;; independently of the surrounding ns body.
-
-(defonce ^:private bundle-isolation-sentinel
-  "rf.derivation.graph/sentinel:rf2-6xm07h-2026-06-12:do-not-rename")


### PR DESCRIPTION
`implementation/core/src/re_frame/derivation/graph.cljc` ended in a
`defonce ^:private bundle-isolation-sentinel` carrying the string
`rf.derivation.graph/sentinel:rf2-6xm07h-2026-06-12:do-not-rename`, under a
seventeen-line comment block. The block asserted two things that are false at
tip, and it is the first thing a reader looking for "the bundle-isolation
sentinel for this namespace" finds.

This removes the var and the comment block: 19 deleted lines, one file, nothing
added. The live sentinel, the roster and every gate assertion are untouched.

## What was measured, before anything was deleted

**The three legs**, on a freshly built
`out/bundle-isolation-positive-control/derivation-graph.js` (artefact mtime
confirmed later than the source read, so no stale `out/` answered):

| leg | instrument | result |
| --- | --- | --- |
| planted literal in the **emitted** module | `grep -cF "rf.derivation.graph/sentinel:rf2-6xm07h-2026-06-12:do-not-rename"` | **0** |
| same-file, same-instrument **control** | `grep -cF "rf/family"` on the same artefact | **1** |
| literal in the **pre-change source** | `grep -cF` on `graph.cljc` at the merge base | **1** |

The control makes the zero a measurement rather than a broken needle; the third
leg makes it attributable to Closure dead-code elimination rather than to a
literal that was never there. `do-not-rename` and `6xm07h` each return 0 in the
artefact as well. Re-measured after the change on a rebuilt artefact: literal
still 0, control still 1 — the module is unchanged in the way that matters.

**Claim 1 — "`check-bundle-isolation.cjs` greps the counter bundle for this
exact string" — false.** A fixed-string search of that checker for
`rf.derivation.graph/sentinel` returns **no hits**; the same search for the
`derivation-egress` twin returns **one**, which is the control proving the
instrument works. The `derivation-graph` roster entry uses the live family
marker `rf/family`, source `re-frame.derivation.graph family marker`.

**Claim 2 — "the string survives `:advanced` because string literals are not
renamed" — false as applied.** The var is `^:private` and nothing consumes its
value, so Closure drops it whole. Leg 1 is the measurement.

The block's third assertion — that the literal sits outside any
`interop/debug-enabled?` gate so DCE cannot drop it independently — is beside
the point once the var itself is gone.

**Consumer census.** A fixed-string search of the whole tree for the literal
(`.beads/issues.jsonl` excluded, since a whole-database export matches almost
any identifier) returned **exactly one hit: the `defonce` itself**, at
`graph.cljc:836`. The tracker export carries one further occurrence, which is
the bead text. Nothing consumes it. Re-run against the merge base after
rebasing, with the same result.

## Why removal rather than a corrected comment

`4e43784ec7` (2026-07-15, "test: require emitted bundle isolation controls")
moved this roster entry — and its `derivation-egress` sibling — off the planted
strings when these controls became emitted-module greps rather than source
greps. Both vars were left behind. rf2-yk2d removed the egress one.

A corrected comment would still leave the false `do-not-rename` instruction
inside the string literal itself, where the next reader meets it first and no
comment can repair it. The correct account already lives beside the
`derivation-graph` roster entry in `check-bundle-isolation.cjs`, which records
this exact history: "`4e43784ec7` moved this entry — and its `derivation-graph`
sibling, onto `rf/family`".

`check-bundle-isolation.cjs` needs no edit for this change: nothing in it claims
the graph literal is planted, and its roster comment already reads correctly for
the graph sibling.

## Quality gates

Every exit code below is the runner's own, captured with the redirect and the
`echo $?` on one command line in one shell, and quoted from the captured file —
never a number the harness reported about the same run.

| gate | attempt | captured exit | result |
| --- | --- | --- | --- |
| `shadow-cljs release bundle-isolation-positive-control` (measurement build) | 1 | `0` | artefact built |
| `npm run test:bundle-isolation` — **before** the change | 1 | `0` | 23 artefact entries; **40 internal sentinels absent**; 3 allow-list budgets ok; **40 emitted positive-control sentinels present**; 12 canonical browser-optional runtimes; 83 example sources co-load isolated |
| `npm run test:bundle-isolation` — **sabotage witness** | 1 | `1` | red, naming the plant |
| `npm run test:bundle-isolation` — **after**, pre-rebase | 1 | `0` | 40 absent / 40 present |
| `npm run test:bundle-isolation` — **after**, on the final base | 2 | `0` | 40 absent / 40 present — **both counts UNMOVED**, which is the evidence that removing a Closure-dropped var cannot move them |
| `implementation/core` JVM suite (`clojure -M:test`) | 1 | `0` | 2176 tests, 11149 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | 1 | `0` | 11206 tests, 55823 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | 2 | `0` | 11206 tests, 55823 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` | 3 | `0` | `PASS fast PR spine` — on the rebased base, with the JVM and node tiers both run |

`mkdocs build --strict` and `scripts/check_doc_slugs.py` are **not** gates for
this change and are not cited: no page is touched, and `implementation/**` is
outside the slug gate's roots, where it exits 0 on a broken link and would be a
green that inspected nothing.

**Sabotage witness.** The bundle-isolation gate reads an emitted artefact, so a
stale `out/` would answer about a build that was never made, and a run that had
wandered into another checkout would come back green on a fault only this tree
carries. The three live `:rf/family` keywords in `graph.cljc` were renamed to
`:rf/fam1ly` (match count read as 3 before the run, and the source blob hash
confirmed to have moved), the gate re-run, and the red named exactly the plant:

```
derivation-graph:
  [FAIL] emitted module 'derivation-graph' present:
         re-frame.derivation.graph family marker: sentinel "rf/family" expected >= 1, was 0
```

captured exit `1`. The tree was then restored and verified by git's own blob
hash against the committed object (`a4aef0f7…` both sides), not by reading a
diff.

**Two spine runs are recorded as NO VERDICT rather than as failures, and the
reason is stated rather than assumed.** Attempts 1 and 2 of
`scripts/test-fast-pr.sh` both went red at the `CLJS node integration` step with
a shadow-cljs `par-compile` abort — "still waiting for `#{re-frame.router-transducer}`"
the first time and "`#{re-frame.websocket-cljs-test}`" the second. Neither
namespace is reachable from this diff, the pending namespace differed between
runs, and the identical command (`npm run test:cljs`) passed standalone twice on
the same tree with identical counts. That is a scheduler abort under concurrent
load, not a source defect. It was re-run rather than interpreted, and attempt 3
passed on the rebased base.

Closes rf2-f8fo.
