### PR TITLE
ssr-node: repair two false-green checks, retire two dead selectors and four below-floor guards (rf2-6r9j.70/.71/.72/.73)

### DIFF
--- a/implementation/ssr-node/README.md
+++ b/implementation/ssr-node/README.md
@@ -195,10 +195,20 @@ bar (HD-012) and this package does not quietly re-open it.
 | p50 service overhead | **5 ms** |
 | p95 service overhead | **25 ms** |
 | worst single sample | **250 ms** |
-| samples | 200, sequential, warm pool, free isolate, `state` ≤ 64 KiB |
+| samples | 200, sequential, warm pool, free isolate, `state` + `runtime` ≤ 64 KiB |
 
 The upper two are deliberately loose, and the reasoning is written where
 the numbers are.
+
+The size condition is one budget over **both** request partitions, keys
+and values, counted in UTF-8 bytes exactly as `src/protocol.cjs` counts
+them — the ceilings are not claimed for a request larger than that. It is
+the envelope's own sampling condition and not the service's refusal
+ceiling, which is `--max-request-bytes` and an order of magnitude higher.
+The condition originally named `state` alone, because that was the only
+partition a request carried when the envelope was registered; widening it
+to the request moved no ceiling and no sample count, and the amendment
+note in `src/envelope.cjs` records that separation.
 
 ## The measured envelope
 

--- a/implementation/ssr-node/src/envelope.cjs
+++ b/implementation/ssr-node/src/envelope.cjs
@@ -37,9 +37,38 @@
 //   - a FREE isolate at dispatch, so no sample includes admission queueing
 //     behind another request (bounded concurrency is guarantee 3's subject,
 //     measured there, and would otherwise be double-counted here);
-//   - a request whose `state` is at most 64 KiB of EDN text in total;
+//   - a request whose `state` and `runtime` partitions are at most 64 KiB
+//     of EDN text TOGETHER, counted the way `protocol.cjs` counts them —
+//     every UTF-8 key byte plus every UTF-8 value byte, over both
+//     partitions (see the amendment below);
 //   - sequential requests — one in flight at a time;
 //   - Node 24 on one box.
+//
+// ## AMENDMENT, AND WHAT IT DID NOT TOUCH (rf2-6r9j.71)
+//
+// The registration above was written when a request carried ONE
+// partition, and it bounded `state` alone. `runtime` became a second
+// cloned partition later (9a42302f7a) and `protocol.cjs` now counts every
+// key and value of BOTH against one combined ceiling — but the condition
+// here was never widened to follow, so the published envelope could be
+// read as covering a runtime-heavy request that its witness never sent,
+// and the witness's own byte definition (two values, no keys) was not the
+// validator's.
+//
+// The condition's DOMAIN is corrected here; its NUMBER is not, and
+// neither is any ceiling. `p50Ms`, `p95Ms`, `maxMs` and `samples` carry
+// the values they were registered with in f39829caa6, before any
+// measurement code existed, and `git log --follow` on this file still
+// separates that registration from this repair. A ceiling moved after a
+// run would be a description of the run; a condition corrected to name
+// the requests the validator actually admits is the opposite — it makes
+// the claim harder to satisfy, not easier.
+//
+// The 64 KiB here is the ENVELOPE's sampling condition and is not
+// `protocol.cjs`'s refusal ceiling, which is `maxRequestBytes` (1 MiB by
+// default). Two different layers: the service refuses above one, and the
+// latency figures are only claimed below the other. What the two must
+// share — and now do — is how a byte is counted.
 //
 // ## Why the ceilings are where they are
 //
@@ -59,6 +88,8 @@
 // milliseconds at the median and never runs away — and never as a
 // benchmark to diff a future run against.
 
