### PR TITLE
refactor: remove four resources/SSR vestiges (rf2-6r9j.62/.56/.54/.65)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -63,7 +63,6 @@
   next successful transition, retaining a bounded per-key tail for Xray."
   (:require [clojure.set :as set]
             [re-frame.error :as error]
-            [re-frame.frame :as frame]
             [re-frame.reply :as reply]
             [re-frame.resources.classification :as classification]
             [re-frame.resources.registry :as registry]
@@ -2384,27 +2383,6 @@
 ;; differs only by the inline durable-layer fallback key (`:data` here for a
 ;; resource entry, `:result` for a mutation instance — rf2-366u0g).
 
-(def ^:private http-aborted-kind
-  "The managed-HTTP failure `:kind` for an intentional abort/cancellation
-  (Spec 014 §Aborts — the transport classifies a `:rf.http/managed-abort`,
-  an actor-destroy cancellation, or a timeout teardown to this kind). A
-  failure envelope carrying this kind is a CANCELLATION, not a user-visible
-  resource error (rf2-z70ujl). Note a `:request-id-superseded` abort never
-  even dispatches a reply — so a superseded supersession is handled by the
-  missing reply + stale-suppression, not here (Spec 014 §Abort precedence —
-  enforced by the transport, relied on here)."
-  :rf.http/aborted)
-
-(defn- abort-failure?
-  "True iff `error` is a managed-HTTP ABORT failure envelope
-  (`{:kind :rf.http/aborted …}`) — an intentional cancellation that must NOT
-  become a user-visible resource `:error` / `:refresh-error` or a failed
-  ledger row (rf2-z70ujl, Spec 016 §Cancellation is opportunistic). Every
-  other `:rf.http/*` category (transport / 5xx / 4xx / timeout-as-failure /
-  decode / accept) is a genuine failure and flows the ordinary failed path."
-  [error]
-  (= http-aborted-kind (:kind error)))
-
 (defn succeeded-handler
   "`:rf.resource.internal/succeeded` — a transport read succeeded. Re-lifts
   the transport's PUBLIC reply into the canonical reply map
@@ -2652,8 +2630,10 @@
         ;; the ONE canonical reply map (Managed-Effects §The uniform reply
         ;; envelope) — `:status :error` (or `:cancelled` for an abort), now
         ;; carrying `:completed-at` (rf2-rl27r2). The internal reply target
-        ;; receives it directly. `abort-failure?` is the family's classifier;
-        ;; the canonical reply's `:status` then drives the branch.
+        ;; receives it directly. The abort classification is `rreply/failure-
+        ;; reply`'s (`re-frame.resources.reply/abort-failure?` — the family's
+        ;; ONE classifier); the canonical reply's `:status` then drives the
+        ;; branch below.
         reply      (rreply/failure-reply payload error
                                          {:work-kind rreply/work-kind-resource
                                           :completed-at completed-at})

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -59,7 +59,6 @@
   follow `:on-conflict` (`:invalidate` by default, or explicit `:force`) and may
   refetch authoritative data."
   (:require [clojure.set :as set]
-            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.reply :as reply]
             [re-frame.resources.classification :as rclass]
@@ -752,7 +751,7 @@
     (let [descriptors (mstate/normalize-invalidation-descriptors
                         (invalidates-fn params result) where)]
       (reduce
-        (fn [plan {:keys [tags cross-scope? refetch-populated?] :as descriptor}]
+        (fn [plan {:keys [tags refetch-populated?] :as descriptor}]
           (if-not (seq tags)
             plan
             (let [[outcome scope-or-id] (resolve-descriptor-scope
@@ -1708,7 +1707,6 @@
             ;; `:rf.resource/remove`). Applied BEFORE the invalidation match so
             ;; a removed key is never ALSO reported stale (it is gone).
             [rdb3 removed-ks removed-work remove-nil-ids remove-skipped] (apply-removes rdb2 (:removes spec) params result scope app-db where)
-            patch-affected      (set/union patched-ks populated-ks)
             timer-policies      (merge patch-policies populate-policies)
             target-nil-ids      (-> (vec patch-nil-ids) (into populate-nil-ids) (into remove-nil-ids))
             ;; rf2-1vpbld — the RECOVERABLE post-write targets the relaxed

--- a/implementation/resources/src/re_frame/resources/mutation_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_registry.cljc
@@ -23,7 +23,6 @@
             [re-frame.resources.mutation-runtime :as mstate]
             [re-frame.resources.params :as params]
             [re-frame.resources.scope-registry :as scope-registry]
-            [re-frame.resources.state :as state]
             [re-frame.source-coords :as source-coords]))
 
 #?(:clj (set! *warn-on-reflection* true))

--- a/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
@@ -820,8 +820,8 @@
   caller's alternate spelling). Throws `:rf.error/mutation-invalid-target`
   otherwise."
   [target resolved-scope registered-resource? where arm]
-  (let [[disposition a b] (classify-target-key target resolved-scope
-                                               registered-resource? where arm)]
+  (let [[disposition a] (classify-target-key target resolved-scope
+                                             registered-resource? where arm)]
     (case disposition
       :apply a
       ;; STRICT policy: a recoverable :skip ALSO throws (the corruption-class

--- a/implementation/resources/src/re_frame/resources/scope_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/scope_registry.cljc
@@ -456,20 +456,6 @@
       (assoc acc input-name (path/get db rf-path)))
     {} (or inputs {})))
 
-(defn input-db-paths
-  "Return the vector of CONCRETE app-db paths a resolver's declared `:inputs`
-  read off the frame app-db — the `<rf-path>` of each `[:db <rf-path>]` source
-  (the only shipped source). The whole-db fn sugar's synthetic `[:db []]`
-  returns `[[]]` (the root path). EP-0025 (rf2-71dr8t) removed the derived-
-  sensitivity propagation pass that read this dependency graph; the accessor
-  remains for tooling that surfaces a resolver's declared db reads (the
-  whole-db cost on the narrow-re-resolution axis). Pure; nil/empty `:inputs` →
-  `[]`. Per Spec 016 §The `:inputs` grammar."
-  [inputs]
-  (into []
-        (keep (fn [[_input-name [_source rf-path]]] rf-path))
-        (or inputs {})))
-
 ;; ---- off-box trace egress projection of scope-resolution rows (rf2-84l82t) -
 ;;
 ;; The `:rf.resource/scope-resolved` trace row carries the resolver's resolved

--- a/implementation/resources/src/re_frame/resources/subs.cljc
+++ b/implementation/resources/src/re_frame/resources/subs.cljc
@@ -48,8 +48,7 @@
   route/event that ensures under the new scope attaches the new owner, and
   route leave / `clear-scope` releases the old — the sub is a passive
   reader throughout (Spec 016 §Views stay passive)."
-  (:require [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
+  (:require [re-frame.interop :as interop]
             [re-frame.resources.registry :as registry]
             [re-frame.resources.state :as state]
             [re-frame.resources.work-ledger :as work-ledger]

--- a/implementation/resources/src/re_frame/resources/tooling.cljc
+++ b/implementation/resources/src/re_frame/resources/tooling.cljc
@@ -581,19 +581,26 @@
       {}
       (or entries {}))))
 
-;; ---- bundle-isolation sentinel ------------------------------------------
+;; ---- bundle isolation ---------------------------------------------------
 ;;
-;; `implementation/scripts/check-bundle-isolation.cjs` greps the counter bundle
-;; for this exact string. The string lives ONLY in
-;; this file's source body — no other namespace, no docstring, no test
-;; fixture references it — so its presence in the production counter bundle
-;; proves the tooling sibling's body got pulled in (most likely via a stray
-;; `:require` from a production-reachable ns). The whole resources artefact is
-;; already bundle-isolated from counter (counter never `:require`s
-;; `re-frame.resources`); this sentinel independently catches a stray
-;; production-reachable require. The string survives `:advanced` because
-;; string literals are not renamed; it sits outside any gate so DCE cannot
-;; drop the literal independently of the surrounding ns body.
-
-(defonce ^:private bundle-isolation-sentinel
-  "rf.resources.tooling/sentinel:rf2-gn9juw-2026-06-12:do-not-rename")
+;; `implementation/scripts/check-bundle-isolation.cjs` proves this tooling
+;; sibling never reaches the production counter bundle. The literal it greps
+;; the EMITTED module for is `resource-process` — the value of
+;; `resource-refined-kind` above, which every algebra node this namespace
+;; builds carries on `:refinement`, so a CLJS keyword's fully-qualified name
+;; is interned into the emitted JS as a string constant Closure does not
+;; rename.
+;;
+;; A `defonce ^:private bundle-isolation-sentinel` string used to sit here
+;; (rf2-gn9juw). It was inert: private, unconsumed, and therefore dropped by
+;; Closure `:advanced`, so the `do-not-rename` instruction it carried guarded
+;; nothing. `4e43784ec7` (2026-07-15) moved this roster entry onto the live
+;; node kind when these controls became emitted-module greps rather than
+;; source greps; the var was simply left behind, and rf2-6r9j.54 removed it.
+;; `re-frame.derivation.egress` records the identical trap and repair
+;; (rf2-yk2d).
+;;
+;; The rule, and the reason a planted string is the WRONG instinct here: pick
+;; a literal a LIVE code path emits, and verify the count in the emitted
+;; module, never in the `.cljc`. The roster comment in check-bundle-
+;; isolation.cjs beside the `resources-tooling` entry is the full account.

--- a/implementation/resources/test/re_frame/resources_scope_registry_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_scope_registry_cljs_test.cljc
@@ -256,19 +256,6 @@
                                          (assoc session-meta :rf.egress/output-sensitivity :rf.egress/publik)
                                          session-resolve)))))
 
