### PR TITLE
docs(adapters): hicasso is the sixth shipped kind; four adapters install flush-render! (rf2-3nw7, rf2-02w1)

### DIFF
--- a/implementation/adapters/README.md
+++ b/implementation/adapters/README.md
@@ -34,7 +34,7 @@ adapter contract, React root calls, disposal, source coordinates, and the
 Each adapter implements the surface defined in [Spec 006 §The adapter API contract](../../spec/006-ReactiveSubstrate.md):
 
 - required (6): `make-state-container`, `read-container`, `replace-container!`, `make-derived-value`, `render`, `render-to-string`
-- optional (3): `subscribe-container`, `register-context-provider`, `flush-render!` — the core falls back (or no-ops) when these are absent. `flush-render!` is the production-grade synchronous render-commit (distinct from the `flush-views!` test helper). 3 of the 6 shipped adapter kinds install it — Reagent, reagent-slim and UIx. The other 3 omit it deliberately: `plain-atom` (in core) and the SSR substrate render without a live commit, so there is nothing to flush, and the test-react fixture hands the render clock to the test.
+- optional (3): `subscribe-container`, `register-context-provider`, `flush-render!` — the core falls back (or no-ops) when these are absent. `flush-render!` is the production-grade synchronous render-commit (distinct from the `flush-views!` test helper). 4 of the 6 shipped adapter kinds install it — Reagent, reagent-slim, UIx and Hicasso (the last two through `spine/make-react-adapter`, which wires the React spine's slot unconditionally). The other 2 omit it deliberately: `plain-atom` (in core) and the SSR substrate render without a live commit, so there is nothing to flush. The test-react fixture is not one of the 6 shipped kinds — it has no `:kind` in the shipped set, per the [canonical inventory](../../spec/006-ReactiveSubstrate.md#cljs-reference-scope) — and provides none either, handing the render clock to the test.
 - lifecycle (1): `dispose-adapter!`
 
 An adapter is a Clojure map carrying these fns under the matching keys plus a `:kind` discriminator keyword (for example `:rf.adapter/reagent-slim`). See [`re-frame.substrate.adapter`](../core/src/re_frame/substrate/adapter.cljc) for the live contract.
@@ -76,7 +76,7 @@ substrate-specific public helpers because they delegate shared mechanics into
 core artefact. There are 2 factory families:
 
 - ratom family — [`make-ratom-spine`](../core/src/re_frame/substrate/spine.cljs) + [`make-ratom-adapter`](../core/src/re_frame/substrate/spine.cljs) (Reagent + reagent-slim)
-- React-hook family — [`make-react-spine`](../core/src/re_frame/substrate/spine.cljs) + [`make-react-adapter`](../core/src/re_frame/substrate/spine.cljs) (UIx)
+- React-hook family — [`make-react-spine`](../core/src/re_frame/substrate/spine.cljs) + [`make-react-adapter`](../core/src/re_frame/substrate/spine.cljs) (UIx here; Hicasso's own substrate, at `implementation/hicasso/`, uses the same pair — which is why both carry `:flush-render!`)
 
 Each adapter file builds a config map and hands it to the appropriate factory pair. The spine carries the epoch scheduler (glitch-freedom), the container quartet, `useSyncExternalStore` hooks, source-coord wrapping, the after-render sentinel, the unmount sentinel, and the nine-/five-hook routed late-bind tables. Reading the spine ns is the fastest path to understanding how the adapters work end-to-end.
 

--- a/implementation/core/src/re_frame/core_routing.cljc
+++ b/implementation/core/src/re_frame/core_routing.cljc
@@ -64,10 +64,18 @@
                     :fragment \"...\"
                     & passthrough-html-attrs} & children]
 
-  The CLJS hook publishes the Reagent-wrapped render fn (returned by
-  `reg-view*`); the JVM hook publishes the SSR-side render fn. Either
-  way `[rf/route-link ...]` in a `.cljc` render tree renders correctly
-  on both platforms."
+  The CLJS hook publishes `re-frame.routing/route-link-element` — a fn that
+  EMITS the hiccup element `[(views/view-head :route/link) props & children]`
+  rather than one that renders. `defwrapper` CALLS whatever its hook holds
+  (see `defwrapper`'s docstring §A hook value MUST be a FUNCTION, never a
+  COMPONENT), and a view head that is called never becomes a component, so it
+  reads its caller's React context instead of its own; publishing the
+  registered head itself is what blanked every routed application in
+  rf2-nvcp. Emitting the element hands the head to the substrate as an
+  element TYPE, which componentizes it exactly as a `reg-view` view. The JVM
+  hook publishes the SSR-side render fn directly — SSR has no React context
+  to read. Either way `[rf/route-link ...]` in a `.cljc` render tree renders
+  correctly on both platforms."
   {:hook :routing/route-link :artefact routing-artefact :on-absent :throw
    :arglists '([props & children])}
   ([& args] :apply))

