### PR TITLE
chore(machines-viz): drop the viewer's framework boot, the inert :root-ref, and two dead test deps

### DIFF
--- a/tools/machines-viz/README.md
+++ b/tools/machines-viz/README.md
@@ -88,14 +88,23 @@ it ships as the compiled `viewer.js` beside that HTML — the jar was never
 its delivery vehicle. Only `src` is on `:paths` and on `:clein/build
 :src-dirs`, so only `src` reaches a consumer.
 
-The split earns its keep rather than merely tidying: the page is the only
-namespace here that picks a substrate (`rf/init!` with the Reagent
-adapter), and picking one is an application's job. Had it stayed in `src`,
-the jar would have had to declare `day8/re-frame2-reagent` to be loadable
-at all — and `day8/reagent-slim` publishes its adapter at the same
-canonical `re-frame.adapter.reagent` namespace, so a slim app taking
-machines-viz would have ended up with two implementations of that
-namespace on one classpath, load order picking the substrate.
+The page boots no framework. `MachineChart` is an ordinary Reagent
+component, so `viewer.cljs` mounts it through a plain
+`reagent.dom.client` root and stops there — no `rf/init!`, no substrate
+adapter, no frame, no dispatch (rf2-6r9j.115). The chart's own DOM suite
+mounts the same component through `adapters/react-chart` and a bare
+`react-dom/client` root, which is the standing proof that no framework
+boot is a rendering prerequisite.
+
+When rf2-k7l2o made the `src`/`page` split the page did still require
+`re-frame.adapter.reagent`, and that require was the sharper half of the
+argument: had it stayed in `src`, the jar would have had to declare
+`day8/re-frame2-reagent` to be loadable at all — and `day8/reagent-slim`
+publishes its adapter at the same canonical `re-frame.adapter.reagent`
+namespace, so a slim app taking machines-viz would have ended up with two
+implementations of that namespace on one classpath, load order picking
+the substrate. The require is gone now, so what keeps the split is the
+application-versus-library-surface line above.
 
 ## Building and hosting the viewer page
 

--- a/tools/machines-viz/deps.edn
+++ b/tools/machines-viz/deps.edn
@@ -28,20 +28,27 @@
 ;; jar. Only `:paths`/`:src-dirs` — i.e. only `src` — reaches a
 ;; consumer.
 ;;
