### PR TITLE
pair-mcp: retire four vestiges and make the second nREPL candidate case run

### DIFF
--- a/tools/re-frame2-pair-mcp/README.md
+++ b/tools/re-frame2-pair-mcp/README.md
@@ -5,8 +5,9 @@ that pair-programs with a live re-frame2 application over a persistent
 nREPL connection.
 
 This is the structural successor to the bash-shim → babashka → nREPL
-chain under `skills/re-frame2-pair/scripts/`. The shims still ship for
-back-compat, but new sessions should prefer the MCP server.
+chain that used to live under `skills/re-frame2-pair/scripts/`. Those
+shims were removed on 2026-07-11 (rf2-dduetj, commit `31594b44c3`);
+this MCP server is the one implementation of every op.
 
 ## What it is
 
@@ -33,7 +34,7 @@ cljs-eval compile.
 
 ## Tool surface
 
-| MCP tool       | Bash-shim equivalent      | What it does |
+| MCP tool       | Former bash shim (retired) | What it does |
 |----------------|---------------------------|--------------|
 | `discover-app` | `discover-app.sh`         | Verify shadow-cljs nREPL is reachable, probe the preloaded re-frame2-pair runtime marker, return a health summary. Run first every session. |
 | `orient`       | _(new — no bash equivalent)_ | App-shape orientation summary in one round-trip (rf2-3bu3d.8) — "what is this app and what can I drive?". Composes liveness + frames + per-app-frame app-db top-keys + registrar counts/ids + machines from the existing introspection surfaces. Compact + summarized by design; drill via `list-handlers` / `snapshot` / `get-path` / `read-sub`. |
@@ -648,10 +649,12 @@ existing turn-shaped surfaces (`trace-window` / `watch-epochs`,
 `watch-until`, `record` + `read-recording`) cover the high-frequency
 debug-loop need; this is the cold-storage slot.
 
-## Back-compat with the bash shims
+## The retired bash shims
 
-The shims under `skills/re-frame2-pair/scripts/` still work and are
-not slated for removal in this drop. Their headers carry a
-deprecation notice pointing here. Migration is opt-in per session;
-agents can mix shim calls and MCP tool calls in the same workflow
-during the transition.
+Until 2026-07-11 a parallel bash/babashka shim chain under
+`skills/re-frame2-pair/scripts/` implemented six of these ops, and this
+section described how to mix the two transports. That chain was removed
+under rf2-dduetj (commit `31594b44c3`) and no longer exists: there are
+no shim scripts to call, and nothing to migrate from. The MCP server is
+the only transport. The "Former bash shim" column in the tool table
+above is kept as a historical name mapping for old runbooks.

--- a/tools/re-frame2-pair-mcp/spec/API.md
+++ b/tools/re-frame2-pair-mcp/spec/API.md
@@ -376,13 +376,20 @@ analogues. Listed here for reference:
 | `:rf/epoch-record` | framework | The epoch record shape returned by trace mode. |
 | `:rf.event/origin :pair` (in event tags) | framework | The pair tool's dispatches surface in the trace stream distinguishably. |
 
-## Back-compat: the bash shims
+## The retired bash shims
 
-The bash shims under `skills/re-frame2-pair/scripts/` continue to
-work; they are not slated for removal. The op vocabulary is
-identical between the two surfaces.
+**There is no second transport.** The bash shims under
+`skills/re-frame2-pair/scripts/` were deleted on 2026-07-11 under
+rf2-dduetj (commit `31594b44c3`); that directory holds no files. MCP
+is the only way to invoke any op, and there are no shim calls to mix
+with tool calls.
 
-| Bash shim | MCP tool |
+The mapping is retained for reading old runbooks, which may still name
+a script that no longer exists. The op vocabulary was identical across
+the two surfaces, so each retired script's name reads directly as its
+MCP tool:
+
+| Retired bash shim | MCP tool |
 |---|---|
 | `discover-app.sh` | `discover-app` |
 | `eval-cljs.sh` | `eval-cljs` |
@@ -390,19 +397,14 @@ identical between the two surfaces.
 | `trace-window.sh` | `trace-window` |
 | `watch-epochs.sh` | `watch-epochs` |
 | `tail-build.sh` | `tail-build` |
-| _(none — MCP-only)_ | `snapshot` |
+| _(never had one — MCP-only)_ | `snapshot` |
 
