### PR TITLE
Three reopened audit repairs: mcp-base orphan parser, http comment, xray skill carrier

### DIFF
--- a/implementation/http/src/re_frame/http/handlers.cljc
+++ b/implementation/http/src/re_frame/http/handlers.cljc
@@ -363,10 +363,10 @@
         sensitive?'  (privacy/request-sensitive? args-map')
         ;; rf2-hp772l — `check-cljs-only-keys!` is JVM per-row degradation
         ;; tracing (a no-op on CLJS), owned by the JVM platform adapter.
-        ;; The frame is threaded for the warning-path trace stamp; HTTP carrier
-        ;; redaction is now process-global (resolved from the :rf.http/managed
-        ;; `:carriers` registration, EP-0025), so it no longer depends on the
-        ;; emitting frame.
+        ;; No frame is threaded: HTTP carrier redaction is process-global
+        ;; (resolved from the :rf.http/managed `:carriers` registration,
+        ;; EP-0025), so the warning path never depends on the emitting
+        ;; frame.
         _            (transport-jvm/check-cljs-only-keys! args-map' sensitive?')
         ;; rf2-uheqq — carry the post-:before middleware-ctx forward so
         ;; the response-side `:after` chain sees the EXACT same ctx its

--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -53,7 +53,7 @@ unless the user asked for the inventory.
 | The evidence sought | First surface | First interaction | Natural next step |
 |---|---|---|---|
 | What did this one dispatch do — the whole cascade, where it failed, what fx fired | **Dynamic → Epoch** (the default landing tab) | pick the frame, click the event row in the L2 list | **Trace** for raw op ordering |
-| What changed in state — is the value I expect actually there | **Dynamic → app-db** | pick the event; changed paths carry inline `← was X` diffs | hover a changed path for its downstream subs |
+| What changed in state — is the value I expect actually there | **Dynamic → app-db** | pick the event; changed paths carry inline `← was X` diffs | **Views** for what re-rendered off the change |
 | Why did this render — sub change or props, what recomputed | **Dynamic → Views** | pick the event; read the render-cause chips (`← :sub-id` vs `← props`) | **app-db** at the sub's input path |
 | Exact raw ordering / payloads the friendly views summarise | **Dynamic → Trace** | pick the event; click a row to expand it | — |
 | What this event did to a state machine — transition, guards, actions | **Dynamic → Machine** (event-driven; blank when the event touched no machine) | pick the event | **Static → Machines** to browse a full topology cold |

--- a/skills/re-frame2-xray/evals/evals.json
+++ b/skills/re-frame2-xray/evals/evals.json
@@ -59,7 +59,7 @@
  "name": "panel-route-state",
  "should_trigger": true,
  "prompt": "Which Xray panel shows me when [:cart :items] last changed in app-db?",
