### PR TITLE
fix(test-react): truth the packaging claims, retire the duplicate cache case, drop the dead extras arm

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -238,7 +238,7 @@ Some checks intentionally exit 0 when their preconditions are absent. They are d
 
 | Gate | Why skip-ok |
 |---|---|
-| Adapter JVM classpath probes (`jvm-{reagent,uix}`) | Adapter namespaces are `:cljs-only`; the probe proves deps + classpath wiring even with a zero-test alias. Two siblings on the same `adapter_diagnostic` gate are **not** skip-ok and must not be read as probes: `jvm-reagent-slim` runs the component-shape detection contract, and `jvm-adapters-test-react` runs the Test-React lifecycle suite (35 deftests / 160 assertions — the adapter is pure CLJC by design, so its `.cljc` tests are real JVM coverage). Real coverage for reagent/uix: the adapter smokes + per-adapter CLJS unit tests. |
+| Adapter JVM classpath probes (`jvm-{reagent,uix}`) | Adapter namespaces are `:cljs-only`; the probe proves deps + classpath wiring even with a zero-test alias. Two siblings on the same `adapter_diagnostic` gate are **not** skip-ok and must not be read as probes: `jvm-reagent-slim` runs the component-shape detection contract, and `jvm-adapters-test-react` runs the Test-React lifecycle suite (35 deftests / 157 assertions — the adapter is pure CLJC by design, so its `.cljc` tests are real JVM coverage). Real coverage for reagent/uix: the adapter smokes + per-adapter CLJS unit tests. |
 | Pair live-overflow without nREPL (`mcp-conformance-re-frame2-pair`) | Exits 0 with a SKIP marker when `$SHADOW_CLJS_NREPL_PORT` is unset — so the SKIP path itself is exercised every run. Real coverage: the hermetic-suite step that follows. |
 
 Never treat a passing skip-ok diagnostic as evidence the behaviour was covered; the real coverage is the changed-surface, nightly, or release gate.

--- a/implementation/adapters/README.md
+++ b/implementation/adapters/README.md
@@ -22,7 +22,7 @@ You pick one (or more) by adding the matching artefact to your `deps.edn` alongs
 |---|---|---|---|
 | [`test-react/`](test-react/) | Test-React adapter | **none — local-test-only** | Pure-CLJC React class-3 lifecycle simulator for lifecycle-order and unmount-during-render tests |
 
-The test-react adapter is not a published artefact. It is a development/test fixture only: it has no Maven coordinate, no `:clein/build` descriptor, and is absent from the lockstep array, the release deploy matrix, and the CI JVM job set by design. Consumers never depend on it. It exists solely so the project's own unit tests can simulate React class-3 lifecycle on the JVM and Node-CLJS without a browser. Bundle isolation treats it as test-only — no example or production build should ever pull it in.
+The test-react adapter is not a published artefact. It is a development/test fixture only: it has no Maven coordinate, no `:clein/build` descriptor, and is absent from the lockstep array and the release deploy matrix by design. That governs publishing, not testing — its suite is gated on every PR by the required `jvm-adapters-test-react` job (its own `clojure -M:test`) and, on the CLJS side, by the consolidated Shadow `:node-test` run; see [TESTING.md](../../TESTING.md). Consumers never depend on it. It exists solely so the project's own unit tests can simulate React class-3 lifecycle on the JVM and Node-CLJS without a browser. Bundle isolation treats it as test-only — no example or production build should ever pull it in.
 
 The `reagent-slim` adapter includes reactive primitives, a render scheduler,
 hiccup translation, and pure-CLJS render-to-string. Its test suite covers the