+const { PARTITIONS } = require('./protocol.cjs');
+
 const ENVELOPE = Object.freeze({
   /** Median service overhead, milliseconds. */
   p50Ms: 5,
@@ -68,9 +99,37 @@ const ENVELOPE = Object.freeze({
   maxMs: 250,
   /** How many samples the witness takes. */
   samples: 200,
-  /** The total `state` EDN budget the ceilings are stated under. */
-  stateBudgetBytes: 64 * 1024,
+  /**
+   * The total request EDN budget the ceilings are stated under — `state`
+   * and `runtime` together, keys and values. Named for the request rather
+   * than for one partition because a partition is a way of naming the
+   * budget, not a second allowance; `protocol.cjs` says the same thing
+   * about its own ceiling.
+   */
+  requestBudgetBytes: 64 * 1024,
 });
+
+/**
+ * The EDN text a request carries, in UTF-8 bytes, counted the way
+ * `validatePartition` counts it: every key plus every value, across every
+ * partition the protocol names.
+ *
+ * It reads `PARTITIONS` from `protocol.cjs` rather than naming `state`
+ * and `runtime` here, so a third partition cannot be added to the wire
+ * and leave this condition silently measuring two of three — which is
+ * precisely how the condition came to bound `state` alone.
+ */
+function requestBytes(request) {
+  let bytes = 0;
+  for (const { field } of PARTITIONS) {
+    const partition = request[field];
+    if (partition === undefined || partition === null) continue;
+    for (const [k, v] of Object.entries(partition)) {
+      bytes += Buffer.byteLength(k, 'utf8') + Buffer.byteLength(String(v), 'utf8');
+    }
+  }
+  return bytes;
+}
 
 /**
  * Percentile of an ARRAY OF NUMBERS, nearest-rank on the sorted sample.
@@ -105,4 +164,4 @@ function judge(overheadsMs, envelope = ENVELOPE) {
   return { ok: breaches.length === 0, p50, p95, max, n: overheadsMs.length, breaches };
 }
 
-module.exports = { ENVELOPE, percentile, judge };
+module.exports = { ENVELOPE, requestBytes, percentile, judge };

--- a/implementation/ssr-node/src/http.cjs
+++ b/implementation/ssr-node/src/http.cjs
@@ -124,7 +124,7 @@ function readBody(req, maxBytes) {
   });
 }
 
-async function handleRender(service, req, res, { maxRequestBytes, streamingDefault }) {
+async function handleRender(service, req, res, { maxRequestBytes }) {
   let parsed;
   let requestId;
   try {
@@ -140,11 +140,17 @@ async function handleRender(service, req, res, { maxRequestBytes, streamingDefau
     return;
   }
 
+  // ONE SELECTOR. Buffered is the default and `?stream=1` is the opt-in,
+  // and there is no second way to say it: the entry point also honoured an
+  // `x-rf-ssr-stream: 1` request header and a `streamingDefault` serve
+  // option (with a `?stream=0` escape that only ever mattered when that
+  // option was on). Neither had a consumer anywhere — no CLI flag, no
+  // README contract, no test, no JVM adapter — so the response framing a
+  // caller got could be changed by a magic header or an unpinned
+  // in-process option that the operational docs did not teach. Retired
+  // under rf2-6r9j.72; `test/bytes.test.cjs` pins that the header is inert.
   const url = new URL(req.url, 'http://localhost');
-  const streaming =
-    url.searchParams.get('stream') === '1' ||
-    req.headers['x-rf-ssr-stream'] === '1' ||
-    (streamingDefault && url.searchParams.get('stream') !== '0');
+  const streaming = url.searchParams.get('stream') === '1';
 
   const buffered = [];
   try {
@@ -218,12 +224,12 @@ function handleHealth(service, res) {
  * the node `Server` plus the port actually bound — which matters because
  * the tests bind port 0 and a fixed test port is a fixed test collision.
  */
-function serve({ service, port = 8148, host = '127.0.0.1', maxRequestBytes = 1 << 20, streamingDefault = false }) {
+function serve({ service, port = 8148, host = '127.0.0.1', maxRequestBytes = 1 << 20 }) {
   const server = http.createServer((req, res) => {
     const url = new URL(req.url, 'http://localhost');
     if (req.method === 'GET' && url.pathname === '/health') return handleHealth(service, res);
     if (req.method === 'POST' && url.pathname === '/render') {
-      return void handleRender(service, req, res, { maxRequestBytes, streamingDefault });
+      return void handleRender(service, req, res, { maxRequestBytes });
     }
     const body = JSON.stringify({
       type: 'refusal',

--- a/implementation/ssr-node/src/http.cjs
+++ b/implementation/ssr-node/src/http.cjs
@@ -253,7 +253,7 @@ function serve({ service, port = 8148, host = '127.0.0.1', maxRequestBytes = 1 <
 
 const closeServer = (server) =>
   new Promise((resolve) => {
-    server.closeAllConnections?.();
+    server.closeAllConnections();
     server.close(() => resolve());
   });
 

--- a/implementation/ssr-node/src/isolate.cjs
+++ b/implementation/ssr-node/src/isolate.cjs
@@ -78,7 +78,7 @@ class Isolate {
           ),
         );
       }, this.bootTimeoutMs);
-      bootTimer.unref?.();
+      bootTimer.unref();
 
       const onReady = (msg) => {
         if (msg.t === 'ready') {
@@ -151,7 +151,7 @@ class Isolate {
         );
         this._die();
       }, timeoutMs);
-      timer.unref?.();
+      timer.unref();
 
       this.pending = { id, timer, resolve, reject, onChunk, chunks: 0 };
       this.worker.postMessage({ t: 'render', id, request });

--- a/implementation/ssr-node/src/pool.cjs
+++ b/implementation/ssr-node/src/pool.cjs
@@ -145,7 +145,7 @@ class Pool {
           ),
         );
       }, this.admissionTimeoutMs);
-      waiter.timer.unref?.();
+      waiter.timer.unref();
       this.waiters.push(waiter);
     });
   }

--- a/implementation/ssr-node/test/bytes.test.cjs
+++ b/implementation/ssr-node/test/bytes.test.cjs
@@ -125,6 +125,39 @@ test('the STREAMING mode delivers byte-identical output to the buffered one', as
   });
 });
 