--- a/implementation/core/src/re_frame/substrate/adapter.cljc
+++ b/implementation/core/src/re_frame/substrate/adapter.cljc
@@ -640,11 +640,15 @@
   production-grade contract surface, not a test helper.
 
   Optional contract fn — returns nil and is a no-op when the installed
-  adapter ships no `:flush-render!`. Three of the six shipped adapter kinds
-  install one — Reagent, reagent-slim and UIx. The other three omit it, each
-  for its own reason: plain-atom and SSR render without a live React commit,
-  so there is nothing to flush, and test-react hands the render clock to the
-  test through `trigger-update!`, so it provides none by design. Calling it
+  adapter ships no `:flush-render!`. Four of the six shipped adapter kinds
+  install one — Reagent, reagent-slim, UIx and Hicasso; the last two get it
+  from `spine/make-react-adapter`, which wires the React spine's slot
+  unconditionally. The other two omit it for one shared reason: plain-atom
+  and SSR render without a live React commit, so there is nothing to flush.
+  The test-react fixture is NOT one of the six shipped kinds (it has no
+  `:kind` in the shipped set — Spec 006 §CLJS reference scope) and provides
+  none either: it hands the render clock to the test through
+  `trigger-update!`, by design. Calling it
   before `(rf/init! ...)` raises `:rf.error/no-adapter-installed`
   (rf2-zdfi1) — the optional-fn nil return is reserved for `adapter
   installed, fn absent`, not for `no adapter installed at all`."

