### PR TITLE
fix(skills): 1,024 is the portable description ceiling, and the gate now enforces it (rf2-cupfi)

### DIFF
--- a/scripts/check_skill_description_budget.py
+++ b/scripts/check_skill_description_budget.py
@@ -1,35 +1,48 @@
 #!/usr/bin/env python3
-"""Guard the two SKILL.md description limits Claude Code actually ENFORCES (rf2-w9p2).
+"""Guard the SKILL.md description limits: the portable 1,024 and the Claude 1,536.
 
-WHY THIS EXISTS, and why it does not check the number everybody quotes.
+WHY THIS EXISTS, and why it checks TWO numbers rather than one.
 
 rf2-cupfi observed that six of nine `skills/*/SKILL.md` descriptions exceeded
-1,024 characters and asked whether that truncates at runtime.  It ruled: *do not
-add a gate unless truncation is confirmed*.  A worker then confirmed truncation
-against the SHIPPED runtime rather than against documentation, and found the
-1,024 figure is **not the enforced one**:
+1,024 characters and asked whether that truncates at runtime.  A worker measured
+the SHIPPED Claude Code runtime and found 1,024 is *not* what that runtime
+enforces — it slices at 1,536.  The first version of this gate therefore checked
+only 1,536, and the merged-PR audit of #9051 reopened rf2-cupfi for exactly that:
+**a particular runtime not enforcing a validation does not make an over-limit
+package conforming.**  `skills/README.md` advertises every skill here as
+distributable as an Agent Skill via `npx skills add`, and the canonical Agent
+Skills specification requires `description` to be 1-1,024 characters:
 
