### PR TITLE
Five comment/coordinator corrections in the workflow + shadow one-toucher lane (rf2-6r9j.100 .110 .133 .136, rf2-6uv9)

### DIFF
--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -315,9 +315,9 @@ jobs:
         run: npm ci
 
       # rf2-qa5ty — `npm ci` installs the playwright PACKAGE but no browser
-      # BINARY, so both Chromium proofs in this tier (the SSR DOM-adoption
-      # proof and the emitted dev-page boot proof) used to exit 2 = skipped
-      # and this job reported green having loaded no page in any browser.
+      # BINARY, so this tier's Chromium proof (the emitted dev-page boot
+      # proof) used to exit 2 = skipped and this job reported green having
+      # loaded no page in any browser.
       # With a browser provisioned, that skip is now a HARD FAILURE under CI
       # (`browser-proofs-required?` in `emitted_test_run_test.clj`).
       # `--with-deps` because the runner carries none of Chromium's shared

--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -191,8 +191,8 @@ jobs:
         working-directory: implementation
         run: npm ci
 
-      # rf2-qa5ty — the emitted-app tier's two Chromium proofs (SSR
-      # DOM-adoption, emitted dev-page boot) need a browser BINARY; `npm ci`
+      # rf2-qa5ty — the emitted-app tier's Chromium proof (the emitted
+      # dev-page boot proof) needs a browser BINARY; `npm ci`
       # only installs the playwright package. Without this step a
       # `template-v…` tag could cut a Release whose gate never loaded the
       # emitted `index.html` in any browser — precisely the page a consumer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2656,10 +2656,17 @@ jobs:
     # rf2-dxndhc — the EP-0014 derivation/process-ALGEBRA conformance tier
     # is a src-less `.cljc` test surface on the root test classpath. Its
     # own `:test` alias runs the SAME `.cljc` namespaces under the JVM so
-    # the `:clj`-side composition (JVM default-contributors auto-resolution,
-    # the pure-data algebra views, the whole-value law over JVM data) is
-    # exercised — previously only the always-on `:node-test` gate ran the
-    # `:cljs` side. Mirrors the security tier.
+    # the `:clj`-side composition (the pure-data algebra views, the
+    # whole-value law over JVM data) is exercised — previously only the
+    # always-on `:node-test` gate ran the `:cljs` side. The suite supplies
+    # an EXPLICIT contributor map on BOTH hosts, so it deliberately does
+    # NOT exercise JVM `default-contributors` auto-resolution; that path is
+    # core's, pinned by `default-contributors-resolves-every-jvm-sibling`
+    # and `default-contributors-wires-the-machine-selector-targets-surface`
+    # in implementation/core/test/re_frame/derivation_graph_test.clj. The
+    # tier proves the four EP-0014 laws across all five families —
+    # subscriptions, flows, resources, route facts, machines. Mirrors the
+    # security tier.
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
@@ -5016,11 +5023,12 @@ jobs:
         working-directory: implementation
         run: npm ci
 
-      # rf2-qa5ty — the emitted-tests tier carries TWO Chromium proofs: the
-      # SSR DOM-adoption proof and the emitted dev-page boot proof. `npm ci`
-      # above installs the playwright PACKAGE but never a browser BINARY, so
-      # before this step BOTH drivers hit their `chromium.launch()` catch,
-      # exited 2, and the tier reported green with zero browser coverage —
+      # rf2-qa5ty — the emitted-tests tier carries ONE Chromium proof: the
+      # emitted dev-page boot proof, run for Reagent, UIx and the setup-skill
+      # leaf. `npm ci` above installs the playwright PACKAGE but never a
+      # browser BINARY, so before this step that driver hit its
+      # `chromium.launch()` catch, exited 2, and the tier reported green with
+      # zero browser coverage —
       # the mask that let three template defects ship, two of them a BLANK
       # first page on every scaffold variant. Because this job now provisions
       # a browser, an unlaunchable Chromium is a HARD FAILURE here rather

