### PR TITLE
chore(mcp-conformance): shrink four private surfaces to their live consumers

### DIFF
--- a/tools/mcp-conformance/lib/overflow-marker.cjs
+++ b/tools/mcp-conformance/lib/overflow-marker.cjs
@@ -200,17 +200,20 @@ function assertBodiesAgree(textBody, structuredBody, ctx) {
   }
 }
 
+// Exported: the surface the two importers actually consume —
+// `test/overflow-marker.test.cjs` (the unit gate) and
+// `test/live-re-frame2-pair-overflow.cjs` (the live gate). `OVERFLOW_KEY`,
+// `REQUIRED_FIELDS`, `parseOverflowText` and `canonicalize` stay module-local:
+// each is live INSIDE this file, and the JVM cross-encoding gate
+// (`js-assertOverflowBody-pins-every-re-frame2-pair-overflow-required-field`)
+// source-greps the `REQUIRED_FIELDS` rows rather than importing the table.
 module.exports = {
-  OVERFLOW_KEY,
   EDN_PARSE_OPTS,
-  REQUIRED_FIELDS,
   isPlainObject,
   unwrapClosedOverflow,
   assertOverflowBody,
   validateOverflowWrapper,
-  parseOverflowText,
   validateOverflowText,
-  canonicalize,
   bodiesEqual,
   assertBodiesAgree,
 };

--- a/tools/mcp-conformance/lib/token-match.cjs
+++ b/tools/mcp-conformance/lib/token-match.cjs
@@ -29,4 +29,6 @@ function includesToken(text, token) {
   return new RegExp('(?<![\\w-])' + escapeRegExp(token) + '(?![\\w-])').test(text);
 }
 
-module.exports = { escapeRegExp, includesToken };
+// `escapeRegExp` is an implementation detail of `includesToken`; only the
+// anchored matcher is a consumer-facing seam.
+module.exports = { includesToken };

