### PR TITLE
Retire four vestiges: the retained streaming Hiccup tree, the unreachable decode fallback, three inert privacy arguments, the orphaned direct projector (rf2-6r9j.42/.39/.40/.41)

### DIFF
--- a/implementation/http/src/re_frame/http/decode.cljc
+++ b/implementation/http/src/re_frame/http/decode.cljc
@@ -302,7 +302,7 @@
       ;; parsing is attempted). Any throw propagates untouched to
       ;; the transport's decode try/catch, which classifies it as
       ;; `:rf.http/decode-failure`.
-      (some? resolved)
+      :else
       ;; The schema decode path is JSON-only: the only
       ;; Malli transformer the decoder wires is the `json-transformer`,
       ;; so a schema rides a JSON body by construction (Spec 014
@@ -334,7 +334,4 @@
         (let [parsed (if (empty-2xx-json-body? body-text)
                        nil
                        (http-json/json-parse body-text parse-opts))]
-          (malli-decode resolved parsed)))
-
-      :else
-      body-text)))
+          (malli-decode resolved parsed))))))

--- a/implementation/http/src/re_frame/http/handlers.cljc
+++ b/implementation/http/src/re_frame/http/handlers.cljc
@@ -224,7 +224,7 @@
         ;; :sensitive? was removed per rf2-hjs2d). The flag rides every
         ;; :rf.http/* trace event emitted within the cascade so
         ;; consumers honour the privacy contract per Spec 009 §Privacy.
-        sensitive?   (privacy/request-sensitive? args-map origin-event)
+        sensitive?   (privacy/request-sensitive? args-map)
         ;; rf2-wu1n5 — keyword-interning DoS guard. The reserved
         ;; `:rf.http/max-decoded-keys` arg overrides the JSON reader's
         ;; default cap on unique decoded object keys. Absent → reader
@@ -330,7 +330,7 @@
         ;; CLJS-only-key warning and `normalise-args` run. The chain
         ;; itself recomputes per-interceptor for its own failure-path
         ;; trace (see `run-chain*` / `run-interceptor-chain!`).
-        sensitive?   (privacy/request-sensitive? args-map origin-event)
+        sensitive?   (privacy/request-sensitive? args-map)
         ctx0         {:request    (:request args-map)
                       :args       args-map
                       :frame      frame-id
@@ -360,14 +360,14 @@
         ;; Recomputing here closes both: the warning fires on the request
         ;; the transport will actually issue, redacted by the effective
         ;; sensitivity.
-        sensitive?'  (privacy/request-sensitive? args-map' origin-event)
+        sensitive?'  (privacy/request-sensitive? args-map')
         ;; rf2-hp772l — `check-cljs-only-keys!` is JVM per-row degradation
         ;; tracing (a no-op on CLJS), owned by the JVM platform adapter.
         ;; The frame is threaded for the warning-path trace stamp; HTTP carrier
         ;; redaction is now process-global (resolved from the :rf.http/managed
         ;; `:carriers` registration, EP-0025), so it no longer depends on the
         ;; emitting frame.
-        _            (transport-jvm/check-cljs-only-keys! args-map' sensitive?' frame-id)
+        _            (transport-jvm/check-cljs-only-keys! args-map' sensitive?')
         ;; rf2-uheqq — carry the post-:before middleware-ctx forward so
         ;; the response-side `:after` chain sees the EXACT same ctx its
         ;; sibling `:before`s ended with. Per Spec 014 §Middleware: a

--- a/implementation/http/src/re_frame/http/middleware.cljc
+++ b/implementation/http/src/re_frame/http/middleware.cljc
@@ -388,12 +388,7 @@
                   (trace/emit-error! :rf.error/http-interceptor-failed
                                      (privacy/prepare-emit-failure
                                        (ex-data data)
-                                       (sensitive-of acc)
-                                       ;; rf2-ppkh3v — the frame whose
-                                       ;; interceptor chain is running, so the
-                                       ;; URL redaction consults its frame-local
-                                       ;; HTTP carriers (EP-0015 §3).
-                                       {:frame frame-id})))
+                                       (sensitive-of acc))))
                 (throw data))))
           acc)))
     init

--- a/implementation/http/src/re_frame/http/privacy.cljc
+++ b/implementation/http/src/re_frame/http/privacy.cljc
@@ -443,7 +443,7 @@
 
   Handler registration metadata is not consulted; request sensitivity is a
   per-call decision."
-  [args-map _origin-event]
+  [args-map]
   (or (true? (:sensitive? args-map))
       (true? (get-in args-map [:request :sensitive?]))))
 
@@ -473,7 +473,7 @@
   [args]
   (if-not (map? args)
     args
-    (let [sensitive?   (request-sensitive? args nil)
+    (let [sensitive?   (request-sensitive? args)
           carriers     (managed-carriers)
           redact-event (or (late-bind/get-fn :classification/redact-event-by-registration)
                            identity)
@@ -512,21 +512,19 @@
   the `:rf.http/managed` `reg-fx` registration (`:carriers` block); they
   are resolved ONCE here (`managed-carriers`) and threaded to the header /
   URL redactors so app-specific carriers redact alongside the built-in
-  defaults. Carriers are process-global, so the optional third arg (kept
-  for call-site compatibility — callers still pass `{:frame …}`) no longer
-  drives carrier resolution. No app `:carriers` block → built-in defaults
-  only."
-  ([tags sensitive?] (prepare-emit-tags tags sensitive? nil))
-  ([tags sensitive? _opts]
-   (let [s?                          (true? sensitive?)
-         carriers                    (managed-carriers)
-         [tags' tag-url-hit?]        (redact-request-tags-with-flag tags s? carriers)
-         [tags'' fail-url-hit?]      (if (contains? tags :failure)
-                                       (let [[f' h?] (redact-failure-with-flag (:failure tags) s? carriers)]
-                                         [(assoc tags' :failure f') h?])
-                                       [tags' false])
-         stamp?                      (or s? tag-url-hit? fail-url-hit?)]
-     (stamp-sensitive tags'' stamp?))))
+  defaults. Carriers are process-global — carrier resolution reads the
+  registration, never frame attribution. No app `:carriers` block →
+  built-in defaults only."
+  [tags sensitive?]
+  (let [s?                          (true? sensitive?)
+        carriers                    (managed-carriers)
+        [tags' tag-url-hit?]        (redact-request-tags-with-flag tags s? carriers)
+        [tags'' fail-url-hit?]      (if (contains? tags :failure)
+                                      (let [[f' h?] (redact-failure-with-flag (:failure tags) s? carriers)]
+                                        [(assoc tags' :failure f') h?])
+                                      [tags' false])
+        stamp?                      (or s? tag-url-hit? fail-url-hit?)]
+    (stamp-sensitive tags'' stamp?)))
 
 (defn prepare-emit-failure
   "Compose `redact-failure` + `stamp-sensitive` for an error-side trace
@@ -544,14 +542,13 @@
   App-declared carrier extension sets ride
   the `:rf.http/managed` `reg-fx` registration (`:carriers` block), resolved
   once (`managed-carriers`) and threaded to the header / URL redactors.
-  Carriers are process-global, so the optional third arg (kept for call-site
-  compatibility — callers still pass `{:frame …}`) no longer drives carrier
-  resolution. No app `:carriers` block → built-in defaults only."
-  ([failure sensitive?] (prepare-emit-failure failure sensitive? nil))
-  ([failure sensitive? _opts]
-   (let [s?                  (true? sensitive?)
-         carriers            (managed-carriers)
-         [failure' url-hit?] (redact-failure-with-flag failure s? carriers)
-         stamp?              (or s? url-hit?)]
-     (when failure'
-       (stamp-sensitive failure' stamp?)))))
+  Carriers are process-global — carrier resolution reads the registration,
+  never frame attribution. No app `:carriers` block → built-in defaults
+  only."
+  [failure sensitive?]
+  (let [s?                  (true? sensitive?)
+        carriers            (managed-carriers)
+        [failure' url-hit?] (redact-failure-with-flag failure s? carriers)
+        stamp?              (or s? url-hit?)]
+    (when failure'
+      (stamp-sensitive failure' stamp?))))

--- a/implementation/http/src/re_frame/http/privacy_body.cljc
+++ b/implementation/http/src/re_frame/http/privacy_body.cljc
@@ -64,10 +64,9 @@
 
   `classify-decoded` is the IN-PROCESS dev-trace projection — it applies the
   per-slot marks but does NOT omit an unschematized body (the local operator
-  inspects their own process). `off-box-classify-body` is the OFF-BOX egress
-  projection — an unschematized body is whole-sensitive and OMITTED, a schema
-  body rides classified. The HTTP trace-emit site stamps `off-box-body-
-  disposition` forward onto the `:rf.http/*` trace event (under
+  inspects their own process). Off-box, the emit site applies that SAME
+  on-box classification and then stamps `off-box-body-disposition`
+  forward onto the `:rf.http/*` trace event (under
   `:rf.http/off-box-body`); the off-box trace-events projector
   (`re-frame.epoch.tool-pair`) enforces it (omits an `:omit` event's body
   slot), since the request's `:decode` is request-private and never on the
@@ -216,31 +215,16 @@
      :large     (extract-paths :schemas/extract-large-paths-from-schema     decode)}
     {:sensitive {} :large {}}))
 
-(defn whole-body-sensitive-mark?
-  "True iff the `:decode` schema marks the WHOLE body (`[]`, the root prop)
-  `:sensitive?` — an opaque-token response whose entire body is the secret.
-  The fine-grained complement of the per-slot marks."
-  [decode]
-  (contains? (:sensitive (decode-schema-marks decode)) []))
-
 ;; ---------------------------------------------------------------------------
 ;; Off-box body disposition (EP-0015 issue 5, fail-closed rule).
 ;;
 ;; For an OFF-BOX egress (a production capture / off-box trace), a body rides
 ;; ONLY when its shape is schema-classified; an unschematized body is
-;; whole-sensitive and omitted. This is the disposition the off-box capture
-;; surface consults; the in-process dev trace uses `classify-decoded` (below)
-;; which applies the schema's per-slot marks without omitting an
-;; unschematized body the local operator is entitled to see.
+;; whole-sensitive and omitted. The emit site stamps this disposition forward
+;; and `re-frame.epoch.tool-pair` enforces it; the in-process dev trace uses
+;; `classify-decoded` (below), which applies the schema's per-slot marks
+;; without omitting an unschematized body the local operator may see.
 ;; ---------------------------------------------------------------------------
-
-(def ^:const off-box-body-marker
-  "The off-box sentinel an UNSCHEMATIZED body is replaced with when it would
-  otherwise ride off-box. The `:rf/redacted` sentinel — the same scalar the
-  rest of the egress projection (event args, runtime-db partition, sensitive
-  app-db slots) fails closed to. The omission is the disposition: the slot is
-  present but carries no body content."
-  :rf/redacted)
 
 (defn off-box-body-disposition
   "Classify how a decoded response body MAY ride an OFF-BOX egress, reading
@@ -248,7 +232,8 @@
 
     :classify  — the body has an INTROSPECTABLE Malli `:decode` schema (the
                  raw EDN VECTOR form); ride it with the schema's per-slot
-                 marks applied (`off-box-classify-body`);
+                 marks, which the emit site already applied on-box via
+                 `classify-decoded`;
     :omit      — the body is UNSCHEMATIZED (`:auto` / `:json` / `:text` /
                  binary / custom fn) OR carries an OPAQUE schema the walker
                  cannot inspect (a keyword registry ref / a compiled
@@ -273,9 +258,10 @@
 ;; ---------------------------------------------------------------------------
 ;; Apply the schema's per-slot marks to a decoded body value.
 ;;
-;; `classify-decoded` is the IN-PROCESS dev-trace projection (the local
-;; operator sees their own process); `off-box-classify-body` is the OFF-BOX
-;; egress projection (fail-closed for an unschematized body). Both delegate
+;; `classify-decoded` is applied by the emit site for BOTH the in-process dev
+;; trace and the on-box half of an off-box egress; the off-box fail-closed
+;; OMISSION rides the `off-box-body-disposition` stamp and is enforced by
+;; `re-frame.epoch.tool-pair`. It delegates
 ;; to the shared `re-frame.classification/redact-with-paths` walker (sensitive →
 ;; `:rf/redacted`, large → `:rf.size/large-elided`, sensitive wins over large)
 ;; — never a body-private walker.
@@ -305,30 +291,3 @@
     (if (or (seq sensitive) (seq large))
       (classification/redact-with-paths decoded (keys sensitive) (keys large))
       decoded)))
-
-(defn off-box-classify-body
-  "Project a decoded response body `decoded` for an OFF-BOX egress, reading
-  the request's `:decode` disposition (EP-0015 issue 5, fail-closed):
-
-    - UNSCHEMATIZED `:decode` (`:auto` / `:json` / `:text` / binary / custom
-      fn) OR an OPAQUE schema the walker cannot inspect (a keyword registry
-      ref `:my-app/token-schema` / a compiled `m/schema` object): the body is
-      whole-sensitive and OMITTED entirely — replaced with the
-      `off-box-body-marker` (`:rf/redacted`). The local operator's raw view
-      does NOT cross the trust boundary; an opaque ref whose marks the walker
-      cannot see fails CLOSED rather than riding unchanged (rf2-y1pgdl — the
-      EP-0015 issue 5 fail-open leak).
-
-    - INTROSPECTABLE Malli-SCHEMA `:decode` (the raw EDN VECTOR form): the
-      body rides CLASSIFIED — the per-slot `:sensitive?` / `:large?` marks
-      applied via `classify-decoded` (the same shared walker the dev trace
-      uses), letting the non-sensitive structure through while sensitive
-      slots redact and large slots elide.
-
-  This is the projection the off-box trace-events egress
-  (`re-frame.epoch.tool-pair`) applies to an `:rf.http/*` trace event's body
-  slot, gated on the disposition the emit site stamped forward. Pure."
-  [decoded decode]
-  (if (introspectable-schema-decode? decode)
-    (classify-decoded decoded decode)
-    off-box-body-marker))

--- a/implementation/http/src/re_frame/http/registry.cljc
+++ b/implementation/http/src/re_frame/http/registry.cljc
@@ -422,12 +422,7 @@
                          {:request-id (:request-id handle)
                           :actor-id   actor-id
                           :url        (:url handle)}
-                         (true? (:sensitive? handle))
-                         ;; The handle carries its originating frame for the
-                         ;; trace stamp; HTTP carrier redaction is process-global
-                         ;; now (the :rf.http/managed `:carriers` registration,
-                         ;; EP-0025), so it no longer depends on the frame.
-                         {:frame (:frame handle)})))
+                         (true? (:sensitive? handle)))))
         (try
           ((:abort-fn handle) :actor-destroyed)
           (catch #?(:clj Throwable :cljs :default) _ nil)))))

--- a/implementation/http/src/re_frame/http/test_support.cljc
+++ b/implementation/http/src/re_frame/http/test_support.cljc
@@ -90,7 +90,7 @@
                        (:frame frame-ctx) :rf.http/managed-canned
                        {:where 'rf.http/run-request-chain})
         origin-event (encoding/resolve-origin-event frame-ctx args-map)
-        sensitive?   (privacy/request-sensitive? args-map origin-event)
+        sensitive?   (privacy/request-sensitive? args-map)
         ctx0         {:request    (:request args-map)
                       :args       args-map
                       :frame      frame-id

--- a/implementation/http/src/re_frame/http/transport.cljc
+++ b/implementation/http/src/re_frame/http/transport.cljc
@@ -171,8 +171,7 @@
                                 "and is surfaced here rather than swallowed. Fix "
                                 "the `:after` interceptor or reply target so it "
                                 "does not throw (Spec 014 §Middleware §Failure mode).")}
-          (true? (:sensitive? ctx))
-          {:frame (:frame ctx)}))))
+          (true? (:sensitive? ctx))))))
   nil)
 
 (defn- dispatch-reply!
@@ -330,7 +329,7 @@
   Aborts (`:rf.http/aborted`, any reason) are EXCLUDED: a cancelled
   request that no longer wants its reply is correct-by-design silence,
   not a swallowed error."
-  [failure url sensitive? frame]
+  [failure url sensitive?]
   (when (and interop/debug-enabled?
              (not= :rf.http/aborted (:kind failure))
              (compare-and-set! failure-swallowed-warned? false true))
@@ -347,8 +346,7 @@
                                   "intentional (fire-and-forget telemetry), "
                                   "ignore this; otherwise supply an "
                                   "`:on-failure` or `:reply-to` target.")}
-                   (true? sensitive?)
-                   {:frame frame}))))
+                   (true? sensitive?)))))
 
 (defn- on-failure-silenced?
   "True when the ctx's failure reply has NO delivery target — `build-reply-
@@ -502,7 +500,7 @@
   `warn-failure-swallowed!` before the (no-op) dispatch."
   [ctx failure]
   (when (on-failure-silenced? ctx)
-    (warn-failure-swallowed! failure (:url ctx) (:sensitive? ctx) (:frame ctx)))
+    (warn-failure-swallowed! failure (:url ctx) (:sensitive? ctx)))
   (let [reply (http-reply/failure-reply (reply-ctx ctx) failure)]
     (emit-reply-trace! ctx reply)
     (dispatch-reply! (assoc ctx
@@ -623,8 +621,7 @@
                          (assoc failure
                                 :url      (:url ctx)
                                 :recovery :no-recovery)
-                         sensitive?
-                         {:frame (:frame ctx)})]
+                         sensitive?)]
         (trace/emit-error! :rf.http/aborted redacted)))
     ;; An abort is terminal for this request-id (this is the
     ;; direct abort-fn choke: user / actor-destroy / supersede / epoch-restore
@@ -738,8 +735,7 @@
                               :request-id (:request-id ctx)
                               :url        (:url ctx)
                               :recovery   :no-recovery)
-                       sensitive?
-                       {:frame (:frame ctx)})
+                       sensitive?)
           ;; rf2-t55hxg.6 — OFF-BOX FAIL-CLOSED (EP-0015 disposition 5). An
           ;; `:rf.http/accept-failure` carries the pre-`:accept` decoded body
           ;; at `:decoded` — same off-box rule as the success `:value`: an
@@ -961,8 +957,7 @@
                           :failure         failure
                           :next-backoff-ms next-backoff-ms
                           :recovery        recovery}
-                         (true? (:sensitive? ctx))
-                         {:frame (:frame ctx)})
+                         (true? (:sensitive? ctx)))
                  (or (contains? failure :body)
                      (contains? failure :body-text))
                  (assoc :rf.http/off-box-body :omit))))

--- a/implementation/http/src/re_frame/http/transport_cljs.cljc
+++ b/implementation/http/src/re_frame/http/transport_cljs.cljc
@@ -99,7 +99,7 @@
      the JVM."
      [{:keys [method url headers body credentials mode redirect cache referrer
               integrity timeout-ms internal-controller decode
-              sensitive? frame]}]
+              sensitive?]}]
      (let [init     #js {}
            _        (do (aset init "method" (str/upper-case (name method)))
                         (when (seq headers)
@@ -141,8 +141,7 @@
                                                     :header k
                                                     :cause  (or (some-> ^js e .-message)
                                                                 (str e))}
-                                                   (true? sensitive?)
-                                                   {:frame frame}))))))
+                                                   (true? sensitive?)))))))
                             (aset init "headers" h)))
                         (when (some? body) (aset init "body" body))
                         (when credentials  (aset init "credentials" (name credentials)))

--- a/implementation/http/src/re_frame/http/transport_jvm.cljc
+++ b/implementation/http/src/re_frame/http/transport_jvm.cljc
@@ -137,7 +137,7 @@
      `ex-info` like this one to the existing `:rf.http/transport`
      catch-all — no new failure category, no new `:rf.error/*` id. Per
      Spec 014 §JVM transport — absolute URLs required."
-     [{:keys [method url headers body timeout-ms sensitive? frame]}]
+     [{:keys [method url headers body timeout-ms sensitive?]}]
      (let [uri (URI/create url)
            _   (when-not (.isAbsolute uri)
                  (throw (ex-info
@@ -196,8 +196,7 @@
                                  {:url     url
                                   :header  k
                                   :cause   (.getMessage t)}
-                                 (true? sensitive?)
-                                 {:frame frame}))))))
+                                 (true? sensitive?)))))))
        (.build b))))
 
 #?(:clj
@@ -368,7 +367,7 @@
 ;; ---- per-row CLJS-only-key tracing on JVM ---------------------------------
 
 #?(:clj
-   (defn- emit-cljs-only-skipped! [k url sensitive? frame]
+   (defn- emit-cljs-only-skipped! [k url sensitive?]
      (when interop/debug-enabled?
        ;; Route through the privacy composer so a denylisted
        ;; query param in the URL is scrubbed and `:sensitive?` is stamped
@@ -378,13 +377,11 @@
        (trace/emit! :warning :rf.http/cljs-only-key-ignored-on-jvm
                     (privacy/prepare-emit-tags
                       {:key k :url url}
-                      (true? sensitive?)
-                      {:frame frame})))))
+                      (true? sensitive?))))))
 
 #?(:clj
    (defn check-cljs-only-keys!
-     ([args sensitive?] (check-cljs-only-keys! args sensitive? nil))
-     ([{:keys [request abort-signal decode]} sensitive? frame]
+     [{:keys [request abort-signal decode]} sensitive?]
      (let [url (:url request)]
        ;; `:credentials` is a JVM-degraded key. Unlike
        ;; `:redirect` (now honoured on JVM via the redirect-policy client),
@@ -397,9 +394,9 @@
        ;; carries the corresponding row so the table and runtime agree.
        (doseq [k [:mode :cache :referrer :integrity :credentials]]
          (when (contains? request k)
-           (emit-cljs-only-skipped! k url sensitive? frame)))
+           (emit-cljs-only-skipped! k url sensitive?)))
        (when abort-signal
-         (emit-cljs-only-skipped! :abort-signal url sensitive? frame))
+         (emit-cljs-only-skipped! :abort-signal url sensitive?))
        ;; Binary decode has a host-specific result shape on the JVM.
        ;; A `:blob` / `:array-buffer` / `:form-data` decode is now HONOURED
        ;; on the JVM (jvm-fetch reads `ofByteArray` and rides the raw bytes
@@ -418,8 +415,7 @@
          (trace/emit! :warning :rf.http/binary-decode-degraded-on-jvm
                       (privacy/prepare-emit-tags
                         {:decode decode :url url}
-                        (true? sensitive?)
-                        {:frame frame})))))))
+                        (true? sensitive?)))))))
 
 ;; A JVM-only no-op stub on CLJS so callers can reach
 ;; `check-cljs-only-keys!` unconditionally without needing their own
@@ -427,5 +423,4 @@
 ;; CLJS-only keys are always honoured on CLJS.
 #?(:cljs
    (defn check-cljs-only-keys!
-     ([_args _sensitive?] nil)
-     ([_args _sensitive? _frame] nil)))
+     [_args _sensitive?] nil))

--- a/implementation/http/test/re_frame/http_privacy_body_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_body_test.clj
@@ -15,7 +15,7 @@
        (rf2-jhyccs);
     4. a root-level (`[]`) `:sensitive?` mark redacts the WHOLE body;
     5. an unschematized body fails CLOSED off-box (omitted via
-       `off-box-classify-body`), while a schema-classified body rides
+       the `off-box-body-disposition` stamp), while a schema-classified body rides
        classified (rf2-t55hxg.6);
     6. a schema that DECLARES a mark with the shared walker hook UNBOUND
        throws `:rf.error/schemas-artefact-missing` rather than reporting no
@@ -99,13 +99,7 @@
             WHOLE body sensitive (the opaque-token-response case)"
     (let [schema  [:string {:sensitive? true}]
           decoded "opaque-token-value"]
-      (is (body/whole-body-sensitive-mark? schema))
       (is (= :rf/redacted (body/classify-decoded decoded schema))))))
-
-(deftest whole-body-mark-absent-for-non-root-marks
-  (testing "a per-slot (non-root) mark is NOT a whole-body mark"
-    (is (not (body/whole-body-sensitive-mark? [:map [:token {:sensitive? true} :string]])))
-    (is (not (body/whole-body-sensitive-mark? :json)))))
 
 ;; ---- 4. off-box disposition (fail-closed) ---------------------------------
 
@@ -176,52 +170,6 @@
           out     (body/classify-decoded decoded schema)]
       (is (= :rf/redacted (:secret out))
           "sensitive wins — the slot is redacted, not a large marker"))))
-
-;; ---- 6. off-box-classify-body (rf2-t55hxg.6) ------------------------------
-
-(deftest off-box-classify-body-omits-unschematized
-  (testing "an UNSCHEMATIZED body is OMITTED (replaced with the marker)
-            off-box regardless of content — fail-closed"
-    (is (= :rf/redacted (body/off-box-classify-body {:token "secret"} :json)))
-    (is (= :rf/redacted (body/off-box-classify-body {:token "secret"} :auto)))
-    (is (= :rf/redacted (body/off-box-classify-body "anything" nil)))
-    (is (= :rf/redacted (body/off-box-classify-body {:a 1} (fn [_ _] {}))))
-    (is (= body/off-box-body-marker
-           (body/off-box-classify-body {:a 1} :text)))))
-
-(deftest off-box-classify-body-omits-opaque-registry-ref
-  (testing "an OPAQUE keyword registry-ref :decode OMITS the body off-box —
-            the walker cannot inspect a registry ref's per-slot marks, so the
-            body must NOT ride unchanged (the rf2-y1pgdl fail-open leak: a
-            sensitive/large opaque-ref body slipping through classified-but-
-            unredacted)"
-    (is (= :rf/redacted (body/off-box-classify-body {:token "bearer-secret"}
-                                                    :my-app/token-schema)))
-    (is (= body/off-box-body-marker
-           (body/off-box-classify-body {:token "secret" :blob "huge"}
-                                       :user/profile)))))
-
-(deftest off-box-classify-body-omits-opaque-compiled-schema
-  (testing "an OPAQUE non-vector schema value OMITS the body off-box —
-            fail-closed (rf2-y1pgdl)"
-    (is (= :rf/redacted (body/off-box-classify-body {:secret "x"}
-                                                    {:opaque :compiled})))))
-
-(deftest off-box-classify-body-classifies-schema-bodies
-  (testing "a SCHEMA body rides CLASSIFIED off-box — per-slot sensitive
-            redacts, large elides, non-marked structure rides verbatim"
-    (let [schema  [:map
-                   [:token {:sensitive? true} :string]
-                   [:blob {:large? true} :string]
-                   [:user-id :int]]
-          decoded {:token "bearer-secret"
-                   :blob (apply str (repeat 100 "x"))
-                   :user-id 42}
-          out     (body/off-box-classify-body decoded schema)]
-      (is (= :rf/redacted (:token out)) "sensitive slot redacted off-box")
-      (is (contains? (:blob out) :rf.size/large-elided)
-          "large slot elided off-box")
-      (is (= 42 (:user-id out)) "non-marked structure rides classified"))))
 
 ;; ---- 7. an UNBOUND shared walker fails LOUD (rf2-ohfym) --------------------
 ;;

--- a/implementation/http/test/re_frame/http_privacy_integration_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_integration_test.clj
@@ -547,8 +547,7 @@
 
 ;; rf2-y1pgdl — the end-to-end emit→projector path for an OPAQUE keyword
 ;; registry-ref / compiled-schema `:decode` is locked at the unit altitude in
-;; `http_privacy_body_test` (`off-box-disposition-omits-opaque-registry-ref`,
-;; `off-box-classify-body-omits-opaque-registry-ref`): the emit site stamps
+;; `http_privacy_body_test` (`off-box-disposition-omits-opaque-registry-ref`): the emit site stamps
 ;; exactly `off-box-body-disposition` and the projector keys on that stamp, so
 ;; the disposition fn IS the path. An integration test here would need a
 ;; SUCCESSFULLY-DECODING opaque ref (a registered Malli registry-ref schema

--- a/implementation/http/test/re_frame/http_privacy_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_test.clj
@@ -166,44 +166,17 @@
 
 (deftest request-sensitive-per-call-true
   (testing "per-call :sensitive? on the args map opts in"
-    (is (true? (privacy/request-sensitive?
-                 {:sensitive? true :request {:url "/x"}}
-                 [:some/event])))))
+    (is (true? (privacy/request-sensitive? {:sensitive? true :request {:url "/x"}})))))
 
 (deftest request-sensitive-per-request-true
   (testing "per-request :sensitive? on the :request map opts in"
-    (is (true? (privacy/request-sensitive?
-                 {:request {:url "/x" :sensitive? true}}
-                 [:some/event])))))
+    (is (true? (privacy/request-sensitive? {:request {:url "/x" :sensitive? true}})))))
 
 (deftest request-sensitive-default-false
-  (testing "no per-call flag = not sensitive (handler-meta :sensitive? has been removed)"
-    (registrar/register! :event :ordinary/op
-                         {:handler-fn (fn [_ctx _ev] nil)
-                          :doc        "Ordinary op"})
-    (is (false? (privacy/request-sensitive?
-                  {:request {:url "/x"}}
-                  [:ordinary/op {}])))))
-
-(deftest request-sensitive-ignores-handler-metadata
-  (testing "handler-meta :sensitive? true no longer triggers sensitivity (annotation removed)"
-    (registrar/register! :event :secret/login
-                         {:handler-fn (fn [_ctx _ev] nil)
-                          :doc        "Secret op"
-                          :sensitive? true})
-    (is (false? (privacy/request-sensitive?
-                  {:request {:url "/x"}}
-                  [:secret/login {:user "ada"}])))))
-
-(deftest request-sensitive-tolerates-missing-handler
-  (testing "unknown handler id does not blow up"
-    (is (false? (privacy/request-sensitive?
-                  {:request {:url "/x"}}
-                  [:never/registered])))))
-
-(deftest request-sensitive-tolerates-nil-origin-event
-  (is (false? (privacy/request-sensitive? {:request {:url "/x"}} nil)))
-  (is (false? (privacy/request-sensitive? {:request {:url "/x"}} []))))
+  (testing "no per-call flag = not sensitive; sensitivity is a per-call
+            decision and the fn has no other input to read"
+    (is (false? (privacy/request-sensitive? {:request {:url "/x"}})))
+    (is (false? (privacy/request-sensitive? {})))))
 
 ;; ---- 4. redact-request-tags ----------------------------------------------
 

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -125,8 +125,7 @@
   Returns the pre-rendered pieces the daemon writer needs to drain the
   chunk stream:
 
-    {:hiccup        <resolved root hiccup>     ;; for the final-hash
-     :head-html     \"…\"                        ;; resolved <head> fragment
+    {:head-html     \"…\"                        ;; resolved <head> fragment
      :html-attrs    {…} or nil                  ;; stamped on <html>
      :body-attrs    {…} or nil                  ;; stamped on <body>
      :head-hash     \"…\" or nil                  ;; client-reconstructible head-model hash
@@ -198,8 +197,7 @@
           ;; string / degraded resolution).
           head-hash  (lifecycle/render-head-hash (:head-model head-bag))
           {:keys [shell-html continuations]} (streaming/render-shell hiccup)]
-      {:hiccup        hiccup
-       :head-html     head-html
+      {:head-html     head-html
        :html-attrs    html-attrs
        :body-attrs    body-attrs
         ;; Head state is drain-invariant, so the writer reuses this pre-drain

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
@@ -204,8 +204,7 @@
           ;; absorbs. The contract under test is unchanged: `catch
           ;; Throwable, then finally close out` — the writer returns
           ;; normally and the OutputStream is left closed.
-          rendered {:hiccup        [:div]
-                    :head-html     ""
+          rendered {:head-html     ""
                     :html-attrs    nil
                     :body-attrs    nil
                     :shell-html    "<div></div>"

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
@@ -80,7 +80,7 @@
       (with-trace-recorder! [captured]
         (@#'streaming/run-streaming-writer!
           pipe-out :no-such-frame
-          {:hiccup [:div] :head-html "" :html-attrs nil :body-attrs nil
+          {:head-html "" :html-attrs nil :body-attrs nil
            :shell-html "<div></div>" :continuations []}
           {:root-view [:div]})
         (let [hits (filterv #(= :rf.error/ssr-streaming-writer-failed (:operation %))
@@ -329,7 +329,7 @@
       (with-redefs [interop/debug-enabled? false]
         (@#'streaming/run-streaming-writer!
           pipe-out :no-such-frame
-          {:hiccup [:div] :head-html "" :html-attrs nil :body-attrs nil
+          {:head-html "" :html-attrs nil :body-attrs nil
            :shell-html "<div></div>" :continuations []}
           {:root-view [:div]}))
       (error-emit/clear-error-listeners!)


### PR DESCRIPTION
Four vestige removals from the audit epic rf2-6r9j: **rf2-6r9j.42**, **rf2-6r9j.39**, **rf2-6r9j.40** and **rf2-6r9j.41**. 16 files, +78 / -229.

Note on scope: `.42`'s subject is `implementation/ssr-ring/`, not `implementation/http/` — the four were clustered as one artefact, but only three are HTTP. The bead governed.

## rf2-6r9j.42 — the retained streaming root Hiccup tree

`render-streaming-shell!` returned the fully resolved root tree under `:hiccup`, and nothing read it.

**What held it alive.** `stream-rendered-response` builds the daemon writer as a closure over the whole `rendered` map and hands that closure to a `Thread`. The closure field, not a stack local, is the holder, and the thread stays alive until the stream drains — bounded by the client's read rate through a 16 KiB `PipedInputStream`, so a slow-loris client extends it arbitrarily. Chain: live `Thread` -> closure field -> `rendered` -> `:hiccup` -> the whole tree, retained alongside the rendered HTML for the request's lifetime.

**That the writer never reads it.** `run-streaming-writer!` destructures exactly seven keys — `head-html`, `html-attrs`, `body-attrs`, `doc-hash`, `head-hash`, `shell-html`, `continuations` — and `:hiccup` is not among them. `rendered` occurs at only three executable sites (created, passed, destructured once); there is no `(:hiccup rendered)`, no `get`, and a two-instrument census (line-oriented and whitespace-flattened, agreeing) found `:hiccup` at exactly five sites in `ssr-ring` — two in `streaming.clj` (the docstring row and the map construction) and three ignored writer-test fixture keys. Control needle `shell-html` fired at 22/23.

**Measured.** A `WeakReference` harness reproducing the exact shape — a parked thread holding a closure over the map, the tree scoped out of the constructing frame, same GC pressure both runs — reports the tree retained with the field present and collectable with it absent. The only difference between the two runs is the field. The sample tree serialises to ~107K characters; real magnitude is the page size, unbounded.

The local `hiccup` binding stays — it still builds `doc-hash` and feeds `streaming/render-shell`. Root-resolution count and hash timing are untouched.

## rf2-6r9j.39 — the unreachable raw-body fallback

`decode-response-body`'s trailing `:else body-text` required `resolved` to be nil. It cannot be: a nil `:decode` normalises to `:auto`, `:auto` resolves through `sniff-decoder`'s exhaustive cond (`:json` / `:text` / `:blob`), and every other value is preserved as-is. The preceding `(some? resolved)` therefore matched everything reaching it — including a `false` decode, since `some?` rejects only nil. That arm is now the final `:else`.

**Proved by probe, with a control.** A side-effecting probe in the fallback (a marker file, immune to being swallowed by the transport's decode try/catch) left no marker across the whole 514-test suite. The *same* probe mechanism planted in the live `:text` arm fired twice. Zero versus two, same suite, same run shape.

The binary arm's synthetic-context `body-binary` -> `body-text` fallback is deliberate and stays.

## rf2-6r9j.40 — three inert compatibility arguments

`request-sensitive?` took an origin event it ignored ever since handler-registration `:sensitive?` was removed; it is now one-argument. Both trace composers took an opts map whose `:frame` carrier lookup has not consulted since resolution moved to the process-global `:rf.http/managed` registration; both are now canonical two-argument functions.

**Call sites changed: 16.** Eleven stopped building a throwaway `{:frame ...}` map (registry x1, transport x5, transport_jvm x3, transport_cljs x1, middleware x1) and five stopped passing an origin event (handlers x3, test_support x1, privacy x1). Stale frame-as-attribution comments went with them.

Removing the arguments made the `frame` values threaded *to reach them* dead, so the thread went too: `warn-failure-swallowed!` and `emit-cljs-only-skipped!` lose a parameter, `jvm-build-request` and the CLJS request builder stop destructuring a key they no longer read, and `check-cljs-only-keys!` collapses to its single live two-argument form on both hosts.

Three tests that passed differing origin values only to prove they did nothing are gone. One of them asserted that handler-registration metadata does not confer sensitivity — that invariant is now enforced by the signature, which cannot see handler metadata at all, rather than by an assertion.

## rf2-6r9j.41 — the orphaned direct-projector layer

`off-box-classify-body`, `off-box-body-marker` and `whole-body-sensitive-mark?` removed, with only their direct self-tests.

**Before deleting privacy code I satisfied myself of two things.** First, the live off-box path does not depend on it: the emit site applies `classify-decoded` on-box (`transport.cljc` x3) and stamps `off-box-body-disposition` forward; `re-frame.epoch.tool-pair`'s `omit-off-box-http-bodies` reads that stamp and substitutes `:rf/redacted` — the same sentinel `off-box-body-marker` held — because Epoch deliberately carries no HTTP-artefact dependency and so could never have called the helper. Composing those gives exactly the removed function on both arms: introspectable schema -> per-slot classified, everything else (unschematized, opaque registry ref, compiled schema) -> whole-body omitted. Equivalent, and it is the one that actually runs.

Second, no deleted test was the only thing asserting a privacy invariant. Each removed row has a live counterpart on the shipped path: unschematized / opaque-ref / compiled-schema omission is asserted through `off-box-body-disposition` returning `:omit`, and schema classification through `classify-decoded`'s per-slot rows. The root-mark product assertion was kept — only the removed predicate's own call was dropped from that test, not the `classify-decoded` assertion beside it.

A two-instrument census (line-oriented and whitespace-flattened, agreeing exactly) put all three symbols only in their own namespace and their own tests — zero production consumers, and no reference in `spec/`, `docs/`, `tools/` or `examples/`. Control needle `off-box-body-disposition` fired at 17 hits across five files including production and `spec/014`. Namespace and integration-test prose no longer claim Epoch calls an HTTP direct projector.

## Quality gates

Captured exit codes are the runner's own, redirected to a log and echoed on one command line — never read through a pipeline.

| Gate | Result | Captured exit |
|---|---|---|
| `clj-kondo --cache false` — `http/src` + `http/test`, merge base | 0 errors, 50 warnings | 2 |
| `clj-kondo --cache false` — `http/src` + `http/test`, this branch | 0 errors, 50 warnings — **identical warning set** | 2 |
| `clj-kondo --cache false` — `ssr-ring/src` + `ssr-ring/test`, merge base | 0 errors, 31 warnings | 2 |
| `clj-kondo --cache false` — `ssr-ring/src` + `ssr-ring/test`, this branch | 0 errors, 31 warnings | 2 |
| `clojure -M:test` in `implementation/http` — baseline | 514 tests, 3901 assertions, 0 failures | 0 |
| `clojure -M:test` in `implementation/http` — this branch, rebased | 506 tests, 3884 assertions, 0 failures | 0 |
| `clojure -M:test` in `implementation/ssr-ring` — baseline | 231 tests, 1163 assertions, 0 failures | 0 |
| `clojure -M:test` in `implementation/ssr-ring` — this branch, rebased | 231 tests, 1163 assertions, 0 failures | 0 |
| `npm run test:cljs` (`:node-test`) | 11209 tests, 55849 assertions, 0 failures; build 1894 files, 0 warnings | 0 |
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine` (core 2176/11149, http 506/3884, ssr-ring 231/1163, CLJS 11209/55849) | 0 |
| `python scripts/check_fast_pr_gap.py --brief` | 97 required CI checks the spine does not decide | 0 |

`clj-kondo`'s exit 2 is its warnings-present code, identical before and after; both artefacts report **0 errors**.

The -8 tests / -17 assertions on the http suite account exactly: 3 tests / 3 assertions from `.40`'s origin-event rows and 5 tests / 14 assertions from `.41`'s direct-projector rows. No suite lost a namespace.

**Lint delta from my own deletions.** Removing the inert arguments orphaned exactly four `frame` bindings (50 -> 54 warnings), then a fifth once those were removed. All five were mine, all are gone, and the branch now reports the same 50 warnings / 0 errors as its merge base. Relevant to rf2-6r9j.46, whose census should be re-derived after this lands.

**Gate proved live.** A single-line fault planted in `privacy.cljc` (`or` -> `and` in `request-sensitive?`, anchor match count read as 1 first) turned the http suite red at **captured exit 1, 12 failures**, naming `request-sensitive-per-call-true` at the planted line — at the identical 506 tests / 3884 assertions, so it failed rows rather than aborting a namespace. Restored and verified by git blob hash against the committed object, not by reading a diff.

**Surface classifier.** `.github/scripts/report-changed-surfaces.sh` over the actual changed paths (it reads bare arguments as paths, not revisions) arms `implementation_jvm`, `cljs_node_test`, `cljs_browser`, `examples_compile`, `cljs_prod` and `bundle_isolation`.

`mkdocs build --strict` and `check_doc_slugs.py` are deliberately not nominated: `implementation/**` is outside the slug gate's roots, where it exits 0 on a broken link.

## Notes

- The spine and CLJS runs above were measured before the final rebase onto `origin/main`; after it, `clj-kondo` and both JVM artefact suites were re-run green on the final base and the merge-base lint baseline re-measured. A second spine run on the rebased base was stopped before it finished and is **no verdict** — CI decides it.
- The rebase conflicted once, where main renamed `util-json` -> `http-json` in `decode.cljc` across the same lines the fallback removal touched. Resolved by keeping **both** intents: main's alias and the removal.
- No spec change was needed. `spec/014-HTTPRequests.md` and `spec/Privacy.md` name the composers but promise no arities; `.41`'s three symbols appear nowhere in `spec/`.
