### PR TITLE
test(reagent-slim): make the error-boundary and callable-prop regressions load-bearing (rf2-6r9j.31 .30 .34 .32)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -572,24 +572,37 @@
       so a keyword like `:rf/foo` on a React-context Provider's `:value`
       is preserved.
 
-  Other rules:
+  Other rules, in the order the `cond` actually takes them — which is
+  load-bearing, because each arm shadows the ones below it:
 
-    - JS values pass through.
+    - `js-val?` (anything `goog/typeOf` does not call \"object\") passes
+      through. This is the arm a PLAIN JS function takes: `goog/typeOf`
+      of a function is \"function\", so an ordinary event handler is
+      returned here, with its identity intact, and never reaches the
+      `fn?` arm below.
     - Maps recursively convert (style maps + custom-component prop maps).
     - Coll? values become JS arrays via clj->js (children, vector classes).
-    - Fn values pass through verbatim — referentially stable across renders.
-      Event handlers and ref callbacks reach React with the SAME identity
-      the caller supplied, so `React.memo` / `shouldComponentUpdate`
-      bail-outs work. Wrapping fns in a fresh closure per render would
-      silently defeat memoisation.
-    - Non-fn `IFn` values (keywords, maps, sets used as fns; vectors used
-      as positional lookups) are wrapped in a variadic shim so the React
-      side can invoke them as plain JS functions.
+    - `fn?` values pass through verbatim — referentially stable across
+      renders. Since plain functions already left at `js-val?`, the
+      values that REACH this arm are the object-backed ones satisfying
+      `Fn`: chiefly `cljs.core/MetaFn`, what `(with-meta some-fn …)`
+      returns. Those must keep their identity too, so `React.memo` /
+      `shouldComponentUpdate` bail-outs work on a metadata-bearing
+      handler; wrapping one in a fresh closure per render would silently
+      defeat memoisation.
+    - Non-fn `IFn` values are wrapped in a variadic shim so the React
+      side can invoke them as plain JS functions. NOTE that keywords,
+      maps, sets and vectors — the usual \"used as a function\" examples —
+      never get here: keywords and symbols are taken by `named?`, maps by
+      `map?`, and sets and vectors by `coll?`. What reaches this arm is
+      an object-backed callable that satisfies `IFn` without satisfying
+      `Fn`, `named?`, `map?` or `coll?` — a `deftype`/`reify` the caller
+      passes as a prop meaning \"React may call this\".
     - Everything else passes through unchanged.
 
-  HOT PATH — this runs once per prop on every render. The `(fn? v)`
-  test sits before `(ifn? v)` so the common case (event-handler fn) does
-  not allocate a wrapper."
+  HOT PATH — this runs once per prop on every render, and the ordering
+  above is what keeps it cheap: the common case (an event-handler fn)
+  returns from the FIRST arm without allocating a wrapper."
   ([prop-value]
    ;; 1-arg form: used recursively for map values where there's no
    ;; outer prop-name context (e.g. nested style objects). Treat

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_source_coord_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_source_coord_dom_cljs_test.cljs
@@ -29,8 +29,7 @@
             [re-frame.core :as rf]
             [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
             [re-frame.test-support :as test-support]
-            [re-frame.views])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.views]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_strict_mode_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_strict_mode_dom_cljs_test.cljs
@@ -3,13 +3,19 @@
   the bespoke class lifecycle + per-component render Reaction, under a React 19
   `createRoot`.
 
-  STATUS (read before running): this file is the ACCEPTANCE GATE for a genuine
-  slim production bug this coverage exercise surfaced — see the FINDING block
-  below. Until that bug is fixed in `reagent2.impl.*`, assertions (a) and (b)
-  FAIL BY DESIGN (they encode the correct contract, which the substrate does
-  not yet honour). Do NOT weaken them to green; they go green when the
-  production fix lands. Per rf2-a07937's charter this file changes NO production
-  code — the fix is a separate bead.
+  STATUS: a required GREEN regression. Both assertions below must pass; a
+  failure here is a real regression, not expected output.
+
+  HISTORY (this header used to say the opposite — corrected under rf2-6r9j.32).
+  This file was written under rf2-a07937 as the ACCEPTANCE GATE for a genuine
+  slim production bug it surfaced, and until the repair landed its assertions
+  (a) and (b) failed BY DESIGN: they encoded the correct contract, which the
+  substrate did not yet honour. That state ended on 2026-07-12, when
+  `2c4a87e3df` — fix(adapters/reagent-slim): re-establish render Reaction
+  after StrictMode remount (rf2-6b6pex) — landed the production repair, the
+  same day as this file's own commit `66e9e2af0e`. The FORMER-BUG block below
+  is kept as the diagnosis that motivated the remount marker; it describes
+  behaviour that no longer occurs.
 
   WHY THIS FILE EXISTS. reagent-slim hand-rolls the entire class lifecycle
   (`reagent2.impl.component`), the microtask render scheduler
@@ -26,9 +32,11 @@
   the load-bearing real-DOM regression.
 
   ─────────────────────────────────────────────────────────────────────────────
-  FINDING (rf2-a07937 — a real slim bug this test surfaced):
+  FORMER BUG (rf2-a07937 — a real slim bug this test surfaced; FIXED
+  2026-07-12 by `2c4a87e3df`, rf2-6b6pex. Past tense throughout: this is the
+  diagnosis the fix was built from, not current behaviour):
 
-    Under React.StrictMode a slim component renders ONCE and then goes
+    Under React.StrictMode a slim component rendered ONCE and then went
     reactively DEAD. StrictMode's dev sequence for a slim class is:
 
         render ×2  →  componentDidMount  →  componentWillUnmount
@@ -38,17 +46,33 @@
     render Reaction. The remount's second `componentDidMount` fires WITHOUT React
     calling `render()` again (StrictMode reuses the committed fiber output), so
     slim — which recreates the render Reaction only lazily inside `render()` —
-    never re-establishes it. The remounted instance is left with
-    `cljsRenderRea = nil` and NO subscription watches: it never re-renders on an
-    app-db change. A/B empirically confirmed (same view, same harness): WITHOUT
-    StrictMode the component is fully reactive (dispatch → DOM updates); WITH
-    StrictMode a post-mount dispatch leaves the DOM stale.
+    never re-established it. The remounted instance was left with
+    `cljsRenderRea = nil` and NO subscription watches: it never re-rendered on an
+    app-db change. A/B empirically confirmed at the time (same view, same
+    harness): WITHOUT StrictMode the component was fully reactive (dispatch →
+    DOM updates); WITH StrictMode a post-mount dispatch left the DOM stale.
 
-    Impact: any slim app wrapped in `<React.StrictMode>` (the React-recommended
-    dev default, scaffolded by CRA / Next.js) has components that stop
-    responding to state changes after mount. Fix belongs in `reagent2.impl.*`
-    (e.g. re-establish the render Reaction on `componentDidMount`, or force a
-    re-render when the cached reaction is absent) — a separate bead, NOT here.
+    Impact, while it lasted: any slim app wrapped in `<React.StrictMode>` (the
+    React-recommended dev default, scaffolded by CRA / Next.js) had components
+    that stopped responding to state changes after mount.
+
+  THE FIX, and what this file now guards (`reagent2.impl.component`):
+
+    `componentWillUnmount` sets a `cljsRemountReattach` marker on the instance
+    when it disposes a LIVE render Reaction, and `componentDidMount` is now
+    installed UNCONDITIONALLY (even with no user `:component-did-mount`) so it
+    can read that marker: seeing it, it clears it and queues a render via
+    `reagent2.impl.batching/queue-render!`. `make-render-method` then recreates
+    the Reaction and re-subscribes its deref'd watches. A normal first mount
+    carries no marker (render() has already run, `cljsRenderRea` is live), so
+    the reattach path is a no-op there. The marker lives on the instance, and
+    React discards it with the instance on a genuine unmount.
+
+    The two assertions below are the regression: (a) fails if the reattach is
+    removed or the marker stops being set — the remounted instance goes
+    reactively dead again and the DOM never advances past the seeded value;
+    (b) fails if the transient Reaction leaks instead (watch count 2) or the
+    surviving one is never re-established (watch count 0).
   ─────────────────────────────────────────────────────────────────────────────
 
   WHAT IT ASSERTS, under `<React.StrictMode>` and driven by `act()` (which
@@ -75,7 +99,7 @@
   TEST-ONLY. ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test`
   discovers it for the real-DOM assertion; the `:node-test` runner also loads it
   (matches `cljs-test$`), where the body gates on `(browser?)` and no-ops."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+  (:require [cljs.test :refer-macros [deftest is use-fixtures async]]
             [reagent2.dom.client :as rdc]
             [reagent2.core :as r]
             ["react" :as React]

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_synthetic_event_frame_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_synthetic_event_frame_dom_cljs_test.cljs
@@ -37,7 +37,7 @@
   into the `:browser-test` build; `:node-test` still loads it (matches
   `cljs-test$`) and the DOM branch self-gates on `(browser?)`, exiting
   early where `js/document` is absent."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+  (:require [cljs.test :refer-macros [deftest is use-fixtures async]]
             [reagent2.dom.client :as rdc]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_view_id_attr_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_view_id_attr_cljs_test.cljs
@@ -27,8 +27,7 @@
             [re-frame.core :as rf]
             [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
             [re-frame.test-support :as test-support]
-            [re-frame.views])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+            [re-frame.views]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture

--- a/implementation/adapters/reagent-slim/test/reagent2/dom/error_boundary_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/error_boundary_dom_cljs_test.cljs
@@ -1,0 +1,198 @@
+(ns reagent2.dom.error-boundary-dom-cljs-test
+  "rf2-6r9j.31 — the MOUNTED React error-boundary proof for
+  `reagent2.core/create-class`'s `:component-did-catch` cap key, under a
+  React 19 `createRoot`.
+
+  WHAT IT PROVES. A descendant that throws during RENDER, and a
+  descendant that throws during COMMIT (`:component-did-mount`), are
+  both routed by React itself to the NEAREST enclosing slim boundary:
+
+    - the throwing descendant's path actually RAN (a render / mount
+      counter advanced), so a subtree React never reached cannot read
+      green;
+    - that boundary's `:component-did-catch` fired, carrying the thrown
+      error;
+    - the default `getDerivedStateFromError` marker reached the public
+      Reagent state atom and the boundary's FALLBACK committed to the
+      DOM;
+    - an OUTER boundary wrapping it did NOT fire.
+
+  WHY A DOM FILE, AND WHY THE OUTER-ONLY ARM. The sibling unit tests in
+  `reagent2.impl.component-cljs-test` invoke `componentDidCatch` on the
+  prototype directly — full control over the payload, but no reconciler,
+  so nothing there can observe React's own propagation. Until rf2-6r9j.31
+  this file did not exist, and the nested-isolation claim was carried by
+  a unit test that constructed an outer boundary, never mounted it, and
+  then asserted its counter was still zero — an assertion nothing could
+  have made fail. `outer-boundary-catches-when-inner-is-absent` below
+  exists so that cannot recur: it mounts the SAME throwing descendant
+  under the outer boundary ALONE and proves that counter does fire, so
+  the zero read by the nested arm is a measurement rather than a
+  tautology.
+
+  TEST-ONLY. ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test`
+  discovers it for the real-DOM assertion; the `:node-test` runner also
+  loads it (matches `cljs-test$`), where the body gates on `(browser?)`
+  and no-ops cleanly (no DOM).
+
+  CONSOLE. React 19 reports a boundary-caught error through the root's
+  `onCaughtError` option, which defaults to `console.error`. Each root
+  below supplies its own, so the expected report is captured as evidence
+  instead of printed as noise. The browser runner treats console output
+  as diagnostic, but an error that reached the PAGE uncaught would be
+  fatal to the lane — every error raised here is caught by a boundary
+  under test, and the captured report is asserted non-empty, which is a
+  second, independent witness that React (not the test) did the routing."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [reagent2.core :as r]
+            [reagent2.dom.client :as rdc]
+            ["react-dom" :as react-dom]))
+
+(def ^:private render-boom "child-render-boom")
+(def ^:private commit-boom "child-commit-boom")
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (when (browser?)
+    (.createElement js/document "div")))
+
+(defn- root-opts
+  "React 19 root options that divert the boundary-caught error report
+  from `console.error` into `reports`."
+  [reports]
+  #js {:onCaughtError (fn [error _info]
+                        (swap! reports conj (.-message ^js error)))})
+
+(defn- boundary-class
+  "A slim Form-3 error boundary named `label`.
+
+  Renders `(child-fn)` until a descendant throws; `:component-did-catch`
+  appends the error message to `fired`; after React's default
+  `getDerivedStateFromError` patch is bridged into the public Reagent
+  state atom (`:cljsHasError`), it renders `\"<label>:fallback\"` — the
+  documented slim fallback contract (IMPL-SPEC §6.5, rf2-ygknv)."
+  [label fired child-fn]
+  (r/create-class
+    {:display-name        (str label "-boundary")
+     :component-did-catch (fn [_this ^js error _info]
+                            (swap! fired conj (.-message error)))
+     :reagent-render
+     (fn []
+       (let [this (r/current-component)]
+         (if (:cljsHasError @(r/state-atom this))
+           [:div {:class (str label "-fallback")} (str label ":fallback")]
+           (child-fn))))}))
+
+(defn- render-thrower
+  "A Form-1 slim component whose RENDER throws, counting its own runs."
+  [runs]
+  (fn []
+    (swap! runs inc)
+    (throw (js/Error. render-boom))))
+
+(defn- commit-thrower
+  "A slim Form-3 component that renders normally and then throws from
+  `:component-did-mount` — React's COMMIT phase."
+  [mounts]
+  (r/create-class
+    {:display-name        "commit-thrower"
+     :component-did-mount (fn [_this]
+                            (swap! mounts inc)
+                            (throw (js/Error. commit-boom)))
+     :reagent-render      (fn [] [:span "child"])}))
+
+(deftest nested-boundaries-inner-catches-outer-does-not
+  (testing "a descendant RENDER throw is caught by the NEAREST slim
+            boundary; the enclosing outer boundary does not fire, and
+            the inner boundary's fallback commits (rf2-6r9j.31)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — the :browser-test runner exercises the assertion")
+      (let [outer-fired   (atom [])
+            inner-fired   (atom [])
+            child-runs    (atom 0)
+            reports       (atom [])
+            thrower       (render-thrower child-runs)
+            inner         (boundary-class "inner" inner-fired (fn [] [thrower]))
+            outer         (boundary-class "outer" outer-fired (fn [] [inner]))
+            mount-node    (make-mount-node!)
+            root          (rdc/create-root mount-node (root-opts reports))]
+        (try
+          (react-dom/flushSync (fn [] (rdc/render root [outer])))
+          ;; Non-vacuity: React really rendered the throwing descendant.
+          ;; (React 19 may re-run a failed render once to recover a better
+          ;; stack, so this is a "ran at least once" check, not a count.)
+          (is (pos? @child-runs)
+              "the throwing descendant's render actually ran")
+          (is (pos? (count @inner-fired))
+              "the INNER boundary's :component-did-catch fired")
+          (is (= #{render-boom} (set @inner-fired))
+              "the inner boundary received the error the descendant threw")
+          (is (= [] @outer-fired)
+              "the OUTER boundary did not fire (React stopped at the nearest boundary)")
+          (is (= "inner:fallback" (.-textContent mount-node))
+              "the inner boundary's fallback committed to the real DOM")
+          (is (pos? (count @reports))
+              "React reported the caught error through the root's onCaughtError")
+          (finally
+            (rdc/unmount root)))))))
+
+(deftest outer-boundary-catches-when-inner-is-absent
+  (testing "the SAME throwing descendant, mounted with no inner
+            boundary, IS caught by the outer boundary — so the zero
+            read above is a measurement, not a tautology (rf2-6r9j.31)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — the :browser-test runner exercises the assertion")
+      (let [outer-fired (atom [])
+            child-runs  (atom 0)
+            reports     (atom [])
+            thrower     (render-thrower child-runs)
+            outer       (boundary-class "outer" outer-fired (fn [] [thrower]))
+            mount-node  (make-mount-node!)
+            root        (rdc/create-root mount-node (root-opts reports))]
+        (try
+          (react-dom/flushSync (fn [] (rdc/render root [outer])))
+          (is (pos? @child-runs)
+              "the throwing descendant's render actually ran")
+          (is (pos? (count @outer-fired))
+              "the outer boundary's :component-did-catch fired when it WAS the nearest one")
+          (is (= #{render-boom} (set @outer-fired))
+              "the outer boundary received the error the descendant threw")
+          (is (= "outer:fallback" (.-textContent mount-node))
+              "the outer boundary's fallback committed to the real DOM")
+          (is (pos? (count @reports))
+              "React reported the caught error through the root's onCaughtError")
+          (finally
+            (rdc/unmount root)))))))
+
+(deftest commit-phase-child-did-mount-throw-reaches-boundary
+  (testing "a descendant that throws from :component-did-mount — React's
+            COMMIT phase — reaches the enclosing slim boundary, which
+            commits its fallback (rf2-6r9j.31)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — the :browser-test runner exercises the assertion")
+      (let [fired      (atom [])
+            mounts     (atom 0)
+            reports    (atom [])
+            child      (commit-thrower mounts)
+            boundary   (boundary-class "commit" fired (fn [] [child]))
+            mount-node (make-mount-node!)
+            root       (rdc/create-root mount-node (root-opts reports))]
+        (try
+          (react-dom/flushSync (fn [] (rdc/render root [boundary])))
+          ;; Non-vacuity: the throwing LIFECYCLE actually ran. Without
+          ;; this the test could pass on a tree React never committed.
+          (is (pos? @mounts)
+              "the descendant's :component-did-mount actually ran")
+          (is (pos? (count @fired))
+              "the boundary's :component-did-catch fired for the commit-phase error")
+          (is (= #{commit-boom} (set @fired))
+              "the boundary received the error the commit lifecycle threw")
+          (is (= "commit:fallback" (.-textContent mount-node))
+              "the boundary's fallback committed to the real DOM")
+          (is (pos? (count @reports))
+              "React reported the caught error through the root's onCaughtError")
+          (finally
+            (rdc/unmount root)))))))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
@@ -8,10 +8,14 @@
     - 7-key cap enforcement: out-of-cap keys throw
       :rf.error/create-class-key-unsupported.
     - Lifecycle key -> React lifecycle method mapping.
