### PR TITLE
fix(bundle-isolation): defmachine is not a registration facade; retract the projection-metadata promise

### DIFF
--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -25,7 +25,8 @@
     durable `:entries`, applying per-entry REDACTION / OMISSION through
     the resource's `:sensitive?` / `:large?` classification and the
     shared `rf/elide-wire-value` walker, and `projection-metadata`
-    records the serialized / redacted / omitted / key-projected / fresh /
+    COMPUTES (for a host to record, if it wants to — nothing here does)
+    the serialized / redacted / omitted / key-projected / fresh /
     stale / refetch-on-client decision per entry.
   - **Server blocking drain** — `blocking-settled?` is the drain
     PREDICATE the host loops on (\"have the blocking resources for this
@@ -867,12 +868,14 @@
                            ;; key-id comparison above. Two dispositions reach it
                            ;; (`:key-projected` and both coarse arms), and a
                            ;; caller enumerating those would have to be revisited
-                           ;; every time a projection learns to re-key. The
-                           ;; server's diagnostics still account for a withheld
-                           ;; entry in full — `:disposition` says why it could
-                           ;; not ride, `:projected-key` says what it projected
-                           ;; to, `:refetch-on-client?` says what the client will
-                           ;; do about it.
+                           ;; every time a projection learns to re-key. These
+                           ;; three slots are what let a server ACCOUNT for a
+                           ;; withheld entry in full — `:disposition` says why
+                           ;; it could not ride, `:projected-key` says what it
+                           ;; projected to, `:refetch-on-client?` says what the
+                           ;; client will do about it. Carrying them to a
+                           ;; diagnostic sink is the host's job, not this
+                           ;; namespace's; see `projection-metadata`.
                            :withheld? (not key-derivable?)
                            :refetch-on-client?
                            (boolean (or metadata-only? stale?)))]