+test('the query is the ONLY streaming selector — the retired header changes nothing', async () => {
+  // `?stream=1` is the whole of the supported contract. The entry point
+  // used to honour an `x-rf-ssr-stream: 1` request header too, with no
+  // consumer, no documentation and no test — a caller could be handed
+  // chunked framing by a header the README never mentioned. It is gone
+  // (rf2-6r9j.72), and "gone" is pinned rather than assumed: a request
+  // carrying it must come back BUFFERED, which `content-length` says and
+  // a streamed response cannot.
+  await withService('chunked', { isolates: 1 }, async (service) => {
+    const http = await serve({ service, port: 0 });
+    const body = { protocol: 1, entry: 'app/root', state: { ':bytes': '["<a>","—","<c/>"]' } };
+    try {
+      const plain = await post(`http://127.0.0.1:${http.port}/render`, body);
+      const withHeader = await post(`http://127.0.0.1:${http.port}/render`, body, {
+        'x-rf-ssr-stream': '1',
+      });
+      assert.strictEqual(withHeader.status, 200);
+      assert.strictEqual(
+        withHeader.headers.get('content-length'),
+        String(utf8(withHeader.text)),
+        'the header must not have selected streaming — a streamed response carries no content-length',
+      );
+      assert.strictEqual(
+        sha256(withHeader.text),
+        sha256(plain.text),
+        'and the bytes are the ordinary buffered response, unchanged',
+      );
+    } finally {
+      await http.close();
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Separability: N chunks stay N chunks
 // ---------------------------------------------------------------------------

--- a/implementation/ssr-node/test/envelope.test.cjs
+++ b/implementation/ssr-node/test/envelope.test.cjs
@@ -22,10 +22,18 @@
 //
 // ## The conditions, which are part of the registration
 //
-// Warm pool, a free isolate at dispatch, sequential requests, small state.
-// The warm-up is here for the first of those: worker boot is a deployment
-// cost, not a per-request one, and folding it in would measure the wrong
-// thing while looking rigorous.
+// Warm pool, a free isolate at dispatch, sequential requests, and a small
+// request — `state` and `runtime` together inside 64 KiB, counted as
+// `protocol.cjs` counts them. The warm-up is here for the first of those:
+// worker boot is a deployment cost, not a per-request one, and folding it
+// in would measure the wrong thing while looking rigorous.
+//
+// THE SIZE CONDITION IS A PRECONDITION, NOT A COMMENT. The measured
+// request is asserted inside the budget before a single sample is taken,
+// with a control row that shows a request over it being turned away —
+// because a condition nothing enforces is a condition the witness can
+// drift out of, which is how this one came to bound `state` alone while
+// the wire grew a second partition (rf2-6r9j.71).
 //
 // ## How to read the numbers
 //
@@ -40,9 +48,21 @@
 const test = require('node:test');
 const assert = require('node:assert');
 const { withService } = require('./_support.cjs');
-const { ENVELOPE, judge, percentile } = require('../src/envelope.cjs');
+const { ENVELOPE, requestBytes, judge, percentile } = require('../src/envelope.cjs');
+const { validateRequest, Refusal } = require('../src/protocol.cjs');
 
 const WARMUP = 20;
+
+/** The tables the `reference` fixture publishes, as the validator wants them. */
+const REFERENCE_TABLES = {
+  buildId: 'reference-build-1',
+  entries: {
+    'app/root': {
+      stateAllowlist: [':todos', ':route', ':delay', ':bytes'],
+      runtimeAllowlist: [':rf.runtime/routing'],
+    },
+  },
+};
 
 test('percentile is nearest-rank, so every figure is a sample some request took', () => {
   const xs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -62,20 +82,91 @@ test('judge names every ceiling it breaches, and stays silent when it clears the
   assert.strictEqual(bad.breaches.length, 3, 'p50, p95 and max all breached');
 });
 
+test('the budget counts a request the way the validator counts it — keys, values, both partitions', () => {
+  // The condition is only as good as its byte definition, and this one is
+  // not asserted in prose: it is pinned against `protocol.cjs`, the thing
+  // that actually enforces a ceiling over the same text. A request of
+  // exactly N bytes must be admitted at a ceiling of N and refused at
+  // N - 1, which is only true if both counts agree key for key.
+  //
+  // The witness used to count two VALUES of one partition and call that
+  // the request's size. It omitted every key and the whole `runtime`
+  // partition, so it could clear a budget the validator would have read
+  // as larger (rf2-6r9j.71).
+  const request = {
+    protocol: 1,
+    entry: 'app/root',
+    state: { ':todos': '[1 2 3]', ':route': '{:name :home}' },
+    runtime: { ':rf.runtime/routing': '{:name :home}' },
+  };
+  const n = requestBytes(request);
+  assert.ok(n > 0);
+
+  assert.doesNotThrow(
+    () => validateRequest(request, REFERENCE_TABLES, { maxRequestBytes: n }),
+    'a request of exactly N bytes must be admitted at a ceiling of N',
+  );
+  assert.throws(
+    () => validateRequest(request, REFERENCE_TABLES, { maxRequestBytes: n - 1 }),
+    (err) => err instanceof Refusal && /are \d+ bytes, over the/.test(err.message),
+    'and refused one byte lower — so the two counts are the same count',
+  );
+
+  // Neither partition is free, and neither are the keys: dropping any one
+  // of the three moves the number.
+  assert.ok(requestBytes({ ...request, runtime: {} }) < n, 'runtime bytes must count');
+  assert.ok(requestBytes({ ...request, state: {} }) < n, 'state bytes must count');
+  assert.strictEqual(
+    requestBytes({ state: { ab: 'cd' } }),
+    4,
+    'two key bytes and two value bytes',
+  );
+});
+
+test('a request over the combined condition is refused by the witness precondition', () => {
+  // THE CONTROL FOR THE ROW BELOW. The measured request clearing the
+  // budget says nothing unless a request that busts it would be turned
+  // away — and the interesting one busts it on `runtime` alone, which is
+  // the partition the condition did not used to see. It is a request the
+  // SERVICE would happily accept (one allowlisted key, far under the
+  // 1 MiB protocol ceiling); it is the envelope's narrower sampling
+  // condition that refuses it, which is the distinction being pinned.
+  const request = {
+    protocol: 1,
+    entry: 'app/root',
+    state: { ':todos': '[]' },
+    runtime: { ':rf.runtime/routing': 'x'.repeat(ENVELOPE.requestBudgetBytes) },
+  };
+  assert.ok(
+    requestBytes(request) > ENVELOPE.requestBudgetBytes,
+    'a runtime-heavy request must be measured as over the combined budget',
+  );
+  assert.doesNotThrow(
+    () => validateRequest(request, REFERENCE_TABLES, {}),
+    'and it must be one the service itself would serve — otherwise the row is about the protocol ceiling',
+  );
+});
+
 test(`the service clears its pre-registered envelope over ${ENVELOPE.samples} samples`, async (t) => {
   await withService('reference', { isolates: 2, admissionTimeoutMs: 10000 }, async (service) => {
-    // A request whose state is comfortably inside the registered budget.
+    // A request comfortably inside the registered budget, and carrying
+    // BOTH partitions — the condition is stated over the request, so a
+    // sample that sent one of them would be measuring a narrower request
+    // than the envelope claims to cover (rf2-6r9j.71).
     const request = {
       protocol: 1,
       entry: 'app/root',
       state: { ':todos': JSON.stringify(Array.from({ length: 40 }, (_, i) => i)), ':route': '{:name :home}' },
+      runtime: { ':rf.runtime/routing': '{:name :home :params {} :query {}}' },
     };
-    const stateBytes =
-      Buffer.byteLength(request.state[':todos'], 'utf8') +
-      Buffer.byteLength(request.state[':route'], 'utf8');
     assert.ok(
-      stateBytes <= ENVELOPE.stateBudgetBytes,
-      `the sample request must sit inside the registered ${ENVELOPE.stateBudgetBytes}-byte budget`,
+      requestBytes(request) <= ENVELOPE.requestBudgetBytes,
+      `the sample request must sit inside the registered ${ENVELOPE.requestBudgetBytes}-byte budget; ` +
+        `it is ${requestBytes(request)} bytes`,
+    );
+    assert.ok(
+      Object.keys(request.runtime).length > 0 && Object.keys(request.state).length > 0,
+      'both partitions must be non-empty, or the combined condition is untested',
     );
 
     // WARM. Worker boot is a deployment cost; folding it in would measure

--- a/implementation/ssr-node/test/fixtures/reference.cjs
+++ b/implementation/ssr-node/test/fixtures/reference.cjs
@@ -25,6 +25,22 @@ const seen = new WeakSet();
 let inFlight = 0;
 let overlapMax = 0;
 
+/**
+ * Boots observed in THIS isolate, counted on the isolate's own global
+ * rather than in module scope — and that placement is the measurement.
+ *
+ * The contract is *the module boots once per ISOLATE, not once per
+ * request*, so a counter that a re-require resets could not tell the two
+ * apart: a per-request `require` + `boot()` would report 1 every time,
+ * which is exactly the reading the row is supposed to refuse. A worker
+ * thread has its own `globalThis`, so this survives a re-require, cannot
+ * see another isolate's boots, and cannot be contaminated by the main
+ * process's copy of this module — the in-process controls require this
+ * file directly, and they increment a different global.
+ */
+const BOOTS = Symbol.for('rf2.ssr-node.test.boots');
+globalThis[BOOTS] ??= 0;
+
 /** What a render of this module observed. Shared with its in-process control. */
 // `runtime` defaults for the in-process CONTROLS that call `render`
 // directly with a state-only call; through the service it always arrives.
@@ -55,6 +71,9 @@ function observe({ entry, state, runtime = {}, args }) {
     readRuntimeRoute: runtime[':rf.runtime/routing'] ?? null,
     runtimeFrozen: Object.isFrozen(runtime),
     overlapMax,
+    // How many times this isolate has booted the module. The boot-once
+    // row reads it; nothing else should need to.
+    boots: globalThis[BOOTS],
     threadId: require('node:worker_threads').threadId,
   };
 }
@@ -70,9 +89,8 @@ module.exports = {
     'app/other': { stateAllowlist: [':route'], runtimeAllowlist: [] },
   },
 
-  booted: false,
   boot() {
-    module.exports.booted = true;
+    globalThis[BOOTS] += 1;
   },
 
   async render(call, emit) {

--- a/implementation/ssr-node/test/isolation.test.cjs
+++ b/implementation/ssr-node/test/isolation.test.cjs
@@ -122,13 +122,28 @@ test('the module boots once per isolate, not once per request', async () => {
   // Spec 006 allows exactly one reactive substrate per process, so booting
   // is a per-isolate decision. If it ran per request the isolation would
   // be real and the cost would be absurd.
+  //
+  // THE ROW COUNTS BOOTS, and that is the whole of what makes it a
+  // witness. It used to assert `overlapMax === 1` on both responses and
+  // call that "the module was not re-required" — but `overlapMax` is
+  // render-concurrency state, and two SEQUENTIAL renders read 1 whether
+  // the hook is called never, once, or before every render. Neither
+  // asserted outcome discriminated the contract the row is named for, so
+  // the hook could have been removed with this file still green
+  // (rf2-6r9j.70). The fixture publishes a per-isolate boot count instead;
+  // the concurrency rows keep `overlapMax`, which is their subject.
   await withService('reference', { isolates: 1 }, async (service) => {
     const a = await collect(service, req({ ':todos': '[]' }));
     const b = await collect(service, req({ ':todos': '[]' }));
+    // The precondition: one isolate served both, so a count that did not
+    // change between them is a reading of one isolate's history rather
+    // than of two.
     assert.strictEqual(observed(a).threadId, observed(b).threadId);
-    // `overlapMax` is module-level state; its survival across the two
-    // renders is what shows the module was not re-required.
-    assert.strictEqual(observed(a).overlapMax, 1);
-    assert.strictEqual(observed(b).overlapMax, 1);
+    assert.strictEqual(observed(a).boots, 1, 'the isolate must have booted the module exactly once');
+    assert.strictEqual(
+      observed(b).boots,
+      1,
+      'a second boot by the time of the second render is a per-request boot',
+    );
   });
 });


### PR DESCRIPTION
Four `implementation/ssr-node/**` beads from the vestigial audit epic. Two are false-green defects, and repairing them is the point of the cluster: a check that passes while measuring something else occupies the slot where real coverage would go.

## rf2-6r9j.70 — the boot-once row never observed the boot hook

`test/isolation.test.cjs`'s row *"the module boots once per isolate, not once per request"* asserted `overlapMax === 1` on two sequential responses, with a comment claiming that proved the module was not re-required. `overlapMax` is render-concurrency state: two sequential renders read `1` whether the hook is called never, once, or before every render. Neither asserted outcome discriminated the contract, so `src/worker.cjs`'s boot call could have been deleted with the file still green. The fixture's only boot signal, `module.exports.booted`, was written and never read anywhere in the repository.

The fixture now counts boots on the isolate's own `globalThis` rather than in module scope — a module-scope counter that a re-require resets would report `1` for a per-request require-and-boot too, which is one of the two failures the row exists to catch. Each worker thread has its own global, so the count cannot see another isolate's boots or the main process's copy of the fixture, which the in-process controls require directly. The same-thread precondition stays; `overlapMax` stays where it is the subject, in the concurrency rows.

## rf2-6r9j.71 — the latency envelope ignored the runtime partition

The pre-registered condition bounded `state` EDN text to 64 KiB, written when a request carried one partition. `runtime` became a second cloned partition later, and `protocol.cjs` now counts every UTF-8 key and value of **both** against one combined ceiling — but the envelope never followed. The witness under-measured on a second axis as well: it summed two state **values**, omitting every key and the whole `runtime` partition.

`stateBudgetBytes` becomes `requestBudgetBytes` (same 64 KiB, now over both partitions); `requestBytes()` counts keys and values across `PARTITIONS` read from `protocol.cjs`, so a third partition cannot be added to the wire and leave the condition measuring two of three. The measured request carries a non-empty allowlisted `runtime` partition and is asserted inside the budget before any sample is taken. Two new rows: one pins `requestBytes` against `validateRequest` by admitting a request at a ceiling of exactly N bytes and refusing it at N-1; one control shows a request busting the condition on `runtime` alone is turned away by the precondition while remaining a request the service itself would serve.

**No ceiling and no sample count moved.** p50 5 ms, p95 25 ms, max 250 ms, 200 samples are the registered values; an amendment note in `src/envelope.cjs` keeps that provenance separate from this repair. The 64 KiB envelope condition and `protocol.cjs`'s `maxRequestBytes` refusal ceiling (1 MiB) are different layers and do not disagree — what they now share is how a byte is counted.

## rf2-6r9j.72 — three streaming selectors, one consumer

`src/http.cjs` chose streaming three ways: `?stream=1`, an undocumented `x-rf-ssr-stream: 1` request header, and a `streamingDefault` serve option whose only escape was `?stream=0`. A whole-repository census (line-oriented and whitespace-flattened, fixed-string, with `?stream=1` as a control that fired at both its known sites) found the header at that one branch and `streamingDefault` only in the `handleRender`/`serve` plumbing that passes it to itself. No CLI flag, README contract, test, JVM adapter, example or build wiring set either.

Buffered is now the default and `?stream=1` the opt-in. The `?stream=0` branch goes with the option it existed for; it was reachable only when that option was on. A new `bytes.test.cjs` row sends the retired header and requires a buffered response — same bytes, and a `content-length` a streamed response cannot carry.

## rf2-6r9j.73 — optional-call guards below the declared floor

`engines.node >= 24`, re-verified at this tip. `Timeout.unref()` has existed since Node v0.9.1 and `http.Server.closeAllConnections()` since v18.2.0, and both are present on the v24.13.0 running these gates. The four optional calls are now direct. Calls and ordering unchanged; only branches that could never be taken are gone. The floor is untouched and still pinned by `serve.test.cjs`.

## Quality gates

`implementation/ssr-node`'s own suite (`node test/run.cjs`) is the primary gate — this is CommonJS Node, not ClojureScript, and it needs no build and no `npm install`. Exit codes below are captured to a file on the runner's own command line, never read from a pipeline.

All figures below are from runs on the FINAL rebased base (`origin/main` at `646c56baa8`), re-run after the rebase because a pre-rebase green is evidence about a tree that no longer exists.

| Gate | Captured exit | Result |
|---|---|---|
| ssr-node suite (`node test/run.cjs`), baseline before any edit | **0** | 9 suites, 104 tests, 104 pass, 0 fail |
| ssr-node suite, all four beads in, post-rebase | **0** | 9 suites, **107 tests, 107 pass, 0 fail** |
| `sh scripts/test-fast-pr.sh`, post-rebase | **0** | `PASS fast PR spine` |
| `python scripts/check_readme_links.py --ci`, post-rebase | **0** | silent green |

**Which gate, and why.** This artefact is CommonJS Node with no build and no npm dependency, so most of this repo's usual gates would be a green that inspected nothing. `.github/scripts/report-changed-surfaces.sh`, given this diff's actual file list, arms exactly one surface — `ssr_node=true`, everything else false — and CI's `node-ssr-node` job runs `test:ssr-node`, which is `node ssr-node/test/run.cjs`: the same runner as the primary gate above. The fast-PR spine skipped the JVM and node tiers as unchanged surfaces and its **documentation tier did fire** for `implementation/ssr-node/README.md`.

`check_readme_links.py` is nominated by PATH, not by job name: `implementation/ssr-node/README.md` is outside `check_doc_slugs.py`'s roots, where that gate exits 0 on a broken link. Its silent green was not taken on faith — a broken target planted in that README returned **exit 1**, naming `implementation\ssr-node\README.md:200` and the missing file, so the gate demonstrably reaches it. `mkdocs build --strict` and `check_doc_slugs.py` are not gates for anything under `implementation/` and are not cited.

The three added rows are the `.71` byte-semantics row, the `.71` over-budget control, and the `.72` retired-header pin. `isolation.test.cjs` stays at 7 rows — `.70` was repaired in place, not added to.

### The repaired checks are load-bearing

A green suite is exactly the evidence that is *not* dispositive for `.70` and `.71`, so each repaired check was made to fail by breaking the behaviour it claims to protect. Every restore was verified by git blob hash against the committed object, not by reading a diff.

| Plant | Check | Captured exit | What it said |
|---|---|---|---|
| `.70` remove `mod.boot()` from `src/worker.cjs` | boot-once row | **1** | `the isolate must have booted the module exactly once` — actual `0`, expected `1`; 6 pass / 1 fail |
| `.70` call `mod.boot()` before every render | boot-once row | **1** | same row, `2 !== 1`; 6 pass / 1 fail |
| `.71` oversize the measured request's `runtime` | envelope precondition | **1** | `the sample request must sit inside the registered 65536-byte budget; it is 70155 bytes`; 5 pass / 1 fail |
| `.72` restore the `x-rf-ssr-stream` branch | retired-header pin | **1** | `the header must not have selected streaming — a streamed response carries no content-length`; 15 pass / 1 fail |

Each plant failed exactly one row — the repaired one — so none of them broke the file out from under its neighbours.

For `.71` the false-green is measured rather than argued. On the very request the repaired precondition refuses at **70155 bytes**, the pre-repair formula (two state values, no keys, no `runtime`) computes **124 bytes** and admits it.
