### PR TITLE
The classification-op guard's durable negative, the api-manifest enrolment rule, and the tools-root reference sweep (rf2-7yth0, rf2-qvhx, rf2-6ka0)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -289,3 +289,53 @@
       (reset! rf.registrar/kind->id->metadata @pretest-registrar)
       (reset! rf.source-store/kind->id->ns->descriptor @pretest-source-store)
       (rf.image-assembly/clear-generation-cache!))))
+
+;; ---- rf2-7yth0 NEGATIVE self-test for the classification-op guard ---------
+;; Mirror of the JVM `classification-op-map-guard`. Saves / restores the
+;; registrar (like the corpus runner) so it doesn't leak into siblings.
+;;
+;; `realise-classification-effects!` refuses a `:fixture/classification-effects`
+;; op-map that does not carry EXACTLY ONE of the four commit-plane axes, and
+;; the FixtureFile schema in `spec/Spec-Schemas.md` states the same contract.
+;; Nothing in the corpus exercises the refusal: every live op is a valid
+;; single-axis map, so deleting the guard leaves the corpus green.
+
+(defn- classification-op-fixture [ops]
+  {:fixture/id           :rf.test/classification-op-guard
+   :fixture/spec-version "1.0"
+   :fixture/capabilities #{:core/event-handler}
+   :fixture/handlers     {:event {:dc/store [[:set [:secret] "s"]]}}
+   :fixture/frame-config {}
+   :fixture/classification-effects ops
+   :fixture/dispatches   [[:dc/store]]
+   :fixture/expect       {:final-app-db {:secret "s"}}})
+
+(def ^:private refused-classification-ops
+  [["an empty op-map"        [{}]]
+   ["a multi-axis op-map"    [{:sensitive [[:secret]] :large [[:secret]]}]]
+   ["an unknown-axis op-map" [{:rf.test/bogus [[:secret]]}]]
+   ["a known axis beside an unknown key"
+    [{:sensitive [[:secret]] :rf.test/bogus [[:secret]]}]]])
+
+(deftest classification-op-map-guard-cljs
+  (reset! pretest-registrar @rf.registrar/kind->id->metadata)
+  (reset! pretest-source-store @rf.source-store/kind->id->ns->descriptor)
+  (try
+    (doseq [[label ops] refused-classification-ops]
+      (let [result (rf.conformance-runner/run-fixture (classification-op-fixture ops) host)]
+        (is (not (:passed? result))
+            (str label " in :fixture/classification-effects MUST fail the fixture, not silently no-op"))
+        (is (some? (re-find #"unrecognised :fixture/classification-effects op-map"
+                            (str (:error result))))
+            (str label " must be refused BY THE CLASSIFICATION-OP GUARD, not by some later check"))))
+    ;; Control: the valid single-axis shape the whole live corpus uses still
+    ;; runs the fixture to a pass, so the guard is not refusing everything.
+    (let [result (rf.conformance-runner/run-fixture
+                   (classification-op-fixture [{:sensitive [[:secret]]}]) host)]
+      (is (:passed? result)
+          (str "a valid single-axis op-map must still run the fixture to a pass; got "
+               (pr-str (select-keys result [:error :final-db :expected-db])))))
+    (finally
+      (reset! rf.registrar/kind->id->metadata @pretest-registrar)
+      (reset! rf.source-store/kind->id->ns->descriptor @pretest-source-store)
+      (rf.image-assembly/clear-generation-cache!))))

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -386,3 +386,52 @@
     (is (:passed? (run {:call :derivation-graph :mode :static
                         :expect-graph {:mode :static}}))
         "the true static graph shape must pass")))
