### PR TITLE
refactor(epoch): retire three vestiges from the epoch surface

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -3412,13 +3412,15 @@
     ;; commit neither harvests B's capture buffer nor claims/commits into B's
     ;; history (rf2-vxgfnd.154). The halting event never ran, so the capture
     ;; buffer is empty and `settle!` would skip; `commit-halt-record!` commits
-    ;; regardless, pinning the halting event's trigger. :frame-state-before
-    ;; equals :frame-state-after — the halting event made no write. rf2-bh56rc:
+    ;; regardless, pinning the halting event's trigger. ONE frame-state value
+    ;; rides the hook (rf2-6r9j.75): the halting event made no write, so the
+    ;; record's :frame-state-before and :frame-state-after are the same value
+    ;; and the epoch surface writes it into both slots. rf2-bh56rc:
     ;; `:committed-at` is the halting event's causal `:rf/time-ms`, not an
     ;; ambient read.
     (when (trace/continuation-live?)
       (when-let [commit-halt! (late-bind/get-fn-cached :epoch/commit-halt-record!)]
-        (commit-halt! frame-id fs-now fs-now halting-time-ms :halted-depth
+        (commit-halt! frame-id fs-now halting-time-ms :halted-depth
                       halt-reason halting-event owner-token)))))))
 
 (defn- settle-event-epoch!

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -337,6 +337,12 @@
   halted event made no write. Residual capture is cleared before commit, and
   `committed-at` comes from the halted event's already-stamped envelope.
 
+  ONE frame-state parameter, not a before/after pair (rf2-6r9j.75). The hook
+  once took both and read neither — `commit-record!` receives the SAME value in
+  both slots, sourced from the last settled record (or, on a first-cascade halt,
+  from this fallback). A second slot could only ever carry a value this path
+  discards, so the pair implied two meaningful snapshots the halt never had.
+
   rf2-vxgfnd.154 — EXACT-INCARNATION halt commit. `exact-owner-token` is A's
   event-owner token (its `:drain-lock`); the router threads it so a depth-error
   listener that destroyed A and published a same-id B cannot have this terminal
@@ -350,7 +356,7 @@
   outermost so the epoch's trace-event-projection keyword references stay DCE-
   able in production (multi-arity perturbed Closure's `:advanced` reachability —
   the rf2-cprm0q elision trap)."
-  [frame-id frame-state-before frame-state-after committed-at outcome halt-reason
+  [frame-id frame-state-after committed-at outcome halt-reason
    trigger-event exact-owner-token]
   (when interop/debug-enabled?
     (when (or (nil? exact-owner-token)

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -113,8 +113,7 @@
   ([record]
    (notify-listeners! record (constantly true)))
   ([record continue?]
-   (let [frame-id          (:frame record)
-         listener-snapshot (state/listeners-snapshot)]
+   (let [listener-snapshot (state/listeners-snapshot)]
      (when (continue?)
        (deliver-listener-snapshot! record listener-snapshot continue? true)))))
 

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -944,8 +944,9 @@
 ;;     re-read. A replacement landing mid-snapshot can therefore never attribute
 ;;     A's observation to a fresh generation H it never observed under.
 ;;   LINEARIZABLE — eligibility AND the mark write are ONE atomic operation
-;;     (`claim-delayed-silence!`, under `silence-lock`): it rechecks the current
-;;     generation, the CURRENT live observers (fresh, not a stale pre-loop set),
+;;     (`claim-and-publish-delayed-silence!`'s reservation half, under
+;;     `silence-lock`): it rechecks the current generation, the CURRENT live
+;;     observers (fresh, not a stale pre-loop set),
 ;;     and the existing mark, then reserves a fresh monotonic seq BEFORE external
 ;;     delivery. The seq is the single total order the observer relies on; two
 ;;     overlapping same-id publishers can never both claim. A reservation is
@@ -1095,8 +1096,8 @@
 ;; frame-id → count of deferred predecessors of THAT frame whose terminal
 ;; evidence is currently outstanding (snapshotted but not yet published). A
 ;; `(frame, cb)` mark can only ever be consulted by a deferred predecessor OF
-;; THAT SAME frame (`claim-delayed-silence!` reads marks keyed by its own
-;; frame-id), so the frame's marks are needed only while its count is positive.
+;; THAT SAME frame (`claim-and-publish-delayed-silence!` reads marks keyed by its
+;; own frame-id), so the frame's marks are needed only while its count is positive.
 ;; When the last outstanding predecessor of a frame resolves, the frame's marks
 ;; are reclaimed — this is what bounds `terminal-silence-marks` under a persistent
 ;; callback that observes and destroys unboundedly many unique frame ids
@@ -1231,9 +1232,10 @@
   `(frame-id, cb-id)` against the FRESHEST listener /
   observation / mark state and, when eligible, RESERVE a fresh monotonic seq
   (writing the mark inside the caller's critical section) and return it; else
-  return nil, writing nothing. Split out so both the reserve-only
-  `claim-delayed-silence!` and the reserve-and-publish
-  `claim-and-publish-delayed-silence!` decide eligibility identically.
+  return nil, writing nothing. Kept separate from
+  `claim-and-publish-delayed-silence!` — its sole caller — so the eligibility
+  DECISION reads in one place under the locks while the external emit that
+  answers it runs outside them.
 
   The three checks:
     1. `cb-id`'s current generation still equals `observed-gen` — a replacement /
@@ -1261,35 +1263,6 @@
     (let [seq (next-terminal-silence-seq)]
       (swap! terminal-silence-marks assoc-in [frame-id cb-id] seq)
       seq)))
-
-(defn claim-delayed-silence!
-  "Atomically CLAIM (reserve only) the one `:rf.epoch.cb/silenced-on-frame-destroy`
-  for `(frame-id, cb-id)` on behalf of a deferred predecessor A whose snapshot
-  observed the frame under `observed-gen` with terminal-silence `baseline`.
-
-  Under `silence-lock` — the single linearization point for this signal — it
-  rechecks eligibility (`eligible-and-reserve!`) against the FRESHEST listener
-  and observation state and, when eligible, RESERVES a fresh monotonic seq and
-  returns it. The caller then delivers the envelope externally and, only if that
-  delivery THROWS, calls `rollback-delayed-silence!` with this seq. When any
-  check fails it writes nothing and returns nil. Two overlapping publishers
-  cannot both reserve: the first writes the mark, the second sees it above
-  baseline and returns nil.
-
-  NOTE this primitive RESERVES ONLY — it EMITS NOTHING. It returns the reserved
-  seq; the CALLER performs the external emit later, which leaves a claim→emit
-  window: a replacement / drop / re-arm landing after this returns but before the
-  caller's emit makes a fresh generation current at the emission point. Because
-  this path does NOT hand the caller the reserved generation to qualify that emit
-  with, a caller wiring it to a bare `{:frame :cb-id}` emit produces an UNQUALIFIED
-  signal — so this primitive remains only for staged tests and any caller whose
-  emit provably cannot race a registry mutation. Callers whose emit CAN race a
-  registry mutation use `claim-and-publish-delayed-silence!`, which reserves here
-  (under both locks), then emits a GENERATION-QUALIFIED signal OUTSIDE the locks so
-  a superseded generation's late emit self-filters at the receiver (rf2-8b9twg)."
-  [frame-id cb-id observed-gen baseline]
-  (with-claim-locks
-    #(eligible-and-reserve! frame-id cb-id observed-gen baseline)))
 
 (defn claim-and-publish-delayed-silence!
   "Reserve the one delayed silence for `(frame-id, cb-id)` under BOTH ledger locks
@@ -1367,10 +1340,11 @@
   current generation AT reservation time, and that is the generation `publish!`
   qualifies the emit with.
 
-  Returns true when the silence was reserved+published, false when ineligible. If
-  `publish!` throws, the reservation is rolled back under `silence-lock` (only
-  while it still stands) — acquiring silence-lock ALONE keeps the global
-  registry→silence order (no inversion) — and the throw propagates.
+  Returns true when the silence was reserved+published and nil (the `when-let`
+  short-circuit, falsey either way) when ineligible. If `publish!` throws, the
+  reservation is rolled back under `silence-lock` (only while it still stands) —
+  acquiring silence-lock ALONE keeps the global registry→silence order (no
+  inversion) — and the throw propagates.
 
   Lock-order safety: the cross-lock nesting to `frame-owner-lock` remains a strict
   DAG (no path holds `frame-owner-lock` while acquiring either ledger lock — the
@@ -1400,19 +1374,6 @@
             (when (= reserved (get-in @terminal-silence-marks [frame-id cb-id]))
               (prune-terminal-silence-mark! frame-id cb-id))))
         (throw ex)))))
-
-(defn rollback-delayed-silence!
-  "Undo a `claim-delayed-silence!` reservation `reserved-seq` for `(frame, cb)`
-  when the external envelope delivery threw — but only if OUR reservation still
-  stands (no fresher delivery or claim superseded it). Restores the ledger to
-  as-if-unclaimed so the one signal can be legitimately re-attempted, keeping a
-  failed delivery from leaving a phantom mark that permanently suppresses it."
-  [frame-id cb-id reserved-seq]
-  (with-silence-lock
-    (fn []
-      (when (= reserved-seq (get-in @terminal-silence-marks [frame-id cb-id]))
-        (prune-terminal-silence-mark! frame-id cb-id))
-      nil)))
 
 (defn terminal-silence-marks-snapshot
   "Read-only view of the `frame-id → {cb-id → seq}` terminal-silence ledger —

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -716,7 +716,8 @@
       (rf/register-listener! :epoch cb (fn [_] nil))
       ;; cb is owed (never a live observer of id), so the claim reserves a mark.
       (state/open-silence-lineage! id)
-      (state/claim-delayed-silence! id cb (:generation (get (state/listeners-snapshot) cb)) 0)
+      (state/claim-and-publish-delayed-silence!
+        id cb (:generation (get (state/listeners-snapshot) cb)) 0 (fn [] nil))
       (is (pos? (vxgfnd285-total-marks)) "a terminal-silence mark is present")
       (state/reset-listeners!)
       (is (zero? (vxgfnd285-total-marks))

--- a/implementation/epoch/test/re_frame/epoch_silence_contract_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silence_contract_test.clj
@@ -167,7 +167,6 @@
           put-doc    (var-doc #'state/put-listener!)
           drop-doc   (var-doc #'state/drop-listener!)
           rec-doc    (var-doc #'state/record-observation!)
-          reserve    (var-doc #'state/claim-delayed-silence!)
           publish    (var-doc #'state/claim-and-publish-delayed-silence!)]
 
       ;; --- NO emit-under-lock authority (a lock spanning the external emit) ---
@@ -180,13 +179,17 @@
       (is (not (str/includes? rec-doc "between its reservation and emit"))
           "record-observation! must NOT exclude a re-arm from the reservation→emit window")
 
-      ;; --- NO reserve-only-emits authority (the reserve-only helper emits none) ---
-      (is (not (str/includes? reserve "primitive emits an UNQUALIFIED signal"))
-          "claim-delayed-silence! must NOT describe the reserve-only primitive as emitting")
-      (is (str/includes? reserve "RESERVES ONLY")
-          "claim-delayed-silence! states it reserves only")
-      (is (str/includes? reserve "EMITS NOTHING")
-          "claim-delayed-silence! states it emits nothing")
+      ;; --- NO reserve-only API at all (rf2-6r9j.78) ---
+      ;; The reserve-only pair was retired: it left a claim→emit window it could
+      ;; not qualify, so its own docstring conceded it was for staged tests and
+      ;; for callers that provably cannot race a registry mutation. Only the
+      ;; integrated generation-qualified operation ships now, and re-introducing
+      ;; a reserve-only seam here flips this RED. (Neither name is a substring of
+      ;; `claim-and-publish-delayed-silence!`, so the correct helper is unaffected.)
+      (is (not (str/includes? src "claim-delayed-silence!"))
+          "the retired reserve-only claim helper must not return")
+      (is (not (str/includes? src "rollback-delayed-silence!"))
+          "the retired reserve-only rollback helper must not return")
 
       ;; --- the CORRECT protocol is stated positively ---
       (is (str/includes? src "runs OUTSIDE both locks")

--- a/implementation/epoch/test/re_frame/epoch_silencing_lineage_285_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_silencing_lineage_285_test.clj
@@ -220,31 +220,69 @@
         (rf/unregister-listener! :trace ::vxgfnd285-rearm-silencing)))))
 
 (deftest failed-delivery-rolls-back-the-reservation-only-then
-  ;; A granted claim RESERVES the signal (mark written) before external delivery,
-  ;; so a concurrent re-claim of the same identity is refused. Rolling back the
-  ;; reservation (the delivery-failed path) releases it so the one signal can be
-  ;; legitimately re-attempted; a successful reservation that is NOT rolled back
-  ;; stays claimed.
-  (let [id       :vxgfnd285/rollback
-        cb       ::vxgfnd285-rollback-cb]
+  ;; A granted claim RESERVES the signal (mark written, under both ledger locks)
+  ;; before the external publish runs OUTSIDE them, so a concurrent re-claim of
+  ;; the same identity is refused. A publish that THROWS rolls the reservation
+  ;; back and propagates, releasing the one signal so it can be legitimately
+  ;; re-attempted; a reservation whose publish SUCCEEDED stays claimed.
+  ;;
+  ;; rf2-6r9j.78: exercised through the shipped
+  ;; `claim-and-publish-delayed-silence!` — the reserve-only
+  ;; `claim-delayed-silence!` / `rollback-delayed-silence!` pair this used to
+  ;; drive is retired, so there is no shipped reserve-only API to stage against.
+  (let [id :vxgfnd285/rollback
+        cb ::vxgfnd285-rollback-cb]
     (rf/register-listener! :epoch cb (fn [_] nil))
     (try
       ;; cb is owed (not a live observer of id), so the claim reserves the signal.
-      (let [g        (cb-generation cb)
-            baseline 0
-            reserved (epoch-state/claim-delayed-silence! id cb g baseline)]
-        (is (some? reserved) "the first claim reserves the signal")
-        (is (nil? (epoch-state/claim-delayed-silence! id cb g baseline))
-            "a second claim is refused while the reservation stands")
-        (epoch-state/rollback-delayed-silence! id cb reserved)
-        (is (some? (epoch-state/claim-delayed-silence! id cb g baseline))
-            "after rollback the one signal can be re-claimed")
-        ;; A stale rollback (wrong seq) must NOT release a standing reservation.
-        (let [current (epoch-state/claim-delayed-silence! id cb g baseline)]
-          (is (nil? current) "reservation still stands")
-          (epoch-state/rollback-delayed-silence! id cb (- reserved 1))
-          (is (nil? (epoch-state/claim-delayed-silence! id cb g baseline))
-              "a rollback for a superseded seq is a no-op")))
+      (let [g      (cb-generation cb)
+            claim! (fn [publish!]
+                     (epoch-state/claim-and-publish-delayed-silence! id cb g 0 publish!))]
+        ;; A publish that throws propagates AND releases the reservation.
+        (is (thrown? clojure.lang.ExceptionInfo
+              (claim! (fn [] (throw (ex-info "delivery failed" {})))))
+            "a throwing publish propagates contained")
+        (is (zero? (total-marks))
+            "the failed delivery left no phantom mark behind")
+        (is (true? (claim! (fn [] nil)))
+            "after the rollback the one signal can be re-claimed and published")
+        (is (pos? (total-marks)) "the successful claim's mark stands")
+        ;; Ineligible short-circuits the `when-let` — nil, not false.
+        (is (nil? (claim! (fn [] nil)))
+            "a second claim is refused while that reservation stands"))
+      (finally
+        (rf/unregister-listener! :epoch cb)))))
+
+(deftest a-failed-publish-prunes-only-its-own-seq-never-a-fresher-mark
+  ;; The rollback is a COMPARE-and-prune: it releases the mark only while OUR
+  ;; reserved seq is still the one standing. A fresher publisher that claimed the
+  ;; same identity while our publish ran outside the ledger locks owns the signal
+  ;; now, and our late failure must not release ITS mark — that would let the one
+  ;; signal be emitted twice.
+  (let [id :vxgfnd285/rollback-stale
+        cb ::vxgfnd285-rollback-stale-cb]
+    (rf/register-listener! :epoch cb (fn [_] nil))
+    (try
+      (let [g           (cb-generation cb)
+            superseded? (atom nil)]
+        (is (thrown? clojure.lang.ExceptionInfo
+              (epoch-state/claim-and-publish-delayed-silence! id cb g 0
+                (fn []
+                  ;; Locks are released here, so a successor publisher — whose
+                  ;; baseline sits above our fresh mark — can claim the identity
+                  ;; between our reservation and our (failing) delivery.
+                  (reset! superseded?
+                          (epoch-state/claim-and-publish-delayed-silence!
+                            id cb g (epoch-state/current-terminal-silence-seq)
+                            (fn [] nil)))
+                  (throw (ex-info "delivery failed" {})))))
+            "our publish still throws contained")
+        (is (true? @superseded?)
+            "the successor reserved and published while we held no lock")
+        (is (pos? (total-marks))
+            "our failed publish compare-and-pruned only its OWN seq — the fresher mark stands")
+        (is (nil? (epoch-state/claim-and-publish-delayed-silence! id cb g 0 (fn [] nil)))
+            "and that fresher mark still refuses a claim at the original baseline"))
       (finally
         (rf/unregister-listener! :epoch cb)))))
 
@@ -341,7 +379,8 @@
     ;; A destroyed predecessor left a terminal-silence mark that `reset-listeners!`
     ;; must clear (cb is owed — not a live observer — so the claim reserves it).
     (epoch-state/open-silence-lineage! id)
-    (epoch-state/claim-delayed-silence! id cb (cb-generation cb) 0)
+    (epoch-state/claim-and-publish-delayed-silence! id cb (cb-generation cb) 0
+                                                    (fn [] nil))
     (is (pos? (total-marks)) "a terminal-silence mark is present")
     (epoch-state/reset-listeners!)
     (is (zero? (total-marks))


### PR DESCRIPTION
Three audit children under rf2-6r9j, each a vestige the epoch surface still
carried. All three premises were checked at source before any edit; all three
held.

## rf2-6r9j.79 — dead `frame-id` binding in the listener fan-out

`notify-listeners!`'s 2-arity bound `frame-id` from the record and never read
it: the two lines below use only the listener snapshot and forward the record
unchanged. `deliver-listener-snapshot!` derives its own `frame-id` at
`listeners.cljc:65` for observation ownership, so no behaviour moves. The
snapshot stays **above** the `continue?` check — that ordering is what the
concurrent-listener-mutation tests pin, and it is untouched.

## rf2-6r9j.75 — redundant pre-state argument on the halt hook

`commit-halt-record!` declared `frame-state-before` and never read it. The
halted-depth record sources **both** snapshots from the last settled record's
`:frame-state-after`, falling back to the router's live value only when no
epoch has settled — so the pre-state value could not affect the record. The
sole caller (`router.cljc`) passed `fs-now` in both positions.

Hook and caller move in one commit because the seam is late-bound: an arity
mismatch is a runtime fault, not a compile error. Kept single-arity — the
source documents that multi-arity perturbed Closure's `:advanced` reachability
and broke production elision (rf2-cprm0q).

Callers and implementors checked, whole repo, fixed-string:

| site | kind | change |
| --- | --- | --- |
| `implementation/core/src/re_frame/router.cljc:3421` | only executable caller | one `fs-now` dropped |
| `implementation/epoch/src/re_frame/epoch.cljc:329` | only implementor | parameter dropped |
| `implementation/epoch/src/re_frame/epoch.cljc:737` | late-bind registration | unchanged (no arity) |
| `implementation/core/src/re_frame/late_bind/directory.cljc:823` | directory entry | unchanged — describes the key, promises no arity |
| `spec/002-Frames.md:2023` | illustrative pseudocode `(commit-halt-record! frame :halted-depth halt-reason)` | unchanged — carries no frame-state argument at all |
| `spec/Conventions.md`, `migration/from-re-frame-v1/README.md`, `spec/conformance/fixtures/drain-depth-limit.edn` | name the key only | unchanged |

No spec change is needed for this signature; the hot-zone files above stay
untouched.

## rf2-6r9j.78 — superseded reserve-only delayed-silence helpers

`claim-delayed-silence!` and `rollback-delayed-silence!` were the reserve-only
pair, superseded when `e9475426bf` moved production publication to
`claim-and-publish-delayed-silence!` so the generation-qualified emit runs
outside the ledger locks. The successor asserts the same reservation contract
through the same private `eligible-and-reserve!` primitive, and implements the
compare-and-prune rollback in its own exception path. The retired pair's own
docstring conceded it left a claim-to-emit race it could not qualify and
"remains only for staged tests".

Both are gone. `eligible-and-reserve!` stays private and shared;
`claim-and-publish-delayed-silence!` is the sole delayed-silence entry and
still reserves under both ledger locks, publishes outside them, carries
`observed-gen` at the caller, and compare-prunes only its own reservation.

Coverage was moved onto the shipped operation rather than dropped:

- `failed-delivery-rolls-back-the-reservation-only-then` now drives
  `claim-and-publish-delayed-silence!` with a throwing publish, and pins
  publish-throw rollback, retry after rollback, and single-winner refusal.
- **New** `a-failed-publish-prunes-only-its-own-seq-never-a-fresher-mark`
  replaces the old stale-seq rollback case: a successor claims the identity
  from inside the failing publish (locks are released there by design), and the
  late failure must not release the successor's fresher mark.
- The CLJ and CLJS `reset-listeners!` cleanup tests seed their mark through the
  integrated operation.
- The source-contract ratchet swaps its three reserve-only docstring assertions
  for a tooth forbidding either retired name's return to `state.cljc`.

Also corrects `claim-and-publish-delayed-silence!`'s stated return value: it
short-circuits through `when-let`, so ineligible is `nil`, not `false`. Falsey
either way, no caller reads it, but the docstring was wrong and the tests here
had to assert against reality.

## Verification

Both deletion premises were measured with two independent instruments plus a
control that fires.

**clj-kondo** (local v2025.10.23), before → after over `implementation/epoch`:
the epoch `src` tree reported exactly two findings, both named by the beads
(`epoch.cljc:353 unused binding frame-state-before`,
`listeners.cljc:116 unused binding frame-id`), and reports **zero** after.

**Fixed-string census** over tracked files, `.beads/` excluded: neither retired
name appears outside `epoch`'s own source and tests. Control: the same census
for `claim-and-publish-delayed-silence!` returned 7 files, and for
`:epoch/commit-halt-record!` the control `:epoch/settle!` returned 15 files
spanning core, epoch, tools, docs and spec — so the instrument reaches
everything the negative result claims to have swept.

**Fault injection** — three planted faults, each restored and verified
byte-identical by `git hash-object` against the committed blob:

| planted fault | gate | result |
| --- | --- | --- |
| unconditional prune in the publish-throw path (compare-and-prune removed) | `a-failed-publish-prunes-only-its-own-seq-never-a-fresher-mark` | RED, both mark assertions |
| retired names reintroduced into `state.cljc` | `source-authority-states-the-outside-lock-generation-qualified-protocol` | RED, both new assertions |
| router restored to passing `fs-now` twice | `re-frame.epoch-test/depth-exceeded-commits-halted-record` | ERROR `ArityException: Wrong number of args (8)` — the halt seam is genuinely exercised end to end |

**Suites run** (foreground, exit codes captured to file):

| suite | exit |
| --- | --- |
| epoch JVM: silencing-lineage-285, silence-contract, silencing-emit-deadlock, silencing-generation-emission (16 tests / 3650 assertions) | 0 |
| epoch JVM: epoch-test, epoch-attribution-test (219 tests / 1018 assertions) | 0 |
| epoch JVM: concurrency-stress, lineage-aba, same-generation-rearm, silence-decision-atomicity, silence-receiver-public-api (28 tests / 1029 assertions) | 0 |
| core JVM: frame-destroy-incarnation-jvm-test (29 tests / 218 assertions) | 0 |
| `scripts/test-epoch-prod-gate.sh` — production elision under `-Dre-frame.debug=false` (25 tests) | 0 |
| clj-kondo over `implementation/epoch` + `implementation/core` | epoch `src` clean; every remaining finding pre-existing |

**Not run locally, left to CI:** the consolidated `npm run test:cljs` node build.
The CLJS edit is a two-line substitution onto a function defined in the same
`.cljc` with no reader conditional around it, and the always-on node-test gate
covers it on this PR.

**Pre-existing, not from this diff:** clj-kondo v2025.10.23 reports one error in
`implementation/epoch/test/re_frame/epoch_egress_redaction_cljs_test.cljc:939`
("Expected: throwable, received: string"). It is present on the merge base and
CI pins a different clj-kondo version.

**Noted, not fixed:** no test covers `commit-halt-record!`'s first-cascade
fallback arm — the one remaining read of the router-passed frame-state, when no
`:ok` epoch has settled. That gap predates this change and the parameter's
behaviour there is unaltered.