--- a/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
+++ b/tools/mcp-conformance/scripts/run-re-frame2-pair-live-hermetic-suite.cjs
@@ -1418,13 +1418,19 @@ if (require.main === module) {
 // still reports the file present, proving the runner now fails LOUD
 // instead of logging-and-continuing into a poll loop that would have
 // trusted the surviving stale file.
-// `finalizeConformance` + `describeDirty` are exported for the teardown-
-// grading regression harness (`hermetic-grading.test.cjs`, rf2-j538f7.19): it
-// drives the REAL grading decision against clean vs dirty cleanup reports,
-// proving a dirty teardown emits NO pass sentinel and returns orchestration
-// exit 2 while a clean teardown emits the sentinel exactly once and returns 0.
-// `closeOutcomeWithin` + `isBrowserProvablyDisconnected` back the browser
-// grading `runner-cleanup.test.cjs` exercises through `makeCleanup`.
+//
+// `finalizeConformance` is exported for the teardown-grading regression
+// harness (`hermetic-grading.test.cjs`, rf2-j538f7.19): it drives the REAL
+// grading decision against clean vs dirty cleanup reports, proving a dirty
+// teardown emits NO pass sentinel and returns orchestration exit 2 while a
+// clean teardown emits the sentinel exactly once and returns 0.
+//
+// `closeOutcomeWithin`, `isBrowserProvablyDisconnected` and `describeDirty`
+// are deliberately NOT exported: each stays module-local and is reached from
+// a test only through the composed behaviour above — the browser-close
+// grading through `makeCleanup`, the dirty-report prose through
+// `finalizeConformance`. Exporting them would advertise a test seam that
+// invites coupling to the helper instead of the decision it serves.
 module.exports = {
   runTrusted,
   SETUP_COMMAND_TIMEOUT_MS,
@@ -1432,10 +1438,7 @@ module.exports = {
   isContainmentEscape,
   makeCleanup,
   settledWithin,
-  closeOutcomeWithin,
-  isBrowserProvablyDisconnected,
   finalizeConformance,
-  describeDirty,
   waitForChildExit,
   spawnAndGradeInnerTest,
   wipeStalePortFileCandidate,

--- a/tools/mcp-conformance/test/_runner.cjs
+++ b/tools/mcp-conformance/test/_runner.cjs
@@ -11,7 +11,9 @@ const { decodeDedupEnvelope } = require('../lib/dedup-envelope.cjs');
 const CLIENT_VERSION = '0.1.0';
 
 // `onClient` runs before connect awaits, making a hung initialize handshake
-// reachable by the caller's watchdog.
+// reachable by the caller's watchdog. Only the client is returned: the SDK
+// `Protocol` takes ownership of the transport at `connect()`, so `client.close()`
+// is the single teardown handle and a second one would invite a double close.
 async function connectServer({ transportSpec, clientName, stderrPrefix = '[server]', onClient }) {
   const transport = new StdioClientTransport({ ...transportSpec, stderr: 'pipe' });
   const client = new Client({ name: clientName, version: CLIENT_VERSION }, { capabilities: {} });
@@ -26,7 +28,7 @@ async function connectServer({ transportSpec, clientName, stderrPrefix = '[serve
     await closeQuietly(client);
     throw connectErr;
   }
-  return { client, transport };
+  return { client };
 }
 
 // Teardown must not mask the conformance outcome already recorded.
@@ -79,15 +81,16 @@ async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) 
   let exitCode;
   let bodyError;
   try {
-    let transport;
     // Capture before connect; retain the resolved binding for finally.
-    ({ client, transport } = await connectServer({
+    ({ client } = await connectServer({
       transportSpec,
       clientName,
       onClient: (c) => { activeClient = c; },
     }));
     activeClient = client;
-    await body(client, transport);
+    // `body` receives the connected client and nothing else — the client owns
+    // its transport, so there is no second handle for a caller to tear down.
+    await body(client);
     exitCode = 0;
   } catch (err) {
     exitCode = 1;

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
@@ -143,9 +143,8 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Inline-emit anti-pin — neither slot literal may appear inline in any
-;; re-frame2-pair-mcp source file OTHER than the helper itself (and the
-;; descriptors file, whitelisted
-;; below). A tool that bypasses the helper to `(assoc envelope
+;; re-frame2-pair-mcp source file OTHER than the helper itself. A tool
+;; that bypasses the helper to `(assoc envelope
 ;; :dropped-sensitive N)` directly violates the MUST-level parity rule
 ;; — the helper exists precisely to centralise the omit-when-zero rule
 ;; and the parity invariant.
@@ -156,13 +155,16 @@
   `:elided-large` keywords. Anything else MUST go through the
   `with-indicators` helper.
 
-  - `wire.cljs`        — the helper itself (the canonical emit-path).
-  - `descriptors.cljs` — tool-descriptor docstrings reference the slot
-                         names; these are documentation strings shipped
-                         in the `tools/list` response shape, not envelope
-                         emissions."
-  #{"tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs"
-    "tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors.cljs"})
+  - `wire.cljs` — the helper itself (the canonical emit-path).
+
+  This set holds ONE entry by design. Documentation that names the slots
+  — descriptor prose shipped in the `tools/list` response, docstrings
+  cross-linking the helper — needs no entry: the gate strips comments,
+  docstrings and strings BEFORE it greps (efd0c8dbf32), so prose is
+  already invisible to it. A whitelist row is strictly stronger than that:
+  it skips the file WHOLE, so a later real emission there would evade the
+  gate. Add a row only for a file that must carry the literal in CODE."
+  #{"tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs"})
 
 (defn- mcp-source-files
   "Walk `src-rel` (a repo-relative subdir) and return every `.cljs`
@@ -193,7 +195,8 @@
   ;; docstring / comment / descriptor-string mentions — descriptor
   ;; descriptions ship the slot names as user-visible documentation
   ;; (e.g. `"Dropped count surfaces as `:dropped-sensitive` ..."` in
-  ;; `descriptors_data.cljs`), and tool-source docstrings cross-link the
+  ;; `descriptors_data.cljs`, which is NOT whitelisted and is scanned like
+  ;; any other file), and tool-source docstrings cross-link the
   ;; helper they delegate to. Those are documentation, not
   ;; emissions; the strip-then-grep posture catches real inline emits
   ;; (`(assoc envelope :dropped-sensitive N)`) while letting prose

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/infinite_trace_ops_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/infinite_trace_ops_test.clj
@@ -35,8 +35,7 @@
   so `:rf.resource/load-more` is NOT reported as a near-miss of
   `:rf.resource/load-more-skipped` (one is a genuine keyword-token prefix of
   the other)."
-  (:require [clojure.string :as str]
-            [clojure.test    :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is testing]]
             [re-frame.mcp-conformance.fixtures :as fx]
             [re-frame.mcp-conformance.wire-vocab.source-pins :as pins]))
 

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/operating_frame_address_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/operating_frame_address_test.clj
@@ -59,8 +59,7 @@
             [clojure.test   :refer [deftest is testing]]
             [malli.core     :as m]
             [malli.error    :as me]
-            [re-frame.mcp-conformance.fixtures :as fx]
-            [re-frame.mcp-conformance.wire-vocab.source-pins :as pins]))
+            [re-frame.mcp-conformance.fixtures :as fx]))
 
 ;; ---------------------------------------------------------------------------
 ;; Canonical schemas. The operating-frame envelope has a SUCCESS shape and a

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/schemas.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab/schemas.clj
@@ -5,8 +5,10 @@
   contracted servers, and representative fixtures. Family-local schemas
   such as result envelopes and event bundles stay beside their focused
   tests. Wrapper maps are closed and single-keyed; marker bodies remain
-  open where additive fields are part of the contract."
-  (:require [malli.core :as m]))
+  open where additive fields are part of the contract.
+
+  This namespace defines schema DATA; the validating test namespaces are
+  where Malli is executed, so it requires nothing.")
 
 ;; ---------------------------------------------------------------------------
 ;; Canonical schemas. Single source of truth.


### PR DESCRIPTION
Four vestige removals across `tools/mcp-conformance/`, one per bead. Each "unconsumed" claim was proved with a fixed-string census over tracked files plus a second independent instrument, and each census was paired with a control that fired.

## rf2-6r9j.129 — remove the zero-consumer transport handle from the runner contract

`test/_runner.cjs`'s `connectServer` returned `{ client, transport }` and `runWithWatchdog` retained a `transport` local solely to call `body(client, transport)`. Nothing read it.

- Census: `transport` across `tools/mcp-conformance` — every hit outside `_runner.cjs` is `transportSpec` (a different, retained parameter) or prose. `client, transport` appears nowhere but the three lines this PR changes.
- Semantic check: all 12 `runWithWatchdog(` sites enumerated. The 11 bodies take `async (client)` ×7, `async (rawClient)` ×2, `async ()` ×2 — none takes a second argument. All four direct `connectServer` callers destructure `{ client }` or read `aux.client`.
- Control: the same fixed-string method over `client, called` returned 3 files, so an existing two-name pattern is detectable by it.

The pinned `@modelcontextprotocol/sdk` 1.29.0 contract says `Protocol` assumes ownership of the transport and `close()` calls `this._transport?.close()`, which is what the existing `closeQuietly(client)` teardown already relies on — a second handle contradicted it. `connectServer` now returns `{ client }`, so call-site churn is zero.

## rf2-6r9j.130 — prune eight unconsumed private CommonJS exports

- `lib/overflow-marker.cjs`: dropped `OVERFLOW_KEY`, `REQUIRED_FIELDS`, `parseOverflowText`, `canonicalize`. Its two importers (`test/overflow-marker.test.cjs`, `test/live-re-frame2-pair-overflow.cjs`) consume the other eight between them.
- `lib/token-match.cjs`: dropped `escapeRegExp`. Both importers request `includesToken` only.
- `scripts/run-re-frame2-pair-live-hermetic-suite.cjs`: dropped `closeOutcomeWithin`, `isBrowserProvablyDisconnected`, `describeDirty`.

Every definition stays live inside its own module — only the export property goes.

- Census: each symbol searched as a fixed string across tracked `*.cjs`/`*.js`/`*.mjs`. All eight are confined to their defining file.
- Semantic check: all six `require(ORCH)` destructurings enumerated; their union is exactly the ten exports that remain.
- Controls: `includesToken` returned two external importers and `settledWithin` / `finalizeConformance` returned external importers in `runner-cleanup.test.cjs` / `hermetic-grading.test.cjs`, so the census demonstrably detects a real external consumer.

`REQUIRED_FIELDS` keeps its named source table: the JVM gate `js-assertOverflowBody-pins-every-re-frame2-pair-overflow-required-field` greps the row literals out of the file text and never imports the table. The orchestrator's export comment claimed `hermetic-grading.test.cjs` imports `describeDirty`; it imports `finalizeConformance` only, and the comment now says so.

## rf2-6r9j.131 — remove three dead namespace requires

- `clojure.string :as str` from `infinite_trace_ops_test.clj` — every `str` in that file is `clojure.core/str` (or `pr-str`); there is no `str/` form.
- `source-pins :as pins` from `operating_frame_address_test.clj` — no `pins/` form. `str`, `m`, `me` and `fx` are all still used there and are untouched.
- `malli.core :as m` from `wire_vocab/schemas.clj` — no `m/` form; that namespace defines schema DATA and the validating test namespaces are where Malli executes. `malli` remains a wire-vocab dependency.

- Census: fixed-string search for each alias-qualified prefix in its file, each paired with a control that hit (`pins/` in the first file, `fx/` in the second, `m/` across the sibling wire-vocab tests).
- Second instrument: `clj-kondo --lint tools/mcp-conformance/wire-vocab/test` reports **0 errors, 0 warnings**. Control — reinstating one of the three requires made it report `namespace clojure.string is required but never used` at that exact line, so `:unused-namespace` is genuinely enabled on this tree. No suppression or config exclusion was added.

## rf2-6r9j.132 — remove the stale descriptor exemption from the indicator gate

`inline-emit-whitelist` in `indicator_field_test.clj` skipped `descriptors.cljs` whole, before the file was read, because its prose mentioned the slot names. Commit `efd0c8dbf32` had already made that unnecessary by stripping comments, docstrings and strings before matching. The whitelist row was strictly stronger than the strip: it made the file invisible to a MUST-level single-emit-path gate.

The bead's stated premise is that descriptor docstrings mention `:dropped-sensitive` / `:elided-large`. **On the current tree that premise no longer holds** — `descriptors.cljs` contains neither literal in any form. The only prose occurrence in the tree is in `descriptors_data.cljs`, which is *not* whitelisted and passes the gate purely on the strip. So the exemption was doubly stale, and removing it is the same fix the bead asks for.

`wire.cljs` remains the explicit central-helper exception.

## Verification

Gate liveness proved once, on the gate this PR tightens:

1. Planted `(defn- planted-fault [envelope] (assoc envelope :dropped-sensitive 1))` in `descriptors.cljs`. The focused namespace went **RED**, naming the file and the literal: `Inline ':dropped-sensitive' literal found in tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/descriptors.cljs (in code, AFTER stripping comments/docstrings/strings)`.
2. With the same fault in place, temporarily restoring the old whitelist row turned it **GREEN** (exit 0) — the blind spot this PR closes, reproduced directly.
3. Both temporary changes reverted; `descriptors.cljs` verified byte-identical by blob hash (`6cbd4df82d18a212c4b69ecd1ce4f211aa06a349` before and after), and it carries no diff in this PR.

Suites, exit codes captured to file and read back:

| gate | result |
|---|---|
| `npm --prefix tools/mcp-conformance run test:unit` | exit **0** — 124 tests, 115 pass, 0 fail, 9 skipped (pre-existing Windows symlink-privilege skips) |
| `clojure -M:test` from `tools/mcp-conformance/wire-vocab` | exit **0** — 94 tests, 1031 assertions, 0 failures, 0 errors |
| `clj-kondo --lint tools/mcp-conformance/wire-vocab/test` | exit **0** — 0 errors, 0 warnings |

The wire-vocab suite was re-run on the final shipping tree after every temporary edit was reverted, and returned the same 94/1031/0/0.

No MCP wire, schema, tool-descriptor or protocol surface changes. No hot-zone file touched.