### PR TITLE
chore(audit): mcp-base + testbed-support vestige sweep (rf2-6r9j.104, .105, .113, .118)

### DIFF
--- a/tools/mcp-base/src/re_frame/mcp_base/args.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/args.cljc
@@ -155,9 +155,33 @@
   [raw default]
   (parse-int* raw default 1))
 
+;; rf2-6r9j.104 — disposition: KEPT, deliberately, with no in-repo caller.
+;; Verified 2026-09-03 by a fixed-string census over tracked files: every
+;; live numeric MCP arg is a positive int (`cursor/parse-limit-arg`'s
+;; `:limit`, story-mcp's `:timeout-ms`) or `cap/max-tokens`, which admits
+;; zero but REJECTS its out-of-domain values rather than defaulting and so
+;; cannot route through a defaulting parser. The floor-0 half is retained
+;; because it is the other half of ONE parser: `parse-int*`'s `floor`
+;; parameter exists precisely because both floors are offered, and the
+;; contracts an auditor might fear are being carried for a lone caller —
+;; the finite/safe-integer guard, the strict string grammar, the
+;; cross-host agreement — are `parse-int*`'s and `coerce-finite-long`'s,
+;; shared with `parse-positive-int` and tested once. What is specific to
+;; this var is the floor, and its own tests are a handful of assertions
+;; about exactly that. Deleting it would leave a `floor` parameter with a
+;; single constant argument and force any consumer whose arg admits a
+;; disabling zero to re-derive the guard by hand.
+
 (defn parse-non-negative-int
-  "Like `parse-positive-int` but admits zero (useful when zero means
-  \"disabled\" — e.g. max-tokens=0 disables the cap)."
+  "Like `parse-positive-int` but clamps to zero rather than one — the
+  parser for a numeric arg whose domain INCLUDES zero, typically as a
+  \"disabled\" sentinel. Same accepted shapes, same cross-runtime
+  finite/safe-integer guard, same fall-back-to-`default` posture for
+  everything out of domain.
+
+  Reach for `parse-positive-int` instead when zero is meaningless for the
+  arg, and for a zero-admitting arg that must REJECT rather than default
+  on bad input, see `cap/max-tokens` for the rejection-marker shape."
   [raw default]
   (parse-int* raw default 0))
 

--- a/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
@@ -324,11 +324,12 @@
   (is (false? (cap/over-cap? 4999 6000 5000)) "tokens < cap does NOT trip"))
 
 (deftest over-cap?-secondary-char-gate-trips-in-isolation
-  ;; The branch the live `apply-cap` path cannot reach: tokens UNDER
-  ;; cap but chars OVER `cap * byte-cap-multiplier`. Reachable only when
-  ;; a future token rule decouples chars from tokens (e.g. base64 / CJK
-  ;; recognised at a lower per-char token cost). `over-cap?` MUST still
-  ;; trip — that is the whole point of the defence-in-depth gate.
+  ;; The secondary disjunct in ISOLATION: tokens UNDER cap but chars
+  ;; OVER `cap * byte-cap-multiplier`. Feeding decoupled sums straight
+  ;; in pins the EXACT boundary (strict `>`) without depending on how
+  ;; `apply-cap` derives its sums; `apply-cap-many-short-strings-trips-
+  ;; char-gate` below proves the same arm is reached through the live
+  ;; path. Two different failure modes, both worth a test.
   (let [cap-tokens 100
         byte-cap   (* cap-tokens cap/byte-cap-multiplier)] ;; 800
     (is (true? (cap/over-cap? 50 (inc byte-cap) cap-tokens))
@@ -339,15 +340,18 @@
         "chars < cap*8 and tokens under cap ⇒ no trip")))
 
 (deftest reported-count-selects-chars-when-char-gate-tripped
-  ;; The `reported = (if (> chars byte-cap) chars tokens)` selector. The
-  ;; chars arm is the one the live path never reaches; pin both arms.
+  ;; The `reported = (if (> chars byte-cap) chars tokens)` selector,
+  ;; pinned at the boundary from ONE computed `byte-cap` so the three
+  ;; cases sit either side of the same number. Both arms are live —
+  ;; `apply-cap-many-short-strings-trips-char-gate` reaches the chars
+  ;; arm through the real pipeline.
   (let [cap-tokens 100
         byte-cap   (* cap-tokens cap/byte-cap-multiplier)] ;; 800
-    (is (= 999 (cap/reported-count 50 999 cap-tokens))
-        "char gate tripped (999 > 800) ⇒ report the char count")
-    (is (= 50 (cap/reported-count 50 800 cap-tokens))
-        "char gate NOT tripped (800 = byte-cap, not >) ⇒ report tokens")
-    (is (= 150 (cap/reported-count 150 700 cap-tokens))
+    (is (= (inc byte-cap) (cap/reported-count 50 (inc byte-cap) cap-tokens))
+        "char gate tripped (chars > byte-cap) ⇒ report the char count")
+    (is (= 50 (cap/reported-count 50 byte-cap cap-tokens))
+        "char gate NOT tripped (chars = byte-cap, not >) ⇒ report tokens")
+    (is (= 150 (cap/reported-count 150 (dec byte-cap) cap-tokens))
         "only the token gate tripped ⇒ report tokens")))
 
 (deftest over-cap?-and-reported-count-agree-with-apply-cap

--- a/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
+++ b/tools/testbed-support/src/re_frame/testbed/open_in_editor_server.clj
@@ -176,11 +176,17 @@
        ;; coordinate than the one being launched. `get-args.js` switches on
        ;; the command BASENAME only, so the substituted values never change
        ;; the fall-through verdict — they only have to be present.
+       ;; The decline is reported by its EXIT CODE alone. `launch!` reads
+       ;; `position-unsupported-exit` and answers with the namespace's own
+       ;; `position-unsupported-error` constant, so a token written here
+       ;; would be drained and discarded — a second diagnostic channel
+       ;; that nothing consumes. Generic launch failures below DO write
+       ;; stderr, because their message is not derivable from the exit
+       ;; code.
        "if(line||col){"
        "var ed=guess(e)[0];"
        "var a=ed?getArgs(ed,'F',line||1,col||1):null;"
        "if(a&&a.length===1&&a[0]==='F'){"
-       "process.stderr.write('" position-unsupported-error "\\n');"
        "process.exit(" position-unsupported-exit ");}}"
        "l(f,e,function(file,msg){"
        "process.stderr.write('launch-editor: '+(msg||'no editor found')+'\\n');"

--- a/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
+++ b/tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj
@@ -1014,39 +1014,43 @@
                   (is (= 12 line) (str tool " kept its line"))
                   (is (= 3 column) (str tool " kept its column")))))))))))
 