--- a/implementation/README.md
+++ b/implementation/README.md
@@ -50,7 +50,8 @@ implementation/
                              plus ../examples for the cross-substrate test and example bundles.
 
   core/                      day8/re-frame2 — the core artefact.
-    deps.edn                 Core's own deps (clojure, clojurescript, reagent).
+    deps.edn                 Core's own deps (clojure, clojurescript). Stock Reagent is
+                             the Reagent adapter's dep, not core's.
     src/re_frame/
       interop.{clj,cljs}     JVM / CLJS host primitives.
       registrar.cljc         (kind, id) → metadata + replacement-hooks.
@@ -163,8 +164,9 @@ implementation/
                              harness — now lives at the repo root as bench/hicasso/,
                              its own hand-run shadow project off this classpath
                              (rf2-6c12m.1).
-    deps.edn                 :local/root dep on ../core; own :test alias (pre-publication,
-                             so no :clein deploy aliases).
+    deps.edn                 :local/root deps on ../core and ../ssr (the server module);
+                             own :test alias, and the :clein + :clein/build deploy
+                             aliases — published as day8/re-frame2-hicasso since rf2-gra70.
     scripts/check_optional_module_reachability.py
                              No optional module is reachable from the public door, and
                              nothing in the package requires UIx or the bench tree.

--- a/implementation/deps.edn
+++ b/implementation/deps.edn
@@ -15,6 +15,7 @@
 ;;   - ssr/      (day8/re-frame2-ssr,      rf2-uo7v)
 ;;   - ssr-ring/ (day8/re-frame2-ssr-ring, rf2-ny6v7)
 ;;   - epoch/    (day8/re-frame2-epoch,    rf2-lt4e)
+;;   - hicasso/  (day8/re-frame2-hicasso,  rf2-gra70)
 ;; see implementation/core/deps.edn,
 ;; implementation/adapters/reagent/deps.edn,
 ;; implementation/adapters/uix/deps.edn,
