### PR TITLE
fix(flows): remove four vestiges from the flows artefact (rf2-6r9j.59, .63, .64, .66)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -214,7 +214,11 @@
 (defn- evaluate-flow!
   "Evaluate one flow against the pending frame-state.
 
-  Returns `[db dirty?]`. A failure is rethrown with the failing flow id AND the
+  Returns the transformed db, or `stale-incarnation` when the owning
+  incarnation died mid-visit — the same two-outcome discrimination
+  `run-flows-on-db*` itself returns to its own caller.
+
+  A failure is rethrown with the failing flow id AND the
   failing PHASE for router attribution — `:derive` for the authored callback,
   `:output-write` for the framework's install of its returned value (see
   [[flow-eval-failure!]]); `run-flows-on-db` restores dirty-check state and the
@@ -239,7 +243,7 @@
                           :input-paths-unchanged (:inputs flow)
                           :frame                 frame-id}))
           (if (owner-live? frame-id owner-token exact-owner?)
-            [db false]
+            db
             stale-incarnation))
         ;; The authored `:derive` callback and the framework's own output
         ;; installation are caught by SEPARATE `try` forms.  The split is the
@@ -290,7 +294,7 @@
                     (if (or (not interop/debug-enabled?)
                             (validate-output! frame-id owner-token exact-owner?
                                               flow new-output))
-                      [new-db true]
+                      new-db
                       stale-incarnation)))
                 (catch #?(:clj Throwable :cljs :default) e
                   (flow-eval-failure! frame-id owner-token exact-owner?
@@ -333,7 +337,7 @@
                                                    runtime-db flow)]
                         (if (= stale-incarnation result)
                           stale-incarnation
-                          (recur (rest remaining) (first result))))))
+                          (recur (rest remaining) result)))))
                   (catch #?(:clj Throwable :cljs :default) e
                     ;; Exact loss detached A's cells during destroy; restoring
                     ;; through the bare id would corrupt B.  When A is still

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -126,12 +126,10 @@
 
 (defn ^:no-doc reset-frame-last-inputs-to!
   "Restore one frame's dirty-check cache from a prior snapshot."
-  ([frame-id prior]
-   (reset! (ensure-frame-last-inputs-atom! frame-id) prior))
-  ([frame-id owner-token prior]
-   (when (frame/event-continuation-live? frame-id owner-token)
-     (when-let [a (get @frame-last-inputs frame-id)]
-       (reset! a prior)))))
+  [frame-id owner-token prior]
+  (when (frame/event-continuation-live? frame-id owner-token)
+    (when-let [a (get @frame-last-inputs frame-id)]
+      (reset! a prior))))
 
 ;; ---- pending abandoned output paths --------------------------------------
 ;;
@@ -172,28 +170,12 @@
    (when (frame/event-continuation-live? frame-id owner-token)
      (abandoned-output-paths-snapshot frame-id))))
 
