### PR TITLE
test(security): the runtime harness fails honestly; drop dead helpers

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_api_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_api_check.clj
@@ -27,8 +27,8 @@
                         reference (`docs/story/api/**`).
 
   RESOLUTION LATITUDE. A reference resolves when its bare var name is carried
-  by ANY manifest row — the same bare-name latitude the secondary projection
-  checks take (`projection/index-by-var-name`). This is correct here: the
+  by ANY manifest row — `check!` below builds exactly that: a BARE-NAME SET
+  over every manifest row (`(set (map :var rows))`). This is correct here: the
   API reference legitimately names vars across several public namespaces
   (`re-frame.core`, `re-frame.story`, `re-frame.machines`, …) under the `rf`
   alias, and a REMOVED var has no manifest row in ANY namespace, so it is

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -806,8 +806,9 @@
    a duplicated `:cljs-only` entry, or a `:cljs-only` row colliding with a
    JVM-derived row, produced a manifest with two rows for one var (possibly
    with conflicting tier/kind/status/runtime metadata) and an inflated
-   `:var-count`. Downstream projections then either silently overwrite one
-   row (`index-by-ns+var` `assoc`) or tolerate multiple tiers — masking the
+   `:var-count`. Downstream projections then either collapse the two rows to
+   one (`xray-spec-check`'s strict `[namespace var]` SET, which cannot
+   represent a duplicate at all) or tolerate multiple tiers — masking the
    contradiction. Detecting duplicates HERE, before write / `--check`, keeps
    the one-row-per-var invariant where it is generated."
   [rows]

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/projection.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/projection.clj
@@ -36,24 +36,15 @@
   []
   (:vars (gen/read-committed-manifest)))
 
