### PR TITLE
machines-viz: retire dead validator, region scan, density keys and lint residue

### DIFF
--- a/tools/machines-viz/page/day8/re_frame2_machines_viz/viewer.cljs
+++ b/tools/machines-viz/page/day8/re_frame2_machines_viz/viewer.cljs
@@ -134,7 +134,7 @@
 (defn- chart-view
   "The success path. Mounts MachineChart read-only with a 'show idle'
   toggle that clears the active-state highlight (Lock #5)."
-  [props]
+  [_props]
   (let [show-idle? (r/atom false)]
     (fn [props]
       [:div {:style (:page styles)}

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/ai_generate.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/ai_generate.cljc
@@ -233,7 +233,7 @@
   resolvers are not deterministic by default; for reproducible tests
   inject a stub resolver that returns canned EDN per known prompt."
   ([user-prompt] (generate-machine user-prompt {}))
-  ([user-prompt {:keys [resolver] :as _opts}]
+  ([user-prompt {:keys [resolver]}]
    (let [resolver-fn   (or resolver default-resolver)
          full-prompt   (build-prompt user-prompt)
          response      (resolver-fn full-prompt)

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -88,23 +88,24 @@
   would return the WRONG region's raw node and mis-attribute its `:entry` /
   `:exit` refs — and thus the surfaced `:rf.cofx/requires` — onto another
   region's node. A NON-region node (flat / compound machine, or a parallel
-  root) resolves within `(:states definition)`, with the legacy region-scan
-  fallback preserved ONLY for the no-`:region` shape. A synthetic node (the
-  machine-root / region-container — empty path, or an in-region path with no
-  raw match) resolves to nil. Used to recover a node's ORIGINAL `:entry` /
-  `:exit` keyword refs (the projection rewrote them to `name-of` strings)."
+  root) resolves STRICTLY within `(:states definition)` — rf2-6r9j.122
+  retired the cross-region fallback that used to run for that shape: every
+  node `project-parallel` mints carries `:region`, so the fallback was
+  reachable only from a hand-built node that had lost its region identity,
+  and silently borrowing the FIRST region that happens to share the path is
+  precisely the wrong-region lifecycle bug rf2-6l01c8 fixed. nil is the right
+  answer there. A synthetic node (the machine-root / region-container — empty
+  path, or an in-region path with no raw match) resolves to nil. Used to
+  recover a node's ORIGINAL `:entry` / `:exit` keyword refs (the projection
+  rewrote them to `name-of` strings)."
   [definition {:keys [path region]}]
   (when (seq path)
     (if region
       ;; region-aware: pin the node to its OWN region's states — never a
       ;; sibling region that happens to share the in-region path.
       (node-at-in-states (:states (get-in definition [:regions region])) path)
-      ;; non-region node: top-level states, with the legacy region-scan
-      ;; fallback kept for the no-`:region` shape.
-      (or (node-at-in-states (:states definition) path)
-          (some (fn [[_region region-def]]
-                  (node-at-in-states (:states region-def) path))
-                (:regions definition))))))
+      ;; non-region node: top-level states only.
+      (node-at-in-states (:states definition) path))))
 
 (defn requirement-label
   "Render one `:rf.cofx/requires` entry (Spec 002 §`parse-requires` grammar:

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings.cljs
@@ -117,7 +117,7 @@
   the ring's pointer-events for a side-rail tooltip; v1 also exposes
   the native SVG `<title>` so the tooltip works without JS wiring."
   [{:keys [cx cy r fraction color cancelled? tooltip testid node-id
-           on-hover on-leave] :as _spec}]
+           on-hover on-leave]}]
   [:g (cond-> {:data-testid (str "rf-mv-chart-after-ring-group-" node-id)
                :data-node-id node-id}
         on-hover (assoc :on-mouse-enter (fn [_] (on-hover node-id)))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
@@ -242,7 +242,7 @@
 ;; rf2-egupfk — the AI-generate, Mermaid, and SCXML emitters each project a
 ;; machine definition onto a different surface, but they must agree on which
 ;; definitions are well-formed enough to project AT ALL. Pre-fix each emitter
-;; hand-rolled its own `valid-state-tree?` / parallel check and the copies had
+;; hand-rolled its own shallow state-tree / parallel check and the copies had
 ;; DRIFTED: SCXML accepted malformed parallel region bodies (regions with no
 ;; `:initial` / `:states`) that AI + Mermaid rejected, and AI required a
 ;; KEYWORD `:initial` per the machine contract (Spec 005 §Transition table
@@ -262,17 +262,6 @@
 ;; the runtime `machines` grammar (`re-frame.machines.validate`), they re-state
 ;; the minimum projectable shape the emitters need.
 
-(defn valid-state-tree?
-  "True when `definition` is a well-formed flat / compound state tree: a map
-  carrying a KEYWORD `:initial` (a state id — Spec 005 §Transition table
-  grammar declares state ids are keywords) and a non-empty `:states` map.
-  The shared minimum-shape predicate the three emitters agree on."
-  [definition]
-  (and (map? definition)
-       (keyword? (:initial definition))
-       (map? (:states definition))
-       (seq (:states definition))))
-
 (defn parallel-definition?
   "True when `definition` is a `:type :parallel` root (Spec 005 §Parallel
   regions). nil-safe / non-map-safe."
@@ -288,7 +277,8 @@
   is valid iff it carries no structural projectability defect.
 
   This is NO LONGER a shallow minimum-shape check. Pre-fix it validated only
-  the ROOT (or parallel-region roots) as a `valid-state-tree?`, so it blessed
+  the ROOT (or parallel-region roots) as a shallow minimum-shape state tree
+  (a keyword `:initial` + a non-empty `:states` map), so it blessed
   structurally-invalid-but-shallowly-ok definitions — a nested compound
   missing `:initial`, a dangling transition target, an unknown bare node key —
   and every boundary that delegates here (share encode/decode, AI generation,

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/mermaid.cljc
@@ -764,14 +764,14 @@
     (str indent "[*] --> " (sanitise-id (conj region-path initial)))))
 
 (defn- render-region-block
-  [[region-id {:keys [initial states on] :as _region}]]
+  [[region-id {:keys [initial states on]}]]
   (let [region-path (vector region-id)]
     (concat
      [(str "    state " (sanitise-id region-path) " {")
       (region-initial-line region-path initial 3)]
      (render-root-fallback-alias region-path on 3)
      (render-compound-blocks region-path states 3)
-     [(str "    }")])))
+     ["    }"])))
 
 (defn- render-parallel-region-blocks
   [regions]

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -712,7 +712,7 @@
   No `type=\"internal|external\"` axis is emitted: a root transition moves
   region substates (never the root itself), so the self/ancestor re-enter
   axis does not apply."
-  [event-name {:keys [target guard action] :as candidate} depth]
+  [event-name {:keys [target guard action]} depth]
   (let [targets   (root-region-qualified-targets target)
         target-id (when (seq targets)
                     (str/join " " (map qualified-id targets)))
@@ -1233,20 +1233,20 @@
                 (update-in acc [:on (id-string->keyword event)]
                            (fnil conj []) cand-map))))
           {}