@@ -66,11 +66,11 @@ adapters/
     └── test/...
 ```
 
-All 4 published adapters declare `day8/re-frame2 {:local/root "../../core"}`. The unpublished test-react fixture declares the same `:local/root` dep. None depend on each other.
+All 3 published adapters declare `day8/re-frame2 {:local/root "../../core"}`. The unpublished test-react fixture declares the same `:local/root` dep. None depend on each other.
 
 ## Where the substrate logic lives
 
-The 4 React-shaped adapter namespaces are primarily configuration and
+The 3 React-shaped adapter namespaces are primarily configuration and
 substrate-specific public helpers because they delegate shared mechanics into
 [`re-frame.substrate.spine`](../core/src/re_frame/substrate/spine.cljs) in the
 core artefact. There are 2 factory families:

--- a/implementation/adapters/test-react/deps.edn
+++ b/implementation/adapters/test-react/deps.edn
@@ -9,8 +9,11 @@
 ;; Packaging status: this is a development/test fixture, NOT a published
 ;; Maven artefact. It deliberately carries NO Maven coordinate and NO
 ;; :clein/build descriptor, and is absent from the lockstep array
-;; (.github/scripts/verify-version-lockstep.sh), the release deploy
-;; matrix, and the CI JVM job set. Unlike the four published adapters
+;; (.github/scripts/verify-version-lockstep.sh) and the release deploy
+;; matrix. That is a PUBLISHING status, not a testing one: this suite IS
+;; in the CI JVM job set — the required `jvm-adapters-test-react` job in
+;; .github/workflows/test.yml runs the `clojure -M:test` alias below.
+;; Unlike the three published adapters
 ;; (reagent, reagent-slim, uix — each its own Clojars artefact),
 ;; consumers never depend on this; it supplies the
 ;; re-frame.adapter.test-react ns ONLY for the project's own unit tests,

--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -102,9 +102,16 @@
 ;; when an entire teardown cascade completes within one clock tick.
 (defonce ^:private phase-seq (atom 0))
 
-(defn- log-phase! [mount phase & {:as extras}]
+;; FIXED ARITY by design (rf2-6r9j.83). The entry shape IS the contract
+;; `lifecycle-log` publishes — exactly `{:phase … :seq …}`, nothing else — so
+;; the literal map is appended directly. It previously took a variadic
+;; `& {:as extras}` merged on TOP of the canonical keys; no call site in the
+;; adapter's whole history ever supplied one, and because the merge landed
+;; last it was an escape hatch that could overwrite `:phase` or `:seq` and
+;; contradict the very ordering invariant the log promises.
+(defn- log-phase! [mount phase]
   (swap! (:lifecycle-log mount)
-         conj (merge {:phase phase :seq (swap! phase-seq inc)} extras)))
+         conj {:phase phase :seq (swap! phase-seq inc)}))
 
 ;; Declared so `run-render!` (which invokes a render body that may mount
 ;; children) can call the mount seam defined below it.

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_cljs_test.cljc
@@ -1,7 +1,7 @@
 (ns re-frame.adapter.test-react-cljs-test
   "Tests for the Test-React adapter.
 
-  Two layers:
+  Three layers:
 
   A. Demonstration scenarios — the original skeleton coverage (rf2-gqyqv):
      happy-path lifecycle ordering, render-tree tracking, adapter-disposal
@@ -27,8 +27,8 @@
           expected; the symptom is an extra :render (and :did-update) entry in
           the lifecycle log — the render counter is higher than the contract.
 
-  C. Harness-contract guards (rf2-ynjts.6) — the documented public-surface
-     invariants the uix browser suites lean on. Each pins a guard /
+  C. Harness-contract guards (rf2-ynjts.6) — self-tests of this local
+     harness's OWN documented public surface. Each pins a guard /
      error / two-entry-point behaviour the harness PROMISES in its docstrings
      but the A/B layers above never exercised: trigger-update! / unmount!
      after teardown, mount-child! outside a render body, mount! under the
@@ -37,11 +37,8 @@
      unmount thunk, and deep (grandchild) leaf-upward cascade ordering."
   (:require [re-frame.adapter.test-react :as test-react]
             [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.core :as rf]
-            [re-frame.subs :as subs]
-            [re-frame.frame :as frame]
-            #?(:clj  [clojure.test :as ctest :refer [deftest is testing use-fixtures]]
-               :cljs [cljs.test :as ctest :refer-macros [deftest is testing use-fixtures]])))
+            #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])))
 
 ;; ---- fixture ---------------------------------------------------------------
 
@@ -99,6 +96,25 @@
       (is (= [:constructor :render :did-mount :render :did-update :will-unmount]
              (mapv :phase (test-react/lifecycle-log mount)))
           "the simulated lifecycle records constructor, mount-render+did-mount, update-render+did-update, will-unmount"))))
+
+(deftest lifecycle-log-entries-carry-exactly-phase-and-seq
+  (testing "every lifecycle entry is EXACTLY #{:phase :seq} — the shape
+            `lifecycle-log`'s docstring publishes as its contract. `log-phase!`
+            is fixed-arity precisely so nothing can smuggle an extra key in
+            (rf2-6r9j.83); this pins that, and would fail if a stray field —
+            or a merge that clobbered :phase / :seq — ever reappeared."
+    (let [mount (test-react/mount! [:div "v1"])]
+      (test-react/trigger-update! mount [:div "v2"])
+      (test-react/unmount! mount)
+      (let [log (test-react/lifecycle-log mount)]
+        (is (seq log) "precondition: the log recorded entries at all")
+        (is (= #{#{:phase :seq}}
+               (into #{} (map (comp set keys)) log))
+            "every entry's key set is exactly #{:phase :seq} — no extras arm")
+        (is (every? (comp keyword? :phase) log)
+            ":phase is always a keyword")
+        (is (apply < (mapv :seq log))
+            ":seq is strictly increasing across the entries, in firing order")))))
 
 (deftest mounted-components-and-current-render-tree
   (testing "mounted-components tracks live mounts; current-render-tree returns the latest hiccup"
@@ -217,103 +233,6 @@
              the tree and never throws :rf.error/no-hiccup-emitter-bound"))
       (finally
         (test-react/set-hiccup-emitter! nil)))))
-
-;; ---- dispose-adapter! clears every live frame's sub-cache (rf2-ghfkkk) ----
-;;
-;; The HIGH-severity finding: test-react's `dispose-adapter!` drained
-;; active-mounts (the host-resource MUST) but did NOT walk per-frame
-;; sub-caches the way the React adapters do via `spine/dispose-frame-sub-
-;; caches!`. Because `make-derived-value` is a plain IDeref reify whose
-;; reaction never auto-disposes (no IWatchable, no published :adapter/dispose!
-;; hook on CLJS), the `{:reaction … :ref-count n}` CACHE ENTRY — which lives
-;; on the FRAME, not the reaction — survived a dispose/reinstall cycle. A
-;; later subscribe could then read the stale cached value instead of
-;; recomputing from fresh state, breaking process isolation.
-;;
-;; The fix routes `dispose-adapter!` through the CLJC-safe shared helper
-;; `re-frame.subs.cache/clear-all-frame-sub-caches!`, the externally-visible
-;; counterpart of the spine walk. This test materializes a real frame
-;; sub-cache entry (with a ref-count), disposes the adapter, asserts the
-;; sub-cache is empty + the ref-count is gone, and verifies a re-subscribe
-;; after reinstall recomputes from the CURRENT app-db rather than serving a
-;; stale slot. Runs on both the JVM (`clojure -M:test`) and — now that this
-;; ns ends in `-cljs-test` — under CLJS via `npm run test:cljs` (rf2-ezbzvm).
-;; The standalone `test_react_dispose_sub_cache_cljs_test.cljc` companion
-;; pins the same contract independently.
-
-(defn- default-sub-cache-keys
-  "The set of cache-keys currently materialised in the :rf/default frame's
-  per-frame sub-cache. Empty when the frame is absent."
-  []
-  (if-let [cache (:sub-cache (frame/frame :rf/default))]
-    (set (keys @cache))
-    #{}))
-
-(defn- default-entry-ref-count
-  "The :ref-count on the :rf/default frame's sub-cache slot for `query-v`,
-  or nil if the slot is absent."
-  [query-v]
-  (get-in @(:sub-cache (frame/frame :rf/default)) [query-v :ref-count]))
-
-(deftest dispose-adapter-clears-frame-sub-cache-no-stale-cross-lifecycle-reads
-  (testing "dispose-adapter! clears every live frame's sub-cache entries +
-            ref-counts (the rf2-ghfkkk High finding): a materialised slot does
-            NOT survive a dispose/reinstall cycle, and a re-subscribe after
-            reinstall recomputes from the CURRENT app-db — no stale read."
-    ;; Start from a clean frame registry so prior tests in this ns can't leak
-    ;; a frame/cache in. The :each fixture installed test-react; ensure the
-    ;; :rf/default frame exists under it.
-    (reset! frame/frames {})
-    (frame/ensure-default-frame!)
-    (rf/reg-event ::seed (fn [{:keys [db]} [_ v]] {:db {:n v}}))
-    (rf/reg-sub ::n (fn [db _] (:n db)))
-    (try
-      ;; Seed app-db = {:n 1} and materialise a sub-cache entry by subscribing.
-      ;; Both the dispatch and the subscribe pin `:rf/default` explicitly: per
-      ;; EP-0002 there is no ambient `:rf/default` floor, so the AMBIENT
-      ;; 1-arity form (no `:frame` opt) would resolve a render-time frame
-      ;; context this headless test does not establish and raise
-      ;; `:rf.error/no-frame-context`. Use the explicit-frame 2-arity opts
-      ;; form (and `subs/subscribe` below) which carries the target frame
-      ;; directly — an explicit `:frame` opt always wins over ambient scope
-      ;; (Spec 002 §Frame target resolution), macro or fn-form alike.
-      (rf/dispatch-sync [::seed 1] {:frame :rf/default})
-      (let [r (subs/subscribe [::n] {:frame :rf/default})]
-        (is (= 1 @r) "sub reads the seeded value")
-        (is (contains? (default-sub-cache-keys) [::n])
-            "subscribe materialised a cache slot on the frame")
-        (is (= 1 (default-entry-ref-count [::n]))
-            "the slot carries a ref-count of 1"))
-
-      ;; Dispose the adapter. Pre-fix this left the [::n] slot + its ref-count
-      ;; in the frame's sub-cache (the reaction never auto-disposes, so the
-      ;; entry survived). The fix walks every live frame's sub-cache and resets
-      ;; it.
-      (substrate-adapter/dispose-adapter!)
-      (is (empty? (default-sub-cache-keys))
-          "dispose-adapter! cleared the frame's sub-cache — no surviving slot")
-      (is (nil? (default-entry-ref-count [::n]))
-          "the stale ref-count is gone — not carried across the dispose")
-
-      ;; Reinstall and change the app-db. A re-subscribe MUST recompute from
-      ;; the new state (98 → 99 below), not serve a stale cached 1. If the
-      ;; pre-fix slot had survived, the re-subscribe would have aliased the old
-      ;; reaction and the isolation guarantee would be broken.
-      (substrate-adapter/install-adapter! test-react/adapter)
-      (rf/dispatch-sync [::seed 99] {:frame :rf/default})
-      (let [r2 (subs/subscribe [::n] {:frame :rf/default})]
-        (is (= 99 @r2)
-            "re-subscribe after reinstall recomputed from the CURRENT app-db")
-        (is (= 1 (default-entry-ref-count [::n]))
-            "the rebuilt slot is a FRESH cache miss (ref-count back to 1), not
-             a resurrected stale entry")
-        (subs/unsubscribe :rf/default [::n]))
-      (finally
-        ;; Clean up: drop the test registrations + the frame so the ns's other
-        ;; tests (and the :each fixture's outer dispose) start clean. The
-        ;; adapter is left installed for the fixture's dispose to tear down.
-        (rf/clear-sub ::n)
-        (reset! frame/frames {})))))
 
 ;; ----------------------------------------------------------------------------
 ;; A'. Recursive child mounting — the structural seam the regressions ride on
@@ -980,16 +899,21 @@
 ;; C. Harness-contract guards (rf2-ynjts.6)
 ;; ----------------------------------------------------------------------------
 ;;
-;; The uix browser suites consume this harness's PUBLIC surface
-;; (`mount!` / `trigger-update!` / `unmount!` / `mount-child!` / the substrate
-;; `:render` entry point / `render-to-string`). Each of the following pins a
-;; guard or two-entry-point behaviour the harness docstrings PROMISE but the
-;; A/B layers above never exercised. A silent regression in any of these would
-;; weaken the downstream suites without tripping their own assertions — e.g. a
-;; `trigger-update!` that no longer throws after teardown would let a test
-;; re-render a dead mount and read a stale tree; a `mount!` that dropped its
-;; installed-adapter guard would silently mount under whatever adapter the
-;; suite forgot to install. These are the harness's own contract.
+;; These pin the harness's OWN documented PUBLIC surface — `mount!` /
+;; `trigger-update!` / `unmount!` / `mount-child!` / the substrate `:render`
+;; entry point / `render-to-string` — the contract its docstrings promise to
+;; whoever writes a lifecycle test against it. There is no downstream
+;; consumer: nothing outside this artefact requires `re-frame.adapter.test-
+;; react` (the only non-test mention anywhere is the quoted producer roster in
+;; `re-frame.late-bind.directory`), so these guards are self-tests, not a
+;; proxy for some other suite's coverage. Each pins a guard or two-entry-point
+;; behaviour the harness docstrings PROMISE but the A/B layers above never
+;; exercised. A silent regression in any of them would weaken every test
+;; WRITTEN AGAINST this harness without tripping that test's own assertions —
+;; e.g. a `trigger-update!` that no longer throws after teardown would let a
+;; test re-render a dead mount and read a stale tree; a `mount!` that dropped
+;; its installed-adapter guard would silently mount under whatever adapter the
+;; test forgot to install.
 
 ;; ---- trigger-update! after unmount throws ---------------------------------
 
@@ -1120,13 +1044,13 @@
 ;; ---- the substrate :render entry point returns a working unmount thunk ----
 
 (deftest substrate-render-entry-point-returns-working-thunk
-  (testing "the substrate contract's :render fn (the path the runtime / browser
-            suites actually drive, distinct from the public mount! driver)
-            returns a thunk that, when called, tears the mount down. mount! and
-            :render share the internal mount-tree! seam; :render discards the
-            record and hands back ONLY the thunk. Pinning this proves the
-            substrate-facing surface the uix adapters route through stays
-            a live unmount handle, not just the inspection-friendly mount!."
+  (testing "the substrate contract's :render fn (the slot the core runtime
+            drives, distinct from the public mount! driver) returns a thunk
+            that, when called, tears the mount down. mount! and :render share
+            the internal mount-tree! seam; :render discards the record and
+            hands back ONLY the thunk. Pinning this proves THIS fixture's
+            substrate-facing :render slot stays a live unmount handle, not just
+            the inspection-friendly mount!."
     (let [thunk (substrate-adapter/render [:div "via-render"] nil nil)]
       (is (fn? thunk)
           ":render returns a callable unmount thunk")

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_dispose_sub_cache_cljs_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_dispose_sub_cache_cljs_test.cljc
@@ -1,8 +1,7 @@
 (ns re-frame.adapter.test-react-dispose-sub-cache-cljs-test
-  "Companion to the rf2-ghfkkk High finding's coverage in
-  `re-frame.adapter.test-react-cljs-test`.
+  "The rf2-ghfkkk High finding's regression coverage — this ns OWNS it.
 
-  The substantive assertion lives in both: test-react's `dispose-adapter!`
+  test-react's `dispose-adapter!`
   MUST clear every live frame's per-frame sub-cache (entries + ref-counts),
   the externally-visible counterpart of the React adapters' CLJS-only
   `re-frame.substrate.spine/dispose-frame-sub-caches!` walk — routed here
@@ -13,21 +12,28 @@
   the FRAME, not the reaction) survived a dispose/reinstall cycle, allowing a
   later subscribe to read a stale value and breaking process isolation.
 
-  Why a SEPARATE ns from `test_react_cljs_test.cljc`: the unique coverage
-  here is `dispose-adapter-clears-sub-caches-across-multiple-frames` — the
-  walk must cover EVERY live frame, not just `:rf/default`. Both files end in
-  `-cljs-test`, so both ride `npm run test:cljs` (and the JVM cognitect
-  runner). This ns uses the standard `make-reset-runtime-fixture` (mirroring
-  `plain_atom_dispose_cljs_test`) for airtight per-test isolation rather than
-  hand-managing frame/registrar state."
+  Two cases, both here rather than split across namespaces (rf2-6r9j.81 —
+  `test_react_cljs_test.cljc` used to carry a byte-for-byte duplicate of the
+  single-frame case, so the same seven assertions were maintained and run
+  twice on each host):
+
+  - `dispose-adapter-clears-sub-cache-and-recomputes-fresh` — the single-frame
+    dispose / reinstall / fresh-recompute property.
+  - `dispose-adapter-clears-sub-caches-across-multiple-frames` — the walk must
+    cover EVERY live frame, not just `:rf/default`.
+
+  The ns ends in `-cljs-test`, so it rides `npm run test:cljs` as well as the
+  JVM cognitect runner. It uses the standard `make-reset-runtime-fixture`
+  (mirroring `plain_atom_dispose_cljs_test`) for airtight per-test isolation
+  rather than hand-managing frame/registrar state."
   (:require [re-frame.adapter.test-react :as test-react]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.core :as rf]
             [re-frame.subs :as subs]
             [re-frame.frame :as frame]
             [re-frame.test-support :as test-support]
-            #?(:clj  [clojure.test :as ctest :refer [deftest is testing use-fixtures]]
-               :cljs [cljs.test :as ctest :refer-macros [deftest is testing use-fixtures]])))
+            #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter test-react/adapter}))
@@ -44,7 +50,7 @@
   (testing "rf2-ghfkkk — test-react dispose-adapter! disposes + clears every
             live frame's sub-cache; a re-subscribe after reinstall recomputes
             from the current app-db (no stale cross-lifecycle read)"
-    (rf/reg-event ::seed (fn [{:keys [db]} [_ v]] {:db {:n v}}))
+    (rf/reg-event ::seed (fn [_ctx [_ v]] {:db {:n v}}))
     (rf/reg-sub ::n (fn [db _] (:n db)))
     (rf/dispatch-sync [::seed 1])
 
@@ -75,7 +81,7 @@
   (testing "rf2-ghfkkk — the walk covers EVERY live frame, not just
             :rf/default: a per-instance frame's materialised slot is disposed
             and cleared by the same dispose-adapter! call"
-    (rf/reg-event ::seed (fn [{:keys [db]} [_ v]] {:db {:n v}}))
+    (rf/reg-event ::seed (fn [_ctx [_ v]] {:db {:n v}}))
     (rf/reg-sub ::n (fn [db _] (:n db)))
     (let [other (frame/make-anon-frame-record! {:doc "second frame"})]
       ;; Seed + subscribe in BOTH frames so each carries a live cache slot.


### PR DESCRIPTION
Three Test-React audit children (rf2-6r9j.85, .83, .81). Documentation-and-test
consolidation plus one dead private arm removed from the simulator; no gate is
narrowed and no packaging metadata changes.

## rf2-6r9j.85 — stale CI, adapter-count and UIx-consumer claims

**CI.** `implementation/adapters/test-react/deps.edn` and
`implementation/adapters/README.md` both said the fixture is absent from "the CI
JVM job set". Verified false at today's tip: `.github/workflows/test.yml:1753`
defines `jvm-adapters-test-react`, which runs the artefact's own
`clojure -M:test`, and `all-required-passed` names it at `:6358`. Both comments
now separate the publishing status (still absent from the lockstep array and the
release deploy matrix — unchanged) from the testing one, and point at the job.

**Counts.** Measured from `git ls-files`, not from the prose: three published
adapter directories under `implementation/adapters/` (`reagent`, `reagent-slim`,
`uix`), plus `test-react/` (unpublished fixture) and `scripts/` (shared smoke
tooling). That matches Spec 006's repository-home paragraph verbatim. So
"All 4 published adapters" → 3, and "The 4 React-shaped adapter namespaces" → 3
(the README's own next paragraph lists exactly Reagent + reagent-slim + UIx
across two factory families, and says test-react "is its own quadrant — pure
CLJC, no React"). `deps.edn`'s "four published adapters (reagent, reagent-slim,
uix …)" → three.

**UIx consumers.** Three sites claimed the UIx browser suites consume / lean on /
route through this harness. Checked with two independent instruments plus a
control that fires:

- Fixed-string census over tracked files: `git grep -F "re-frame.adapter.test-react"`
  returns hits only inside the test-react artefact, plus
  `implementation/core/src/re_frame/late_bind/directory.cljc` (a quoted producer
  roster) and two `implementation/shadow-cljs.edn` comments. `git grep -F
  "test-react"` and `-F "test_react"` under `implementation/adapters/uix` both
  exit 1. Control: the same instrument for `re-frame.adapter.uix` on that path
  returns hits.
- History: `git log --all -S're-frame.adapter.test-react' -- implementation/adapters/uix
  implementation/adapters/helix implementation/core/test` is empty. Control: the
  same search on `implementation/adapters/test-react` returns three commits.

Section C is now described as what it is — self-tests of the harness's own
documented public surface, with a note that there is no downstream consumer.

## rf2-6r9j.83 — the never-used lifecycle-log extras arm

`log-phase!` was `[mount phase & {:as extras}]`, merging caller extras **on top
of** the canonical `{:phase … :seq …}` map. Two instruments, control fires:
the fixed-string census finds six call sites (`:135 :178 :199 :266 :285 :506`),
all two-argument, and the fn is `defn-` so the file is the whole population
(control: the same census on `mount-child!` returns hits in four files including
`spec/009`); and `git log --all -p | grep -E '^[+-].*\(log-phase!'` shows every
call line ever added or removed is two-argument (control: the instrument returns
13 lines, so it is not silently empty).

Now fixed-arity, appending the literal entry. A new focused test,
`lifecycle-log-entries-carry-exactly-phase-and-seq`, pins that every entry's key
set is exactly `#{:phase :seq}`, that `:phase` is always a keyword, and that
`:seq` is strictly increasing.