-    - :component-did-catch error-boundary contract:
-        * error during a child's render is caught.
-        * error during a child's commit (componentDidMount) is caught.
-        * nested boundaries: inner catches, outer does not fire.
+    - :component-did-catch error-boundary PLUMBING (this file only —
+      the wrapper forwards (this error info); getDerivedStateFromError
+      is auto-installed, and only when opted into; the marker bridges
+      into the public Reagent state atom; a user rethrow escapes).
+      React's own propagation — a throwing descendant reaching the
+      nearest boundary, and an enclosing boundary staying silent — is
+      proved under a real createRoot by
+      `reagent2.dom.error-boundary-dom-cljs-test`, NOT here.
     - :get-snapshot-before-update pairs with :component-did-update's
       snapshot arg, and both paired update lifecycles forward React's
       prevState (rf2-08hx1).
@@ -21,16 +25,15 @@
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up.
 
-  Test strategy: most tests directly exercise the public surface
-  (`create-class*`, `wrap-render`, `fn-to-class`) without rendering
-  through React. The error-boundary tests use a real ReactDOM root
-  so we get the actual React-19 boundary semantics, gated on whether
-  `react-dom/client` exposes a usable root in the node test target."
+  Test strategy: every test here exercises the public surface
+  (`create-class*`, `wrap-render`, `fn-to-class`) DIRECTLY, without
+  rendering through React — full control over the arguments, and no
+  reconciler. Anything that needs React itself to do the routing lives
+  in a `-dom-cljs-test` sibling that mounts a real `createRoot`."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [reagent2.impl.component :as component]
             [reagent2.impl.template :as template]