-The `snapshot` mega-op has no bash equivalent — it's a coarse-grained
-composition of the existing per-slice runtime readers, shipped as
-part of the rf2-x70e drop to cut round-trips for investigate-X
-workflows. Agents that need its semantics under the bash shim chain
+The `snapshot` mega-op never had a bash equivalent — it's a
+coarse-grained composition of the existing per-slice runtime readers,
+shipped as part of the rf2-x70e drop to cut round-trips for
+investigate-X workflows. Under the shim chain its semantics required
 the per-op reads (`app-db/snapshot` + `subs/cache` + `machines/list`
 + `epoch/history` + `trace/buffer`) in sequence.
-
-Agents may mix shim calls and MCP tool calls in the same workflow
-during the transition. New sessions should prefer the MCP server for
-latency reasons (see
-[`Principles.md`](./Principles.md) § Single persistent nREPL socket).
 
 ## Versioning
 

--- a/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
@@ -277,7 +277,7 @@ decomposition; bounded surface) still holds — both amendments are
   composed server-side over the existing per-slice runtime readers.
   Earns its keep as a mega-op for investigate-X workflows that would
   otherwise chain 5–10 individual `eval-cljs` reads. No bash-shim
-  equivalent; the shim chain stays at six.
+  equivalent; the shim chain stayed at six.
 - **rf2-hq49** added `subscribe` / `unsubscribe`: streaming
   subscription on the trace + epoch bus, layered over MCP's
   `notifications/progress` mechanism. Push-mode replacement for the
@@ -296,9 +296,10 @@ grew the catalogue further, and the rf2-ahjbc streaming retirement
 shrank it — the canonical count lives in
 the live [`registry.cljs`](../src/re_frame2_pair_mcp/tools/registry.cljs),
 full listing at [`003-Tool-Catalogue.md`](./003-Tool-Catalogue.md).
-The bash shims ship six. The shim catalogue is a strict subset of the
-MCP catalogue, with identical names and arg shapes for every
-overlapping op.
+The bash shims shipped six — a strict subset of the MCP catalogue,
+with identical names and arg shapes for every overlapping op. (That
+chain was itself retired under rf2-dduetj on 2026-07-11; see Lock #6,
+discharged.)
 
 Post-Lock additions accumulated as follows:
 
@@ -482,10 +483,22 @@ position-vs-bytes footgun was hit; locked at PR #423 merge.
 
 ---
 
-## Lock #6 — Bash-shim deprecation cadence
+## Lock #6 — Bash-shim deprecation cadence *(discharged 2026-07-11)*
 
 **Locked 2026-05-12 (Mike).** **Both surfaces ship side-by-side.**
 No removal scheduled; shims remain working with deprecation notice.
