### PR TITLE
build(bench): drop the unreached spec roots from the Hicasso bench classpath (rf2-6r9j.82)

### DIFF
--- a/bench/hicasso/shadow-cljs.edn
+++ b/bench/hicasso/shadow-cljs.edn
@@ -16,6 +16,20 @@
 ;; `hicasso/test` for the witness applications under
 ;; `re-frame.hicasso.examples.*` that the slice and ledger clocks drive.
 ;;
+;; The COMPILE is what derives them, and there is no roster test to keep in
+;; step: `npm run check`'s first arm walks `src/` and compiles every namespace
+;; under it warnings-fatal from a cleared cache, so a root the closure does
+;; not reach cannot change the build, and one it does reach reds the gate by
+;; name. MEASURED both ways when rf2-6r9j.82 dropped `spec-resource/src` and
+;; `spec` from this list: dropping `hicasso/src` instead fails with
+;; `re-frame.hicasso is not available`, while dropping those two left the same
+;; 155 namespaces compiling warnings-free to the same 931 output files. The
+;; comparison is that file SET and not its bytes: two compiles of one
+;; unchanged tree do not agree byte for byte. Neither root had ever been
+;; reached — `re-frame.build.spec-resource` inlines committed `spec/` data at
+;; macro-expansion time and the lane inlines none, its only `spec/` mentions
+;; being prose in comments.
+;;
 ;; No `node_modules` of its own. `package.json` beside this file declares the
 ;; shadow-cljs pin so the CLI does not warn; the CLI is spawned from the
 ;; implementation install by `lane_build.cjs`, and `:node-modules-dir` points
@@ -34,9 +48,7 @@
                 "../../implementation/resources/test"
                 "../../implementation/routing/src"
                 "../../implementation/schemas/src"
-                "../../implementation/ssr/src"
-                "../../implementation/spec-resource/src"
-                "../../spec"]
+                "../../implementation/ssr/src"]
 
  :dependencies [[reagent            "2.0.1"]
                 [metosin/malli      "0.20.1"]


### PR DESCRIPTION
## What

`bench/hicasso/shadow-cljs.edn` listed `../../implementation/spec-resource/src` and `../../spec` among its `:source-paths`, directly under a header promising that every root below it is one the lane's require closure reaches. Neither was. Both are dropped, and the header now records how the remaining roots are derived and what proves it.

Closes rf2-6r9j.82.

## Why neither root was reached

`re-frame.build.spec-resource` exists to read a committed `spec/` data file at macro-expansion time, so a build that inlines the value still depends on the bytes. The bench inlines none.

A fixed-string census across `bench/hicasso/src` and all fifteen implementation roots this file lists returns **0** for `spec-resource`, `spec_resource`, `shadow.resource`, `slurp-resource` and `build.spec`. The census is not vacuous: the same sweep returns 12 for `re-frame.bench.calibration`, 312 for `re-frame.hicasso.examples` and 345 for `re-frame.test-support`.

The `io/resource` and `clojure.java.io` hits in that sweep are all in `implementation/core/test/**/*.clj` — JVM-only namespaces resolving `re_frame/*` classpath paths, never `spec/`. The one that does read the spec corpus, `re-frame.conformance-fixtures`, locates it with `io/file "../../spec/conformance/fixtures"` — the filesystem, not the classpath — so it is unaffected by this list either way, and it is not a lane entry.

The only `spec/` strings anywhere under `bench/hicasso/` are prose in three comments (`ambient_refusal_cljs_test.cljs:316,318`, `front/state.cljc:40`). The sole live `spec-resource` consumer, `re-frame.api-manifest.cljs-publics`, lives under `implementation/scripts/api-manifest/probe/src`, which is not on this path.

## Verification

`npm run check`'s first arm walks `src/` and compiles every lane namespace warnings-fatal from a cleared cache, so it is the execution instrument.

| run | tree | result |
|---|---|---|
| baseline | unmodified | `npm run check` exit **0** — 155 namespaces, zero warnings |
| **control** | `implementation/hicasso/src` removed instead | `compile_gate.cjs` exit **1** — `The required namespace "re-frame.hicasso" is not available` |
| final | both spec roots removed | `npm run check` exit **0** — 155 namespaces, zero warnings |

The control is the point: the gate is demonstrably sensitive to removing a root the closure *does* reach, so its silence about these two is evidence rather than absence of evidence. The control file was restored and `git hash-object` re-checked against the committed blob (`a9b9ec75…`) before the real edit.

Compiled output before and after is the **same set of 931 files** (`diff` of the sorted file lists is empty), and no `spec_resource` artefact is emitted in either. Byte comparison is deliberately not the test — two `compile_gate.cjs` runs over one *unchanged* tree produce different fingerprints (`142798d0…` vs `6846ebbc…`), so byte-identity would have been a false instrument. The header comment says so, to stop the next reader reaching for it.

Source-path census: `"../../implementation/spec-resource/src"` 1 → 0, `"../../spec"]` 1 → 0, controls `"../../implementation/ssr/src"` 1 → 1 and `"../../implementation/hicasso/src"` 1 → 1; vector entries 17 → 15.

`git diff --check` exit 0.

## Notes

No structural test pinned the classpath roster, so per the bead's fourth criterion the header records why clean compilation is the sufficient proof rather than a new census test being added — the compile already walks the whole lane, and a roster test would be a second thing to keep in step with it.

The diff is one EDN config file and touches no Clojure source, so clj-kondo has nothing to inspect here; the compile gate is the live gate for this change. `bench/hicasso/README.md` carries no source-path roster, so nothing there needed updating.