-          ts)]
-    ;; rf2-mnp93.8 — finalise the candidate vectors via the shared
-    ;; `simplify-candidates`. `:always` keeps the full vector-of-maps form so
-    ;; it lines up with `(transition-candidates ...)`.
-    (let [on*      (when (:on coll)
-                     (into {} (map (fn [[ev cands]] [ev (simplify-candidates cands)]) (:on coll))))
-          after*   (when (:after coll)
-                     (into {} (map (fn [[k cands]] [k (simplify-candidates cands)]) (:after coll))))
-          ondone*  (when (contains? coll :on-done) (simplify-candidates (:on-done coll)))]
-      (cond-> {:children-tokens non-transitions}
-        (:on coll)               (assoc :on on*)
-        (:after coll)            (assoc :after after*)
-        (:always coll)           (assoc :always (:always coll))
-        (contains? coll :on-done) (assoc :on-done ondone*)))))
+          ts)
+        ;; rf2-mnp93.8 — finalise the candidate vectors via the shared
+        ;; `simplify-candidates`. `:always` keeps the full vector-of-maps form
+        ;; so it lines up with `(transition-candidates ...)`.
+        on*      (when (:on coll)
+                   (into {} (map (fn [[ev cands]] [ev (simplify-candidates cands)]) (:on coll))))
+        after*   (when (:after coll)
+                   (into {} (map (fn [[k cands]] [k (simplify-candidates cands)]) (:after coll))))
+        ondone*  (when (contains? coll :on-done) (simplify-candidates (:on-done coll)))]
+    (cond-> {:children-tokens non-transitions}
+      (:on coll)                (assoc :on on*)
+      (:after coll)             (assoc :after after*)
+      (:always coll)            (assoc :always (:always coll))
+      (contains? coll :on-done) (assoc :on-done ondone*))))
 
 (declare parse-state-block)
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
@@ -794,7 +794,7 @@
             cur-num (js/parseInt current-version 10)
             newer? (if (and (not (js/isNaN v-num)) (not (js/isNaN cur-num)))
                      (> v-num cur-num)
-                     (pos? (compare (str v) (str current-version))))]
+                     (pos? (compare (str v) current-version)))]
         (when newer?
           (decode-error :unknown-version
                         "share-URL was produced by a newer Machines-Viz"

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
@@ -43,6 +43,15 @@
   arrowhead size rides the density alongside the stroke (the projector
   baked literal 10 / 18 / 12 before, ignoring `:density`).
 
+  rf2-6r9j.117 — removed four more density-map keys no renderer ever
+  read: `:root-title-height` / `:root-title-px` / `:root-context-pad` (the
+  root chrome moved INTO the root-container frame in rf2-q129z8 and reads
+  the `:container-title-*` keys; the context band reads `chart.projection`'s
+  own constants) and `:action-pill-gap` (an action row paints ONE chip, so
+  no renderer has ever had adjacent action pills to space). They tuned
+  nothing — changing them changed no pixel — while their three-map
+  duplication implied a supported tuning surface.
+
   rf2-g6cig — corner-radius locked at 6px across every density. The
   React Flow default (8) reads as 'product chrome'; brutalist (0)
   reads as 'wireframe'; 6 is the sweet spot — soft enough to feel
@@ -123,7 +132,6 @@
     :action-pill-pad-x        — action pill horizontal padding
     :action-pill-px           — action pill text font-size
     :action-pill-radius       — action pill corner radius
-    :action-pill-gap          — gap between adjacent action pills
     :action-pill-row-gap      — gap from action pill row to its
                                 anchor (state label / edge event line)
     :dot-grid-spacing-px      — dot-grid background pattern spacing
@@ -161,7 +169,6 @@
    :action-pill-pad-x      6
    :action-pill-px         9
    :action-pill-radius     6
-   :action-pill-gap        4
    :action-pill-row-gap    4
 
    ;; ── structured topology grammar (rf2-az6e2) ──────────────────
@@ -199,11 +206,6 @@
    :pseudo-size            12
    :pseudo-radius          6
    :pseudo-px              8
-   ;; Root chrome (title strip + context panel).
-   :root-title-height      30
-   :root-title-px          14
-   :root-context-pad       8
-
    ;; ── dot-grid background (rf2-m4nj4) ──────────────────────────
    :dot-grid-spacing-px    16
    :dot-grid-radius-px     1.0})