@@ -882,8 +885,22 @@
   "Compute the per-entry SSR projection metadata for a frame's resource
   `:entries` against `clock-ms` (Spec 016 §SSR and hydration step 7 — the
   serialized / redacted / omitted / fresh / stale / refetch-on-client
-  decisions). Returns a vector of per-entry metadata maps. PURE; the host
-  adapter records it in route/SSR diagnostics."
+  decisions). Returns a vector of per-entry metadata maps.
+
+  PURE, and an AFFORDANCE rather than a wiring: it computes the decision
+  record and returns it. It does not route it anywhere, and nothing in this
+  repository consumes it outside tests. That is deliberate — Spec 016 §SSR and
+  hydration addresses step 7 to \"Server route handling\", and the host owns the
+  route slice and the diagnostic sink, so a host wanting this accounting calls
+  this and records the result. `:ssr/extend-runtime-db-projection` is NOT that
+  carrier and must not be made one: its single return value is merged onto the
+  hydration WIRE payload, while these maps carry the raw scoped `:resource/key`
+  the withholding rule exists to suppress.
+
+  So do not read this helper's existence as evidence that projection decisions
+  are recorded anywhere — an earlier version of this docstring asserted that the
+  host adapter records it, which was never true of any adapter in-tree
+  (rf2-6r9j.53)."
   [frame-id clock-ms entries]
   (mapv (fn [[_k-id entry]] (second (project-entry frame-id clock-ms entry)))
         entries))

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -1306,9 +1306,24 @@ function assertCanonicalInventoryCovered(required = discoverBrowserOptionalRunti
 // (`skills/re-frame-migration/references/auto-cross-cutting.md` states the same
 // rule for migrating apps: "Add the dep AND the `:require` in every namespace
 // that uses the surface").
+//
+// REGISTRATION is the whole of the rule, and `defmachine` is the row that is
+// deliberately ABSENT for that reason. `(rf/defmachine m {…})` is re-frame.core's
+// own `def`-replacement: `expand-defmachine` walks the literal spec at expansion
+// time and emits `(def m <stamped-spec>)` — nothing else. Its own docstring says
+// so ("`def` is not a registration"), and the sibling expander makes the contrast
+// exact: `expand-reg-machine` emits a real `(re-frame.core-machines/reg-machine
+// …)` call, which is what needs the artefact's load-time hooks; `expand-defmachine`
+// emits no call at all. So a namespace may legitimately DEFINE machine values
+// while requiring only `re-frame.core`, and require `re-frame.machines` solely in
+// the boot namespace that REGISTERS them — a split this roster must not forbid.
+// Listing `defmachine` here would reject that shape and force a pointless
+// side-effecting require into the definition namespace. The sibling self-test
+// pins BOTH halves of the distinction (a defmachine-only ns passes; a
+// `reg-machine` call in that same ns still fails, and the violation must name
+// `reg-machine` alone), so restoring the row fails the gate by name.
 const OPTIONAL_ARTEFACT_FACADES = [
   { call: 'reg-machine',    artefact: 're-frame.machines',  absentError: 'rf.error/machines-artefact-missing' },
-  { call: 'defmachine',     artefact: 're-frame.machines',  absentError: 'rf.error/machines-artefact-missing' },
   { call: 'reg-route',      artefact: 're-frame.routing',   absentError: 'rf.error/routing-artefact-missing' },
   { call: 'reg-resource',   artefact: 're-frame.resources', absentError: 'rf.error/resources-artefact-missing' },
   { call: 'reg-mutation',   artefact: 're-frame.resources', absentError: 'rf.error/resources-artefact-missing' },

--- a/implementation/scripts/check-bundle-isolation.test.cjs
+++ b/implementation/scripts/check-bundle-isolation.test.cjs
@@ -571,6 +571,9 @@ const CO_LOAD_COMPLIANT = `(ns fixture.app
             ;; the reader machine below is why this require is here
             [re-frame.machines]))
 (rf/reg-machine :fixture.app/reader {})
+;; Present deliberately, and deliberately NOT a roster row: a defmachine
+;; alongside a reg-machine must not raise a second violation of its own. The
+;; two blocks below pin the distinction on its own.
 (rf/defmachine fixture-machine {})
 (rf/reg-route :fixture.app/home {} "/")
 (rf/reg-resource :fixture/thing {})
@@ -608,6 +611,57 @@ for (const row of OPTIONAL_ARTEFACT_FACADES) {
   assert(!res.ok, `${row.call}: a call site with no [${row.artefact}] require must FAIL`);
   assert(res.violations.some((v) => v.call === row.call && v.artefact === row.artefact),
     `${row.call}: the violation must name the call and the artefact it needs`);
+}
+
+// REGISTRATION vs DEFINITION — the distinction the roster turns on, pinned in
+// BOTH directions because the roster is one edit away from losing it.
+//
+// `defmachine` is NOT a registration façade. `expand-defmachine` walks the
+// literal spec at expansion time and emits `(def m <stamped-spec>)` and nothing
+// else — its own docstring says "`def` is not a registration" — while the
+// sibling `expand-reg-machine` emits a real `(re-frame.core-machines/reg-machine
+// …)` call, which is what needs re-frame.machines' load-time hooks. So a
+// namespace may DEFINE machine values requiring only re-frame.core and leave the
+// artefact require to the boot namespace that REGISTERS them.
+//
+// The first block would fail if `defmachine` were restored to the roster; the
+// second would fail if removing it were mistaken for "machines are now
+// unchecked". A single fixture carrying both calls over one shared require —
+// which is what CO_LOAD_COMPLIANT is — cannot tell these two apart, so each gets
+// a namespace of its own.
+//
+// Both assert on `violations`, NOT on `ok`, and the negative case is why. `ok`
+// also folds in the corpus-level non-vacuity guards (deadRows /
+// unprovenArtefacts), which a one-file fixture can never satisfy — so `!res.ok`
+// below would hold whatever the rule did, passing for a reason unrelated to the
+// contract under test. The prose-only and trailing-comment fixtures read
+// `violations` for the same reason.
+{
+  coLoadMutations += 1;
+  const res = assertExampleCoLoadIsolation([coLoadFixture('defmachine-only.cljs', `(ns fixture.machine-defs
+  (:require [re-frame.core :as rf]))
+(rf/defmachine door-machine
+  {:initial :locked
+   :states  {:locked {} :open {}}})
+`)]);
+  assert.deepStrictEqual(res.violations, [],
+    'a defmachine-only namespace requiring only re-frame.core is VALID — defmachine ' +
+    'expands to a plain def, fires no load-time hook registration, and must not ' +
+    'demand a [re-frame.machines] require');
+}
+{
+  coLoadMutations += 1;
+  const res = assertExampleCoLoadIsolation([coLoadFixture('defmachine-then-reg.cljs', `(ns fixture.machine-boot
+  (:require [re-frame.core :as rf]))
+(rf/defmachine door-machine {:initial :locked})
+(rf/reg-machine :door/main door-machine)
+`)]);
+  assert.deepStrictEqual(res.violations.map((v) => v.call), ['reg-machine'],
+    'REGISTERING a machine still requires [re-frame.machines], and the violation ' +
+    'must name reg-machine ALONE — defmachine in that same namespace is a def, ' +
+    'not a second violation');
+  assert.strictEqual(res.violations[0].artefact, 're-frame.machines',
+    'and it must name the artefact whose require is missing');
 }
 
 // A façade named only in PROSE is not a call site. Without this the rule would
@@ -698,7 +752,9 @@ console.log(
   'lockstep consumes the shared EDN authority; ' +
   'module-ownership and sentinel-ownership confusion rejected; ' +
   `${coLoadMutations} example co-load isolation mutations ` +
-  '(each dropped require caught by name; prose-only mention is not a call site; ' +
+  '(each dropped require caught by name; defmachine defines and does not register, ' +
+  'so a defmachine-only ns passes while reg-machine in that same ns still fails ' +
+  'naming reg-machine alone; prose-only mention is not a call site; ' +
   'trailing comment does not hide one; zero-call-site and zero-require corpora ' +
   'fail loud rather than pass vacuously)'
 );


### PR DESCRIPTION
Two beads, both of which turned out to be about a claim being wrong rather than a mechanism being missing.

## rf2-k4oe — `defmachine` misclassified as a registration facade

The reopened state of this bead (the merged-PR audit of #9066), not the original false-green, which #9027 and #9066 already fixed.

The example co-load gate listed `defmachine` beside `reg-machine` in `OPTIONAL_ARTEFACT_FACADES`, so it demanded a `[re-frame.machines]` require from any namespace that merely **defined** a machine value.

Verified at source rather than taken from the audit. The two expanders settle it:

- `expand-reg-machine` emits `(re-frame.core-machines/reg-machine …)` — a real call, which is what needs the artefact's load-time hooks.
- `expand-defmachine` emits `` `(def ~name' ~stamped) `` and nothing else. Its own docstring: *"`def` is not a registration."*

So a namespace may legitimately define machine values while requiring only `re-frame.core`, and require `re-frame.machines` solely in the boot namespace that registers them. The roster rejected that split and forced a pointless side-effecting require into the definition namespace.

**Reproduced before fixing.** A `defmachine`-only fixture against the committed checker returned `ok=false` with a violation naming `defmachine` / `re-frame.machines`. After the fix, no violation.

**No example in the tree was affected** — every current `defmachine` caller also calls `reg-machine` in the same file, so all existing requires stay genuinely earned. The defect was latent: it forbade a valid shape rather than breaking a present one.

Live corpus, before → after: 83 example sources, 0 violations both ways; facade call sites 111 → 100, the difference being exactly the 11 `defmachine` call sites that were never the gate's business. No dead rows, no unproven artefacts.

### Why the self-test missed it, and what now stops it

The single compliant fixture carried `reg-machine` and `defmachine` over one shared `[re-frame.machines]` require, so the drop-one-require loop implicated both rows at once and the two contracts were indistinguishable. They now get a namespace each:

- a `defmachine`-only namespace requiring only `re-frame.core` **must pass**;
- a `reg-machine` call in that same namespace **must still fail**, and the violation must name `reg-machine` **alone**.

Restoring the roster row fails the first by name — verified by planting it back: exit 1 on the exact assertion, then restored byte-exact (`git hash-object` 9478af0fb3 both sides, so the plant was real and not the silent CRLF no-op recorded on the previous PR).

Both new fixtures assert on `violations`, not `ok`, and that is deliberate. `ok` also folds in the corpus-level non-vacuity guards (`deadRows` / `unprovenArtefacts`), which a one-file fixture can never satisfy — so `!res.ok` in the negative case would have held whatever the rule did and passed for a reason unrelated to the contract. The self-test caught that in my own first draft.

## rf2-6r9j.53 — the promise was the defect, not the wiring

`projection-metadata`'s docstring asserted *"PURE; the host adapter records it in route/SSR diagnostics."* No adapter here does, and none ever did: the only production caller of `project-entry` is `project-resources-runtime-db`, which reads `:withheld?` and discards the rest; every other reference is a direct unit-test call.

Checked whether the spec obliges the framework to carry it. It does not:

- Spec 016 §SSR and hydration addresses the cited step to **"Server route handling:"** and states it with **no modal** — unlike its neighbour, which does say "SSR MUST use request-local frames".
- The nearby MUST governs **withholding** the re-keyed row, which the projection satisfies, and the three facts that MUST accompany it (`:disposition`, `:projected-key`, `:refetch-on-client?`) are all genuinely present in the returned map.

So there is no unmet MUST, no orphan-helper problem, and no spec change to make — the specification was accurate; the docstring was not. Corrected to say what is true and why it is deliberate rather than unfinished, plus the one thing a future fix must not do: `:ssr/extend-runtime-db-projection` cannot be the carrier, since its single return value is merged onto the hydration **wire** payload while these maps carry the raw scoped `:resource/key` the withholding rule exists to suppress.

Comments and docstrings only; the namespace reads to the same 49 top-level forms before and after.

**Left open deliberately.** Whether re-frame2 should *ship* server-side projection accounting (a catalogued `:rf.resource/*` trace op emitted from the existing single `project-entry` pass) is a product decision plus a Spec 009 catalogue addition, not a worker's call. This PR removes the false promise; it does not answer that question.

## Gates

Foreground, unfiltered, exit codes captured to files.

- `node scripts/check-bundle-isolation.test.cjs` — **exit 0**; 12 co-load mutations (was 10).
- Planted `defmachine` row restored → **exit 1** on the new assertion; removed → exit 0. Blob hash verified identical across the plant/restore cycle.
- Live `assertExampleCoLoadIsolation()` over `examples/` — **exit 0**, 83 sources, 0 violations, 0 dead rows, 0 unproven artefacts.
- `ssr.cljc` parsed with `clojure.tools.reader` — **exit 0**, 49 forms, equal to HEAD.

`npm run test:bundle-isolation` also front-loads a seven-build shadow-cljs release; this worktree has no `node_modules`, so CI owns that. The only part of the gate this diff can affect is the co-load rule, which was run directly against the live corpus above.
