### PR TITLE
Vestige sweep: SSR test residue, host-scoped SSR definitions, flows test deps, spec-resource fallback

### DIFF
--- a/implementation/flows/deps.edn
+++ b/implementation/flows/deps.edn
@@ -17,11 +17,13 @@
 
  :aliases
  {:test {:extra-paths ["test"]
-         ;; The shared reset fixture reloads these optional artefacts when they
-         ;; are present. They remain test-only dependencies here.
+         ;; The shared reset fixture (`make-reset-runtime-fixture`) fires
+         ;; late-bound reset hooks and no-ops any row whose hook is
+         ;; unregistered — it never requires an optional artefact itself, so
+         ;; classpath presence alone registers nothing. An artefact belongs
+         ;; here only when a test namespace requires it: `re-frame.schemas`
+         ;; is required by four of them, and test-quiet is the runner.
          :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
-                       day8/re-frame2-routing    {:local/root "../routing"}
-                       day8/re-frame2-ssr        {:local/root "../ssr"}
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
          ;; Keep the contention suite out of the default gate; `:slow-test`
          ;; selects it for nightly and rigorous-local runs.
@@ -31,8 +33,6 @@
   :slow-test
   {:extra-paths ["test"]
    :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
-                 day8/re-frame2-routing    {:local/root "../routing"}
-                 day8/re-frame2-ssr        {:local/root "../ssr"}
                  day8/re-frame2-test-quiet {:local/root "../test-quiet"}}
    :main-opts   ["-m" "re-frame.test-quiet.runner" "-i" ":slow" "-i" ":stress"]}
 

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -111,7 +111,6 @@
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.subs :as subs]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))

--- a/implementation/spec-resource/src/re_frame/build/spec_resource.clj
+++ b/implementation/spec-resource/src/re_frame/build/spec_resource.clj
@@ -20,11 +20,10 @@
   committed spec-side data file a build inlines is resolvable — so a
   consumer names its file relative to that root.
 
-  The JVM lanes need no such edge (`clojure -M:test` and the manifest
-  generator have no persistent analyzer cache, so every run re-reads the
-  file) and do not carry that root on their classpath, so outside a
-  ClojureScript compile the same file is located by walking up from the
-  compile CWD instead.
+  Every consumer is a ClojureScript macro, so that recorded edge is the
+  only lane this reader has: [[slurp-resource]] requires a ClojureScript
+  macro-expansion `&env` and rejects anything else rather than reaching
+  the tree by a second, unrecorded route.
 
   ## Why the reader is resolved, and why resolving it is subtle
 
@@ -48,14 +47,7 @@
   namespace has finished loading. A per-consumer `delay` does NOT fix
   this: it makes one consumer single-flight with ITSELF and leaves two
   consumers free to race each other. That is why this reader is shared