@@ -254,7 +256,6 @@
    :action-pill-pad-x      5
    :action-pill-px         7
    :action-pill-radius     5
-   :action-pill-gap        3
    :action-pill-row-gap    3
 
    ;; ── structured topology grammar (rf2-az6e2 — ~25% tighter) ───
@@ -284,10 +285,6 @@
    :pseudo-size            10
    :pseudo-radius          5
    :pseudo-px              7
-   :root-title-height      26
-   :root-title-px          12
-   :root-context-pad       6
-
    ;; ── dot-grid background ──────────────────────────────────────
    :dot-grid-spacing-px    12
    :dot-grid-radius-px     0.85})
@@ -336,7 +333,6 @@
    :action-pill-pad-x      7
    :action-pill-px         11
    :action-pill-radius     8
-   :action-pill-gap        5
    :action-pill-row-gap    5
 
    ;; ── structured topology grammar (rf2-az6e2 — ~25% looser) ────
@@ -366,10 +362,6 @@
    :pseudo-size            14
    :pseudo-radius          7
    :pseudo-px              9
-   :root-title-height      34
-   :root-title-px          16
-   :root-context-pad       10
-
    ;; ── dot-grid background ──────────────────────────────────────
    :dot-grid-spacing-px    20
    :dot-grid-radius-px     1.15})

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
@@ -1361,7 +1361,7 @@
           root-edges (filter :parallel-root-on? edges)
           ids        (map :id root-edges)]
       (is (= 2 (count root-edges)) "both the root :on and root :after edges project")
