### PR TITLE
Remove dead bindings in the UIx test slice and proven no-op lint residue in ssr-ring

### DIFF
--- a/implementation/adapters/uix/test/re_frame/adapter/uix_consumer_deps_recipe_test.clj
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_consumer_deps_recipe_test.clj
@@ -26,7 +26,6 @@
    mount requires with no consumer coordinate that owns it."
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
-            [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -680,7 +680,7 @@
               (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
               (reset! probe-frame-provider-observed [])
               (rf/make-frame {:id frame-kw :doc "rf2-7kii2 trailing-children frame-provider probe"})
-              (rf/reg-event ::dollar-shape-seed (fn [{:keys [db]} _] {:db {:k :wrapped}}))
+              (rf/reg-event ::dollar-shape-seed (fn [_ _] {:db {:k :wrapped}}))
               (rf/dispatch-sync [::dollar-shape-seed] {:frame frame-kw})
               (rf/reg-sub (first query-v) (fn [db _] (:k db)))
               (let [mount-node (.createElement js/document "div")

--- a/implementation/adapters/uix/testbed/adapter_testbed_uix/core.cljs
+++ b/implementation/adapters/uix/testbed/adapter_testbed_uix/core.cljs
@@ -17,7 +17,7 @@
 ;; -- Events / subs ----------------------------------------------------------
 
 (rf/reg-event :counter/init
-  (fn [{:keys [db]} _event] {:db {:counter/value 0}}))
+  (fn [_ _event] {:db {:counter/value 0}}))
 
 (rf/reg-event :counter/inc
   (fn [{:keys [db]} _event] {:db (update db :counter/value inc)}))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
@@ -45,8 +45,8 @@
   fabricated into an empty header."
   [ring-headers [header-name header-value]]
   (when (and interop/debug-enabled?
-             (and (some? header-value)
-                  (not (string? header-value))))
+             (some? header-value)
+             (not (string? header-value)))
     (trace/emit! :warning :rf.ssr/ssr-non-string-header-value
                  {:where      :ssr-ring/merge-pair-into-header-map
                   :header     header-name

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
@@ -86,9 +86,9 @@
             [re-frame.core :as rf]
             [re-frame.ssr.ring :as ssr-ring]
             [re-frame.ssr.ring.test-support :as ts])
-  (:import [java.io InputStream IOException]
+  (:import [java.io InputStream]
            [java.net.http HttpResponse$BodyHandlers]
-           [java.util.concurrent CountDownLatch TimeUnit]
+           [java.util.concurrent CountDownLatch]
            [java.util.concurrent.atomic AtomicInteger AtomicLong]))
 
 (use-fixtures :each ts/reset-runtime)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
@@ -84,7 +84,7 @@
             [re-frame.ssr.ring :as ssr-ring]
             [re-frame.ssr.ring.streaming :as streaming]
             [re-frame.ssr.ring.test-support :as ts])
-  (:import [java.io InputStream IOException OutputStream
+  (:import [java.io InputStream IOException
                     PipedInputStream PipedOutputStream]
            [java.net.http HttpResponse$BodyHandlers]))
 

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -26,7 +26,7 @@
   (ts/reset-runtime
     (fn []
       (rf/reg-event :rf.test/seed-articles
-        (fn [{:keys [db]} [_ arts]] {:db {:articles arts}}))
+        (fn [_ [_ arts]] {:db {:articles arts}}))
       (rf/reg-event :rf.test.server/init
         {:platforms #{:server}}
         (fn [_ _]

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -89,7 +89,7 @@
 (deftest cookie-attribute-crlf-injection-rejected
   (testing "rf2-rpedl §P1.2 — CR / LF / NUL in :domain throws
             :rf.error/cookie-invalid-attribute"
-    (doseq [hostile [(str "evil.com\r\nSet-Cookie: admin=1; Path=/")
+    (doseq [hostile ["evil.com\r\nSet-Cookie: admin=1; Path=/"
                      "evil.com\rinjected"
                      "evil.com\ninjected"
                      (str "evil.com" (char 0) "nul")]]
@@ -2616,10 +2616,10 @@
               ;; (`:public/article-title`) or the `#:public{...}`
               ;; namespace-map shorthand (`:article-title`) — match
               ;; either rendering for robustness.
-              literal     (or (second
-                                (re-find
-                                  #":(?:public/)?article-title (\"[^\"]*\")"
-                                  payload-edn)))
+              literal     (second
+                            (re-find
+                              #":(?:public/)?article-title (\"[^\"]*\")"
+                              payload-edn))
               recovered   (when literal (clojure.edn/read-string literal))]
           (is (some? literal)
               "the article-title's EDN string literal is locatable in the payload")


### PR DESCRIPTION
Two mechanical vestige removals on separate artefacts. No runtime API, event behaviour, fixture shape, dependency coordinate or test intent changes; every evaluated value is preserved.

## rf2-6r9j.38 — UIx test slice

- `uix_consumer_deps_recipe_test.clj` required `[clojure.string :as str]` with no `str/`-qualified call anywhere in the file. Every bare `str` in it resolves to `clojure.core/str`, which a namespace alias never shadowed.
- `::dollar-shape-seed` and `:counter/init` each destructured `db` and then replaced `:db` with a literal that never consults the old value. Both keep their two-argument handler shape and return the same maps.

## rf2-6r9j.50 — ssr-ring

Three unused imports, one unused destructured binding, three no-op wrapper forms. `catch` breadth, the regex, db-replacement semantics and the debug gate are untouched, and the separately-owned `pipeline.clj` dead var and unused `resp` binding are left alone.

Notably retained, because they are genuinely used: `IOException` in `streaming_robustness_test` (`(catch IOException _ true)`), and `InputStream` / `CountDownLatch` / `AtomicInteger` / `AtomicLong` sitting on the same import forms as the removed entries. The CR/LF hostile literal in `ring_test.clj` is byte-identical — only the single-argument `(str …)` wrapper around it went — and the sibling two-argument `(str "evil.com" (char 0) "nul")` is unchanged.

## Verification

Each removal was proven with two independent instruments plus a control that fires.

- **Census** — `git grep -F` over tracked files, plus word-boundary greps where a longer name contains a shorter one (`PipedOutputStream` contains `OutputStream`). Control: `str/` reads 0 in the recipe test and 3 in a sibling file in the same directory.
- **clj-kondo** — `--lint <artefact>/src <artefact>/test [testbed] --cache false`. Control: on the same two `(:import …)` forms clj-kondo flags exactly the unused entries and stays silent on the used ones, so the census discriminates rather than reporting uniformly.

| Gate | Before | After |
|---|---|---|
| clj-kondo, `adapters/uix/{src,test,testbed}` | 3 findings, exit 2 | **0 findings, exit 0** |
| clj-kondo, `ssr-ring/{src,test}` | 35 finding lines | **28** — a set diff shows exactly the seven target lines gone and nothing else changed |
| `clojure -M:test` in `implementation/ssr-ring` | — | **231 tests, 1163 assertions, 0 failures, 0 errors, exit 0** |
| `clojure -M:test` in `implementation/adapters/uix` | — | **4 tests, 34 assertions, 0 failures, 0 errors, exit 0** |
| `-n concurrency-stress-test -n streaming-robustness-test` | — | **loads + 7 tests green, exit 0** — compile proof that the removed imports were unreferenced |

`headers.clj` is the only production change, so its gate was proven live rather than assumed: inverting `(some? header-value)` to `(nil? header-value)` in the flattened `and` turned `pipeline_materialiser_test` red (5 failures, exit 1). The file was then restored and re-verified by `git hash-object` against the pre-plant blob (`7f8814a23b622662fef4d9f97f035b45b988ae1a`), and the full ssr-ring suite re-run green on the restored tree.

All eight touched files are CRLF in the working tree under `core.autocrlf=true`; edits were applied byte-wise and re-read afterwards. All files remain valid UTF-8 and the 13 added lines are pure ASCII.

**Spec unchanged because** no `tools/machines-viz/` or `tools/xray/` file is touched by this PR — see the deferral note below.

## Two beads deliberately not included

- **rf2-6r9j.36** (remove UIx's no-doc warn-cache reset export) — the removal itself is sound: `re-frame.adapter.uix/clear-warned-non-dom-roots!` is `^:no-doc`, is deliberately omitted from `spec/api-manifest.edn`, and a repo-wide exact census finds its only two consumers are lines 75 and 88 of its own shared-suite entry file. But it cannot be landed from this fence. The shared roster `public-surface-keys` and the assertion `assert-clear-warned-non-dom-roots-resets-directly` live in `implementation/core/test/re_frame/adapter/react_shared_suite.cljs`, its forwarder row in `react_shared_suite_tests.clj`, and Hicasso supplies the same `:clear-warn!` / `:public-surface` cfg keys. Dropping them from the UIx cfg alone turns the shared suite red. Left open with the full change-set map on the bead.
- **rf2-fti6** (machines-viz cites a renamed machines test namespace) — the rename it depends on is in PR #9103, which is still **open**: `git merge-base --is-ancestor c33fcd83 origin/main` exits 1, and `machine_remediation_ee38b_test.clj` is still the file on `main`. Editing the two citations now would invert the bug, so it waits for #9103 to merge.