-  * 1,024 is the Agent Skills PACKAGING spec's figure.  Claude Code's SKILL.md
-    frontmatter validator checks only that `description` is a string ("description
-    must be a string, got <type>.  At runtime this value is dropped.") and applies
-    NO length check whatsoever.  The one enforced 1,024 in the runtime is a
-    `.max(1024)` on the *plugin marketplace manifest* description — a different
-    field on a different surface, and this repo's nine `plugin.json` descriptions
-    run 146-418 characters, nowhere near it.
+    https://github.com/agentskills/agentskills/blob/main/docs/specification.mdx#description-field
 
-  * The enforced per-description cap is **1,536** (`skillListingMaxDescChars`),
+So there are two ceilings, and they are not alternatives:
+
+  * **1,024 is the PORTABLE PACKAGE ceiling** — the contract this repo advertises,
+    and what any conforming Agent Skills host may validate against.  It is the
+    number this gate FAILS on, because it is the tighter one and the one that
+    makes a package conforming everywhere rather than in one runtime.
+
+  * **1,536 is what Claude Code ENFORCES today** (`skillListingMaxDescChars`),
     applied as a HARD SLICE — `.slice(0, 1536)`, no ellipsis, no warning in the
     listing the model reads, and the cut lands mid-word.  So the TAIL is always
-    what is lost.
+    what is lost.  A description that clears 1,024 clears this automatically; the
+    figure is retained because it explains WHY the tail matters, and it is
+    reported on every run.
 
-  * A SECOND mechanism has no per-skill spelling at all: the listing carries a
+  * **A THIRD mechanism has no per-skill spelling at all**: the listing carries a
     TOTAL budget, and past it Claude Code stops trimming tails and starts dropping
     ENTIRE descriptions, lowest-priority first, rendering those skills as a bare
-    `- name` with NOTHING for the model to route on.
+    `- name` with NOTHING for the model to route on.  No per-description cap can
+    see that, so it is guarded separately, as a ratchet.
 
-A gate written against 1,024 would therefore red six descriptions that are fine
-and miss the mechanism that actually degrades this family.  This gate is written
-against what is enforced.
+Claude Code's own SKILL.md frontmatter validator, for the record, checks only that
+`description` is a string ("description must be a string, got <type>.  At runtime
+this value is dropped.") and applies no length check at all.  The one enforced
+1,024 inside that runtime is a `.max(1024)` on the *plugin marketplace manifest*
+description — a different field on a different surface (this repo's nine
+`plugin.json` descriptions run 146-418 characters, nowhere near it).  Neither
+observation licenses shipping a non-conforming package: the packaging spec is the
+contract, and the runtime measurement is only evidence about one consumer of it.
 
 THE RUNTIME MECHANISM, transcribed from the shipped bundle (Claude Code 2.1.258,
 `claude.exe`; the listing planner and its renderer):
@@ -57,22 +70,27 @@ THE RUNTIME MECHANISM, transcribed from the shipped bundle (Claude Code 2.1.258,
 
 WHAT THIS GATE CHECKS, and why each is the severity it is.
 
-  C1  PER-DESCRIPTION CAP (hard fail).  Every skill's resolved description must
-      be <= 1,536 characters.  This is a real cliff, it is local, and its remedy
+  C1  PER-DESCRIPTION CAP (hard fail) at **1,024**, the portable package ceiling.
+      Every skill's resolved description must be <= 1,024 characters.  The remedy
       is local: shorten or reorder ONE description.  All nine currently pass, so
       the gate lands green and stays a regression guard rather than a backlog.
+      A failure escalates its message when the description is ALSO past Claude
+      Code's 1,536 slice, because then it is not merely non-portable — it is
+      being silently truncated in the listing today.
 
   C2  FAMILY LISTING FOOTPRINT (hard fail, RATCHETED — not the absolute).  The
       family's contribution to the listing is computed with the runtime's own
       formula and compared against a pinned ceiling.
 
       The absolute 8,000 budget is NOT the fail threshold, deliberately.  The
-      family already costs 10,727 characters — 134% of the entire listing budget
-      — before the consumer installs a single skill of their own and before
-      Claude Code's own bundled commands take their share.  Failing at 8,000
-      would red this repo on day one with no in-repo remedy, because the remedy
-      is not "shorten a description": nine skills averaging ~1,200 characters
-      cannot all fit in 8,000 no matter how they are written.  That is a product
+      family still costs well over the entire listing budget (see the summary
+      the gate prints) — before the consumer installs a single skill of their
+      own and before Claude Code's own bundled commands take their share.
+      Failing at 8,000 would red this repo on day one with no in-repo remedy,
+      because the remedy is not "shorten a description": nine skills each
+      carrying a routing contract cannot all fit in 8,000 no matter how they are
+      written — bringing every one of them under 1,024 did not achieve it and
+      could not have.  That is a product
       decision (ship fewer skills, or accept that the lowest-priority ones render
       bare), and a gate cannot make it.
 
@@ -86,20 +104,17 @@ WHAT THIS GATE DOES NOT CHECK — stated because a gate's silence reads as cover
 
   DISQUALIFIER-FIRST ORDERING IS NOT MECHANICALLY CHECKABLE HERE, and pretending
   otherwise would be worse than omitting it.  Ordering is the half that makes a
-  truncation survivable — whatever is last is what the slice removes, which is
-  why PR #9051 moved re-frame2-xray's "**Do not use** ... re-frame2-pair" clause
-  to the FRONT.  But detecting the two halves requires agreed markers, and there
-  are none: measured across the nine live descriptions, only six contain any
-  "trigger" marker at all, only eight contain any recognisable disqualifier
-  phrasing (spelled variously "Do not use", "Not for", "Never", "Activates only
-  on explicit pull", "... instead"), and among the six carrying both, the
-  disqualifier follows the trigger list in five.  A mechanical assertion would
-  red four to five compliant descriptions on a heuristic nobody agreed to.
+  truncation survivable — whatever is last is what a slice removes, which is why
+  every description in this family now leads with its disqualifier and trails
+  its trigger phrases.  But detecting the two halves requires agreed markers,
+  and there are none: disqualifiers are spelled variously ("Do not use", "Not
+  for", "Never", "Activates only on explicit pull", "... instead"), several
+  descriptions carry no "trigger" marker at all, and a mechanical assertion
+  would red compliant descriptions on a heuristic nobody agreed to.
 
   What IS mechanical, and what this gate prints instead, is HEADROOM: how many
-  characters each description has before the slice starts eating its tail.  That
-  is the actionable form of the same concern — reagent-migration currently sits
-  49 characters from the cliff — and it needs no guess about phrasing.
+  characters each description has before it crosses the portable cap.  That is
+  the actionable form of the same concern, and it needs no guess about phrasing.
 
 CAVEAT, carried deliberately.  1,536 and 0.01 are DEFAULTS of user-configurable
 settings (`skillListingMaxDescChars`, `skillListingBudgetFraction`), and the
@@ -151,10 +166,18 @@ SKILLS_DIR = REPO_ROOT / "skills"
 # Pinned runtime constants.  Read from the shipped bundle, not from docs.
 # ---------------------------------------------------------------------------
 
-#: Version of Claude Code these numbers were read out of.
+#: Version of Claude Code the RUNTIME numbers below were read out of.
 PINNED_RUNTIME_VERSION = "2.1.258"
 
+#: The Agent Skills packaging specification's `description` ceiling (1-1,024).
+#: This is the ENFORCED number here: it is the portable contract this repo
+#: advertises with `npx skills add`, and it is tighter than the runtime slice.
+#: https://github.com/agentskills/agentskills/blob/main/docs/specification.mdx#description-field
+PACKAGE_MAX_DESC_CHARS = 1024
+
 #: `skillListingMaxDescChars` default.  Applied as a hard `.slice(0, N)`.
+#: NOT the fail threshold — anything within 1,024 is within this — but retained
+#: because it is what makes a lost TAIL the specific risk, and it is reported.
 LISTING_MAX_DESC_CHARS = 1536
 
 #: `skillListingBudgetFraction` default.
@@ -170,10 +193,11 @@ DEFAULT_CONTEXT_WINDOW = 200_000
 ENTRY_OVERHEAD_CHARS = 4
 
 #: Ratchet ceiling for the family's listing footprint (see C2 above).
-#: Measured 2026-09-03 over the nine live SKILL.md files at 10,727.  LOWER this
-#: when descriptions shrink; RAISING it is a deliberate act that says the family
-#: now costs the listing more, and wants a reason in the commit message.
-FAMILY_FOOTPRINT_CEILING = 10_727
+#: Re-measured 2026-09-03 at 8,864, after rf2-cupfi brought all nine
+#: descriptions under the portable 1,024 cap (was 10,727).  LOWER this when
+#: descriptions shrink; RAISING it is a deliberate act that says the family now
+#: costs the listing more, and wants a reason in the commit message.
+FAMILY_FOOTPRINT_CEILING = 8_864
 
 
 def listing_budget(context_window: int = DEFAULT_CONTEXT_WINDOW) -> int:
@@ -210,12 +234,18 @@ class SkillEntry:
 
     @property
     def over_cap(self) -> bool:
+        """Past the portable Agent Skills ceiling — the number this gate fails on."""
+        return self.resolved_len > PACKAGE_MAX_DESC_CHARS
+
+    @property
+    def sliced_by_runtime(self) -> bool:
+        """Past Claude Code's hard slice as well, so the tail is being cut today."""
         return self.resolved_len > LISTING_MAX_DESC_CHARS
 
     @property
     def headroom(self) -> int:
-        """Characters left before the hard slice starts removing the tail."""
-        return LISTING_MAX_DESC_CHARS - self.resolved_len
+        """Characters left before the portable ceiling is crossed."""
+        return PACKAGE_MAX_DESC_CHARS - self.resolved_len
 
     @property
     def rel(self) -> str:
@@ -289,19 +319,29 @@ def check(entries: list[SkillEntry], ceiling: int = FAMILY_FOOTPRINT_CEILING) ->
     """Return a list of failure messages; empty means clean."""
     failures: list[str] = []
 
-    # C1 - per-description hard cap.
+    # C1 - per-description hard cap, at the portable packaging ceiling.
     for entry in sorted(entries, key=lambda e: e.name):
         if entry.over_cap:
-            lost = entry.resolved_len - LISTING_MAX_DESC_CHARS
-            failures.append(
+            over = entry.resolved_len - PACKAGE_MAX_DESC_CHARS
+            message = (
                 f"{entry.rel}: resolved description is {entry.resolved_len} chars, "
-                f"over the enforced {LISTING_MAX_DESC_CHARS}-char cap "
-                f"(skillListingMaxDescChars, Claude Code {PINNED_RUNTIME_VERSION}). "
-                f"The listing hard-slices it, so the LAST {lost} char"
-                f"{'' if lost == 1 else 's'} are dropped mid-word with no ellipsis "
-                f"and no warning. Shorten it, or move whatever must survive "
-                f"(a disqualifier clause especially) ahead of the cut."
+                f"{over} over the {PACKAGE_MAX_DESC_CHARS}-char Agent Skills "
+                f"packaging cap. skills/README.md advertises this skill as "
+                f"distributable via `npx skills add`, and the specification "
+                f"requires description to be 1-{PACKAGE_MAX_DESC_CHARS} characters, "
+                f"so an over-limit package is non-conforming wherever that "
+                f"validation runs. Shorten it, and keep whatever must survive a "
+                f"truncation (the disqualifier clause especially) at the FRONT."
             )
+            if entry.sliced_by_runtime:
+                lost = entry.resolved_len - LISTING_MAX_DESC_CHARS
+                message += (
+                    f" It is ALSO past Claude Code's {LISTING_MAX_DESC_CHARS}-char "
+                    f"slice (skillListingMaxDescChars, {PINNED_RUNTIME_VERSION}), so "
+                    f"the last {lost} char{'' if lost == 1 else 's'} are being cut "
+                    f"mid-word from the listing today, with no ellipsis and no warning."
+                )
+            failures.append(message)
 
     # C2 - family footprint ratchet.
     total = family_footprint(entries)
@@ -328,7 +368,11 @@ def render_table(entries: list[SkillEntry]) -> str:
         f"{'-' * 24} {'-' * 8} {'-' * 7} {'-' * 6} {'-' * 9}",
     ]
     for entry in sorted(entries, key=lambda e: -e.resolved_len):
-        flag = "  OVER CAP" if entry.over_cap else ""
+        flag = ""
+        if entry.sliced_by_runtime:
+            flag = "  OVER CAP + SLICED"
+        elif entry.over_cap:
+            flag = "  OVER CAP"
         lines.append(
             f"{entry.name:<24} {entry.resolved_len:>8} {entry.capped_len:>7} "
             f"{entry.entry_len:>6} {entry.headroom:>9}{flag}"
@@ -345,6 +389,11 @@ def render_summary(entries: list[SkillEntry], ceiling: int = FAMILY_FOOTPRINT_CE
     return "\n".join(
         [
             f"family entries              : {len(entries)}",
+            f"portable description cap    : {PACKAGE_MAX_DESC_CHARS} chars "
+            f"(Agent Skills packaging spec; the ENFORCED number here)",
+            f"Claude Code listing slice   : {LISTING_MAX_DESC_CHARS} chars "
+            f"(skillListingMaxDescChars, {PINNED_RUNTIME_VERSION}; hard slice, "
+            f"tail lost, no warning)",
             f"family listing footprint    : {total} chars",
             f"pinned ratchet ceiling      : {ceiling} chars",
             f"whole-listing budget        : {budget} chars "
@@ -394,39 +443,57 @@ def run_self_test() -> int:
         root.mkdir()
 
         # --- C1 negative: a compliant description passes. -------------------
-        _write_skill(root, "compliant", "x" * (LISTING_MAX_DESC_CHARS - 1))
+        _write_skill(root, "compliant", "x" * (PACKAGE_MAX_DESC_CHARS - 1))
         entries, errors = collect_skills(root)
         expect("C1 fixture parses", not errors and len(entries) == 1, str(errors))
         expect(
-            "C1 PASSES a description one char under the cap",
+            "C1 PASSES a description one char under the portable cap",
             check(entries, ceiling=10**9) == [],
         )
 
-        # --- C1 positive: one char over the cap reds it. --------------------
-        _write_skill(root, "compliant", "x" * (LISTING_MAX_DESC_CHARS + 1))
+        # --- C1 positive: one char over the portable cap reds it. -----------
+        _write_skill(root, "compliant", "x" * (PACKAGE_MAX_DESC_CHARS + 1))
         entries, _ = collect_skills(root)
         failures_seen = check(entries, ceiling=10**9)
         expect(
-            "C1 FAILS a description one char over the cap",
-            len(failures_seen) == 1 and "over the enforced" in failures_seen[0],
+            "C1 FAILS a description one char over the portable cap",
+            len(failures_seen) == 1
+            and "Agent Skills packaging cap" in failures_seen[0],
             str(failures_seen),
         )
         expect(
-            "C1 boundary: exactly AT the cap passes",
+            "C1 message does NOT claim runtime truncation below 1,536",
+            "being cut" not in failures_seen[0],
+            failures_seen[0],
+        )
+        expect(
+            "C1 boundary: exactly AT the portable cap passes",
             (
-                _write_skill(root, "compliant", "x" * LISTING_MAX_DESC_CHARS),
+                _write_skill(root, "compliant", "x" * PACKAGE_MAX_DESC_CHARS),
                 check(collect_skills(root)[0], ceiling=10**9),
             )[1]
             == [],
         )
 
+        # --- C1 escalation: past the runtime slice too, the message says so. -
+        _write_skill(root, "compliant", "x" * (LISTING_MAX_DESC_CHARS + 1))
+        entries, _ = collect_skills(root)
+        escalated = check(entries, ceiling=10**9)
+        expect(
+            "C1 ESCALATES when the description is also past the 1,536 slice",
+            len(escalated) == 1
+            and "Agent Skills packaging cap" in escalated[0]
+            and "being cut" in escalated[0],
+            str(escalated),
+        )
+
         # --- when_to_use is folded into the measured length. ----------------
-        _write_skill(root, "compliant", "x" * 1000, when_to_use="y" * 600)
+        _write_skill(root, "compliant", "x" * 800, when_to_use="y" * 300)
         entries, _ = collect_skills(root)
         entry = entries[0]
         expect(
             "resolved length includes ' - ' + when_to_use",
-            entry.resolved_len == 1000 + 3 + 600,
+            entry.resolved_len == 800 + 3 + 300,
             f"got {entry.resolved_len}",
         )
         expect(
@@ -503,6 +570,10 @@ def run_self_test() -> int:
 
     # --- the pinned budget arithmetic. -------------------------------------
     expect("listing budget is 8000 at a 200K window", listing_budget() == 8000)
+    expect(
+        "the portable cap is the tighter of the two, so it is the one enforced",
+        PACKAGE_MAX_DESC_CHARS < LISTING_MAX_DESC_CHARS,
+    )
 
     print()
     if failures:
@@ -584,9 +655,10 @@ def main(argv: Iterable[str]) -> int:
 
     if args.verbose:
         print(
-            f"OK: all {len(entries)} descriptions are within the "
-            f"{LISTING_MAX_DESC_CHARS}-char cap, and the family footprint is "
-            f"within the pinned ceiling."
+            f"OK: all {len(entries)} descriptions are within the portable "
+            f"{PACKAGE_MAX_DESC_CHARS}-char Agent Skills cap (and so within "
+            f"Claude Code's {LISTING_MAX_DESC_CHARS}-char slice), and the family "
+            f"footprint is within the pinned ceiling."
         )
     return 0
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -285,16 +285,23 @@ ceiling is not unreachable in general: de-duplication brought
 `re-frame2/references/cross-cutting/testing.md` was genuinely split, carving
 out `testing-views.md`. Try both before recording an exception.
 
-### `SKILL.md` frontmatter `description` — the cap that actually bites
+### `SKILL.md` frontmatter `description` — two ceilings, author to the tighter
 
-**The 1,024-character figure from the Agent Skills packaging spec is not
-the one to author against, because Claude Code does not enforce it**
-(measured against the shipped v2.1.258 runtime, rf2-cupfi). Its frontmatter
-validator checks that `description` is a string and warns when it is
-missing; it applies no length check at all, and no packaging gate in this
-repo checks one either.
+**Author to 1,024 characters.** That is the Agent Skills packaging
+specification's ceiling on `description` (1–1,024 characters), and every
+skill in this directory is advertised above as distributable via
+`npx skills add`, so it is the contract we ship under. A host that
+validates it will reject an over-limit package; the fact that one
+particular runtime does not validate it does not make an over-limit
+package conforming. `scripts/check_skill_description_budget.py` enforces
+1,024, and all nine descriptions are inside it.
 
-What Claude Code *does* enforce is a **per-skill cap of 1,536 characters**
+Claude Code, measured against the shipped v2.1.258 runtime (rf2-cupfi),
+enforces something looser and differently shaped, and it is worth knowing
+because it explains *which part* of a description is at risk. Its
+frontmatter validator checks only that `description` is a string and warns
+when it is missing — no length check at all. What it *does* enforce is a
+**per-skill cap of 1,536 characters**
 on the entry it puts in the skill listing — the setting is
 `skillListingMaxDescChars`, and the default is 1,536. The value it caps is
 the `description` alone, or `"<description> - <when_to_use>"` where a
@@ -309,10 +316,11 @@ Two consequences for authoring, and the first is the one that matters:
   must never be the sentence a silent slice removes. Trigger-phrase lists
   are the right thing to carry the risk: they are long, they are
   redundant by design, and losing the last few costs almost nothing.
-  `re-frame2-xray` was the one description over the enforced cap (1,713
-  characters, so 177 were being cut — and what they cut was exactly its
-  `re-frame2-pair` disqualifier, mid-word); it now leads with the
-  disqualifier and measures 1,482.
+  `re-frame2-xray` was once over even the 1,536 slice (1,713 characters,
+  so 177 were being cut — and what they cut was exactly its
+  `re-frame2-pair` disqualifier, mid-word). Every description in the
+  family now leads with its disqualifier and trails its trigger phrases,
+  and every one is under 1,024.
 - **A second, blunter mechanism can drop a description whole.** The
   listing also has a total budget — the context window times four bytes
   per token times `skillListingBudgetFraction`, which defaults to `0.01`,
@@ -321,14 +329,20 @@ Two consequences for authoring, and the first is the one that matters:
   descriptions, lowest-priority first, rendering those skills as a bare
   `- <name>` with nothing to route on. **Skills bundled with Claude Code
   are exempt from that pass; skills installed by a consumer — every skill
-  in this directory — are not.** This family currently totals ~10.8K
-  characters of listing across nine skills, so a consumer who installs
-  several of them alongside their own is already in the regime where the
-  budget, not the per-skill cap, decides what survives.
+  in this directory — are not.** Bringing every description under 1,024
+  took this family from ~10.7K to ~8.9K characters of listing across nine
+  skills — a real improvement that still does not clear an ~8,000
+  budget, so a consumer who installs several of them alongside their own
+  remains in the regime where the budget, not the per-skill cap, decides
+  what survives. Nine skills each carrying a routing contract cannot fit
+  in 8,000 however they are written; that is a product decision (ship
+  fewer skills, or accept that the lowest-priority ones render bare), not
+  something more trimming can reach.
 
-Keeping each description meaningfully under 1,536 is therefore worth
-doing for the listing budget's sake even where nothing is being sliced
-today. Treat the ordering rule as the load-bearing half of this section.
+So: 1,024 is the number to author against and the number the gate
+enforces; 1,536 and the listing budget are why the *tail* is the part
+that must be expendable. Treat the ordering rule as the load-bearing
+half of this section.
 
 ### Published-skill `allowed-tools` baseline (security policy)
 

--- a/skills/re-frame-migration/SKILL.md
+++ b/skills/re-frame-migration/SKILL.md
@@ -5,17 +5,16 @@ description: >
   Swaps the artefact coord (re-frame/re-frame → day8/re-frame2 + a substrate
   adapter), applies the mechanical (Type A) rewrites from MIGRATION.md
   automatically, and flags the judgment-call (Type B) call sites for human
-  review before touching them. Trigger on phrasing like "migrate to
-  re-frame2", "upgrade re-frame", "v1 to v2", "what breaks under re-frame2",
-  or any prompt referencing a v1 surface (re-frame.db, dispatch-with,
-  reg-global-interceptor, reg-sub-raw, ^:flush-dom, re-frame.alpha,
-  re-frame-test, old top-level :dispatch / :dispatch-n effect-map keys),
-  or a v1 add-on library (http-fx / :http-xhrio, async-flow-fx /
-  :async-flow).
-  **Do not use** for: greenfield bootstrap, writing v2 application code,
-  live v2-app inspection, static critique, devtools tours, or porting
-  re-frame2 itself — see the full routing table in `skills/README.md`
-  §Skill routing for the right sibling skill.
+  review before touching them. **Do not use** for: greenfield bootstrap,
+  writing v2 application code, live v2-app inspection, static critique,
+  devtools tours, or porting re-frame2 itself — see the full routing table in
+  `skills/README.md` §Skill routing for the right sibling skill. Trigger on
+  phrasing like "migrate to re-frame2", "upgrade re-frame", "v1 to v2", "what
+  breaks under re-frame2", or any prompt referencing a v1 surface
+  (re-frame.db, dispatch-with, reg-global-interceptor, reg-sub-raw,
+  ^:flush-dom, re-frame.alpha, re-frame-test, old top-level :dispatch /
+  :dispatch-n effect-map keys), or a v1 add-on library (http-fx / :http-xhrio,
+  async-flow-fx / :async-flow).
 allowed-tools:
   - Bash(rg *)
   # The project's OWN noninteractive install / compile / test gates, for every

--- a/skills/re-frame2-implementor/SKILL.md
+++ b/skills/re-frame2-implementor/SKILL.md
@@ -2,24 +2,19 @@
 name: re-frame2-implementor
 description: >
   Guides an engineer building a NEW re-frame2 implementation in one of the
-  eight in-scope JS-cross-compile-to-React+VDOM host languages —
-  ClojureScript (the reference), TypeScript, Melange/ReScript/Reason,
-  F# (Fable), Squint, Scala.js, PureScript, Kotlin/JS. Drives a two-phase
-  workflow (Phase 1: record the port profile; Phase 2: one EP loop driven
-  by the pinned spec and live conformance fixtures, with the conformance
-  corpus as the acceptance test).
-  Trigger on phrasing like "port re-frame2", "implement re-frame2 in
-  <language>", "second re-frame2 implementation", "implementor checklist",
-  "conformance corpus", or any prompt about building re-frame2 itself.
-  **Do not use** for: writing apps on the CLJS reference (use
-  `re-frame2`), greenfield bootstrap (use `re-frame2-setup`), v1→v2
-  migration (use `re-frame-migration`), live-app inspection (use
-  `re-frame2-pair`), or a port to an out-of-scope target — a non-React
-  substrate (Vue, Solid, Svelte, vanilla DOM) or a host that does not
-  cross-compile to JS (Python, Ruby, native Rust, Go, server-side JVM):
-  out of scope by deliberate spec choice, so surface the
-  `spec/000-Vision.md` scope footnote and stop rather than starting
-  Phase 1.
+  eight in-scope JS-cross-compile-to-React+VDOM host languages — ClojureScript
+  (the reference), TypeScript, Melange/ReScript/Reason, F# (Fable), Squint,
+  Scala.js, PureScript, Kotlin/JS — over a two-phase workflow (record the port
+  profile, then one EP loop driven by the pinned spec and live conformance
+  fixtures, with the conformance corpus as the acceptance test). **Do not
+  use** for: writing apps on the CLJS reference (`re-frame2`), greenfield
+  bootstrap (`re-frame2-setup`), v1→v2 migration (`re-frame-migration`),
+  live-app inspection (`re-frame2-pair`), or an out-of-scope target — a
+  non-React substrate (Vue, Solid, Svelte, vanilla DOM) or a host that does
+  not cross-compile to JS (Python, Ruby, native Rust, Go, server-side JVM):
+  out of scope by deliberate spec choice, so surface the `spec/000-Vision.md`
+  scope footnote and stop. Trigger on "port re-frame2", "implement re-frame2
+  in <language>", "conformance corpus".
 allowed-tools:
   - Bash(gh issue *)
   - Bash(git -C * rev-parse *)

--- a/skills/re-frame2-improver/SKILL.md
+++ b/skills/re-frame2-improver/SKILL.md
@@ -1,24 +1,20 @@
 ---
 name: re-frame2-improver
 description: >
-  Focused critique-mode for **existing** re-frame2 ClojureScript code.
-  Reviews a body of source files (or a user-supplied snippet) against
-  a small catalogue of re-frame2 anti-patterns, surfaces concrete
-  findings cross-linked to canonical idioms, and may suggest inline
-  fixes. **Activates only on explicit pull** — phrasings like "review
-  my re-frame2 code for anti-patterns", "audit this against re-frame2
-  best practices", "any improvements?", "is there a better re-frame2
-  pattern here", "spot any anti-patterns in cart/handlers.cljs". A
-  body of re-frame2 source must be in scope: read or edited in this
-  conversation, supplied as a snippet, or named as a resolvable
-  `.cljs` / `.cljc` file or directory (which the skill reads before
-  critiquing) — vocabulary alone is not enough. **Do not use** for
-  greenfield bootstrap, authoring new code, live-runtime work, retro
-  on a pair session, migrating a re-frame v1.x codebase to re-frame2,
-  porting Reagent views to Hicasso (a migration ask even on an
-  already-re-frame2 app), touring the Xray devtools panel, porting
-  re-frame2 itself to a new host, spec/architecture discussion, or
-  inline mid-edit interruption.
+  Focused critique-mode for **existing** re-frame2 ClojureScript code: reviews
+  source files (or a supplied snippet) against a small catalogue of re-frame2
+  anti-patterns, surfaces concrete findings cross-linked to canonical idioms,
+  and may suggest inline fixes. **Do not use** for greenfield bootstrap,
+  authoring new code, live-runtime work, retro on a pair session, migrating a
+  re-frame v1.x codebase, porting Reagent views to Hicasso (a migration ask
+  even on an already-re-frame2 app), touring the Xray devtools panel, porting
+  re-frame2 itself, spec/architecture discussion, or inline mid-edit
+  interruption. **Activates only on explicit pull** — "review my re-frame2
+  code for anti-patterns", "audit this against re-frame2 best practices",
+  "spot any anti-patterns in cart/handlers.cljs" — and a body of re-frame2
+  source must be in scope: read or edited in this conversation, supplied as a
+  snippet, or named as a resolvable `.cljs` / `.cljc` file or directory.
+  Vocabulary alone is not enough.
 allowed-tools:
   - Read
   - Edit

--- a/skills/re-frame2-pair-retro/SKILL.md
+++ b/skills/re-frame2-pair-retro/SKILL.md
@@ -1,24 +1,20 @@
 ---
 name: re-frame2-pair-retro
 description: >
- Retrospect on a `re-frame2-pair` session and turn it into prioritised
- improvement ideas for the pair skill, scripts, MCP surface, or upstream
- `re-frame2` Tool-Pair contract; optionally drafts a GitHub issue the
- user can file. Activates on two triggers: (a) **explicit pull** — user
- asks for a retrospective on a recent pair session ("retro on this pair
- session", "what went wrong with my pair session", "review my
- re-frame2-pair session", "draft an issue about that"); or (b)
- **post-error within a re-frame2-pair session** — after a stack trace, a
- pair tool returning `{:ok? false :reason <kw>}`, or an `:rf.error/*` or
- `:rf.epoch/restore-*` trace firing during live pair work, to
- post-mortem the firefight. Requires evidence: a concrete
- `re-frame2-pair` session in this conversation (turns where the user
- attached, dispatched, walked traces/epochs, hot-swapped, or
- time-travelled), **or** a user-supplied recap of one. **Not** for
- ordinary `re-frame2-pair` operation, nor for code/spec/framework work
- the body's routing matrix sends elsewhere. Vocabulary matches alone
- ("retro", "what went wrong", "any improvements?") do not justify
- activation — a real pair session must have occurred or be recapped.
+  Retrospect on a `re-frame2-pair` session and turn it into prioritised
+  improvement ideas for the pair skill, scripts, MCP surface, or upstream
+  `re-frame2` Tool-Pair contract; optionally drafts a GitHub issue the user
+  can file. **Not** for ordinary `re-frame2-pair` operation, nor for the
+  code/spec/framework work the body's routing matrix sends elsewhere. Requires
+  evidence: a concrete `re-frame2-pair` session in this conversation (turns
+  where the user attached, dispatched, walked traces/epochs, hot-swapped, or
+  time-travelled), **or** a user-supplied recap of one — vocabulary alone
+  ("retro", "what went wrong", "any improvements?") does not justify
+  activation. Two triggers: (a) **explicit pull** — "retro on this pair
+  session", "review my re-frame2-pair session", "draft an issue about that";
+  or (b) **post-error inside a pair session** — after a stack trace, a pair
+  tool returning `{:ok? false :reason <kw>}`, or an `:rf.error/*` or
+  `:rf.epoch/restore-*` trace during live pair work.
 allowed-tools:
  - Read
  - Grep

--- a/skills/re-frame2-setup/SKILL.md
+++ b/skills/re-frame2-setup/SKILL.md
@@ -2,21 +2,19 @@
 name: re-frame2-setup
 description: >
   Greenfield-only bootstrap for re-frame2 ClojureScript projects. Scope:
-  brand-new apps from nothing, or empty CLJS projects (shadow-cljs /
-  Clojure already present but zero re-frame2 wiring). Writes the
-  canonical twelve-file counter SPA the generator template emits — core
-  + the Reagent adapter, `shadow-cljs.edn`, the entry namespace with
-  `rf/init!`, events / subs / views — then installs, compiles, serves it
-  and reports the URL. Trigger on phrasing like "start a re-frame2
-  project", "scaffold re-frame2", "hello-world re-frame2 app", "new
-  re-frame2 app", or a build failure on a freshly-scaffolded project that
-  traces to missing `re-frame.core` / `re-frame.adapter.reagent` wiring.
-  Exits once the counter mounts. **Do not use** for writing app code
-  on an already-bootstrapped project (use `re-frame2`), v1→v2 migration
-  (use `re-frame-migration`), live-app inspection (use `re-frame2-pair`),
-  or porting re-frame2 itself (use `re-frame2-implementor`). For the
-  full disqualifier list and routing to sibling skills, see
-  `skills/README.md` §Skill routing — single source.
+  brand-new apps from nothing, or empty CLJS projects (shadow-cljs / Clojure
+  already present but zero re-frame2 wiring). Writes the canonical twelve-file
+  counter SPA the generator template emits — core + the Reagent adapter,
+  `shadow-cljs.edn`, the entry namespace with `rf/init!`, events / subs /
+  views — then installs, compiles, serves it and reports the URL, exiting once
+  the counter mounts. **Do not use** for writing app code on an
+  already-bootstrapped project (use `re-frame2`), v1→v2 migration
+  (`re-frame-migration`), live-app inspection (`re-frame2-pair`), or porting
+  re-frame2 itself (`re-frame2-implementor`); the full disqualifier list is
+  `skills/README.md` §Skill routing. Trigger on "start a re-frame2 project",
+  "scaffold re-frame2", "hello-world re-frame2 app", or a build failure on a
+  freshly-scaffolded project that traces to missing `re-frame.core` /
+  `re-frame.adapter.reagent` wiring.
 allowed-tools:
   - Bash(clojure -Stree)
   - Bash(clojure -Stree:*)

--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -1,31 +1,21 @@
 ---
 name: re-frame2-xray
 description: >
- Question-first tour of **Xray** — the re-frame2 devtools panel. Use when the
- user wants to know how to *launch* Xray (in-app inline panel, the
- overlay fallback for hosts with no layout column / full-screen-canvas /
- no `[data-rf-xray-host]` — `open-overlay!`, pop-out window, programmatic
- mount, or the wired hotkeys), which of its two
- modes (Dynamic event-spine / Static registry browse) and which tab
- surfaces the data they're looking for, or what each tab is *for*.
- **Do not use** when the user asks the AGENT to inspect or change their
- running app — read-only included (read a sub, get a path, snapshot
- state, walk traces, dispatch): that's `re-frame2-pair`, the
- agent-facing runtime companion. Nor for authoring the host app
- (`re-frame2`), bootstrapping a new project (`re-frame2-setup`), or
- implementing Xray itself (no implementor skill exists — the spec is
- the answer).
- Trigger phrases: "open Xray",
- "which Xray panel shows…", "Xray Static mode", "browse registered
- machines/routes/schemas", "Ctrl+Shift+C", "Xray overlay",
- "Xray open-overlay!", "open Xray with no layout host /
- full-screen canvas", "Xray machine inspector",
- "Xray epoch cascade", "where do Xray issues show up", "Xray Graph
- tab", "where does this value come
- from in Xray", "Xray Resources tab", "Xray Frames tab", "Xray
- module-view", "which image loaded this frame",
- "Xray Hicasso tab", "which Hicasso boundaries are mounted", "what reads
- this subscription", "why did this boundary re-render", and similar.
+  Question-first tour of **Xray**, the re-frame2 devtools panel: how to
+  *launch* it (inline in-app panel; the `open-overlay!` fallback for hosts
+  with no `[data-rf-xray-host]` layout column; pop-out window; programmatic
+  mount; the wired hotkeys), which of its two modes (Dynamic event-spine /
+  Static registry browse) applies, and what each tab is for. **Do not use**
+  when the user asks the AGENT to inspect or change their running app,
+  read-only included (read a sub, snapshot state, walk traces, dispatch) —
+  that is `re-frame2-pair`, the agent-facing runtime companion. Nor for
+  authoring the host app (`re-frame2`), bootstrapping a project
+  (`re-frame2-setup`), or implementing Xray itself (no implementor skill
+  exists — the spec is the answer). Trigger phrases: "open Xray", "which Xray
+  panel shows…", "Xray Static mode", "browse registered
+  machines/routes/schemas", "Xray overlay", "Xray machine inspector", "Xray
+  Graph / Resources / Frames / Hicasso tab", "why did this boundary
+  re-render".
 allowed-tools:
  - Read
  - Grep

--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -2,24 +2,19 @@
 name: re-frame2
 description: >
   Writes re-frame2 ClojureScript application code — events, subscriptions,
-  effects, flows, frames, state machines (reg-machine, parallel regions,
-  tags, spawn), schemas, stories, routing, tests, and the canonical patterns
-  (RemoteData, Resources, ResourcesMutations, Forms, Boot, WebSocket,
-  NineStates, ManagedHTTP, AsyncEffect, LongRunningWork, StaleDetection,
-  ReusableComponents, StatefulComponents, FormAction). Use whenever the user
-  mentions re-frame2, reg-event, reg-sub, reg-fx,
-  reg-cofx, reg-flow, reg-view, reg-machine, reg-route, reg-story,
-  reg-app-schema, reg-resource, reg-mutation, dispatch, subscribe, app-db,
-  flows, frames, regions, tags, the nine UI states, managed HTTP,
-  RemoteData lifecycles, cached server-state / query-cache / TanStack-Query
-  shapes, writing tests for a re-frame2 app, or state-machine-for-HTTP
-  shapes — even when re-frame2 is not named explicitly. **Authoring only**
-  (writing new code).
-  **Do not use** for: live-app inspection (use `re-frame2-pair`),
-  greenfield project bootstrap (use `re-frame2-setup`), v1→v2 migration
-  (use `re-frame-migration`), porting existing Reagent views onto Hicasso,
-  re-frame2's re-frame-native view layer (use `reagent-migration`), or
-  porting re-frame2 itself (use `re-frame2-implementor`).
+  effects, flows, frames, state machines (reg-machine, parallel regions, tags,
+  spawn), schemas, stories, routing, tests, and the canonical patterns
+  (RemoteData, Resources, Forms, Boot, WebSocket, NineStates, ManagedHTTP,
+  AsyncEffect, StaleDetection, FormAction). **Authoring only.** **Do not use**
+  for: live-app inspection (`re-frame2-pair`), greenfield bootstrap
+  (`re-frame2-setup`), v1→v2 migration (`re-frame-migration`), porting Reagent
+  views onto Hicasso (`reagent-migration`), or porting re-frame2 itself
+  (`re-frame2-implementor`). Use whenever the user mentions re-frame2,
+  reg-event, reg-sub, reg-fx, reg-cofx, reg-flow, reg-view, reg-machine,
+  reg-route, reg-resource, reg-mutation, dispatch, subscribe, app-db, flows,
+  frames, regions, tags, the nine UI states, managed HTTP, RemoteData
+  lifecycles, cached server-state / query-cache / TanStack-Query shapes, or
+  tests for a re-frame2 app — even when re-frame2 is not named explicitly.
 allowed-tools:
   - Read
   - Edit

--- a/skills/reagent-migration/SKILL.md
+++ b/skills/reagent-migration/SKILL.md
@@ -1,28 +1,20 @@
 ---
 name: reagent-migration
 description: >
-  Rewrites Reagent VIEW code into **Hicasso** (`re-frame.hicasso`, alias
-  `h`) — re-frame2's re-frame-native view layer. A Reagent hiccup view
-  becomes an `h/defview` mounted in brackets; `@(subscribe …)` becomes
-  `(h/sub …)`; `#(dispatch …)` handlers become event vectors in the tree;
-  Form-2 atoms and Form-3 lifecycle move out of the component.
-  **First establish whether the user needs this at all.** re-frame2's
-  Reagent adapter is first-class and actively supported, so an app moving
-  from re-frame v1 keeps its view code and needs NO rewrite to land on
-  re-frame2 — that is the `re-frame-migration` skill, and it finishes the
-  job. This skill is a genuinely OPTIONAL second step, chosen for what
-  Hicasso offers, and Hicasso is **pre-publication with no released Maven
-  coordinate**. Staying on Reagent is a complete, supported configuration.
-  Trigger on phrasing like "migrate my Reagent views to Hicasso", "port
-  this component to h/defview", "what does r/atom become under Hicasso",
-  "move off Reagent hiccup", or a Reagent view surface named in a Hicasso
-  context (`reagent.core` / `r/atom` / `r/with-let` / `r/create-class` /
-  `reagent.dom` `render` / `adapt-react-class` / `[:> …]` prop dialect /
-  `@(subscribe …)` in a view).
-  **Do not use** for: the re-frame v1→v2 events/subs/db migration
-  (`re-frame-migration`), writing new re-frame2 code (`re-frame2`),
-  greenfield setup (`re-frame2-setup`), or live-runtime inspection
-  (`re-frame2-pair`). See `skills/README.md` §Skill routing for the map.
+  Rewrites Reagent VIEW code into **Hicasso** (`re-frame.hicasso`, alias `h`)
+  — re-frame2's re-frame-native view layer: a view becomes an `h/defview`
+  mounted in brackets, `@(subscribe …)` becomes `(h/sub …)`, handlers become
+  event vectors, Form-2/Form-3 state moves out of the component. **First
+  establish whether the user needs this at all**: re-frame2's Reagent adapter
+  is first-class and supported, so a v1 app keeps its view code and needs NO
+  rewrite to land on re-frame2 — that is `re-frame-migration`, and it finishes
+  the job. This is an OPTIONAL second step, and Hicasso is pre-publication
+  with no released Maven coordinate. **Do not use** for: the v1→v2
+  events/subs/db migration (`re-frame-migration`), writing new re-frame2 code
+  (`re-frame2`), greenfield setup (`re-frame2-setup`), or live-runtime
+  inspection (`re-frame2-pair`). Trigger on "migrate my Reagent views to
+  Hicasso", "port this component to h/defview", or a Reagent view surface
+  (`r/atom`, `@(subscribe …)` in a view) named in a Hicasso context.
 allowed-tools:
   - Bash(rg *)
   - Bash(rg -l *)


### PR DESCRIPTION
Closes rf2-cupfi (reopened by the merged-PR audit of #9051).

## What this changes

`skills/README.md` advertises every skill in this repo as distributable as an
Agent Skill via `npx skills add`, and the [Agent Skills
specification](https://github.com/agentskills/agentskills/blob/main/docs/specification.mdx#description-field)
requires `description` to be 1–1,024 characters.

The first pass at this bead measured Claude Code's shipped runtime instead,
found it slices the listing entry at 1,536 rather than validating at 1,024, and
then wrote **both** the gate and the author-facing guidance against 1,536 — which
left seven advertised skills over the packaging limit and told authors that 1,024
was not a number to write against. A particular runtime not enforcing a
validation does not make an over-limit package conforming, which is what the
audit reopened this for.

**1,024 is now the enforced ceiling; 1,536 and the listing budget are retained as
the reason the *tail* is the part at risk.**

### Descriptions (all nine now under 1,024, disqualifier-first)

Each description now leads with its `**Do not use**` / activation-limit clause and
trails its trigger phrases, so whatever any truncation removes is the expendable
half.

| skill | before | after |
| --- | ---: | ---: |
| `reagent-migration` | 1487 | 1015 |
| `re-frame2-xray` | 1482 | 991 |
| `re-frame2` | 1251 | 1012 |
| `re-frame2-pair-retro` | 1203 | 989 |
| `re-frame2-implementor` | 1186 | 996 |
| `re-frame2-improver` | 1150 | 990 |
| `re-frame2-setup` | 1068 | 971 |
| `re-frame-migration` | 963 | 963 (reordered only — disqualifier moved ahead of the triggers) |
| `re-frame2-pair` | 747 | 747 (untouched) |

No `when_to_use` field exists on any of the nine, so the resolved length is the
`description` alone. Each rewrite was applied by regenerating the folded YAML
block and asserting the re-parsed value equals the intended string exactly.

### Gate

`scripts/check_skill_description_budget.py`:

- **C1 now fails at 1,024**, the portable packaging ceiling, with a message that
  names the spec and the contract this repo advertises.
- The 1,536 slice is **retained and reported**, not deleted: a C1 failure
  *escalates* its message when the description is past 1,536 as well, i.e. when
  it is being silently cut mid-word from the listing today. Both self-test
  directions are covered.
- The `--verbose` summary now names both ceilings explicitly, and `headroom` is
  measured against 1,024.
- **C2 ratchet lowered 10,727 → 8,864**, the family's new listing footprint.

The family footprint still exceeds the ~8,000 whole-listing budget (110.8%, down
from 134.1%). That is not something more trimming can reach: nine skills each
carrying a routing contract cannot fit in 8,000 however they are written. The gate
prints the comparison on every run, passing or failing, and the docstring and
`skills/README.md` both say plainly that it is a product decision rather than a
gate's to make.

The three leaf-size exceptions are untouched, per the audit note.

## Verification of truncation behaviour

Not re-established from scratch — the audit's ruling is that the packaging spec is
the contract regardless of what one runtime enforces, so the 1,024 figure is taken
from the specification (cited above and in the gate), and the 1,536 runtime
measurement is carried forward from rf2-w9p2 rather than re-measured.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/skillcap-a`; exit codes captured
with `echo $?` on the same command line as the runner, never through a pipe.

| gate | exit |
| --- | ---: |
| `python scripts/check_skill_description_budget.py --self-test` (17 cases) | **0** |
| `python scripts/check_skill_description_budget.py --verbose --ci` | **0** |
| `python scripts/check_doc_slugs.py --self-test --verbose` (146 cases) | **0** |
| `python scripts/check_doc_slugs.py --verbose` | **0** — `no broken links.` |

Not run, deliberately: `npm run test:cljs`, `scripts/test-fast-pr.sh`, the Xray /
artefact JVM suites, `mkdocs build --strict`, `clj-kondo`. The diff is markdown
front-matter, one prose section and one Python gate; none of those would inspect
it. `check_doc_slugs.py` is the link gate whose roots include `skills/`.

### Plant proof — the gate reads this tree

Two padding lines appended to `re-frame2-setup`'s description (971 → 1125 chars,
deliberately below 1,536 so the escalation clause should stay silent):

```
ERROR: skills/re-frame2-setup/SKILL.md: resolved description is 1125 chars, 101
over the 1024-char Agent Skills packaging cap. …
ERROR: skills/: the family's listing footprint is 9018 chars, over the pinned
ceiling of 8864. …
re-frame2-setup   1125   1125   1144   -101  OVER CAP
```

exit **1**, naming the planted file; the runtime-slice escalation correctly did
not appear. Restored with `git checkout HEAD --`, and the restore verified by
hash rather than by eye:

```
WORKING_BLOB=2a6796e1e367a2c0930161de7c4204b4c89bb19e
COMMITTED_BLOB=2a6796e1e367a2c0930161de7c4204b4c89bb19e
git status --porcelain -> (empty)
```

Gate green again at exit **0** after the restore.

### CI surfaces armed

`.github/scripts/report-changed-surfaces.sh` (no arguments):
`skills_structural=true`, every other surface `false`.