-(defn ^:no-doc drain-abandoned-output-paths!
-  "Atomically read-and-clear `frame-id`'s pending abandoned output paths,
-  returning the set that was pending. The current drain's `run-flows-on-db`
-  consumes these once — dissocing each from the pending
-  `:db` BEFORE the flow walk — and a throw / post-commit rollback re-records
-  them via `restore-abandoned-output-paths!` so the move re-attempts cleanly
-  next drain. Frame-local: returns an empty set when the frame has no
-  container."
-  [frame-id]
-  (when-let [a (get @frame-abandoned-output-paths frame-id)]
-    (let [drained (volatile! #{})]
-      (swap! a (fn [s] (vreset! drained s) #{}))
-      @drained)))
-
 (defn ^:no-doc restore-abandoned-output-paths!
   "Restore one frame's pending output-path vacations from a prior snapshot."
-  ([frame-id prior]
-   (reset! (ensure-frame-abandoned-paths-atom! frame-id) (set prior)))
-  ([frame-id owner-token prior]
-   (when (frame/event-continuation-live? frame-id owner-token)
-     (when-let [a (get @frame-abandoned-output-paths frame-id)]
-       (reset! a (set prior))))))
+  [frame-id owner-token prior]
+  (when (frame/event-continuation-live? frame-id owner-token)
+    (when-let [a (get @frame-abandoned-output-paths frame-id)]
+      (reset! a (set prior)))))
 
 ;; ---- exact-incarnation flow-pass ownership -------------------------------
 
@@ -468,15 +450,12 @@
 (defn- write-flow-output-marks!
   "Install or refresh one flow's output declarations in its frame.
 
-  rf2-vxgfnd.155 — the 3-arity threads A's `owner-token` through the exact-
-  incarnation elision write so a synchronous container watch that destroys A
-  mid-write cannot bump same-id B's commit epoch or write B's runtime-db."
-  ([frame-id flow] (write-flow-output-marks! frame-id nil flow))
-  ([frame-id owner-token flow]
-   (let [xf (fn [reg] (fold-flow-declarations reg flow))]
-     (if owner-token
-       (elision/swap-elision-slot! frame-id owner-token xf)
-       (elision/swap-elision-slot! frame-id xf)))))
+  rf2-vxgfnd.155 — `owner-token` is threaded through the exact-incarnation
+  elision write so a synchronous container watch that destroys A mid-write
+  cannot bump same-id B's commit epoch or write B's runtime-db."
+  [frame-id owner-token flow]
+  (elision/swap-elision-slot! frame-id owner-token
+                              (fn [reg] (fold-flow-declarations reg flow))))
 
 (defn- clear-flow-output-marks!
   "Remove one flow's declarations while preserving every other declaration
@@ -486,19 +465,17 @@
   Frame teardown needs no per-flow scrub because the elision registry belongs
   to the frame-state container that destruction removes.
 
-  rf2-vxgfnd.155 — the 3-arity threads A's `owner-token` through the exact-
-  incarnation elision write so a synchronous container watch that destroys A
-  mid-write cannot bump same-id B's commit epoch or write B's runtime-db."
-  ([frame-id flow-id] (clear-flow-output-marks! frame-id nil flow-id))
-  ([frame-id owner-token flow-id]
-   (let [owner (flow-owner flow-id)
-         xf    (fn [reg]
-                 (-> (or reg {})
-                     (elision/remove-owner :sensitive-declarations owner)
-                     (elision/remove-owner :declarations owner)))]
-     (if owner-token
-       (elision/swap-elision-slot! frame-id owner-token xf)
-       (elision/swap-elision-slot! frame-id xf)))))
+  rf2-vxgfnd.155 — `owner-token` is threaded through the exact-incarnation
+  elision write so a synchronous container watch that destroys A mid-write
+  cannot bump same-id B's commit epoch or write B's runtime-db."
+  [frame-id owner-token flow-id]
+  (let [owner (flow-owner flow-id)]
+    (elision/swap-elision-slot!
+      frame-id owner-token
+      (fn [reg]
+        (-> (or reg {})
+            (elision/remove-owner :sensitive-declarations owner)
+            (elision/remove-owner :declarations owner))))))
 
 ;; ---- registration --------------------------------------------------------
 
@@ -816,17 +793,14 @@
 (defn- vacate-output-path!
   "Remove an output path from a frame's app-db, skipping no-op writes.
 
-  rf2-vxgfnd.155 — the 3-arity threads A's `owner-token` through the exact-
-  incarnation app-db write so a synchronous container watch that destroys A
-  mid-vacation cannot bump same-id B's commit epoch or write B's app-db."
-  ([frame-id path] (vacate-output-path! frame-id nil path))
-  ([frame-id owner-token path]
-   (when-let [db (frame/frame-app-db-value frame-id)]
-     (let [new-db (vacate-path-in-db db path)]
-       (when-not (identical? new-db db)
-         (if owner-token
-           (frame/swap-frame-db-exact! frame-id owner-token (constantly new-db))
-           (frame/swap-frame-db! frame-id (constantly new-db))))))))
+  rf2-vxgfnd.155 — `owner-token` is threaded through the exact-incarnation
+  app-db write so a synchronous container watch that destroys A mid-vacation
+  cannot bump same-id B's commit epoch or write B's app-db."
+  [frame-id owner-token path]
+  (when-let [db (frame/frame-app-db-value frame-id)]
+    (let [new-db (vacate-path-in-db db path)]
+      (when-not (identical? new-db db)
+        (frame/swap-frame-db-exact! frame-id owner-token (constantly new-db))))))
 
 (defn clear-flow
   "Deregister a flow and remove its output leaf from the selected frame.

--- a/implementation/flows/src/re_frame/flows/tooling.cljc
+++ b/implementation/flows/src/re_frame/flows/tooling.cljc
@@ -38,7 +38,7 @@
 
 (defn- with-metadata
   "Attach optional registration metadata and the opaque derive token."
-  [node _frame-id flow]
+  [node flow]
   (let [source (flow-source-coords flow)]
     (cond-> node
       (some? source)           (assoc :source source)
@@ -59,7 +59,7 @@
         (assoc :source-form {:kind :reg-flow :id flow-id}
                :inputs      (declared-inputs flow)
                :owner       [:frame frame-id])
-        (with-metadata frame-id flow))))
+        (with-metadata flow))))
 
 (defn flow-algebra-view
   "Return normalized derivation nodes for registered flows.
@@ -87,12 +87,3 @@
          (assoc m flow-id (node-for frame-id flow)))
        {}
        (or flow-map {})))))