-  rather than copied, and why every consumer calls it."
-  (:require [clojure.java.io :as io]))
-
-(def ^:private classpath-root
-  "The repository directory that is the classpath root for these reads —
-  the shadow-cljs `:source-path` the ClojureScript lane resolves resource
-  paths against, and what the other lanes walk up the tree looking for."
-  "spec")
+  rather than copied, and why every consumer calls it.")
 
 (defn resolve-after-require
   "Resolve the Var named by the qualified symbol `sym`, entering
@@ -83,38 +75,25 @@
   "shadow-cljs's recording classpath reader, resolved once and cached.
 
   Cached because the resolution is the expensive, order-sensitive part;
-  forced lazily because the JVM lanes never take this branch and
-  shadow-cljs is not on their classpath."
+  forced lazily so the namespace stays loadable without shadow-cljs —
+  its own JVM test suite loads it on a classpath that has none."
   (delay (resolve-after-require 'shadow.resource/slurp-resource)))
-
-(defn- spec-file
-  "Locate the committed file at `path` by walking up from the compile CWD
-  looking for the [[classpath-root]] directory — the locator for lanes
-  where that root is not on the classpath. Throws an actionable error
-  rather than yielding an absent value."
-  [path]
-  (loop [dir (io/file (System/getProperty "user.dir"))]
-    (when (nil? dir)
-      (throw (ex-info (str "Build-time resource reader: " classpath-root "/" path
-                           " not found walking up from "
-                           (System/getProperty "user.dir") ".")
-                      {:path path :root classpath-root})))
-    (let [candidate (io/file dir classpath-root path)]
-      (if (.exists candidate)
-        candidate
-        (recur (.getParentFile dir))))))
 
 (defn slurp-resource
   "Return the text of the committed `spec/` data file at `path` (relative
   to that root, e.g. `conformance/fixtures/after-hierarchy.edn`),
-  read in the macro-expansion environment `env`.
+  read in the ClojureScript macro-expansion environment `env`.
 
-  Under a ClojureScript compile — `&env` carries the compiling `:ns` —
-  the read goes through shadow-cljs, which registers `path` as a build
-  dependency of that namespace: the edge that makes a data-only edit
-  invalidate the cached consumer. Anywhere else there is no cache to
-  invalidate and the file is read from the tree directly."
+  `env` MUST be a ClojureScript macro `&env` — it carries the compiling
+  `:ns`. The read then goes through shadow-cljs, which registers `path`
+  as a build dependency of that namespace: the edge that makes a
+  data-only edit invalidate the cached consumer, and the whole reason
+  this reader exists. Any other `env` is a caller error and says so."
   [env path]
-  (if (:ns env)
-    (@recording-slurp env path)
-    (slurp (spec-file path))))
+  (when-not (:ns env)
+    (throw (ex-info (str "Build-time resource reader: " path " must be read from a "
+                         "ClojureScript macro-expansion environment (an `&env` "
+                         "carrying :ns). Reading it any other way would inline the "
+                         "bytes with no build dependency recorded against them.")
+                    {:path path})))
+  (@recording-slurp env path))

--- a/implementation/ssr/src/re_frame/ssr/head/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/emit.cljc
@@ -17,8 +17,11 @@
   `render-head`, `active-head`, `default-head`, the per-frame snapshot
   bookkeeping, and the late-bind hook registrations — live in the
   `re-frame.ssr.head` façade."
-  (:require [clojure.string :as str]
-            [re-frame.error :as error]
+  ;; `clojure.string` and `re-frame.error` are JVM-only: every use is
+  ;; inside `ld-json-string`'s `:clj` arm (the hand-rolled JSON emitter and
+  ;; its two fail-fast gates). CLJS goes through `js/JSON.stringify`.
+  (:require #?@(:clj [[clojure.string :as str]
+                      [re-frame.error :as error]])
             [re-frame.ssr.html-helpers :as html]))
 
 ;; Reflection warnings guard the hand-rolled JVM JSON emitter.

--- a/implementation/ssr/src/re_frame/ssr/suspense.cljc
+++ b/implementation/ssr/src/re_frame/ssr/suspense.cljc
@@ -189,17 +189,20 @@
 
 ;; ---- the component ---------------------------------------------------------
 
-(defn- subtree
-  "The body as ONE hiccup form. Mirrors the walker's continuation-subtree
-  construction (`re-frame.ssr.streaming/walk-suspense-boundary`): a lone
-  child renders as itself, several are wrapped in a `:<>` fragment. The
-  fragment emits no DOM, so the client's rendered structure matches the
-  server's resolved-subtree html exactly."
-  [body]
-  (case (count body)
-    0 nil
-    1 (first body)
-    (into [:<>] body)))
+#?(:cljs
+   ;; Client-only: the `:clj` arm of `boundary` expands to the wire marker
+   ;; and never assembles the body itself.
+   (defn- subtree
+     "The body as ONE hiccup form. Mirrors the walker's continuation-subtree
+     construction (`re-frame.ssr.streaming/walk-suspense-boundary`): a lone
+     child renders as itself, several are wrapped in a `:<>` fragment. The
+     fragment emits no DOM, so the client's rendered structure matches the
+     server's resolved-subtree html exactly."
+     [body]
+     (case (count body)
+       0 nil
+       1 (first body)
+       (into [:<>] body))))
 
 (defn boundary
   "Declare a streaming suspense boundary around `body`.

--- a/implementation/ssr/test/re_frame/ssr/failed_root_isolation_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/failed_root_isolation_cljs_test.cljc
@@ -60,7 +60,9 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.error-emit :as error-emit]
-            [re-frame.interop :as interop]
+            ;; JVM-only: the sole executable read is the `#?(:clj …)`
+            ;; `with-redefs [interop/debug-enabled? false]` arm below.
+            #?(:clj [re-frame.interop :as interop])
             [re-frame.ssr :as ssr]
             [re-frame.ssr.boot :as boot]
             [re-frame.ssr.install :as install]

--- a/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
@@ -114,10 +114,6 @@
   (str (ssr/streaming-failed-template id fallback-html)
        (ssr/streaming-hydrate-delta-script id (pr-str delta))))
 
-(defn- final-payload-html []
-  (str "<script id=\"" constants/payload-script-id
-       "\" type=\"application/edn\">{:rf/version 1 :rf/app-db {} :rf/render-hash \"00000000\"}</script>"))
-
 ;; ---- DOM scaffolding -------------------------------------------------------
 
 (defn- make-root!

--- a/implementation/ssr/test/re_frame/ssr/streaming_component_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/streaming_component_cljs_test.cljc
@@ -41,15 +41,20 @@
     {:adapter #?(:clj ssr/adapter :cljs reagent-slim-adapter/adapter)
      :ambient-frame nil}))
 