-(deftest input-db-paths-extracts-the-dependency-graph
-  (testing "input-db-paths returns the concrete :db paths a resolver reads"
-    (is (= [[:auth :user :username]]
-           (scope/input-db-paths {:username [:db [:auth :user :username]]})))
-    (is (= #{[:auth :user :username] [:i18n :locale]}
-           (set (scope/input-db-paths {:username [:db [:auth :user :username]]
-                                       :locale   [:db [:i18n :locale]]})))))
-  (testing "nil / empty inputs → [] (no dependency)"
-    (is (= [] (scope/input-db-paths nil)))
-    (is (= [] (scope/input-db-paths {}))))
-  (testing "the whole-db sugar's synthetic [:db []] is the root path [[]]"
-    (is (= [[]] (scope/input-db-paths {:db [:db []]})))))
-
 ;; ===========================================================================
 ;; 8. The canonical 3-slot registration grammar (rf2-bqstzr)
 ;; ===========================================================================

--- a/implementation/ssr/src/re_frame/ssr/manifest.cljc
+++ b/implementation/ssr/src/re_frame/ssr/manifest.cljc
@@ -20,8 +20,13 @@
   stays `1` across both shapes (additive keys never bump the integer,
   004C §2 rule 3), so there is no migration step, no negotiation
   handshake, and no second schema to keep in sync. `problems` below is