--- a/implementation/routing/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/routing/test/re_frame/late_bind_missing_test.clj
@@ -85,10 +85,14 @@
 (deftest route-link-raises-when-routing-artefact-missing
   (testing "rf/route-link raises :rf.error/routing-artefact-missing when the :routing/route-link hook is nil"
     ;; Per rf2-uhv2 the route-link surface is published through the
-    ;; :routing/route-link late-bind hook (CLJS → Reagent-wrapped render
-    ;; fn; JVM → SSR render fn). Consumers without the routing artefact
-    ;; see the hook unregistered; the wrapper in re-frame.core-routing
-    ;; raises the documented missing-artefact error.
+    ;; :routing/route-link late-bind hook. CLJS publishes the ELEMENT-
+    ;; emitting `routing/route-link-element`, NOT the registered view head:
+    ;; `rf/route-link` is a `defwrapper`, so the hook value is CALLED, and a
+    ;; head that is called never becomes a component that can read the frame
+    ;; context (rf2-nvcp). JVM publishes the SSR render fn directly. Either
+    ;; way, consumers without the routing artefact see the hook unregistered
+    ;; and the wrapper in re-frame.core-routing raises the documented
+    ;; missing-artefact error — which is what this JVM test pins.
     (with-hook-as-nil :routing/route-link
       (fn []
         (let [thrown (try (rf/route-link {:to :route/probe})


### PR DESCRIPTION
Prose-only. Two beads landed; two left open as fence-blocked (below).

## rf2-3nw7 — the six shipped adapter kinds

`implementation/adapters/README.md:37` and the `flush-render!` docstring in
`implementation/core/src/re_frame/substrate/adapter.cljc:643-647` were
near-verbatim mirrors of the same wrong roster: both counted `test-react` as
one of the six shipped adapter kinds and reported "three of six" install the
slot. They move together in one commit for that reason.

Spec 006 §CLJS reference scope is the canonical inventory and was read, not
edited (hot-zone, one-toucher). Its six published rows are **Reagent,
reagent-slim, UIx, Hicasso, plain-atom, SSR**; `test-react/` is a
local-test-only fixture with "no `:kind` in the shipped set", and `scripts/`
is shared smoke tooling. `git ls-files implementation/adapters/` confirms the
five directories independently.

### The `:flush-render!` measurement — four of six, not three

| kind | `:flush-render!` | how |
|---|---|---|
| `:rf.adapter/reagent` | **yes** | injected into `make-ratom-spine` (`reagent.cljs:113`), re-emitted by `make-ratom-adapter` (`spine.cljs:3848`) |
| `:rf.adapter/reagent-slim` | **yes** | same path (`reagent_slim.cljs:50`) |
| `:rf.adapter/uix` | **yes** | `make-react-adapter` (`spine.cljs:3371`) from `make-react-spine` (`spine.cljs:3239`) |
| `:rf.adapter/hicasso` | **yes** | same pair — `hicasso/substrate.cljs:157` |
| `:rf.adapter/plain-atom` | no | `plain_atom.cljc:153-162`, key absent |
| `:rf.adapter/ssr` | no | `ssr/substrate.cljc:80-88`, key absent |

`make-react-adapter` wires `:flush-render! (:flush-render! spine-fns)`
unconditionally and `make-react-spine` always returns one (`flush-render!` is
a plain top-level `defn` at `spine.cljs:1773`), so Hicasso carries it for the
same structural reason UIx does. The corrected sentence therefore reads
**four of six**, and the two omissions share one reason — no live React
commit to flush — rather than the three-way split the old prose described.

The README's factory-family bullet said the React-hook pair was UIx only,
which the new sentence would have contradicted, so it now names Hicasso too.

### Reserved-value call

Nothing was deleted from any kind roster. The `:rf.adapter/ui` /
`:rf.adapter/freehand` **reserved-kind contract** rows and the struck-through
retirement bookkeeping are untouched — this change only corrects which
*shipped* kinds carry an optional contract slot, and adds no roster member
and removes none.

## rf2-02w1 — route-link's publication contract

The merged-PR audit on #9050 narrowed this to two residual statements still
describing the OLD contract. Both corrected:

- `implementation/core/src/re_frame/core_routing.cljc:64-69` — said the CLJS
  hook publishes "the Reagent-wrapped render fn (returned by `reg-view*`)".
  It publishes `routing/route-link-element`, an **element-emitting** shim
  (`routing.cljc:437-470`, `set-fn!` at `:553`).
- `implementation/routing/test/re_frame/late_bind_missing_test.clj:87-89` —
  repeated the same model in a comment.

No runtime, macro or gate change, per the ruling. PR #9060 already carries the
general constraint in `defwrapper`'s own docstring
(`core_artefact.cljc:62-92`), which was verified present on tip.

**Census (the ruling's step 1), full result:** 51 `defwrapper` forms across the
seven `core_*.cljc` files, 51 distinct hooks, 1:1. Every value is a plain
function — registration verbs, clear verbs, query getters, setters, the SSR
render/head family. `:routing/route-link` is the only view-shaped one and is
now element-emitting. Independent check: of the 207 `set-fn!` / `chain-fn!`
publications in non-test source, **zero** close over `view-head` or
`reg-view*` (control: the unfiltered grep returns 207). So no component-valued
hook remains, and the docstring branch of the ruling stands.

## Left open — fence-blocked

**rf2-6r9j.52** (retire `:rf.resource.internal/aborted`). The bead's core
premise **holds**: `git grep -F` over `implementation/*/src` finds **no**
production dispatcher (exit 1, zero hits), against a control of 20 files
carrying the sibling `:rf.resource.internal/failed`. But completing it needs
two edits outside this fence:
- `spec/Conventions.md:110,111` list the event as a **reserved member** of
  `:rf.resource.internal/*` — hot-zone, one-toucher.
- `implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj:3946`
  **executably dispatches** it, and `:4067` treats it as a named branch of a
  whole-record egress sweep. `implementation/epoch` is held elsewhere;
  removing the registration reds that suite.

**rf2-6r9j.47** (remove `status-defect-record-slots`). Premise verified —
`git grep -F` finds the var defined at
`implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj:62` and referenced
from **no** executable site. But the artefact is in the SSR family, and its
acceptance criteria require editing `spec/009-Instrumentation.md:2126` (which
names the var "the source of truth") — hot-zone, one-toucher — plus
`implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj:1282`.
Landing a partial would leave the tree self-contradictory, so it is untouched.

## Gates

Captured to files, read from the files, run in the foreground.

| gate | exit |
|---|---|
| `python scripts/check_readme_links.py --ci` | **0** (re-run post-rebase: 0) |
| `python scripts/lint_kondo.py` (the CI invocation) | **0** — `errors: 0` |
| `clojure -M:test -n re-frame.late-bind-missing-test` (routing) | **0** — 6 tests, 33 assertions |
| `clojure -M:test -n re-frame.late-bind-drift-test -n re-frame.late-bind-cache-test` (core) | **0** — 24 tests, 739 assertions |

**Control that fired:** `check_readme_links.py --ci` is the right gate by PATH
for `implementation/adapters/README.md` (a README beside source, outside
`check_doc_slugs.py`'s roots). Proved live rather than assumed: breaking the
new `#cljs-reference-scope` anchor took it from exit 0 to **exit 1**, which
also confirms it validates that cross-file anchor into
`spec/006-ReactiveSubstrate.md`. Restored and re-verified by hash.

**Hand-verified, because no gate reads it:** neither link gate inspects prose,
tables, or anything inside a fenced code block. The README's changed bullet is
prose in a list, and the factory-family bullet likewise — both read and
checked by hand. No table column counts changed. `mkdocs build --strict` is
**not** nominated: `docs_dir` is `docs`, and `implementation/**` was never a
candidate for it.

**CRLF / cp1252:** all four files are wholly CRLF (93 / 848 / 73 / 203 lines,
all CR-terminated). Every edit was re-read as bytes afterwards — all four
still 100% CRLF and valid UTF-8, and the README edit was re-applied through an
explicit-bytes write after the control restore, verified by `git hash-object`.

Rebased onto current `origin/main` (was 9 behind). None of the four files was
touched upstream since the merge base, so the rebase was clean and no
hand-resolution occurred.