-(defn- card-skeleton [id]
-  [:div.card.skeleton [:h3 (str "Loading " (name id))]])
+;; Server-side fixture components. JVM-only: every reference is inside a
+;; `#?(:clj …)` deftest below — the client half builds its own trees.
+#?(:clj
+   (defn- card-skeleton [id]
+     [:div.card.skeleton [:h3 (str "Loading " (name id))]]))
 
-(defn- card-view [id]
-  (let [c @(rf/subscribe [:card/by-id id])]
-    [:div.card [:h3 (:title c)] [:p.value (str (:value c))]]))
+#?(:clj
+   (defn- card-view [id]
+     (let [c @(rf/subscribe [:card/by-id id])]
+       [:div.card [:h3 (:title c)] [:p.value (str (:value c))]])))
 
-(defn- throwing-card []
-  (throw (ex-info "flaky third-party metric service" {})))
+#?(:clj
+   (defn- throwing-card []
+     (throw (ex-info "flaky third-party metric service" {}))))
 
 ;; ---- host-neutral contract -------------------------------------------------
 

--- a/implementation/ssr/test/re_frame/ssr/streaming_hydration_lifecycle_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_hydration_lifecycle_dom_cljs_test.cljs
@@ -54,7 +54,6 @@
             ["react-dom/client" :as react-dom-client]
             [reagent2.core :as r2]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
             [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.suspense :as suspense :refer [boundary]]
@@ -168,9 +167,6 @@
 ;; attributes rather than on anything the feature does. Emitting the
 ;; fixture makes the test a genuine cross-host parity check: same hiccup,
 ;; server render vs client render, reconciled by React.
-
-(def ^:private app-db-seed
-  {:cards {:revenue {:title "Revenue" :value 42375}}})
 
 (defn- server-render!
   "Run the REAL server pipeline over `[dashboard]` under a server frame:

--- a/implementation/ssr/test/re_frame/ssr_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_conformance_test.clj
@@ -152,7 +152,6 @@
             [re-frame.ssr.head :as ssr-head]
             [re-frame.ssr.test-fixture :as tf]
             [re-frame.subs :as subs]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.trace :as trace]))
 
 ;; The shared reset fixture is `:each` — every fixture in the corpus

--- a/implementation/ssr/test/re_frame/ssr_render_state_jvm_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_render_state_jvm_test.clj
@@ -17,7 +17,7 @@
     `:rf.error/ssr-render-state-invalid`, and the same key with an in-domain
     value is the control."
   (:require [clojure.string :as str]
-            [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.test :refer [deftest is use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.ssr.render-state :as render-state]

--- a/implementation/ssr/test/re_frame/ssr_route_slice_projection_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_route_slice_projection_test.clj
@@ -34,7 +34,6 @@
   uses a NON-sensitive sample route, so the leak was invisible there — this is
   the sensitive-route regression that gap called for (rf2-ugoxyv)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
-            [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.frame :as frame]
             ;; Loading routing publishes the route classification machinery

--- a/implementation/ssr/test/re_frame/ssr_streaming_hydration_egress_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_hydration_egress_test.clj
@@ -18,7 +18,6 @@
   rf2-bt9kct) through the actual `build-final-payload` path."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
             [re-frame.privacy :as privacy]
             [re-frame.ssr.streaming :as streaming]
             [re-frame.ssr.test-fixture :as tf]))


### PR DESCRIPTION
Four audit children from rf2-6r9j, all mechanical.

## rf2-6r9j.68 — two uncalled helpers, five redundant requires (SSR tests)

`final-payload-html` (streaming client DOM test) and `app-db-seed`
(streaming hydration lifecycle DOM test) had no caller anywhere in the
repository. Removed with the five requires/refers that had no symbol read
and no unique namespace-load role — `re-frame.frame` twice,
`re-frame.substrate.adapter`, `re-frame.core`, and a `clojure.test/testing`
refer. `re-frame.core` already loads `re-frame.frame` and
`re-frame.substrate.adapter`; `re-frame.ssr.test-fixture` already loads the
core facade.

Left alone deliberately: `constants/payload-script-id` (two live
assertions), and the alias-unused `re-frame.ssr.head` / `re-frame.ssr`
requires, which publish registrations consumed through `resolve`/teardown.

## rf2-6r9j.69 — seven definitions reader-conditioned to their live host