-      (is (= 1 (count (filter #(and (:parallel-root-after? %)) root-edges)))
+      (is (= 1 (count (filter :parallel-root-after? root-edges)))
           "exactly one is the :after edge")
       (is (= 1 (count (remove :parallel-root-after? root-edges)))
           "exactly one is the plain :on edge")
@@ -1522,6 +1522,46 @@
       (is (not= (:exit-requires audio) (:exit-requires video))
           "region :audio's exit-requires do NOT bleed onto region :video's
            same-named node"))))
+
+(deftest raw-node-at-no-region-node-never-borrows-a-sibling-region
+  (testing "rf2-6r9j.122 — a node with a region-relative `:path` but NO
+            `:region` resolves against the TOP-LEVEL `:states` only, and a
+            parallel definition has none — so the answer is nil, never the
+            first region that happens to carry a state of that name. The
+            retired fallback scanned `(:regions definition)` in map order and
+            returned whichever region matched first, which is exactly the
+            wrong-region lifecycle attribution rf2-6l01c8 fixed; every node
+            `project-parallel` mints carries `:region`, so nothing in the
+            pipeline can reach this shape — a hand-built node that has lost
+            its region identity gets nil rather than a plausible-looking
+            neighbour."
+    (let [m {:type    :parallel
+             :regions {:audio {:initial :active
+                               :states  {:active {:entry :enter-a} :off {}}}
+                       :video {:initial :active
+                               :states  {:active {:entry :enter-b} :off {}}}}}]
+      (is (nil? (layout/raw-node-at m {:path [:active]}))
+          "a no-:region region-relative node resolves to nil, not region
+           :audio's raw node")
+      (is (= {:entry :enter-a} (layout/raw-node-at m {:path [:active] :region :audio}))
+          "the :audio node still resolves strictly within its own region")
+      (is (= {:entry :enter-b} (layout/raw-node-at m {:path [:active] :region :video}))
+          "the :video node still resolves strictly within its own region")))
+  (testing "rf2-6r9j.122 — flat / compound (no-`:region`) lookup is unchanged:
+            a top-level `:states` node and a nested compound descendant both
+            still resolve, and an absent path is still nil"
+    (let [m {:initial :idle
+             :states  {:idle {:entry :log}
+                       :busy {:initial :step1
+                              :states  {:step1 {:exit :cleanup}}}}}]
+      (is (= {:entry :log} (layout/raw-node-at m {:path [:idle]}))
+          "a flat top-level node resolves")
+      (is (= {:exit :cleanup} (layout/raw-node-at m {:path [:busy :step1]}))
+          "a nested compound descendant resolves")
+      (is (nil? (layout/raw-node-at m {:path [:nope]}))
+          "an absent path is nil")
+      (is (nil? (layout/raw-node-at m {:path []}))
+          "the synthetic empty-path node is nil"))))
 
 ;; ---- a REGION's OWN top-level :on-done (rf2-2ydc87) ---------------------
 ;;

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/overlays/after_rings_geometry_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/overlays/after_rings_geometry_cljs_test.cljc
@@ -10,8 +10,8 @@
 
   Dual-target via the `_cljs_test.cljc` extension — same pattern every
   machines-viz helper test uses."
-  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
-               :cljs [cljs.test    :refer-macros [deftest is testing]])
+  (:require #?(:clj  [clojure.test :refer [deftest is]]
+               :cljs [cljs.test    :refer-macros [deftest is]])
             [day8.re-frame2-machines-viz.chart.overlays.after-rings-geometry
              :as geo]))
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -142,12 +142,6 @@
   [elk-children]
   (:children (first elk-children)))
 
-(defn- root-child-by-id
-  "rf2-q129z8 — pluck one effective-top-level elk child by id (an element
-  of `root-children`)."
-  [elk-children id]
-  (first (filter #(= id (:id %)) (root-children elk-children))))
-
 (defn- event-node-for
   "rf2-qo5xy — find the event-node a projected graph emitted for a
   given parsed-edge id. The events-as-nodes paradigm hoists each
@@ -1934,9 +1928,9 @@
 (deftest elk-edge-omits-priority-when-no-initial-set
   (testing "rf2-k504af — with no `initial-ids` (the pre-bead 2-arity
             path), NO edge carries the direction-priority option"
-    (let [parsed  (layout/project-definition idle-loading)
-          elk-eds (projection/->elk-edges parsed)] ;; 2-arity → no initial set...
-      ;; ->elk-edges DOES derive the set, so assert via the bare ->elk-edge.
+    (let [parsed (layout/project-definition idle-loading)]
+      ;; `->elk-edges` DERIVES the initial set itself, so the no-initial-set
+      ;; arity is reachable only through the bare `->elk-edge`.
       (is (every? #(nil? (in-edge-priority %))
                   (mapcat #(projection/->elk-edge % nil nil) (:edges parsed)))
           "the nil initial-ids arity leaves every edge unset"))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/cross_emitter_agreement_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/cross_emitter_agreement_cljs_test.cljc
@@ -530,7 +530,7 @@
 ;; ---------------------------------------------------------------------------
 ;; rf2-egupfk — the three emitters agree on DEFINITION-SHAPE VALIDATION.
 ;;
-;; Pre-fix each emitter hand-rolled its own `valid-state-tree?` / parallel
+;; Pre-fix each emitter hand-rolled its own shallow state-tree / parallel
 ;; check and the copies had DRIFTED:
 ;;
 ;;   - SCXML accepted MALFORMED PARALLEL REGION BODIES (a region with no

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
@@ -91,11 +91,14 @@
     :action-pill-pad-x
     :action-pill-px
     :action-pill-radius
-    :action-pill-gap
     :action-pill-row-gap
     ;; structured topology grammar (rf2-az6e2) — state title/body box,
     ;; compound container, parallel region, event route chip, pseudo-
-    ;; state markers, action-section caption, root chrome.
+    ;; state markers, action-section caption. The root chrome lives in the
+    ;; root-container frame (rf2-q129z8) and reads the `:container-title-*`
+    ;; keys; the `:root-title-*` / `:root-context-pad` keys it superseded
+    ;; retired unread in rf2-6r9j.117, alongside `:action-pill-gap` (an
+    ;; action row paints ONE chip, so nothing ever spaced two).
     :state-title-height
     :state-title-pad-x
     :state-title-px
@@ -122,9 +125,6 @@
     :pseudo-size
     :pseudo-radius
     :pseudo-px
-    :root-title-height
-    :root-title-px
-    :root-context-pad
     ;; dot-grid background (rf2-m4nj4)
     :dot-grid-spacing-px
     :dot-grid-radius-px})
@@ -285,7 +285,7 @@
 (deftest structured-grammar-geometry-monotonic
   (testing "rf2-az6e2 — the structured-topology grammar geometry
             (state title strip, container title, event chip, region
-            title, root title) is monotonic across the density axis:
+            title) is monotonic across the density axis:
             compact < regular < cosy. Density scales QUANTITY; a key
             that walked back or up unexpectedly would ship a mislabelled
             density. The corner-radius lock (6) remains the only
@@ -293,8 +293,7 @@
     (doseq [k [:state-title-height :state-title-px
                :container-title-height :event-chip-min-w
                :event-chip-min-h :event-chip-px
-               :region-title-height :pseudo-size :root-title-height
-               :root-title-px]]
+               :region-title-height :pseudo-size]]
       (is (< (get vc/chart-compact k)
              (get vc/chart-regular k)
              (get vc/chart-cosy k))


### PR DESCRIPTION
Four vestige removals across `tools/machines-viz/**` (rf2-6r9j.107, .117, .122, .125). Every premise was checked at source before acting; all four held.

## rf2-6r9j.107 — orphan `valid-state-tree?` validator

`grammar/valid-state-tree?` deleted. A repo-wide exact-symbol search found the definition and three prose mentions, and no caller in source, test, Xray, build or docs. `76a27a4edb` routed `valid-definition?` through the recursive `definition-defect`; the shallow predicate stayed behind as a second, weaker definition-validity concept a future caller could select by accident. `valid-definition?` still delegates to `definition-defect` and its diagnostics are untouched. The historical comments now name the shape (a keyword `:initial` plus a non-empty `:states` map) instead of a var that no longer exists.

## rf2-6r9j.122 — unreachable legacy region scan in `raw-node-at`

`chart.layout/raw-node-at`'s no-`:region` fallback scanned every parallel region for the same path and returned the FIRST match. It is unreachable from the pipeline:

- `project-parallel` stamps `:region` on every region state node and on the synthetic region container.
- The parallel-root chip's path segment is `:rf.machines-viz.layout/parallel-root` — namespaced precisely so it can never name a real region or state — so its top-level miss falls through the scan to nil anyway.
- The machine-root chip has an empty path and is rejected before lookup.
- Flat and compound nodes live under top-level `:states`, so their first lookup resolves; a flat definition has no `:regions` for the scan to walk.

So the branch could only fire for a hand-built node that had lost its region identity, and there silently borrowing a sibling region's `:entry` / `:exit` refs — and thus the surfaced `:rf.cofx/requires` — is exactly the wrong-region lifecycle attribution rf2-6l01c8 fixed. nil is the right answer. `raw-node-at` is absent from `spec/API.md`'s enumerated public surface and from `tools/machines-viz/spec/API.md`, so no compatibility obligation was found.

New regression `raw-node-at-no-region-node-never-borrows-a-sibling-region` pins both halves: a no-`:region` region-relative node returns nil (not the first region's raw node), each region's node still resolves strictly within its own region, and flat / nested-compound / absent-path / empty-path lookup is unchanged.

## rf2-6r9j.117 — four unread density constants

`:root-title-height`, `:root-title-px`, `:root-context-pad` and `:action-pill-gap` removed from the compact, regular and cosy maps, from the regular map's key documentation, and from the key-set and monotonicity tests. Root chrome moved into the root-container frame under rf2-q129z8 and reads the `:container-title-*` keys; the context band reads `chart.projection`'s own constants; an action row paints one chip, so no renderer has ever had adjacent action pills to space. Changing any of the four changed no pixel while their three-map duplication implied a supported tuning surface.

A repo-wide sweep across `.clj/.cljs/.cljc/.md/.edn/.js/.cjs/.html` now finds only the deliberate retirement bookkeeping. The three maps still share an identical key set (the invariant test still asserts it) and no rendered value changed.

## rf2-6r9j.125 — dead bindings, helper and no-op wrappers

clj-kondo over `src`, `page` and `test` reported eight warnings; all eight are gone, plus the three underscore-named aliases whose naming hid them from ordinary unused-binding lint:

- `scxml.cljc` — unused `:as candidate` destructure; the redundant `let` wrapping `consume-transitions`' final expression merged into the enclosing binding vector.
- `ai_generate.cljc` `:as _opts`, `chart/overlays/after_rings.cljs` `:as _spec`, `mermaid.cljc` `:as _region` — removed.
- Two single-argument `str` wrappers: a string literal in `mermaid.cljc`, and the already-string `current-version` (the literal `"2"`) in `share.cljs`.
- `projection_cljs_test.cljc` — orphan private `root-child-by-id` deleted; the discarded `(projection/->elk-edges parsed)` binding in `elk-edge-omits-priority-when-no-initial-set` removed, so the test now contains only the bare `->elk-edge` path it actually asserts.
- `after_rings_geometry_cljs_test.cljc` — `testing` referred on both reader branches but never used.
- `layout_cljs_test.cljc` — single-argument `and` collapsed to the keyword itself.
- `viewer.cljs` — the form-2 outer argument is structurally required but never read (the inner fn shadows it); renamed `_props`.

The readable unit-factor nesting in `resolve-timeout-ms` is deliberately kept per the bead — those six info-level arithmetic hints are not dead behaviour. No required React/Reagent callback arity was touched, SCXML candidate simplification is unchanged, and the projection test's real bare `->elk-edge` assertion is intact.

## Verification

- `tools/machines-viz` JVM suite (`clojure -M:test`): **642 tests, 2785 assertions, 0 failures, 0 errors, exit 0**. Every file this PR touches other than three `.cljs` ones is `.cljc` and runs in that lane, including all five modified test namespaces.
- `clj-kondo --lint tools/machines-viz/{src,page,test}`: **exit 2 with 8 warnings before, exit 0 with 0 warnings after**. The six remaining findings are the info-level `resolve-timeout-ms` hints the bead says to keep.
- Gate liveness proved on the new regression: restoring the region scan as a one-line fault turned the suite red at `layout_cljs_test.cljc:1543` (`actual: (not (nil? {:entry :enter-a}))` — the borrowed neighbour), exit 1; restoring the file returned blob `8c6649a212...`, byte-identical to the pre-fault hash, and the suite went green again.
- The three `.cljs`-only edits are behaviour-identical by inspection: an unread parameter renamed, an unused destructure alias dropped, and `(str "2")` reduced to `"2"`. The `cljs-tools-machines-viz` and browser lanes were left to CI rather than run locally.
- No hot-zone file touched. Spec unchanged because none of the four removed surfaces appears in `tools/xray/spec/`, `tools/machines-viz/spec/` or `spec/` — all four are internal residue with no documented contract (verified by grep).