+
+> **DISCHARGED 2026-07-11 — the removal this lock deferred has happened.**
+> The bash/babashka shim chain under `skills/re-frame2-pair/scripts/`
+> was deleted under rf2-dduetj (commit `31594b44c3`); that directory
+> holds no files, and Pair MCP is the one implementation of every op.
+> This lock is **not overturned** — it played out exactly as its final
+> *Why* bullet anticipated ("if/when the MCP server is the obvious
+> answer for every consumer, the shims come out in a later drop; the
+> decision is reversible"). The side-by-side period ran 2026-05-12 to
+> 2026-07-11. The record below is the reasoning as locked, retained
+> unaltered; read it as history, not as current guidance. Nothing in
+> it still describes a shipping surface.
 
 ### Question
 
@@ -533,12 +546,15 @@ changes.
 
 ### Date locked
 
-2026-05-12 (Mike).
+2026-05-12 (Mike). Discharged 2026-07-11 by the shim removal
+(rf2-dduetj, commit `31594b44c3`).
 
 ### Trail-of-thought citations
 
 - rf2-5b8e PR #423 description.
-- `tools/re-frame2-pair-mcp/README.md` § Back-compat with the bash shims.
+- `tools/re-frame2-pair-mcp/README.md` § The retired bash shims.
+- rf2-dduetj — `chore(pair): remove retired bash/babashka transport;
+  Pair MCP is the one implementation` (commit `31594b44c3`).
 
 ---
 
@@ -955,7 +971,7 @@ read, not a registrar-union enumeration. What verb does it take?
 | 3 | Connection model | **Single persistent nREPL socket** | 2026-05-12 |
 | 4 | Tool catalogue cardinality | **Seven ops at v0.1.0; grown additively to thirty** (canonical count: the live [`registry.cljs`](../src/re_frame2_pair_mcp/tools/registry.cljs); full listing: [`003-Tool-Catalogue.md`](./003-Tool-Catalogue.md); see Lock #4 *Subsequent evolution* for the drop-by-drop lineage) | 2026-05-12 |
 | 5 | bencode pinning | **`bencode@~2.0.3`** (CommonJS; position-not-bytes) | 2026-05-12 |
-| 6 | Bash-shim deprecation | **Side-by-side, no removal scheduled** | 2026-05-12 |
+| 6 | Bash-shim deprecation | **Side-by-side, no removal scheduled** — **discharged 2026-07-11**: the shims were removed (rf2-dduetj, commit `31594b44c3`) and Pair MCP is now the one transport | 2026-05-12 |
 | 7 | Wire-boundary token cap | **Egress-centralised wrapper + pluggable `:strategy` + truncate-with-`{:rf.mcp/overflow …}`-marker** | 2026-05-13 |
 | 8 | Recorder verb shapes | **`record` bare mega-op; `read-recording` (`read-`); `watch-until` (new `watch-` prefix)** | 2026-05-31 |
 | 9 | Orientation verb shape | **`orient` bare mega-op; `read-sub` (`read-`)** | 2026-06-02 |

--- a/tools/re-frame2-pair-mcp/spec/Principles.md
+++ b/tools/re-frame2-pair-mcp/spec/Principles.md
@@ -114,21 +114,26 @@ The agent-host workflow is *don't make the user restart anything*.
 The server's job is to keep working through the gaps and surface a
 useful error when the runtime isn't ready.
 
-## Bash-shim back-compat preserved
+## Bash-shim back-compat: preserved, then discharged
 
-The bash shims under `skills/re-frame2-pair/scripts/` continue to
-work and are not slated for removal. Their headers carry a
-deprecation notice pointing here; migration is opt-in per session.
+This principle originally read *bash-shim back-compat preserved*: the
+shims under `skills/re-frame2-pair/scripts/` kept working alongside the
+MCP server, migration was opt-in per session, and agents could mix the
+two transports in one workflow. That was the deliberate posture while
+both transports existed.
 
-The migration discipline is *additive, not destructive*. Agents can
-mix shim calls and MCP tool calls in the same workflow during the
-transition. Existing skill docs and runbooks that reference the
-shims keep working; nothing breaks because the MCP server shipped.
+**Both no longer do.** The shim chain was deleted on 2026-07-11 under
+rf2-dduetj (commit `31594b44c3`), and `skills/re-frame2-pair/scripts/`
+holds no files. There is no second transport to preserve compatibility
+with, nothing to mix, and no migration left to opt into — MCP is the
+one implementation of every op. The principle is recorded here because
+it explains the shape the server was built to: contract-identical op
+names and arg shapes, which is why the changeover cost nothing.
 
-The op vocabulary overlaps cleanly: the bash shims cover six of the
+The overlap that made it tractable: the shims covered six of the
 canonical re-frame2-pair ops (`discover-app`, `eval-cljs`, `dispatch`,
 `trace-window`, `watch-epochs`, `tail-build`), with identical names
-and arg shapes — only the transport differs. Every other MCP tool
+and arg shapes — only the transport differed. Every other MCP tool
 (the write pair `restore-epoch` / `replace-app-db`, `dispatch-dry-run`,
 the mega-op reads `snapshot` / `get-path`, the read-orientation pair
 `orient` / `read-sub`, the view-plane reads `read-dom` / `read-ui`,
@@ -138,9 +143,9 @@ operating-frame trio `set-operating-frame` / `reset-operating-frame` /
 the registrar-introspection pair `handler-meta` / `list-handlers`, and
 `get-re-frame2-pair-instructions` — full catalogue in
 [`003-Tool-Catalogue.md`](003-Tool-Catalogue.md)) has no shim
-equivalent. This is what makes
-the back-compat tractable: the overlap is contract-identical; the
-plumbing underneath is different.
+equivalent. That is what made the back-compat tractable while it
+lasted: the overlap was contract-identical, and only the plumbing
+underneath differed.
 
 ## Tight token budget per response
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/roots_discovery.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/roots_discovery.cljs
@@ -180,7 +180,9 @@
   or nil if no port file is present (shadow isn't running for that project).
 
   Injected `read-file-fn` is the fs reader (path → string, throws on missing).
-  Test seam — production callers use [[project-home->candidate]]."
+  Production reaches this fn through [[candidates-from-edns*]], which
+  [[discover-via-roots*]] calls with the reader threaded down from
+  [[discover-via-roots]]; tests call it directly with a stub reader."
   [read-file-fn project-home]
   (some (fn [rel]
           (let [pf   (node-path/join project-home rel)
@@ -190,12 +192,6 @@
                :port-file    pf
                :port         port})))
         port-file-relpaths))
-
-(defn project-home->candidate
-  "Default-arity wrapper around [[project-home->candidate*]] using
-  `fs.readFileSync`. See that fn's docstring for the contract."
-  [project-home]
-  (project-home->candidate* (.-readFileSync fs) project-home))
 
 (defn candidates-from-edns*
   "Map a JS array of `shadow-cljs.edn` paths to the live nREPL candidates.
@@ -211,12 +207,6 @@
        (distinct)
        (keep #(project-home->candidate* read-file-fn %))
        (vec)))
-
-(defn candidates-from-edns
-  "Default-arity wrapper around [[candidates-from-edns*]] using
-  `fs.readFileSync`."
-  [edn-paths]
-  (candidates-from-edns* (.-readFileSync fs) edn-paths))
 
 ;; ---------------------------------------------------------------------------
 ;; Top-level discovery — `roots/list` → walk → candidates

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
@@ -322,8 +322,8 @@
         queued?      (boolean (and (wire/arg args :queued)
                                    (not trace?) (not sync?) (not settle?)))
         ;; Coerce `frame` via the colon-tolerant `->frame-keyword` (the
-        ;; shared `fresh-keyword` path), NOT the raw `(keyword ...)` of
-        ;; `wire/arg-keyword`. The documented `frame` arg is the
+        ;; shared `fresh-keyword` path), NOT a raw `(keyword ...)`.
+        ;; The documented `frame` arg is the
         ;; colon-prefixed id (`":rf/xray"`, `":foo"` — Tool-Catalogue §Id
         ;; representation). Raw `(keyword ":rf/xray")` would mint the
         ;; MALFORMED `::rf/xray` (namespace literally `":rf"`), which

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
@@ -35,8 +35,8 @@
   (let [ms        (or (wire/arg raw-args :ms) 1000)
         build-id  (wire/arg-build conn raw-args)
         ;; Coerce `:frame` via the colon-tolerant
-        ;; `->frame-keyword` (the shared `fresh-keyword` path), not the
-        ;; raw `(keyword ...)` of `arg-keyword`. A documented `:rf/default`
+        ;; `->frame-keyword` (the shared `fresh-keyword` path), not a
+        ;; raw `(keyword ...)`. A documented `:rf/default`
         ;; / `:foo` frame-id passed with its leading colon must resolve
         ;; rather than minting the malformed `::rf/default`, which matches
         ;; no frame. Same coercion `dispatch` uses.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
@@ -167,23 +167,6 @@
       ;; payload keeps its namespace inside the envelope too.
       (if (object? sc) sc (clj->js {"rf.mcp/value" (qualify-keywords v)})))))
 