## rf2-6r9j.81 — the superseded duplicate cache case

The single-frame dispose/reinstall cache regression was maintained twice. The
successor is named and it asserts the same thing:
`dispose-adapter-clears-sub-cache-and-recomputes-fresh` in
`test_react_dispose_sub_cache_cljs_test.cljc` pins all seven — sub reads the
seeded value, the slot is materialised, ref-count 1, the slot is gone after
dispose, the ref-count is gone, a re-subscribe after reinstall reads 99, and the
rebuilt slot is a fresh miss at ref-count 1 — which is exactly the retired copy's
assertion list. The split existed only because the main ns once ended in `-test`
and Shadow's `cljs-test$` selector skipped it; both namespaces end in
`-cljs-test` today and both roots are in `implementation/shadow-cljs.edn`'s
`:node-test` source paths.

The companion now owns both cache cases and says so. The main suite drops the
copy, its two one-consumer helpers, and the `re-frame.core` / `re-frame.subs` /
`re-frame.frame` requires only it needed. Both ns forms lose the unreferenced
`:as ctest` alias and the unread `{:keys [db]}` seed-handler bindings.

## Gates

- `clojure -M:test` in `implementation/adapters/test-react` — **exit 0**,
  35 tests / 157 assertions (was 35 / 160: −1 test / −7 assertions for the
  retired duplicate, +1 test / +4 for the key-shape pin). `TESTING.md:241`'s
  hard-coded count is updated from that runner output.