-            [reagent2.impl.batching :as batching]
-            ["react" :as react]))
+            [reagent2.impl.batching :as batching]))
 
 ;; ---------------------------------------------------------------------------
 ;; Test helpers — minimal "fake" React component instance
@@ -45,17 +48,14 @@
     (set! (.-cljsArgv c) argv)
     c))
 
-;; Tiny helpers to keep the inference checker quiet — the tests poke at
+;; A tiny helper to keep the inference checker quiet — the tests poke at
 ;; React's prototype chain (`.. klass -prototype -render`), and the
 ;; CLJS analyser can't infer the type of the synthesised constructor
-;; without a hint at every callsite. These wrappers concentrate the
+;; without a hint at every callsite. This wrapper concentrates the
 ;; ^js hint in one place.
 
 (defn- proto-method [^js klass name]
   (aget (.-prototype klass) name))
-
-(defn- static-prop [^js klass name]
-  (aget klass name))
 
 ;; ---------------------------------------------------------------------------
 ;; The 7-key cap (per IMPL-SPEC §6.1)
@@ -453,18 +453,23 @@
 ;; cljsHasError flag on state — apps that want fallback rendering
 ;; check that flag in :reagent-render.
 ;;
-;; rf2-gigc test enumeration:
-;;   1. error-during-child-render-caught-by-boundary
-;;   2. error-during-child-commit-caught-by-boundary
-;;   3. nested-boundary-isolates-inner-from-outer
-;;   4. boundary-without-component-did-catch-no-fallback (negative)
+;; SCOPE. These tests exercise the boundary PLUMBING directly (no real
+;; React render): the wrapper's (this error info) forwarding, that
+;; getDerivedStateFromError is auto-installed exactly when
+;; :component-did-catch is in the spec, that its marker bridges into the
+;; public Reagent state atom, and that a user rethrow is not swallowed.
 ;;