-(defn index-by-var-name
-  "`{bare-var-name -> #{manifest-row ...}}` over the supplied rows. A bare
-   var name can be ambiguous across namespaces (e.g. `configure!` lives on
-   both `re-frame.core` and `re-frame.story`); a projection reference that
-   does not pin a namespace resolves if ANY manifest row carries the name,
-   which is the same name-resolution latitude `api-md-check` takes."
-  [rows]
-  (reduce (fn [acc {:keys [var] :as row}]
-            (update acc var (fnil conj #{}) row))
-          {} rows))
-
-(defn index-by-ns+var
-  "`{[ns-str var-str] -> manifest-row}` over the supplied rows — the strict
-   index for fully-namespace-qualified references (the Xray panel symbols)."
-  [rows]
-  (reduce (fn [acc {:keys [namespace var] :as row}]
-            (assoc acc [namespace var] row))
-          {} rows))
+;; NB (rf2-6r9j.137): there is deliberately NO shared row index here. Each
+;; check builds the projection its own contract needs — a bare-name set
+;; (`doc-api-check`), a per-namespace var set (`rows-in-ns` below), tier sets
+;; (`api-md-check`), a strict `[namespace var]` set (`xray-spec-check`) — and
+;; those are DISTINCT contracts, not four spellings of one. Bare-name latitude
+;; is sound where a surface names vars across several public namespaces under
+;; one alias; it is unsound for the Xray panel symbols, where ten namespaces
+;; carry the same `:var "Panel"`. Consolidating them would trade a real
+;; guarantee for a shared helper.
 
 (defn rows-in-ns
   "Manifest rows whose `:namespace` is `ns-str`."

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
@@ -10,8 +10,9 @@
   JVM-derived row — produced two manifest rows for one var (possibly with
   conflicting tier/kind/status/runtime metadata) and an inflated
   `:var-count`. Drift checks could still pass (committed + regenerated agree
-  on the duplicate), while downstream projections silently overwrite one row
-  (`index-by-ns+var`'s `assoc`) or tolerate multiple tiers — masking the
+  on the duplicate), while downstream projections silently collapse the two
+  rows to one (`xray-spec-check`'s strict `[namespace var]` SET, which cannot
+  represent a duplicate at all) or tolerate multiple tiers — masking the
   spec/implementation contradiction through generation AND verification.
 
   THE FIX. `duplicate-rows` detects any `[namespace var]` carried by more

--- a/implementation/scripts/lib/edn.cjs
+++ b/implementation/scripts/lib/edn.cjs
@@ -1,8 +1,16 @@
 'use strict';
 
 /*
- * A small, complete EDN reader for the G-13 production-dependency boundary
- * proof (rf2-2n0cv).
+ * A small, complete EDN reader shared by the release-policy gates that must
+ * read a `deps.edn` as STRUCTURE rather than as text (rf2-2n0cv).
+ *
+ * Current consumers, all of them reading `deps.edn` coordinates / aliases:
+ *
+ *   implementation/scripts/lib/publishable-runtimes.cjs   — the publishable
+ *     runtime roster (a `:clein/build` alias makes an artefact publishable)
+ *   implementation/scripts/_release-dag-policy.test.cjs   — release DAG policy
+ *   implementation/scripts/_preflight-xray-package.test.cjs — release preflight
+ *   .github/scripts/verify-version-lockstep.sh            — version lockstep
  *
  * Where a balanced-brace byte scan cannot tell a real `}` from one that sits
  * inside a `; comment`, a "string", or a `#_` reader-discarded form, this
@@ -262,15 +270,6 @@ function isMap(form) {
   return form !== null && typeof form === 'object' && form.edn === 'map';
 }
 
-function isSymbol(form, name) {
-  return (
-    form !== null &&
-    typeof form === 'object' &&
-    form.edn === 'symbol' &&
-    (name === undefined || form.name === name)
-  );
-}
-
 function isKeyword(form, name) {
   return (
     form !== null &&
@@ -288,36 +287,10 @@ function mapGetKeyword(mapForm, name) {
   return undefined;
 }
 
-// True iff the EDN map form has a symbol key named `name`.
-function mapHasSymbolKey(mapForm, name) {
-  return mapForm.entries.some(([k]) => isSymbol(k, name));
-}
-
-// Parse `uiDepsEdn` and return the real, top-level production `:deps` map
-// form — reading EDN structure, never text slices. Fail-closed on unreadable
-// input, a non-map top-level form, a missing `:deps`, or a non-map `:deps`
-// value, routing every rejection through the injected gate `fail`.
-function productionDepsMap(uiDepsEdn, fail) {
-  let top;
-  try {
-    top = readEdn(uiDepsEdn);
-  } catch (err) {
-    fail(`ui/deps.edn is not readable EDN (${err.message})`);
-  }
-  if (!isMap(top)) fail('ui/deps.edn top-level form is not a map');
-  const deps = mapGetKeyword(top, 'deps');
-  if (deps === undefined) fail('ui/deps.edn has no production :deps map');
-  if (!isMap(deps)) fail('ui/deps.edn production :deps is not a map');
-  return deps;
-}
-
 module.exports = {
   EdnReadError,
   readEdn,
   isMap,
-  isSymbol,
   isKeyword,
   mapGetKeyword,
-  mapHasSymbolKey,
-  productionDepsMap,
 };

--- a/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
@@ -16,9 +16,13 @@
             ;; without it `route-url` soft-passes (no validation throw) and the
             ;; `:schemas/redact-validation-tags` sensitivity oracle is unbound.
             [re-frame.schemas.malli]
-            [re-frame.classification :as classification]
             [re-frame.mcp-base.sensitive :as sens]
-            [re-frame.routing :as routing]
+            ;; SIDE-EFFECT REQUIRE, no alias: `rf/reg-route` is a late-bound
+            ;; facade over the OPTIONAL `day8/re-frame2-routing` artefact,
+            ;; which `re-frame.core` deliberately does not require. Loading
+            ;; this ns is what publishes the routing implementation the facade
+            ;; binds to; no `routing/` var is named here.
+            [re-frame.routing]
             ;; A validation reject short-circuits before browser effects, so
             ;; the handler can be driven directly with synthetic coeffects.
             [re-frame.routing.navigate :as navigate]

--- a/implementation/security/test/re_frame/security/public_profile_projection_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/public_profile_projection_security_cljs_test.cljc
@@ -49,8 +49,9 @@
 
 (deftest off-box-profiles-redact-frame-owned-app-db
   (testing "project-egress under each off-box / redacted profile redacts the
-            retired frame-config :sensitive :app-db leaf and elides the :large :app-db
-            leaf under frame-owned durable classification"
+            :sensitive :app-db leaf and elides the :large :app-db leaf under
+            frame-owned durable classification (the post-EP-0025 commit-plane
+            contract, NOT retired frame config)"
     (mk-frame! :pub/offbox)
     (doseq [profile [:rf.egress/off-box-tool
                      :rf.egress/off-box-observability

--- a/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
@@ -70,7 +70,13 @@
             ;; transform on `dispatch-sync`; `plain-atom` is the substrate the
             ;; drain / subscribe paths run against.
             [re-frame.flows]
-            [re-frame.late-bind :as late-bind]
+            ;; CLJS-only: the sole `late-bind` use left in this ns is the
+            ;; `:subs/resolve-sub-override` publish inside the `#?(:cljs …)`
+            ;; sub-override driver below (the `:sub-overrides` subscribe seam
+            ;; is a CLJS-only dev surface). Scoping the require to `:cljs`
+            ;; keeps the JVM branch honest rather than carrying a require no
+            ;; `:clj` form reads.
+            #?(:cljs [re-frame.late-bind :as late-bind])
             [re-frame.substrate.plain-atom :as plain-atom]
             #?(:clj  [re-frame.test-support :as test-support :refer [with-trace-recorder!]]
                :cljs [re-frame.test-support :as test-support :refer-macros [with-trace-recorder!]])
@@ -390,22 +396,38 @@
 
 (defn- with-runtime*
   "Install the plain-atom substrate + ensure the `:rf/default` frame for the
-  extent of `thunk`, then dispose. The shared adapter-less reset fixture
-  (which `:clear-app-schemas?`-resets and pins `:rf/default` as the ambient
-  scope) does NOT install an adapter — the flow drain / subscribe production
-  paths need one. The outer fixture's `frame/*current-frame* :rf/default`
-  binding supplies the ambient scope; we just stand up the substrate and the
-  default frame here, and the next test's fixture run disposes the adapter on
-  the way in (we dispose eagerly too for symmetry)."
+  extent of `thunk`. The shared adapter-less reset fixture (which
+  `:clear-app-schemas?`-resets and pins `:rf/default` as the ambient scope)
+  does NOT install an adapter — the flow drain / subscribe production paths
+  need one. The outer fixture's `frame/*current-frame* :rf/default` binding
+  supplies the ambient scope; we just stand up the substrate and the default
+  frame here.
+
+  ## Setup failures PROPAGATE (rf2-6r9j.102)
+
+  `rf/init!` is documented idempotent and raises only on a nil / non-map
+  adapter, so in this fixture state a throw out of it is a genuine setup
+  failure — a partially-initialised runtime, not a benign re-entry. This
+  helper therefore does NOT catch it. A security invariant asserted against
+  a runtime that failed to stand up is worth nothing: swallowing the throw
+  converts it into a misleading downstream assertion failure or, worse, a
+  false green on a suite whose whole job is to fail RED on a leak.
+
+  ## Adapter lifetime is the OUTER fixture's (rf2-6r9j.102)
+
+  Teardown is DELEGATED, deliberately and in full, to
+  `make-reset-runtime-fixture` above: it disposes the installed adapter on
+  its way IN to every test (`reset-runtime!` → `adapter/dispose-adapter!`)
+  and, in its own post-test `finally`, resets `frame/frames` AND the flow
+  registry (`finish-runtime-reset!` → the `:flows/reset-flows!` late-bind
+  hook) without swallowing failure. So this helper disposes nothing and
+  resets nothing: there is no within-test lifecycle here that the outer
+  fixture's boundary does not already cover, and every caller wraps its
+  whole test body in exactly one `with-runtime*`."
   [thunk]
-  (try (rf/init! plain-atom/adapter) (catch #?(:clj Throwable :cljs :default) _ nil))
+  (rf/init! plain-atom/adapter)
   (frame/ensure-default-frame!)
-  (try (thunk)
-       (finally
-         ;; Drop the flow registry + dirty-check rows so a sibling test in
-         ;; this ns does not re-run our flow on its own dispatch.
-         (when-let [reset! (late-bind/get-fn :flows/reset-flows!)]
-           (try (reset!) (catch #?(:clj Throwable :cljs :default) _ nil))))))
+  (thunk))
 
 (deftest flow-output-production-path-redacts-sensitive
   (testing "rf2-g1a4ho — :where :flow-output PRODUCTION PATH: a flow whose
@@ -421,7 +443,7 @@
         ;; the :sensitive? output schema. The failing value carries the
         ;; sentinel so, absent redaction, it rides verbatim in :value /
         ;; :explain on the trace bus.
-        (rf/reg-event :flow/seed (fn [{:keys [db]} _] {:db {:in failing-sensitive-value}}))
+        (rf/reg-event :flow/seed (fn [_ _] {:db {:in failing-sensitive-value}}))
         (rf/reg-flow :flow/secret {:inputs [[:in]] :output-path [:derived] :schema sensitive-map-schema} (fn [in] in))
         (let [trace (capture-failure
                       #(rf/dispatch-sync [:flow/seed]))]


### PR DESCRIPTION
Four beads under the vestige audit epic. The first is the substantive one: a
harness that could not fail was reporting green over a broken runtime.

## rf2-6r9j.102 — `with-runtime*` fails honestly

`with-runtime*` in `validation_redaction_invariant_security_cljs_test.cljc`
wrapped `rf/init!` in a blanket `catch Throwable → nil`. `rf/init!` is
documented idempotent and raises only on a nil / non-map adapter, so in this
fixture state a throw is a real setup failure, not a benign re-entry. The
catch is gone; setup failures propagate.

Its docstring claimed "…then dispose" and "we dispose eagerly too" while the
body disposed nothing. Disposal is in fact the OUTER fixture's:
`make-reset-runtime-fixture` → `reset-runtime!` calls `adapter/dispose-adapter!`
on its way IN to every test. The docstring now says that, rather than
promising a shorter adapter lifetime than the helper has.

The helper's own `finally` also swallowed a `:flows/reset-flows!` call that
`finish-runtime-reset!` already performs in the fixture's post-test `finally`,
unswallowed. Removed as duplicate; no within-test isolation need was
demonstrated (every caller wraps its whole body in exactly one `with-runtime*`).

**Control — the deliverable's proof.** Planted `(rf/init! nil)` in the helper
and ran `clojure -M:test` from `implementation/security`, in both directions:

| harness | exit | what the runner reported |
|---|---|---|
| **after this PR** | 1 | 4 ERRORs, each naming `rf/init!` and `:rf.error/no-adapter-specified` |
| **pre-PR blanket catch, same fault** | 1 | 4 ERRORs naming `rf/make-state-container` / `:rf.error/adapter-disposed` |

That second row is the bead's "misleading downstream assertion failure" caught
live: the same broken setup surfaced as a frame-creation symptom with no
mention of `init!` at all. Plant restored and verified by blob hash
(`346b5500…` before and after).

## rf2-6r9j.103 — vestigial bindings and stale prose

- Removed the unused `re-frame.classification` require: `re-frame.core`
  requires it directly at boot, so the test ns's copy was redundant.
- `re-frame.routing` **stays required** — `rf/reg-route` is a late-bound facade
  over the optional `day8/re-frame2-routing` artefact, which `re-frame.core`
  deliberately does not require — but as an unaliased side-effect require with
  the reason at the require site.
- Flow seed handler no longer destructures a `db` it never reads.
- `public_profile_projection_security_cljs_test.cljc` prose called a currently
  frame-owned durable-classification leaf a "retired frame-config" leaf,
  contradicting its own next line. Now names the post-EP-0025 commit-plane
  contract.
- `re-frame.late-bind` narrowed to `#?(:cljs …)`: after the duplicate flow
  cleanup went, its only remaining use is the `:subs/resolve-sub-override`
  publish inside the CLJS-only sub-override driver. Without this the `:clj`
  lint gains a fresh "required but never used" — reported, not papered over.

## rf2-6r9j.134 — retired UI helpers out of the shared EDN reader

`scripts/lib/edn.cjs` drops `isSymbol`, `mapHasSymbolKey` and
`productionDepsMap` (an orphan chain hard-coded around the removed
`ui/deps.edn`) and their exports. The module header described the retired G-13
UI production-dependency boundary; it now names the reader's live consumers.
The parser — `EdnReadError`, `readEdn`, `isMap`, `isKeyword`, `mapGetKeyword`
and its fail-closed behaviour — is untouched.

These were genuinely unreachable helper CODE, not retirement bookkeeping and
not a reserved-kind contract value: nothing that survives here is a `ui`/
`freehand` reference to keep.

## rf2-6r9j.137 — unused API-manifest projection index helpers

`api_manifest/projection.clj` drops `index-by-var-name` and `index-by-ns+var`,
which no caller ever had. The three comments that cited them now describe the
live purpose-specific projections instead: `doc-api-check` builds a bare-name
SET, `xray-spec-check` a strict `[namespace var]` SET. A note at the deletion
site records why there is deliberately no shared index — bare-name latitude,
tier sets, strict namespace identity and duplicate rejection are distinct
contracts, and the Xray path is unsound under bare-name resolution because ten
namespaces carry the same `:var "Panel"`.

## Proving the "unused" claims

Two independent instruments plus controls that fired, for every helper removed.

**Fixed-string census** (`git grep -F` over tracked files, `.beads` excluded):
`productionDepsMap` and `mapHasSymbolKey` appear only at declaration + export;
`isSymbol` only inside `mapHasSymbolKey`; `index-by-var-name` /
`index-by-ns+var` only at their definitions and in the three stale comments.
Controls: `readEdn` / `mapGetKeyword` / `isMap` hit four out-of-module
consumers each; `rows-in-ns` 3 call sites, `manifest-rows` 7, `table-var-rows` 1.

**Semantic — clj-kondo var-usage analysis** over `api-manifest/{src,test}`:
`index-by-var-name` → 0 usages, `index-by-ns+var` → 0, against controls
`rows-in-ns` → 3, `manifest-rows` → 7, `table-var-rows` → 1, out of 2213
var-usages analysed.

**Consumer enumeration** for the CJS side: every `require` of `edn.cjs`
destructures only `readEdn` / `isMap` / `isKeyword` / `mapGetKeyword`.
`implementation/package.json` is `private: true` with no `files` or `main`
field, so there is no published package API to break.

## Quality gates

All foreground, exit codes captured to file.

| gate | exit | result |
|---|---|---|
| `clojure -M:test` (implementation/security) | 0 | 94 tests, 723 assertions, 0 failures/errors |
| `npm run test:security` (implementation) | 0 | 95 tests, 730 assertions, 0 failures/errors |
| `clojure -M:test` (scripts/api-manifest) | 0 | 91 tests, 189 assertions, 0 failures/errors |
| `node --test` `_preflight-xray-package` + `_release-dag-policy` | 0 | 28 tests passed |
| `node --test check-bundle-isolation.test.cjs` | 0 | passed |
| `npx eslint implementation/scripts` | 0 | clean |
| clj-kondo, three security test files, `:clj` and `:cljs` | — | 0 errors, 0 warnings both branches |

The clj-kondo control: linting the pristine `HEAD` copies of those three files
reports exactly the three warnings the bead named — `re-frame.classification`
unused, `re-frame.routing` unused, `unused binding db` — and the working tree
reports none, in either language branch.

`npx eslint scripts` from `implementation` (as the bead worded it) cannot run:
`eslint.config.mjs` lives at repo root and imports `globals` from the root
lockfile. The equivalent run is the one CI performs — root `npm ci` then
eslint — scoped here to `implementation/scripts`.
