### PR TITLE
refactor(core): remove four zero-consumer vestiges

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -410,8 +410,6 @@
 
 ;; ---- do-fx ----------------------------------------------------------------
 
-(declare dispatch-fx-handler)
-
 ;; ---- reserved fx-id table -------------------------------------------------
 ;;
 ;; Per Conventions §Reserved fx-ids — `:dispatch`, `:dispatch-later`,
@@ -554,8 +552,8 @@
 (defn classify-fx-override
   "Resolve `overrides`[`fx-id`] into ONE structured disposition, performing the
   registrar + protected-target lookup EXACTLY ONCE. This is THE single override
-  policy — `real-override?`, `override-applies?`, and `resolve-fx-with-overrides`
-  all express themselves over it, and the machines join-completion transport
+  policy — `real-override?` and `resolve-fx-with-overrides` both express
+  themselves over it, and the machines join-completion transport
   (`:rf.machine/join-dispatch`) consumes the SAME disposition under its
   exact-owner fence (rf2-5g6qq). Because the classification is taken once and
   wholly determines the caller's branch, a concurrent register / unregister can
@@ -601,18 +599,6 @@
   the ONE `classify-fx-override` policy (any non-`:noop` disposition)."
   [overrides fx-id]
   (not= :noop (:disposition (classify-fx-override overrides fx-id))))