-
-;; ---- bundle-isolation sentinel ------------------------------------------
-;;
-;; The bundle-isolation gate searches production output for this unique literal.
-;; Keep it in the namespace body and out of all other sources so its presence
-;; proves that the tooling sibling became reachable.
-
-(defonce ^:private bundle-isolation-sentinel
-  "rf.flows.tooling/sentinel:rf2-s8w3nw-2026-06-12:do-not-rename")


### PR DESCRIPTION
Four vestige removals in the flows artefact, clustered because they share one
artefact and two of them edit one file. Every premise was re-measured at source
before anything was deleted; all four held.

## rf2-6r9j.59 — tooling's dead bundle sentinel

`flows/tooling.cljc` ended in a `defonce ^:private bundle-isolation-sentinel`
under a comment claiming "the bundle-isolation gate searches production output
for this unique literal". It does not. The `flows-tooling` roster entry in
`check-bundle-isolation.cjs` uses the LIVE `:evaluation :after-event`
classification reached through `flow-algebra-view`.

Three-legged measurement on the EMITTED module (not the source), built fresh —
module mtime 11:56:15 against a source read at 11:31:58:

| leg | measurement | result |
|---|---|---|
| 1 | planted literal in `out/bundle-isolation-positive-control/flows-tooling.js` | **0** |
| 2 | live `after-event` in the SAME file, SAME instrument (control) | **1** |
| 3 | planted literal in the pre-change source | **1** |

The zero is Closure dead-code elimination, not a dead needle: the var is
`^:private` and nothing reads its value, so `do-not-rename` guarded nothing.

`check-bundle-isolation.cjs` needed **no edit**, measured rather than assumed: a
fixed-string search of the checker for the flows literal returns **0**, while the
same search for the `rf.derivation.egress` twin returns **1** — the control
proving the instrument fires. The checker's flows row needle is
`sentinel: 'after-event'`.

Removed with its comment rather than corrected in place, following the rf2-f8fo
ruling: a corrected comment still leaves the false `do-not-rename` instruction
inside the string literal, which is the first thing a reader grepping for "the
sentinel" meets. The correct account already lives beside the roster entry.
Third and last of these, after rf2-yk2d (egress) and rf2-f8fo (graph).

## rf2-6r9j.63 — the unused frame-id hop

`with-metadata` took `[node _frame-id flow]` and read only `node` and `flow`.
`d8bc29e2e0` replaced `frame-matched-source-coords [frame-id flow-id]` with
`flow-source-coords [flow]` and renamed the parameter instead of dropping it.
`node-for` still builds `:owner [:frame frame-id]` unchanged. Closure had
already inlined the hop away.

## rf2-6r9j.64 — the unread dirty slot

`evaluate-flow!` returned `[db dirty?]`. Its ONE caller discriminates the stale
marker and then takes `(first result)` — it never reads the second element:

```clojure
(if (= stale-incarnation result)
  stale-incarnation
  (recur (rest remaining) (first result)))
```

No source, test, tool, trace, spec or public API destructures or indexes the
second element; every tree-wide mention of `evaluate-flow!` outside its own file
is a comment, a docstring or spec prose, and no test reaches the private var
through `#'`.

This adds no new marker ambiguity, which is the bead's stated risk.
`run-flows-on-db*` ALREADY returns either a bare `db` or `stale-incarnation` to
its own caller, so `evaluate-flow!` now returns the same two outcomes its
enclosing fold does, discriminated the same way.

## rf2-6r9j.66 — dead bare-id registry paths