-;; These tests exercise the boundary plumbing directly (no real React
-;; render) — we assert the shape of the installed methods + that
-;; getDerivedStateFromError is auto-installed when :component-did-catch
-;; is in the spec. A real-DOM end-to-end Suspense + boundary integration
-;; test belongs on the browser-test target where Stage 4-D's hiccup
-;; interpreter lands.
+;; They do NOT — and cannot — prove React's own propagation. Between
+;; rf2-gigc and rf2-6r9j.31 two of them claimed to: one built an outer
+;; boundary, never mounted it, then asserted its counter was still zero
+;; (nothing could have made that fail), and one named a commit-phase
+;; scenario while invoking the boundary's componentDidCatch by hand,
+;; duplicating the forwarding test directly above. Both were removed
+;; under rf2-6r9j.31 and replaced by a MOUNTED proof under a real React
+;; 19 createRoot: `reagent2.dom.error-boundary-dom-cljs-test` covers the
+;; child-render throw, the child-commit (componentDidMount) throw,
+;; nested-boundary isolation, and — as its own control — the outer
+;; boundary firing when it is the nearest one.
 ;; ---------------------------------------------------------------------------
 
 (deftest error-boundary-component-did-catch-fires
@@ -508,51 +513,6 @@
                   {:reagent-render (fn [_] [:div])})]
       (is (nil? (.-getDerivedStateFromError klass))
           "no auto-install when the user didn't opt into boundary semantics"))))