- "expected_output": "The agent's first paragraph routes to ONE first surface: the Dynamic app-db tab (with the L2 spine to locate the epoch that changed the path). It names the first interaction — pick the frame/event; changed paths carry the inline `← was X` diff — and may offer the downstream-subs hover as the natural next step. It does NOT enumerate the full tab inventory for this one routed question.",
+ "expected_output": "The agent's first paragraph routes to ONE first surface: the Dynamic app-db tab (with the L2 spine to locate the epoch that changed the path). It names the first interaction — pick the frame/event; changed paths carry the inline `← was X` diff. It does NOT enumerate the full tab inventory for this one routed question.",
  "expectations": [
  "The output's first paragraph names the Dynamic app-db tab as the first surface (using the L2 event spine to find the epoch that changed the path).",
  "The output names the first interaction — pick the frame and event; changed paths carry the inline `← was X` diff annotation.",

--- a/skills/re-frame2-xray/references/panels-state.md
+++ b/skills/re-frame2-xray/references/panels-state.md
@@ -33,16 +33,12 @@ clutter. The operator-facing section labels map onto framework state in
 the runtime-db partition; the mapping is normative in
 [`004-App-DB-Diff.md` §Reserved-keys group](../../../tools/xray/spec/004-App-DB-Diff.md).
 
-**Downstream-subs hover popover** — hover any changed path to surface
-the subs depending on it + the views they render + an inline `⤴` jump to
-the Views panel scrolled to those subs. Keyboard-dismissable.
-
 When the L2 spine is at head (no historical epoch focused), sections show
 the most-recent epoch's state with its inline diffs — current db,
 sectioned. Same render shape, no second mode.
 
-**Open when:** "what just changed in app-db?", "what's downstream of
-`[:cart :items]`?", "show me the full db at this epoch."
+**Open when:** "what just changed in app-db?", "when did
+`[:cart :items]` last change?", "show me the full db at this epoch."
 
 Spec: [`021-Dynamic-Panel-Designs.md` §4](../../../tools/xray/spec/021-Dynamic-Panel-Designs.md)
 + [`004-App-DB-Diff.md`](../../../tools/xray/spec/004-App-DB-Diff.md).

--- a/tools/mcp-base/spec/args.md
+++ b/tools/mcp-base/spec/args.md
@@ -9,7 +9,7 @@ This doc is one of thirteen per-namespace contracts indexed from [`README.md`](R
 
 `args` owns:
 
-- The cross-MCP parser catalogue (`parse-boolean`, `parse-positive-int`, `parse-non-negative-int`, `fresh-keyword`, `safe-keyword`, `parse-mode`).
+- The cross-MCP parser catalogue (`parse-boolean`, `parse-positive-int`, `fresh-keyword`, `safe-keyword`, `parse-mode`).
 - The default-handling posture for each parser (call-sites supply the default; the parser is policy-free).
 - The keyword-interning safety rule: bounded lookups route through `safe-keyword`; only deliberate, operator-gated allocation paths use `fresh-keyword`.
 
@@ -31,7 +31,6 @@ The rejection posture (default-suppress vs default-allow) is named at the call-s
 |---|---|---|---|
 | `parse-boolean` | bools, strings (`"true"`/`"false"`/`"1"`/`"0"`/`"yes"`/`"no"`/`"y"`/`"n"`/`"on"`/`"off"`, case-insensitive), keywords (`:true`/`:false`), nil | boolean | Unrecognised → `default`. Call-sites wrap to bake the default. |
 | `parse-positive-int` | finite in-range numbers, integer strings | positive int or `default` | Numbers floor toward zero, then clamp to 1. Invalid or out-of-domain inputs return `default`. |
-| `parse-non-negative-int` | ints, parsable strings | non-negative int or `default` | Zero allowed. Out-of-domain numerics → `default` (same cross-runtime guard). |
 | `fresh-keyword` | keywords, strings (leading `:` optional), nil | keyword or `nil` | INTERNS by design — reserved for operator-gated paths that deliberately allocate a new id. It is not a registry lookup helper. |
 | `fresh-keyword-checked` | keywords, strings (leading `:` optional), nil; a `[ns name] → bool` shape predicate; optional `max-len` | keyword or `nil` | Validates a string's decomposed shape and length before interning. Keyword inputs are already interned, so they are shape-checked but not length-checked. |
 | `safe-keyword` | keywords, strings, nil | keyword from `allowed` set, or `nil` | Bounded-allowlist gate — never interns a fresh JVM keyword on rejection. Use for finite options and live registry lookups. |
@@ -51,7 +50,7 @@ The keyword-interning cap (`:rf.http/max-decoded-keys`) defends against the body
 
 ## Cross-runtime numeric domain
 
-`parse-positive-int` / `parse-non-negative-int` (and, via `cursor/parse-limit-arg` and `cap/max-tokens`, every numeric MCP arg) coerce through one shared finite/range guard (`coerce-finite-long`) BEFORE `(long raw)`. The guard exists because `(long raw)` is unsafe at the arg boundary:
+`parse-positive-int` (and, via `cursor/parse-limit-arg` and `cap/max-tokens`, every numeric MCP arg) coerces through one shared finite/range guard (`coerce-finite-long`) BEFORE `(long raw)`. The guard exists because `(long raw)` is unsafe at the arg boundary:
 
 - On the JVM `(long ##Inf)` and `(long 1.0E20)` THROW `IllegalArgumentException` — a crash at the wire boundary instead of a recoverable default; `(long ##NaN)` truncates to a real `0` (a real, non-sentinel value).
 - The hosts have different numeric ranges and parsing behavior, so both arms enforce the JS safe-integer window before returning a value.

--- a/tools/mcp-base/src/re_frame/mcp_base/args.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/args.cljc
@@ -99,8 +99,8 @@
     (long n)))
 
 (defn- parse-int*
-  "Shared helper for `parse-positive-int` / `parse-non-negative-int`.
-  `floor` is the lower clamp (1 for positive, 0 for non-negative).
+  "Cross-host integer coercion behind `parse-positive-int`; the parsed
+  value is clamped to a floor of 1.
   Two input arms: a numeric `raw` is finite/range-guarded then floored
   (out-of-domain — `##Inf` / `##NaN` / past the safe-integer window —
   falls back to `default` rather than throwing or truncating to a real
@@ -109,14 +109,14 @@
   garbage and out-of-range magnitudes fall back to `default`, identically
   on JVM and CLJS). Every other shape falls
   back to `default`."
-  [raw default floor]
+  [raw default]
   (cond
     (nil? raw)
     default
 
     (number? raw)
     (if-let [n (coerce-finite-long raw)]
-      (max floor n)
+      (max 1 n)
       default)
 
     (string? raw)
@@ -133,12 +133,12 @@
         ;; (the JS safe-integer window) instead of two divergent ones.
         #?(:clj  (let [n (try (bigint s) (catch NumberFormatException _ nil))]
                    (if (and n (<= (- max-safe-integer) n max-safe-integer))
-                     (max floor (long n))
+                     (max 1 (long n))
                      default))
            :cljs (let [n (js/parseInt s 10)]
                    (if (and (not (js/isNaN n))
                             (js/Number.isSafeInteger n))
-                     (max floor (long n))
+                     (max 1 (long n))
                      default)))))
 
     :else
