### PR TITLE
refactor(resources): retire four zero-consumer vestiges (rf2-6r9j.57/.58/.60/.61)

### DIFF
--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -317,8 +317,9 @@
 ;; sentinel) + its `:revision` at apply time, applies the forward patch
 ;; (`mstate/apply-optimistic-patch`, which bumps the entry's `:revision`), and
 ;; records the inverse on the instance row's `:patch-summary` `:rollback` slot.
-;; The SETTLE slice (next) consumes that recorded inverse + slice-1's
-;; `state/revision-conflict?` to commit / rollback / reconcile.
+;; The SETTLE slice (next) consumes that recorded inverse +
+;; `mstate/optimistic-conflict?` (the recorded POST-apply `:applied-revision`)
+;; to commit / rollback / reconcile.
 ;;
 ;; `:optimistic` is the EXACT-target twin of `:patches` (the same map-form
 ;; targets, the same `resolve-exact-target-scope` + `validate-target-map!`
@@ -532,9 +533,9 @@
 ;; ---- the settle protocol (phase 4) — commit / rollback / reconcile --------
 ;;
 ;; The SETTLE slice (EP-0019 Decision 3) consumes the recorded inverse on the
-;; instance row's `:patch-summary` `:rollback` slot + slice-1's
-;; `state/revision-conflict?` to deterministically dispose each optimistic apply
-;; when its mutation reply settles:
+;; instance row's `:patch-summary` `:rollback` slot + `mstate/optimistic-conflict?`
+;; (the recorded POST-apply `:applied-revision`) to deterministically dispose
+;; each optimistic apply when its mutation reply settles:
 ;;
 ;;   - SUCCESS (`:rf.mutation/optimistic-reconciled`) — the authoritative
 ;;     `:populates` / `:patches` overwrite the optimistic value; the recorded

--- a/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
@@ -445,8 +445,10 @@
 ;; ---- the settle protocol (phase 4) — commit / rollback / reconcile ---------
 ;;
 ;; The SETTLE slice (EP-0019 Decision 3) consumes the recorded inverse +
-;; slice-1's `state/revision-conflict?` to decide, per touched entry, the
-;; deterministic terminal disposition of an optimistic apply:
+;; `optimistic-conflict?` (below — the entry's current `:revision` against the
+;; recorded POST-apply `:applied-revision`, so the apply's own bump is not a
+;; conflict) to decide, per touched entry, the deterministic terminal
+;; disposition of an optimistic apply:
 ;;
 ;;   - on mutation SUCCESS  -> COMMIT (the optimistic value is overwritten by
 ;;     the authoritative `:populates` / `:patches`; the recorded inverse is

--- a/implementation/resources/src/re_frame/resources/route.cljc
+++ b/implementation/resources/src/re_frame/resources/route.cljc
@@ -173,13 +173,6 @@
   []
   [routing-key :resource-plan])
 
-(defn plan-identities
-  "The scoped resource identities the plan for `nav-token` owned, read from
-  `runtime-db` as `{<key-id> <scoped-key>}` (`{}` when none). The plan-diff's
-  PREVIOUS-identity input."
-  [runtime-db nav-token]
-  (or (get-in runtime-db (plan-path nav-token)) {}))
-
 (defn clear-plan-slot
   "Pure: dissoc the ENTIRE plan-identity slot for a superseded `nav-token`.
   Returns the updated runtime-db (a no-op when no slot exists). Cleared

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -171,13 +171,6 @@
 ;; in. They allocate plain EDN — no host handles, which live OUTSIDE
 ;; durable frame-state in side tables keyed by `[frame-id work-id]`.
 
-(def lifecycle-states
-  "The five resource lifecycle FSM states (cache-entry status). The
-  transition function over these states lives in the runtime; the closed
-  set is pinned here so siblings agree on it. Per
-  Spec 016 §Lifecycle is an FSM."
-  #{:idle :loading :fetching :loaded :error})
-
 (def terminal-work-statuses
   "The terminal work-ledger statuses an attempt may reach. Terminal rows
   are pruned on the linked entry's next successful transition (a small
@@ -211,8 +204,9 @@
    ;; false-conflict on every in-flight refetch, before any authoritative write
    ;; lands. `:revision` moves only when an authoritative write actually
    ;; SETTLES the entry. It is the substrate the EP-0019 optimistic-rollback
-   ;; settle protocol compares against (`revision-conflict?`) to decide whether
-   ;; a recorded inverse is still a truthful "before" or has been overtaken.
+   ;; settle protocol compares against (`mutation-runtime/optimistic-conflict?`,
+   ;; against the post-apply `:applied-revision`) to decide whether a recorded
+   ;; inverse is still a truthful "before" or has been overtaken.
    ;; Base value 0. Per Spec 016 §Status semantics / EP-0019 §Decision 2.
    :revision       0
    :request-id     nil
@@ -812,27 +806,10 @@
   "Pure: read an entry's per-entry `:revision` write identity, defaulting to 0
   for an absent / nil entry or a pre-EP-0019 entry that predates the fact. The
   value the optimistic-rollback settle protocol records at apply time and
-  compares at settle time (`revision-conflict?`). Per EP-0019 §Decision 2."
+  compares at settle time (`mutation-runtime/optimistic-conflict?`, against the
+  post-apply `:applied-revision`). Per EP-0019 §Decision 2."
   [entry]
   (if entry (:revision entry 0) 0))
-
-(defn revision-conflict?
-  "Pure: the EP-0019 settle-time conflict check (Decision 3). True iff the
-  entry's CURRENT revision has MOVED away from the `recorded-revision` an
-  optimistic apply observed — i.e. an authoritative durable write landed on the
-  entry between the apply and the reply settling, so the recorded inverse is a
-  stale \"before\" a blind rollback must NOT restore. A canonical-identity
-  comparison (`not=` over the monotone counter), never a value diff.
-
-  Conflict-positive (`true`) is the BIAS-SAFE answer: on a true conflict the
-  settle reconciles by invalidation (the read path recovers authoritative
-  truth); a false positive costs only a refetch, while a false negative would
-  let a stale inverse clobber newer truth. The recorded revision is read
-  through `entry-revision` semantics (an absent recorded value, e.g. an apply
-  against a then-missing entry whose revision was 0, compares against the
-  current entry's revision the same way). Per EP-0019 §Decision 3."
-  [entry recorded-revision]
-  (not= (entry-revision entry) (or recorded-revision 0)))
 
 (defn entry-invalidate
   "Pure: mark `entry` durably STALE (set the `:invalidated-at` fact to

--- a/implementation/resources/src/re_frame/resources/work_ledger.cljc
+++ b/implementation/resources/src/re_frame/resources/work_ledger.cljc
@@ -413,7 +413,8 @@
 ;; `prune-terminal-for-key` self-heals by rebuilding the whole index when it
 ;; finds the ledger populated but the index absent (the post-hydration shape),
 ;; so no SSR / restore install site has to thread it. Maintained incrementally
-;; on the live path by `put-record` (add) / `prune-record` + the prune (remove).
+;; on the live path by `put-record` (add) and `prune-terminal-for-key`, which
+;; drops a whole batch of terminal rows and updates the bucket in bulk (remove).
 
 (def work-ledger-by-key-key
   "Reserved runtime-db key for the work-ledger's resource-key → work-id-id
@@ -453,18 +454,6 @@
   [runtime-db rk-id work-id-id*]
   (if (index-present? runtime-db)
     (update-in runtime-db [work-ledger-by-key-key rk-id] (fnil conj #{}) work-id-id*)
-    runtime-db))
-
-(defn- index-remove
-  "Remove `work-id-id` from its `rk-id` bucket in the inverse index, dropping an
-  emptied bucket entirely (the recompute shape never leaves empty buckets) —
-  ONLY when the index already exists. Pure."
-  [runtime-db rk-id work-id-id*]
-  (if (index-present? runtime-db)
-    (let [s (disj (get-in runtime-db [work-ledger-by-key-key rk-id] #{}) work-id-id*)]
-      (if (seq s)
-        (assoc-in runtime-db [work-ledger-by-key-key rk-id] s)
-        (update runtime-db work-ledger-by-key-key dissoc rk-id)))
     runtime-db))
 
 (defn put-record
@@ -513,18 +502,6 @@
     (apply update-in runtime-db (record-path work-id) f args)
     runtime-db))
 
-(defn prune-record
-  "Remove the work record under `work-id` from `runtime-db`, and drop it from
-  the resource-key inverse index (rf2-wyan7e). Used when a terminal row is
-  pruned on the linked entry's next successful transition (Spec 016 §Ledger row
-  retention and identity). No-op for the index when no record exists. Returns
-  the updated runtime-db."
-  [runtime-db work-id]
-  (let [wid-id (work-id-id work-id)
-        record (get-in runtime-db [:rf.runtime/work-ledger wid-id])]
-    (cond-> (update runtime-db :rf.runtime/work-ledger dissoc wid-id)
-      record (index-remove (state/key-id (:resource/key record)) wid-id))))
-
 (defn update-record-by-id
   "Apply `f` (and `args`) to the work record under an ALREADY-COMPUTED byte
   `work-id-id` (a ledger map key from a `(map key)` ledger scan) in
@@ -559,7 +536,8 @@
    ;; rf2-wyan7e — self-heal: a wholesale-installed ledger (hydration /
    ;; restore) arrives with NO inverse index (it is a derived projection, never
    ;; trusted from the wire). Rebuild it ONCE here so the per-key visit below is
-   ;; bounded; live operation keeps it in step via put-record / prune-record.
+   ;; bounded; live operation keeps it in step via put-record and this prune's
+   ;; own bulk bucket update below.
    ;; A ledger present but index absent is exactly the post-install shape.
    (let [ledger (:rf.runtime/work-ledger runtime-db)
          runtime-db (if (and (seq ledger)

--- a/implementation/resources/test/re_frame/resources_optimistic_settle_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_optimistic_settle_cljs_test.cljc
@@ -3,8 +3,9 @@
   the `:on-conflict` conflict rule.
 
   Execute applies the forward patch and records a truthful snapshot inverse on
-  the instance row. Settlement consumes that inverse and `revision-conflict?`
-  to deterministically dispose each optimistic apply:
+  the instance row. Settlement consumes that inverse and `optimistic-conflict?`
+  (the entry's current `:revision` against the recorded post-apply
+  `:applied-revision`) to deterministically dispose each optimistic apply:
 
     1. SUCCESS-COMMIT — an accepted `:ok` reply settles the optimistic value
        authoritatively (`:populates` / `:patches` overwrite it); the recorded

--- a/implementation/resources/test/re_frame/resources_revision_substrate_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_revision_substrate_cljs_test.cljc
@@ -5,8 +5,9 @@
 
   `:revision` is the per-entry WRITE identity: a monotone counter bumped on
   EVERY authoritative durable entry write a rollback could clobber, and the
-  basis of the settle-time conflict check (`state/revision-conflict?`). These
-  JVM+CLJS unit tests pin the substrate contract the later slices depend on:
+  basis of the settle-time conflict check
+  (`mutation-runtime/optimistic-conflict?`). These JVM+CLJS unit tests pin the
+  substrate contract the later slices depend on:
 
     1. SHAPE — `empty-entry` carries `:revision 0`, DISTINCT from `:generation`;
     2. DISTINCT FROM `:generation` — `entry-start-load` bumps `:generation`
@@ -15,8 +16,11 @@
     3. UNCONDITIONAL BUMP — `entry-succeeded` / `patch-entry` / `populate-entry`
        bump `:revision` even when `:data` is `=`-shared (the freshness-only
        settle the ruling names — a value-gated token would MISS it);
-    4. CONFLICT COMPARISON — `revision-conflict?` is false when the recorded
-       revision matches and TRUE when a competing authoritative write moved it.
+    4. CONFLICT COMPARISON — `optimistic-conflict?` is false when the entry
+       still stands at the recorded post-apply `:applied-revision` and TRUE when
+       a competing authoritative write moved it; the `:removed` sentinel branch
+       treats a still-absent entry as unmoved and a re-created one as a
+       conflict.
 
   PURE — the substrate is the pure transition functions in `re-frame.resources
   .state` + `re-frame.resources.mutation-runtime`; CLJC so the load-bearing JVM
@@ -179,7 +183,7 @@
         (is (= (inc rec-rev) (:revision settled))
             "the failure settle moved the write identity past the snapshot's"))
       (testing "so the optimistic-rollback conflict check now DETECTS the move"
-        (is (true? (state/revision-conflict? settled rec-rev))
+        (is (true? (mut-rt/optimistic-conflict? settled rec-rev))
             "a snapshot recorded at the in-flight revision sees the settle as a
              conflict — the rollback will NOT resurrect the stale :before")))))
 
@@ -197,7 +201,7 @@
       (is (nil? (:current-work settled)))
       (is (= (inc rec-rev) (:revision settled))
           ":revision moved on the first-load failure settle")
-      (is (true? (state/revision-conflict? settled rec-rev))
+      (is (true? (mut-rt/optimistic-conflict? settled rec-rev))
           "the conflict check sees the settle"))))
 
 (deftest entry-page-failed-bumps-revision-on-a-load-more-failure
@@ -216,7 +220,7 @@
       (is (nil? (:current-work settled)) ":current-work cleared")
       (is (= (inc rec-rev) (:revision settled))
           "the page-failure settle moved :revision (the rf2-mx0w2o fix)")
-      (is (true? (state/revision-conflict? settled rec-rev))
+      (is (true? (mut-rt/optimistic-conflict? settled rec-rev))
           "the conflict check sees the load-more failure settle"))))
 
 (deftest optimistic-rollback-does-not-resurrect-a-settled-in-flight-snapshot
@@ -272,34 +276,56 @@
 
 ;; ---- the canonical-identity conflict comparison ---------------------------
 
-(deftest revision-conflict-detects-a-competing-authoritative-write
-  (testing "no conflict when the recorded revision matches the current one"
-    (let [loaded (-> (state/empty-entry :conduit/article)
-                     (state/entry-succeeded {:data {:n 1} :loaded-at 1
-                                             :stale-at 2 :tags #{}}))
-          rec    (state/entry-revision loaded)]
-      (is (false? (state/revision-conflict? loaded rec))
-          "an entry that has NOT been written since the apply is conflict-free")))
-  (testing "CONFLICT when a competing authoritative write moved the revision
-            between the recorded apply and the settle"
+(deftest optimistic-conflict-detects-a-competing-authoritative-write
+  (testing "the apply's OWN bump is NOT a conflict: the baseline is the
+            POST-apply :applied-revision, so an entry still standing where the
+            apply left it is conflict-free"
+    (let [sk       (state/scoped-resource-key :rf.scope/global :conduit/article {:slug "a"})
+          loaded   (-> (state/empty-entry :conduit/article sk)
+                       (state/entry-succeeded {:data {:n 1} :loaded-at 1
+                                               :stale-at 2 :tags #{}}))
+          observed (state/entry-revision loaded)
+          applied  (mut-rt/apply-optimistic-patch
+                     loaded (fn [d] (assoc d :n 99)) :conduit/article
+                     {:clock-ms 5 :stale-at 9 :scoped-key sk})
+          recorded (mut-rt/record-optimistic-entry
+                     sk loaded :patch observed (state/entry-revision applied))]
+      (is (= (inc observed) (:applied-revision recorded))
+          "the apply left the entry one bump past what it observed")
+      (is (false? (mut-rt/optimistic-conflict? applied (:applied-revision recorded)))
+          "the apply's own numeric bump is expected — NOT a conflict")))
+  (testing "CONFLICT when a competing authoritative write moves the entry BEYOND
+            the applied baseline between the apply and the settle"
     (let [loaded   (-> (state/empty-entry :conduit/article)
                        (state/entry-succeeded {:data {:n 1} :loaded-at 1
                                                :stale-at 2 :tags #{}}))
-          recorded (state/entry-revision loaded)         ;; observed at apply time
+          applied-revision (state/entry-revision loaded)
           ;; a competing write lands (a refetch returning equal data — still an
           ;; authoritative freshness settle that bumps :revision):
           competed (state/entry-succeeded
                      loaded {:data {:n 1} :loaded-at 500 :stale-at 600 :tags #{}})]
-      (is (= (inc recorded) (state/entry-revision competed)))
-      (is (true? (state/revision-conflict? competed recorded))
+      (is (= (inc applied-revision) (state/entry-revision competed)))
+      (is (true? (mut-rt/optimistic-conflict? competed applied-revision))
           "the moved revision is detected as a conflict — the recorded inverse
            is now a stale `before` the settle must NOT blindly restore")))
-  (testing "the comparison is canonical-identity over the counter, not a value
-            diff: a recorded nil compares as 0"
-    (is (false? (state/revision-conflict? {:revision 0} nil))
-        "recorded nil ~ 0 vs current 0 — no conflict")
-    (is (true? (state/revision-conflict? {:revision 1} nil))
-        "recorded nil ~ 0 vs current 1 — conflict")))
+  (testing "the REMOVE branch (`applied-removed-revision` sentinel): a
+            still-absent entry is UNMOVED, a re-created one is a conflict"
+    (let [removed-baseline (:applied-revision
+                             (mut-rt/record-optimistic-entry
+                               (state/scoped-resource-key
+                                 :rf.scope/global :conduit/article {:slug "r"})
+                               mut-rt/absent-snapshot :remove))]
+      (is (false? (mut-rt/optimistic-conflict? nil removed-baseline))
+          "absent-after-remove — the remove stands, no conflict")
+      (is (true? (mut-rt/optimistic-conflict?
+                   (state/empty-entry :conduit/article) removed-baseline))
+          "re-created-after-remove — a competing write seeded the removed key")))
+  (testing "the comparison is canonical-identity over the monotone counter, not
+            a value diff: an absent entry reads as revision 0"
+    (is (false? (mut-rt/optimistic-conflict? nil 0))
+        "absent entry ~ 0 vs applied 0 — no conflict")
+    (is (true? (mut-rt/optimistic-conflict? {:revision 1} 0))
+        "current 1 vs applied 0 — conflict")))
 
 ;; ---- owner-liveness writes: the NO-OP GATE (rf2-k49jec / rf2-cxwuhl) --------
 ;;
@@ -382,7 +408,7 @@
           re-ens   (state/attach-owner attached :owner/a)]   ;; a re-ensure re-attaches
       (is (= recorded (state/entry-revision re-ens))
           "the no-op re-attach did not move the write identity")
-      (is (false? (state/revision-conflict? re-ens recorded))
+      (is (false? (mut-rt/optimistic-conflict? re-ens recorded))
           "so the settle conflict check sees NO conflict — the gate prevents the
            phantom conflict that an unconditional bump would manufacture")))
   (testing "conversely a GENUINE mid-flight owner change DOES bump, so it is
@@ -395,7 +421,7 @@
           changed  (state/attach-owner attached :owner/b)]
       (is (= (inc recorded) (state/entry-revision changed))
           "the genuine new-owner attach bumped past the snapshot")
-      (is (true? (state/revision-conflict? changed recorded))
+      (is (true? (mut-rt/optimistic-conflict? changed recorded))
           "so the settle detects the conflict and :invalidates rather than
            blindly restoring the stale :before (which would DROP the new owner)"))
     (testing "and the RELEASE side is symmetric — a present-owner release bumps
@@ -407,5 +433,5 @@
             released (state/detach-owner with-two :owner/a)]
         (is (= (inc recorded) (state/entry-revision released))
             "the present-owner release bumped past the snapshot")
-        (is (true? (state/revision-conflict? released recorded))
+        (is (true? (mut-rt/optimistic-conflict? released recorded))
             "so a rollback will NOT resurrect the departed owner")))))

--- a/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
@@ -812,8 +812,8 @@
 
 (deftest ledger-inverse-index-equals-full-rebuild-under-random-mutation
   (testing "rf2-wyan7e — across a randomised sequence of put-record /
-            prune-record / prune-terminal-for-key ops, the incrementally
-            maintained inverse index equals a full rebuild after EVERY op"
+            prune-terminal-for-key ops, the incrementally maintained inverse
+            index equals a full rebuild after EVERY op"
     (let [seed    (atom 88172645)
           nextint (fn [n]
                     (let [x (-> (* @seed 1103515245) (+ 12345) (bit-and 0x7fffffff))]
@@ -826,7 +826,7 @@
       (loop [step 0, rdb start, gen 0]
         (if (= step 500)
           (is true "500 randomised ledger ops stayed in lock-step with the rebuild")
-          (let [op  (nextint 3)
+          (let [op  (nextint 2)
                 k   (nth keys' (nextint (count keys')))
                 rdb' (case op
                        ;; put a fresh record
@@ -837,10 +837,7 @@
                                              (nextint 1000))]
                            (work-ledger/put-record rdb [:rf.work/resource k g] r))
                        ;; prune one terminal tail for the key
-                       1 (work-ledger/prune-terminal-for-key rdb k (nextint 3))
-                       ;; prune a specific record (if any exist for the key)
-                       2 (let [g (inc (nextint (inc gen)))]
-                           (work-ledger/prune-record rdb [:rf.work/resource k g])))
+                       1 (work-ledger/prune-terminal-for-key rdb k (nextint 3)))
                 full (-> rdb' work-ledger/recompute-ledger-index
                          :rf.runtime/work-ledger-by-key)]
             (is (= full (:rf.runtime/work-ledger-by-key rdb'))


### PR DESCRIPTION
Four vestige removals in the resources artefact, clustered because they share one artefact and two of them edit the same file (`state.cljc`).

Every one of these beads rested on an "exact repository search finds no caller" claim. Each was re-verified here by **two independent instruments, each with a live control that fired**, before anything was deleted.

## Reachability census

Roster: 4818 tracked files, `.beads/issues.jsonl` and `.beads/metadata.json` excluded (whole-database exports match almost any identifier).

Instrument A — fixed-string census, run twice per symbol: line-oriented, and again over whitespace-stripped file content (neither is a superset of the other; the second catches a name broken across lines). `-F` never combined with `-i`.

Instrument B — `clj-kondo` var-usage analysis over `implementation/` + `tools/`, a semantic instrument rather than a textual one.

| symbol | definition | usages found | verdict |
|---|---|---|---|
| `state/lifecycle-states` | state.cljc | **none at all** | unreachable |
| `state/revision-conflict?` | state.cljc | test ns only (10 call sites) | no production caller |
| `route/plan-identities` | route.cljc | **none at all** | unreachable |
| `work-ledger/prune-record` | work_ledger.cljc | test ns only (1 call site) | no production caller |
| `work-ledger/index-remove` (private) | work_ledger.cljc | `prune-record` only | cascades with it |

Controls, chosen as live exported vars in the same namespaces, all fired in both instruments: `entry-revision` (4 namespaces, incl. production `mutation-runtime`), `terminal-work-statuses` (6 files, incl. production `work_ledger`), `put-record` (6 namespaces, incl. production `events` / `mutation-events`), `plan-path`, `optimistic-conflict?` (production `mutation-runtime`).

The census was re-run after the rebase and still holds; the controls fired again.

All four premises **hold**.

## What was removed

- **rf2-6r9j.58 — `lifecycle-states`.** Zero usages of any kind. Its docstring claimed the closed set was pinned "so siblings agree on it"; no sibling ever read it, so adding or removing a lifecycle state could leave the claim stale with nothing failing. The five shipped states and their transitions are untouched.
- **rf2-6r9j.61 — `revision-conflict?`.** Zero production callers. Production optimistic settlement uses `mutation-runtime/optimistic-conflict?`, which compares against the POST-apply `:applied-revision` (so the apply's own bump is not a conflict) and handles the `:removed` sentinel. Comments in `mutation_runtime`, `mutation_events` and `state` named the superseded helper as the live authority; they now name the live rule.
- **rf2-6r9j.57 — `plan-identities`.** Zero usages of any kind. Both live plan-diff consumers read the slot path directly, which is what keeps routing free of a static dependency on the optional resources artefact. `plan-path`, `plan-slots-map-path` and `clear-plan-slot` retained per the ruling.
- **rf2-6r9j.60 — `prune-record`.** Zero production callers; the live operation is the indexed batch `prune-terminal-for-key`. Removing it orphaned the private `index-remove`, whose only caller it was, so that goes too. Comments claiming the index is maintained via `prune-record` now describe the actual batch path.

## Test handling

A test whose only subject was a removed symbol goes with it; a test merely **using** one as an assertion instrument is re-pointed at the live predicate rather than dropped. Six such instrument sites were re-pointed to `optimistic-conflict?`. The recorded baseline at each is numeric, where the two predicates are the identical `not=` over the monotone counter, so the re-point is semantically exact.

Two guarantees were checked against the live path rather than silently dropped:

- The deftest whose subject was `revision-conflict?` is re-aimed at `optimistic-conflict?`. It now also covers the `:removed` sentinel branch — absent-after-remove is not a conflict, re-created-after-remove is — which **no test exercised before** (`applied-removed-revision` and `absent-snapshot` appeared in no test file at all). This closes the one genuine gap against the bead's acceptance criteria; the `:invalidate` and `:force` dispositions they also name were already covered end-to-end in `resources_optimistic_settle_cljs_test`.
- `prune-record`'s only executable consumer was one operation in a randomised 500-op property test asserting the incrementally-maintained inverse index equals a full rebuild after every op. That property is retained over the remaining two operations; the batch prune's own index maintenance, tail retention, empty-bucket cleanup and index self-heal keep their dedicated tests.

## Quality gates

Every exit code below is the runner's own, captured to a file with `echo $? > …` on the same command line and quoted from that file. Nothing is piped through a filter.

| gate | captured exit | result |
|---|---|---|
| `clj-kondo` BEFORE — `resources/src` + `resources/test`, `--cache false` | 2 | **0 errors, 31 warnings** |
| `clj-kondo` AFTER (post-rebase), same scope + flags | 2 | **0 errors, 31 warnings — warning set identical to BEFORE** once line numbers are normalised; no new warning, and no orphaned `index-remove` |
| resources JVM suite — `clojure -M:test` in `implementation/resources` | 0 | **829 tests, 7479 assertions, 0 failures, 0 errors** |
| gate-liveness plant (see below) | 1 | red named the planted line |
| `npm run test:cljs` (`:node-test`) from `implementation` | 0 | **11209 tests, 55852 assertions, 0 failures, 0 errors** |
| `sh scripts/test-fast-pr.sh` | 0 | 68 tiers; aggregates core **2176/11149**, resources **829/7479**, node-test **11209/55852**; 0 FAIL/ERROR |
| `python scripts/check_fast_pr_gap.py --brief` | 0 | enumerated the 97 required checks the spine does not decide |

**Gate liveness was proved, not assumed.** A single-line fault was planted in a line this PR edits — flipping `(is (false? …))` to `(is (true? …))` on the new absent-after-remove assertion. The anchor was confirmed to match exactly one line before the edit. The resources JVM suite then returned **captured exit 1**, naming the planted file, the planted line (318), the enclosing deftest and the exact assertion. The fault was reverted and the restore verified by comparing `git hash-object --path` against `git rev-parse HEAD:<path>` — matching blobs — rather than by reading a diff, since line endings are translated on this machine.

**Scope note on `clj-kondo`.** The local binary is v2025.10.23 while CI pins 2026.04.15, so the local numbers above are a valid before/after delta on one binary and are **not** a claim about the CI lint gate. The spine invokes the pinned 2026.04.15 build itself, and that run reported `errors: 0` at `--fail-level error`.

The suite runs were captured on the pre-rebase base; after rebasing, the census and `clj-kondo` were re-run (both unchanged) and CI re-ran the full rollup on the final tree.