-
-(deftest error-boundary-nested-isolation
-  (testing "nested boundaries: an inner boundary's catch does NOT propagate to outer"
-    ;; Without a real React tree we exercise the contract directly:
-    ;; each boundary class has its own componentDidCatch, and a call
-    ;; to one's cDC does NOT chain into another's.
-    (let [outer-fired (atom 0)
-          inner-fired (atom 0)
-          ^js outer   (component/create-class*
-                        {:reagent-render      (fn [_] [:div])
-                         :component-did-catch (fn [_ _ _]
-                                                (swap! outer-fired inc))})
-          ^js inner   (component/create-class*
-                        {:reagent-render      (fn [_] [:div])
-                         :component-did-catch (fn [_ _ _]
-                                                (swap! inner-fired inc))})
-          inner-inst  (new inner #js {:__rfArgv []})]
-      (.call (.. inner -prototype -componentDidCatch)
-             inner-inst (js/Error. "child threw") #js {})
-      (is (= 1 @inner-fired) "inner boundary caught")
-      (is (= 0 @outer-fired)
-          "outer boundary did not fire (nested isolation contract)"))))
-
-(deftest error-boundary-during-commit-via-component-did-mount
-  (testing "an error in a child's componentDidMount reaches the boundary's componentDidCatch"
-    ;; Per the React contract, errors thrown during commit-phase
-    ;; lifecycle methods (e.g. componentDidMount) are also caught by
-    ;; the closest enclosing boundary. We model this by directly
-    ;; routing the boundary's cDC + asserting it receives the right
-    ;; (error, info) payload — the integration with React's commit
-    ;; phase is a React contract that a real-DOM browser-test target
-    ;; covers end-to-end (Stage 4-D).
-    (let [caught (atom nil)
-          klass  (component/create-class*
-                   {:reagent-render      (fn [_] [:div])
-                    :component-did-catch (fn [_this error ^js info]
-                                           (reset! caught
-                                             {:error error
-                                              :phase (.-phase info)}))})
-          inst   (new klass #js {:__rfArgv []})
-          err    (js/Error. "commit-phase error")]
-      (.call (.. klass -prototype -componentDidCatch)
-             inst err #js {:phase "commit"})
-      (is (= "commit" (:phase @caught)))
-      (is (= err (:error @caught))))))
 
 (deftest error-boundary-derived-state-syncs-into-reagent-atom-rf2-ygknv
   (testing "rf2-ygknv finding 4: the default getDerivedStateFromError

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -194,46 +194,99 @@
           out (template/convert-prop-value :on-click f)]
       (is (fn? out)))))
 
+;; rf2-6r9j.30 — a fixture that actually REACHES `convert-prop-value`'s
+;; `ifn?` arm: object-backed, satisfies IFn, and satisfies none of the
+;; arms that come first (`js-val?`, `named?`, `map?`, `coll?`, `fn?`).
+;; A deftype implementing IFn does NOT satisfy the `Fn` marker protocol,
+;; which is what separates it from a function. Each -invoke records its
+;; own arguments so a call through the wrapper can be proven to have
+;; reached the fixture rather than merely returned something.
+(deftype CallableProbe [calls]
+  IFn
+  (-invoke [_]     (swap! calls conj [])       :called-0)
+  (-invoke [_ a]   (swap! calls conj [a])      [:called-1 a])
+  (-invoke [_ a b] (swap! calls conj [a b])    [:called-2 a b]))
+
 (deftest convert-prop-value-fn-preserves-identity-rf2-wyocr
-  (testing "rf2-wyocr: fn props pass through with === identity preserved
-            so React.memo / shouldComponentUpdate bail-outs work. Two
-            calls with the SAME fn return the SAME reference."
-    (let [handler (fn [_e] :clicked)
-          ;; 2-arg form — the production path through
-          ;; `add-converted-nested-prop!`.
-          a (template/convert-prop-value :on-click handler)
-          b (template/convert-prop-value :on-click handler)]
-      (is (identical? handler a)
-          "fn returned is the SAME reference passed in (=== check)")
-      (is (identical? a b)
-          "two conversions of the same fn produce the same reference"))
-    (let [handler (fn [_e] :nested)
-          ;; 1-arg form — used for nested map values.
-          a (template/convert-prop-value handler)
-          b (template/convert-prop-value handler)]
-      (is (identical? handler a)
-          "1-arg form preserves identity too")
-      (is (identical? a b)
-          "1-arg form: repeat conversions return the same reference"))))
+  (testing "rf2-wyocr: an object-backed Fn prop — a fn carrying metadata,
+            i.e. cljs.core/MetaFn — passes through the `fn?` arm with ===
+            identity preserved, so React.memo / shouldComponentUpdate
+            bail-outs work on a metadata-bearing handler.
+
+            rf2-6r9j.30: this test used to pass a PLAIN fn, which
+            `goog/typeOf`s as \"function\" and therefore returns from the
+            earlier `js-val?` arm — so it would have stayed green with
+            both `fn?` arms deleted. MetaFn is the ordinary value shape
+            that actually reaches the arm this regression names."
+    (let [handler (with-meta (fn [_e] :clicked) {:rf/probe true})]
+      ;; Preconditions, asserted rather than assumed — these are what
+      ;; route the value past the earlier arms and INTO `fn?`.
+      (is (= "object" (goog/typeOf handler))
+          "precondition: a metadata-bearing fn is object-backed, so js-val? declines it")
+      (is (fn? handler)
+          "precondition: MetaFn satisfies Fn, so the fn? arm takes it")
+      ;; 2-arg form — the production path through `add-converted-nested-prop!`.
+      (let [a (template/convert-prop-value :on-click handler)
+            b (template/convert-prop-value :on-click handler)]
+        (is (identical? handler a)
+            "2-arg: fn returned is the SAME reference passed in (=== check)")
+        (is (identical? a b)
+            "2-arg: two conversions of the same fn produce the same reference"))
+      ;; 1-arg form — used for nested map values.
+      (let [a (template/convert-prop-value handler)
+            b (template/convert-prop-value handler)]
+        (is (identical? handler a)
+            "1-arg form preserves identity too")
+        (is (identical? a b)
+            "1-arg form: repeat conversions return the same reference")))
+    ;; A plain JS fn still passes through unchanged — by the js-val? arm.
+    (let [plain (fn [_e] :plain)]
+      (is (identical? plain (template/convert-prop-value :on-click plain))
+          "a plain JS fn is still returned unchanged (js-val? arm)")
+      (is (identical? plain (template/convert-prop-value plain))
+          "1-arg form: plain JS fn unchanged too"))))
 
 (deftest convert-prop-value-non-fn-ifn-still-wrapped
-  (testing "rf2-wyocr: keyword (IFn but not fn?) still wraps via shim
-            so the React side can invoke it as a JS function"
-    (let [out (template/convert-prop-value :on-click :some-kw)]
-      ;; Keyword is named? so it hits the named? branch first; this is
-      ;; the warn-once path, not the ifn wrap. Verify a true non-fn IFn
-      ;; (a map-as-fn) goes through the wrapper path.
-      (is (or (keyword? out) (string? out))
-          "keyword routed through named? branch (warn-once path)"))
-    (let [m   {:a 1 :b 2}
-          out (template/convert-prop-value :custom-lookup m)]
-      ;; Maps are routed to the map? branch (recursive conversion), not
-      ;; the ifn? branch — that's correct (a prop-map value is recursively
-      ;; converted as a JS object, not invoked as a fn).
-      (is (= "object" (goog/typeOf out))
-          "map value recursively converts to JS object (map? branch wins)")
-      (is (= 1 (aget out "a")) "key a flows through")
-      (is (= 2 (aget out "b")) "key b flows through"))))
+  (testing "rf2-wyocr: an object-backed callable that satisfies IFn but
+            not Fn reaches the `ifn?` arm and comes back as a genuinely
+            JavaScript-invokable function.
+
+            rf2-6r9j.30: this test used to offer a keyword and a map, and
+            said so in its own comments — the keyword is taken by the
+            `named?` arm and the map by `map?`, so neither could reach
+            the wrapper and the test would have stayed green with both
+            `ifn?` arms deleted."
+    (let [calls (atom [])
+          probe (->CallableProbe calls)]
+      ;; Preconditions: every earlier arm of the cond must decline this.
+      (is (= "object" (goog/typeOf probe))
+          "precondition: object-backed, so js-val? declines it")
+      (is (not (or (keyword? probe) (symbol? probe)))
+          "precondition: not named?, so the named? arm declines it")
+      (is (not (map? probe))  "precondition: not a map")
+      (is (not (coll? probe)) "precondition: not a coll")
+      (is (not (fn? probe))
+          "precondition: does NOT satisfy Fn, so the fn? arm declines it")
+      (is (ifn? probe)
+          "precondition: satisfies IFn — this is the arm under test")
+      (let [out (template/convert-prop-value :on-select probe)]
+        (is (= "function" (goog/typeOf out))
+            "the ifn? arm returns a real JS function React can call")
+        (is (not (identical? probe out))
+            "the wrapper is a distinct value — this arm allocates, by design")
+        ;; Invoke it the way React would: as a plain JS function.
+        (is (= [:called-1 :a] (.call out nil :a))
+            "1-arg JS call forwards to the fixture and returns its value")
+        (is (= [:called-2 :a :b] (.call out nil :a :b))
+            "2-arg JS call forwards both arguments")
+        (is (= [[:a] [:a :b]] @calls)
+            "the fixture's own -invoke ran for each call (not a stub returning shapes)"))
+      ;; The 1-arg form takes the same arm.
+      (let [out1 (template/convert-prop-value probe)]
+        (is (= "function" (goog/typeOf out1))
+            "1-arg form also wraps into a JS function")
+        (is (= :called-0 (.call out1 nil))
+            "0-arg JS call forwards")))))
 
 (deftest nested-style-keyword-value-stringifies-on-live-path-rf2-fdm4rm
   (testing "rf2-fdm4rm: a nested style-map keyword value reaches React as


### PR DESCRIPTION
Four children of the rf2-6r9j audit epic, clustered because they share `implementation/adapters/reagent-slim/\*\*` and because .31 and .34 edit the same file.

Two of them are false-green bugs: tests that passed while exercising nothing.

## rf2-6r9j.31 — error-boundary tests that could not fail

`component_cljs_test.cljs` carried two tests advertised as React error-boundary integration proofs:

- `error-boundary-nested-isolation` built an `outer` boundary class, **never mounted it**, invoked only `inner.prototype.componentDidCatch` by hand, then asserted `outer-fired` was still zero — an assertion nothing could have made fail. clj-kondo independently reported `outer` as an unused binding.
- `error-boundary-during-commit-via-component-did-mount` named a commit-phase scenario but created no child, invoked no `componentDidMount` and mounted no tree; it called the boundary's `componentDidCatch` directly, duplicating the forwarding test immediately above it.

Both removed, replaced by a mounted proof under a real React 19 `createRoot`: **`reagent2.dom.error-boundary-dom-cljs-test`**, following the artefact's established `_dom_cljs_test` pattern (browser lane; `:node-test` loads it and the `(browser?)` gate no-ops). Three arms:

1. nested boundaries, child **render** throw → inner catches, outer does not, inner's fallback commits;
2. the same throwing descendant with **no inner boundary** → the outer one fires. This arm exists so the zero in (1) is a measurement rather than a tautology;
3. child **commit** throw (`:component-did-mount`) → reaches the boundary.

Every arm asserts the throwing path actually ran (render/mount counter), that the fallback reached the real DOM, and that React reported the error through the root's `onCaughtError` — which also keeps the expected report out of the console as noise.

The unit file's ns docstring claimed the error-boundary tests "use a real ReactDOM root"; it never did — that claim has been wrong since `21d4b06aae` introduced both. It now states what the file does prove and points at the DOM sibling for the rest.

## rf2-6r9j.30 — a TEST defect, not a production ordering defect

`convert-prop-value` puts `(js-val? v)` before `(fn? v)` and `(ifn? v)`, and `goog/typeOf` of an ordinary function is `"function"`, so `js-val?` is true for it. Consequently the plain `(fn ...)` values in `convert-prop-value-fn-preserves-identity-rf2-wyocr`, and the keyword and map in `convert-prop-value-non-fn-ifn-still-wrapped`, all returned from **earlier** arms — the latter test said so in its own comments while its name claimed otherwise. Both would have stayed green with the `fn?` and `ifn?` arms deleted.

The ladder itself is correct: `map?`, `coll?` and `named?` conversion are published prop-conversion behaviour, and reordering to make the old examples true would change production semantics. So the tests move to the value shapes that actually reach the named arms:

- **`fn?`**: a `MetaFn` — what `(with-meta some-fn {...})` returns. Object-backed, so `js-val?` declines it; satisfies `Fn`, so `fn?` takes it. Identity asserted for both public arities. A plain fn is still asserted to pass through unchanged, via `js-val?`.
- **`ifn?`**: a `deftype` satisfying `IFn` but not `Fn`, `named?`, `map?` or `coll?`. Proven to come back as a real JS function, invoked through `.call` with arguments forwarded and the fixture's own `-invoke` recording each call.

Each test asserts its routing preconditions rather than assuming them, so a future reordering fails here loudly.

The `convert-prop-value` docstring cited keywords, maps, sets and vectors as examples of the `ifn?` wrapper — all four are intercepted earlier. It now walks the `cond` in the order it is actually taken. Docstring only; no behaviour change.

## rf2-6r9j.34 — five dead requires and a dead private var

Removed: the `"react"` require and private `static-prop` in `component_cljs_test.cljs`; two `(:require-macros [re-frame.core :refer [reg-view]])` forms whose files call `rf/reg-view` through the live alias (nine sibling files in `adapters/reagent/test` already do exactly this with no `:require-macros`); two unused `cljs.test/testing` refers.

Sequenced after .31 as the bead directs, and re-linted: **neither `react` nor `static-prop` was revived** by the boundary repair, since its real-DOM proof is a new file. The excluded `db` bindings and other beads' surfaces are untouched.

## rf2-6r9j.32 — a fixed bug's test still said it fails by design

`reagent_slim_strict_mode_dom_cljs_test.cljs` told contributors that assertions (a) and (b) `FAIL BY DESIGN`, that the substrate did not honour the contract, and that the fix belonged to a separate bead. The fix landed the same day as the test — 2026-07-12, `2c4a87e3df` (rf2-6b6pex) — and it is now a required green regression.

The header records that as dated history rather than pretending it never was: the STATUS block states the file is a required green and then says what it used to say and when that ended; the FINDING block is retitled FORMER BUG, moved to past tense, and kept, because it is the diagnosis the remount marker was built from. A new section describes the fix and states what each assertion now fails on.

## Quality gates

All exit codes below are captured from the runner's own `$?`, redirected to a file, never read from a harness summary (one browser run disagreed: harness 0, captured 1).

Re-run on the final base after the last rebase.

**Rebased onto the codex-naming-04 rename pass** (which landed first and touched fifteen reagent-slim files, three of them mine). Two files conflicted and were merged by hand — never `--ours`/`--theirs`, since the two intents differ in kind: theirs is a pure rename, mine is a correctness fix, and taking either side wholesale would silently revert the other. `template.cljs`: kept their renamed arglist (`prop-value`) with my rewritten HOT PATH paragraph. `template_cljs_test.cljs`: kept my MetaFn/`CallableProbe` shapes with their `kv-conv` → `add-converted-nested-prop!` rename applied to my comment. The strict-mode header auto-merged (their `install-lifecycle!` → `install-lifecycle-methods!` sits above my rewrite). Every symbol this PR's prose and tests name was re-verified to still exist under the new names, and the three gates below plus both non-vacuity proofs were re-run on the merged tree.

| Gate | Captured exit | Result |
|---|---|---|
| `clj-kondo --lint <slim>/src <slim>/test --cache false` — BEFORE | 2 | 19 warnings, 0 errors |
| `clj-kondo …` — AFTER | 2 | **12 warnings, 0 errors**; all 7 targeted warnings gone, none introduced |
| clj-kondo 2026.04.15 (CI's pinned binary, via the spine) | 0 | `--fail-level error`: 0 errors; no reagent-slim finding among the six removed |
| `clojure -M:test` in `adapters/reagent-slim` | 0 | 11 tests, 12 assertions, 0 failures |
| `compile-node-test.cjs node-test` | 0 | 1895 files, 0 warnings |
| `node out/node-test.js` (full `:node-test`) | 0 | **11165 tests, 55721 assertions, 0 failures** |
| `shadow-cljs compile browser-test` | 0 | 1024 files, 5 pre-existing infer-warnings, none in changed files |
| `serve-and-run-browser-tests.cjs` | 0 | **781 tests, 4249 assertions, 0 failures** |
| `scripts/test-fast-pr.sh` | 0 | `PASS fast PR spine` |
| `scripts/check_fast_pr_gap.py --brief` | 0 | names 97 required CI checks the spine does not decide |

### Non-vacuity: the repaired tests are load-bearing

A green suite is exactly the evidence that is *not* dispositive here, since both P2 beads are about tests that passed while proving nothing. Each repaired test was therefore shown to go RED when the production behaviour it names is broken, and each break was reverted and the revert verified by git blob hash against the committed object (not by reading a diff — line endings are translated here).

| Break planted in production | Captured exit | Failures |
|---|---|---|
| `fn?` arm removed from both `convert-prop-value` forms | 1 | 4, all in the MetaFn identity test: `(not (identical? #object[cljs.core.MetaFn] #object[G__…]))` — the wrapper replaced the value. Callable-object test stayed green. |
| `ifn?` arm removed from both forms | 1 | 3, all in the callable-object test: `(not (= "function" "object"))` plus the wrapper no longer distinct. MetaFn test stayed green. |
| `getDerivedStateFromError` auto-install disabled | 1 | 3, one in **each** new DOM test, each naming its own uncommitted fallback: `(not (= "inner:fallback" ""))`, `"outer:fallback"`, `"commit:fallback"`. |
| StrictMode reattach disabled | 1 | 3, all in the StrictMode test: `(not (= "n=2" "n=1"))` (reactively dead) and `(not (= 1 0))` twice (Reaction never re-established) — exactly what the rewritten header now says each assertion fails on. |

Test and assertion totals were identical across every planted and control run (98/301 focused, 781/4249 browser), so no namespace was skipped or crashed by a plant.

