### PR TITLE
Story/Story-MCP vestige sweep: explain-variant raw-data policy, JVM var probes, host listener leak (rf2-6r9j.127 .119 .128 .116)

### DIFF
--- a/tools/story-mcp/README.md
+++ b/tools/story-mcp/README.md
@@ -254,7 +254,7 @@ tools/story-mcp/
         ├── registry.cljc                         ; tool-registry + descriptors + by-name
         ├── result.cljc                           ; result-envelope builders (pr-edn, text-result, error-result)
         ├── args.cljc                             ; arg readers + bounded-allowlist coercions (with-variant, read-run-opts, include-sensitive?)
-        ├── cljs_resolve.cljc                     ; cross-platform CLJS var resolution (registered-substrates)
+        ├── cljs_resolve.cljc                     ; browser-only provider seams (*substrate-provider*, *a11y-provider*) + availability predicates
         ├── lifecycle.cljc                        ; shared blocking run + error normalization
         ├── egress.cljc                           ; wire-egress scrubbers (elide-app-db, scrub-assertions+count, scrub-rendered)
         ├── schemas.cljc                          ; recurring JSON-schema fragments

--- a/tools/story-mcp/spec/002-Tool-Registry.md
+++ b/tools/story-mcp/spec/002-Tool-Registry.md
@@ -165,11 +165,18 @@ The value-bearing tools (`preview-variant` / `run-variant` /
 the `:include-sensitive` opt-in slot in `tools/list` only when the
 `--allow-sensitive-reads` gate is open; the docs-discovery tools —
 `explain-variant` included, since it ships author data raw (rf2-7k5mce) —
-never advertise it (they have no value-bearing slot to gate). The egress scrubs
-keep the live and non-live cases coherent — a declared-sensitive value
-redacts and a declared-large value elides identically (i.e. neither crosses
-raw, by default) whether it reaches the wire via a live derived tree or a
-plan-resolved arg. **Non-live posture:** one surface
+never advertise it (they have no value-bearing slot to gate). Within the
+runtime/captured-VALUE class the egress scrubs are uniform — a
+declared-sensitive value redacts and a declared-large value elides
+identically (i.e. neither crosses raw, by default) across every derived
+tree those four tools return. **Classification marks do NOT reach the
+author-metadata class**, and `explain-variant` is the surface where that
+matters: its plan-RESOLVED value slots are static author data, so a
+`:sensitive?` declaration on a matching app-db path does **not** redact
+them — the whole `:explain` map ships raw, and there is no
+`:include-sensitive` escape hatch because there is nothing gated to
+release (rf2-7k5mce). A secret that must not cross the wire must not be
+written into a variant's registration. **Non-live posture:** one surface
 (`read-a11y-violations`'s axe
 DOM nodes) carries an inherently RE-KEYED runtime payload whose path-scrub is a
 no-op even live; it takes the **named, narrow re-keyed-runtime egress

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/cljs_resolve.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/cljs_resolve.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.story-mcp.tools.cljs-resolve
   "The Story-MCP host-capability / provider BOUNDARY for browser-only
-  reads, plus the low-level CLJS-var resolver it is built on.
+  reads.
 
   ## The two browser-only surfaces
 
@@ -61,56 +61,15 @@
   provider through `result/capability-unavailable-result` rather than
   returning a false-empty success.
 
-  ## The low-level resolver
+  ## No var probing, on either platform (rf2-6r9j.119)
 
-  `resolve-cljs-var` probes for a CLJS-only `def` via `clojure.core/
-  resolve` on the JVM (nil on miss); it is the mechanism the two JVM-side
-  default probes attempt — both resolve nil on the stdio host, since the
-  substrate registry and the a11y atom are CLJS-only."
-  ;; `re-frame.story` is required (loaded) so the JVM `resolve-cljs-var`
-  ;; can reach its CLJC vars; it is no longer aliased, because both
-  ;; provider-seam defaults are now nil symmetrically (rf2-jyjadg) and no
-  ;; branch dereferences it — the resolver reaches it by fully-qualified
-  ;; symbol below.
-  (:require [re-frame.story]))
-
-(defn resolve-cljs-var
-  "Resolve a fully-qualified symbol (`fully.qualified.ns/sym`) to the
-  underlying var on the JVM, returning `nil` on miss. Wraps
-  `clojure.core/resolve` in a try/catch so a CLJS-only `def` (which has
-  no JVM Var) yields nil rather than blowing up.
-
-  Callers MUST pass the FULLY-QUALIFIED ns (`re-frame.story/…`), not an
-  alias-qualified symbol — even though `resolve` does honour the calling
-  ns's aliases, passing the real ns keeps the contract self-describing.
-  The two default providers below wire from this resolver against the
-  substrate registry + the a11y violations atom."
-  [sym]
-  (try (resolve sym) (catch Throwable _ nil)))
-
-;; ---------------------------------------------------------------------------
-;; Resolved CLJS-only vars — the JVM-side default probe sources.
-;;
-;; Each is probed ONCE at ns-load. On a JVM host the CLJS-only Var does not
-;; exist, so the probe is nil and the surface is UNAVAILABLE (NOT empty).
-;; The CLJS defaults do NOT read these surfaces directly either: both seams
-;; default nil on every platform (rf2-jyjadg — see the ns docstring), so a
-;; browser-local host binds BOTH providers rather than inheriting a
-;; half-working default.
-;; ---------------------------------------------------------------------------
-
-#?(:clj
-   (defonce ^:private registered-substrates-var
-     (resolve-cljs-var 're-frame.story/registered-substrates)))
-
-#?(:clj
-   ;; `re-frame.story.ui.a11y/violations-by-frame` is the CLJS-side panel
-   ;; atom — a JVM process cannot dereference a CLJS atom in a browser heap,
-   ;; so this resolves nil on the stdio host. Probed once, here, so the a11y
-   ;; provider seam has a single resolution site (co-located with the
-   ;; substrate one) rather than a var buried in `testing`.
-   (defonce ^:private violations-by-frame-var
-     (resolve-cljs-var 're-frame.story.ui.a11y/violations-by-frame)))
+  This ns holds NOTHING but the two seams and their accessors. Earlier
+  revisions carried a `clojure.core/resolve` probe that tried to
+  auto-discover the two providers from the JVM; it could never succeed —
+  both sources are CLJS-only `def`s with no JVM Var, and the shipped
+  Story-MCP entry point is a JVM stdio subprocess with no bridge to a
+  browser heap — so it only obscured the explicit-provider contract above
+  (and dragged the whole Story facade onto the load path to do it).")
 
 ;; ---------------------------------------------------------------------------
 ;; Substrate-registry provider seam
@@ -129,9 +88,7 @@
   held nil to stay SYMMETRIC with `*a11y-provider*`, whose UI-ns source is
   bundle-isolated out of this helper and so CANNOT auto-wire. A browser
   bridge binds BOTH seams together; see the ns docstring."
-  #?(:clj  (when registered-substrates-var
-             (fn [] (registered-substrates-var)))
-     :cljs nil))
+  nil)
 
 (defn substrate-provider-available?
   "True iff a substrate-registry provider is reachable. The availability
@@ -182,14 +139,8 @@
   this helper must NOT require (bundle isolation). It is held SYMMETRIC
   with `*substrate-provider*` (also nil on CLJS) so the browser bridge
   wires BOTH seams together — no silent half-working default (rf2-jyjadg;
-  see the ns docstring).
-
-  The `:clj` default derefs the resolved var-of-atom (`@var` → the atom,
-  `(deref …)` → the by-frame map), matching the shape a browser-local
-  consumer would supply."
-  #?(:clj  (when violations-by-frame-var
-             (fn [] (deref @violations-by-frame-var)))
-     :cljs nil))
+  see the ns docstring)."
+  nil)
 
 (defn a11y-provider-available?
   "True iff an a11y-panel-state provider is reachable. Availability is

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -304,8 +304,7 @@
   ;; not a universal default), so they MUST be open-world. EVERY other
   ;; tool is closed-world: reads, registry writes, static docs.
   (testing "matrix: only the lifecycle-run tools are open-world (rf2-e6knrq)"
-    (let [by-name      (into {} (map (juxt :name identity)) registry/tool-registry)
-          open-world   #{"run-variant" "preview-variant"}]
+    (let [open-world #{"run-variant" "preview-variant"}]
       (doseq [t registry/tool-registry
               :let [n (:name t)
                     ow (get-in t [:annotations :openWorldHint])]]
@@ -629,19 +628,6 @@
             s (:structuredContent r)]
         (is (success? r))
         (is (= [:reagent :uix] (:substrates s)) "the reached registry's ids, sorted")))))
-
-;; Pin the CLJS-var resolver contract. `clojure.core/resolve` honours
-;; the calling ns's aliases, and the substrate var is nil on the JVM purely
-;; because it is CLJS-only (a `#?(:cljs …)` def with no JVM Var). These
-;; tests pin both facts so the contract can't silently regress.
-(deftest resolve-cljs-var-finds-fully-qualified-jvm-var
-  (testing "a fully-qualified symbol for a real JVM-side (CLJC) var resolves"
-    (is (= #'re-frame.story/canonical-assertion-ids
-           (cljs-resolve/resolve-cljs-var 're-frame.story/canonical-assertion-ids))
-        "the resolver returns the underlying Var for a JVM-resident symbol"))
-  (testing "an unresolvable symbol yields nil rather than throwing"
-    (is (nil? (cljs-resolve/resolve-cljs-var 're-frame.story/no-such-var-xyz)))
-    (is (nil? (cljs-resolve/resolve-cljs-var 'no.such.ns/whatever)))))
 
 (deftest substrate-provider-availability-is-not-emptiness
   ;; rf2-3fc89f.21 — availability is represented SEPARATELY from the
@@ -1056,8 +1042,7 @@
 
 (deftest list-stories-limit-clamped-to-max
   (testing ":limit above the ceiling clamps DOWN to max-limit"
-    (let [r (invoke "list-stories" {:limit 99999})
-          s (:structuredContent r)]
+    (let [r (invoke "list-stories" {:limit 99999})]
       (is (success? r))
       ;; With 1 fixture story, no pagination kicks in — but if it did,
       ;; the :limit slot would be 200 (max-limit), not 99999. We verify

--- a/tools/story/spec/006-MCP-Surface.md
+++ b/tools/story/spec/006-MCP-Surface.md
@@ -142,8 +142,10 @@ data, so the egress classifies each payload as runtime/captured VALUE
   redacts the WHOLE payload to `:rf/redacted` rather than ship it raw off-box
   — the earlier carve-out that shipped the raw tree on a non-live frame was
   retired. The live-state tools (`run-variant` / `preview-variant` /
-  `read-failures` / `explain-variant`) always hold a live variant frame, so
-  they redact-by-path / fail-closed accordingly.
+  `read-failures`) always hold a live variant frame, so
+  they redact-by-path / fail-closed accordingly. (`explain-variant` is NOT
+  one of them — it runs nothing, allocates no frame, and does not reach
+  this boundary at all; see the author-metadata bullet below.)
   **One surface —
   `read-a11y-violations` (browser-panel axe-core nodes) — scrubs against a
   routinely NON-LIVE variant frame, and its payload is inherently
@@ -166,12 +168,10 @@ data, so the egress classifies each payload as runtime/captured VALUE
   opt-in is the deliberate way to cross any payload raw.
   This path-projection covers the live-state tools' `:app-db` /
   `:rendered-hiccup` / `:snapshot` / evidence slots and assertion records
-  (`preview-variant` / `run-variant` / `read-failures`),
-  `read-a11y-violations`'s `:violations` (axe-core nodes), AND the
-  non-live value-bearing slots: `explain-variant`'s plan-RESOLVED
-  `:effective-args` / `:args` / `:substitutions` / `:network` /
-  `:db-seed` / `:sub-overrides` / `:setup-order` / `:script-order`.
-  Plan step STRUCTURE is always preserved. The shared
+  (`preview-variant` / `run-variant` / `read-failures`) and
+  `read-a11y-violations`'s `:violations` (axe-core nodes). Those FOUR
+  tools are the whole of the runtime-value class; no other tool reaches
+  this boundary. The shared
   `--allow-sensitive-reads` + per-call `:include-sensitive` opt-in is the
   one documented escape hatch (gate closed ⇒ the opt-in is omitted from
   `tools/list` and silently ignored at egress); note that the opt-in only
@@ -180,19 +180,31 @@ data, so the egress classifies each payload as runtime/captured VALUE
   scrubbed.** The docs-discovery surfaces return the catalogue an author
   publishes: `get-story` / `get-variant` / `variant->edn` bodies,
   `list-stories` / `list-modes` / `list-decorators` / `list-tags` /
-  `list-assertions` enumerations, the markdown render, and the
-  `explain` map's plan-STRUCTURE slots (`:source-chain` /
-  `:parent-chain` / `:compose` / `:merge` / `:strict-conflicts` /
-  `:tags` / `:platforms` / …). These
+  `list-assertions` enumerations, the markdown render, and
+  `explain-variant`'s **ENTIRE** `explain` map — the plan-STRUCTURE slots
+  (`:source-chain` / `:parent-chain` / `:compose` / `:merge` /
+  `:strict-conflicts` / `:tags` / `:platforms` / …) AND the plan-RESOLVED
+  value slots (`:effective-args` / `:args` / `:substitutions` /
+  `:network` / `:db-seed` / `:sub-overrides` / `:setup-order` /
+  `:script-order`). These
   are registration-time authoring prose, not runtime/user state, so they
   cross unredacted by design — scrubbing them would only degrade the
-  discovery UX without protecting any secret. NOTE: `:setup-order` /
-  `:script-order` are NOT in this list — although their step STRUCTURE
-  (which fx ids, in which order) is discovery metadata, `substitute-args`
-  injects resolved arg VALUES into the step payloads at plan-compile
-  time, so the post-substitution sequences are value-bearing and scrubbed
-  (rf2-q8ebq.1). The value-only redaction preserves the public structure
-  while redacting the embedded secrets. Registry-wide enumerations
+  discovery UX without protecting any secret. NOTE on `:setup-order` /
+  `:script-order`: `substitute-args` injects resolved arg VALUES into the
+  step payloads at plan-compile time, and those post-substitution
+  sequences **still ship raw** — they are the author's own registered
+  arguments, resolved, not observed user state. `explain-variant` is a
+  NO-RUN projection over the registry side-table (rf2-7k5mce, Mike
+  2026-07-08): it allocates no frame, so the whole map ships raw exactly
+  like `get-variant` / `variant->edn` and like the human Explain panel it
+  mirrors. The earlier posture — path-scrubbing the resolved slots
+  (rf2-q8ebq.1) — is **RETIRED**: it over-redacted the tool's most useful
+  output on the common static-inspection path. **A `:sensitive?` or
+  `:large` classification does NOT scrub authored registration values
+  exposed by `explain-variant`, and there is no `:include-sensitive` gate
+  on it** (nothing is withheld, so nothing can be released). Keep secrets
+  out of a variant's registration; classification marks protect the
+  OBSERVED runtime only. Registry-wide enumerations
   (modes, decorators) are not frame-keyed and carry no runtime values;
   their `:args` / `:app-db-patch` / `:response` slots are the author's
   own published fixture data.

--- a/tools/testbed-support/test/re_frame/testbed/story_host_dom_cljs_test.cljs
+++ b/tools/testbed-support/test/re_frame/testbed/story_host_dom_cljs_test.cljs
@@ -3,7 +3,14 @@
 
   The Node suite covers listener identity with mount stubs. This suite uses a
   real DOM node and minimal real React roots to verify that each surface
-  unmounts before the other claims `#app`. Its bodies no-op under Node."
+  unmounts before the other claims `#app`. Its bodies no-op under Node.
+
+  Unlike the Node suite's fake window — which `clear-window!` throws away
+  whole between cases — `js/window` here is the SHARED browser page, so a
+  listener this suite installs outlives the test that installed it unless
+  the fixture removes it by its exact recorded identity. See
+  `unregister-host-listener!` and the census test at the bottom
+  (rf2-6r9j.116)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [reagent.dom.client :as rdc]
@@ -70,7 +77,25 @@
         (str/includes? m "already been passed")
         (str/includes? m "already mounted"))))
 
+(defn- unregister-host-listener!
+  "Remove the EXACT hashchange listener the host recorded, using the stored
+  identity — the ONLY handle able to unregister it — BEFORE that handle is
+  discarded.
+
+  Production never needs this: the host owns `#app` for the life of the page
+  and `mount-with-hash-routing!` re-registration is self-balancing, because it
+  removes `@hash-listener*` before adding the new fn. But a fixture that only
+  nils the atom strands a live listener on the shared browser page — the next
+  mount then finds `nil` where the previous handle was, so it ADDS a second
+  listener rather than replacing the first, and every later namespace on the
+  page inherits them all."
+  []
+  (when (browser?)
+    (when-let [listener @@#'host/hash-listener*]
+      (.removeEventListener js/window "hashchange" listener))))
+
 (defn- reset-host-handles! []
+  (unregister-host-listener!)
   (reset! @#'host/hash-listener* nil)
   (reset! @#'host/root-view* nil)
   (reset! @#'host/app-root nil))
@@ -167,3 +192,67 @@
               (is (not (identical? handle-1 handle-2))
                   "the stored handle advanced to the recompiled listener fn — the
                    prior one was removed, not stacked"))))))))
+
+;; ---------------------------------------------------------------------------
+;; Listener census — the probe that makes the teardown above load-bearing.
+;;
+;; The two tests above inspect the STORED HANDLE, which stays green whether or
+;; not the listener was actually unregistered from the page. `js/window`
+;; publishes no listener registry, so counting the calls is the only way to
+;; prove a mount/teardown cycle nets to zero.
+;; ---------------------------------------------------------------------------
+
+(defn- with-hashchange-census
+  "Calls `(f net)` with `js/window`'s listener API wrapped to count
+  \"hashchange\" registrations into the `net` atom (add ⇒ inc, remove ⇒ dec),
+  and returns the net still registered when `f` returns.
+
+  The wrappers are own properties on `js/window`; `addEventListener` /
+  `removeEventListener` are inherited from `EventTarget.prototype`, so
+  `js-delete` restores the page exactly."
+  [f]
+  (let [net      (atom 0)
+        orig-add (.-addEventListener js/window)
+        orig-rem (.-removeEventListener js/window)]
+    (try
+      (set! (.-addEventListener js/window)
+            (fn [type listener opts]
+              (when (= type "hashchange") (swap! net inc))
+              (.call orig-add js/window type listener opts)))
+      (set! (.-removeEventListener js/window)
+            (fn [type listener opts]
+              (when (= type "hashchange") (swap! net dec))
+              (.call orig-rem js/window type listener opts)))
+      (f net)
+      @net
+      (finally
+        (js-delete js/window "addEventListener")
+        (js-delete js/window "removeEventListener")))))
+
+(deftest fixture-teardown-leaves-no-hashchange-listener-on-the-page
+  (testing "a mount + fixture teardown cycle nets ZERO registered hashchange
+            listeners — the recorded handle is unregistered before it is
+            discarded, so the next test's mount cannot stack a second one"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — :browser-test runner exercises the assertion")
+      (do
+        (ensure-app-node!)
+        (let [net (with-hashchange-census
+                    (fn [net]
+                      (with-redefs [story/mount-shell!   shell-mount!
+                                    story/unmount-shell! shell-unmount!]
+                        (set-hash! "#/")
+                        (react-dom/flushSync
+                         (fn [] (host/mount-with-hash-routing! live-view))))
+                      ;; Non-vacuity: the census saw the real registration.
+                      (is (= 1 @net)
+                          "the mount registered exactly one hashchange listener")
+                      (is (some? @@#'host/hash-listener*)
+                          "and the host recorded its handle")
+                      ;; The fixture teardown, run explicitly so its balance is
+                      ;; observable inside the census window.
+                      (reset-host-handles!)))]
+          (is (zero? net)
+              (str "every hashchange listener the host registered was removed "
+               "from js/window before its handle was discarded; net still "
+               "registered: " net)))))))


### PR DESCRIPTION
Four beads from the vestige/naming audit epic, across `tools/story-mcp`, `tools/story/spec` and the Story-host DOM suite.

## rf2-6r9j.127 — explain-variant raw-author-data policy (spec vs. spec vs. code)

Two normative specs disagreed with each other, and one of them disagreed with the shipped code, about whether `explain-variant`'s plan-resolved value slots redact under a `:sensitive?` classification.

**The code was treated as authoritative.** `tool-explain-variant` (`tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc`) wraps `story/explain` in `result/edn-result` and reaches no egress projector at all; `spec/API.md` documents it as no-run; three focused tests (`explain-variant-ships-value-slots-raw-even-with-classified-path`, `...-ships-sub-overrides-and-step-order-raw`, `...-no-run-non-live-frame-ships-value-slots-raw`) pin classified `:db-seed`, `:effective-args`, `:network`, `:sub-overrides` and step payloads shipping raw; and the Story-MCP privacy table already stated the rf2-7k5mce policy. Only the surrounding prose was stale, so the prose moved.

- `tools/story-mcp/spec/002-Tool-Registry.md` — the paragraph after the table claimed a declared-sensitive value redacts "whether it reaches the wire via a live derived tree or a plan-resolved arg". That uniformity now scopes explicitly to the runtime/captured-VALUE class, and the paragraph states that classification marks do **not** reach author metadata, that `explain-variant` has no `:include-sensitive` gate because nothing is withheld, and that the practical remedy is to keep secrets out of a variant's registration.
- `tools/story/spec/006-MCP-Surface.md` — `explain-variant` is removed from the live-state tool list and from the path-projected value-bearing set; its ENTIRE explain map (plan-STRUCTURE *and* plan-RESOLVED slots) joins the author-published static class; the rf2-q8ebq.1 note that carved `:setup-order` / `:script-order` out of that class is marked retired with its reason.

The four runtime-value tools (`run-variant` / `preview-variant` / `read-failures` / `read-a11y-violations`) and the `--allow-sensitive-reads` gate are unchanged and still enumerated as the whole of that class. No scrubbing was reintroduced — the raw-author-data policy is deliberate and stays.

## rf2-6r9j.119 — unreachable JVM CLJS-var auto-probes

`cljs-resolve` kept `resolve-cljs-var` plus two cached probe vars whose only production job was auto-discovering the substrate-registry and a11y providers from the JVM. Neither target can exist there (`re-frame.story/registered-substrates` is inside `#?(:cljs ...)`; `re-frame.story.ui.a11y/violations-by-frame` is in a `.cljs` namespace; Story-MCP is JVM stdio with no browser bridge). Commit 82ec7aa84f already made both seams nil-by-default and symmetric; these defaults were left behind.

Removed: the resolver, both probe vars, the resolver-only unit test, and the `[re-frame.story]` require that existed only to feed the probe. Both provider vars now read a plain `nil` on every platform.

Kept: `*substrate-provider*`, `*a11y-provider*`, `substrate-provider-available?`, `a11y-provider-available?`, the accessors and the capability-unavailable routing. Availability still distinguishes an absent provider from one reached-and-empty — verified by the planted-fault run below.

Consumer check: a repo-wide search finds `resolve-cljs-var` only in its own namespace and the test now deleted. It appears in no documented, package or protocol API surface. The `tools/story-mcp/README.md` file-tree line for `cljs_resolve.cljc` now describes what the file actually holds.

## rf2-6r9j.128 — two unread test locals

clj-kondo's only two genuine warnings in the package: the second `by-name` index in the open-world annotation matrix (the loop reads each descriptor from `registry/tool-registry` directly) and the first `list-stories` response's `:structuredContent` in the max-limit clamp test. Both deleted; the `(invoke "list-stories" {:limit 99999})` call and its success assertion stay, as does the exact open-world matrix.

## rf2-6r9j.116 — Story-host DOM tests leaked hashchange listeners

The DOM suite runs against the real browser page. Its fixture reset `host/hash-listener*` to nil without calling `removeEventListener`, discarding the one function identity able to unregister the listener. The next mount found nil where the handle had been, so `mount-with-hash-routing!`'s remove-then-add became add-only and stacked a second listener; the final teardown left them all on the page for later namespaces. The suite named `no-listener-or-root-leak` was leaking, and stayed green because its assertions inspect only the stored handle.

`reset-host-handles!` now removes the exact recorded listener from `js/window` before nilling the atom — stored identity only, no blanket handler replacement, production `defonce` / hot-reload behaviour untouched, Node fake-window cleanup unchanged.

New test `fixture-teardown-leaves-no-hashchange-listener-on-the-page` wraps `js/window`'s listener API for one mount + teardown cycle and counts `"hashchange"` registrations. It asserts the census saw exactly one add (non-vacuity) and that the cycle nets to zero, so a regression that nils the handle without unregistering makes the browser suite red.

## Verification (exit codes captured to files, read from the files)

| Gate | Exit |
|---|---|
| `tools/story-mcp` → `clojure -M:test` (278 tests, 1473 assertions, 0 failures 0 errors) | 0 |
| `tools/story-mcp` → `clojure -M:gen --check` (descriptor drift; "in sync (19 tools)") | 0 |
| `implementation` → `npm run test:testbed-support` (focused node build; 684 files, **0 warnings**, 17 tests / 63 assertions green) | 0 |
| `scripts/check_doc_slugs.py` (covers `tools/*/spec`, so both edited specs) | 0 |
| `clj-kondo --lint tools/story-mcp/src tools/story-mcp/test` | 2 (17 pre-existing `.cljc` unresolved-symbol warnings; **0 unused-binding**) |

clj-kondo baseline check: linting `HEAD:tools/story-mcp/test/re_frame/story_mcp/tools_test.clj` reports exactly two `unused binding` warnings, at lines 307 (`by-name`) and 1060 (`s`) — the two this PR removes. No replacement warning was introduced.

**Gate proved live once.** Planted a one-line fault in `cljs_resolve.cljc` — `*substrate-provider*`'s default changed from `nil` to `(fn [] [])`, i.e. exactly the auto-wire this PR removes — and re-ran the story-mcp suite: exit **1**, 9 failures naming `list-substrates-unavailable-on-jvm-host-is-error` (610, 611, 613, 614, 615), `provider-seams-are-symmetric-no-silent-asymmetry` (663, 675), `substrate-provider-availability-is-not-emptiness` (639) and `run-variant-explicit-substrate-unavailable-is-error-no-intern` (4431), with `actual: (not (error? {... :structuredContent {:substrates []}}))` — the false-empty success the availability contract exists to prevent. Restored and confirmed by blob hash (`b56fddf2a81f05f66753591b10825d4eff35fb37`, identical before and after).

**Not run locally:** the `:browser-test` gate that owns rf2-6r9j.116's new assertion — it needs a full browser-test compile plus Chromium. The file compiles clean and its Node path passes under the focused `test:testbed-support` build above; CI's browser gate owns the real-DOM run.

Markdown checked by hand: heading anchors unchanged in both specs (only body prose moved), no tables edited in `006-MCP-Surface.md`, and the one table row edited in `002-Tool-Registry.md` is untouched — the rewritten paragraph sits below it.

## Note on scope

rf2-6r9j.116's evidence lives in `tools/testbed-support/test/`, outside the dispatch fence for this bundle. The change there is confined to that single test file (teardown + one new test; no source change, no other file), so it should not collide with anything holding that tree — but flagging it explicitly for the merge decision.