@@ -48,7 +49,17 @@
          ;; EP-0003). Managed resource queries: reg-resource, the
          ;; :rf.resource/* events + passive subs, work ledger,
          ;; invalidation/GC, and hydration — runtime landed and tested.
-         day8/re-frame2-resources {:local/root "resources"}}
+         day8/re-frame2-resources {:local/root "resources"}
+         ;; rf2-6r9j.133 — Hicasso, re-frame2's own native view
+         ;; substrate. It became a PUBLISHED artefact under rf2-gra70 — its
+         ;; `:clein/build` alias carries the coordinate and it is enrolled in
+         ;; .github/scripts/verify-version-lockstep.sh and release.yml's
+         ;; deploy DAG — but this coordinator did not follow, so `hicasso/src`
+         ;; was off the aggregate classpath while the `:test` alias below
+         ;; already carried `hicasso/test`. The shadow coordinator is
+         ;; unaffected either way: implementation/shadow-cljs.edn enumerates
+         ;; its own `:source-paths` and does not read this map.
+         day8/re-frame2-hicasso  {:local/root "hicasso"}}
 
  :aliases
  {;; Combined CLJS-test path: convenient for ad-hoc REPL work that wants
@@ -80,7 +91,15 @@
                  ;; bench/hicasso/, its own project off this classpath.
                  ;; This alias is REPL convenience; production CI still runs
                  ;; each artefact's own :test alias separately.
+                 ;;
+                 ;; `test_kit/src` is the supported L0–L2 testing surface
+                 ;; (rf2-hic-020). It sits deliberately OUTSIDE the artefact's
+                 ;; `:paths`, so the `:local/root` dep above does not carry it;
+                 ;; Hicasso's own `:test` alias names it as an `:extra-path`
+                 ;; and this aggregate has to do the same to match it
+                 ;; (rf2-6r9j.133).
                  "hicasso/test"
+                 "hicasso/test_kit/src"
                  ;; examples are organised by concept; each bucket is a
                  ;; classpath root so JVM tests can `require` the example
                  ;; source namespaces like `ssr.core` (under

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -324,13 +324,24 @@
                 ;; tools/machines-viz/page (rf2-k7l2o). The artefact's one
                 ;; APPLICATION — `viewer.cljs`, the `^:export run` entry
                 ;; public/viewer.html loads — lives on its own root, OFF the
-                ;; jar's `:paths`/`:src-dirs`, because it is the only namespace
-                ;; in the tree that picks a substrate (`rf/init!` with the
-                ;; Reagent adapter). Shipping it as library surface would have
-                ;; forced a published `re-frame.adapter.reagent` dependency on
-                ;; every consumer, colliding with day8/reagent-slim (which
-                ;; publishes ITS adapter at that same canonical ns) on a slim
-                ;; app's classpath. Listed here for the two builds that DO need
+                ;; jar's `:paths`/`:src-dirs`. The split is application-versus-
+                ;; library-surface: the page is an entry point a browser loads
+                ;; — an `^:export` symbol, a DOM lookup and a
+                ;; `reagent.dom.client` root it owns — and a consumer requiring
+                ;; this jar wants the chart, not a page's mount code.
+                ;;
+                ;; When rf2-k7l2o made the split the argument was sharper: the
+                ;; page then required `re-frame.adapter.reagent`, so shipping it
+                ;; as library surface would have forced a published
+                ;; `day8/re-frame2-reagent` dependency on every consumer,
+                ;; colliding with day8/reagent-slim (which publishes ITS adapter
+                ;; at that same canonical ns) on a slim app's classpath.
+                ;; rf2-6r9j.115 deleted the page's `rf/init!` and that require
+                ;; outright — the page picks no substrate now — so the
+                ;; dependency-forcing half is discharged history rather than a
+                ;; live justification.
+                ;;
+                ;; Listed here for the two builds that DO need
                 ;; it: `:machines-viz-viewer` below, and `:node-test`, whose
                 ;; `cljs-test$` selector reaches the page's own unit suite
                 ;; (`viewer-cljs-test`, in the `test` root above).
@@ -1175,11 +1186,21 @@
   ;; Example apps (rf2-lyj0).
   ;;
   ;; Each example compiles into out/examples/<name>/ and is paired with a
-  ;; hand-written examples/<substrate>/<name>/index.html host page that loads
-  ;; main.js from the same directory. The serve-and-run-examples script
-  ;; builds the site layout, serves it, and runs the Playwright specs that
-  ;; sit alongside each example (examples/<substrate>/<name>/<name>.spec.cjs,
-  ;; plus the per-task 7GUIs sub-folders under examples/reagent/seven_guis/).
+  ;; hand-written examples/<concept>/<name>/index.html host page that loads
+  ;; main.js from the same directory. The tree is CONCEPT-grouped, so
+  ;; <concept> is one of core/, patterns/, real-apps/, substrates/ or
+  ;; capabilities/<capability>/ — the `:source-paths` inventory near the top
+  ;; of this file enumerates them.
+  ;;
+  ;; The serve-and-run-examples script builds the site layout and serves it.
+  ;; It runs NO example-adjacent Playwright specs, because none exist:
+  ;; examples are TEST-FREE (locked 2026-05-19, rf2-8cevm) and
+  ;; `git ls-files 'examples/**/*.spec.cjs'` returns nothing. Browser smoke
+  ;; coverage is one adapter-level smoke per shipped adapter, at
+  ;; implementation/adapters/<name>/testbed/spec.cjs; real regression
+  ;; coverage lives in the substrate contract tests (`npm run test:cljs`),
+  ;; the Xray feature-matrix gate, bundle-isolation, the perf-bundle gate
+  ;; and mcp-conformance.
   ;;
   ;; :asset-path is "." so the bundle's runtime resolves siblings (cljs_base,
   ;; cljs-runtime, etc.) relative to the page rather than the document root —
