### PR TITLE
Retire three security-tier vestiges and the schemas tests' dead syntax (rf2-6r9j.93/.94/.95/.55)

### DIFF
--- a/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
@@ -59,7 +59,7 @@
 (deftest live-dispatch-validates-app-db-under-reagent
   (testing "a malformed :db commit emits :rf.error/schema-validation-failure under the Reagent adapter"
     (rf/reg-app-schema [:n] [:int])
-    (rf/reg-event :n/init  (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :n/init  (fn [_ _] {:db {:n 0}}))
     (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "boom")}))
     (with-trace-recorder! [traces]
       (rf/dispatch-sync [:n/init])
@@ -82,7 +82,7 @@
 (deftest live-dispatch-well-typed-passes-silently
   (testing "well-typed :db commits trigger no schema-validation-failure trace"
     (rf/reg-app-schema [:n] [:int])
-    (rf/reg-event :n/init (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :n/init (fn [_ _] {:db {:n 0}}))
     (rf/reg-event :n/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (with-trace-recorder! [traces]
       (rf/dispatch-sync [:n/init])
@@ -339,7 +339,7 @@
       (schemas/set-schema-validator! custom)
       (try
         (rf/reg-app-schema [:n] :int)
-        (rf/reg-event :n/init  (fn [{:keys [db]} _] {:db {:n 42}}))
+        (rf/reg-event :n/init  (fn [_ _] {:db {:n 42}}))
         (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n 99)}))
         (with-trace-recorder! [traces]
           (rf/dispatch-sync [:n/init])

--- a/implementation/schemas/test/re_frame/schemas_concurrency_stress_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_concurrency_stress_test.clj
@@ -81,7 +81,6 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.schemas :as schemas]
-            [re-frame.schemas.digest :as digest]
             [re-frame.schemas.storage :as storage]
             ;; Explicit test dependency; the facade also loads this adapter.
             [re-frame.schemas.malli]

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -72,7 +72,6 @@
             [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.subs :as subs]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)

--- a/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
@@ -40,7 +40,6 @@
             [re-frame.schemas :as schemas]
             [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf]
-            [re-frame.schemas.validator :as validator]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)
@@ -166,7 +165,7 @@
   (testing "rf2-a5kzs (finding 2) — a malformed sub :schema yields the default
             (nil) per :replaced-with-default recovery instead of returning the
             unvalidated value via throw-as-pass; a malformed-schema trace fires."
-    (rf/reg-event :sub/init (fn [{:keys [db]} _] {:db {:items [1 2 3]}}))
+    (rf/reg-event :sub/init (fn [_ _] {:db {:items [1 2 3]}}))
     (rf/reg-sub :sub/malformed
       {:schema [:vector]}                          ;; childless — throws at validate-time
       (fn [db _] (:items db)))
@@ -174,16 +173,16 @@
                    (fn []
                      (rf/dispatch-sync [:sub/init])
                      (is (nil? (rf/subscribe-once [:sub/malformed]))
-                         "malformed sub schema → nil (replaced-with-default), not the raw value")))]
-      (let [mal (malformed-traces traces)]
-        (is (pos? (count mal)) "a malformed-schema trace fired")
-        (is (= :sub-return (-> (first mal) :tags :where)))
-        ;; rf2-mxs7a — the malformed sub trace must report
-        ;; :replaced-with-default (the sub yielded nil), NOT the
-        ;; previous unconditional :no-recovery lie. `:recovery` hoists
-        ;; to the top-level envelope.
-        (is (= :replaced-with-default (:recovery (first mal)))
-            "malformed sub trace reports :replaced-with-default (yielded the default)")))))
+                         "malformed sub schema → nil (replaced-with-default), not the raw value")))
+          mal    (malformed-traces traces)]
+      (is (pos? (count mal)) "a malformed-schema trace fired")
+      (is (= :sub-return (-> (first mal) :tags :where)))
+      ;; rf2-mxs7a — the malformed sub trace must report
+      ;; :replaced-with-default (the sub yielded nil), NOT the
+      ;; previous unconditional :no-recovery lie. `:recovery` hoists
+      ;; to the top-level envelope.
+      (is (= :replaced-with-default (:recovery (first mal)))
+          "malformed sub trace reports :replaced-with-default (yielded the default)"))))
 
 (deftest boundary-seam-malformed-schema-returns-false
   (testing "rf2-a5kzs (finding 2, boundary seam) — validate-with-registered-fn
@@ -229,11 +228,11 @@
       (let [traces (capture
                      (fn []
                        (is (false? (schemas/validate-app-schema! {:n "bad"} :n/bad))
-                           "fail-closed: false (rollback) — the explainer throw did not flip the verdict")))]
-        (let [v (first (validation-failures traces))]
-          (is (some? v) "the failure trace still fired")
-          (is (= :app-db (-> v :tags :where)))
-          (is (nil? (-> v :tags :explain)) ":explain degraded to nil — explainer threw")))
+                           "fail-closed: false (rollback) — the explainer throw did not flip the verdict")))
+            v      (first (validation-failures traces))]
+        (is (some? v) "the failure trace still fired")
+        (is (= :app-db (-> v :tags :where)))
+        (is (nil? (-> v :tags :explain)) ":explain degraded to nil — explainer threw"))
       (finally (schemas/reset-schema-validator!)))))
 
 (deftest sub-return-explainer-throw-preserves-failure
@@ -243,7 +242,7 @@
     (schemas/set-schema-fns! {:validate (fn [_ _] false)
                               :explain  throwing-explainer})
     (try
-      (rf/reg-event :s/init (fn [{:keys [db]} _] {:db {:v [1 2 3]}}))
+      (rf/reg-event :s/init (fn [_ _] {:db {:v [1 2 3]}}))
       (rf/reg-sub :s/strict
         {:schema [:vector :string]}
         (fn [db _] (:v db)))
@@ -251,11 +250,11 @@
                      (fn []
                        (rf/dispatch-sync [:s/init])
                        (is (nil? (rf/subscribe-once [:s/strict]))
-                           "sub yields default — the explainer throw did not become a pass")))]
-        (let [v (first (validation-failures traces))]
-          (is (some? v) "the sub-return failure trace fired")
-          (is (= :sub-return (-> v :tags :where)))
-          (is (nil? (-> v :tags :explain)) ":explain degraded to nil")))
+                           "sub yields default — the explainer throw did not become a pass")))
+            v      (first (validation-failures traces))]
+        (is (some? v) "the sub-return failure trace fired")
+        (is (= :sub-return (-> v :tags :where)))
+        (is (nil? (-> v :tags :explain)) ":explain degraded to nil"))
       (finally (schemas/reset-schema-validator!)))))
 
 (deftest direct-validate-event-explainer-throw-preserves-false
@@ -269,11 +268,11 @@
                        (is (false? (schemas/validate-event!
                                      :ev/x [:ev/x "bad"]
                                      {:schema [:cat [:= :ev/x] :int]}))
-                           "false despite the explainer throwing")))]
-        (let [v (first (validation-failures traces))]
-          (is (some? v))
-          (is (= :event (-> v :tags :where)))
-          (is (nil? (-> v :tags :explain)))))
+                           "false despite the explainer throwing")))
+            v      (first (validation-failures traces))]
+        (is (some? v))
+        (is (= :event (-> v :tags :where)))
+        (is (nil? (-> v :tags :explain))))
       (finally (schemas/reset-schema-validator!)))))
 
 (deftest boundary-explain-seam-isolates-explainer-throw

--- a/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
@@ -37,7 +37,6 @@
             [re-frame.schemas :as schemas]
             [re-frame.schemas.malli]
             [re-frame.schemas.test-fixture :as tf]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -1158,20 +1158,19 @@
 (deftest event-validation-redacts-container-level-sensitive-payload
   (testing "rf2-a5kzs — a container-level {:sensitive? true} on the event
             payload schema also drives redaction"
-    (let [secret "TOKEN-leak-check"]
-      (rf/reg-event :auth/token
-        ;; The whole payload (element 1 of the :cat) is sensitive; supply an
-        ;; int where :string is expected so it fails.
-        {:schema [:cat [:= :auth/token] [:string {:sensitive? true}]]}
-        (fn [{:keys [db]} _] {:db db}))
-      (with-trace-recorder! [traces]
-        (rf/dispatch-sync [:auth/token 12345])
-        (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
-                               @traces))]
-          (is (some? v))
-          (is (true? (:sensitive? v)) "container-level :sensitive? triggers redaction")
-          (is (= :rf/redacted (-> v :tags :received)))
-          (is (= :rf/redacted (-> v :tags :value))))))))
+    (rf/reg-event :auth/token
+      ;; The whole payload (element 1 of the :cat) is sensitive; supply an
+      ;; int where :string is expected so it fails.
+      {:schema [:cat [:= :auth/token] [:string {:sensitive? true}]]}
+      (fn [{:keys [db]} _] {:db db}))
+    (with-trace-recorder! [traces]
+      (rf/dispatch-sync [:auth/token 12345])
+      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                             @traces))]
+        (is (some? v))
+        (is (true? (:sensitive? v)) "container-level :sensitive? triggers redaction")
+        (is (= :rf/redacted (-> v :tags :received)))
+        (is (= :rf/redacted (-> v :tags :value)))))))
 
 (deftest event-validation-non-sensitive-cat-still-verbatim
   (testing "rf2-a5kzs — no over-redaction: an event schema with a payload map
@@ -1558,7 +1557,7 @@
             [:string {:sensitive? true}]`) drives sub-return redaction
             now that the handler/sub-meta `:sensitive?` annotation has
             been removed."
-    (rf/reg-event :secrets/init (fn [{:keys [db]} _] {:db {:secrets ["a-secret"]}}))
+    (rf/reg-event :secrets/init (fn [_ _] {:db {:secrets ["a-secret"]}}))
     (rf/reg-event :secrets/break (fn [{:keys [db]} _] {:db (assoc db :secrets [1 2 3])}))
     (rf/reg-sub :secrets
       {:schema [:vector [:string {:sensitive? true}]]}
@@ -1594,7 +1593,7 @@
             gating — user ids, auth tokens, document ids); without
             redaction the failure trace re-leaks it alongside the
             return value the existing clauses scrub."
-    (rf/reg-event :tokens/init  (fn [{:keys [db]} _]   {:db {:tokens {"user-42-token" "ok"}}}))
+    (rf/reg-event :tokens/init  (fn [_ _]   {:db {:tokens {"user-42-token" "ok"}}}))
     (rf/reg-event :tokens/break (fn [{:keys [db]} _] {:db (assoc-in db
                                                        [:tokens "user-42-token"]
                                                        99)})) ; int — fails :string
@@ -1629,7 +1628,7 @@
   (testing "Backward-compat — a sub without :sensitive? emits :rf.sub/query-v
             verbatim on the validation-failure trace (legacy behaviour
             preserved for non-sensitive subs). Redaction is opt-in."
-    (rf/reg-event :widgets/init  (fn [{:keys [db]} _]   {:db {:widgets {:w1 "ok"}}}))
+    (rf/reg-event :widgets/init  (fn [_ _]   {:db {:widgets {:w1 "ok"}}}))
     (rf/reg-event :widgets/break (fn [{:keys [db]} _] {:db (assoc-in db [:widgets :w1] 99)}))
     (rf/reg-sub :widget
       {:schema :string}                                  ; no :sensitive?
@@ -1725,7 +1724,7 @@
             omitted) on a sensitive failure, and the raw value never
             surfaces in the humanized slot"
     (let [secret "sub-secret-deadbeef"]
-      (rf/reg-event :secrets/init  (fn [{:keys [db]} _] {:db {:secrets [secret]}}))
+      (rf/reg-event :secrets/init  (fn [_ _] {:db {:secrets [secret]}}))
       (rf/reg-event :secrets/break (fn [{:keys [db]} _] {:db (assoc db :secrets [1 2 3])}))
       (rf/reg-sub :secrets
         {:schema [:vector [:string {:sensitive? true}]]}
@@ -1750,7 +1749,7 @@
 (deftest non-sensitive-sub-return-failure-carries-humanized-payload
   (testing "rf2-qhq3f — backward-compat on the sub-return surface: a
             non-sensitive sub keeps the real humanized payload"
-    (rf/reg-event :widgets/init  (fn [{:keys [db]} _] {:db {:widgets {:w1 "ok"}}}))
+    (rf/reg-event :widgets/init  (fn [_ _] {:db {:widgets {:w1 "ok"}}}))
     (rf/reg-event :widgets/break (fn [{:keys [db]} _] {:db (assoc-in db [:widgets :w1] 99)}))
     (rf/reg-sub :widget
       {:schema :string}                                  ;; no :sensitive?

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -38,10 +38,8 @@
             ;; Reuse the shared empty-set digest fixture.
             [re-frame.schemas.digest-parity-fixtures :as digest-fixtures]
             [re-frame.schemas.test-fixture :as tf]
-            [re-frame.registrar :as registrar]
             [re-frame.spec :as spec]
-            [re-frame.test-support :refer [with-trace-recorder!]]
-            [re-frame.trace :as trace]))
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)
 
@@ -94,7 +92,7 @@
   (testing "live dispatch through the runtime validates the candidate :db
             before install (rf2-uhk9ko)"
     (rf/reg-app-schema [:n] [:int])
-    (rf/reg-event :n/init (fn [{:keys [db]} _] {:db {:n 0}}))
+    (rf/reg-event :n/init (fn [_ _] {:db {:n 0}}))
     (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "boom")}))
     (with-trace-recorder! [traces]
       (rf/dispatch-sync [:n/init])
@@ -121,7 +119,7 @@
             — app-db keeps its pre-handler value. The dispatch is treated
             as failed; the bad candidate never stands."
     (rf/reg-app-schema [:n] [:int])
-    (rf/reg-event :n/init  (fn [{:keys [db]} _]  {:db {:n 0}}))
+    (rf/reg-event :n/init  (fn [_ _]  {:db {:n 0}}))
     (rf/reg-event :n/ok    (fn [{:keys [db]} _] {:db (assoc db :n 42)}))
     (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "boom")}))
     (rf/dispatch-sync [:n/init])
@@ -162,7 +160,7 @@
             (Supersedes the retired commit-then-rollback pair: forward
             db-changed → failure → :phase :rollback db-changed.)"
     (rf/reg-app-schema [:n] [:int])
-    (rf/reg-event :n/init  (fn [{:keys [db]} _]  {:db {:n 0}}))
+    (rf/reg-event :n/init  (fn [_ _]  {:db {:n 0}}))
     (rf/reg-event :n/break (fn [{:keys [db]} _] {:db (assoc db :n "boom")}))
     ;; rf2-bhh8my: deliberately NOT migrated to `with-trace-recorder!` — this
     ;; listener PROJECTS each event to an `[operation phase]` tuple on capture
@@ -294,7 +292,7 @@
   (testing "Per Spec 010 §step 6 (rf2-wcam): a sub whose return value fails
             its :schema emits :rf.error/schema-validation-failure :where :sub-return
             and the caller sees nil (default :replaced-with-default recovery)"
-    (rf/reg-event :items/init (fn [{:keys [db]} _] {:db {:items ["a" "b" "c"]}}))
+    (rf/reg-event :items/init (fn [_ _] {:db {:items ["a" "b" "c"]}}))
     (rf/reg-event :items/break (fn [{:keys [db]} _] {:db (assoc db :items [1 2 3])}))
     (rf/reg-sub :items
       {:schema [:vector :string]}

--- a/implementation/schemas/test/re_frame/schemas_validator_unavailable_warning_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_validator_unavailable_warning_test.clj
@@ -29,8 +29,7 @@
             [re-frame.late-bind :as late-bind]
             [re-frame.schemas :as schemas]
             [re-frame.schemas.test-fixture :as tf]
-            [re-frame.test-support :refer [with-trace-recorder!]]
-            [re-frame.trace :as trace]))
+            [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)
 

--- a/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
@@ -4,8 +4,9 @@
   Malformed schemas and throwing validators reject rather than validate;
   ambiguous or non-string navigation targets classify as external; and
   malformed SSR hydration payloads leave both frame-state partitions unchanged.
-  Each boundary combines named hostile inputs with deterministic generated
-  coverage."
+  The malformed-schema corpus is closed, so it is checked EXHAUSTIVELY; the URL
+  and hydration boundaries draw deterministic generated coverage on top of
+  their named hostile inputs."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
@@ -101,28 +102,6 @@
       (is (false? (schemas/validate-with-registered-fn [:int] 1))
           "throwing validator → false (fail closed), not a propagated throw, not true")
       (finally (schemas/reset-schema-validator!)))))
-
-(def ^:private gen-malformed-schema
-  (gen/gen-elem malformed-schemas))
-
-(deftest every-schema-kind-rejects-every-malformed-schema
-  (testing "across the malformed-schema corpus,
-            EVERY callable schema-validation kind returns FALSE. One kind
-            that returns true (or throws) for any draw = one fail-open."
-    (let [result
-          (gen/for-all
-            gen-malformed-schema 80 7
-            (fn [schema]
-              (every?
-                false?
-                [(try (schemas/validate-with-registered-fn schema [:x])
-                      (catch #?(:clj Throwable :cljs :default) _ :threw))
-                 (schemas/validate-event! :ev/x [:ev/x 1] {:schema schema})
-                 (schemas/validate-fx!   :fx/x :ev/x {} {:schema schema})
-                 (schemas/validate-sub!  :sub/x [:sub/x] {} {:schema schema})])))]
-      (is (nil? result)
-          (str "a schema kind coerced a malformed schema to success: "
-               (pr-str (when result (dissoc result :threw))))))))
 
 (def ^:private untrusted-url-inputs
   "Hostile / malformed URL-sink inputs. Each MUST classify EXTERNAL

--- a/implementation/security/test/re_frame/security/gen.cljc
+++ b/implementation/security/test/re_frame/security/gen.cljc
@@ -140,34 +140,36 @@
 (defn sample
   "Draw `n` values from generator `g` starting at `seed`. Returns a vector
   of the drawn values (state threaded internally). Deterministic in
-  `(seed, g, n)`."
-  ([g n] (sample g n 0))
-  ([g n seed]
-   (loop [draw-index 0, current-rng (make-rng seed), accumulated-values []]
-     (if (< draw-index n)
-       (let [[drawn-value next-rng] (g current-rng)]
-         (recur (inc draw-index) next-rng (conj accumulated-values drawn-value)))
-       accumulated-values))))
+  `(seed, g, n)`. `seed` is always explicit - there is no default, so a
+  drawn corpus can never depend on an invisible global."
+  [g n seed]
+  (loop [draw-index 0, current-rng (make-rng seed), accumulated-values []]
+    (if (< draw-index n)
+      (let [[drawn-value next-rng] (g current-rng)]
+        (recur (inc draw-index) next-rng (conj accumulated-values drawn-value)))
+      accumulated-values)))
 
 (defn for-all
-  "Run `pred` over `n` draws of generator `g` (seeded at `seed`, default
-  0). Returns `nil` when every draw satisfied `pred`, else a map
+  "Run `pred` over `n` draws of generator `g`, seeded at `seed`. Returns
+  `nil` when every draw satisfied `pred`, else a map
   `{:fail value :index i :seed seed}` describing the first counter-example
   - the seed + index reproduce it exactly. `pred` may throw; a throw is
-  treated as a failure and the exception is captured under `:threw`."
-  ([g n pred] (for-all g n 0 pred))
-  ([g n seed pred]
-   (loop [draw-index 0, current-rng (make-rng seed)]
-     (if (< draw-index n)
-       (let [[drawn-value next-rng] (g current-rng)
-             [ok? thrown-exception] (try [(boolean (pred drawn-value)) nil]
-                              (catch #?(:clj Throwable :cljs :default) e
-                                [false e]))]
-         (if ok?
-           (recur (inc draw-index) next-rng)
-           (cond-> {:fail drawn-value :index draw-index :seed seed}
-             thrown-exception (assoc :threw thrown-exception))))
-       nil))))
+  treated as a failure and the exception is captured under `:threw`.
+
+  `seed` is always explicit - there is no default, so a property can never
+  silently share an invisible global seed with its siblings."
+  [g n seed pred]
+  (loop [draw-index 0, current-rng (make-rng seed)]
+    (if (< draw-index n)
+      (let [[drawn-value next-rng] (g current-rng)
+            [ok? thrown-exception] (try [(boolean (pred drawn-value)) nil]
+                             (catch #?(:clj Throwable :cljs :default) e
+                               [false e]))]
+        (if ok?
+          (recur (inc draw-index) next-rng)
+          (cond-> {:fail drawn-value :index draw-index :seed seed}
+            thrown-exception (assoc :threw thrown-exception))))
+      nil)))
 
 ;; ---------------------------------------------------------------------------
 ;; Shared egress-scan helpers - lifted from the per-surface security test

--- a/implementation/security/test/re_frame/security/reply_envelope_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/reply_envelope_egress_security_cljs_test.cljc
@@ -251,22 +251,3 @@
     (is (reply/valid-reply? {:status :ok :value {:public 1}
                              :work/id [:rf.work/http :h 2] :rf.reply/work-status :completed}))
     (is (reply/data-only-target? {:event [:app/on-reply] :delivery :append}))))
-
-(deftest reply-value-projects-through-project-egress
-  (testing "project-egress of a reply value under an off-box profile redacts
-            the declared-sensitive leaf, elides large, and fails closed when
-            no frame is known"
-    (mk-frame! :reply/proj)
-    (let [value {:token sentinel :doc big-string :public 7}
-          out (rf/project-egress value
-                {:frame :reply/proj
-                 :rf.egress/profile :rf.egress/off-box-tool})]
-      (is (gen/redacted? (:token out)) "off-box-tool redacts the sensitive reply leaf")
-      (is (gen/large-marker? (:doc out)) "off-box-tool elides the large reply leaf")
-      (is (= 7 (:public out)))
-      (is (not (contains-sentinel? out))))
-    ;; Frameless project-egress fails closed (no :rf/default synthesis).
-    (binding [frame/*current-frame* nil]
-      (let [out (rf/project-egress {:token sentinel}
-                  {:rf.egress/profile :rf.egress/off-box-observability})]
-        (is (gen/redacted? out) "frameless reply-value egress fails closed")))))


### PR DESCRIPTION
Four audit children from rf2-6r9j, all test-only. No production behaviour changes.

## rf2-6r9j.93 — the fixed-corpus pseudo-property

`every-schema-kind-rejects-every-malformed-schema` drew 80 random samples from `malformed-schemas`, a **closed six-value vector**, and re-invoked the same four validators that the two tests immediately above it already invoke **exhaustively**:

- `boundary-seam-never-passes-a-malformed-schema` doseqs the whole corpus through `validate-with-registered-fn`
- `meta-bearing-surfaces-never-pass-a-malformed-schema` doseqs it through `validate-event!`, `validate-fx!` and `validate-sub!`

`gen/gen-elem` over a fixed vector cannot produce a schema shape outside that corpus, so the row asserted a strict subset of what already held — and its sampling did not itself guarantee that every corpus member was drawn, despite the "every malformed schema" title.

**Disposition: deleted, not relabelled.** Relabelling a pseudo-property as an honest example test is the right call when retiring it would leave an invariant unasserted. Here the invariant is asserted four lines above and more strongly, so an honest label would just name a duplicate.

The ns docstring claimed "each boundary combines named hostile inputs with deterministic generated coverage" — no longer true of the schema boundary. It now says the closed schema corpus is checked exhaustively while the URL and hydration boundaries draw generated coverage.

## rf2-6r9j.94 — the mislocated generic projector row

`reply-value-projects-through-project-egress` never constructed a reply envelope or touched `re-frame.reply`. **Named successor: `public_profile_projection_security_cljs_test.cljc`.**

Framed contracts — `off-box-profiles-redact-frame-owned-app-db`, which loops all three off-box profiles and pins:

```clojure
(is (gen/redacted? (get-in out [:auth :token]))    (str profile ": frame-owned sensitive app-db leaf redacted"))
(is (gen/large-marker? (get-in out [:docs :blob])) (str profile ": frame-owned large app-db leaf elided to a marker"))
(is (= 3 (get-in out [:public :count]))            (str profile ": unmarked sibling passes through"))
(is (not (contains-sentinel? out))                 (str profile ": the sensitive value never crosses the boundary"))
```

Frameless fail-closed — `no-frame-egress-fails-closed`:

```clojure
(binding [frame/*current-frame* nil]
  (let [out (rf/project-egress (app-db-value) {:rf.egress/profile :rf.egress/off-box-tool})]
    (is (gen/redacted? out) "frameless egress fails closed to :rf/redacted")))
```

The retired row used `:rf.egress/off-box-observability` for its frameless case where the successor uses `:rf.egress/off-box-tool`. That is not a distinct contract: `projection.cljc` delegates the whole no-live-frame decision to `elide-wire-value`, so fail-closed is one profile-independent control point, and the observability profile is separately exercised framed by the successor's profile loop and by `sensitive-wins-over-large-at-projection`. Every row that actually builds or projects a reply envelope stays, `frameless-trace-summary-fails-closed` included.

## rf2-6r9j.95 — default-seed arities

`sample`'s `[g n]` and `for-all`'s `[g n pred]` silently selected seed 0. Both removed; the seeded signatures are the only API.

Census, two instruments, both agreeing:

| instrument | result | control |
|---|---|---|
| `git grep -F` over tracked files | 17 `gen/for-all` sites, all 4-arg; 2 `gen/sample` sites (5 calls), all 3-arg | `gen/gen-elem` = 9; a non-existent name = 0 |
| clj-kondo `var-usages` | `for-all` only at arity 4 (36); `sample` only at arity 3 (12) | listed usages non-empty across all `gen` vars |

The only uses of the default-seed forms were the two self-delegating bodies removed. No namespace outside `implementation/security` requires `re-frame.security.gen`; the two other files naming it do so in prose comments about the LCG's cross-runtime contract. No spec or docs page documents the helper API.

## rf2-6r9j.55 — dead imports, bindings and wrapper lets

Focused clj-kondo over `implementation/schemas/{src,test}`: **33 warnings before, 7 after**, `errors: 0` both times. The 26 cleared are exactly the enumerated set — seven requires, fifteen locals, four redundant lets.

Each require proven absent by two instruments: a boundary-anchored `git grep` for the alias in its own file, and clj-kondo's own alias resolution, with a control alias in the same file returning a stable non-zero count each time. A naive `digest/` / `trace/` substring grep returns false hits inside the qualified keywords `:utdxg.digest/seed` and `:rf.trace/phase`; the anchored form reads 0.

Fourteen cofx destructures whose init handlers return a fixed map became `_`; sibling handlers on adjacent lines that **do** read `db` are untouched. The fifteenth is the never-read `secret` in `event-validation-redacts-container-level-sensitive-payload`, which dispatches the integer `12345`, not the binding. The four single-body nested lets merged into their enclosing let — the inner init depends on the outer binding, so evaluation and assertion order are preserved.

Deliberately kept, per the bead's exclusions: the matched-build `re-frame.core` requires in both schemas bundle fixtures, the effect-only `re-frame.schemas` loads in conformance and reg-side-effects, and the app-db source's nested let in `validate.cljc`.

## Gates

| gate | result |
|---|---|
| `implementation/security` `clojure -M:test` | exit 0 — 92 tests / 717 assertions (was 94 / 723; −2 tests, −6 assertions = exactly the two retired rows) |
| `implementation/schemas` `clojure -M:test` | exit 0 — 372 tests / 19221 assertions |
| `npm run test:security` | exit 0 — 93 tests / 724 assertions (was 95 / 730) |
| `npm run test:cljs` | exit 0 — 11168 tests / 55740 assertions |
| `clj-kondo implementation/schemas/{src,test}` | 33 → 7 warnings, errors 0 |
| `clj-kondo implementation/security` | 1 warning, identical to the `origin/main` baseline (`mask32` unused under the `:cljs` reader arm) |

Gates proven live: `(is (false? verdict))` → `(is (true? verdict))` in the security suite gave exit 1 with six `FAIL in (boundary-seam-never-passes-a-malformed-schema) (fail_closed_invariant_security_cljs_test.cljc:60)`; `(is (pos? (count mal)) ...)` → `(is (neg? ...))` in the flattened fail-open let gave exit 1 naming `schemas_fail_open_test.clj:178` — the flattened block's own body line. Both restored and confirmed byte-identical by `git hash-object`.

No new non-ASCII prose was added: every added line in the diff containing non-ASCII is a pre-existing `→` or `—` carried through a dedent, and all decode as valid UTF-8.
