### PR TITLE
Retire three proven-dead branches in schemas validation and the conformance runner (rf2-6r9j.45/.49/.48)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -389,6 +389,17 @@
   sensitivity decision, and the trace emit. Returns true on pass / no
   schema / no validator; false on a logged failure.
 
+  When the validator fails, the schema's per-slot `:sensitive?` walker
+  is ALWAYS consulted before emitting. An event vector isn't itself
+  `:map`-shaped but its `:cat`/`:catn` payload commonly is (a login schema
+  marks `:password` sensitive), and fx / sub-return validate a map value
+  directly. The decision is the whole-schema `schema-has-sensitive?` (NOT
+  the leaf-precise `schema-sensitive-at?`): every value-bearing slot on
+  these surfaces carries the WHOLE checked value, so a conforming sensitive
+  sibling rides inside it and the redaction scope must match the
+  carried-value scope (see the `:else` branch's PER-SLOT DECISION SCOPING
+  note).
+
   Parameters:
     - `reg-meta`     the registration metadata (handler / sub /
                      fx) — its `:schema` entry, when PRESENT, is the
@@ -401,19 +412,6 @@
                      means no declaration.
     - `value`        the value being checked (event vector, sub
                      return value, fx args).
-    - `walk-schema?` boolean — when true and the validator fails,
-                     consult the schema's per-slot `:sensitive?` walker
-                     before emitting. An event vector
-                     isn't itself `:map`-shaped but its `:cat`/`:catn` payload
-                     commonly is (a login schema marks `:password` sensitive),
-                     and fx / sub-return validate a map value directly.
-                     The decision here is the whole-schema
-                     `schema-has-sensitive?` (NOT the leaf-precise
-                     `schema-sensitive-at?`): every value-bearing slot on these
-                     surfaces carries the WHOLE checked value, so a conforming
-                     sensitive sibling rides inside it and the redaction scope
-                     must match the carried-value scope (see the `:else`
-                     branch's PER-SLOT DECISION SCOPING note).
     - `build-base-tags`  `(fn [schema explanation] -> map)` — produces
                      the per-fn tag map (`:where`, `:reason`, etc.)
                      EXCLUDING any sensitivity stamping. Also the source
@@ -452,7 +450,7 @@
   redactor scrubs it symmetrically with `:explain` on sensitive
   failures rather than the humanizer being handed an already-redacted
   `:explain` and silently dropping the slot."
-  [reg-meta value walk-schema? build-base-tags continue?]
+  [reg-meta value build-base-tags continue?]
   (if-not (continue?)
     :rf/stale-incarnation
     (if-let [validate-fn @validator/validator-fn]
@@ -528,8 +526,7 @@
                 ;; because there is no narrowed slot:
                 ;; the whole payload carries the sibling. (It DOES still apply
                 ;; to the app-db `:value` slot, which is genuinely leaf-narrowed
-                ;; — see `validate-app-schema!`.) `walk-schema?` stays the knob
-                ;; for whether to consult the walker at all.
+                ;; — see `validate-app-schema!`.)
                 ;; A compiled or opaque schema (a non-vector,
                 ;; non-keyword `m/schema` object) cannot be walked, so the
                 ;; per-slot `:sensitive?` flag Malli honoured for the failure
@@ -543,18 +540,16 @@
                 ;; `:cat`/`:map` element that is itself a compiled `m/schema`
                 ;; value) is just as unintrospectable, so the whole-payload
                 ;; check uses the recursive `schema-has-opaque-child?`.
-                        sensitive?  (and walk-schema?
-                                          (or (walker/schema-has-sensitive? schema)
-                                              (walker/schema-has-opaque-child? schema)))
+                        sensitive?  (or (walker/schema-has-sensitive? schema)
+                                        (walker/schema-has-opaque-child? schema))
                 ;; When the schema declares any `:large?`
                 ;; slot AND the failure is not sensitive (sensitive wins),
                 ;; elide the value-bearing slots to the `:rf.size/large-elided`
                 ;; marker. An opaque schema is already handled fail-closed
                 ;; SENSITIVE above (which subsumes large), so `:large?` is only
                 ;; consulted for a walkable schema here.
-                        large?      (and walk-schema?
-                                          (not sensitive?)
-                                          (walker/schema-has-large? schema))
+                        large?      (and (not sensitive?)
+                                         (walker/schema-has-large? schema))
                 ;; Humanize from the raw explanation here,
                 ;; before redaction, and fold the slot into base-tags so
                 ;; `redact-tags` scrubs it symmetrically with `:explain`
@@ -924,7 +919,6 @@
      (run-validation
        handler-meta
        event
-       true   ;; consult the event schema's per-slot `:sensitive?` walker
        (fn [schema explanation]
          (cond-> {:where      :event
                   :event-id   event-id
@@ -960,7 +954,6 @@
      (run-validation
        sub-meta
        value
-       true   ;; consult schema's per-slot `:sensitive?` walker on fail
        (fn [schema explanation]
          (cond-> {:where          :sub-return
                   :rf.sub/id      sub-id
@@ -1006,7 +999,6 @@
      (run-validation
        fx-meta
        args
-       true   ;; consult schema's per-slot `:sensitive?` walker on fail
        (fn [schema explanation]
          (cond-> {:where      :fx-args
                   :rf.fx/id   fx-id

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -144,16 +144,18 @@
     form))
 
 (defn- load-fixture
-  "Read one EDN fixture. The corpus does not use auto-resolved keywords
-  in schema fixtures (the `::name` rewrite the machines / ssr runners
-  carry is for `:rf.machine.timer/*` synthetic events). We apply the
-  same rewrite here for symmetry — a no-op on the schemas subset, but
-  the runner stays robust if a future fixture grows a `::` form."
+  "Read one EDN fixture as EXACTLY ONE top-level EDN form, or throw.
+
+  The fixture text is parsed VERBATIM. Schema fixtures carry no
+  auto-resolved `::name` keywords, and the machines / ssr runners'
+  `::name` -> `:rf.machine.timer/name` rewrite has no business here: it
+  resolves nothing in the fixture's own namespace; it merely restamps the
+  token with an unrelated machines-timer identity, which could make a
+  future schema fixture pass or fail under a false id. If schema fixtures
+  ever need an alias facility, the conformance format should define one
+  explicitly (rf2-6r9j.49)."
   [file]
-  (let [raw   (slurp file)
-        fixed (str/replace raw #"::([a-zA-Z][a-zA-Z0-9_-]*)"
-                           ":rf.machine.timer/$1")]
-    (read-one-form fixed (.getName file))))
+  (read-one-form (slurp file) (.getName file)))
 
 (defn- schema-fixture-file?
   "True for the schemas-relevant fixture filenames:
@@ -501,18 +503,37 @@
        :error      (.getMessage e)
        :exception  e})))
 
+;; ---- loader regression ---------------------------------------------------
+
+(deftest loader-does-not-restamp-auto-resolved-keywords
+  ;; rf2-6r9j.49. The machines / ssr runners rewrite `::name` to
+  ;; `:rf.machine.timer/name` for their synthetic timer events. This runner
+  ;; carried a copy "for symmetry"; on a schemas fixture it would not have
+  ;; RESOLVED the token; it would have restamped it with an unrelated
+  ;; namespace, so a future fixture could pass or fail under a false id.
+  ;; The loader now parses verbatim, so the token is REJECTED instead,
+  ;; which is acceptable until the conformance format defines such syntax.
+  (let [f (java.io.File/createTempFile "rf2-schemas-conformance-probe" ".edn")]
+    (try
+      (spit f "{:fixture/id :probe/x :k ::probe}")
+      (let [outcome (try {:form (load-fixture f)}
+                         (catch Exception e {:threw (.getMessage e)}))]
+        (is (not= :rf.machine.timer/probe (-> outcome :form :k))
+            "a bare `::probe` must never arrive as a machines-timer keyword")
+        (is (contains? outcome :threw)
+            "an auto-resolved keyword is not EDN, so the loader rejects it"))
+      (finally (.delete f)))))
+
 ;; ---- the test entrypoint -------------------------------------------------
 
 (deftest run-schemas-conformance-corpus
   (let [results (atom [])]
     (doseq [[fname fixture] (all-schemas-fixtures)]
+      ;; There is no load-error arm. `load-fixture` THROWS on an
+      ;; unreadable / empty / multi-form fixture (rf2-98ni, rf2-5mr6), so a
+      ;; parse failure escapes `all-schemas-fixtures` before this loop and
+      ;; fails the gate, rather than disappearing as a skip (rf2-6r9j.48).
       (cond
-        (:fixture/load-error fixture)
-        (swap! results conj {:fixture-id fname
-                             :skipped?   true
-                             :reason     "load error"
-                             :error      (:fixture/load-error fixture)})
-
         (not (spec-version-claimed? fixture))
         (swap! results conj {:fixture-id   (:fixture/id fixture)
                              :fname        fname
@@ -563,7 +584,7 @@
           (println "Skipped:")
           (doseq [s skipped]
             (println "  " (:fixture-id s) "—" (:reason s)
-                     (or (:capabilities s) (:spec-version s) (:error s)))))
+                     (or (:capabilities s) (:spec-version s)))))
         (println)
         (println "Failures:")
         (doseq [f failed]


### PR DESCRIPTION
Three slice-local vestige removals in `implementation/schemas/**`. Each dead branch was proven with an execution probe carrying a control that fires, not a census alone.

## rf2-6r9j.45 — `run-validation`'s `walk-schema?` knob

`run-validation` is private, has exactly three callers (`validate-event!`, `validate-sub!`, `validate-fx!`), and all three passed the literal `true`. The knob's `false` direction was unreachable residue from a retired topology (introduced `f899bdd8e4`; event validation flipped to `true` in `14a91d956f`; injection-time cofx validation retired in `99d37fa6bf` / `f56f5495e7`).

Both walks are now unconditional inside the already-failing branch. Unchanged: sensitive-wins-over-large ordering, the fail-closed opaque-schema handling, the whole-payload (not leaf-precise) decision scope, every redaction marker and tag, and the outer `interop/debug-enabled?` gates that production DCE relies on. The parameter bullet's substance moved into the fn's opening prose so the invariant stays documented rather than deleted.

## rf2-6r9j.49 — the machines-timer rewrite in the fixture loader

`load-fixture` rewrote every `::name` to `:rf.machine.timer/name`. That is the machines / ssr runners' synthetic-timer facility, copied here "for symmetry". On a schemas fixture it resolves nothing in the fixture's own namespace; it merely restamps the token with an unrelated identity, so a future fixture could pass or fail under a false id. The loader now passes the fixture text to `read-one-form` verbatim, and a focused regression pins that a bare `::probe` never arrives as `:rf.machine.timer/probe`.

**One premise did not hold.** The bead's conditional criterion — "remove `clojure.string` if the rewrite was its last use" — does not fire: `schema-fixture-file?` still calls `str/starts-with?` and `str/ends-with?`. `clojure.string` stays.

## rf2-6r9j.48 — the unreachable load-error skip arm

`read-one-form` has thrown on every load failure since `b6e26366a8`, and `load-fixture` has no catch, so no loader output could reach `(:fixture/load-error fixture)`. The arm preserved exactly the "malformed fixture disappears as a skip" policy that change retired. Removed, along with the `(:error s)` slot in the skipped-summary that existed only to render it. A comment in its place records why there is no such arm. Spec-version and capability skips are untouched.

## Unreachability probes

A side-effecting marker was planted in each dead branch and the same marker in a live sibling arm, then the schemas JVM suite was run once:

| probe | dead arm | live sibling |
| --- | --- | --- |
| `.45` `walk-schema?` false direction | **0** | **50** |
| `.48` `:fixture/load-error` cond arm | **0** | **5** (= the five selected fixtures) |

## Gates

| gate | result |
| --- | --- |
| schemas JVM suite, baseline | exit 0 — 372 tests / 19221 assertions |
| schemas JVM suite, after | exit 0 — 373 tests / 19223 assertions |
| clj-kondo `--fail-level error --lint implementation/schemas` | exit 0 — errors: 0 |

The gate is demonstrably live: an intermediate revision that referenced `testing` without referring it returned exit 1 with a compile error.

**Negative controls, both fired.**

- `.48`: a trailing form planted in `schema-event-payload-validates.edn` turned the focused run red — 1 **error**, exit 1, `must hold exactly ONE top-level EDN form`, and **zero** skips. Fixture restored and verified identical by `git hash-object` (`88cf0752…`).
- `.49`: restoring the rewrite turned the new regression red on both assertions, with `actual: :rf.machine.timer/probe` — i.e. it reproduces the exact silent restamping the bead describes.

clj-kondo over the HEAD versions of both files and over the changed versions returns the same 0 errors / 3 warnings, so this introduces no new lint findings. The three warnings that name these files (`re-frame.schemas` and `re-frame.substrate.adapter` unused requires, the `validate.cljc:852` redundant `let`) are pre-existing and owned by rf2-6r9j.51 / rf2-6r9j.55.

**CLJS not run locally.** `validate.cljc` is `.cljc`, so the edit reaches CLJS, but it is a mechanical arity reduction with no platform-specific content, no new symbol and no reader conditional; clj-kondo analyses both branches and reports no arity error, and the JVM suite exercises the identical redaction logic across 19223 assertions. `test:cljs`, `test:schemas-bundle` and `browser-schemas-boundary-prod` are CI's.

## Collision note

`rf2-6r9j.51` (the fourth bead in this slice) is **left open**. `worker/sectier-a` holds `rf2-6r9j.55` and has uncommitted edits to `schemas_cljs_test.cljs`, which is `.51`'s primary file; that branch had no PR and was unpushed at the time of checking, so the overlap was found in the local worktree rather than through the GitHub listing.

That worker also edits `schemas_conformance_test.clj`, but only to drop `[re-frame.substrate.adapter]` from the ns form — ten lines from anything here, and this PR touches no ns form in that file, so the two diffs are disjoint.

The one surviving `walk-schema?` token repo-wide is a dated past-tense comment at `schemas_sensitive_test.clj:1118` recording the rf2-a5kzs fix. It is accurate history and sits in a file `rf2-6r9j.55` owns, so it is deliberately left alone.

Anchors and table column counts in this PR body were checked by hand.