+
+;; ---- rf2-7yth0 NEGATIVE self-test for the classification-op guard ---------
+;;
+;; `realise-classification-effects!` refuses a `:fixture/classification-effects`
+;; op-map that does not carry EXACTLY ONE of the four commit-plane axes, and
+;; the FixtureFile schema in `spec/Spec-Schemas.md` states the same contract.
+;; Nothing in the corpus exercises the refusal: every live op is a valid
+;; single-axis map, so deleting the guard leaves the corpus green. Without it
+;; the runner's priority-ordered `cond` silently applies a multi-axis op's
+;; FIRST arm only, and applies nothing at all for an empty or unknown-key op
+;; -- a fixture author writing two axes gets one, with no error. This is the
+;; durable negative; the CLJS leaf carries the mirror.
+
+(defn- classification-op-fixture
+  "A minimal runnable fixture whose only variable is its
+  `:fixture/classification-effects` vector."
+  [ops]
+  {:fixture/id           :rf.test/classification-op-guard
+   :fixture/spec-version "1.0"
+   :fixture/capabilities #{:core/event-handler}
+   :fixture/handlers     {:event {:dc/store [[:set [:secret] "s"]]}}
+   :fixture/frame-config {}
+   :fixture/classification-effects ops
+   :fixture/dispatches   [[:dc/store]]
+   :fixture/expect       {:final-app-db {:secret "s"}}})
+
+(def ^:private refused-classification-ops
+  "The three shapes the closed four-way schema refuses, plus the mixed case."
+  [["an empty op-map"        [{}]]
+   ["a multi-axis op-map"    [{:sensitive [[:secret]] :large [[:secret]]}]]
+   ["an unknown-axis op-map" [{:rf.test/bogus [[:secret]]}]]
+   ["a known axis beside an unknown key"
+    [{:sensitive [[:secret]] :rf.test/bogus [[:secret]]}]]])
+
+(deftest classification-op-map-guard
+  (doseq [[label ops] refused-classification-ops]
+    (let [result (rf.conformance-runner/run-fixture (classification-op-fixture ops) host)]
+      (is (not (:passed? result))
+          (str label " in :fixture/classification-effects MUST fail the fixture, not silently no-op"))
+      (is (some? (re-find #"unrecognised :fixture/classification-effects op-map"
+                          (str (:error result))))
+          (str label " must be refused BY THE CLASSIFICATION-OP GUARD, not by some later check"))))
+  ;; Control: the valid single-axis shape the whole live corpus uses still runs
+  ;; the fixture to a pass, so the guard is not simply refusing everything.
+  (let [result (rf.conformance-runner/run-fixture
+                 (classification-op-fixture [{:sensitive [[:secret]]}]) host)]
+    (is (:passed? result)
+        (str "a valid single-axis op-map must still run the fixture to a pass; got "
+             (pr-str (select-keys result [:error :final-db :expected-db]))))))

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -243,6 +243,30 @@
 ;; separately requirable BECAUSE they are opt-in, so its door could not
 ;; re-export them. That distinction is the useful predictor for the remaining
 ;; trees, and it is what rf2-hjj4's verdict rests on.