| definition | host | why |
|---|---|---|
| `suspense/subtree` | `:cljs` | only call is inside `boundary`'s `:cljs` arm; the `:clj` arm expands to the wire marker |
| `head/emit` `clojure.string` | `:clj` | every `str/` use is inside `ld-json-string`'s `:clj` arm |
| `head/emit` `re-frame.error` | `:clj` | every `error/` use is inside the same arm; CLJS goes through `JSON.stringify` |
| isolation test `re-frame.interop` | `:clj` | sole executable read is the JVM-only `with-redefs` arm |
| `card-skeleton` | `:clj` | every reference is inside a `#?(:clj …)` deftest |
| `card-view` | `:clj` | as above |
| `throwing-card` | `:clj` | as above |

No live host implementation is deleted or rewritten. JVM JSON-LD error
paths, CLJS boundary body/fallback behaviour and the server-side
streaming fixture markup are byte-identical.

## rf2-6r9j.67 — flows test deps

No flows source or test namespace requires `re-frame.routing` or
`re-frame.ssr`; the coordinates occurred only in the four `:test` /
`:slow-test` alias entries. The shared reset fixture fires late-bound
hooks and no-ops any row whose hook is unregistered — it never loads an
optional artefact itself, so classpath presence registered nothing. The
comment claiming otherwise is corrected. The unused
`re-frame.substrate.adapter` require goes; the `plain-atom` adapter beside
it is the fixture dependency actually used and stays.

`clojure -Spath` on both aliases now resolves `core`, `schemas` and
`test-quiet` only.

## rf2-6r9j.80 — post-Freehand fallback in spec-resource

Every remaining `slurp-resource` call site is a ClojureScript macro
expansion: the sole tracked caller is `api_manifest/cljs_publics`'
`read-sidecar`, reached only from `emit-cljs-only-rows` and
`emit-classification-rows`, both consumed from `.cljs` namespaces whose
`&env` carries `:ns`. The last no-`:ns` caller was a Freehand test,
deleted with that retirement. The non-ClojureScript branch — and the
`clojure.java.io` require, `classpath-root` and `spec-file` that existed
only to serve it — was an unreachable filesystem walk that could bind to
the wrong ancestor `spec/` tree if reused. `slurp-resource` now requires
the macro-expansion environment and says so when it does not get one.
`resolve-after-require`, `recording-slurp` and the cold-load race test are
untouched.

Two of that bead's five acceptance criteria are **not** met here because
they fall outside this branch's surface, and the bead is left open for
them:

* `implementation/deps.edn:132` still carries `day8/re-frame2-spec-resource`
  on the root `:test` alias (hot-zone, one-toucher).
* `.github/workflows/test.yml:2560-2564` still describes the reader as
  "shared by the Freehand fixture loader and the api-manifest CLJS probe",
  and `implementation/scripts/api-manifest/probe/.../cljs_publics.clj:100-102`
  still describes the removed non-ClojureScript path. Both are comments;
  no gate reads them.

## Verification

Every helper/import removal was censused with two independent instruments
plus a control that fired: a fixed-string `git grep -F` over tracked files
(`payload-script-id` → 3 hits and `failed-chunk-html` → 5 hits in the same
file, versus `final-payload-html` → 1 and `app-db-seed` → 1, both
definition-only) and clj-kondo var-usage. The thirteen targeted clj-kondo
findings are gone; the unrelated intentional ones in the same files
(`re-frame.ssr.head`, `re-frame.ssr`, `malli.transform`, the redundant-let
and unused-binding rows) are untouched.

Gate liveness was proved by planting a wrong-host reference on each host
and confirming both go red:

* `#?(:clj (def wrong-host-probe (subtree …)))` → SSR JVM suite exit 1,
  `Unable to resolve symbol: subtree`.
* `#?(:cljs (def wrong-host-probe (card-view …)))` → node-test compile
  exit 1, `Use of undeclared Var … card-view`.

Both plants were reverted and the restored files verified byte-identical
by `git hash-object` against the committed blobs.

Green, foreground, exit codes captured to file:

| gate | result |
|---|---|
| `implementation/ssr` `clojure -M:test` | 623 tests / 3172 assertions, 0 failures, exit 0 |
| `implementation/flows` `clojure -M:test` | 250 tests / 6102 assertions, 0 failures, exit 0 |
| `implementation/flows` `clojure -M:slow-test` | 1 test / 60 assertions, 0 failures, exit 0 |
| `implementation/spec-resource` `clojure -M:test` | 3 tests / 126 assertions, 0 failures, exit 0 |
| `implementation` `npm run test:cljs` | 11170 tests / 55749 assertions, 0 failures, exit 0 |
| clj-kondo over ssr + flows + spec-resource | 0 errors; targeted findings gone |

Browser DOM lanes are left to CI. Prose, tables and anchors in the edited
comments were checked by hand — no doc gate covers a `deps.edn` comment or
a Clojure docstring.