- `clj-kondo --lint` over the artefact's `src` + `test` — **exit 0**, 0 errors,
  0 warnings. Control: linting the pre-change files out of `git show HEAD:` still
  reports the three unread `db` bindings the bead cited.
- `scripts/check_readme_links.py --ci` — **exit 0**. This is the gate for
  `implementation/adapters/README.md` (a README beside source) and repo-root
  `TESTING.md`; `check_doc_slugs.py` does not reach either path.
  Proven live: planting a broken target in the new `TESTING.md` link returns
  exit 1 naming the file and line.

Three negative controls, each planted and reverted (files restored and verified
byte-identical by `sha1sum`, then the suite re-run green):

1. Clearing only `:rf/default` instead of calling `dispose-adapter!` makes the
   surviving multi-frame case **fail** on the second frame's slot — the
   all-frame tooth is live, so consolidating did not erase it.
2. Suppressing the dispose in the surviving single-frame case makes it **fail**
   on both the slot and the ref-count — the retained copy is non-vacuous.
3. Adding a stray key inside `log-phase!` makes the new key-shape test **fail**
   with `#{#{:phase :control :seq}}`.

**Not run locally:** the consolidated Shadow `:node-test` build. CI's `cljs` job
owns it. Nothing here changes CLJS discovery — both namespaces keep their
`-cljs-test` suffix and their source roots — and the new test uses only
portable forms.

**Verified by hand** (no gate reads prose, tables or rendering): the
`TESTING.md` table row keeps its 3 pipes, matching its header and neighbours;
the README edits are prose, not table cells.

## Out of fence, reported not touched

- `.github/workflows/test.yml:1788` and `:6355` carry the same
  "35 deftests / 160 assertions" figure, in historical narrative about rf2-ftmh0.
  The deftest count still holds; the assertion count is now 157. Left for the
  worker who owns that file.
- `implementation/adapters/README.md:37` says "3 of the 6 shipped adapter kinds"
  and counts test-react as one of the six. Spec 006's canonical inventory has
  **hicasso** as the sixth and says test-react has "no `:kind` in the shipped
  set". The wording mirrors
  `implementation/core/src/re_frame/substrate/adapter.cljc:643-647` almost
  verbatim, so the two must move together; `implementation/core` is held
  elsewhere. Filed separately, untouched here.