-(defn structured-content
-  "Public projection of `v` to the SDK-friendly `:structuredContent` JS
-  value — the SAME namespace-preserving, null-safe projection `ok-text`
-  / `err-text` use.
-
-  Exposed for the handful of result envelopes built OUTSIDE
-  the per-tool callbacks — server-level handler-threw / discovery
-  errors (server.cljs), the cache-hit marker (cache.cljs), and the
-  overflow marker (cap.cljs). A bare
-  `:structuredContent (clj->js payload)` at those sites would be
-  namespace-LOSSY: `:rf.mcp/cache-hit` → `\"cache-hit\"`,
-  `:rf.mcp/overflow` → `\"overflow\"`, and `:rf.error/*` reason VALUES
-  would lose their namespace. Routing them through this single helper
-  keeps the structured-content round-trip contract intact everywhere."
-  [v]
-  (structured-of v))
-
 (defn result
   "Build an arbitrary MCP result envelope carrying both the
   pr-str EDN `:content` text and the namespace-preserving
@@ -257,15 +240,6 @@
   [args k]
   (let [v (j/get args (name k))]
     (when-not (or (nil? v) (undefined? v)) v)))
-
-(defn arg-keyword
-  "Pluck an arg slot and coerce to a keyword via `(some-> v keyword)`.
-  Returns nil when the slot is absent. Compresses the
-  `(some-> (wire/arg args :foo) keyword)` pattern that recurs across
-  the per-tool bodies (topic / frame plucks) — single source of truth
-  for the str→kw coercion shape callers don't need to spell out."
-  [args k]
-  (some-> (arg args k) keyword))
 
 (defn mark-resolved-build-id!
   "Record the build-id that `discover-app` just resolved on the conn-atom.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/args_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/args_test.cljs
@@ -15,7 +15,7 @@
   `re-frame.mcp-base.args-test/parse-boolean-*` — the cross-MCP base
   parser this wrapper delegates to. These tests verify the table lookup
   and the JS-args / nil handling on top."
-  (:require [cljs.test :refer-macros [deftest is testing]]
+  (:require [cljs.test :refer-macros [deftest is]]
             [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.tools.args :as args]))
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -96,9 +96,6 @@
 (defn- extract-edn [^js result]
   (some-> (extract-text result) edn/read-string))
 
-(defn- error? [^js result]
-  (true? (j/get result :isError)))
-
 ;; ---------------------------------------------------------------------------
 ;; Stub installation — `set!` the `nrepl/cljs-eval-value` var with an
 ;; async-friendly Promise-returning fn, restore in `.finally` once the

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/error_boundary_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/error_boundary_test.cljs
@@ -95,7 +95,7 @@
   carrier for both because one tool body reaches both relays: it builds
   its form with `ef/rt-let` and shapes its response with
   `run-wire-pipeline`."
-  (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+  (:require [cljs.test :refer-macros [deftest is async use-fixtures]]
             [clojure.string :as str]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.server :as server]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
@@ -772,7 +772,12 @@
 ;; read — NOT a fixed derivation. The server caches whatever discovery
 ;; resolved, so the per-tool-call re-read checks the right file and doesn't
 ;; false-positive "file vanished".
-(deftest discover-port-shadow-probe-surfaces-each-candidate-file
+;;
+;; The two candidate orders are SEPARATE deftests on purpose: ClojureScript
+;; runs only the FIRST `async` form in a `deftest`, so a sibling `async`
+;; alongside it never executes and can never fail. Keep one `async` per
+;; `deftest` here — adding a second would silently drop its assertions.
+(deftest discover-port-shadow-probe-surfaces-dot-shadow-candidate-file
   (testing ".shadow-cljs/nrepl.port wins → that exact file is surfaced"
     (async done
       (let [stub-fn (fn [^js path]
@@ -792,7 +797,12 @@
                      (is (not (re-find #"target[\\/]shadow-cljs" (str (:port-file r))))
                          "the absent target candidate is NOT what's cached")
                      (restore!)
-                     (done)))))))
+                     (done))))))))
+
+;; Second candidate order: both earlier candidates absent, so the LAST
+;; standard candidate (.nrepl-port) is the one that reads — and the one
+;; whose path must be surfaced.
+(deftest discover-port-shadow-probe-surfaces-nrepl-port-candidate-file
   (testing ".nrepl-port wins (last candidate) → that exact file is surfaced"
     (async done
       (let [stub-fn (fn [^js path]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_file_stability_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_file_stability_test.cljs
@@ -17,7 +17,6 @@
   cached conn is REUSED when the cached port-file still reads the same
   port — i.e. no spurious 'file vanished' reconnect."
   (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
-            [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.server :as server]
             ["fs" :as fs]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/sticky_build_invoke_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/sticky_build_invoke_test.cljs
@@ -21,7 +21,6 @@
   These tests prove the build STICKS across the `invoke` boundary so the
   follow-up no-`build` calls target the resolved build."
   (:require [cljs.test :refer-macros [deftest is async]]
-            [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools :as tools]
             [re-frame2-pair-mcp.tools.discover-app :as discover-app]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_pipeline_benchmark_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_pipeline_benchmark_test.cljs
@@ -52,7 +52,7 @@
   ratchets surface to the same log a contributor reads when
   iterating on the per-pipeline arm. A separate runner would
   duplicate the deps wiring for no information gain."
-  (:require [cljs.test :refer-macros [deftest is testing]]
+  (:require [cljs.test :refer-macros [deftest is]]
             [re-frame.mcp-base.dedup :as base-dedup]
             [re-frame.mcp-base.elision :as base-elision]
             [re-frame2-pair-mcp.tools.wire-pipeline :as wp]))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/with_indicators_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/with_indicators_test.cljs
@@ -29,8 +29,7 @@
     A new tool that walks a payload but bypasses the helper would
     only be caught by hand-review today; this test makes the bypass
     a build failure."
-  (:require [cljs.test :refer-macros [deftest is testing]]
-            [clojure.string :as str]
+  (:require [cljs.test :refer-macros [deftest is]]
             [re-frame2-pair-mcp.tools.wire :as wire]))
 
 (def ^:private fs (js/require "fs"))


### PR DESCRIPTION
Four children of the rf2-6r9j audit epic, clustered because they share one surface: `tools/re-frame2-pair-mcp/`.

Every one asserted a reachability proof. All four were re-run at this tip before anything was deleted. **Three held exactly. One — .9's — did not, and the correction is below.**

## rf2-6r9j.9 — the second nREPL candidate case (P2, bug)

`nrepl_test.cljs`'s `discover-port-shadow-probe-surfaces-each-candidate-file` held two sibling `cljs.test/async` forms in one `deftest`. Split into two deftests with one `async` each — the idiom every other async test in this file already uses (it was the only deftest in the file with two).

**The bead's stated mechanism does not hold, and the record should say so.** It claimed the second branch was *unreachable* and "cannot contribute assertions or a failure". Measured, by planting a deliberately failing assertion in that branch **on the unmodified original** and running the suite:

```
FAIL in (discover-port-shadow-probe-surfaces-each-candidate-file) (nrepl_test.cljs:810:26)
expected: (= 999999 (:port r))
  actual: (not (= 999999 5562))
```

Captured exit 1. The branch's assertions **do** execute and **can** fail. So the finding as written is wrong.

What is genuinely wrong with the original shape, and what the split fixes:

- The second block runs **outside the awaited async lifecycle**. `cljs.test` completes the deftest on the *first* block's `done`; the second block's promise chain continues unawaited. It happened to land in time here, but that is a race, not a guarantee.
- It could not fail **independently** — both branches shared one deftest identity, so the failure above is attributed to the combined test.
- The assertion total was not faithful: the same five `(is ...)` forms counted **4067** assertions before and **4070** after, a delta of +3 where only 2 assertions moved into a new deftest.

After the split, the same planted failure is attributed to its own test:

```
FAIL in (discover-port-shadow-probe-surfaces-nrepl-port-candidate-file) (nrepl_test.cljs:820:26)
```

Captured exit 1 — the negative control AC 4 asks for. Both branches now run inside their own awaited lifecycle and can fail independently, and clj-kondo's `multiple-async-in-deftest` is gone. The disposition the bead ordered is right; only its explanation of why needed correcting.

## rf2-6r9j.12 — eight dead bindings in the test tree (P3)

All eight clj-kondo findings reproduced at this tip. Removed the seven unused requires and the unused private `error?`. js-interop stays required in `conformance_test.cljs`: removing `error?` deletes one `j/get`, but four other call sites remain. No unrelated lint cleanup is bundled — three pre-existing warnings outside these beads are left alone, per AC 4.

## rf2-6r9j.10 — four zero-consumer helpers (P3)

Premise held for all four. Removed `project-home->candidate`, `candidates-from-edns`, `structured-content` and `arg-keyword`.

Two independent instruments, each run against a live control in the same files:

- Line-oriented fixed-string search across tracked files.
- A whitespace-flattened per-file census over 4810 tracked files, which a line-oriented search cannot substitute for.

Both returned **zero call heads** for all four targets; controls (`wire/result`, `wire/arg`, `rd/project-home->candidate*`, `candidates-from-edns*`, `rd/discover-via-roots*`) all fired. Production root discovery runs `discover-via-roots` -> `discover-via-roots*` -> `candidates-from-edns*` -> `project-home->candidate*`, bypassing both unstarred wrappers. The sibling unstarred `walk-for-shadow-edns` is **live** — passed to `discover-via-roots*` at the production call site — and is untouched.

Stale pointers to the removed vars are corrected rather than left dangling:

- `project-home->candidate*`'s docstring claimed *production callers use `project-home->candidate`* — false, and pointing at a deleted var. It now describes the real call path.
- `structured-content`'s docstring named server, cache and cap as its consumers. All three route through `wire/result`; verified at each site.
- The `dispatch` and `trace-window` comments citing `wire/arg-keyword` as the coercion *not* to use now say `(keyword ...)` directly.

## rf2-6r9j.7 — stale bash-shim promises in docs (P3)

The shim chain was deleted 2026-07-11 (rf2-dduetj, `31594b44c3`); `git ls-files skills/re-frame2-pair/scripts` returns nothing against a control returning 57. Four documents still promised the shims ship, work and may be mixed with MCP.

History is kept, not erased. Design Lock #6 retains its question, options, pick and reasoning verbatim under a dated DISCHARGED banner — the lock was not overturned, it played out as its own final bullet anticipated (*"future removal is cheap ... the decision is reversible"*). Name-mapping tables are retained and relabelled historical so an old runbook naming a deleted script still resolves to its MCP tool.

Two further present-tense claims were found beyond the bead's list, inside Lock #4's evolution narrative ("The bash shims ship six"), and past-tensed.

## Quality gates

Every exit code below is the runner's own, captured to a file on the same command line, never the harness's report. All were re-run after the rebase onto `b92c9a7e8f`; figures below are from that final base.

| Gate | Captured exit | Result |
|---|---|---|
| `clj-kondo --lint tools/re-frame2-pair-mcp/{src,test}` (before) | 2 | 0 errors, **12 warnings** |
| `clj-kondo --lint tools/re-frame2-pair-mcp/{src,test}` (after, rebased) | 2 | 0 errors, **3 warnings** |
| `npm test` (pair-mcp) on final base | 0 | **1120 tests, 4070 assertions, 0 failures, 0 errors** |
| `sh scripts/test-fast-pr.sh` | 0 | **PASS fast PR spine**, zero FAIL lines |
| `python scripts/check_doc_slugs.py --self-test --verbose` | 0 | 146/146 self-tests passed |
| `python scripts/check_doc_slugs.py --verbose` | 0 | no broken links; covers `tools/re-frame2-pair-mcp/spec` (8 files) |
| `python scripts/check_readme_links.py --ci` | 0 | clean |
| `python scripts/check_fast_pr_gap.py --brief` | 0 | names the 97 required checks the spine does not decide |

clj-kondo drops 12 to 3: exactly the nine these beads name (eight from .12, plus `multiple-async-in-deftest` from .9). The three that remain are pre-existing and outside scope. **Caveat, not a claim of green:** CI pins clj-kondo 2026.04.15 and this ran 2025.10.23; `check_fast_pr_gap.py` warns that a differently-versioned local pass proves nothing about the `Lint required` context. Both runs report **0 errors**, and that job fails on ERROR level only.

Reachability evidence for .9, both directions, captured exits:

| Control | Captured exit | Attribution |
|---|---|---|
| Planted failure in the branch, **original** shape | 1 | `...-each-candidate-file` (combined) |
| Planted failure in the branch, **split** shape | 1 | `...-nrepl-port-candidate-file` (its own test) |
| No plant, original shape | 0 | 1119 tests / 4067 assertions |
| No plant, split shape | 0 | 1120 tests / 4070 assertions |

**Gate nomination is by path, not job name.** `tools/*/spec` is inside `check_doc_slugs.py`'s roots, so it covers the three spec files; the README is **not** in those roots and falls to `check_readme_links.py --ci`. Both run in `test.yml`'s `verify-readme-links` job, whose name reads as though it checks READMEs while the gate that actually does is the other one. `mkdocs build --strict` is not a gate here: `docs_dir` is `docs` and `tools/` sits outside it.

Both link gates were fault-planted to prove they read this tree, and each red named the planted line — `check_doc_slugs.py` exit 1 on `spec/API.md:384`, `check_readme_links.py` exit 1 on `README.md:10`. Every plant was reverted and the revert verified by git blob hash against the committed object, not by reading a diff.

**The spine's documentation tier did not fire on this diff** (the classifier does not class markdown under `tools/` as documentation surface), so the local spine pass is not evidence for the two link gates. That is why both were run directly and planted against.

**Both link gates strip fenced code blocks before reading, and nothing validates prose or tables.** Table column counts were hand-counted after editing: DESIGN-RATIONALE's summary table 4 columns across header, separator and all eleven rows (including the edited row 6); API.md's retired-shim table 2 across all nine rows; README's tool-surface table 3. Edited section headings were checked by hand against their inbound links, including the DESIGN-RATIONALE citation that pointed at the README section this PR renames.