-
-(defn override-applies?
-  "True iff `overrides` carries an override for `fx-id` that will ACTUALLY run
-  an application-controlled handler IN PLACE OF the fx — a fn-value, or a
-  keyword redirect to a REGISTERED, NON-PROTECTED fx. The STRICTER companion to
-  `real-override?`: a nil/false noop, an UNREGISTERED-keyword or MALFORMED value,
-  and a redirect whose TARGET is a PROTECTED internal id all return false. A thin
-  predicate over the ONE `classify-fx-override` policy (an `:applied-fn` /
-  `:applied-redirect` disposition)."
-  [overrides fx-id]
-  (contains? #{:applied-fn :applied-redirect}
-             (:disposition (classify-fx-override overrides fx-id))))
 
 (defn- real-reject-override?
   "True iff `overrides` carries a GENUINE reject-tier override attempt for

--- a/implementation/core/src/re_frame/image_assembly.cljc
+++ b/implementation/core/src/re_frame/image_assembly.cljc
@@ -741,9 +741,6 @@
 ;; ---- the collision validator — THE central \"order never decides\" guarantee
 ;;      (EP-0023 §Image Composition / §Image Validation) ----------------------
 
-(defn- standard-descriptor?
-  [d] (boolean (:standard d)))
-
 (defn- inline-descriptor?
   "True when a descriptor is an IMAGE-INLINE descriptor (carries
   `:rf.provenance/inline`), as opposed to a namespace-selected (registered) or a

--- a/implementation/core/src/re_frame/views/provider.cljs
+++ b/implementation/core/src/re_frame/views/provider.cljs
@@ -244,8 +244,6 @@
 
 ;; ---- frame resolution at render time -------------------------------------
 
-(def ^:dynamic *current-frame* nil)
-
 (defn current-frame
   "Resolution chain (READER) per Spec 002 §Frame target resolution — the
   carried invariant (EP-0002). Returns the scope frame, or **nil** when no


### PR DESCRIPTION
Removes four vestiges from `implementation/core`, each with no executable consumer anywhere in the repository. All four bead premises were re-verified at tip and **all four held**.

Beads: rf2-6r9j.20, rf2-6r9j.21, rf2-6r9j.19, rf2-6r9j.22 (children of the rf2-6r9j vestige/naming audit epic).

## What is removed

| Symbol | File | Why it is dead |
|---|---|---|
| `(declare dispatch-fx-handler)` | `core/src/re_frame/fx.cljc` | Declared Var never acquired a root; the declaration was its sole repository-wide occurrence and solved no forward-reference cycle. |
| `override-applies?` | `core/src/re_frame/fx.cljc` | Its sole caller was removed when join completion moved to one pre-resolved `classify-fx-override` disposition. |
| `standard-descriptor?` (private) | `core/src/re_frame/image_assembly.cljc` | Stranded by the EP-0026 layered-collision rewrite; current standard-vs-inline resolution expresses `:standard` directly. |
| `^:dynamic *current-frame*` | `core/src/re_frame/views/provider.cljs` | Duplicate of the canonical `re-frame.frame/*current-frame*`; bound and read by nothing, so binding it had no effect. |

One docstring correction: `classify-fx-override` no longer lists `override-applies?` among the predicates expressing themselves over the policy.

Behaviour-neutral. No change to effect dispatch, override resolution, collision precedence, or frame-resolution order.

## Reachability evidence

Every symbol was censused with **two text instruments** (line-oriented and whitespace-flattened fixed-string over 4818 tracked files, `.beads` excluded, plus a hyphen-normalised third pass) **and** at the analyser level via clj-kondo `:analysis`, each paired with a **live control**:

| Symbol | Text hits | Analyser var-usages | Control (fired) |
|---|---|---|---|
| `dispatch-fx-handler` | 1 (the declaration) | 0 | `handle-one-fx` — 85 |
| `override-applies?` | 7, none executable (2 in `fx.cljc`, 5 machines-test prose) | 0 | `real-override?` — 10, incl. an executable call |
| `standard-descriptor?` | 1 (the definition) | 0 | `inline-descriptor?` — 3, incl. 2 calls |
| `views.provider/*current-frame*` | 0 qualified, 0 via the sole `provider/` alias | 0 | `re-frame.frame/*current-frame*` — 179 usages |

The two `*current-frame*` Vars were distinguished **by namespace at the analyser level**, not by name: of 179 var-usages, **179 resolve to `re-frame.frame` and zero to `re-frame.views.provider`**. No `:refer` route exists, and `re-frame.views` does not re-export it (it does re-export `*render-key*`, so dynamic-var re-export is a live pattern there that this Var did not participate in). Every `binding` form in the repository targets the canonical Var (126 via the `frame/` alias, 2 fully qualified, 2 bare — one a comment, one inside `re-frame.frame` itself).

`re-frame.fx` has no rows in `spec/api-manifest.edn` (46 namespaces present, `re-frame.core` among them with 103 vars), so `override-applies?` is not manifested and no regeneration is required. `re-frame.image-assembly` and `re-frame.views.provider` are likewise absent.

clj-kondo reports **no other** unused private var in `image_assembly.cljc` — or anywhere in `core/src` — so the EP-0026 rewrite left no siblings beyond `standard-descriptor?`.

## Quality gates

Exit codes below are the runner's own, captured to a file and quoted from it.

| Gate | Exit | Result |
|---|---|---|
| `implementation/core` JVM `:test` | **0** | **2176 tests / 11149 assertions, 0 failures, 0 errors** |
| `test:cljs` compile (`node-test`) | **0** | 1894 files, 1893 compiled, **0 warnings** |
| `test:cljs` run (`node-test` bundle) | **0** | **11209 tests / 55849 assertions, 0 failures, 0 errors** |
| clj-kondo `core/src` + `core/test`, `--cache false` — BEFORE | 2 | errors 0, warnings **641** |
| clj-kondo `core/src` + `core/test`, `--cache false` — AFTER | 2 | errors 0, warnings **640** |
| `npm ci` (own `node_modules`, from lockfile) | **0** | 110 packages |

The single clj-kondo delta is the removal of `Unused private var re-frame.image-assembly/standard-descriptor?`. No new findings; the only other diff line is a line-number shift caused by the deletion.

**Gate proved live against this tree.** A fault planted at a line adjacent to the `image_assembly.cljc` deletion (inverting `inline-descriptor?`) took the JVM suite to **exit 1 with 22 failures**, naming the image-assembly collision suites the bead's acceptance criteria cite (`within-image-two-selected-is-ambiguous`, `within-image-two-inline-is-malformed`, `re-frame.image-assembly-cljs-test`, `re-frame.image-assembly-default-cljs-test`). Test counts were **unchanged at 2176 / 11149** across the plant, showing no namespace was silently stopped. The plant was restored and verified by git blob hash against the committed object, not by reading a diff.

`mkdocs build --strict` and `check_doc_slugs.py` are deliberately not nominated: `implementation/**` lies outside the slug gate's roots, where it exits 0 on a broken link and would be a green that inspected nothing.
