### PR TITLE
chore(template): truth the template surface to the reduced scaffold

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -430,9 +430,10 @@ is_story_xray_node_test_path() {
 #     one should be a deliberate edit here rather than a silent widening.
 #
 # Its NON-CLJS fan-out is unchanged and already correct: `tools/story/src/*`
-# arms examples_compile, and the `tools/{story,xray}/*` case arms tools_jvm,
-# mcp_conformance and template_expensive (the emitted-`:app` compile), for
-# macros.clj as for any other src file.
+# arms examples_compile, and the `tools/{story,xray}/*` case arms tools_jvm
+# and mcp_conformance, for macros.clj as for any other src file. (It does NOT
+# arm template_expensive: rf2-6r9j.108 removed that fan-out when rf2-zq34m's
+# reduced scaffold stopped compiling against either tool. See that case.)
 is_story_xray_dom_test_path() {
   case "$1" in
     tools/story/test/*_dom_cljs_test.cljs|tools/story/test/*_dom_cljs_test.cljc)
@@ -721,9 +722,10 @@ else
     # is what `skills_structural=true` actually means here. The three added
     # roots also each already have an arm in the big `case` below (the
     # per-feature fan-out), so the shadowing argument above applies to them
-    # unchanged — epoch keeps `mcp_conformance`/`mcp_live`, schemas keeps
-    # `template_expensive`, machines keeps the machines-viz and `playground`
-    # lanes. This dispatch only ever SETS the flag; it cannot narrow them.
+    # unchanged — epoch keeps `mcp_conformance`/`mcp_live`, schemas keeps its
+    # own per-feature lanes (implementation_jvm, cljs_*, bundle_isolation),
+    # machines keeps the machines-viz and `playground` lanes. This dispatch
+    # only ever SETS the flag; it cannot narrow them.
     #
     # The over-fire trade is the same one, and no larger: ssr and hicasso
     # over-fire `re-frame2-pair-fixture-pure`, epoch/schemas/machines over-fire
@@ -1154,24 +1156,22 @@ else
         cljs_browser=true
         cljs_prod=true
         bundle_isolation=true
-        # rf2-jdj17.1 — false-green fix. The template's generated `:app`
-        # build compiles `day8/re-frame2-schemas` (events.cljs side-loads
-        # re-frame.schemas + re-frame.schemas.malli; schema.cljs calls
-        # rf/reg-app-schema). The ONLY PR-time gate that compiles the
-        # emitted `:app` (emitted_test_run_test, RF2_TEMPLATE_RUN_EMITTED_TESTS)
-        # fires only under template_expensive. So a PR breaking the
-        # re-frame.schemas / reg-app-schema surface used to merge GREEN at
-        # PR time and surface only in the nightly cron. Fire
-        # template_expensive for an implementation/schemas/* change so
-        # jvm-tools-template runs the emitted-app compile at PR time.
-        # (The other per-feature artefacts here — machines/routing/flows/
-        # http/ssr/ssr-ring — are NOT pulled into today's scaffold,
-        # so they do not arm template_expensive; add them here if a future
-        # scaffold flag wires one in. epoch has its own case above,
-        # rf2-ribu5a.)
-        case "$file" in
-          implementation/schemas/*) template_expensive=true ;;
-        esac
+        # rf2-6r9j.108 — NO template_expensive arm here, for schemas or for
+        # any other per-feature artefact. rf2-jdj17.1 armed it for
+        # implementation/schemas/* because the then-current scaffold's
+        # events.cljs side-loaded re-frame.schemas and its schema.cljs called
+        # rf/reg-app-schema. rf2-zq34m (18b9486664) deleted both: today's
+        # twelve-file emission requires core, the selected adapter and the
+        # view library only, and `template_test.clj` FORBIDS
+        # `day8/re-frame2-schemas` in an emitted deps.edn and the strings
+        # `re-frame.schemas` / `reg-app-schema` in any emitted text file. So
+        # the generated `:app` has no schemas edge for a schemas change to
+        # break, and firing the ~30-minute jvm-tools-template job (npm ci +
+        # Playwright Chromium) for one bought nothing. schemas keeps every
+        # lane of its own above — implementation_jvm, cljs_node_test,
+        # cljs_browser, cljs_prod, bundle_isolation. Re-add an arm here only
+        # WITH a real emitted dependency and a fixture that compiles it.
+        # (epoch has its own case above, rf2-ribu5a.)
         # rf2-2h1yhk / rf2-tzy13 — the docs/cljs live-cell SCI bundle BAKES IN
         # the machines and flows artefacts (`re-frame.machines` +
         # `re-frame.flows` are :require'd at bundle init, and the bundle carries
@@ -2107,24 +2107,26 @@ else
           *)
             tools_jvm=true
             mcp_conformance=true
-            # rf2-jdj17.1 — false-green fix. The template's generated
-            # `:app` build compiles against Story + Xray: the with-story
-            # scaffold's core requires re-frame.story and calls
-            # story/mount-shell! / unmount-shell!, and EVERY scaffold wires
-            # day8.re-frame2-xray.preload via :devtools/preloads in
-            # shadow-cljs.edn. The ONLY PR-time gate that compiles the
-            # emitted `:app` (emitted_test_run_test,
-            # RF2_TEMPLATE_RUN_EMITTED_TESTS) fires only under
-            # template_expensive — so a PR breaking the re-frame.story
-            # shell API or renaming/removing the xray preload ns used to
-            # merge GREEN at PR time and surface only in the nightly cron
-            # (generated apps then fail their first `shadow-cljs watch app`
-            # / `release app`). Fire template_expensive for any non-spec-md
-            # Story/Xray change so jvm-tools-template runs the emitted-app
-            # compile at PR time. Scoped exactly like tools_jvm/mcp above:
-            # a pure spec-md change can't break the generated `:app`
-            # compile, so it stays excluded.
-            template_expensive=true
+            # rf2-6r9j.108 — deliberately NO template_expensive arm.
+            # rf2-jdj17.1 fired it here because the then-current scaffold
+            # compiled against both tools: a `:with-story` variant whose core
+            # required re-frame.story and called story/mount-shell!, and
+            # `:devtools/preloads [day8.re-frame2-xray.preload]` in every
+            # emitted shadow-cljs.edn. rf2-zq34m (18b9486664) removed the
+            # Story variant and the preload outright. Today's emitted
+            # shadow-cljs.edn declares no `:devtools/preloads` at all, no
+            # emitted file names either tool (the generated README links their
+            # docs under `docs/`, which is not this surface), and
+            # `template_test.clj` FORBIDS `day8/re-frame2-xray` /
+            # `day8/re-frame2-story` in deps.edn plus the strings
+            # `day8.re-frame2-xray`, `data-rf-xray-host` and `include-story?`
+            # in any emitted text file. So a Story/Xray change cannot break
+            # the generated `:app` compile, and queueing the ~30-minute
+            # jvm-tools-template job (npm ci + Playwright Chromium) for one
+            # bought nothing. Both tools keep every lane of their own —
+            # tools_jvm and mcp_conformance right here, and story_xray_browser
+            # below. Re-add an arm only WITH a real emitted dependency and a
+            # fixture that compiles it.
             ;;
         esac
         # story_xray_browser is narrowed (rf2-k9ekz): it fires ONLY when

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -690,12 +690,14 @@ test('Story macros.clj schedules BOTH CLJS lanes (rf2-eyyd2)', () => {
 test('Story macros.clj keeps its existing non-CLJS fan-out (rf2-eyyd2)', () => {
   // The arm widens; it must not narrow. macros.clj is under
   // tools/story/src/**, so the examples_compile roster and the
-  // tools_jvm / mcp_conformance / template_expensive fan-out all still fire.
+  // tools_jvm / mcp_conformance fan-out all still fire.
   const result = classify(STORY_MACROS);
   assert.equal(result.examples_compile, 'true');
   assert.equal(result.tools_jvm, 'true');
   assert.equal(result.mcp_conformance, 'true');
-  assert.equal(result.template_expensive, 'true');
+  // template_expensive is NOT in that roster (rf2-6r9j.108): the reduced
+  // scaffold compiles against no Story surface, macros.clj included.
+  assert.equal(result.template_expensive, 'false');
 });
 
 // rf2-uqf5q — the THIRD predicate. rf2-eyyd2 armed macros.clj on the two CLJS
@@ -1909,39 +1911,61 @@ test('Other spec/*.md change does NOT light cljs_node_test (scope discipline) (r
   assert.equal(result.cljs_node_test, 'false');
 });
 
-// rf2-jdj17.1 — template_expensive false-green fix. The template's
-// generated `:app` build transitively compiles against tools/xray
-// (:devtools/preloads [day8.re-frame2-xray.preload]),
-// implementation/schemas (events.cljs side-loads re-frame.schemas;
-// schema.cljs calls reg-app-schema), and tools/story (the with-story
-// scaffold requires re-frame.story). The ONLY PR-time gate that compiles
-// the emitted `:app` (emitted_test_run_test, gated on template_expensive)
-// must therefore RUN when any of those three surfaces changes — else a
-// breaking change merges GREEN at PR time and surfaces only in the
-// nightly cron. These assertions lock the classifier OR-ing
-// template_expensive into the xray/story/schemas cases.
+// rf2-6r9j.108 — template_expensive is armed by the generated app's ACTUAL
+// inputs and nothing else. rf2-jdj17.1 armed it for tools/xray, tools/story
+// and implementation/schemas because the then-current scaffold compiled
+// against all three: `:devtools/preloads [day8.re-frame2-xray.preload]` in
+// every emitted shadow-cljs.edn, a `:with-story` variant requiring
+// re-frame.story, and an events.cljs/schema.cljs pair calling reg-app-schema.
+// rf2-zq34m (18b9486664) deleted all of that. The current twelve-file
+// emission requires core, the selected adapter and the view library only —
+// and tools/template's own `template_test.clj` FORBIDS the three coordinates
+// and their marker strings in anything emitted. So none of the three can
+// break the generated `:app` compile, and arming the ~30-minute
+// jvm-tools-template job (npm ci + Playwright Chromium provisioning) for a
+// schemas-only or Story/Xray-only PR was pure cost.
+//
+// These are the NEGATIVE CONTROLS that replaced the three positive
+// assertions. Each surface keeps its own independent lanes, asserted here
+// alongside so a mistaken "narrow everything" edit reds instead of passing:
+// re-add a template_expensive arm only with a real emitted dependency and a
+// fixture that compiles it.
 
-test('Xray src change arms template_expensive (generated :app preloads xray) (rf2-jdj17.1)', () => {
+test('Xray src change does NOT arm template_expensive — not in the reduced scaffold (rf2-6r9j.108)', () => {
   const result = classify('tools/xray/src/day8/re_frame2_xray/preload.cljs');
-  assert.equal(result.template_expensive, 'true');
+  assert.equal(result.template_expensive, 'false');
+  // ...but Xray's own lanes are untouched.
+  assert.equal(result.tools_jvm, 'true');
+  assert.equal(result.mcp_conformance, 'true');
+  assert.equal(result.story_xray_browser, 'true');
 });
 
-test('Story src change arms template_expensive (with-story scaffold requires re-frame.story) (rf2-jdj17.1)', () => {
+test('Story src change does NOT arm template_expensive — the with-story variant is gone (rf2-6r9j.108)', () => {
   const result = classify('tools/story/src/re_frame/story.cljs');
-  assert.equal(result.template_expensive, 'true');
+  assert.equal(result.template_expensive, 'false');
+  // ...but Story's own lanes are untouched.
+  assert.equal(result.tools_jvm, 'true');
+  assert.equal(result.mcp_conformance, 'true');
+  assert.equal(result.story_xray_browser, 'true');
 });
 
-test('Schemas change arms template_expensive (generated events/schema compile against re-frame.schemas) (rf2-jdj17.1)', () => {
+test('Schemas change does NOT arm template_expensive — the scaffold registers no schema (rf2-6r9j.108)', () => {
   const result = classify('implementation/schemas/src/re_frame/schemas.cljc');
-  assert.equal(result.template_expensive, 'true');
+  assert.equal(result.template_expensive, 'false');
+  // ...but schemas keeps every per-feature lane of its own.
+  assert.equal(result.implementation_jvm, 'true');
+  assert.equal(result.cljs_node_test, 'true');
+  assert.equal(result.cljs_browser, 'true');
+  assert.equal(result.cljs_prod, 'true');
+  assert.equal(result.bundle_isolation, 'true');
 });
 
-test('Story spec-md-only change does NOT arm template_expensive (cannot break :app compile) (rf2-jdj17.1)', () => {
+test('Story spec-md-only change does NOT arm template_expensive (rf2-jdj17.1, rf2-6r9j.108)', () => {
   const result = classify('tools/story/spec/002-Runtime.md');
   assert.equal(result.template_expensive, 'false');
 });
 
-test('Xray spec-md-only change does NOT arm template_expensive (rf2-jdj17.1)', () => {
+test('Xray spec-md-only change does NOT arm template_expensive (rf2-jdj17.1, rf2-6r9j.108)', () => {
   const result = classify('tools/xray/spec/017-Test-Coverage-Matrix.md');
   assert.equal(result.template_expensive, 'false');
 });
@@ -2484,8 +2508,11 @@ for (const [file, keys] of [
     ['implementation_jvm', 'cljs_node_test', 'cljs_browser', 'examples_compile', 'cljs_prod', 'bundle_isolation', 'mcp_conformance', 'mcp_live'],
   ],
   [
+    // template_expensive is deliberately absent from this roster
+    // (rf2-6r9j.108): the reduced scaffold registers no schema, so schemas
+    // never armed it on merit. The negative control lives above.
     'implementation/schemas/src/re_frame/schemas.cljc',
-    ['implementation_jvm', 'cljs_node_test', 'cljs_browser', 'examples_compile', 'cljs_prod', 'bundle_isolation', 'template_expensive'],
+    ['implementation_jvm', 'cljs_node_test', 'cljs_browser', 'examples_compile', 'cljs_prod', 'bundle_isolation'],
   ],
   [
     'implementation/machines/src/re_frame/machines.cljc',

--- a/tools/template/spec/001-Substrate-Variants.md
+++ b/tools/template/spec/001-Substrate-Variants.md
@@ -8,7 +8,7 @@
 
 | Substrate | Default? | View library | Generated `core.cljs` shape |
 |---|---|---|---|
-| `:reagent` | yes | Reagent | `rf/frame-root` rendered through `reagent.dom.client` |
+| `:reagent` | yes | Reagent | `rf/frame-root` rendered through the adapter's `client-root` |
 | `:uix` | no | UIx | `uix-adapter/frame-root` rendered through `uix.dom` |
 
 Reagent is the default — the substrate every re-frame and re-frame2
@@ -68,9 +68,15 @@ Both variants emit the same project shape. The substrate choice swaps:
   `day8/re-frame2-uix`) and the view library (`reagent/reagent`, or
   `com.pitch/uix.core` + `com.pitch/uix.dom`). `day8/re-frame2` (core)
   rides both.
-- `core.cljs` — the entry point. Reagent creates its root with
-  `reagent.dom.client/create-root` and renders `[rf/frame-root …]`;
-  UIx uses `uix.dom/create-root` + `render-root` around
+- `core.cljs` — the entry point, and the one place the two substrates
+  differ on who owns the React root. Reagent holds an inert
+  `reagent-adapter/client-root` handle and renders `[rf/frame-root …]`
+  through `reagent-adapter/render!`: the adapter creates (or hydrates)
+  the underlying React Root on that first render, reuses it across hot
+  reloads, and releases it from `rf/destroy-adapter!` — direct
+  `reagent.dom.client` construction is encapsulated, so the emitted
+  scaffold never names it. UIx owns its root itself, with
+  `uix.dom/create-root` + `render-root` around
   `($ uix-adapter/frame-root …)`. Both carry the same
   `^:dev/after-load mount!` hook and the same `init`.
 - `views.cljs` — the counter view. Reagent uses `rf/reg-view` and

--- a/tools/template/spec/002-Generated-Shape.md
+++ b/tools/template/spec/002-Generated-Shape.md
@@ -68,9 +68,12 @@ bundle load, and thereafter invokes only `^:dev/after-load` hooks
 therefore carries such a hook — `mount!` — and that hook, not `init`, is
 what a save re-runs:
 
-1. **One retained root.** The React root lives in a `defonce` cell;
-   `mount!` creates it once and renders into it on every call rather
-   than creating a second root over a live DOM node.
+1. **One retained root.** The React root lives in a `defonce` cell and
+   is created once, then rendered into on every later call rather than
+   a second root going over a live DOM node. Reagent puts an
+   adapter-owned `client-root` handle in that cell and lets the first
+   `reagent-adapter/render!` create the underlying Root; UIx puts the
+   `uix.dom/create-root` Root there itself.
 2. **The frame is created by the view, and reused.** `rf/frame-root`
    (or `uix-adapter/frame-root`) creates `:rf/default` the first time,
    running `:initial-events [[:counter/initialise]]` synchronously so
@@ -83,7 +86,9 @@ what a save re-runs:
 
 `template_emission_test.clj` pins these facts on the emitted
 `core.cljs`: exactly one `^:dev/after-load` hook, its body renders,
-`init` calls it, exactly one `create-root`, a `defonce` root, and the
+`init` calls it, exactly one root allocation
+(`reagent-adapter/client-root` or `uix-dom/create-root`), a `defonce`
+cell holding it, and the
 `:initial-events` seed. The behavioural tier then proves the page a
 newcomer opens actually mounts and moves the counter 0 → 1 in Chromium.
 

--- a/tools/template/test-support/dev-page-boot-proof.cjs
+++ b/tools/template/test-support/dev-page-boot-proof.cjs
@@ -5,39 +5,39 @@
  * `npx shadow-cljs watch app`.
  *
  * Driven by `emitted_test_run_test.clj` (behind `RF2_TEMPLATE_RUN_EMITTED_TESTS`),
- * as a sibling of `ssr-hydration-dom-proof.cjs`. The JVM half has already
- * generated the scaffold, rewritten its deps to :local/root, linked
- * node_modules, and run `shadow compile app` — so `<proj>/resources/public`
- * holds the emitted `index.html`, `css/app.css`, and the DEV (`:optimizations
- * :none`) bundle at `js/main.js` + `js/cljs-runtime/`.
+ * which runs it for the Reagent variant, the UIx variant, and the setup
+ * skill's shipped leaf scaffold. The JVM half has already generated the
+ * scaffold, rewritten its deps to :local/root, linked node_modules, and run
+ * `shadow compile app` — so `<proj>/resources/public` holds the emitted
+ * `index.html`, `css/app.css`, and the DEV (`:optimizations :none`) bundle at
+ * `js/main.js` + `js/cljs-runtime/`.
  *
- * WHY THIS EXISTS. Until this proof, no gate anywhere loaded the emitted
- * `index.html` in a browser. Everything upstream compiles through the pure-JVM
- * route, and the only browser proof drives a SYNTHETIC `_ssr_proof.html`
- * rendered by the SSR server — a page that never carries the emitted
- * `index.html`'s `<meta http-equiv="Content-Security-Policy">`. So a CSP that
- * blocks the dev bundle outright shipped green: shadow's `:none` builds load
- * every namespace through `goog.globalEval`, and without `'unsafe-eval'` in
- * `script-src` the documented first run is a BLANK PAGE on every variant.
- * That is the defect this driver exists to catch, and it can only be caught by
- * loading the REAL emitted page.
+ * WHY THIS EXISTS. Every other gate over the generated app stops at the
+ * pure-JVM route: it compiles, so it is presumed to boot. But a scaffold can
+ * compile clean and still hand a newcomer a BLANK PAGE — an `:output-dir` /
+ * `:asset-path` that disagrees with the `<script src>`, a `:init-fn` that never
+ * fires, a namespace that throws on load. Nothing but loading the REAL emitted
+ * page in a REAL browser catches that class, which is what this driver does.
  *
  * The three teeth, in order:
  *
  *   1. MOUNT — `#app` must paint the scaffold's counter (an `<h1>` with the
- *      project name, a `<button>`, and the counter `<span>`). A CSP that
- *      blocks `eval`, a broken `:init-fn`, or a namespace that throws on load
+ *      project name, a `<button>`, and the counter `<span>`). A bundle that
+ *      does not load, a broken `:init-fn`, or a namespace that throws on load
  *      all leave `#app` empty; this is the blank-first-page tooth.
  *   2. LIVE — clicking the `+1` button must move the counter 0 -> 1, so the
  *      dataflow (event -> app-db -> subscription -> re-render) is actually
- *      wired, not just server-shaped markup.
+ *      wired, not just static markup.
  *   3. CLEAN — ZERO uncaught `pageerror`s. Console noise stays diagnostic
  *      (a 404 favicon, a dev-only warn); only `pageerror` is fatal, matching
  *      every adjacent runner's policy in this repo.
  *
- * The static server sets NO Content-Security-Policy response header — the
- * emitted `<meta>` CSP is the only policy in play, which is exactly the
- * surface under test.
+ * NO CONTENT-SECURITY-POLICY IS IN PLAY, by design on both ends: the emitted
+ * `index.html` carries no `<meta http-equiv="Content-Security-Policy">` (both
+ * `template_test.clj` and the setup skill's drift lock forbid one), and the
+ * static server below sets no CSP response header. A CSP recipe added later
+ * brings its own policy-bearing fixture and its own diagnostics — this driver
+ * deliberately keeps none for a policy no page under it can have.
  *
  * Usage:  node dev-page-boot-proof.cjs <publicRoot> <implRoot> [label]
  *   publicRoot — <proj>/resources/public (holds index.html + js/ + css/)
@@ -84,8 +84,8 @@ const MIME = {
 
 // A tiny contained static file server rooted at PUBLIC_ROOT — enough to serve
 // the emitted index.html, the dev bundle, its cljs-runtime chunks and the CSS.
-// Never escapes the root, and deliberately sets no CSP header so the emitted
-// page's own <meta> policy is the one under test.
+// Never escapes the root, and sets no security headers of its own: the page
+// under test is served exactly as emitted.
 function startStaticServer(root) {
   const canonRoot = path.resolve(root);
   const server = http.createServer((req, res) => {
@@ -114,24 +114,10 @@ function startStaticServer(root) {
 
 // Turn the captured browser noise into a POINTED diagnosis where we can. A
 // bare "the counter never appeared" is a true but useless verdict; naming the
-// CSP as the blocker is what makes this gate worth having.
+// unloadable bundle is what makes this gate worth having.
 function diagnose(lines) {
   const blob = lines.join('\n');
   const hints = [];
-  if (/Content Security Policy|EvalError|unsafe-eval|refused to evaluate/i.test(blob)) {
-    hints.push(
-      "the emitted index.html's <meta> Content-Security-Policy BLOCKS the dev " +
-        "bundle: shadow-cljs :none builds load every namespace through " +
-        "goog.globalEval, so `script-src` must admit 'unsafe-eval' or the " +
-        'documented first run is a blank page.',
-    );
-  }
-  if (/Refused to load|violates the following Content Security Policy/i.test(blob)) {
-    hints.push(
-      'a resource the emitted page needs was refused by its own <meta> CSP — ' +
-        'widen the offending directive or drop the resource.',
-    );
-  }
   if (/Failed to load resource.*(main\.js|cljs-runtime)/i.test(blob)) {
     hints.push(
       'the dev bundle (js/main.js or a js/cljs-runtime chunk) did not load — ' +

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -74,13 +74,17 @@
 ;; --- deps.edn local-root rewrite ------------------------------------------
 
 (defn- rewrite-deps-for-local-run!
-  "Swap the `day8/re-frame2*` :mvn/version coords in a project's deps.edn
-  for `:local/root` paths into the in-repo source tree, then write it
-  back. Core and the substrate adapter are always rewritten; schemas and
-  Xray only when the deps.edn names them (neither the template nor the
-  setup skill's derived scaffold does any more — the arms stay for a
-  project that added them) — an unconditional assoc would ADD a
-  coordinate the project does not declare."
+  "Swap the two `day8/re-frame2*` :mvn/version coords in a project's
+  deps.edn for `:local/root` paths into the in-repo source tree, then
+  write it back. Core and the substrate adapter are the whole set: since
+  rf2-zq34m both callers hand this a deps.edn carrying exactly those two
+  framework coords (the emitted scaffold; the setup skill's derived leaf,
+  which `mount-skill-scaffold!` asserts against `reduced-day-one-coords`
+  right after this call), and `template_test.clj` forbids every other
+  `day8/re-frame2*` coordinate in an emitted project. A future fixture
+  that deliberately adds an optional artefact adds its rewrite here
+  together with a test that reaches the new arm — speculative arms for
+  coordinates no caller declares are what this docstring replaced."
   [^java.io.File root ^java.io.File proj-dir substrate]
   (let [deps-file (io/file proj-dir "deps.edn")
         deps      (edn/read-string (slurp deps-file))
@@ -92,17 +96,11 @@
         adapter-coord (symbol "day8" (str "re-frame2-" (name substrate)))
         adapter-path  (str "implementation/adapters/" (name substrate))
         rewritten
-        (cond-> (-> deps
-                    (assoc-in [:deps 'day8/re-frame2]
-                              {:local/root (rel-of "implementation/core")})
-                    (assoc-in [:deps adapter-coord]
-                              {:local/root (rel-of adapter-path)}))
-          (contains? (:deps deps) 'day8/re-frame2-schemas)
-          (assoc-in [:deps 'day8/re-frame2-schemas]
-                    {:local/root (rel-of "implementation/schemas")})
-          (contains? (:deps deps) 'day8/re-frame2-xray)
-          (assoc-in [:deps 'day8/re-frame2-xray]
-                    {:local/root (rel-of "tools/xray")}))]
+        (-> deps
+            (assoc-in [:deps 'day8/re-frame2]
+                      {:local/root (rel-of "implementation/core")})
+            (assoc-in [:deps adapter-coord]
+                      {:local/root (rel-of adapter-path)}))]
     (spit deps-file (with-out-str (pprint/pprint rewritten)))))
 
 ;; --- node_modules symlink --------------------------------------------------


### PR DESCRIPTION
Four vestige beads from the rf2-6r9j audit (rf2-6r9j.114, .110, .106, .108).
All four are the same shape: prose and dead branches left behind by
rf2-zq34m's template reduction and rf2-k5r9t's adapter-owned Reagent root.

## rf2-6r9j.114 — the substrate spec matched an API the scaffold no longer calls

`tools/template/spec/001-Substrate-Variants.md` said the Reagent variant
creates its root with `reagent.dom.client/create-root`. It has not since
rf2-k5r9t (7f104b4de9): the emitted `_reagent/core.cljs` holds an inert
`reagent-adapter/client-root` handle and renders through
`reagent-adapter/render!`. The adapter owns the React Root — creating or
hydrating it on the first render, reusing it across hot reloads, releasing it
from `rf/destroy-adapter!`. The resource comments and `template_emission_test.clj`
were updated then; spec/001 was not.

Both descriptions now name the real surface, and the entry states the
meaningful Reagent/UIx distinction the old wording hid: adapter-owned opaque
handle versus caller-owned `uix.dom` root. spec/002's "exactly one
`create-root`" line is reconciled to what the emission test actually pins per
substrate (`reagent-adapter/client-root` / `uix-dom/create-root`). UIx wording
is unchanged.

## rf2-6r9j.110 — dead CSP/SSR remnants in the browser proof

`tools/template/test-support/dev-page-boot-proof.cjs` described the emitted
`index.html` as carrying a `<meta http-equiv="Content-Security-Policy">`,
positioned itself against a synthetic SSR page, and carried two `diagnose()`
branches for CSP refusal and `unsafe-eval`.

Verified: the emitted `index.html` has no CSP; `template_test.clj` bans the
string in any emitted text file; `skills/re-frame2-setup/tests/setup_drift_test.clj`
locks the default route CSP-free; the driver's own static server sets no CSP
header. And `ssr-hydration-dom-proof.cjs`, the sibling the header named, is not
in the tree at all — `git ls-files` returns nothing for it, and the only
reference anywhere was that comment.

Both CSP-only branches are removed and the header rewritten around the SPA
proof the driver actually runs. The missing-bundle diagnostic stays, as does
every functional tooth: browser provisioning, the CI-hard launch verdict,
static-server containment, mount / 0-to-1 click / zero-pageerror, and both red
witnesses.

## rf2-6r9j.106 — unreachable rewrites in the smoke harness

`rewrite-deps-for-local-run!` had presence-gated `assoc-in` arms for
`day8/re-frame2-schemas` and `day8/re-frame2-xray`. Two call sites exist
repo-wide, and both hand it a `deps.edn` carrying core + the adapter + the view
library and nothing else — the setup-skill site asserts `reduced-day-one-coords`
exactly, immediately after the call. Neither arm could be true in any current
execution. Removed; the docstring is narrowed to the two live rewrites and says
what a future optional-artefact fixture would have to bring with it.

## rf2-6r9j.108 — CI fan-out from inputs the scaffold no longer has

`report-changed-surfaces.sh` set `template_expensive` for
`implementation/schemas/**` and for every non-spec-md change under
`tools/story/**` or `tools/xray/**`, on the premise that the generated `:app`
compiles `re-frame.schemas`, the Xray preload and the Story entry point.

None of that survived rf2-zq34m (18b9486664). The emitted `shadow-cljs.edn`
declares no `:devtools/preloads` at all; no emitted file names either tool (the
generated README links their docs under `docs/`, which is a different surface);
and `template_test.clj` forbids all three coordinates in `deps.edn` plus their
marker strings in any emitted text. So schemas-only and Story/Xray-only PRs
were queueing the ~30-minute `jvm-tools-template` job — `npm ci` plus Playwright
Chromium provisioning — for a compile with no edge to break.

The arm is removed from both cases. The three stale positive assertions in
`_changed-surfaces.test.cjs` are replaced by negative controls that *also* pin
each surface's own lanes (`tools_jvm` / `mcp_conformance` / `story_xray_browser`
for the tools; the full per-feature set for schemas), so an over-broad
"narrow everything" edit reds rather than passing. Two adjacent rosters that
listed `template_expensive` for Story macros and for schemas are corrected the
same way. Core, both adapters, `implementation/package.json` + lockfile,
`tools/template` and `skills/re-frame2-setup/references` all still arm it.

> **One-toucher pair.** This touches `.github/scripts/report-changed-surfaces.sh`
> and its mirror `implementation/scripts/_changed-surfaces.test.cjs` in one
> commit, because the change alters what the classifier outputs *and* what the
> test pins about those outputs — split across two PRs it would land a tree
> where the suite contradicts the script. Sequence any other PR touching that
> pair behind this one.

## Evidence

Each deletion was proved with two independent instruments and a control that
fired, per the audit protocol.

**.106** — (1) fixed-string census with `git grep -F` over tracked files under
`tools/template/resources/` and `skills/re-frame2-setup/references/first-counter.md`:
0 hits for `re-frame.schemas`, `reg-app-schema`, `re-frame.story`, `mount-shell!`,
`devtools/preloads`, `re-frame2-xray`; control `day8/re-frame2-reagent` returned
hits including the emitted `deps.edn`, and `frame-root` / `counter` returned 4
and 9 files. (2) execution probe evaluating the helper's own `contains?`
predicates against the real inputs both call sites feed it — emitted Reagent
`deps.edn`, emitted UIx `deps.edn`, and the leaf's `deps.edn` extracted from the
generated markdown block — all `false`/`false`; synthetic control naming both
coordinates read `true`/`true`.

**.110** — (1) census: `ssr-hydration-dom-proof` appears exactly once in the
tree, in the comment being deleted, and `git ls-files` has no such path;
control `dev-page-boot-proof` resolves to the tracked file. (2) direct read of
the emitted `index.html` (no CSP meta), the driver's server (no CSP header),
and the two locks that forbid one.

**.108** — (1) census as above, plus the emitted `shadow-cljs.edn` read
directly: no `:devtools/preloads` key. (2) the classifier executed on each
surface, before and after. Across all 28 outputs for the three surfaces exactly
three lines move, all `template_expensive` `true` to `false`; every retained
input still reads `true`.

**Gate liveness, proved once**: planted the removed schemas arm back into
`report-changed-surfaces.sh`; `_changed-surfaces.test.cjs` went red naming
`Schemas change does NOT arm template_expensive (rf2-6r9j.108)`. Restored and
verified byte-identical by blob hash (`git hash-object` unchanged for both
files).

## Gates run locally

| Gate | Exit |
|---|---|
| `node --test implementation/scripts/_changed-surfaces.test.cjs` | 0 — 335 passed |
| `clojure -M:test` in `tools/template` | 0 — 39 tests, 296 assertions, 0 failures |
| `python scripts/check_doc_slugs.py` | 0 |
| `npx eslint` on both touched `.cjs` files | 0 |
| `node --check dev-page-boot-proof.cjs` | 0 |

The tools/template suite's 39 tests / behavioural gating semantics are
unchanged, which is .106's acceptance criterion. The `RF2_TEMPLATE_RUN_EMITTED_TESTS`
behavioural tier is CI's — this PR changes the classifier, so
`template_expensive` arms for it and `jvm-tools-template` runs.

Nothing here validates the markdown's prose, tables or rendering, so the
anchors and table column counts in the two touched spec pages were checked by
hand: spec/001's substrate table keeps its 4 columns and the edit is confined
to one cell; spec/002's edits are inside a numbered list and a paragraph, no
anchors added or renamed, no headings touched.

## Left open

**rf2-6r9j.110 is NOT fully closed.** Its third acceptance criterion needs the
stale "two Chromium proofs including an SSR DOM-adoption proof" comments
corrected in `.github/workflows/test.yml` (~line 5019), `expensive-tests.yml`
(~line 318) and `template-release.yml` (~line 194). Those are hot-zone
one-toucher files held by other work, so they are untouched here and the bead
stays open with a note naming the three sites and the wording needed.