-;; The split is load-bearing, not tidiness. The page is the only
-;; namespace here that picks a SUBSTRATE (`rf/init!` with the Reagent
-;; adapter), and picking one is an application's job: `day8/reagent-slim`
-;; publishes its adapter at the same canonical `re-frame.adapter.reagent`
-;; namespace (release.yml renames `reagent_slim.cljs` → `reagent.cljs` at
-;; publication, and states downstream apps depend on EXACTLY ONE of
-;; {day8/re-frame2-reagent, day8/reagent-slim}). Had the page stayed in
-;; `src`, this jar would have had to declare an adapter to be loadable at
-;; all, putting two `re-frame.adapter.reagent` implementations on a slim
-;; app's classpath with load order deciding the winner.
+;; The split is application-versus-library-surface. `viewer.cljs` is an
+;; entry point a browser loads — an `^:export` symbol, a DOM lookup, and a
+;; `reagent.dom.client` root it owns — and a consumer requiring this jar
+;; wants the chart, not a page's mount code.
+;;
+;; When rf2-k7l2o made the split the argument was sharper still: the page
+;; then required `re-frame.adapter.reagent`, so had it stayed in `src` this
+;; jar would have had to declare an adapter to be loadable at all, putting
+;; two `re-frame.adapter.reagent` implementations on a `day8/reagent-slim`
+;; app's classpath with load order deciding the winner (release.yml renames
+;; `reagent_slim.cljs` → `reagent.cljs` at publication, and states
+;; downstream apps depend on EXACTLY ONE of {day8/re-frame2-reagent,
+;; day8/reagent-slim}). rf2-6r9j.115 removed that require — the page never
+;; needed a substrate, only a Reagent root — so the dependency-forcing half
+;; of the argument is discharged rather than pending. NO adapter coordinate
+;; appears anywhere in this file, including its test aliases.
 {:paths ["src"]
- :deps  {;; Core supplies re-frame.error, trace/interop helpers, and the
-         ;; viewer page's re-frame initialisation. Hosts obtain
-         ;; definitions and snapshots themselves and pass them to
+ :deps  {;; Core supplies re-frame.error (grammar/mermaid/scxml/share/export
+         ;; diagnostics) and re-frame.trace / re-frame.interop (chart.cljs's
+         ;; layout-failure emit and its dev-build console gating). Hosts
+         ;; obtain definitions and snapshots themselves and pass them to
          ;; MachineChart.
          day8/re-frame2 {:local/root "../../implementation/core"}
 
@@ -72,27 +79,18 @@
          ;; bundle never pulls Reagent through it.
          reagent/reagent {:mvn/version "2.0.1"}
 
-         ;; NO ADAPTER COORDINATE BELONGS IN THIS MAP, and the reason has
-         ;; already been acted on rather than merely noted (rf2-3d5u3 →
-         ;; rf2-k7l2o, both landed). `re-frame.adapter.reagent` was required by
-         ;; `viewer.cljs` while that file sat in `src`, and undeclared it killed
-         ;; the whole jar at namespace LOAD for a consumer. Declaring
-         ;; `day8/re-frame2-reagent` would have been worse than the hole:
-         ;; `day8/reagent-slim` publishes ITS adapter at the same canonical
-         ;; `re-frame.adapter.reagent` ns (release.yml renames
-         ;; `reagent_slim.cljs` → `reagent.cljs` before clein packages, and says
-         ;; downstream apps depend on EXACTLY ONE of {day8/re-frame2-reagent,
-         ;; day8/reagent-slim}), so a slim app would have carried two
-         ;; implementations of one namespace with load order picking the
-         ;; substrate — and in-tree the slim ns is still `reagent_slim`, so the
-         ;; monorepo build cannot see the collision. It would not have reached
-         ;; the published pom anyway: `clein pom` silently skips `:local/root`
-         ;; and `release-machines-viz.yml` rewrites exactly one coordinate.
-         ;;
-         ;; The page moved to the `page` root instead — see "Two source roots"
-         ;; at the top of this file. The require left the jar with it, so there
-         ;; is nothing here to declare; the coordinate the page needs is scoped
-         ;; to `:cljs-test`, the lane that compiles it.
+         ;; NO ADAPTER COORDINATE BELONGS ANYWHERE IN THIS FILE — not in
+         ;; this map and not in a test alias. `day8/reagent-slim` publishes
+         ;; ITS adapter at the same canonical `re-frame.adapter.reagent` ns
+         ;; (release.yml renames `reagent_slim.cljs` → `reagent.cljs` before
+         ;; clein packages, and says downstream apps depend on EXACTLY ONE of
+         ;; {day8/re-frame2-reagent, day8/reagent-slim}), so a coordinate here
+         ;; would put two implementations of one namespace on a slim app's
+         ;; classpath with load order picking the substrate — and in-tree the
+         ;; slim ns is still `reagent_slim`, so the monorepo build cannot see
+         ;; the collision. Nothing in this artefact requires an adapter:
+         ;; rf2-3d5u3 → rf2-k7l2o moved the viewer page off `src`, and
+         ;; rf2-6r9j.115 deleted its `rf/init!` outright.
 
          ;; `adapters/uix.cljs` requires `uix.core` for `defui` / `$`
          ;; (rf2-3d5u3). Undeclared, that namespace dies at LOAD the same way.
@@ -172,39 +170,24 @@
   ;; :requires the page entry, and the page root is off `:paths` precisely so
   ;; it never ships. A test lane is not a consumer, so putting it on the TEST
   ;; classpath is exactly the right scope — the page keeps its coverage and
-  ;; the jar keeps its independence from any substrate adapter.
+  ;; the jar keeps its `src`-only surface.
   :cljs-test
   {:extra-paths ["test" "page"]
+   ;; NOTHING UIx-SHAPED AND NOTHING ADAPTER-SHAPED BELONGS IN THIS MAP
+   ;; (rf2-6r9j.111, rf2-6r9j.115). `uix.core` is a SHIPPED dep in `:deps`
+   ;; above — `adapters/uix.cljs` is library surface — so repeating it on
+   ;; this alias only created a second place to bump the version; the
+   ;; rf2-odlm3 comment that used to sit here explaining the repeat was
+   ;; written while `:deps` still lacked the coordinate, and bcf7d291ac
+   ;; added it days later. `uix.dom` was never required by any namespace in
+   ;; this artefact — src, page or test — so it bought the lane nothing at
+   ;; all. And `day8/re-frame2-reagent` went the same way as the viewer
+   ;; page's `rf/init!`: see the adapter-coordinate note in `:deps` above.
    :extra-deps  {day8/re-frame2-test-quiet
                  {:local/root "../../implementation/test-quiet"}
                  day8/re-frame2-machines
                  {:local/root "../../implementation/machines"}
-                 thheller/shadow-cljs {:mvn/version "3.4.10"}
-                 ;; FINDING (rf2-odlm3): `src/day8/re_frame2_machines_viz/
-                 ;; adapters/uix.cljs` :requires `uix.core`, and this artefact's
-                 ;; `:deps` map does not declare it — the namespace compiles
-                 ;; today ONLY because implementation/shadow-cljs.edn carries
-                 ;; com.pitch/uix.{core,dom} in its own `:dependencies` and
-                 ;; borrows the tree onto that classpath. A consumer whose only
-                 ;; tool dep is day8/re-frame2-machines-viz cannot compile the
-                 ;; UIx adapter at all: the rf2-r8trk shape, one artefact over.
-                 ;;
-                 ;; Declaring it HERE unblocks the lane without changing the
-                 ;; PUBLISHED dependency graph, which is a separate decision
-                 ;; (optional adapter → provided dep?) and is filed rather than
-                 ;; taken in a CI-arming PR.
-                 com.pitch/uix.core   {:mvn/version "1.4.4"}
-                 com.pitch/uix.dom    {:mvn/version "1.4.4"}
-                 ;; The viewer PAGE (`page/.../viewer.cljs`) :requires
-                 ;; `re-frame.adapter.reagent`. That require is why the page is
-                 ;; not in `src` (rf2-k7l2o — see the source-roots note at the
-                 ;; top of this file): as library surface it would have forced
-                 ;; a published adapter dep and collided with day8/reagent-slim
-                 ;; on a slim app's classpath. As a page it is an application
-                 ;; choosing its own substrate, and the coordinate it needs is
-                 ;; scoped to the lane that compiles it — here.
-                 day8/re-frame2-reagent
-                 {:local/root "../../implementation/adapters/reagent"}}}
+                 thheller/shadow-cljs {:mvn/version "3.4.10"}}}
 
   ;; Clojars deploy. The release
   ;; workflow rewrites :local/root → :mvn/version before invoking
@@ -230,9 +213,9 @@
   ;; — for a library jar this only populates the manifest's Main-Class.
   ;;
   ;; `:src-dirs ["src"]` — `page` is deliberately absent (rf2-k7l2o). It
-  ;; is the line that keeps the viewer page out of the jar, so a consumer
-  ;; is never asked to resolve `re-frame.adapter.reagent`. Adding `page`
-  ;; here would republish the defect.
+  ;; is the line that keeps the viewer page's `^:export` entry and its own
+  ;; mount root out of a library jar; the page ships as the compiled
+  ;; `viewer.js` beside `public/viewer.html` instead.
   :clein/build
   {:lib      day8/re-frame2-machines-viz
    :main     day8.re-frame2-machines-viz.chart

--- a/tools/machines-viz/page/day8/re_frame2_machines_viz/viewer.cljs
+++ b/tools/machines-viz/page/day8/re_frame2_machines_viz/viewer.cljs
@@ -37,40 +37,43 @@
 
   Compiled to a single bundle the static `public/viewer.html` loads.
   `(viewer/run)` is the `^:export` entry. The page is presentation-only:
-  it initialises re-frame purely so the Reagent adapter is live (the
-  chart is a Reagent component); it registers no frame, dispatches no
-  events, and reads no `[:rf.runtime/machines :snapshots]` runtime-db slot.
+  it mounts `MachineChart` — an ordinary Reagent component — through a
+  plain `reagent.dom.client` root and stops there. There is NO
+  `rf/init!` and no substrate adapter (rf2-6r9j.115): `init!` installs a
+  framework substrate and re-seeds framework registrations, none of
+  which a Reagent render needs, and this page registers no frame,
+  dispatches no event, and reads no `[:rf.runtime/machines :snapshots]`
+  runtime-db slot. The chart's own DOM suite mounts the same component
+  through `adapters.react-chart/chart-element` + a bare
+  `react-dom/client` root with no framework boot at all, which is the
+  standing proof that none is a rendering prerequisite.
 
   ## Why this file lives under `page/` and not `src/` (rf2-k7l2o)
 
   It is the artefact's only APPLICATION. Everything under `src/` is
   library surface a host requires; this namespace is an entry point a
-  browser loads, and it is the only one in the tree that picks a
-  substrate — `(rf/init! reagent-adapter/adapter)` on the line below.
-  Picking a substrate is an application's job. `implementation/core` is
-  deliberately adapter-free for exactly that reason, and a library jar
-  that named `re-frame.adapter.reagent` in its dependency graph would
-  force the choice on every consumer: `day8/reagent-slim` publishes ITS
-  adapter at the same canonical namespace (`release.yml` renames
-  `reagent_slim.cljs` → `reagent.cljs` at publication), so a slim app
-  taking machines-viz would get two `re-frame.adapter.reagent`
-  implementations on one classpath — one bound to `reagent.*`, one to
-  `reagent2.*` — with classpath order deciding which its own
-  `(:require [re-frame.adapter.reagent])` resolved to.
+  browser loads — an `^:export` symbol, a DOM lookup, and a mount root
+  it owns. A consumer that requires the jar wants the chart, not a
+  page's mount code.
 
   `page/` is a source root the jar does not carry (`:clein/build
-  :src-dirs [\"src\"]`), so the require never reaches a consumer's
-  classpath and no dependency is needed to satisfy it. The page is
-  shipped as the compiled `viewer.js` beside `public/viewer.html`, which
-  is how a static page ships anyway — the jar was never its delivery
-  vehicle.
+  :src-dirs [\"src\"]`), and the compiled `viewer.js` ships beside
+  `public/viewer.html`, which is how a static page ships anyway — the
+  jar was never its delivery vehicle.
+
+  Historical note: when rf2-k7l2o moved this file out of `src/` the
+  argument was sharper still, because the page then required
+  `re-frame.adapter.reagent` and a library jar naming that namespace
+  would have forced a substrate on every consumer (`day8/reagent-slim`
+  publishes ITS adapter at the same canonical namespace). That require
+  is gone as of rf2-6r9j.115, so the dependency-forcing half of the
+  argument no longer applies; the application-versus-library-surface
+  half is what keeps the split.
 
   Per [`API.md`](../../../spec/API.md) §Read-only viewer + §Share-URL
   encoding."
   (:require [reagent.core :as r]
             [reagent.dom.client :as rdc]
-            [re-frame.core :as rf]
-            [re-frame.adapter.reagent :as reagent-adapter]
             [day8.re-frame2-machines-viz.chart :as chart]
             [day8.re-frame2-machines-viz.share :as share]))
 
@@ -170,10 +173,10 @@
   (try (.. js/window -location -href) (catch :default _ "")))
 
 (defn ^:export run
-  "Viewer entry. Initialises re-frame (so the Reagent component renders),
-  decodes the current location, and mounts the viewer into `#app`."
+  "Viewer entry. Decodes the current location and mounts the viewer into
+  `#app` through a `reagent.dom.client` root. No framework boot — see the
+  ns docstring §Build."
   []
-  (rf/init! reagent-adapter/adapter)
   (let [el (.getElementById js/document "app")]
     (when el
       (when (nil? @app-root)

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1669,18 +1669,31 @@ namespace a consumer can `:require`. Self-hosting means serving the two
 static files, exactly as [DESIGN-RATIONALE Lock #7](./DESIGN-RATIONALE.md)
 describes; it never meant requiring the entry namespace.
 
-The reason is a contract, not a packaging preference. The viewer is the
-only namespace in this artefact that chooses a **substrate** — it calls
-`rf/init!` with the Reagent adapter — and choosing one is an
-application's job, which is why `implementation/core` is adapter-free.
-A library jar carrying that require would have to declare
-`day8/re-frame2-reagent`, and `day8/reagent-slim` publishes its own
-adapter at the same canonical `re-frame.adapter.reagent` namespace; a
-slim application adding machines-viz would then hold two implementations
-of one namespace, with classpath order deciding which its own
-`(:require [re-frame.adapter.reagent])` resolved to. Keeping the page
-off `:src-dirs` removes the require from the jar and the choice from the
-consumer (rf2-k7l2o).
+The reason is a contract, not a packaging preference. The viewer is an
+**application**: an `^:export` entry a browser calls, a `#app` lookup,
+and a mount root it owns. A consumer requiring this jar wants the chart,
+not a page's mount code, and `:src-dirs ["src"]` is the line that draws
+that boundary.
+
+The page boots **no framework**. `MachineChart` is an ordinary Reagent
+component, so the viewer mounts it through a plain `reagent.dom.client`
+root — no `rf/init!`, no substrate adapter, no frame, no dispatch
+(rf2-6r9j.115). `rf/init!` installs a substrate and re-seeds framework
+registrations; neither is a Reagent rendering prerequisite, which the
+chart's own DOM suite demonstrates by mounting the same component
+through `adapters/react-chart` and a bare `react-dom/client` root.
+
+Until rf2-6r9j.115 the page did require `re-frame.adapter.reagent`, and
+that require was the sharper half of the rf2-k7l2o argument: a library
+jar carrying it would have to declare `day8/re-frame2-reagent`, and
+`day8/reagent-slim` publishes its own adapter at the same canonical
+`re-frame.adapter.reagent` namespace, so a slim application adding
+machines-viz would then hold two implementations of one namespace with
+classpath order deciding which its own
+`(:require [re-frame.adapter.reagent])` resolved to. That hazard is now
+discharged at the source rather than merely fenced by the source-root
+split — no adapter coordinate appears anywhere in
+`tools/machines-viz/deps.edn`, test aliases included.
 
 Source: lifted from
 [Xray 003 §Share affordance](../../xray/spec/003-Machine-Inspector.md#share-affordance).

--- a/tools/machines-viz/spec/DESIGN-RATIONALE.md
+++ b/tools/machines-viz/spec/DESIGN-RATIONALE.md
@@ -645,25 +645,33 @@ rf2-j3iwt.
 
 ## Lock #10 — Source migration from Xray 003
 
-**Locked 2026-05-13 (Mike).** **The following content migrates
-from Xray 003 to this jar's spec when implementation work
-begins. Until then, Xray 003 remains the read-the-spec source of
-truth.**
+**Locked 2026-05-13 (Mike). MIGRATION COMPLETE — reconciled against
+the shipped tree 2026-09-03 (rf2-6r9j.126).** Every row below has
+landed. Machines-Viz's own spec is the read-the-spec source of truth
+for the chart component; Xray 003 keeps the embedding-host side listed
+further down. **There is no `001-Rendering.md`, and nothing is waiting
+on one** — the rendering contract lives in [`API.md`](./API.md) and the
+parity / layout analysis in
+[`001-Topology-Parity.md`](./001-Topology-Parity.md), which took the
+`001-` slot. (That doc's §5 roadmap row D1 leaves open whether a
+narrower "rendering pipeline internals" reference is ever worth
+writing; it would be a new document, not this lock's unfinished
+business.)
 
-### Migrating content
+### Where each topic landed
 
-| Topic | Xray 003 section | Lands in Machines-Viz spec at |
+| Topic | Xray 003 section | Lives in Machines-Viz spec at |
 |---|---|---|
-| `MachineChart` prop contract | §Embedding posture | [`API.md`](./API.md) §MachineChart (already lifted) |
-| Share-URL encoding pipeline | §Share affordance §Share URL + §Performance | [`API.md`](./API.md) §Share-URL encoding (already lifted) |
-| Read-only viewer behaviour | §Share-URL §Read-only viewer | [`API.md`](./API.md) §Read-only viewer (already lifted) |
+| `MachineChart` prop contract | §Embedding posture | [`API.md`](./API.md) §`MachineChart` component |
+| Share-URL encoding pipeline | §Share affordance §Share URL + §Performance | [`API.md`](./API.md) §Share-URL encoding |
+| Read-only viewer behaviour | §Share-URL §Read-only viewer | [`API.md`](./API.md) §Read-only viewer |
 | `:after` countdown rings — render rules | §Performance | [`API.md`](./API.md) §Performance invariants + Lock #8 above |
 | Layout-recompute rules | §Performance | [`API.md`](./API.md) §Performance invariants + Lock #9 above |
 | Topology / runtime-highlight separation (load-bearing) | (originated here 2026-05-14 per rf2-t1yvw) | [`API.md`](./API.md) §Performance invariants + Lock #11 below |
-| `:spawn-all` viz — row of mini-machines | §`:spawn-all` viz | future 001-Rendering.md (post-scaffold; not in this PR) |
+| `:spawn-all` viz | §`:spawn-all` viz | [`API.md`](./API.md) §`:overlays` slot descriptor schema — the `:spawn-all-join` descriptor (rf2-3ow55, re-slotted rf2-7w4qr). The row-of-mini-machines sketch was NOT what shipped: it is a host-fed join inspector anchored beside the spawn-all-bearing state |
 | PNG / SVG export — accessibility | §Accessibility | [`API.md`](./API.md) §Exporters |
-| Privacy posture for share-URL | §Privacy posture | [Principles §No session data in shares](./Principles.md) (already lifted) |
-| Auto-pan on transition | §Auto-pan | future 001-Rendering.md |
+| Privacy posture for share-URL | §Privacy posture | [Principles §No session data in shares](./Principles.md) |
+| Auto-pan on transition | §Auto-pan | [`API.md`](./API.md) §Auto-fit on async layout settle + §Fit-on-entry signal (rf2-6tw7t). The chart owns viewport re-fitting; the auto-pan TOGGLE and its persistence stayed with Xray, below |
 
 ### What stays in Xray 003 (the embedding-host side)
 
@@ -682,14 +690,13 @@ concerns**. Everything that's about rendering / encoding /
 export lives here; everything that's about Xray's panel chrome
 or Story's per-variant ribbon lives in those tools' spec.
 
-The migration is staged: this scaffold PR (rf2-x50eu) covers
-[`API.md`](./API.md) + this rationale + Principles + Vision. The
-detailed rendering / layout / export specs (a future
-`001-Rendering.md`, possibly more) land as separate beads once
-implementation work picks up.
-
-Until those land, **Xray 003 is the source of truth for
-unmigrated content**, and this DESIGN-RATIONALE cites back to it.
+The migration was staged. The scaffold PR (rf2-x50eu) covered
+[`API.md`](./API.md) + this rationale + Principles + Vision; the
+rendering, layout and export detail then landed **into `API.md` and
+[`001-Topology-Parity.md`](./001-Topology-Parity.md)** rather than into
+the separate `001-Rendering.md` this lock originally anticipated. Read
+that as a filed plan superseded by where the content actually went, not
+as a document still owed.
 
 ---
 
@@ -787,29 +794,56 @@ Per `ai/findings/perf-audit-machines-viz-2026-05-14.md` findings 1+2
 
 ---
 
-## Open questions
+## Questions the implementation settled
 
-The locks above cover the v1.0 surface. Open questions deferred
-to implementation:
+The locks above cover the v1.0 surface. Five questions were left open
+at scaffold time and deferred to implementation. All five are now
+answered by shipped code; they are recorded here with their outcomes so
+a reader does not re-open them (reconciled 2026-09-03, rf2-6r9j.126).
 
-- **Layout algorithm** — Dagre? ELK? Custom? (Xray 003 doesn't
-  pick; defer until first cut.)
-- **SVG primitive vs Canvas vs HTML/CSS** — Xray 003 hints
-  "SVG primitive" (per §Share affordance §Performance) but
-  doesn't lock; defer to a `001-Rendering.md` bead.
-- **Component substrate** — `MachineChart` is registered via
-  `reg-view` (Spec 001 §Allowed forms of the middle slot) so it works
-  across Reagent / UIx;
-  the registration spec lives in a future capability doc.
-- **Test corpus shape** — a snapshot-tested fixture per
-  rendering case (compound, parallel, `:after`, `:spawn-all`,
-  `:final?`); shape mirrors the framework's conformance corpus.
-  Defer to implementation.
-- **Edge labels on dense graphs** — Xray 003 doesn't address
-  label collision; defer.
+- **Layout algorithm** — was "Dagre? ELK? Custom?". **ELK (`elkjs`),
+  Layered algorithm, `ORTHOGONAL` edge routing with
+  `elk.json.edgeCoords ROOT`.** `chart.cljs` requires
+  `elkjs/lib/elk.bundled.js` and holds `default-elk-options`; the
+  reasoning and the parity bar are
+  [`001-Topology-Parity.md`](./001-Topology-Parity.md) §1.7, and the
+  measure-then-relayout pass is [`API.md`](./API.md) §Measure-then-relayout.
+- **SVG primitive vs Canvas vs HTML/CSS** — **none of the three alone:
+  `@xyflow/react`.** Nodes are HTML/CSS `<div>`s (`chart/nodes.cljs`),
+  edges are SVG paths through xyflow's `BaseEdge`, and edge labels are
+  HTML through `EdgeLabelRenderer` (`chart/edges.cljs`). Canvas was
+  never taken — a DOM node tree is what makes the testids, the
+  hover/click surface and the SVG exporter possible.
+- **Component substrate** — the scaffold's guess was that `MachineChart`
+  would be registered via `reg-view`. **It is not, and never was.** The
+  chart is a plain **host-fed Reagent component** the host passes props
+  to; it touches no registry and no frame. Substrate reach comes from
+  one bridge, not from registration: `adapters/react-chart` reactifies
+  the component ONCE and exposes `chart-element`, and
+  `adapters/uix.cljs` is a thin `defui` shell over it. See
+  [`API.md`](./API.md) §Substrate adapters and
+  [`Principles.md`](./Principles.md) §Embedding-host-agnostic.
+- **Test corpus shape** — **not snapshot fixtures.** Three lanes:
+  a JVM `.cljc` pure-data suite (`clojure -M:test`), the
+  artefact-owned CLJS node lane
+  (`npm run test:tools-machines-viz`), and real-DOM browser suites
+  (`*-dom-cljs-test`) on the consolidated `:browser-test` build. The
+  rendered-topology geometry gate ([`API.md`](./API.md) §Rendered-topology
+  geometry gate) is what pins each rendering case, in place of a
+  golden-image snapshot.
+- **Edge labels on dense graphs** — **dissolved rather than solved.**
+  Under events-as-nodes (rf2-qo5xy) each transition gets its own
+  event-node carrying the label, and the in/out edges are label-less, so
+  the post-render collision-avoidance overlay (rf2-r7vsr) was inert and
+  was retired (rf2-0xbgx). ELK's `elk.edgeLabels.placement` /
+  `elk.spacing.edgeLabel` handle what remains. See
+  [`001-Topology-Parity.md`](./001-Topology-Parity.md) §1.5 and
+  [`API.md`](./API.md) §Post-render label-collision avoidance — RETIRED.
 
-Each of these will land as a Locked entry above when picked, or
-as a bead against this jar.
+Genuinely open scope lives in [`000-Vision.md`](./000-Vision.md)
+§Scope and roadmap — its §What v1.0 does NOT do, §Committed with a
+trigger and §Candidates on demand — and in beads against this jar, not
+here.
 
 ---
 

--- a/tools/machines-viz/spec/README.md
+++ b/tools/machines-viz/spec/README.md
@@ -35,5 +35,23 @@ see [Xray's Machine Inspector spec](../../xray/spec/003-Machine-Inspector.md).
 - AI generation through a caller-supplied resolver. No provider bridge or
   credentials ship in this artefact.
 
-The JVM-runnable pure-data suite runs with `clojure -M:test`. CLJS and DOM
-coverage use the consolidated builds in `implementation/shadow-cljs.edn`.
+## Test lanes
+
+Three, not two:
+
+- **JVM pure-data** - `clojure -M:test` from `tools/machines-viz`. The
+  `.cljc` grammar / layout / projection / emitter corpus.
+- **Artefact-owned CLJS (node)** - this artefact's own
+  `tools/machines-viz/shadow-cljs.edn` `:machines-viz-node-test` build on
+  its own `:cljs-test` classpath, run as `npm run test:tools-machines-viz`
+  from `implementation/`. Its `-test$` selector reaches the suites the
+  consolidated `cljs-test$` one does not (rf2-odlm3), and it carries the
+  `page` root, so the viewer entry is covered here.
+- **Consolidated CLJS + browser DOM** - `implementation/shadow-cljs.edn`
+  borrows this artefact's `src`, `test` and `page` roots onto its
+  `:node-test` (`cljs-test$`) and `:browser-test` (`-dom-cljs-test$`)
+  builds. The real-DOM chart and export suites run there.
+
+The viewer page is built and staged by `npm run build:machines-viz-viewer`
+(the consolidated `:machines-viz-viewer` release build plus
+`scripts/stage-viewer-page.cjs`).

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings.cljs
@@ -179,7 +179,6 @@
                                  (vec (measure-rings root @latest-specs)))))]
     (scaffold/make-resizing-overlay-class
       {:display-name "MachinesViz.AfterRingsOverlay"
-       :root-ref     root-ref
        :remeasure!   remeasure!
        :render
        (fn [{:keys [ring-specs tick testid on-hover on-leave]

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
@@ -160,7 +160,6 @@
                                    anchor/anchor-below root (:node-id spec))))))]
     (scaffold/make-resizing-overlay-class
       {:display-name "MachinesViz.CancellationCascadeOverlay"
-       :root-ref     root-ref
        :remeasure!   remeasure!
        :render
        (fn [{:keys [cascade-spec tick testid]

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_scaffold.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_scaffold.cljs
@@ -8,10 +8,10 @@
   measure-on-mount/update/resize lifecycle and an absolutely-positioned
   full-bleed root `<div>` that captures its `offsetParent` so the DOM
   walk shares the chart wrapper's coordinate origin. That scaffold —
-  the `root-ref` atom, the `remeasure!`-on-resize listener, the three
-  `create-class` lifecycle hooks, and the overlay root `<div>` style —
-  lives here ONCE so each overlay keeps only its measurement strategy +
-  paint.
+  the `remeasure!`-on-resize listener, the three `create-class`
+  lifecycle hooks, and the overlay root `<div>` style (including the
+  `:ref` that fills the overlay's own `root-ref` atom) — lives here
+  ONCE so each overlay keeps only its measurement strategy + paint.
 
   CLJS-only: the lifecycle + DOM ref plumbing is browser-specific
   (`reagent.core/create-class`, `js/window`, `offsetParent`). The PURE
@@ -27,21 +27,20 @@
   Args (single map):
 
     :display-name — the React `:display-name`.
-    :root-ref     — the `r/atom` the render fn populates with the
-                    overlay's `offsetParent` (the shared coordinate
-                    origin). The scaffold reads it only to gate the
-                    resize listener teardown; the caller's `remeasure!`
-                    closure already reads it.
     :remeasure!   — `(fn [] ...)` the caller supplies; invoked on mount,
                     every did-update, and every window resize. It reads
                     the latest props/specs (which the render fn stashes
                     in atoms) and re-measures the DOM.
     :render       — the `:reagent-render` fn `(fn [props] hiccup)`.
 
+  The overlay's `root-ref` atom is NOT one of these. Each overlay owns
+  its own — `overlay-root-props` below wires the `:ref` that fills it,
+  and the caller's `remeasure!` closure is the only thing that reads it.
+  The scaffold never needs it: teardown removes the resize listener
+  unconditionally.
+
   Returns the form-3 component. The resize listener is registered on
-  mount and torn down on unmount (the `_root-ref` is unused directly but
-  kept in the arg map so a future scaffold variant can key teardown on
-  it without a signature change)."
+  mount and torn down on unmount."
   [{:keys [display-name remeasure! render]}]
   (let [resize-fn (fn [_] (remeasure!))]
     (r/create-class

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
@@ -195,7 +195,6 @@
                                    anchor/anchor-right-of root (:node-id spec))))))]
     (scaffold/make-resizing-overlay-class
       {:display-name "MachinesViz.SpawnAllJoinOverlay"
-       :root-ref     root-ref
        :remeasure!   remeasure!
        :render
        (fn [{:keys [join-spec tick testid on-child-click]


### PR DESCRIPTION
Four vestiges in `tools/machines-viz`, each removed only after a fixed-string census over tracked files **and** a semantic instrument agreed, with a planted control to prove each instrument was live. Beads: rf2-6r9j.115, rf2-6r9j.111, rf2-6r9j.109, rf2-6r9j.126.

## rf2-6r9j.115 — the viewer page boots no framework

`page/day8/re_frame2_machines_viz/viewer.cljs` called `(rf/init! reagent-adapter/adapter)` before mounting `MachineChart` through `reagent.dom.client`. `init!` installs a substrate adapter and re-seeds framework interceptors/events; neither is a Reagent rendering prerequisite. The chart's own DOM suite has always mounted the same component through `adapters.react-chart/chart-element` plus a bare `react-dom/client` root with no framework boot at all.

The `re-frame.core` and `re-frame.adapter.reagent` requires and the `rf/init!` call are gone, and `day8/re-frame2-reagent` leaves the `:cljs-test` alias with them. **No adapter coordinate now appears anywhere in `tools/machines-viz/deps.edn`, test aliases included.** The main `day8/re-frame2` dep stays — `src/` genuinely uses `re-frame.error` (grammar / mermaid / scxml / share / export diagnostics) and `re-frame.trace` / `re-frame.interop` (chart.cljs's layout-failure emit and its dev-build console gating), and the deps.edn comment now says so instead of citing "the viewer page's re-frame initialisation".

`page/` stays out of the jar. What keeps the split is now the application-versus-library-surface line rather than the dependency-forcing one, and viewer.cljs, deps.edn, README.md and API.md all say that, keeping the historical reason as history.

## rf2-6r9j.111 — two dead UIx coordinates on `:cljs-test`

`com.pitch/uix.core` is a **shipped** dep in the main `:deps` map (`adapters/uix.cljs` is library surface), so repeating it on the alias was a second place to bump one version. The rf2-odlm3 comment explaining the repeat was written while `:deps` still lacked the coordinate; `bcf7d291ac` added it days later and left the comment behind. `com.pitch/uix.dom` is required by **no** namespace in the artefact — src, page or test.

## rf2-6r9j.109 — `:root-ref` never reached the overlay scaffold

`make-resizing-overlay-class` destructures `{:keys [display-name remeasure! render]}` and never reads `:root-ref`, while its docstring claimed the scaffold "reads it only to gate the resize listener teardown" — teardown removes the listener unconditionally. The key is dropped from the docstring and from all three constructor maps (`after_rings`, `spawn_all_join`, `cancellation_cascade`). Each overlay keeps its own `root-ref` atom, its `overlay-root-props` `:ref` that captures `offsetParent`, and its `remeasure!` closure; nothing about the measurement, lifecycle or DOM changes.

## rf2-6r9j.126 — DESIGN-RATIONALE reconciled against the shipped tree

**The shipped code was treated as authoritative and the document moved to match**, because every disagreement was the doc describing a pre-implementation plan the implementation then diverged from, while `API.md` and `001-Topology-Parity.md` already carried the current decisions with bead trails. Nothing was invented; each outcome below was read out of the source named beside it.

**Lock #10** said implementation had not begun, Xray 003 remained the read-the-spec source of truth, and a future `001-Rendering.md` would carry the `:spawn-all` and auto-pan rows. It is now a completed migration map naming where each row actually landed — the `:spawn-all-join` overlay descriptor for the first (and noting the "row of mini-machines" sketch is **not** what shipped), auto-fit-on-settle plus the `:fit-signal` prop for the second, with the auto-pan *toggle* still Xray's. There is no `001-Rendering.md`; `001-Topology-Parity.md` took the slot.

**The five open questions** are all answered by shipped code, so the section is now "Questions the implementation settled":

| Question | Shipped answer | Read from |
|---|---|---|
| Layout algorithm | ELK (`elkjs`), Layered, `ORTHOGONAL` + `edgeCoords ROOT` | `chart.cljs` require + `default-elk-options`; 001 §1.7 |
| SVG / Canvas / HTML | `@xyflow/react` — HTML `<div>` nodes, SVG `BaseEdge` paths, HTML `EdgeLabelRenderer` labels | `chart/nodes.cljs`, `chart/edges.cljs` |
| Component substrate | **not `reg-view`** — a host-fed Reagent component, one reactify bridge, a thin UIx `defui` shell | `chart.cljs`, `adapters/react_chart.cljs`, `adapters/uix.cljs`; API.md §Substrate adapters |
| Test corpus shape | **not snapshot fixtures** — three lanes plus the rendered-topology geometry gate | shadow-cljs configs; API.md §Rendered-topology geometry gate |
| Dense edge labels | dissolved by events-as-nodes; the collision overlay was inert and retired | 001 §1.5; API.md §Post-render label-collision avoidance — RETIRED |

The `reg-view` claim was the sharpest one: a fixed-string census found `reg-view` in exactly **one** place across `tools/machines-viz` — that sentence — with the control firing on `implementation/core/src`.

**`spec/README.md`** claimed CLJS and DOM coverage use only the consolidated `implementation/shadow-cljs.edn` builds. It now names three lanes, including the artefact-owned `tools/machines-viz/shadow-cljs.edn` `:machines-viz-node-test` build that `implementation/package.json` and `expensive-tests.yml` invoke.

Genuinely open scope (000-Vision's non-goals, trigger-committed items and candidates-on-demand), Xray's ownership of host-side concerns, the page-versus-jar boundary and the labelled-historical sections are all untouched.

## Gates

Exit codes were captured to files and read from the files, never through a pipe.

| Gate | Result |
|---|---|
| `clojure -M:test` from `tools/machines-viz` | 641 tests / 2784 assertions, 0 failures, 0 errors — **exit 0** |
| `npm run test:tools-machines-viz` (artefact-owned CLJS node lane) | 216 files compiled, 0 warnings; 844 tests / 3745 assertions, 0 failures, 0 errors — **exit 0** |
| `npm run build:machines-viz-viewer` | 0 warnings; staged `viewer.html` + `viewer.js`, page boots the exported `run` — **exit 0** |
| `clj-kondo --parallel --fail-level error --lint tools/machines-viz` | **exit 0**, errors: 0, warnings: 8 |
| `scripts/check_doc_slugs.py` | **exit 0** |
| `scripts/check_readme_links.py --ci` | **exit 0** |

The CLJS lane is the decisive instrument for the two dependency beads: it compiles `page/…/viewer.cljs` and `adapters/uix.cljs` (both confirmed present in the emitted bundle) on a classpath carrying **no** `uix.dom`, **no** duplicate `uix.core`, and **no** `day8/re-frame2-reagent`.

### Controls that fired

- **clj-kondo baseline.** `origin/main`'s `tools/machines-viz` + `.clj-kondo` were extracted with `git archive` and linted the same way: an identical warning set, 8 warnings, 0 errors. The only difference is a line number shifting 137 → 140 as the viewer docstring grew. Zero new findings.
- **`check_doc_slugs.py` is live on this diff.** A broken link planted in `tools/machines-viz/spec/DESIGN-RATIONALE.md` returned exit 1 naming that file and line; removed, exit 0.
- **`check_readme_links.py --ci` is live on this diff.** The same link planted in `tools/machines-viz/README.md` returned exit 1 naming that file and line; removed, exit 0.
- **Deletion censuses.** Each removal ran `git grep -F` over tracked files with a control string known present through the same invocation: `uix.dom` (control `uix.core`, which fires in `adapters/uix.cljs`), `re-frame.adapter` / `rf/init!` (control `reagent.core`, which fires across `src/`), `:root-ref` (control `root-ref`, still 3 hits per overlay as the local atom), `reg-view` (control: it fires in `implementation/core/src`).

### Gates deliberately NOT nominated

`mkdocs build --strict` does not see these documents. `mkdocs_hooks.py`'s `_STAGE` table stages only top-level `spec/` and `migration/` into `docs_dir`; `tools/*/spec` is neither staged nor inside `docs_dir`, so a strict build would have inspected none of the four markdown files changed here. `check_doc_slugs.py` (whose roots include `tools/*/spec`) and `check_readme_links.py --ci` (whose roster includes READMEs beside source) are the gates that reach them, and both were proved live above.

Neither gate reads prose, tables or rendering, so **by hand**: the rewritten Lock #10 table is 3 columns across the header, separator and all 10 data rows (verified by pipe count); every `§`-reference added points at a heading that exists (`API.md` §Substrate adapters, §Auto-fit on async layout settle, §Fit-on-entry signal, §Rendered-topology geometry gate, §`:overlays` slot descriptor schema, §Post-render label-collision avoidance — RETIRED; `Principles.md` §Embedding-host-agnostic; `000-Vision.md` §Scope and roadmap and its three sub-headings; `001-Topology-Parity.md` §1.5 and §1.7). Renaming the "Open questions" heading is safe: a repo-wide census for `#open-questions` found no link into this document.

## Xray spec

`tools/xray/spec/*` unchanged because no Xray-spec claim is falsified here. Xray 003's `reg-view` references describe **Xray's own** panels and Topology renderer, which are correctly reg-view-registered; the `rf/init!` references in 007/008/011 describe a **host app's** boot, not the machines-viz viewer's. Xray 003 mentions the viewer page only as a delivery surface. The three changed surfaces — the viewer's boot, the overlay scaffold's internal constructor key, and machines-viz's own dependency aliases — are entirely internal to `tools/machines-viz`.

## One hot-zone file needs a follow-up (not touched here)

`implementation/shadow-cljs.edn` lines ~324-331 justify the `../tools/machines-viz/page` source-path entry with "it is the only namespace in the tree that picks a substrate (`rf/init!` with the Reagent adapter)". That sentence is stale as of this PR. The file is one-toucher hot-zone, so it is left alone and filed instead.