Six zero-consumer entry points, not the one the title names. `drain-abandoned-
output-paths!` removed outright (no caller anywhere; its docstring still claimed
`run-flows-on-db` consumed it, while the live drain calls
`pass-drain-abandoned-paths!`). Five collapsed to their owner-token arities:
`reset-frame-last-inputs-to!`, `restore-abandoned-output-paths!`,
`write-flow-output-marks!`, `clear-flow-output-marks!`, `vacate-output-path!`.

The router's only invocations of the two late-bind restore hooks pass three
arguments. Dropping the `(if owner-token ...)` fallbacks does not widen a hole:
`swap-partition!`'s exact path admits a write only under
`(identical? owner-token (:drain-lock frame-record))`, so a nil token is a safe
no-op that writes nothing — the removed branch was the one that would have
written through a bare id after the incarnation fence had already failed.
`reg-flow` additionally throws `:rf.error/flow-frame-not-live` first.

Preserved: `legacy-flow-pass-state`, the documented three-argument
`run-flows-on-db` path, and the consumed test/snapshot accessors. The drain-race
test that patches `vacate-output-path!` through its var is unaffected — its
replacement is variadic.

## Consumer census

Fixed-string, run twice (line-oriented and whitespace-flattened), excluding the
tracker export, each with a control known live (`pass-drain-abandoned-paths!` and
`record-abandoned-output-path!` both fired):

| symbol | tree-wide hits | verdict |
|---|---|---|
| planted sentinel literal | 1 | the `defonce` itself |
| `with-metadata` (flows) | 2 | `defn-` + its sole call |
| `drain-abandoned-output-paths!` | 1 | the `defn` itself |
| `reset-frame-last-inputs-to!` | 2 | `defn` + late-bind registration |
| `restore-abandoned-output-paths!` | 3 | `defn` + registration + a docstring mention |
| second slot of `evaluate-flow!` | 0 | no destructure, no index |

## Quality gates

| gate | exit | result |
|---|---|---|
| `npm run test:bundle-isolation` — release builds | **0** | 7 builds |
| `check-bundle-isolation.test.cjs` | **0** | self-test PASS |
| `check-bundle-isolation.cjs` | **0** | 23 artefacts; **40 internal sentinels absent; 40 emitted positive-control sentinels present** — unmoved |
| `check-uix-reagent-free.cjs` | **0** | PASS |
| `check-login-bundle-isolation.cjs` | **0** | PASS |
| flows suite (`clojure -M:test` from `implementation/flows`) | **0** | **250 tests, 6102 assertions, 0 failures, 0 errors** |
| `test:cljs` compile (`compile-node-test.cjs`) | **0** | 1894 files, **0 warnings** |
| `test:cljs` run (`node out/node-test.js`) | **0** | **11209 tests, 55849 assertions, 0 failures, 0 errors** |
| `clj-kondo --cache false` over `flows/src` + `flows/test` BEFORE | 2 | errors 0, warnings **84** |
| `clj-kondo --cache false` over `flows/src` + `flows/test` AFTER | 2 | errors 0, warnings **83** |
| `check_fast_pr_gap.py --brief` | **0** | 97 required CI checks this spine does not decide |

clj-kondo exits 2 on warnings on both sides; the sole delta is the removed
`Unused private var re-frame.flows.tooling/bundle-isolation-sentinel`, with no
new findings. Local binary is v2025.10.23 — the same version the bead cited —
and the fast-PR spine's own pinned 2026.04.15 run reported errors 0 across the
repo.

### Sabotage witness — proving the gate is live on this namespace

Committed first, then planted on a single-line anchor whose match count was read
as exactly 1 before running anything:

- Renamed the live `:evaluation :after-event` keyword. Emitted module
  `after-event` count fell 1 → **0**; `check-bundle-isolation.cjs` exit **1**,
  naming exactly `[FAIL] emitted module 'flows-tooling' present:
  re-frame.flows.tooling evaluation classification: sentinel "after-event"
  expected >= 1, was 0`.
- Restored via `git checkout HEAD --`, verified by blob hash against the
  committed object (`181de688eb…`, identical). Rebuilt: emitted count back to
  **1**, checker exit **0**, 40/40 unmoved.

Acceptance criterion for .59 confirmed directly: the live sentinel is present in
its allowed emitted module (1) and absent from the disallowed counter bundle (0).