-  the executable statement of the property; the subset-property test
-  pins it.
+  the executable statement of the property, and it is checked over
+  HAND-BUILT manifests only. `re-frame.ui` was retired (rf2-0yp7w) and no
+  remaining substrate emits a Root Descriptor, so the compiler-backed
+  subset-property suite that once fed real descriptor output to the
+  validator has no producer left; it was deleted rather than re-expressed
+  over a transcribed fixture, and `re-frame.ssr.root-manifest-cljs-test`
+  records that gap.
 
   Readers ignore unknown keys (004C §2 rule 2). `problems` therefore
   validates only the keys it KNOWS, and only for SHAPE — it never
@@ -82,7 +87,7 @@
                :cljs [cljs.reader :as reader])))
 
 ;; ---------------------------------------------------------------------------
-;; The key sets (004C §2)
+;; The schema version, the dev-only key set, and the wire type (004C §2)
 ;; ---------------------------------------------------------------------------
 
 (def ^:const schema-version
@@ -90,30 +95,6 @@
   descriptor and the manifest extending it declare the SAME value —
   additive keys never bump it (004C §2 rule 3)."
   1)
-
-(def descriptor-keys
-  "Root Descriptor v1 — the compile-time static key set a view compiler's
-  root descriptor emits (004C §2). Listed here
-  as DATA so the subset property is checkable rather than asserted."
-  #{:rf.root/schema-version
-    :root-id
-    :root-id-provenance
-    :view-id
-    :props-shape
-    :static-props
-    :frame-plans
-    :template-fingerprint})
-
-(def extension-keys
-  "The six render-time keys Root Manifest v1 ADDS to the descriptor
-  (004C §2). Every one is OPTIONAL — that optionality IS the subset
-  property."
-  #{:element-locator
-    :props
-    :frame-payload-ids
-    :render-fingerprint
-    :identifier-prefix
-    :phase})
 
 (def dev-only-keys
   "Descriptor keys that are dev-only and MUST NOT ride a shipped
@@ -152,7 +133,9 @@
   and is shape-checked ONLY when present. Unknown keys are ignored
   (004C §2 rule 2). An unmodified S1 Root Descriptor therefore validates
   unchanged — making any extension key mandatory here would break that,
-  which is exactly what the subset-property test watches."
+  which is exactly what this namespace's validation tests watch — over
+  hand-built manifests, there being no live descriptor producer left to
+  check it against (see the ns docstring)."
   [m]
   (cond
     (not (map? m))

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -471,8 +471,11 @@ required key is `:rf.root/schema-version`, whose value is `1` for both shapes. A
 unmodified S1 root descriptor is therefore **already a valid Root Manifest v1** — no
 edit, no upgrade step, no migration. Making any extension key mandatory would silently
 convert this superset into a second schema, which is exactly the failure the reference
-implementation's subset-property suite pins against the real compiler's descriptor
-output.
+implementation's Root Manifest suite watches. It watches over **hand-built** manifests:
+the substrate that emitted a real Root Descriptor is retired, so the compiler-backed
+subset-property suite that once fed real descriptor output to the validator has no
+producer left and was deleted rather than re-expressed over a transcribed fixture,
+which would have asserted the transcription and not the compiler.
 
 There is deliberately **no version-negotiation protocol and no migration mechanism**.
 v1 is the first version, not a compatibility layer: additive keys never bump


### PR DESCRIPTION
Four audit children from rf2-6r9j, each a vestige with no reader.

## rf2-6r9j.62 — eight dead imports, bindings and a duplicate classifier

`implementation/resources/src` carried nine clj-kondo diagnostics that were pure residue: `re-frame.frame` required and unused in `events.cljc` / `mutation_events.cljc` / `subs.cljc`; `re-frame.resources.state` required and unused in `mutation_registry.cljc`; the `cross-scope?` destructure in `invalidation-plan`'s reducing fn (`resolve-descriptor-scope` takes the whole descriptor and owns that decision); the `patch-affected` binding, superseded by the `affected` union a few bindings later; the third tuple slot `b` in `target-key`'s strict wrapper, which reconstructs every message from `target`; and the private `abort-failure?` / `http-aborted-kind` pair — a byte-for-byte duplicate of the live classifier in `re-frame.resources.reply`, which is what `rreply/failure-reply` already routes through. The comment claiming otherwise now names the real classifier.

The `revalidate_listeners` `frame-id` warning is retained deliberately: that parameter is used by the CLJS arm.

## rf2-6r9j.56 — `input-db-paths`

Added for EP-0025's derived-sensitivity propagation pass; `710440d342` removed the pass and rewrote the docstring to claim the accessor "remains for tooling", without wiring any. The real static-tooling enrichment reads resolver metadata directly and emits `(vec (vals (:inputs rmeta)))`. The only other reference was a direct unit test of the accessor, so the pair tested nothing but its own existence. Removed both. Resolver `:inputs` storage, `eval-inputs` and the static algebra enrichment are untouched.

## rf2-6r9j.54 — the private bundle-isolation sentinel

`4e43784ec7` moved the `resources-tooling` checker entry onto `resource-process` — the live node-kind refinement — when those controls became emitted-module greps rather than source greps. The planted string was left behind, along with a comment asserting the checker greps for it. A private unconsumed var is dropped by Closure `:advanced`, so it guarded nothing. Deleted; the section comment now records what the checker actually greps and why a planted string is the wrong instinct, the same disposition `re-frame.derivation.egress` already carries for its identical residue (rf2-yk2d). The `resource-process` positive marker and the negative forbidden-symbol checks are untouched.

## rf2-6r9j.65 — the Root Descriptor key inventories

`re-frame.ssr.manifest/descriptor-keys` and `extension-keys` existed to make the Root Descriptor -> Root Manifest subset property mechanically checkable by the compiler-backed suite `b24c6ab015` introduced with them. `a3e5e17e73` removed the sole descriptor producer and the eleven descriptor-coupled tests but left both inventories and the prose claiming that suite still runs.

Both are unreachable and internal (`re-frame.ssr.manifest` is on the api-manifest generator's internal roster; Spec 011's artefact line names `problems` / `valid?` / `validate!` / `manifest` / `script-html` / `read-manifest` / `discover`). Neither is retirement bookkeeping — no dated retirement statement, no struck-through catalogue row — and neither is a reserved-value roster of the `:rf.adapter/ui` kind that tooling refuses defensively; they are duplicate key data the live validator already encodes itself. `dev-only-keys` stays: it has a live consumer on the emit path.

The three stale claims that a real-compiler subset-property suite still pins the invariant are corrected in the namespace docstring, the `problems` docstring and `spec/011-SSR.md`. The deliberate coverage gap stays recorded where `re-frame.ssr.root-manifest-cljs-test` already records it.

**No schema contraction:** `:rf.root/schema-version` is still the only required key, unknown keys are still ignored, every extension key is still optional and shape-checked only when present, and a descriptor-shaped map still validates.

## Verification

Every removal was proved with two independent instruments and a control that fires.

- **Census** — `git grep -F` (alias-anchored where an alias is involved) plus a separator/case-insensitive regex pass, over tracked files, excluding `.beads`. Controls: the same alias-anchored `frame/` matcher finds five other resources namespaces that do use it; `eval-inputs` returns its two production callers; `dev-only-keys` returns its emit-path consumer.
- **clj-kondo** — `implementation/resources/src` drops from 10 warnings to the 1 deliberately retained. A full run over `implementation` + `tools` reports no unresolved var for any removed name; the four analogous `bundle-isolation-sentinel` warnings in the other tooling siblings, each with its own bead, still report. Control: a planted `scope/input-db-paths` call was reported as `Unresolved var` before being reverted.

Gates, exit codes captured to file and read from the file:

| Gate | Exit | Result |
|---|---|---|
| `clj-kondo --lint implementation/resources/src` | 2 | 1 warning (the retained cross-platform `frame-id`) |
| `clj-kondo --lint implementation/ssr/src` | 2 | 12 warnings, none in `manifest.cljc`, all pre-existing |
| `implementation/resources` `clojure -M:test` | 0 | 829 tests, 7479 assertions, 0 failures, 0 errors |
| `implementation/ssr` `clojure -M:test` | 0 | 623 tests, 3172 assertions, 0 failures, 0 errors |
| `api-manifest.gen --check` | 0 | in sync, 528 public vars |
| `node --test scripts/check-bundle-isolation.test.cjs` | 0 | 23 artefacts, 40 sentinel-removal mutations, 40 leaks |
| `scripts/check_doc_slugs.py` | 0 | clean |

The `spec/011-SSR.md` change is prose inside an existing paragraph: no headings, links or anchors added or removed, and no table touched. The release-sized bundle-isolation gate and the CLJS suites are left to CI.