+;;
+;; THAT PREDICTOR IS NOW THE RULE, and it REPLACED the schedule rather than
+;; pausing it (mayor ruling 2026-09-03, rf2-qvhx). Enrol a tree WHEN IT
+;; ACQUIRES A SECOND REQUIRABLE DOOR — never off a queue of trees ordered by
+;; size or by guessed blast radius, which is the axis routing and resources
+;; refuted. Nothing can hide behind a single re-exporting door, because the
+;; door is already rowed. `machines`, `http`, `schemas`, `flows`, `epoch` and
+;; `core` each publish ONE façade namespace already in `jvm-namespaces`, so
+;; the ~190 namespaces beneath them stay unenrolled on present evidence.
+;; Rubber-stamping them to reach a green is not coverage; it is effort spent
+;; producing the appearance of it, and a rubber-stamped classification is
+;; worse than none because it looks like a decision.
+;;
+;; THE ADAPTERS EXCEPTION WAS PRICED AND DECLINED. Adapters are requirable BY
+;; DEFINITION — an app requires the adapter it uses — so they wear the hicasso
+;; shape rather than the façade one, and the ruling named them as the one tree
+;; worth enrolling next, at three namespaces. THE COUNT IS FIFTEEN: four
+;; adapter doors (reagent, uix, test-react, reagent-slim) plus a VENDORED
+;; REAGENT FORK of eleven `reagent2.*` files under reagent-slim. Enrolling a
+;; root obliges a classification for EVERY namespace beneath it, so the real
+;; bill is eleven rubber-stamp entries for somebody else's library internals —
+;; the exact editorial cost this section refuses. Before revisiting it, the
+;; question to answer is what to do about the vendored tree, not whether three
+;; doors are worth enrolling.
 ;; ---------------------------------------------------------------------------
 
 (def roster-covered-roots

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -4587,6 +4587,15 @@ The host-agnostic conformance fixture format. Per [conformance/README.md](confor
    ;; with no error. Each arm is `{:closed true}`, which is what refuses
    ;; the second axis and the unknown key; requiring the arm's own key is
    ;; what refuses the empty map.
+   ;;
+   ;; The DURABLE NEGATIVE is `classification-op-map-guard` in
+   ;; `implementation/core/test/re_frame/conformance_test.clj` and its CLJS
+   ;; mirror `classification-op-map-guard-cljs` — the live corpus carries
+   ;; only valid single-axis ops, so nothing in it reds when the harness's
+   ;; matching pre-apply check is deleted. Those two tests feed the runner an
+   ;; empty, a multi-axis, an unknown-axis and a mixed op-map, and assert a
+   ;; FAILED fixture naming the classification-op error, with a valid
+   ;; single-axis op as the control.
    [:fixture/classification-effects
     {:optional true}
     [:vector

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
@@ -152,10 +152,9 @@
   under one ruler and admitted under the other (rf2-2rtt6.131). That arm
   was also unreachable: this ns requires `clojure.edn` and catches
   `Throwable` unconditionally, and story-mcp is a JVM-only artefact by
-  declaration (`tools/story-mcp/deps.edn` §JVM-only; `tools/shadow-cljs.edn`
-  lists it among the JVM-only tools). A phantom second host publishing a
-  WRONG number is worse than no second host, so the conditional is gone and
-  the one ruler that runs is the correct one. Code units equal UTF-8 bytes
+  declaration (`tools/story-mcp/deps.edn` §JVM-only). A phantom second host
+  publishing a WRONG number is worse than no second host, so the conditional
+  is gone and the one ruler that runs is the correct one. Code units equal UTF-8 bytes
   only for ASCII — which is exactly why an ASCII-only oversize fixture
   could never see the defect."
   [^String body]

--- a/tools/story-mcp/test/re_frame/story_mcp/run_result_roundtrip_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/run_result_roundtrip_test.clj
@@ -45,18 +45,18 @@
   (schemas/clear-schemas-by-frame!)
   (recorder/clear!)
   ;; Disable epoch-ring recording for the duration of each story-mcp test
-  ;; (restored below). story-mcp's OWN artefact carries NO epoch dep, so a
-  ;; standalone `cd tools/story-mcp && clojure -M:test` never loads
-  ;; `re-frame.epoch` and `run-variant`'s `:narrative` projection reads an
-  ;; empty tape. Under the tools-root aggregate (`cd tools && clojure
-  ;; -M:test`) a STORY test namespace REQUIRES `re-frame.epoch`, installing
-  ;; the capture hooks process-wide — so story-mcp's `run-variant` then
-  ;; projects a full per-event narrative (each beat carries full :db /
-  ;; trace-events), ballooning the wire payload past the MCP token cap (the
-  ;; whole run-result is replaced by a `:rf.mcp/overflow` marker, failing the
-  ;; shape assertions). `(rf/configure! {:epoch-history {:depth 0}})` reproduces
-  ;; the artefact's own epoch-free posture: it is a core-facade knob that
-  ;; no-ops when epoch is absent and disables ring recording when present.
+  ;; (restored below). story-mcp's OWN artefact carries NO epoch dep, so
+  ;; `cd tools/story-mcp && clojure -M:test` never loads `re-frame.epoch`
+  ;; and `run-variant`'s `:narrative` projection reads an empty tape. This
+  ;; call PINS that posture rather than inheriting it: `re-frame.epoch`
+  ;; installs its capture hooks PROCESS-WIDE at ns-load, so any JVM that
+  ;; puts epoch on this suite's classpath would silently switch
+  ;; `run-variant` to a full per-event narrative (each beat carrying full
+  ;; :db / trace-events), ballooning the wire payload past the MCP token cap
+  ;; — the whole run-result replaced by a `:rf.mcp/overflow` marker, failing
+  ;; the shape assertions. `(rf/configure! {:epoch-history {:depth 0}})` is a
+  ;; core-facade knob that no-ops when epoch is absent and disables ring
+  ;; recording when present, so it is correct under either classpath.
   (rf/configure! {:epoch-history {:depth 0}})
   (story/reg-story :story.cart
     {:doc "A cart." :component :app.ui/cart :tags #{:dev :test} :args {}})

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -93,19 +93,19 @@
   ;; test's captured events don't bleed in.
   (recorder/clear!)
   ;; Disable epoch-ring recording for the duration of each story-mcp test
-  ;; (restored below). story-mcp's OWN artefact carries NO epoch dep, so a
-  ;; standalone `cd tools/story-mcp && clojure -M:test` never loads
-  ;; `re-frame.epoch` and `run-variant`'s `:narrative` projection reads an
-  ;; empty tape. Under the tools-root aggregate (`cd tools && clojure
-  ;; -M:test`) a STORY test namespace REQUIRES `re-frame.epoch`, installing
-  ;; the capture hooks process-wide — so story-mcp's `run-variant` then
-  ;; projects a full per-event narrative (each beat carries full :db /
-  ;; trace-events), ballooning the wire payload past the MCP token cap (the
-  ;; whole run-result is replaced by a `:rf.mcp/overflow` marker, failing the
-  ;; shape + elision-indicator assertions). `(rf/configure! {:epoch-history
-  ;; {:depth 0}})` reproduces the artefact's own epoch-free posture: it is a
-  ;; core-facade knob that no-ops when epoch is absent and disables ring
-  ;; recording when present.
+  ;; (restored below). story-mcp's OWN artefact carries NO epoch dep, so
+  ;; `cd tools/story-mcp && clojure -M:test` never loads `re-frame.epoch`
+  ;; and `run-variant`'s `:narrative` projection reads an empty tape. This
+  ;; call PINS that posture rather than inheriting it: `re-frame.epoch`
+  ;; installs its capture hooks PROCESS-WIDE at ns-load, so any JVM that
+  ;; puts epoch on this suite's classpath would silently switch
+  ;; `run-variant` to a full per-event narrative (each beat carrying full
+  ;; :db / trace-events), ballooning the wire payload past the MCP token cap
+  ;; — the whole run-result replaced by a `:rf.mcp/overflow` marker, failing
+  ;; the shape + elision-indicator assertions. `(rf/configure!
+  ;; {:epoch-history {:depth 0}})` is a core-facade knob that no-ops when
+  ;; epoch is absent and disables ring recording when present, so it is
+  ;; correct under either classpath.
   (rf/configure! {:epoch-history {:depth 0}})
   ;; Fixture story + variant.
   (story/reg-story :story.button

--- a/tools/template/spec/005-Repo-Split.md
+++ b/tools/template/spec/005-Repo-Split.md
@@ -526,11 +526,15 @@ references that survived the docs sweep and either:
 - Point at the external repo (`https://github.com/day8/re-frame2-template`).
 - Delete if the reference is now meaningless.
 
-`tools/deps.edn`'s `:local/root "template"` entry retires (the
-testbed / cross-tool tests no longer link the template; the
-template's tests run in its own CI on the external repo). The
-`tools/shadow-cljs.edn` "JVM-only" exclusion comment retires —
-the template is no longer part of the tools/ classpath at all.
+Both build-file edits this step used to list are ALREADY TAKEN, ahead
+of the split and for unrelated reasons. `tools/deps.edn`'s `:local/root
+"template"` entry is gone: it hung off the aggregate `:test` alias,
+which PR #9093 (rf2-6r9j.139) retired as a second hand-written JVM-lane
+inventory beside `scripts/test-jvm-tools.sh`. The `tools/shadow-cljs.edn`
+"JVM-only" exclusion comment is gone with the whole file, deleted by the
+same PR (rf2-6r9j.140) as an ungated mirror of two of Pair MCP's builds.
+The template is already off the tools/ classpath, so this step is now the
+docs sweep above plus the README entry below.
 
 The repo-root README's Project Layout entry retires (replace the
 `template/` row with a one-line "see github.com/day8/re-frame2-template"


### PR DESCRIPTION
Three beads. Two premises did not hold as briefed and are reported as measured rather than followed.

## rf2-7yth0 — the classification-op guard gets its durable negative

**The briefed premise did not hold.** The claim was that the FixtureFile `:fixture/classification-effects` schema permits zero-or-many axes while the prose says exactly one. It does not: `f0f2e40f9f` already tightened it to a closed four-way `:or` of single-required-key maps, and `realise-classification-effects!` already checks the same thing before applying anything. **Authoritative side: the exactly-one prose** — and the schema and the harness already agree with it, so there was nothing to decide, and nothing in the live corpus would fail a tightened schema (measured below).

What the bead's newest note (audit #9052) actually asks for is the missing **durable negative**, and that gap is real: every live corpus op is a valid single-axis map, so deleting the harness check leaves the whole corpus green.

Adds the table-driven regression on both hosts — `classification-op-map-guard` (JVM) and `classification-op-map-guard-cljs`. An empty op-map, a multi-axis op-map, an unknown-axis op-map and a known axis beside an unknown key must each FAIL the fixture *with the classification-op error*, with a valid single-axis op as the control proving the guard is not simply refusing everything.

**The gate is proved live, not asserted.** With the guard's condition neutered, the JVM test reds **8 of its 9 assertions** — all four refused shapes, on both the `:passed?` and the error-message assertion — while the control stays green. The runner was then restored byte-identically: `git hash-object` equals the HEAD blob `37976da1a53efbe01243013fc646a3ede5dfbbf8`.

**The fenced schema was checked by an EXECUTABLE parse, by hand, because neither doc gate reads inside a fence** — and `spec/Spec-Schemas.md` is a fenced-schema page. The `[:fixture/classification-effects ...]` entry was read out of the markdown with `clojure.edn` and run through Malli:

- 12 live ops across 8 fixtures — **all accepted**; the 8 whole-vector values — **all accepted**. So the tightened schema does not reject the corpus.
- empty map, multi-axis, unknown-axis, and known-beside-unknown — **all four rejected**.
- all four valid single-axis shapes — **all accepted**.

`spec/Spec-Schemas.md` gains one comment pointing at the two tests, so the fenced contract names its own durable negative.

**Overlap declared:** draft PR #9103 (`worker/aliasq-a`, 401 files) renames the `runner` require-alias in both leaf files. The new tests use `runner/run-fixture` at EOF and change no `ns` form, so a rebase merges cleanly but that PR's rename pass must catch two more call sites. Flagging it rather than deferring the bead a fifth time.

## rf2-qvhx — the standing enrolment rule now lives beside the mechanism

**The briefed premise did not hold.** This was briefed as an open analysis question. It is already ruled, twice, on the bead: the mayor replaced the blast-radius schedule with rf2-hjj4's structural rule (2026-09-03 07:3x), then priced and declined the adapters exception (07:5x) with "DO NOT FILE THE SLICE". **No tree is enrolled here and no mechanism changes** — that would contradict a standing ruling.

What was genuinely missing is what the ruling itself asked for: the rule beside the mechanism. `gen.clj`'s section header carried the *evidence* (routing/resources: 51 of 51 internal; hicasso: 5 of 26 public) but stopped at calling the facade/opt-in distinction "the useful predictor", so a reader arriving at `roster-covered-roots` still met an open question. The header now records the rule — **enrol a tree when it acquires a second requirable door, never off a queue** — with why machines, http, schemas, flows, epoch and core stay out, and the adapters exception priced.

**One figure in the ruling re-measured and confirmed:** the ruling first called adapters "three namespaces". `find implementation/adapters -path '*/src/*'` returns **fifteen** — four doors (reagent, uix, test-react, reagent-slim) plus a vendored reagent2 fork of eleven files under reagent-slim. Enrolling a root obliges a classification for every namespace beneath it, so the bill is eleven rubber-stamps for another library's internals.

The bead stays OPEN as the standing question, per the ruling.

## rf2-6ka0 — the four tools-root-coordinator references

**Collision check: no collision.** The brief said `tools/story-mcp` was held by a PR from `worker/prosefixb-a`. **No such branch or PR exists** — `git ls-remote --heads origin` for `worker/prosefix*` returns nothing, and `gh pr list --state all --search prosefixb` returns an empty array. The only open PR in the repo is #9103, and its full 401-file list (fetched with `--paginate`, not the 100-file cap) contains no `tools/` path at all. All three items landed.

1. `write.cljc`'s oversize-body docstring cited two proofs that story-mcp is JVM-only; the dead `tools/shadow-cljs.edn` half is dropped, the live `tools/story-mcp/deps.edn` half kept.
2. The two identical fixture comments justified `(rf/configure! {:epoch-history {:depth 0}})` by contrasting a standalone run with the retired tools-root aggregate. **The code is unchanged** — the rationale now stands on its own terms: `re-frame.epoch` installs its capture hooks process-wide at ns-load, so the call PINS the artefact's epoch-free posture rather than inheriting it, and is right under either classpath.
3. `005-Repo-Split.md` section 3.6 listed two build-file edits as pending split steps. Both are already taken, by #9093 rather than by the split.

**Premises verified at tip:** `tools/shadow-cljs.edn` does not exist; `tools/deps.edn` carries no `:local/root "template"` entry; and after the sweep no tracked file outside the tracker export names the aggregate run. The three surviving `tools/shadow-cljs.edn` mentions are retirement bookkeeping in `tools/README.md`, `tools/deps.edn` and the new section 3.6 text.

## Gates

Exit codes captured to files and read from the files, never through a pipe.

| Gate | Exit |
|---|---|
| `implementation/core`: `clojure -M:test -v re-frame.conformance-test/classification-op-map-guard` | **0** — 1 test, 9 assertions, 0 failures |
| same, guard neutered (liveness proof) | **1** — 8 failures, control green |
| `implementation/scripts/api-manifest`: `clojure -M:test` | **0** — 84 tests, 170 assertions |
| `tools/story-mcp`: `clojure -M:test` | **0** — 282 tests, 1527 assertions |
| `scripts/check_doc_slugs.py` | **0** |
| `scripts/check_readme_links.py --ci` | **0** |
| `python -m mkdocs build --strict` | **0** |
| Malli parse of the fenced FixtureFile schema (hand check) | **PASS** |

**Hand-verification, stated because no gate covers it.** The `spec/Spec-Schemas.md` edit is inside a fenced code block, so `check_doc_slugs.py` and `mkdocs build --strict` both inspect nothing I changed there — the executable Malli parse above is what checks it, and the fence's surrounding anchors and link targets were read by eye. `tools/template/spec/005-Repo-Split.md` is outside `docs_dir` and is not staged into the build, so `check_doc_slugs.py` (whose roots include `tools/*/spec`) is its gate; its prose, its two links and its heading structure were read by hand.

**CLJS not run locally.** `npm run test:cljs` is a cold whole-suite shadow-cljs compile and was out of scope for this dispatch; CI owns it. The new CLJS test is a structural mirror of the passing `derivation-graph-expect-graph-guard-cljs` in the same file, adds no `ns` require, and the file was reader-checked (17 top-level forms read cleanly, the new `deftest` last).

**Encoding.** Every edited file is CRLF and stayed CRLF (byte-counted: CRLF count equals LF count in all eight). New non-ASCII was written as explicit UTF-8 and each file re-decodes as UTF-8; the two test files' new prose is pure ASCII.