@@ -1246,7 +1267,7 @@
 
   ;; Performance-API instrumented variant of the counter example
   ;; (rf2-du3i). The SAME canonical source as `:examples/counter`
-  ;; (`counter.core/run`, examples/reagent/counter/core.cljs), same
+  ;; (`counter.core/run`, examples/core/counter/core.cljs), same
   ;; `:advanced` compilation, but with the `re-frame.performance/enabled?`
   ;; goog-define flipped to `true`. Its sole consumer is the
   ;; bundle-presence assertion in scripts/check-perf-bundle.cjs (`npm run
@@ -1675,8 +1696,8 @@
   ;; metadata read passively via `[:rf.resource/*]` subs; writes are
   ;; `reg-mutation` with `:invalidates` driving the read→write→invalidate→
   ;; refetch loop. `realworld-resources.*` namespaces resolve via the
-  ;; `../examples/reagent` source-path (already on :source-paths near the top
-  ;; of this file), so no per-build deps.
+  ;; `../examples/real-apps` source-path (already on :source-paths near the
+  ;; top of this file), so no per-build deps.
   :examples/realworld-resources
   {:target     :browser
    :output-dir "out/examples/realworld-resources"
@@ -1753,9 +1774,10 @@
   ;; on :ok or ROLLS BACK (runtime-recorded snapshot inverse) on :error. A
   ;; 'fail the next write' demo seam arms the canned `:rf.http/managed` stub
   ;; to answer the next write with a 503 so the rollback is the headline
-  ;; demonstration. `../examples/reagent` is already on :source-paths above,
-  ;; so the mutation runtime + `:rf.mutation/*` / `:rf.resource/*` subs
-  ;; resolve without per-build deps. Served at http://localhost:8044 via the
+  ;; demonstration. `../examples/capabilities/resources` is already on
+  ;; :source-paths above, so the mutation runtime + `:rf.mutation/*` /
+  ;; `:rf.resource/*` subs resolve without per-build deps. Served at
+  ;; http://localhost:8044 via the
   ;; top-level `:dev-http` map. Complements `:examples/realworld-resources`
   ;; (`:optimistic-tags` favorite) + `:examples/infinite-feed` (read-side
   ;; load-more).
@@ -1769,7 +1791,7 @@
   ;; (rf2-jxmb4p). The page's server-state is a RESOURCE preloaded under an
   ;; [:ssr …] owner and serialized into the hydration payload's runtime-db
   ;; projection; the static index.html bakes the projection (a stand-in for
-  ;; a real server). Sibling of `examples/reagent/ssr/` (which writes
+  ;; a real server). Sibling of `examples/capabilities/ssr/ssr/` (which writes
   ;; server-state into app-db rather than a resource).
   :examples/resources-ssr
   {:target     :browser
@@ -1832,7 +1854,7 @@
                                  day8.re-frame2-xray.preload]}}
 
   ;; Nine States Story + Xray showcase (rf2-rgyia). The
-  ;; examples/reagent/nine_states example wired up as a Story showcase:
+  ;; examples/patterns/nine_states example wired up as a Story showcase:
   ;; `nine-states.stories` registers one variant per canonical UI state
   ;; (Nothing / Loading / Empty / One / Some / Too Many / Incorrect /
   ;; Correct / Done) plus the RemoteData fetch-lifecycle variants
@@ -1843,7 +1865,7 @@
   ;; `:rf.http/managed` → reply cascade light up Xray's Epoch / Trace /
   ;; Side Effects panels.
   ;;
-  ;; The `nine-states.*` namespaces resolve via the `../examples/reagent`
+  ;; The `nine-states.*` namespaces resolve via the `../examples/patterns`
   ;; source-path (already on :source-paths near the top of this file). The
   ;; Story 'open in editor' chips need no build-time configuration: this
   ;; build's `:dev-http` entry runs the JVM
@@ -1860,7 +1882,7 @@
    :devtools         {:preloads [re-frame2-pair.runtime
                                  day8.re-frame2-xray.preload]}}
 
-  ;; Login Story + Xray showcase (rf2-p8v0q). The examples/reagent/login
+  ;; Login Story + Xray showcase (rf2-p8v0q). The examples/core/login
   ;; example wired up as a Story showcase: `login.stories` registers one
   ;; variant per reachable state of the `:auth.login/flow` machine (empty
   ;; / submitting / invalid-credentials / auth-error / locked-out /
@@ -1872,7 +1894,7 @@
   ;; — light up Xray's Epoch / Trace / Side Effects panels (and the
   ;; schema-rejection / 401 paths light the Issues ribbon).
   ;;
-  ;; The `login.*` namespaces resolve via the `../examples/reagent`
+  ;; The `login.*` namespaces resolve via the `../examples/core`
   ;; source-path (already on :source-paths near the top of this file). The
   ;; Story 'open in editor' chips need no build-time configuration: this
   ;; build's `:dev-http` entry runs the JVM


### PR DESCRIPTION
Three corrections that had all stalled against the `.github/workflows/*` one-toucher fence, plus the coordinator half of a Hicasso enrolment bug.

## rf2-6r9j.100 — derivation-conformance uses explicit contributors

`test.yml`'s `jvm-derivation-conformance` comment credited the tier with *JVM `default-contributors` auto-resolution*. It never invokes that path:

- `grep -rn default-contributors implementation/derivation-conformance` exits 1 — zero hits.
- All 30 `derivation-graph` / `live-derivation-graph` calls pass `all-contributors` or a named synthetic map; there is no zero-arity call.
- The auto-resolution path is core's, pinned by `default-contributors-resolves-every-jvm-sibling` (`derivation_graph_test.clj:361`) and `default-contributors-wires-the-machine-selector-targets-surface` (`:525`). Control fired: both tests exist at those lines.
- `all-contributors` carries five families — `:subs :flows :resources :routes :machines` — where the old wording implied four.

The comment now states what the JVM lane actually buys and names the two core tests that do pin the auto-resolution path. Its two sibling carriers (`scripts/test-jvm-implementation.sh`, root `README.md`) are in #9090; this is the third and last.

## rf2-6r9j.110 — one Chromium proof, not two

`test.yml`, `expensive-tests.yml` and `template-release.yml` each described the template browser tier as carrying two Chromium proofs, the second an SSR DOM-adoption proof. That fixture went in the rf2-zq34m reduction:

- `tools/template/test-support/` holds exactly one file, `dev-page-boot-proof.cjs`.
- `emitted_test_run_test.clj` drives only `run-boot-proof-driver!` against it, for Reagent, UIx and the setup-skill leaf.
- The sole surviving `ssr-hydration-dom-proof` mention repo-wide is the driver comment #9091 removes.

Each comment now names the single proof. Everything else is verbatim: the npm-ci-installs-no-binary point, the hard-failure-under-CI rule keyed off `browser-proofs-required?`, the `--with-deps` rationale, the rf2-169n caching paragraph, and template-release's release-gate-cannot-skip argument. This is acceptance 3 of that bead; 1, 2 and 4 are in #9091.

## rf2-6r9j.133 — enroll published Hicasso in the root coordinator

`implementation/deps.edn` claims its `:deps` pull every artefact onto one classpath, but never followed Hicasso's move to a published artefact (rf2-gra70). There was no `day8/re-frame2-hicasso {:local/root "hicasso"}`, while the `:test` alias already carried `hicasso/test` — a test root whose implementation was off the classpath, and `slot_cljs_test.cljc` requires `re-frame.hicasso.impl.slot` directly.

- `deps.edn` names the artefact as a root `:local/root` dep, and the header inventory lists it beside the other published coordinates.
- The `:test` alias also picks up `hicasso/test_kit/src`. That root is deliberately off the artefact's `:paths` (rf2-hic-020), so the `:local/root` dep does not carry it; Hicasso's own `:test` alias names it as an `:extra-path` and the aggregate has to match.
- `implementation/README.md` no longer calls Hicasso pre-publication with no `:clein` deploy alias, and no longer lists reagent among core's deps — `d44c4f7d20` moved that to the Reagent adapter, and `core/deps.edn` names only `org.clojure/clojure` and `org.clojure/clojurescript`.

Shadow is untouched. `implementation/shadow-cljs.edn` enumerates its own `:source-paths` (it already listed `hicasso/src`, `hicasso/test` and both test-kit roots) and has no `:deps true`, so it does not read this map at all. No change to Hicasso's published dependency DAG, no second coordinate for the test kit.

## The workflow diff is comment-only

Every changed line in all three workflow files begins with `#`. Proven two ways rather than by eye:

- `git diff -U0 | grep -E '^[+-]' | grep -v '^(\+\+\+|---)' | grep -vE '^[+-][[:space:]]*#'` returns nothing (exit 1).
- Parsing each file with PyYAML before and after: `before == after` is `True` for all three. The parsed job graphs are identical objects.

Exact lines changed:

| File | Lines | Job / step |
|---|---|---|
| `.github/workflows/test.yml` | 2659–2663 → 2659–2670 | `jvm-derivation-conformance` job header comment |
| `.github/workflows/test.yml` | 5019–5023 → 5026–5031 | `jvm-tools-template`, comment above *Cache Playwright browser binary* |
| `.github/workflows/expensive-tests.yml` | 318–320 | comment above *Cache Playwright browser binary* |
| `.github/workflows/template-release.yml` | 194–195 | comment above *Cache Playwright browser binary* |

No job, step, trigger, matrix or `needs:` wiring moved.

## Gates

Exit codes captured to files and read from the files, never through a pipe.

| Gate | Exit |
|---|---|
| PyYAML parse of all three workflows | 0 |
| PyYAML before/after structural equality, all three | 0 (`True` each) |
| `python scripts/check_jvm_lane_rosters.py` | 0 — 31 rostered artefacts, bijection holds |
| `python scripts/check_test_lane_bijection.py` | 0 — 1547 files, 45 lanes |
| `clojure -Spath -M:test` from `implementation/` | 0 — now lists `implementation/hicasso/src`, `implementation/hicasso/resources`, `hicasso/test_kit/src` |
| load probe: `re-frame.hicasso.impl.slot` + `re-frame.hicasso.slot-cljs-test` off that classpath | 0 |
| `python scripts/check_readme_inventories.py` | 0 |
| `python scripts/check_adapter_disposition.py` | 0 |
| `python scripts/check_readme_links.py --ci` | 0 |

`check_doc_slugs.py` is not the gate for `implementation/README.md` — that path is outside its roots and it exits 0 on a broken link there; `check_readme_links.py --ci` is the one that covers it. Both run in `test.yml`'s `verify-readme-links` job. The README tree edits sit inside the fenced layout block, which neither link gate inspects, so column alignment was checked by hand (description column 29, longest new line 91 against a 97-char block maximum).

## Sequencing

#9092 (`worker/catvest-a`) is open on `.github/workflows/test.yml` and `implementation/shadow-cljs.edn`. Its `test.yml` change is a comment in `jvm-tools-testbed-support` around line 4945; mine are at 2659 and 5026, so the intents are independent and both wanted. I do not touch `shadow-cljs.edn` at all. Merge this behind #9092 and rebase if git asks.

---

## rf2-6uv9 — the machines-viz page picks no substrate any more

`implementation/shadow-cljs.edn`'s `../tools/machines-viz/page` source-path comment justified the split by calling the page *"the only namespace in the tree that picks a substrate (`rf/init!` with the Reagent adapter)"*. PR #9094 (rf2-6r9j.115) removed that `rf/init!` and the `re-frame.adapter.reagent` require from `viewer.cljs`, and dropped `day8/re-frame2-reagent` from the artefact's `:cljs-test` alias.

The clause is rewritten the way #9094 rewrote its three siblings (`tools/machines-viz/deps.edn`, `README.md`, `spec/API.md`): the split is application-versus-library-surface, and the adapter-collision reasoning is kept as dated history — rf2-k7l2o's argument, discharged at source by rf2-6r9j.115 — rather than as a live justification. What the entry is for and the two builds that need it (`:machines-viz-viewer`, `:node-test`) are unchanged.

**Sequencing note:** #9094 has **not** merged as of this writing, so on `main` today the clause is still true. Merge this behind #9094.

## rf2-6r9j.136 — coordinator comments after the examples concept split

Nine present-tense comments still described the `examples/<substrate>/<name>` topology that `210f812fe2` replaced with the concept-grouped tree. The change list came from worker `toolsroot-a` (#9093); I spot-checked it at source rather than transcribing it — `examples/` is `_shared, capabilities, core, patterns, real-apps, substrates`, `implementation/examples/reagent` does not exist, and each new target directory was confirmed on disk.

| Was | Now |
|---|---|
| `examples/reagent/counter/core.cljs` | `examples/core/counter/core.cljs` |
| `../examples/reagent` (RealWorld-resources) | `../examples/real-apps` |
| `../examples/reagent` (Linearlite) | `../examples/capabilities/resources` |
| `examples/reagent/ssr/` (resources-ssr sibling) | `examples/capabilities/ssr/ssr/` |
| `examples/reagent/nine_states` | `examples/patterns/nine_states` |
| `../examples/reagent` (nine-states ns) | `../examples/patterns` |
| `examples/reagent/login` | `examples/core/login` |
| `../examples/reagent` (login ns) | `../examples/core` |

The examples-section header needed more than a repointed path, and that is the one judgment call here. It promised Playwright specs beside each example plus per-task 7GUIs sub-folders under `examples/reagent/seven_guis/`. Examples are **test-free** (locked 2026-05-19, rf2-8cevm) and `git ls-files 'examples/**/*.spec.cjs'` returns **0** rows, so repointing the path alone would have left a comment promising specs that cannot exist. It now says the script builds and serves the site layout and runs no example-adjacent specs, and points at where the coverage actually lives: one adapter-level smoke per shipped adapter at `implementation/adapters/<name>/testbed/spec.cjs`, plus the substrate contract tests, the Xray feature-matrix gate, bundle-isolation, the perf-bundle gate and mcp-conformance.

Archaeology preserved per the bead's risk note: `"formerly under examples/reagent/"` (line 361) and `"relocated from examples/reagent/"` (line 1835). `grep -n examples/reagent implementation/shadow-cljs.edn` now returns exactly those two lines and nothing else.

### shadow-cljs.edn diff is comment-only

| Check | Result |
|---|---|
| `clojure.edn/read-string` before vs after — structural equality | `true` |
| source-paths / builds after | 69 / 80, unchanged |
| every configured `:source-paths` entry exists on disk | `()` missing |
| `git diff -U0` lines outside a `;;` comment | none (grep exit 1) |
| `python scripts/check_test_lane_bijection.py` | exit 0 — 1547 files, 45 lanes |

No `:source-paths`, `:builds` key, `:output-dir`, `:modules`, `:closure-defines` or `:dev-http` entry moved. #9092 also touches this file, at line ~792 (`:node-test-testbed-support`); my edits are at ~324, ~1177, ~1249, ~1678, ~1756, ~1772, ~1835, ~1846, ~1863, ~1875, so the two are independent and both intents are wanted.