@@ -153,37 +153,7 @@
   The caller supplies the documented default (for example, a cursor
   pagination limit)."
   [raw default]
-  (parse-int* raw default 1))
-
-;; rf2-6r9j.104 — disposition: KEPT, deliberately, with no in-repo caller.
-;; Verified 2026-09-03 by a fixed-string census over tracked files: every
-;; live numeric MCP arg is a positive int (`cursor/parse-limit-arg`'s
-;; `:limit`, story-mcp's `:timeout-ms`) or `cap/max-tokens`, which admits
-;; zero but REJECTS its out-of-domain values rather than defaulting and so
-;; cannot route through a defaulting parser. The floor-0 half is retained
-;; because it is the other half of ONE parser: `parse-int*`'s `floor`
-;; parameter exists precisely because both floors are offered, and the
-;; contracts an auditor might fear are being carried for a lone caller —
-;; the finite/safe-integer guard, the strict string grammar, the
-;; cross-host agreement — are `parse-int*`'s and `coerce-finite-long`'s,
-;; shared with `parse-positive-int` and tested once. What is specific to
-;; this var is the floor, and its own tests are a handful of assertions
-;; about exactly that. Deleting it would leave a `floor` parameter with a
-;; single constant argument and force any consumer whose arg admits a
-;; disabling zero to re-derive the guard by hand.
-
-(defn parse-non-negative-int
-  "Like `parse-positive-int` but clamps to zero rather than one — the
-  parser for a numeric arg whose domain INCLUDES zero, typically as a
-  \"disabled\" sentinel. Same accepted shapes, same cross-runtime
-  finite/safe-integer guard, same fall-back-to-`default` posture for
-  everything out of domain.
-
-  Reach for `parse-positive-int` instead when zero is meaningless for the
-  arg, and for a zero-admitting arg that must REJECT rather than default
-  on bad input, see `cap/max-tokens` for the rejection-marker shape."
-  [raw default]
-  (parse-int* raw default 0))
+  (parse-int* raw default))
 
 ;; ---------------------------------------------------------------------------
 ;; Keyword coercion — bounded-allowlist gate

--- a/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
@@ -61,17 +61,6 @@
   (is (= 50 (args/parse-positive-int "" 50))))
 
 ;; ---------------------------------------------------------------------------
-;; parse-non-negative-int
-;; ---------------------------------------------------------------------------
-
-(deftest parse-non-negative-int-admits-zero
-  (is (zero? (args/parse-non-negative-int 0 5000)))
-  (is (zero? (args/parse-non-negative-int "0" 5000))))
-
-(deftest parse-non-negative-int-clamps-negative-to-zero
-  (is (zero? (args/parse-non-negative-int -5 5000))))
-
-;; ---------------------------------------------------------------------------
 ;; Cross-host strict-parse contract.
 ;;
 ;; Pin the trailing-garbage case where the hosts could diverge: JVM