-(deftest without-the-endpoint-the-same-coordinate-does-not-resolve
-  (testing "the NEGATIVE half: it is the dev-http handler, not the retired
-            checkout-root plumbing, that makes these coordinates resolve. A
+(deftest off-endpoint-request-404s-and-the-uri-fallback-stays-relative
+  (testing "the NEGATIVE half, stated as what it actually executes. A
             `:dev-http` entry with no re-frame2 handler serves static files
-            only, so the POST is answered by shadow's own 404 — a non-2xx,
-            which is exactly what sends the browser to its `editor://` URI
-            fallback (pinned client-side in
-            `re-frame.testbed.open-in-editor-client-cljs-test`). That fallback
-            composes the RAW coordinate, which is relative, so an OS editor
-            handler cannot stat it"
-    (with-testbed-source-roots*
-      (fn []
-        (doseq [{:keys [tool file]} consumer-coords]
-          ;; An unwired port never reaches this namespace at all.
-          (is (nil? (oies/handle {:uri            "/index.html"
-                                  :request-method :post
-                                  :query-string   (str "file=" file)
-                                  :headers        {"host" "localhost:8042"}}))
-              (str tool ": a request that is not the endpoint path is not
-                   handled here"))
-          (is (= 404 (:status (oies/handler {:uri            "/index.html"
-                                             :request-method :post
-                                             :query-string   (str "file=" file)
-                                             :headers        {"host" "localhost:8042"}})))
-              (str tool ": the non-endpoint answer is a non-2xx, so the client
-                   falls back"))
-          ;; …and the fallback's own input is still relative.
-          (is (not (editor-uri/absolute-path? file))
-              (str tool " coordinate is relative — the URI fallback alone
-                   cannot reach the file"))
-          (is (= file (#'editor-uri/compose-path nil file))
-              (str tool " composes to itself with no project-root — the
-                   composition step the retired pipeline used to feed")))))))
+            only, so an off-endpoint POST never reaches this namespace's
+            resolution at all: `handle` falls through and `handler` answers
+            shadow's own 404 — a non-2xx, which is exactly what sends the
+            browser to its `editor://` URI fallback (pinned client-side in
+            `re-frame.testbed.open-in-editor-client-cljs-test`). That
+            fallback composes the RAW coordinate, which is relative, so an OS
+            editor handler cannot stat it.
+
+            No source roots are installed here, deliberately: every
+            expression below is either an early fall-through or a pure
+            string/path-shape check, so a context classloader could not
+            change a single answer. The positive witness above is where the
+            real roots earn their keep"
+    (doseq [{:keys [tool file]} consumer-coords]
+      ;; An unwired port never reaches this namespace at all.
+      (is (nil? (oies/handle {:uri            "/index.html"
+                              :request-method :post
+                              :query-string   (str "file=" file)
+                              :headers        {"host" "localhost:8042"}}))
+          (str tool ": a request that is not the endpoint path is not
+               handled here"))
+      (is (= 404 (:status (oies/handler {:uri            "/index.html"
+                                         :request-method :post
+                                         :query-string   (str "file=" file)
+                                         :headers        {"host" "localhost:8042"}})))
+          (str tool ": the non-endpoint answer is a non-2xx, so the client
+               falls back"))
+      ;; …and the fallback's own input is still relative.
+      (is (not (editor-uri/absolute-path? file))
+          (str tool " coordinate is relative — the URI fallback alone
+               cannot reach the file"))
+      (is (= file (#'editor-uri/compose-path nil file))
+          (str tool " composes to itself with no project-root — the
+               composition step the retired pipeline used to feed")))))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-1i1ec (audit) — auto-detect is a capability question too


### PR DESCRIPTION
Four small audit beads from the rf2-6r9j sweep, over `tools/mcp-base/**` and `tools/testbed-support/**`.

## rf2-6r9j.105 — mcp-base/cap tests: stale unreachable-branch residue

Commit `12e7296021` added the live-path proof that the secondary char gate is reachable through `apply-cap`, but left two older comments behind saying the opposite. Within about seventy lines the file told mutually exclusive stories: the section preamble and `apply-cap-many-short-strings-trips-char-gate` say the gate is load-bearing, while `over-cap?-secondary-char-gate-trips-in-isolation` said it was "the branch the live `apply-cap` path cannot reach" and `reported-count-selects-chars-when-char-gate-tripped` said the chars arm was "the one the live path never reaches". Both restated as what those isolated cases actually are — exact-boundary pins that complement the live-path regression rather than substitute for it. Neither test lost an assertion.

The same `reported-count` test bound `byte-cap` and then asserted against hard-coded `999`/`800`/`700`. That was the only clj-kondo warning in the slice. The three cases now sit either side of the one computed boundary, so the binding is read and the magic numbers go away.

## rf2-6r9j.104 — mcp-base/args: `parse-non-negative-int` — **justified, not retired**

The premise holds: a fixed-string census over tracked files finds no in-repo caller. Every live numeric MCP arg is a positive int (the `:limit` behind `cursor/parse-limit-arg`, story-mcp's `:timeout-ms`) or `cap/max-tokens`, which admits zero but *rejects* out-of-domain values rather than defaulting, so it cannot route through a defaulting parser. The control fired — the same census on `parse-positive-int` returns four production namespaces across both MCP servers.

Kept anyway, deliberately. It is the floor-0 half of one parser: `parse-int*` carries a `floor` parameter precisely because both floors are offered, and every contract an auditor might fear is being maintained for a lone caller — the finite/safe-integer guard, the strict string grammar, the cross-host agreement — belongs to `parse-int*` and `coerce-finite-long`, shared with `parse-positive-int` and tested once. What is specific to this var is the floor, and its own tests are a handful of assertions about exactly that. Removing it would leave a `floor` parameter with a single constant argument, and push any consumer whose arg admits a disabling zero into re-deriving the guard by hand.

The docstring did overstate one thing: it cited `max-tokens=0` as its example, which reads as a claim that `max-tokens` calls it. Restated to describe the parser's own domain and to point at `cap/max-tokens` for the rejecting posture. The disposition and the census are recorded beside the var so the next sweep does not re-file this.

No behaviour change in this file — comments and docstring only.

## rf2-6r9j.113 — discarded stderr write on the open-in-editor decline

`launch-shim`'s position-decline branch wrote `editor-position-unsupported` to stderr and then exited with `position-unsupported-exit`. `launch!` always drains that stderr, but on exit 3 it answers with the namespace's own `position-unsupported-error` constant and never reads the drained value — the retained `err` is consulted only by the generic non-3 failure branch. The surrounding comment already says the verdict is read off the exit code rather than scraped from stderr, so the write was a second diagnostic channel with no consumer. Removed.

Exit code 3, the client-visible token, the generic launch-failure stderr, the pipe draining, and the endpoint's 422 mapping are all untouched.

## rf2-6r9j.118 — inert source-root fixture on the endpoint negative test

`without-the-endpoint-the-same-coordinate-does-not-resolve` wrapped itself in `with-testbed-source-roots*`, installing two real source directories on the thread context classloader — but nothing inside it resolves a classpath. `handle` returns at the `uri` check before any query parsing; `handler` repeats that fall-through and returns its fixed 404; `absolute-path?` and `compose-path` are pure string and path-shape checks. The expensive-looking setup made the test look like it exercised an unwired shadow server when it exercises this namespace's off-path fall-through and the URI fallback's relative-path composition.

Wrapper removed, and the test renamed to what it runs: `off-endpoint-request-404s-and-the-uri-fallback-stays-relative`. The positive witness above it keeps its real roots, unchanged.

## Verification

Focused suites only — CI owns the spine.

| Gate | Result |
|---|---|
| `clj-kondo --lint tools/mcp-base/src tools/mcp-base/test` | exit 0, **0 warnings** (was 1) |
| mcp-base JVM (`clojure -M:test`) | exit 0 — 288 tests, 998 assertions, 0 failures |
| mcp-base CLJS (`:cljs-test` node build) | exit 0 — 48 tests, 289 assertions, 0 warnings |
| testbed-support JVM, `RF2_REQUIRE_NODE_PROBES=1` | exit 0 — 42 tests, 260 assertions, 0 failures |

The node probes really ran: under `RF2_REQUIRE_NODE_PROBES` a self-skip is a failure, so a green there cannot be a skipped lane.

**Controls, each fired and each restored by blob hash:**

- **clj-kondo is live.** An appended `(let [unused-control-binding 42] ...)` took the lint to exit 2 naming the line and the warning class; restoring returned exit 0, 0 warnings, and the identical blob.
- **The decline verdict rides the exit code, not stderr (.113).** Diverting the shim's decline exit to `9` while `launch!` still compared against `3` turned three real-node assertions red with `:message "launch-editor exited 9"` — the empty-stderr fallback. That shows both that the suite is live on the path I edited and that nothing downstream needed the removed token. (My first attempt at this control was wrong and is worth recording: mutating `position-unsupported-exit` itself changes *both* sides of the comparison and stays green — a reassuring non-result.)
- **The classloader fixture is inert where it was removed and load-bearing where it stays (.118).** Removing the same wrapper from the *positive* test turns it red in two assertions, so the suite can detect a lost classloader; the negative test's green without it is therefore meaningful rather than vacuous.
- **The stderr census can tell read from discarded (.113).** `git grep -F editor-position-unsupported` over tracked files finds it only in README prose, the source constant, and tests asserting `launch!`'s returned map or the JSON body — never scraped from child stderr. The control census on `"launch-editor: "`, the token that *is* scraped, finds both the write and the test that reads it back.

No hot-zone file needed a change.