@@ -97,10 +86,6 @@
   (is (= 12 (args/parse-positive-int "  12  " 50)) "surrounding whitespace trimmed")
   (is (= 12 (args/parse-positive-int "+12" 50)) "leading plus accepted")
   (is (= 1 (args/parse-positive-int "-5" 50)) "negative parses then clamps to floor"))
-
-(deftest parse-non-negative-int-rejects-trailing-garbage
-  (is (= 5000 (args/parse-non-negative-int "12abc" 5000)))
-  (is (= 5000 (args/parse-non-negative-int "100x" 5000))))
 
 (deftest parse-positive-int-rejects-out-of-long-range
   ;; A digit string that overflows a JVM long is a parse failure →
@@ -128,11 +113,6 @@
   (is (= 50 (args/parse-positive-int ##NaN 50)) "##NaN defaults (was a real floor of 1)")
   (is (= 50 (args/parse-positive-int 1.0E20 50)) "1.0E20 defaults (was IllegalArgumentException)")
   (is (= 50 (args/parse-positive-int -1.0E20 50)) "-1.0E20 defaults"))
-
-(deftest parse-non-negative-int-out-of-domain-numerics-default-not-throw
-  (is (= 5000 (args/parse-non-negative-int ##Inf 5000)) "##Inf defaults")
-  (is (= 5000 (args/parse-non-negative-int ##NaN 5000)) "##NaN defaults (was a real floor of 0)")
-  (is (= 5000 (args/parse-non-negative-int 1.0E20 5000)) "1.0E20 defaults"))
 
 (deftest parse-positive-int-in-domain-numerics-still-parse
   ;; The guard must not regress the legitimate small-int surface.

--- a/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
+++ b/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
@@ -228,8 +228,7 @@
     (is (= 50 (args/parse-positive-int "12abc" 50)) "was 12 on CLJS before the fix")
     (is (= 50 (args/parse-positive-int "5xyz" 50)))
     (is (= 50 (args/parse-positive-int "1.5" 50)))
-    (is (= 50 (args/parse-positive-int "1e3" 50)))
-    (is (= 5000 (args/parse-non-negative-int "100x" 5000))))
+    (is (= 50 (args/parse-positive-int "1e3" 50))))
   (testing "clean and signed strings still parse"
     (is (= 12 (args/parse-positive-int "12" 50)))
     (is (= 12 (args/parse-positive-int "+12" 50)))
@@ -252,8 +251,7 @@
     (is (= 50 (args/parse-positive-int js/Infinity 50)) "Infinity defaults")
     (is (= 50 (args/parse-positive-int (- js/Infinity) 50)) "-Infinity defaults")
     (is (= 50 (args/parse-positive-int js/NaN 50)) "NaN defaults (not a real floor)")
-    (is (= 50 (args/parse-positive-int 1e20 50)) "1e20 defaults (past safe-integer window)")
-    (is (= 5000 (args/parse-non-negative-int js/NaN 5000)) "NaN defaults (not a real 0)"))
+    (is (= 50 (args/parse-positive-int 1e20 50)) "1e20 defaults (past safe-integer window)"))
   (testing "in-domain numerics still parse"
     (is (= 5 (args/parse-positive-int 5 50)))
     (is (= 2 (args/parse-positive-int 2.9 50)) "in-range fractional floors")


### PR DESCRIPTION
Three small, unrelated repairs on three surfaces. All three beads were closed, then REOPENED by a merged-PR audit; each commit works the audit's ruling, which is narrower than — and in one case opposite to — what the closing worker concluded.

## rf2-6r9j.104 — mcp-base: retire the orphaned `parse-non-negative-int`

The audit of PR #9087 **rejected** the keep-with-justification disposition: the justification cited `parse-int*`'s `floor` parameter and a hypothetical future zero-admitting argument, which is circular and speculative rather than a live contract. The bead's acceptance criteria admit retention only with a real supported consumer plus a consumer-level test.

Census re-run with two independent instruments and a control that fires:

| instrument | `parse-non-negative-int` | CONTROL `parse-positive-int` |
|---|---|---|
| `git grep -F` over tracked files (`:!.beads`) | definition, own docstring cross-refs, `spec/args.md` catalogue, dedicated self-tests. **No production call site.** | `tools/mcp-base/src/re_frame/mcp_base/cursor.cljc:186`, `tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc:373`, pair-mcp arg/cursor modules |
| clj-kondo `:var-usages` over `tools implementation examples skills` | 44 occurrences, all in `args.cljc` + the two self-test files | 185 occurrences including the same live cross-artefact `src/` callers |

The control establishes that both instruments reach production consumers of an `re-frame.mcp-base.args` var **across artefact boundaries**; this var has none.

Removed: the public var, its `spec/args.md` catalogue bullet / surface-table row / cross-runtime-domain mention, four dedicated deftests and two CLJS assertions. `parse-int*` loses its `floor` parameter along with the second floor — leaving a parameter whose only argument is a constant would be the same vestige one level down.

No contract is lost: every guard the removed assertions pinned (trailing garbage, `##Inf`, `##NaN`, `1.0E20`, the safe-integer window) is pinned by the `parse-positive-int` assertions in the same deftests. `cursor/parse-limit-arg`, `cap/max-tokens` and `coerce-finite-long` are untouched.

## rf2-6r9j.40 — http: the cljs-only-key check is no longer handed a frame

Audit of PR #9081: acceptance criterion 3 was still unmet. That PR removed the frame argument from `check-cljs-only-keys!` — the live call passes only `args-map'` and `sensitive?'` — while the comment beside it still read *"The frame is threaded for the warning-path trace stamp"*. Corrected in place; the true half (carrier redaction is process-global, from the `:rf.http/managed` `:carriers` registration per EP-0025) is kept. **No code change.**

## rf2-6r9j.17 — xray skill: drop the retired downstream-subs hover

Audit of PR #9080: the resolver went, but a live carrier survived in the skill telling an agent it may offer the downstream-subs hover as the natural next step. The popover went with `95d92180bb` and its resolver with `bda17e1f35`.

Three carriers, all inside `skills/re-frame2-xray/`. The audit named the first; the bead's third acceptance criterion covers the other two, which PR #9080 did not reach:

- `evals/evals.json` eval 6 — clause dropped from `expected_output`. Its `expectations` array never mentioned the hover, so no expectation changes and the harness is **not** restructured.
- `SKILL.md` routing table — the app-db row's *Natural next step* becomes **Views** for what re-rendered off the change, which is the real surface the retired popover jumped to.
- `references/panels-state.md` — the "Downstream-subs hover popover" paragraph deleted; the *Open when* line's "what's downstream of `[:cart :items]`?" becomes "when did `[:cart :items]` last change?", which the panel does answer.

`git grep -i "downstream-sub"` over `skills/` is now empty.

## Verification

| gate | result |
|---|---|
| mcp-base JVM (`clojure -M:test`) | exit 0 — 284 tests, 990 assertions, 0 failures 0 errors |
| http JVM (`clojure -M:test`) | exit 0 — 506 tests, 3884 assertions, 0 failures 0 errors |
| clj-kondo `tools/mcp-base/{src,test}` + `implementation/http/src` | 0 errors, 21 warnings — **findings byte-identical to the pre-change baseline** |
| `check_skill_eval_docs --verbose --ci` | exit 0 |
| `check_skill_eval_packaging --verbose --ci` | exit 0 |
| `check_skill_xray_tab_inventory_drift --verbose --ci` | exit 0 |
| `check_skill_description_budget --verbose --ci` | exit 0 |
| `check_skill_package_refs --verbose --ci` | exit 0 |
| `check_skill_mcp_drift --verbose --ci` | exit 0 |
| `check_doc_slugs --verbose` | exit 0 |
| `check_readme_links --ci` | exit 0 |
| `python -m json.tool evals.json` | exit 0; `json.load` parses 32 evals |

**Gate liveness proved once**: planting `floor` = 2 in `parse-int*`'s numeric arm reddened the mcp-base JVM suite at exit 1 with 4 failures naming `args_test.clj:52`, `:53`, `:121` and `cursor_test.clj:356`. Restored and confirmed byte-identical by `git hash-object` (`eeb01a1489…` before and after).

Encoding checked by bytes on every touched file: CRLF counts unchanged, whole files decode as UTF-8, and the only added lines carrying non-ASCII are pre-existing em-dash / arrow bytes moved unchanged.

The mcp-base CLJS suite (`npm run test:cljs`) was not run locally — no `node_modules` exists for that artefact in either checkout. The change there is the deletion of two assertions with the enclosing `testing` forms rebalanced; clj-kondo parses the file with 0 errors. CI owns that lane, along with `mcp_conformance` / `mcp_live`, which the classifier arms for this diff.

Beads: rf2-6r9j.104, rf2-6r9j.40, rf2-6r9j.17.
